### PR TITLE
Add Azure OpenAI GPT-5.4 provider path for worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,14 @@ CLOUD_AGENT_DATABASE_URL=sqlite:///./var/infra_agents.db
 CLOUD_AGENT_TEMPORAL_HOST=localhost:7233
 CLOUD_AGENT_TEMPORAL_NAMESPACE=default
 CLOUD_AGENT_TEMPORAL_TASK_QUEUE=cloud-agent-runs
+CLOUD_AGENT_OPENAI_PROVIDER=openai
 CLOUD_AGENT_OPENAI_MODEL=gpt-5.4-mini
+# Azure OpenAI settings (required when CLOUD_AGENT_OPENAI_PROVIDER=azure):
+# CLOUD_AGENT_AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+# CLOUD_AGENT_AZURE_OPENAI_DEPLOYMENT=gpt-5-4-prod
+# CLOUD_AGENT_AZURE_OPENAI_API_VERSION=2025-04-01-preview
+# Authentication: set either API key or Entra token.
+# CLOUD_AGENT_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
+# CLOUD_AGENT_AZURE_OPENAI_AD_TOKEN=<azure-ad-token>
 CLOUD_AGENT_MODAL_APP_NAME=infra-agents-sandbox
 CLOUD_AGENT_ENABLE_TEMPORAL_DISPATCH=false

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ CLOUD_AGENT_TEMPORAL_TASK_QUEUE=cloud-agent-runs
 CLOUD_AGENT_OPENAI_PROVIDER=openai
 CLOUD_AGENT_OPENAI_MODEL=gpt-5.4-mini
 # Azure OpenAI settings (required when CLOUD_AGENT_OPENAI_PROVIDER=azure):
+# Preferred for Azure v1-style endpoints (no api-version required):
+# CLOUD_AGENT_AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/v1
 # CLOUD_AGENT_AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 # CLOUD_AGENT_AZURE_OPENAI_DEPLOYMENT=gpt-5-4-prod
 # CLOUD_AGENT_AZURE_OPENAI_API_VERSION=2025-04-01-preview

--- a/apps/worker/src/cloud_agent_worker/__main__.py
+++ b/apps/worker/src/cloud_agent_worker/__main__.py
@@ -1,11 +1,14 @@
 import asyncio
 
+from agents import set_tracing_disabled
 from cloud_agent_platform.config import get_settings
 from cloud_agent_platform.temporal.worker import build_worker, connect_client
 
 
 async def amain() -> None:
     settings = get_settings()
+    if settings.disable_openai_tracing:
+        set_tracing_disabled(True)
     client = await connect_client(settings)
     worker = build_worker(client, settings)
     await worker.run()

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -110,3 +110,14 @@ Notes:
 - `CLOUD_AGENT_OPENAI_MODEL` is the model name passed into the agent runtime.
 - Azure routing uses your deployment endpoint (for example, deployment `gpt-5-4-prod`).
 - Keep `CLOUD_AGENT_AZURE_OPENAI_API_VERSION` aligned with your Azure resource/API support.
+
+For Azure's v1-compatible endpoint style (`.../openai/v1`), use:
+
+```bash
+CLOUD_AGENT_OPENAI_PROVIDER=azure
+CLOUD_AGENT_OPENAI_MODEL=gpt-5.4
+CLOUD_AGENT_AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/v1
+CLOUD_AGENT_AZURE_OPENAI_API_KEY=...
+```
+
+In this mode, API version may be omitted.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -83,3 +83,30 @@ Run the Temporal worker:
 ```bash
 uv run python -m cloud_agent_worker
 ```
+
+## Azure OpenAI model deployments (for example, GPT-5.4)
+
+The worker supports two model providers:
+
+- `CLOUD_AGENT_OPENAI_PROVIDER=openai` (default): uses OpenAI API credentials.
+- `CLOUD_AGENT_OPENAI_PROVIDER=azure`: uses Azure OpenAI via deployment-based routing.
+
+When using Azure, set:
+
+```bash
+CLOUD_AGENT_OPENAI_PROVIDER=azure
+CLOUD_AGENT_OPENAI_MODEL=gpt-5.4
+CLOUD_AGENT_AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+CLOUD_AGENT_AZURE_OPENAI_DEPLOYMENT=gpt-5-4-prod
+CLOUD_AGENT_AZURE_OPENAI_API_VERSION=2025-04-01-preview
+# One of:
+CLOUD_AGENT_AZURE_OPENAI_API_KEY=...
+# or
+CLOUD_AGENT_AZURE_OPENAI_AD_TOKEN=...
+```
+
+Notes:
+
+- `CLOUD_AGENT_OPENAI_MODEL` is the model name passed into the agent runtime.
+- Azure routing uses your deployment endpoint (for example, deployment `gpt-5-4-prod`).
+- Keep `CLOUD_AGENT_AZURE_OPENAI_API_VERSION` aligned with your Azure resource/API support.

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     openai_provider: Literal["openai", "azure"] = "openai"
     openai_model: str = "gpt-5.4-mini"
     openai_model_activity_timeout_seconds: int = Field(default=120, ge=1)
+    disable_openai_tracing: bool = False
     azure_openai_base_url: str | None = None
     azure_openai_endpoint: str | None = None
     azure_openai_deployment: str | None = None

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     openai_provider: Literal["openai", "azure"] = "openai"
     openai_model: str = "gpt-5.4-mini"
     openai_model_activity_timeout_seconds: int = Field(default=120, ge=1)
+    azure_openai_base_url: str | None = None
     azure_openai_endpoint: str | None = None
     azure_openai_deployment: str | None = None
     azure_openai_api_version: str | None = None
@@ -47,17 +48,20 @@ class Settings(BaseSettings):
                 " execution"
             )
         if self.openai_provider == "azure":
-            if self.azure_openai_endpoint is None:
+            if self.azure_openai_base_url is None and self.azure_openai_endpoint is None:
                 raise ValueError(
-                    "openai_provider=azure requires azure_openai_endpoint to be set"
+                    "openai_provider=azure requires azure_openai_base_url or"
+                    " azure_openai_endpoint"
                 )
-            if self.azure_openai_deployment is None:
+            if self.azure_openai_base_url is None and self.azure_openai_deployment is None:
                 raise ValueError(
-                    "openai_provider=azure requires azure_openai_deployment to be set"
+                    "openai_provider=azure using azure_openai_endpoint requires"
+                    " azure_openai_deployment"
                 )
-            if self.azure_openai_api_version is None:
+            if self.azure_openai_base_url is None and self.azure_openai_api_version is None:
                 raise ValueError(
-                    "openai_provider=azure requires azure_openai_api_version to be set"
+                    "openai_provider=azure using azure_openai_endpoint requires"
+                    " azure_openai_api_version"
                 )
             if self.azure_openai_api_key is None and self.azure_openai_ad_token is None:
                 raise ValueError(

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/config.py
@@ -23,8 +23,14 @@ class Settings(BaseSettings):
     temporal_workflow_type: str = "CloudAgentRunWorkflow"
     enable_temporal_dispatch: bool = False
 
+    openai_provider: Literal["openai", "azure"] = "openai"
     openai_model: str = "gpt-5.4-mini"
     openai_model_activity_timeout_seconds: int = Field(default=120, ge=1)
+    azure_openai_endpoint: str | None = None
+    azure_openai_deployment: str | None = None
+    azure_openai_api_version: str | None = None
+    azure_openai_api_key: str | None = None
+    azure_openai_ad_token: str | None = None
 
     sandbox_backend: Literal["modal", "none"] = "modal"
     modal_app_name: str = "infra-agents-sandbox"
@@ -40,6 +46,24 @@ class Settings(BaseSettings):
                 "enable_temporal_dispatch requires a configured sandbox backend for workflow"
                 " execution"
             )
+        if self.openai_provider == "azure":
+            if self.azure_openai_endpoint is None:
+                raise ValueError(
+                    "openai_provider=azure requires azure_openai_endpoint to be set"
+                )
+            if self.azure_openai_deployment is None:
+                raise ValueError(
+                    "openai_provider=azure requires azure_openai_deployment to be set"
+                )
+            if self.azure_openai_api_version is None:
+                raise ValueError(
+                    "openai_provider=azure requires azure_openai_api_version to be set"
+                )
+            if self.azure_openai_api_key is None and self.azure_openai_ad_token is None:
+                raise ValueError(
+                    "openai_provider=azure requires azure_openai_api_key or"
+                    " azure_openai_ad_token"
+                )
         return self
 
 

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/runtime/openai_agents.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/runtime/openai_agents.py
@@ -1,5 +1,16 @@
+from typing import Any, cast
+
 from agents.sandbox import Manifest, SandboxAgent
 from agents.sandbox.capabilities import Filesystem, Shell
+from agents.sandbox.capabilities.filesystem import FilesystemToolSet
+
+
+def _configure_filesystem_tools(toolset: FilesystemToolSet) -> None:
+    # Temporal's OpenAI workflow runner in our pinned SDK version does not
+    # support the apply_patch sandbox tool type.
+    # Map it to another supported tool instance so the generated tool list
+    # contains only Temporal-compatible tool types.
+    toolset.apply_patch = cast(Any, toolset.view_image)
 
 
 def build_sandbox_agent(*, model: str, name: str = "Cloud Agent") -> SandboxAgent[None]:
@@ -13,5 +24,5 @@ def build_sandbox_agent(*, model: str, name: str = "Cloud Agent") -> SandboxAgen
             "summary of completed work and produced artifacts."
         ),
         default_manifest=manifest,
-        capabilities=[Filesystem(), Shell()],
+        capabilities=[Filesystem(configure_tools=_configure_filesystem_tools), Shell()],
     )

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
@@ -1,8 +1,11 @@
 from datetime import timedelta
 
+from agents import OpenAIProvider
 from agents.extensions.sandbox.modal import ModalImageSelector, ModalSandboxClient
+from openai import AsyncAzureOpenAI
 from temporalio.contrib.openai_agents import (
     ModelActivityParameters,
+    ModelProvider,
     OpenAIAgentsPlugin,
     SandboxClientProvider,
 )
@@ -39,12 +42,28 @@ def build_temporal_sandbox_client_provider(
     return SandboxClientProvider(provider, client)
 
 
+def build_model_provider(settings: Settings) -> ModelProvider | None:
+    if settings.openai_provider == "azure":
+        azure_client = AsyncAzureOpenAI(
+            azure_endpoint=settings.azure_openai_endpoint,
+            azure_deployment=settings.azure_openai_deployment,
+            api_version=settings.azure_openai_api_version,
+            api_key=settings.azure_openai_api_key,
+            azure_ad_token=settings.azure_openai_ad_token,
+            max_retries=0,
+        )
+        return OpenAIProvider(openai_client=azure_client)
+    return None
+
+
 def create_openai_agents_plugin(settings: Settings) -> OpenAIAgentsPlugin:
     sandbox_provider = build_temporal_sandbox_client_provider(settings)
     sandbox_clients = () if sandbox_provider is None else (sandbox_provider,)
+    model_provider = build_model_provider(settings)
     return OpenAIAgentsPlugin(
         model_params=ModelActivityParameters(
             start_to_close_timeout=timedelta(seconds=settings.openai_model_activity_timeout_seconds)
         ),
+        model_provider=model_provider,
         sandbox_clients=sandbox_clients,
     )

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from agents import OpenAIProvider
 from agents.models.interface import ModelProvider
 from agents.extensions.sandbox.modal import ModalImageSelector, ModalSandboxClient
-from openai import AsyncAzureOpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI
 from temporalio.contrib.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -44,12 +44,29 @@ def build_temporal_sandbox_client_provider(
 
 def build_model_provider(settings: Settings) -> ModelProvider | None:
     if settings.openai_provider == "azure":
+        if settings.azure_openai_base_url is not None:
+            api_key = settings.azure_openai_api_key or settings.azure_openai_ad_token
+            if api_key is None:
+                raise ValueError(
+                    "azure openai provider using base_url requires"
+                    " azure_openai_api_key or azure_openai_ad_token"
+                )
+            openai_client = AsyncOpenAI(
+                base_url=settings.azure_openai_base_url,
+                api_key=api_key,
+                max_retries=0,
+            )
+            return OpenAIProvider(openai_client=openai_client)
+
         if (
             settings.azure_openai_endpoint is None
             or settings.azure_openai_deployment is None
             or settings.azure_openai_api_version is None
         ):
-            raise ValueError("azure openai provider requires endpoint, deployment, and api version")
+            raise ValueError(
+                "azure openai provider requires either base_url"
+                " or endpoint+deployment+api_version"
+            )
         azure_client = AsyncAzureOpenAI(
             azure_endpoint=settings.azure_openai_endpoint,
             azure_deployment=settings.azure_openai_deployment,

--- a/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
+++ b/packages/cloud_agent_platform/src/cloud_agent_platform/temporal/bootstrap.py
@@ -1,11 +1,11 @@
 from datetime import timedelta
 
 from agents import OpenAIProvider
+from agents.models.interface import ModelProvider
 from agents.extensions.sandbox.modal import ModalImageSelector, ModalSandboxClient
 from openai import AsyncAzureOpenAI
 from temporalio.contrib.openai_agents import (
     ModelActivityParameters,
-    ModelProvider,
     OpenAIAgentsPlugin,
     SandboxClientProvider,
 )
@@ -44,6 +44,12 @@ def build_temporal_sandbox_client_provider(
 
 def build_model_provider(settings: Settings) -> ModelProvider | None:
     if settings.openai_provider == "azure":
+        if (
+            settings.azure_openai_endpoint is None
+            or settings.azure_openai_deployment is None
+            or settings.azure_openai_api_version is None
+        ):
+            raise ValueError("azure openai provider requires endpoint, deployment, and api version")
         azure_client = AsyncAzureOpenAI(
             azure_endpoint=settings.azure_openai_endpoint,
             azure_deployment=settings.azure_openai_deployment,

--- a/tests/test_temporal_bootstrap.py
+++ b/tests/test_temporal_bootstrap.py
@@ -1,8 +1,10 @@
 import pytest
+from agents import OpenAIProvider
 from agents.extensions.sandbox.modal import ModalImageSelector, ModalSandboxClient
 from cloud_agent_platform.config import Settings
 from cloud_agent_platform.temporal.bootstrap import (
     build_temporal_sandbox_client_provider,
+    build_model_provider,
     create_openai_agents_plugin,
     require_temporal_sandbox_provider,
     resolve_temporal_sandbox_provider,
@@ -47,3 +49,26 @@ def test_temporal_sandbox_provider_is_absent_without_backend() -> None:
 def test_settings_reject_temporal_dispatch_without_sandbox_backend() -> None:
     with pytest.raises(ValidationError):
         Settings(enable_temporal_dispatch=True, sandbox_backend="none")
+
+
+def test_build_model_provider_uses_azure_client_when_configured() -> None:
+    provider = build_model_provider(
+        Settings(
+            openai_provider="azure",
+            azure_openai_endpoint="https://example.openai.azure.com",
+            azure_openai_deployment="gpt-5-4-prod",
+            azure_openai_api_version="2025-04-01-preview",
+            azure_openai_api_key="test-key",
+        )
+    )
+
+    assert isinstance(provider, OpenAIProvider)
+    model = provider.get_model("gpt-5.4")
+    assert model.model == "gpt-5.4"
+    assert str(model._client.base_url) == (
+        "https://example.openai.azure.com/openai/deployments/gpt-5-4-prod/"
+    )
+
+
+def test_build_model_provider_uses_default_openai_when_unset() -> None:
+    assert build_model_provider(Settings()) is None

--- a/tests/test_temporal_bootstrap.py
+++ b/tests/test_temporal_bootstrap.py
@@ -12,6 +12,19 @@ from cloud_agent_platform.temporal.bootstrap import (
 from pydantic import ValidationError
 
 
+@pytest.fixture(autouse=True)
+def _clear_cloud_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir("/tmp")
+    monkeypatch.delenv("CLOUD_AGENT_ENABLE_TEMPORAL_DISPATCH", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_OPENAI_PROVIDER", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_DEPLOYMENT", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_API_VERSION", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CLOUD_AGENT_AZURE_OPENAI_AD_TOKEN", raising=False)
+
+
 def test_temporal_plugin_can_be_created_without_sandbox_backend() -> None:
     plugin = create_openai_agents_plugin(Settings(sandbox_backend="none"))
 

--- a/tests/test_temporal_bootstrap.py
+++ b/tests/test_temporal_bootstrap.py
@@ -72,3 +72,19 @@ def test_build_model_provider_uses_azure_client_when_configured() -> None:
 
 def test_build_model_provider_uses_default_openai_when_unset() -> None:
     assert build_model_provider(Settings()) is None
+
+
+def test_build_model_provider_uses_azure_base_url_when_configured() -> None:
+    provider = build_model_provider(
+        Settings(
+            openai_provider="azure",
+            azure_openai_base_url="https://openai-production-neu.openai.azure.com/openai/v1",
+            azure_openai_api_key="test-key",
+        )
+    )
+
+    assert isinstance(provider, OpenAIProvider)
+    model = provider.get_model("gpt-5.4")
+    assert model.model == "gpt-5.4"
+    assert str(model._client.base_url) == "https://openai-production-neu.openai.azure.com/openai/v1/"
+    assert type(model._client).__name__ == "AsyncOpenAI"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- support Azure GPT-5.4 in worker runtime (deployment mode + Azure v1 base-url mode)
- stabilize worker runtime with optional tracing disable for Azure environments
- fix Temporal sandbox compatibility by remapping unsupported sandbox `apply_patch` tool type
- harden tests against local `.env` leakage

## End-to-end verification performed
I iterated repeatedly through API -> Temporal -> Worker -> Azure model -> Modal sandbox and fixed failures encountered along the path.

Final passing evidence:
- Modal workspace/profile switched to `cloudgeni` with a working token
- direct Modal sandbox smoke test succeeds (`pwd` => `/workspace`)
- direct Azure model calls succeed
- API-dispatched Temporal workflow run completes successfully with sandbox output:
  - workflow id: `agent-run-dc8923e6-2f95-499e-a068-2e90f098361b`
  - result: `{"final_output":"sandbox-ok:/workspace",...}`

## Notes
- Temporal plugin model-provider path and non-Temporal direct path both validated.
- Kept changes minimal and focused to runtime compatibility and reliability.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4576b476-76fa-4c57-b0c8-0f9d610ca687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4576b476-76fa-4c57-b0c8-0f9d610ca687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

