### PR TITLE
Harden scheduled task sync paths

### DIFF
--- a/apps/api/src/domain/scheduled-tasks.ts
+++ b/apps/api/src/domain/scheduled-tasks.ts
@@ -7,11 +7,13 @@ import type {
 } from "@infra-agents/contracts";
 import {
   createScheduledTask,
+  deleteScheduledTask,
   getScheduledTask,
   updateScheduledTask,
   type Database,
 } from "@infra-agents/db";
 import { HTTPException } from "hono/http-exception";
+import type { SessionWorkflowClient } from "../dependencies";
 import type { ObjectStorageDependency } from "../dependencies";
 import {
   normalizeResources,
@@ -99,6 +101,33 @@ export async function restoreScheduledTask(db: Database, task: ScheduledTask): P
     reusableSessionId: task.reusableSessionId,
     metadata: task.metadata,
   });
+}
+
+export async function syncCreatedScheduledTask(input: {
+  db: Database;
+  workflowClient: SessionWorkflowClient;
+  task: ScheduledTask;
+}): Promise<void> {
+  try {
+    await input.workflowClient.syncScheduledTask({ task: input.task });
+  } catch (error) {
+    await deleteScheduledTask(input.db, input.task.id).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function syncUpdatedScheduledTask(input: {
+  db: Database;
+  workflowClient: SessionWorkflowClient;
+  previous: ScheduledTask;
+  task: ScheduledTask;
+}): Promise<void> {
+  try {
+    await input.workflowClient.syncScheduledTask({ task: input.task });
+  } catch (error) {
+    await restoreScheduledTask(input.db, input.previous).catch(() => undefined);
+    throw error;
+  }
 }
 
 export function scheduledTaskTemporalScheduleId(taskId: string): string {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import { getSettings } from "@infra-agents/config";
 import type { ScheduledTask, ScheduledTaskOverlapPolicy, ScheduledTaskScheduleSpec } from "@infra-agents/contracts";
 import { createDb } from "@infra-agents/db";
 import { createNatsEventBus } from "@infra-agents/events";
-import { Connection, Client as TemporalClient, ScheduleOverlapPolicy } from "@temporalio/client";
+import { Connection, Client as TemporalClient, ScheduleNotFoundError, ScheduleOverlapPolicy } from "@temporalio/client";
 import type { ScheduleOptions, ScheduleSpec, ScheduleUpdateOptions } from "@temporalio/client";
 import { createApp, type DocumentIndexClient, type SessionWorkflowClient } from "./app";
 
@@ -53,9 +53,14 @@ export async function createTemporalWorkflowClient(settings: ReturnType<typeof g
     syncScheduledTask: async ({ task }) => {
       const schedule = temporal.schedule.getHandle(task.temporalScheduleId);
       const options = temporalScheduleOptions(task, settings.temporalTaskQueue);
-      await schedule.update(() => temporalScheduleUpdateOptions(options)).catch(async () => {
+      try {
+        await schedule.update(() => temporalScheduleUpdateOptions(options));
+      } catch (error) {
+        if (!shouldCreateScheduleAfterUpdateError(error)) {
+          throw error;
+        }
         await temporal.schedule.create(options);
-      });
+      }
     },
     deleteScheduledTaskSchedule: async ({ temporalScheduleId }) => {
       await temporal.schedule.getHandle(temporalScheduleId).delete().catch(() => undefined);
@@ -134,6 +139,10 @@ export function temporalOverlapPolicy(policy: ScheduledTaskOverlapPolicy): Sched
     return ScheduleOverlapPolicy.BUFFER_ONE;
   }
   return ScheduleOverlapPolicy.ALLOW_ALL;
+}
+
+export function shouldCreateScheduleAfterUpdateError(error: unknown): boolean {
+  return error instanceof ScheduleNotFoundError;
 }
 
 export function temporalScheduleSpec(schedule: ScheduledTaskScheduleSpec): ScheduleSpec {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -14,6 +14,8 @@ import * as z4 from "zod/v4";
 import type { ApiRouteDeps } from "../dependencies";
 import {
   createValidatedScheduledTask,
+  syncCreatedScheduledTask,
+  syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
 } from "../domain/scheduled-tasks";
 
@@ -48,7 +50,7 @@ export function buildInfraAgentsMcpServer(deps: ApiRouteDeps): McpServer {
   }, async (args) => {
     const payload = CreateScheduledTaskRequest.parse(args);
     const task = await createValidatedScheduledTask({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, payload });
-    await deps.workflowClient.syncScheduledTask({ task });
+    await syncCreatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, task });
     return json(task);
   });
 
@@ -69,7 +71,7 @@ export function buildInfraAgentsMcpServer(deps: ApiRouteDeps): McpServer {
     const payload = UpdateScheduledTaskRequest.parse(raw);
     const update = await validatedScheduledTaskUpdate({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, existing, payload });
     const task = await updateScheduledTask(deps.db, id, update);
-    await deps.workflowClient.syncScheduledTask({ task });
+    await syncUpdatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, previous: existing, task });
     return json(task);
   });
 
@@ -77,8 +79,9 @@ export function buildInfraAgentsMcpServer(deps: ApiRouteDeps): McpServer {
     description: "Pause a scheduled task.",
     inputSchema: { id: z4.string().uuid() },
   }, async ({ id }) => {
+    const existing = await requireScheduledTask(deps.db, id);
     const task = await updateScheduledTask(deps.db, id, { status: "paused" });
-    await deps.workflowClient.syncScheduledTask({ task });
+    await syncUpdatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, previous: existing, task });
     return json(task);
   });
 
@@ -86,8 +89,9 @@ export function buildInfraAgentsMcpServer(deps: ApiRouteDeps): McpServer {
     description: "Resume a scheduled task.",
     inputSchema: { id: z4.string().uuid() },
   }, async ({ id }) => {
+    const existing = await requireScheduledTask(deps.db, id);
     const task = await updateScheduledTask(deps.db, id, { status: "active" });
-    await deps.workflowClient.syncScheduledTask({ task });
+    await syncUpdatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, previous: existing, task });
     return json(task);
   });
 

--- a/apps/api/src/routes/scheduled-tasks.ts
+++ b/apps/api/src/routes/scheduled-tasks.ts
@@ -10,7 +10,8 @@ import type { ApiRouteDeps } from "../dependencies";
 import {
   createValidatedScheduledTask,
   requireScheduledTaskForApi,
-  restoreScheduledTask,
+  syncCreatedScheduledTask,
+  syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
 } from "../domain/scheduled-tasks";
 import { boundedLimit } from "../http/common";
@@ -21,12 +22,7 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
   app.post("/v1/scheduled-tasks", async (c) => {
     const payload = CreateScheduledTaskRequest.parse(await c.req.json());
     const task = await createValidatedScheduledTask({ settings, db, objectStorage, payload });
-    try {
-      await workflowClient.syncScheduledTask({ task });
-    } catch (error) {
-      await deleteScheduledTask(db, task.id).catch(() => undefined);
-      throw error;
-    }
+    await syncCreatedScheduledTask({ db, workflowClient, task });
     return c.json(task, 201);
   });
 
@@ -44,36 +40,21 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
     const payload = UpdateScheduledTaskRequest.parse(await c.req.json());
     const update = await validatedScheduledTaskUpdate({ settings, db, objectStorage, existing, payload });
     const task = await updateScheduledTask(db, taskId, update);
-    try {
-      await workflowClient.syncScheduledTask({ task });
-    } catch (error) {
-      await restoreScheduledTask(db, existing).catch(() => undefined);
-      throw error;
-    }
+    await syncUpdatedScheduledTask({ db, workflowClient, previous: existing, task });
     return c.json(task);
   });
 
   app.post("/v1/scheduled-tasks/:taskId/pause", async (c) => {
     const existing = await requireScheduledTaskForApi(db, c.req.param("taskId"));
     const task = await updateScheduledTask(db, existing.id, { status: "paused" });
-    try {
-      await workflowClient.syncScheduledTask({ task });
-    } catch (error) {
-      await restoreScheduledTask(db, existing).catch(() => undefined);
-      throw error;
-    }
+    await syncUpdatedScheduledTask({ db, workflowClient, previous: existing, task });
     return c.json(task);
   });
 
   app.post("/v1/scheduled-tasks/:taskId/resume", async (c) => {
     const existing = await requireScheduledTaskForApi(db, c.req.param("taskId"));
     const task = await updateScheduledTask(db, existing.id, { status: "active" });
-    try {
-      await workflowClient.syncScheduledTask({ task });
-    } catch (error) {
-      await restoreScheduledTask(db, existing).catch(() => undefined);
-      throw error;
-    }
+    await syncUpdatedScheduledTask({ db, workflowClient, previous: existing, task });
     return c.json(task);
   });
 

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { ScheduleOverlapPolicy } from "@temporalio/client";
+import { ScheduleNotFoundError, ScheduleOverlapPolicy } from "@temporalio/client";
 import { allowedCorsOrigin, normalizeResources, replaySessionEvents, validateGitHubRepositorySelection, workflowIdForSession } from "../src/app";
-import { temporalOverlapPolicy, temporalScheduleSpec } from "../src/index";
+import { shouldCreateScheduleAfterUpdateError, temporalOverlapPolicy, temporalScheduleSpec } from "../src/index";
 import type { SessionEvent } from "@infra-agents/contracts";
 
 describe("API helpers", () => {
@@ -55,6 +55,11 @@ describe("API helpers", () => {
     expect(temporalOverlapPolicy("allow_concurrent")).toBe(ScheduleOverlapPolicy.ALLOW_ALL);
     expect(temporalOverlapPolicy("skip")).toBe(ScheduleOverlapPolicy.SKIP);
     expect(temporalOverlapPolicy("buffer_one")).toBe(ScheduleOverlapPolicy.BUFFER_ONE);
+  });
+
+  test("only creates a schedule after update when Temporal reports not found", () => {
+    expect(shouldCreateScheduleAfterUpdateError(new ScheduleNotFoundError("missing", "schedule-1"))).toBe(true);
+    expect(shouldCreateScheduleAfterUpdateError(new Error("network unavailable"))).toBe(false);
   });
 
   test("rejects selected GitHub App repos from multiple installations", () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3,6 +3,7 @@ import { createDb, getScheduledTask, listSessionEvents, listScheduledTasks, list
 import { appendAndPublishEvents } from "@infra-agents/events";
 import type { SessionEvent } from "@infra-agents/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
+import { buildInfraAgentsMcpServer } from "../../apps/api/src/mcp/server";
 import { MemoryEventBus, parseSseBlock, startTestServices, testSettings, type TestServices } from "@infra-agents/testing";
 import { prepareAgentTools } from "@infra-agents/runtime";
 
@@ -346,6 +347,44 @@ describe("API component integration", () => {
     const failedPause = await app.request(`/v1/scheduled-tasks/${task.id}/pause`, { method: "POST" });
     expect(failedPause.status).toBe(500);
     expect((await getScheduledTask(dbClient.db, task.id))?.status).toBe("active");
+  });
+
+  test("keeps MCP scheduled task persistence consistent when schedule sync fails", async () => {
+    workflow = new FakeWorkflowClient();
+    const settings = testSettings({ databaseUrl: services.databaseUrl });
+    const mcp = buildInfraAgentsMcpServer({
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by scheduled task MCP tests");
+      },
+    });
+
+    workflow.syncError = new Error("temporal unavailable");
+    const failedCreateName = `mcp-sync-fail-${crypto.randomUUID()}`;
+    await expect(callMcpTool(mcp, "scheduled_tasks_create", {
+      name: failedCreateName,
+      schedule: { type: "interval", everySeconds: 3600 },
+      agentConfig: { prompt: "inspect" },
+    })).rejects.toThrow("temporal unavailable");
+    expect((await listScheduledTasks(dbClient.db)).some((task) => task.name === failedCreateName)).toBe(false);
+
+    workflow.syncError = null;
+    const task = await callMcpTool<{ id: string }>(mcp, "scheduled_tasks_create", {
+      name: `mcp-rollback-${crypto.randomUUID()}`,
+      schedule: { type: "interval", everySeconds: 3600 },
+      agentConfig: { prompt: "inspect" },
+    });
+
+    workflow.syncError = new Error("temporal unavailable");
+    await expect(callMcpTool(mcp, "scheduled_tasks_pause", { id: task.id })).rejects.toThrow("temporal unavailable");
+    expect((await getScheduledTask(dbClient.db, task.id))?.status).toBe("active");
+    await expect(callMcpTool(mcp, "scheduled_tasks_resume", { id: crypto.randomUUID() })).rejects.toThrow("Scheduled task not found");
   });
 
   test("returns 404 for missing scheduled task actions", async () => {
@@ -824,6 +863,19 @@ async function readSseEvents(response: Response, count: number, abort: AbortCont
     abort.abort();
     await reader.cancel().catch(() => undefined);
   }
+}
+
+async function callMcpTool<T = unknown>(server: unknown, name: string, args: Record<string, unknown>): Promise<T> {
+  const tool = (server as { _registeredTools?: Record<string, { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }> })._registeredTools?.[name];
+  if (!tool) {
+    throw new Error(`MCP tool not registered: ${name}`);
+  }
+  const result = await tool.handler(args, {});
+  const text = (result as { content?: Array<{ text?: string }> }).content?.[0]?.text;
+  if (!text) {
+    throw new Error(`MCP tool returned no text: ${name}`);
+  }
+  return JSON.parse(text) as T;
 }
 
 class FakeWorkflowClient implements SessionWorkflowClient {


### PR DESCRIPTION
## Summary
- Share scheduled task sync rollback helpers between HTTP routes and MCP tools
- Roll back MCP scheduled task creates/updates/pause/resume when Temporal sync fails
- Only create Temporal schedules after update when the update failed because the schedule was not found

## Verification
- bun run typecheck
- bun test
- bun run test:integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled-task persistence and Temporal schedule synchronization paths; failures could impact task creation/update consistency, though changes are narrowly scoped and covered by added unit/integration tests.
> 
> **Overview**
> **Hardens scheduled-task sync with Temporal to avoid DB/workflow drift.** Scheduled-task create/update/pause/resume now use shared domain helpers (`syncCreatedScheduledTask`, `syncUpdatedScheduledTask`) that roll back DB changes (delete on create failure, restore previous state on update failure) when `workflowClient.syncScheduledTask` fails, and this behavior is applied consistently to both HTTP routes and MCP tools.
> 
> **Narrows Temporal schedule creation behavior.** `syncScheduledTask` now only falls back to `temporal.schedule.create` after an update when the error is specifically `ScheduleNotFoundError` (via `shouldCreateScheduleAfterUpdateError`), with new unit and integration coverage including MCP rollback scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f8165cb4f9eb5b4ee7622dd9575c097982ccc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->