### PR TITLE
[codex] Add file download MCP profile

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -6,6 +6,7 @@ import {
   deleteScheduledTask,
   listScheduledTaskRuns,
   listScheduledTasks,
+  requireFile,
   requireScheduledTask,
   updateScheduledTask,
 } from "@infra-agents/db";
@@ -23,6 +24,37 @@ export function buildInfraAgentsMcpServer(deps: ApiRouteDeps): McpServer {
     version: "1.0.0",
   });
   const json = (value: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] });
+
+  server.registerTool("files_get_download_url", {
+    description: "Create a short-lived download URL for a ready file asset.",
+    inputSchema: { fileId: z4.string().uuid() },
+  }, async ({ fileId }) => {
+    if (!deps.objectStorage) {
+      throw new Error("object storage is not configured");
+    }
+    const file = await requireFile(deps.db, fileId);
+    if (file.status !== "ready") {
+      throw new Error(`file is ${file.status}`);
+    }
+    const signed = await deps.objectStorage.createGetUrl({ key: file.objectKey });
+    return json({
+      file: {
+        id: file.id,
+        filename: file.filename,
+        safeFilename: file.safeFilename,
+        contentType: file.contentType,
+        sizeBytes: file.sizeBytes,
+        sha256: file.sha256,
+        status: file.status,
+        createdAt: file.createdAt,
+        updatedAt: file.updatedAt,
+      },
+      downloadUrl: {
+        url: signed.url,
+        expiresAt: signed.expiresAt.toISOString(),
+      },
+    });
+  });
 
   server.registerTool("scheduled_tasks_list", {
     description: "List scheduled tasks.",

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -85,9 +85,10 @@ describe("projectConversation", () => {
 });
 
 describe("buildTools", () => {
-  test("adds document search once when enabled", () => {
-    expect(buildTools(undefined, true)).toEqual([{ kind: "mcp", id: "docs" }]);
-    expect(buildTools([{ kind: "mcp", id: "docs" }], true)).toEqual([{ kind: "mcp", id: "docs" }]);
+  test("adds document search and file download tools once when enabled", () => {
+    expect(buildTools(undefined, true)).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
+    expect(buildTools([{ kind: "mcp", id: "docs" }], true)).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
+    expect(buildTools([{ kind: "mcp", id: "files" }], true)).toEqual([{ kind: "mcp", id: "files" }, { kind: "mcp", id: "docs" }]);
   });
 
   test("preserves existing tools when document search is disabled", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2222,8 +2222,12 @@ function buildResources(manualRepos: RepoDraft[], repos: GitHubRepository[], sel
 
 export function buildTools(existing: ToolRef[] | undefined, documentSearchEnabled: boolean): ToolRef[] {
   const out = [...(existing ?? [])];
-  if (documentSearchEnabled && !out.some((tool) => tool.kind === "mcp" && tool.id === "docs")) {
-    out.push({ kind: "mcp", id: "docs" });
+  if (documentSearchEnabled) {
+    for (const id of ["docs", "files"]) {
+      if (!out.some((tool) => tool.kind === "mcp" && tool.id === id)) {
+        out.push({ kind: "mcp", id });
+      }
+    }
   }
   return out;
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -270,14 +270,23 @@ export function parseMcpServers(raw: string | undefined): unknown[] | undefined 
 
 function ensureBuiltInMcpServers(settings: Settings): Settings["mcpServers"] {
   const existing = settings.mcpServers.filter((server) => server.id !== "infra_agents");
+  const firstPartyMcpUrl = settings.infraAgentsMcpUrl ?? `http://127.0.0.1:${settings.apiPort}/v1/mcp`;
+  const hasFiles = existing.some((server) => server.id === "files");
   const hasDocs = existing.some((server) => server.id === "docs");
   return [
     {
       id: "infra_agents",
       name: "Infra Agents",
-      url: settings.infraAgentsMcpUrl ?? `http://127.0.0.1:${settings.apiPort}/v1/mcp`,
+      url: firstPartyMcpUrl,
       cacheToolsList: true,
     },
+    ...(hasFiles ? [] : [{
+      id: "files",
+      name: "Files",
+      url: firstPartyMcpUrl,
+      allowedTools: ["files_get_download_url"],
+      cacheToolsList: true,
+    }]),
     ...(hasDocs ? [] : [{
       id: "docs",
       name: "Document Search",

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -84,13 +84,39 @@ describe("sandbox environment profiles", () => {
     expect(settings.mcpServers[0]?.allowedTools).toEqual(["search_documents"]);
   });
 
-  test("registers built-in document MCP server by default", () => {
+  test("registers built-in MCP profiles by default", () => {
     const settings = getSettings();
+    expect(settings.mcpServers.find((server) => server.id === "infra_agents")).toMatchObject({
+      name: "Infra Agents",
+      url: `http://127.0.0.1:${settings.apiPort}/v1/mcp`,
+    });
+    expect(settings.mcpServers.find((server) => server.id === "files")).toMatchObject({
+      name: "Files",
+      url: `http://127.0.0.1:${settings.apiPort}/v1/mcp`,
+      allowedTools: ["files_get_download_url"],
+    });
     expect(settings.mcpServers.find((server) => server.id === "docs")).toMatchObject({
       name: "Document Search",
       url: `http://127.0.0.1:${settings.apiPort}/v1/mcp/docs`,
       allowedTools: ["search_documents", "fetch_document_chunk", "list_document_bases"],
     });
+  });
+
+  test("does not duplicate a custom files MCP profile", () => {
+    const original = { ...process.env };
+    try {
+      process.env.INFRA_AGENT_MCP_SERVERS = '[{"id":"files","name":"Custom Files","url":"http://127.0.0.1:8787/mcp","allowedTools":["custom_download"]}]';
+      const settings = getSettings();
+      const ids = settings.mcpServers.map((server) => server.id);
+      expect(ids.filter((id) => id === "files")).toHaveLength(1);
+      expect(settings.mcpServers.find((server) => server.id === "files")).toMatchObject({
+        name: "Custom Files",
+        url: "http://127.0.0.1:8787/mcp",
+        allowedTools: ["custom_download"],
+      });
+    } finally {
+      process.env = original;
+    }
   });
 
   test("rejects non-array MCP server registry JSON", () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -302,6 +302,7 @@ describe("runtime event normalization", () => {
 
   test("prefixes MCP tool names deterministically", () => {
     expect(prefixedMcpToolName("docs", "search_documents")).toBe("docs__search_documents");
+    expect(prefixedMcpToolName("files", "files_get_download_url")).toBe("files__files_get_download_url");
   });
 
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -750,6 +750,13 @@ describe("API component integration", () => {
         allowedTools: ["search_documents", "fetch_document_chunk", "list_document_bases"],
         timeoutMs: undefined,
         cacheToolsList: false,
+      }, {
+        id: "files",
+        name: "Files",
+        url: `http://127.0.0.1:${port}/v1/mcp`,
+        allowedTools: ["files_get_download_url"],
+        timeoutMs: undefined,
+        cacheToolsList: false,
       }],
     };
     const app = createApp({
@@ -781,17 +788,81 @@ describe("API component integration", () => {
         headers: { "content-type": "application/json" },
       })).status).toBe(201);
 
-      prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "docs" }]);
-      const tools = await prepared.mcpServers[0]!.listTools();
-      expect(tools.map((tool) => tool.name)).toContain("docs__search_documents");
-      const result = await prepared.mcpServers[0]!.callTool("docs__search_documents", { query: "private endpoint", baseIds: [base.id], limit: 3 });
+      prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
+      const docsServer = prepared.mcpServers[0]!;
+      const filesServer = prepared.mcpServers[1]!;
+      const docTools = await docsServer.listTools();
+      expect(docTools.map((tool) => tool.name)).toContain("docs__search_documents");
+      const fileTools = await filesServer.listTools();
+      expect(fileTools.map((tool) => tool.name)).toEqual(["files__files_get_download_url"]);
+
+      const result = await docsServer.callTool("docs__search_documents", { query: "private endpoint", baseIds: [base.id], limit: 3 });
       expect(JSON.stringify(result)).toContain("private endpoint runbook");
+
+      const downloadResult = await filesServer.callTool("files__files_get_download_url", { fileId: upload.fileId });
+      const downloadPayload = JSON.parse(mcpText(downloadResult)) as { file: { id: string; filename: string }; downloadUrl: { url: string } };
+      expect(downloadPayload.file).toMatchObject({ id: upload.fileId, filename: "mcp-runbook.txt" });
+      const downloaded = await fetch(downloadPayload.downloadUrl.url);
+      expect(downloaded.status).toBe(200);
+      expect(await downloaded.text()).toContain("private endpoint runbook");
+
+      const pendingUploadResponse = await app.request("/v1/files/uploads", {
+        method: "POST",
+        body: JSON.stringify({ filename: "pending-mcp.txt", contentType: "text/plain", sizeBytes: 7 }),
+        headers: { "content-type": "application/json" },
+      });
+      const pendingUpload = await pendingUploadResponse.json() as { fileId: string };
+      expect(mcpText(await filesServer.callTool("files__files_get_download_url", { fileId: pendingUpload.fileId }))).toContain("file is pending_upload");
+      expect(mcpText(await filesServer.callTool("files__files_get_download_url", { fileId: crypto.randomUUID() }))).toContain("File not found");
+    } finally {
+      await prepared?.close().catch(() => undefined);
+      server.stop(true);
+    }
+  });
+
+  test("file download MCP tool reports unconfigured object storage", async () => {
+    const port = 20_000 + Math.floor(Math.random() * 1_000);
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      mcpServers: [{
+        id: "files",
+        name: "Files",
+        url: `http://127.0.0.1:${port}/v1/mcp`,
+        allowedTools: ["files_get_download_url"],
+        timeoutMs: undefined,
+        cacheToolsList: false,
+      }],
+    });
+    const app = createApp({
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const server = Bun.serve({ port, hostname: "127.0.0.1", fetch: app.fetch });
+    let prepared: Awaited<ReturnType<typeof prepareAgentTools>> | null = null;
+    try {
+      prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "files" }]);
+      expect(mcpText(await prepared.mcpServers[0]!.callTool("files__files_get_download_url", { fileId: crypto.randomUUID() }))).toContain("object storage is not configured");
     } finally {
       await prepared?.close().catch(() => undefined);
       server.stop(true);
     }
   });
 });
+
+function mcpText(result: unknown): string {
+  const content = Array.isArray(result)
+    ? result
+    : result && typeof result === "object" && Array.isArray((result as { content?: unknown }).content)
+      ? (result as { content: unknown[] }).content
+      : [];
+  const first = content[0];
+  if (first && typeof first === "object" && typeof (first as { text?: unknown }).text === "string") {
+    return (first as { text: string }).text;
+  }
+  throw new Error(`MCP result did not contain text content: ${JSON.stringify(result)}`);
+}
 
 async function readSseEvents(response: Response, count: number, abort: AbortController): Promise<SessionEvent[]> {
   expect(response.body).toBeTruthy();


### PR DESCRIPTION
## Summary
- add `files_get_download_url` to the first-party `/v1/mcp` API-wrapper server
- register a least-privilege built-in `files` MCP profile over the same endpoint
- attach the `files` profile automatically when the example client enables built-in document search

## Verification
- `bun run typecheck`
- `bun test`
- `bun run test:integration`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new MCP tool that returns signed object-storage download URLs, which touches file access and object storage configuration paths. Risk is moderate because incorrect checks or configuration could expose unintended file downloads, though the tool is limited to ready assets and least-privilege allowed tool lists.
> 
> **Overview**
> Adds a new first-party MCP tool, `files_get_download_url`, on the main `/v1/mcp` server to mint short-lived download URLs for *ready* file assets (erroring when object storage is missing or the file is not ready).
> 
> Registers a built-in least-privilege `files` MCP profile (allowed only `files_get_download_url`) alongside the existing built-ins, and updates the web client helper to auto-attach both `docs` and `files` MCP tools when document search is enabled.
> 
> Extends unit and integration coverage to validate tool prefixing, prevent duplicate custom `files` profiles, and verify successful/failed download URL behavior (pending uploads, missing files, and unconfigured object storage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821419ff9f847943182bea5809972fa8f572bd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->