### PR TITLE
Fix Azure base URL API version and sandbox auth refresh

### DIFF
--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -229,11 +229,7 @@ export function documentOpenAIEmbeddingConfig(settings?: Settings): {
   }
   if (settings.openaiProvider === "azure") {
     const baseURL = settings.azureOpenaiBaseUrl ?? azureDeploymentBaseUrl(settings);
-    const defaultQuery = settings.azureOpenaiBaseUrl
-      ? undefined
-      : settings.azureOpenaiApiVersion
-        ? { "api-version": settings.azureOpenaiApiVersion }
-        : undefined;
+    const defaultQuery = settings.azureOpenaiApiVersion ? { "api-version": settings.azureOpenaiApiVersion } : undefined;
     return {
       apiKey: settings.azureOpenaiApiKey ?? settings.azureOpenaiAdToken ?? "azure-ad-token",
       baseURL,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -142,7 +142,7 @@ export function configureOpenAI(settings: Settings): void {
     setDefaultOpenAIClient(new OpenAI({
       apiKey,
       baseURL,
-      defaultQuery: settings.azureOpenaiBaseUrl ? undefined : { "api-version": settings.azureOpenaiApiVersion },
+      defaultQuery: settings.azureOpenaiApiVersion ? { "api-version": settings.azureOpenaiApiVersion } : undefined,
       defaultHeaders: settings.azureOpenaiAdToken && !settings.azureOpenaiApiKey
         ? { Authorization: `Bearer ${settings.azureOpenaiAdToken}` }
         : undefined,
@@ -595,7 +595,11 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
       throw new Error(`Cannot replace existing sandbox manifest entry: ${path}`);
     }
   }
-  if (Object.keys(entries).length === 0) {
+  const environmentChanged = stableJson(currentManifest.environment) !== stableJson(target.environment);
+  if (environmentChanged && !session.applyManifest) {
+    throw new Error("Resumed sandbox session cannot refresh manifest environment because it does not support applyManifest()");
+  }
+  if (Object.keys(entries).length === 0 && !environmentChanged) {
     return;
   }
   const delta = new Manifest({
@@ -612,7 +616,7 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
   }
   (session as { state?: { manifest?: Manifest } }).state!.manifest = new Manifest({
     root: currentManifest.root,
-    environment: currentManifest.environment,
+    environment: environmentChanged ? target.environment : currentManifest.environment,
     entries: {
       ...currentManifest.entries,
       ...entries,

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -407,6 +407,36 @@ describe("runtime event normalization", () => {
     expect(Object.keys(applied[0]!.entries)).toEqual(["repos/acme/two"]);
   });
 
+  test("refreshes manifest environment on resumed sandbox sessions", async () => {
+    const current = new Manifest({
+      root: "/workspace",
+      entries: {
+        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
+      },
+      environment: { GH_TOKEN: "old-token" },
+    });
+    const target = new Manifest({
+      root: "/workspace",
+      entries: {
+        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
+      },
+      environment: { GH_TOKEN: "new-token" },
+    });
+    const applied: Manifest[] = [];
+    const session = {
+      state: { manifest: current },
+      applyManifest: async (manifest: Manifest) => {
+        applied.push(manifest);
+      },
+    };
+    await applyMissingManifestEntries(session as any, target);
+    expect(applied).toHaveLength(1);
+    expect(Object.keys(applied[0]!.entries)).toEqual([]);
+    expect(JSON.parse(JSON.stringify((session.state.manifest as Manifest).environment))).toMatchObject({
+      GH_TOKEN: { value: "new-token" },
+    });
+  });
+
   test("normalizes serialized manifest state before applying missing entries", async () => {
     const current = buildManifest(testSettings(), [{
       kind: "repository",


### PR DESCRIPTION
## Summary
- Always include Azure OpenAI api-version query when using Azure base URL mode for runtime and document embedding clients.
- Refresh resumed sandbox manifest environment variables so GitHub App tokens and git auth headers are updated on follow-up turns.
- Add regression coverage for environment refresh on resumed sandbox sessions.

## Verification
- bun test packages/runtime/test/runtime.test.ts
- bun test packages/documents/test/documents.test.ts
- bun run typecheck