### PR TITLE
Restart OTEL collector on config changes

### DIFF
--- a/deploy/helm/opengeni/templates/otel-collector-deployment.yaml
+++ b/deploy/helm/opengeni/templates/otel-collector-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         {{- include "opengeni.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: otel-collector
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       containers:

--- a/packages/deployment/test/deployment.test.ts
+++ b/packages/deployment/test/deployment.test.ts
@@ -47,6 +47,14 @@ describe("deployment contract", () => {
     expect(checks).toContain("conformance-session");
   });
 
+  test("restarts the chart-managed OTEL collector when collector config changes", () => {
+    const deployment = readFileSync("deploy/helm/opengeni/templates/otel-collector-deployment.yaml", "utf8");
+
+    expect(deployment).toContain("annotations:");
+    expect(deployment).toContain("checksum/config:");
+    expect(deployment).toContain("/otel-collector-configmap.yaml");
+  });
+
   test("models local Kubernetes as Helm with in-cluster dependencies and port-forward conformance", () => {
     const contract = deploymentProfiles["local-kubernetes"];
     const plan = stackPlanFor(contract);

--- a/packages/deployment/test/deployment.test.ts
+++ b/packages/deployment/test/deployment.test.ts
@@ -48,7 +48,10 @@ describe("deployment contract", () => {
   });
 
   test("restarts the chart-managed OTEL collector when collector config changes", () => {
-    const deployment = readFileSync("deploy/helm/opengeni/templates/otel-collector-deployment.yaml", "utf8");
+    const deployment = readFileSync(
+      new URL("../../../deploy/helm/opengeni/templates/otel-collector-deployment.yaml", import.meta.url),
+      "utf8",
+    );
 
     expect(deployment).toContain("annotations:");
     expect(deployment).toContain("checksum/config:");


### PR DESCRIPTION
## Summary

- Adds a checksum annotation to the chart-managed OTEL collector Deployment so collector ConfigMap changes roll the pod.
- Adds a deployment test that locks this restart behavior.

## Verification

- bun test packages/deployment/test/deployment.test.ts
- bun run typecheck
- bun test

## Production evidence

This fixes the reproducibility gap found during production verification: the private production workflow updated collector config to detailed debug output, but the collector pod did not restart until the chart had a ConfigMap checksum. After applying this chart fix through the production workflow, production canary evidence passed for https://app.opengeni.ai with digest-pinned artifacts and verified trace/log correlation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm template change aligned with existing checksum patterns; only affects chart-managed OTEL collector rollouts on config updates.
> 
> **Overview**
> The chart-managed OTEL collector Deployment now gets a pod-template **`checksum/config`** annotation derived from `otel-collector-configmap.yaml`, matching the rollout-on-config-change pattern already used for API/web/worker. When the collector ConfigMap changes, Kubernetes rolls the collector pod so it picks up the new config instead of running stale settings.
> 
> A deployment package test asserts the OTEL collector template includes that annotation and references the collector ConfigMap template, so this behavior stays enforced in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c79bc9ed2e66ec4ba9f75a339060f357fdf841a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->