### PR TITLE
Stabilize integration test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typecheck": "cd packages/contracts && bun run typecheck && cd ../config && bun run typecheck && cd ../deployment && bun run typecheck && cd ../db && bun run typecheck && cd ../events && bun run typecheck && cd ../github && bun run typecheck && cd ../storage && bun run typecheck && cd ../documents && bun run typecheck && cd ../observability && bun run typecheck && cd ../runtime && bun run typecheck && cd ../testing && bun run typecheck && cd ../../apps/api && bun run typecheck && cd ../worker && bun run typecheck && cd ../web && bun run typecheck",
     "test": "bun test",
     "test:unit": "bun test",
-    "test:integration": "bun test ./test/integration/api.integration.ts && bun test ./test/integration/db.integration.ts && bun test ./test/integration/nats.integration.ts && bun test ./test/integration/workspace-isolation.integration.ts && bun test ./test/integration/temporal-workflow.integration.ts && bun test ./test/integration/worker-activity.integration.ts",
+    "test:integration": "bun test --timeout 30000 ./test/integration/api.integration.ts && bun test --timeout 30000 ./test/integration/db.integration.ts && bun test --timeout 30000 ./test/integration/nats.integration.ts && bun test --timeout 30000 ./test/integration/workspace-isolation.integration.ts && bun test --timeout 30000 ./test/integration/temporal-workflow.integration.ts && bun test --timeout 30000 ./test/integration/worker-activity.integration.ts",
     "test:e2e": "bun scripts/run-browser-e2e.ts && bun test ./test/e2e/sandbox.e2e.ts",
     "test:live": "bun test ./test/live/*.live.ts",
     "test:all": "bun run test:unit && bun run test:integration && bun run test:e2e",


### PR DESCRIPTION
## Summary\n\n- Give integration test shards an explicit 30s per-test timeout instead of relying on Bun's 5s unit-test default.\n- This prevents cold-start/runtime-heavy integration shards from failing before assertions complete.\n\n## Verification\n\n- `bun test --timeout 30000 ./test/integration/worker-activity.integration.ts`\n- `bun run check:workspace-billing`\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes how integration tests are invoked in npm scripts; no production or runtime behavior.
> 
> **Overview**
> Updates the root **`test:integration`** script so every integration shard runs with **`bun test --timeout 30000`** instead of Bun’s default per-test timeout (about 5s).
> 
> Each of the six integration entrypoints (`api`, `db`, `nats`, `workspace-isolation`, `temporal-workflow`, `worker-activity`) gets the same 30s limit so slow cold starts and runtime-heavy cases can finish before the runner aborts. **`test:unit`** and other test scripts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 188b69e49bb67db29632153b78452a3bff799195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->