### PR TITLE
Session goals: durable objectives with an auto-continuation loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Generate with: openssl rand -base64 32
 # OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY=replace-with-base64-32-byte-key
 
+# Session goal guard rails (see docs/goals.md). Defaults shown.
+# OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS=20
+# OPENGENI_GOAL_NO_PROGRESS_LIMIT=3
+
 # Managed mode human auth and transactional email.
 # OPENGENI_BETTER_AUTH_SECRET=replace-with-long-random-better-auth-secret
 # OPENGENI_BETTER_AUTH_TRUSTED_ORIGINS=https://app.opengeni.ai,https://staging.app.opengeni.ai

--- a/apps/api/src/access/index.ts
+++ b/apps/api/src/access/index.ts
@@ -161,7 +161,9 @@ async function delegatedAccessContext(c: Context, deps: AccessDeps, mode: "confi
       subjectId: payload.subjectId,
       ...(payload.subjectLabel ? { subjectLabel: payload.subjectLabel } : {}),
       permissions: payload.permissions,
-      metadata: { delegated: true },
+      // sessionId is worker-asserted (HMAC-signed token claim), not agent
+      // controlled; it scopes session-bound MCP tools such as goal management.
+      metadata: { delegated: true, ...(payload.sessionId ? { sessionId: payload.sessionId } : {}) },
     }],
     defaultAccountId: payload.accountId,
     defaultWorkspaceId: payload.workspaceId,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -243,6 +243,7 @@ const routeLabelPatterns: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/turns\/reorder$/, label: "/v1/workspaces/:workspaceId/sessions/:id/turns/reorder" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/turns\/[^/]+$/, label: "/v1/workspaces/:workspaceId/sessions/:id/turns/:turnId" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/turns$/, label: "/v1/workspaces/:workspaceId/sessions/:id/turns" },
+  { pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/goal$/, label: "/v1/workspaces/:workspaceId/sessions/:id/goal" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+$/, label: "/v1/workspaces/:workspaceId/sessions/:id" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/files\/uploads$/, label: "/v1/workspaces/:workspaceId/files/uploads" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/files\/uploads\/[^/]+\/complete$/, label: "/v1/workspaces/:workspaceId/files/uploads/:id/complete" },

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -1,12 +1,14 @@
 import type { Settings } from "@opengeni/config";
 import {
   reasoningEffortForMetadata,
+  type GoalSpec,
   type ResourceRef,
   type SessionTurn,
   type ToolRef,
 } from "@opengeni/contracts";
 import {
   createSession,
+  createSessionGoal,
   enqueueSessionTurn,
   getSessionTurn,
   requireSession,
@@ -33,6 +35,7 @@ export async function createAndStartSession(input: {
   metadata: Record<string, unknown>;
   // Names/ids only; the session.created payload never carries variable values.
   environment?: { id: string; name: string } | null;
+  goal?: GoalSpec | null;
 }) {
   const session = await createSession(input.db, {
     accountId: input.accountId,
@@ -49,6 +52,19 @@ export async function createAndStartSession(input: {
     sandboxBackend: input.sandboxBackend,
     environmentId: input.environment?.id ?? null,
   });
+  // The goal row is durable session state; the workflow picks it up from the
+  // database once the first turn completes — no extra workflow plumbing here.
+  const goal = input.goal
+    ? await createSessionGoal(input.db, {
+      accountId: session.accountId,
+      workspaceId: session.workspaceId,
+      sessionId: session.id,
+      text: input.goal.text,
+      successCriteria: input.goal.successCriteria ?? null,
+      maxAutoContinuations: input.goal.maxAutoContinuations ?? null,
+      createdBy: "api",
+    })
+    : null;
   const initialPayload = {
     text: input.initialMessage,
     ...(input.resources.length ? { resources: input.resources } : {}),
@@ -62,6 +78,17 @@ export async function createAndStartSession(input: {
         ...(input.environment ? { environmentId: input.environment.id, environmentName: input.environment.name } : {}),
       },
     },
+    ...(goal ? [{
+      type: "goal.set" as const,
+      payload: {
+        goalId: goal.id,
+        text: goal.text,
+        ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+        version: goal.version,
+        actor: "api",
+        replaced: false,
+      },
+    }] : []),
     {
       type: "user.message",
       payload: initialPayload,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -7,6 +7,7 @@ import {
 } from "@opengeni/contracts";
 import {
   deleteScheduledTask,
+  getSessionGoal,
   listGitHubInstallationIdsForWorkspace,
   listScheduledTaskRuns,
   listScheduledTasks,
@@ -14,8 +15,13 @@ import {
   listSocialPosts,
   requireFile,
   requireScheduledTask,
+  requireSession,
+  setSessionGoalStatus,
   updateScheduledTask,
+  updateSessionGoal,
+  upsertSessionGoal,
 } from "@opengeni/db";
+import { appendAndPublishEvents } from "@opengeni/events";
 import {
   GitHubAppConfigurationError,
   listGitHubAppRepositories,
@@ -38,6 +44,14 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant): 
     version: "1.0.0",
   });
   const json = (value: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] });
+
+  // Goal tools are session-scoped: they are only registered when the grant
+  // carries the worker-asserted sessionId claim (signed into the delegated
+  // token by the worker, never agent-controlled) plus goals:manage.
+  const goalSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
+  if (goalSessionId !== null && hasPermission(grant.permissions, "goals:manage")) {
+    registerGoalTools(server, deps, grant, goalSessionId, json);
+  }
 
   server.registerTool("files_get_download_url", {
     description: "Create a short-lived download URL for a ready file asset.",
@@ -273,6 +287,129 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant): 
   }, async ({ taskId, limit }) => json({ runs: await listScheduledTaskRuns(deps.db, grant.workspaceId, taskId, limit ?? 100) }));
 
   return server;
+}
+
+function registerGoalTools(
+  server: McpServer,
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  sessionId: string,
+  json: (value: unknown) => { content: Array<{ type: "text"; text: string }> },
+): void {
+  server.registerTool("goal_set", {
+    description: "Set or replace this session's goal. While a goal is active the session keeps working: idle moments synthesize continuation turns until goal_complete or goal_pause is called. Replacing a goal reactivates it and resets the continuation budget.",
+    inputSchema: {
+      text: z4.string().min(1),
+      successCriteria: z4.string().min(1).optional(),
+      maxAutoContinuations: z4.number().int().positive().optional(),
+    },
+  }, async ({ text, successCriteria, maxAutoContinuations }) => {
+    await requireSession(deps.db, grant.workspaceId, sessionId);
+    const { goal, replaced } = await upsertSessionGoal(deps.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId,
+      text,
+      successCriteria: successCriteria ?? null,
+      maxAutoContinuations: maxAutoContinuations ?? null,
+      createdBy: "agent",
+    });
+    await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [{
+      type: "goal.set",
+      payload: {
+        goalId: goal.id,
+        text: goal.text,
+        ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+        version: goal.version,
+        actor: "agent",
+        replaced,
+      },
+    }]);
+    return json(goal);
+  });
+
+  server.registerTool("goal_update", {
+    description: "Revise the session goal's text or success criteria, or record a progress note. Counts as progress for the no-progress detector; the goal stays active.",
+    inputSchema: {
+      text: z4.string().min(1).optional(),
+      successCriteria: z4.string().min(1).optional(),
+      progressNote: z4.string().min(1).optional(),
+    },
+  }, async ({ text, successCriteria, progressNote }) => {
+    await requireSession(deps.db, grant.workspaceId, sessionId);
+    const existing = await getSessionGoal(deps.db, grant.workspaceId, sessionId);
+    if (!existing) {
+      throw new Error("this session has no goal; use goal_set first");
+    }
+    const goal = await updateSessionGoal(deps.db, grant.workspaceId, sessionId, {
+      ...(text !== undefined ? { text } : {}),
+      ...(successCriteria !== undefined ? { successCriteria } : {}),
+    });
+    await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [{
+      type: "goal.updated",
+      payload: {
+        goalId: goal.id,
+        text: goal.text,
+        ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+        ...(progressNote ? { progressNote } : {}),
+        version: goal.version,
+        actor: "agent",
+      },
+    }]);
+    return json(goal);
+  });
+
+  server.registerTool("goal_complete", {
+    description: "Mark the session goal as completed. Requires concrete evidence (what was done and how it satisfies the success criteria). This is the explicit stop signal: no further continuation turns are synthesized.",
+    inputSchema: { evidence: z4.string().min(1) },
+  }, async ({ evidence }) => {
+    await requireSession(deps.db, grant.workspaceId, sessionId);
+    const existing = await getSessionGoal(deps.db, grant.workspaceId, sessionId);
+    if (!existing) {
+      throw new Error("this session has no goal; use goal_set first");
+    }
+    const { goal, changed } = await setSessionGoalStatus(deps.db, grant.workspaceId, sessionId, {
+      status: "completed",
+      evidence,
+    });
+    if (changed) {
+      await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [{
+        type: "goal.completed",
+        payload: { goalId: goal.id, evidence, version: goal.version },
+      }]);
+    }
+    return json(goal);
+  });
+
+  server.registerTool("goal_pause", {
+    description: "Pause the session goal with a rationale (blocked, not productive, needs human input). This is the explicit stop signal: no further continuation turns are synthesized until the goal is resumed or replaced.",
+    inputSchema: { rationale: z4.string().min(1) },
+  }, async ({ rationale }) => {
+    await requireSession(deps.db, grant.workspaceId, sessionId);
+    const existing = await getSessionGoal(deps.db, grant.workspaceId, sessionId);
+    if (!existing) {
+      throw new Error("this session has no goal; use goal_set first");
+    }
+    const { goal, changed } = await setSessionGoalStatus(deps.db, grant.workspaceId, sessionId, {
+      status: "paused",
+      rationale,
+      pausedReason: "agent",
+    });
+    if (changed) {
+      await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [{
+        type: "goal.paused",
+        payload: {
+          goalId: goal.id,
+          actor: "agent",
+          reason: "agent",
+          rationale,
+          autoContinuations: goal.autoContinuations,
+          noProgressStreak: goal.noProgressStreak,
+        },
+      }]);
+    }
+    return json(goal);
+  });
 }
 
 // Defense-in-depth for invariant "agents cannot self-attach": the worker's

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -341,6 +341,9 @@ function registerGoalTools(
     if (!existing) {
       throw new Error("this session has no goal; use goal_set first");
     }
+    if (existing.status === "completed") {
+      throw new Error("session goal is completed; use goal_set to start a new goal");
+    }
     const goal = await updateSessionGoal(deps.db, grant.workspaceId, sessionId, {
       ...(text !== undefined ? { text } : {}),
       ...(successCriteria !== undefined ? { successCriteria } : {}),

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -165,20 +165,24 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (existing.status !== "paused") {
       throw new HTTPException(409, { message: `session goal is ${existing.status}; only paused goals can be resumed` });
     }
-    const { goal } = await setSessionGoalStatus(db, workspaceId, sessionId, { status: "active" });
-    await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
-      type: "goal.resumed",
-      payload: {
-        goalId: goal.id,
-        text: goal.text,
-        ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
-        version: goal.version,
-        actor: "api",
-      },
-    }]);
-    // signalWithStart restarts a completed workflow whose first claim finds no
-    // queued turn, so maybeContinueGoal fires — resume works on an idle session.
-    await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId: workflowIdForSession(sessionId) });
+    const { goal, changed } = await setSessionGoalStatus(db, workspaceId, sessionId, { status: "active" });
+    // `changed` guards the racing-PATCH case: both requests can pass the
+    // status pre-check, but only the transition winner emits and wakes.
+    if (changed) {
+      await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+        type: "goal.resumed",
+        payload: {
+          goalId: goal.id,
+          text: goal.text,
+          ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+          version: goal.version,
+          actor: "api",
+        },
+      }]);
+      // signalWithStart restarts a completed workflow whose first claim finds no
+      // queued turn, so maybeContinueGoal fires — resume works on an idle session.
+      await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId: workflowIdForSession(sessionId) });
+    }
     return c.json(goal);
   });
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2,17 +2,21 @@ import {
   ClientSessionEvent,
   CreateSessionRequest,
   ReorderSessionTurnsRequest,
+  UpdateSessionGoalRequest,
   UpdateSessionTurnRequest,
+  type ToolRef,
 } from "@opengeni/contracts";
 import {
   appendSessionEventsWithLockedSessionUpdate,
   cancelQueuedSessionTurn,
   enqueueSessionTurn,
   getSession,
+  getSessionGoal,
   listSessionEvents,
   listSessionTurns,
   reorderQueuedSessionTurns,
   requireSession,
+  setSessionGoalStatus,
   updateQueuedSessionTurn,
   type AppendEventInput,
 } from "@opengeni/db";
@@ -53,9 +57,12 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
     const resources = normalizeResources(payload.resources);
     const requestedTools = validateToolRefs(payload.tools, runtimeSettings);
-    const tools = hasOwnProperty(rawPayload, "tools")
+    const defaultedTools = hasOwnProperty(rawPayload, "tools")
       ? requestedTools
       : withDefaultEnabledCapabilityMcpTools(requestedTools, settings, runtimeSettings);
+    // Goal-bearing sessions force the first-party MCP server so the goal
+    // tools the continuation prompt references are reachable.
+    const tools = payload.goal ? withFirstPartyGoalTools(defaultedTools, runtimeSettings) : defaultedTools;
     await validateGitHubRepositorySelection(db, workspaceId, resources);
     if (resources.some((resource) => resource.kind === "file") && !objectStorage) {
       throw new HTTPException(503, { message: "object storage is not configured" });
@@ -82,6 +89,7 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       sandboxBackend: payload.sandboxBackend ?? settings.sandboxBackend,
       metadata: payload.metadata,
       environment: environment ? { id: environment.id, name: environment.name } : null,
+      goal: payload.goal ?? null,
     });
     await recordWorkspaceUsage(deps, {
       accountId: grant.accountId,
@@ -105,6 +113,73 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(404, { message: "session not found" });
     }
     return c.json(session);
+  });
+
+  app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/goal", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "sessions:read");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
+    const goal = await getSessionGoal(db, workspaceId, sessionId);
+    if (!goal) {
+      throw new HTTPException(404, { message: "session goal not found" });
+    }
+    return c.json(goal);
+  });
+
+  app.patch("/v1/workspaces/:workspaceId/sessions/:sessionId/goal", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
+    const payload = UpdateSessionGoalRequest.parse(await c.req.json());
+    const existing = await getSessionGoal(db, workspaceId, sessionId);
+    if (!existing) {
+      throw new HTTPException(404, { message: "session goal not found" });
+    }
+    if (existing.status === "completed") {
+      throw new HTTPException(409, { message: "session goal is completed; set a new goal instead" });
+    }
+    if (payload.status === "paused") {
+      const { goal, changed } = await setSessionGoalStatus(db, workspaceId, sessionId, {
+        status: "paused",
+        ...(payload.rationale ? { rationale: payload.rationale } : {}),
+        pausedReason: "api",
+      });
+      if (changed) {
+        await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+          type: "goal.paused",
+          payload: {
+            goalId: goal.id,
+            actor: "api",
+            reason: "api",
+            ...(payload.rationale ? { rationale: payload.rationale } : {}),
+            autoContinuations: goal.autoContinuations,
+            noProgressStreak: goal.noProgressStreak,
+          },
+        }]);
+      }
+      return c.json(goal);
+    }
+    // Resume: only valid from paused; resets counters and re-arms the loop.
+    if (existing.status !== "paused") {
+      throw new HTTPException(409, { message: `session goal is ${existing.status}; only paused goals can be resumed` });
+    }
+    const { goal } = await setSessionGoalStatus(db, workspaceId, sessionId, { status: "active" });
+    await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+      type: "goal.resumed",
+      payload: {
+        goalId: goal.id,
+        text: goal.text,
+        ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+        version: goal.version,
+        actor: "api",
+      },
+    }]);
+    // signalWithStart restarts a completed workflow whose first claim finds no
+    // queued turn, so maybeContinueGoal fires — resume works on an idle session.
+    await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId: workflowIdForSession(sessionId) });
+    return c.json(goal);
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/events", async (c) => {
@@ -316,6 +391,13 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     }
     return c.json(accepted, 202);
   });
+}
+
+function withFirstPartyGoalTools(tools: ToolRef[], runtimeSettings: { mcpServers: Array<{ id: string }> }): ToolRef[] {
+  if (!runtimeSettings.mcpServers.some((server) => server.id === "opengeni")) {
+    return tools;
+  }
+  return mergeToolRefs(tools, [{ kind: "mcp", id: "opengeni" }]);
 }
 
 function hasOwnProperty(value: unknown, key: string): boolean {

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -7,6 +7,7 @@ import { createProductionAgentRuntime } from "@opengeni/runtime";
 import { createObjectStorage } from "@opengeni/storage";
 import { createRunAgentSegmentActivity } from "./activities/agent-segment";
 import { createDocumentActivities } from "./activities/documents";
+import { createGoalActivities } from "./activities/goals";
 import { createScheduledTaskActivities } from "./activities/scheduled-tasks";
 import { createSessionStateActivities } from "./activities/session-state";
 import type { ActivityDependencies, ActivityServices } from "./activities/types";
@@ -16,6 +17,9 @@ export type {
   DispatchScheduledTaskRunInput,
   DispatchScheduledTaskRunResult,
   IndexDocumentInput,
+  MaybeContinueGoalInput,
+  MaybeContinueGoalResult,
+  PauseGoalForInterruptInput,
   RunAgentSegmentInput,
   RunAgentSegmentResult,
 } from "./activities/types";
@@ -45,6 +49,7 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
     ...createDocumentActivities(services),
     ...createSessionStateActivities(services),
     ...createScheduledTaskActivities(services),
+    ...createGoalActivities(services),
   };
 }
 
@@ -57,3 +62,5 @@ export const interruptActiveTurn = defaultActivities.interruptActiveTurn;
 export const claimNextQueuedTurn = defaultActivities.claimNextQueuedTurn;
 export const markSessionIdle = defaultActivities.markSessionIdle;
 export const dispatchScheduledTaskRun = defaultActivities.dispatchScheduledTaskRun;
+export const maybeContinueGoal = defaultActivities.maybeContinueGoal;
+export const pauseGoalForInterrupt = defaultActivities.pauseGoalForInterrupt;

--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -138,6 +138,7 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
       preparedTools = await runtime.prepareTools(runSettings, turnTools, {
         accountId: input.accountId,
         workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
         subjectId: "worker:first-party-mcp",
         subjectLabel: "OpenGeni worker",
       });

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -28,11 +28,21 @@ import type {
 export function createGoalActivities(services: () => Promise<ActivityServices>) {
   async function maybeContinueGoal(input: MaybeContinueGoalInput): Promise<MaybeContinueGoalResult> {
     const { settings, db, bus } = await services();
+    // Cheap pre-read: the common goal-less session skips the budget queries.
+    const existingGoal = await getSessionGoal(db, input.workspaceId, input.sessionId);
+    if (!existingGoal || existingGoal.status !== "active") {
+      return { action: "none" };
+    }
+    // Budget exhaustion pauses the goal visibly instead of failing the
+    // session. Computed up front and applied inside the locked decision so a
+    // limits pause never consumes continuation budget.
+    const budgetBlocked = await goalRunBudgetBlocked(settings, db, input.accountId, input.workspaceId);
     const decision = await evaluateGoalContinuation(db, {
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
       defaultMaxAutoContinuations: settings.goalMaxAutoContinuations,
       noProgressLimit: settings.goalNoProgressLimit,
+      budgetBlocked,
     });
     if (decision.decision === "none" || decision.decision === "queue") {
       return { action: decision.decision };
@@ -44,33 +54,11 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
           goalId: decision.goal.id,
           actor: "system",
           reason: decision.reason,
+          ...(decision.goal.rationale ? { rationale: decision.goal.rationale } : {}),
           autoContinuations: decision.goal.autoContinuations,
           noProgressStreak: decision.goal.noProgressStreak,
         },
       }]);
-      return { action: "paused" };
-    }
-    // Budget exhaustion pauses the goal visibly instead of failing the session.
-    const budgetBlock = await goalRunBudgetBlocked(settings, db, input.accountId, input.workspaceId);
-    if (budgetBlock) {
-      const { goal, changed } = await setSessionGoalStatus(db, input.workspaceId, input.sessionId, {
-        status: "paused",
-        pausedReason: "limits",
-        rationale: budgetBlock,
-      });
-      if (changed) {
-        await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
-          type: "goal.paused",
-          payload: {
-            goalId: goal.id,
-            actor: "system",
-            reason: "limits",
-            rationale: budgetBlock,
-            autoContinuations: goal.autoContinuations,
-            noProgressStreak: goal.noProgressStreak,
-          },
-        }]);
-      }
       return { action: "paused" };
     }
     const session = await requireSession(db, input.workspaceId, input.sessionId);

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -62,6 +62,16 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
       return { action: "paused" };
     }
     const session = await requireSession(db, input.workspaceId, input.sessionId);
+    // Stop/continue race guard: a concurrent goal_complete/goal_pause/operator
+    // PATCH between the locked decision and this synthesis must win. The
+    // version check also catches a replace. A pause landing after this point
+    // results in at most one already-admitted continuation turn; the next
+    // pass sees the non-active goal and stops, and interrupt-driven pauses
+    // additionally cancel the claimed turn via the workflow interrupt path.
+    const recheck = await getSessionGoal(db, input.workspaceId, input.sessionId);
+    if (!recheck || recheck.status !== "active" || recheck.version !== decision.goal.version) {
+      return { action: "none" };
+    }
     const prompt = goalContinuationPrompt(decision.goal, decision.autoContinuation, decision.cap);
     const [continuationEvent] = await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
       type: "goal.continuation",

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -1,0 +1,231 @@
+import { configuredStaticUsageLimits, type Settings } from "@opengeni/config";
+import {
+  mergeToolRefs,
+  reasoningEffortForMetadata,
+  type SessionGoal,
+  type ToolRef,
+} from "@opengeni/contracts";
+import {
+  enqueueSessionTurn,
+  evaluateGoalContinuation,
+  getBillingBalance,
+  getSessionGoal,
+  recordUsageEvent,
+  requireSession,
+  setSessionGoalLastContinuationTurn,
+  setSessionGoalStatus,
+  sumUsageQuantity,
+  type Database,
+} from "@opengeni/db";
+import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
+import type {
+  ActivityServices,
+  MaybeContinueGoalInput,
+  MaybeContinueGoalResult,
+  PauseGoalForInterruptInput,
+} from "./types";
+
+export function createGoalActivities(services: () => Promise<ActivityServices>) {
+  async function maybeContinueGoal(input: MaybeContinueGoalInput): Promise<MaybeContinueGoalResult> {
+    const { settings, db, bus } = await services();
+    const decision = await evaluateGoalContinuation(db, {
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      defaultMaxAutoContinuations: settings.goalMaxAutoContinuations,
+      noProgressLimit: settings.goalNoProgressLimit,
+    });
+    if (decision.decision === "none" || decision.decision === "queue") {
+      return { action: decision.decision };
+    }
+    if (decision.decision === "paused") {
+      await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+        type: "goal.paused",
+        payload: {
+          goalId: decision.goal.id,
+          actor: "system",
+          reason: decision.reason,
+          autoContinuations: decision.goal.autoContinuations,
+          noProgressStreak: decision.goal.noProgressStreak,
+        },
+      }]);
+      return { action: "paused" };
+    }
+    // Budget exhaustion pauses the goal visibly instead of failing the session.
+    const budgetBlock = await goalRunBudgetBlocked(settings, db, input.accountId, input.workspaceId);
+    if (budgetBlock) {
+      const { goal, changed } = await setSessionGoalStatus(db, input.workspaceId, input.sessionId, {
+        status: "paused",
+        pausedReason: "limits",
+        rationale: budgetBlock,
+      });
+      if (changed) {
+        await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+          type: "goal.paused",
+          payload: {
+            goalId: goal.id,
+            actor: "system",
+            reason: "limits",
+            rationale: budgetBlock,
+            autoContinuations: goal.autoContinuations,
+            noProgressStreak: goal.noProgressStreak,
+          },
+        }]);
+      }
+      return { action: "paused" };
+    }
+    const session = await requireSession(db, input.workspaceId, input.sessionId);
+    const prompt = goalContinuationPrompt(decision.goal, decision.autoContinuation, decision.cap);
+    const [continuationEvent] = await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+      type: "goal.continuation",
+      payload: {
+        goalId: decision.goal.id,
+        text: prompt,
+        autoContinuation: decision.autoContinuation,
+        maxAutoContinuations: decision.cap,
+        goalVersion: decision.goal.version,
+      },
+    }]);
+    if (!continuationEvent) {
+      throw new Error("failed to append goal continuation trigger event");
+    }
+    const turn = await enqueueSessionTurn(db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      triggerEventId: continuationEvent.id,
+      temporalWorkflowId: input.workflowId,
+      source: "goal",
+      prompt,
+      resources: [],
+      // Continuations keep the session tool surface and force the first-party
+      // server so the goal_complete/goal_pause escape hatches stay reachable.
+      tools: goalSessionTools(settings, session.tools),
+      model: session.model,
+      reasoningEffort: reasoningEffortForMetadata(session.metadata, settings.openaiReasoningEffort),
+      sandboxBackend: session.sandboxBackend,
+      metadata: { goalId: decision.goal.id, autoContinuation: decision.autoContinuation },
+    });
+    await setSessionGoalLastContinuationTurn(db, input.workspaceId, input.sessionId, turn.id);
+    await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+      type: "turn.queued",
+      turnId: turn.id,
+      payload: { turnId: turn.id, triggerEventId: continuationEvent.id, source: turn.source },
+    }]);
+    // Continuations count as agent runs for limits/metering parity with
+    // user-initiated and scheduled turns.
+    await recordUsageEvent(db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      eventType: "agent_run.created",
+      quantity: 1,
+      unit: "run",
+      sourceResourceType: "session_turn",
+      sourceResourceId: turn.id,
+      idempotencyKey: `agent_run.created:goal:${input.workspaceId}:${turn.id}`,
+    });
+    return { action: "continue" };
+  }
+
+  async function pauseGoalForInterrupt(input: PauseGoalForInterruptInput): Promise<void> {
+    const { db, bus } = await services();
+    await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
+  }
+
+  return {
+    maybeContinueGoal,
+    pauseGoalForInterrupt,
+  };
+}
+
+/**
+ * A user interrupt is the explicit act of stopping, so it pauses an active
+ * goal. Shared by the idle-interrupt activity and `interruptActiveTurn` so the
+ * loop never auto-continues a goal the user just stopped. No-op when the
+ * session has no goal or it is not active.
+ */
+export async function pauseActiveGoalOnInterrupt(db: Database, bus: EventBus, workspaceId: string, sessionId: string): Promise<void> {
+  const goal = await getSessionGoal(db, workspaceId, sessionId);
+  if (!goal || goal.status !== "active") {
+    return;
+  }
+  const { goal: paused, changed } = await setSessionGoalStatus(db, workspaceId, sessionId, {
+    status: "paused",
+    pausedReason: "user_interrupt",
+  });
+  if (changed) {
+    await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+      type: "goal.paused",
+      payload: {
+        goalId: paused.id,
+        actor: "user",
+        reason: "user_interrupt",
+        autoContinuations: paused.autoContinuations,
+        noProgressStreak: paused.noProgressStreak,
+      },
+    }]);
+  }
+}
+
+export function goalContinuationPrompt(goal: SessionGoal, autoContinuation: number, cap: number): string {
+  return [
+    `[GOAL CONTINUATION ${autoContinuation}/${cap}] The session goal is not done. Goal: ${goal.text}.`,
+    `Success criteria: ${goal.successCriteria ?? "none specified"}.`,
+    "Continue working toward the goal now. If it is actually complete, call opengeni__goal_complete with concrete evidence.",
+    "If you are blocked or continuing is not productive, call opengeni__goal_pause with your rationale.",
+    "You may revise the goal with opengeni__goal_update. Do not stop without one of these explicit actions.",
+  ].join("\n");
+}
+
+/**
+ * Goal-bearing sessions/turns must carry the first-party "opengeni" MCP server
+ * so the goal tools are reachable; built-in tool refs are not auto-added to
+ * empty tool lists anywhere else in the pipeline.
+ */
+export function goalSessionTools(settings: Settings, tools: ToolRef[]): ToolRef[] {
+  if (!settings.mcpServers.some((server) => server.id === "opengeni")) {
+    return tools;
+  }
+  return mergeToolRefs(tools, [{ kind: "mcp", id: "opengeni" }]);
+}
+
+/**
+ * Non-throwing variant of the scheduled-run admission check: returns a human
+ * readable reason when balance or monthly caps block another agent run.
+ */
+async function goalRunBudgetBlocked(settings: Settings, db: Database, accountId: string, workspaceId: string): Promise<string | null> {
+  if (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed") {
+    const balance = await getBillingBalance(db, accountId);
+    if (balance.balanceMicros <= 0) {
+      return "insufficient OpenGeni credits";
+    }
+  }
+  if (settings.usageLimitsMode === "static" || settings.usageLimitsMode === "managed") {
+    const limits = configuredStaticUsageLimits(settings);
+    if (limits.maxMonthlyCostMicrosPerAccount) {
+      const used = await sumUsageQuantity(db, {
+        accountId,
+        eventType: "model.cost",
+        since: startOfUtcMonth(),
+      });
+      if (used >= limits.maxMonthlyCostMicrosPerAccount) {
+        return `monthly model cost limit reached (${limits.maxMonthlyCostMicrosPerAccount} micros)`;
+      }
+    }
+    if (limits.maxMonthlyAgentRunsPerWorkspace) {
+      const used = await sumUsageQuantity(db, {
+        workspaceId,
+        eventType: "agent_run.created",
+        since: startOfUtcMonth(),
+      });
+      if (used + 1 > limits.maxMonthlyAgentRunsPerWorkspace) {
+        return `monthly agent run limit reached (${limits.maxMonthlyAgentRunsPerWorkspace})`;
+      }
+    }
+  }
+  return null;
+}
+
+function startOfUtcMonth(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -34,6 +34,20 @@ export async function segmentInput(
       serializedRunState: latestState?.serializedRunState ?? null,
     });
   }
+  if (trigger.type === "goal.continuation") {
+    const payload = trigger.payload as { text?: unknown };
+    if (typeof payload.text !== "string" || payload.text.trim().length === 0) {
+      throw new Error("goal.continuation payload is missing text");
+    }
+    // Threading serializedRunState keeps the agent's full conversation context
+    // across continuations — this is what makes "keep working" coherent.
+    const latestState = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
+    return await runtime.prepareInput(agent, {
+      kind: "message",
+      text: payload.text,
+      serializedRunState: latestState?.serializedRunState ?? null,
+    });
+  }
   if (trigger.type === "user.approvalDecision") {
     const payload = trigger.payload as {
       approvalId?: unknown;

--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -2,6 +2,7 @@ import {
   appendSessionEventsWithLockedSessionUpdate,
   createScheduledTaskRun,
   createSession,
+  createSessionGoal,
   enqueueSessionTurn,
   getBillingBalance,
   getWorkspaceEnvironment,
@@ -12,6 +13,7 @@ import {
   sumUsageQuantity,
   updateScheduledTask,
   updateScheduledTaskRun,
+  upsertSessionGoal,
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { configuredStaticUsageLimits, type Settings } from "@opengeni/config";
@@ -21,6 +23,7 @@ import {
   scheduledUserMessagePayload,
   workflowIdForSession,
 } from "./common";
+import { goalSessionTools } from "./goals";
 import type {
   ActivityServices,
   DispatchScheduledTaskRunInput,
@@ -54,6 +57,10 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
         const model = task.agentConfig.model ?? settings.openaiModel;
         const reasoningEffort = task.agentConfig.reasoningEffort ?? settings.openaiReasoningEffort;
         const sandboxBackend = task.agentConfig.sandboxBackend ?? settings.sandboxBackend;
+        const goalSpec = task.agentConfig.goal ?? null;
+        // Goal-bearing dispatches force the first-party MCP server so the goal
+        // tools the continuation prompt references are reachable.
+        const taskTools = goalSpec ? goalSessionTools(settings, task.agentConfig.tools) : task.agentConfig.tools;
         if (task.runMode === "new_session_per_run" || !task.reusableSessionId) {
           // The FK on scheduled_tasks.environment_id is ON DELETE RESTRICT, so
           // an attached environment must still exist here; fail closed if not.
@@ -68,7 +75,7 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
             workspaceId: task.workspaceId,
             initialMessage: task.agentConfig.prompt,
             resources: task.agentConfig.resources,
-            tools: task.agentConfig.tools,
+            tools: taskTools,
             metadata: {
               ...task.agentConfig.metadata,
               model,
@@ -80,6 +87,17 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
             sandboxBackend,
             environmentId: task.environmentId ?? null,
           });
+          const goal = goalSpec
+            ? await createSessionGoal(db, {
+              accountId: task.accountId,
+              workspaceId: task.workspaceId,
+              sessionId: session.id,
+              text: goalSpec.text,
+              successCriteria: goalSpec.successCriteria ?? null,
+              maxAutoContinuations: goalSpec.maxAutoContinuations ?? null,
+              createdBy: "scheduled_task",
+            })
+            : null;
           const workflowId = workflowIdForSession(session.id);
           await setTemporalWorkflowId(db, task.workspaceId, session.id, workflowId);
           if (task.runMode === "reusable_session") {
@@ -96,9 +114,20 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
                 ...(environment ? { environmentId: environment.id, environmentName: environment.name } : {}),
               },
             },
+            ...(goal ? [{
+              type: "goal.set" as const,
+              payload: {
+                goalId: goal.id,
+                text: goal.text,
+                ...(goal.successCriteria ? { successCriteria: goal.successCriteria } : {}),
+                version: goal.version,
+                actor: "scheduled_task",
+                replaced: false,
+              },
+            }] : []),
             {
               type: "user.message",
-              payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, task.agentConfig.tools, task.id, run.id),
+              payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, taskTools, task.id, run.id),
             },
             { type: "session.status.changed", payload: { status: "queued" } },
           ]);
@@ -115,7 +144,7 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
             source: "scheduled_task",
             prompt: task.agentConfig.prompt,
             resources: task.agentConfig.resources,
-            tools: task.agentConfig.tools,
+            tools: taskTools,
             model,
             reasoningEffort,
             sandboxBackend,
@@ -150,18 +179,44 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
           if ((session.environmentId ?? null) !== (task.environmentId ?? null)) {
             throw new Error("scheduled task environment attachment does not match its reusable session");
           }
+          // A recurring "maintain X" task re-establishes its objective on every
+          // fire: replace the goal text, reactivate it, and reset the counters.
+          const reusableGoal = goalSpec
+            ? await upsertSessionGoal(db, {
+              accountId: task.accountId,
+              workspaceId: task.workspaceId,
+              sessionId: session.id,
+              text: goalSpec.text,
+              successCriteria: goalSpec.successCriteria ?? null,
+              maxAutoContinuations: goalSpec.maxAutoContinuations ?? null,
+              createdBy: "scheduled_task",
+            })
+            : null;
           const events = await appendSessionEventsWithLockedSessionUpdate(db, task.workspaceId, session.id, (locked) => ({
-            events: [{
-              type: "user.message",
-              payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, task.agentConfig.tools, task.id, run.id),
-            }],
+            events: [
+              ...(reusableGoal ? [{
+                type: "goal.set" as const,
+                payload: {
+                  goalId: reusableGoal.goal.id,
+                  text: reusableGoal.goal.text,
+                  ...(reusableGoal.goal.successCriteria ? { successCriteria: reusableGoal.goal.successCriteria } : {}),
+                  version: reusableGoal.goal.version,
+                  actor: "scheduled_task",
+                  replaced: reusableGoal.replaced,
+                },
+              }] : []),
+              {
+                type: "user.message",
+                payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, taskTools, task.id, run.id),
+              },
+            ],
             update: {
               resources: mergeResourceRefs(locked.resources, task.agentConfig.resources),
-              tools: mergeToolRefs(locked.tools, task.agentConfig.tools),
+              tools: mergeToolRefs(locked.tools, taskTools),
             },
           }));
           await bus.publish(task.workspaceId, session.id, events);
-          const trigger = events[0];
+          const trigger = events.find((event) => event.type === "user.message");
           if (!trigger) {
             throw new Error("failed to append scheduled task trigger event");
           }
@@ -174,7 +229,7 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
             source: "scheduled_task",
             prompt: task.agentConfig.prompt,
             resources: task.agentConfig.resources,
-            tools: task.agentConfig.tools,
+            tools: taskTools,
             model,
             reasoningEffort,
             sandboxBackend,

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -6,6 +6,7 @@ import {
   setSessionStatus,
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
+import { pauseActiveGoalOnInterrupt } from "./goals";
 import type {
   ActivityServices,
   ClaimNextQueuedTurnInput,
@@ -44,6 +45,10 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
   async function interruptActiveTurn(input: RunAgentSegmentInput): Promise<void> {
     const { db, bus } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
+    // Pause an active goal before the early return below: an interrupt can
+    // land after the turn already cleared activeTurnId, and skipping the pause
+    // there would let the loop auto-continue the goal the user just stopped.
+    await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
     if (!session.activeTurnId) {
       return;
     }

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -39,6 +39,22 @@ export type MarkSessionIdleInput = {
   sessionId: string;
 };
 
+export type MaybeContinueGoalInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  workflowId: string;
+};
+
+export type MaybeContinueGoalResult = {
+  action: "none" | "queue" | "continue" | "paused";
+};
+
+export type PauseGoalForInterruptInput = {
+  workspaceId: string;
+  sessionId: string;
+};
+
 export type DispatchScheduledTaskRunInput = {
   workspaceId: string;
   taskId: string;

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -1,4 +1,4 @@
-import { CancellationScope, condition, defineSignal, setHandler, workflowInfo } from "@temporalio/workflow";
+import { CancellationScope, condition, defineSignal, isCancellation, setHandler, workflowInfo } from "@temporalio/workflow";
 import type * as activities from "../activities";
 import { activity, workflowFailureMessage } from "./activities";
 
@@ -36,10 +36,40 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
     const workflowId = workflowInfo().workflowId;
     const turn = await activity.claimNextQueuedTurn({ workspaceId: input.workspaceId, sessionId: input.sessionId, workflowId });
     if (!turn) {
+      if (interruptedEventId === null) {
+        // With an active goal, idling out is replaced by a synthesized
+        // continuation turn; the queue (any non-terminal turn) always wins and
+        // the no-progress/max-continuation guards auto-pause runaway goals.
+        let continuation: activities.MaybeContinueGoalResult = { action: "none" };
+        try {
+          continuation = await activity.maybeContinueGoal({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            workflowId,
+          });
+        } catch (error) {
+          if (isCancellation(error)) {
+            throw error;
+          }
+          // A failing goal check must not kill the session (activity retry is
+          // 1). Fall through to the idle path: the goal stays active in the
+          // database and the next wake retries, which means the workflow CAN
+          // complete normally with an active goal on this error path.
+        }
+        if (continuation.action === "continue" || continuation.action === "queue") {
+          // "continue": a goal continuation turn was just enqueued; "queue":
+          // queued work appeared concurrently. Claim it on the next loop pass.
+          continue;
+        }
+      }
       const seenWakeups = wakeups;
       const woke = await condition(() => interruptedEventId !== null || wakeups !== seenWakeups, "5s");
       if (interruptedEventId) {
         interruptedEventId = null;
+        // An idle interrupt is an explicit stop: pause an active goal before
+        // shutting down so a later wake does not auto-continue it.
+        await activity.pauseGoalForInterrupt({ workspaceId: input.workspaceId, sessionId: input.sessionId });
         await activity.markSessionIdle({ workspaceId: input.workspaceId, sessionId: input.sessionId });
         return;
       }

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -58,7 +58,11 @@ activity for a decision:
 Continuation turns are ordinary turns: they bill, meter (`agent_run.created`
 with source `session_turn`), and stream exactly like user turns. If billing or
 usage limits would block another run, the goal pauses visibly
-(`goal.paused`, `reason: "limits"`) instead of failing the session.
+(`goal.paused`, `reason: "limits"`) instead of failing the session; the limits
+gate is applied inside the same locked decision, before the counter bump, so a
+budget pause never consumes continuation budget. Re-arming a goal (resume or
+replace) starts a fresh continuation epoch: counters and the
+previous-continuation pointers are cleared together.
 
 ## Interrupts and failures
 

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,113 @@
+# Session goals
+
+Agents stop prematurely. A session goal flips the default: while a goal is
+`active`, a session that finishes a turn with nothing queued does not idle out.
+Instead the session workflow synthesizes a continuation turn ("your goal is not
+done — keep working, or explicitly complete/pause it"). Stopping becomes an
+explicit act: the agent calls `opengeni__goal_complete` with evidence or
+`opengeni__goal_pause` with a rationale, or a user interrupts the session.
+
+Goal state is one durable Postgres row per session (`session_goals`,
+RLS-isolated like every other workspace table). The Temporal workflow never
+holds goal state in memory — it reads and mutates it only through activities,
+so the loop is replay-safe by construction.
+
+## Lifecycle
+
+A goal is `active`, `paused`, or `completed`.
+
+- `goal_set` (agent tool), `CreateSessionRequest.goal`, or
+  `ScheduledTaskAgentConfig.goal` create it. Setting a goal on a session that
+  already has one replaces it in place: text/criteria are overwritten, the goal
+  is re-activated (even from `paused`/`completed`), the version bumps, and the
+  continuation counters reset.
+- `goal_update` revises text/criteria or records a progress note. The version
+  bump counts as progress for the no-progress detector. Status is unchanged.
+- `goal_complete { evidence }` is terminal. Only a new `goal_set` can replace a
+  completed goal.
+- `goal_pause { rationale }` stops the loop until the goal is resumed or
+  replaced.
+
+Every transition lands on the session timeline as `goal.set`, `goal.updated`,
+`goal.completed`, `goal.paused`, `goal.resumed`, or `goal.continuation` events.
+
+## The continuation loop
+
+When the session workflow finds no queued turn it asks the `maybeContinueGoal`
+activity for a decision:
+
+1. No goal, or goal not `active` → idle shutdown, exactly as before.
+2. Any non-terminal turn exists (`queued`, `running`, or `requires_action`) →
+   the queue wins. A pending human approval is never bypassed by a
+   continuation.
+3. Otherwise progress since the previous continuation is scored: a continuation
+   turn that produced zero tool calls and no goal revision increments a
+   no-progress streak (a user/scheduled turn in between resets the streak and
+   the budget — human re-engagement re-arms the loop).
+4. Guards: `noProgressStreak >= OPENGENI_GOAL_NO_PROGRESS_LIMIT` (default 3) or
+   `autoContinuations >= cap` auto-pause the goal with a visible `goal.paused`
+   event (`reason: "no_progress" | "max_auto_continuations"`). The cap is
+   `min(goal.maxAutoContinuations, OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS)`
+   (default 20) — the deployment setting is a hard ceiling.
+5. Otherwise a continuation turn is enqueued: a deterministic prompt referencing
+   the goal text and success criteria, the session's tool surface plus the
+   first-party `opengeni` MCP server (so the goal tools are always reachable),
+   and the session's saved run state — the agent keeps its full conversation
+   context.
+
+Continuation turns are ordinary turns: they bill, meter (`agent_run.created`
+with source `session_turn`), and stream exactly like user turns. If billing or
+usage limits would block another run, the goal pauses visibly
+(`goal.paused`, `reason: "limits"`) instead of failing the session.
+
+## Interrupts and failures
+
+- A user interrupt is the explicit act of stopping, so it pauses an active goal
+  (`pausedReason: "user_interrupt"`, `goal.paused` with `actor: "user"`) in both
+  interrupt paths: idle interrupt and mid-turn interrupt.
+- If a turn fails and the session is marked `failed`, the goal row is left
+  as-is; a failed session rejects new messages, so nothing drives the goal.
+- If the `maybeContinueGoal` activity itself throws, the workflow falls through
+  to the normal idle shutdown rather than failing the session. This means the
+  workflow can complete normally while a goal is still `active` in the
+  database; the goal is not lost — the next wake (a user message, a manual
+  resume, or a scheduled fire) re-enters the loop and retries.
+
+## API
+
+- `POST /v1/workspaces/:id/sessions` accepts `goal: { text, successCriteria?,
+  maxAutoContinuations? }`. A `goal.set` event is appended right after
+  `session.created`.
+- `GET /v1/workspaces/:id/sessions/:sessionId/goal` returns the goal
+  (`sessions:read`; 404 when the session has no goal).
+- `PATCH /v1/workspaces/:id/sessions/:sessionId/goal` with
+  `{ status: "paused" | "active", rationale? }` is the operator override
+  (`sessions:control`). Pausing emits `goal.paused` (`actor: "api"`). Resuming
+  is only valid from `paused`: it resets the counters, emits `goal.resumed`,
+  and wakes the session workflow — resume works even on a fully idle session
+  because `signalWithStart` restarts a completed workflow. Invalid transitions
+  (e.g. resuming a completed goal) return 409.
+
+## Scheduled tasks
+
+`agentConfig.goal` arms a goal on dispatched sessions. New-session runs create
+the goal with the session; reusable-session runs re-arm it on every fire
+(replace text, reactivate, reset counters) — a recurring "maintain X" task
+re-establishes its objective each time.
+
+## Agent tool access
+
+The goal tools are session-scoped first-party MCP tools. The worker signs the
+session id into the delegated access token it uses for first-party MCP calls
+(HMAC, worker-asserted — not agent-controlled), and the API registers
+`goal_set`/`goal_update`/`goal_complete`/`goal_pause` only for grants carrying
+that claim plus the `goals:manage` permission. Goal-bearing sessions, turns,
+and scheduled dispatches force-merge the `opengeni` tool ref so these tools are
+reachable even when the session was created with an empty tool list.
+
+## Settings
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` | `20` | Hard ceiling on synthesized continuation turns per goal arming. |
+| `OPENGENI_GOAL_NO_PROGRESS_LIMIT` | `3` | Consecutive zero-progress continuations tolerated before auto-pause. |

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -83,6 +83,11 @@ const SettingsSchema = z.object({
   staticUsageLimitsJson: z.string().default("{}"),
   delegationSecret: z.string().optional(),
   environmentsEncryptionKey: z.string().optional(),
+  // Session goal guard rails: the hard ceiling on synthesized continuation
+  // turns per goal arming, and the consecutive zero-progress continuations
+  // tolerated before the goal auto-pauses.
+  goalMaxAutoContinuations: z.coerce.number().int().positive().default(20),
+  goalNoProgressLimit: z.coerce.number().int().positive().default(3),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),
@@ -295,6 +300,8 @@ export function getSettings(): Settings {
     staticUsageLimitsJson: optional("OPENGENI_STATIC_USAGE_LIMITS_JSON"),
     delegationSecret: optional("OPENGENI_DELEGATION_SECRET"),
     environmentsEncryptionKey: optional("OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY"),
+    goalMaxAutoContinuations: optional("OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS"),
+    goalNoProgressLimit: optional("OPENGENI_GOAL_NO_PROGRESS_LIMIT"),
     authRequired: optional("OPENGENI_AUTH_REQUIRED"),
     accessKey: optional("OPENGENI_ACCESS_KEY"),
     authAllowHealth: optional("OPENGENI_AUTH_ALLOW_HEALTH"),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -77,6 +77,7 @@ export const Permission = z.enum([
   "api_keys:manage",
   "environments:manage",
   "environments:use",
+  "goals:manage",
 ]);
 export type Permission = z.infer<typeof Permission>;
 
@@ -154,6 +155,9 @@ export const DelegatedAccessTokenPayload = z.object({
   subjectId: z.string().min(1),
   subjectLabel: z.string().optional(),
   permissions: z.array(Permission).min(1),
+  // Worker-asserted session scope for first-party MCP calls (HMAC-signed, not
+  // agent-controlled); enables session-scoped tools such as goal management.
+  sessionId: z.string().uuid().optional(),
   exp: z.number().int().positive(),
 });
 export type DelegatedAccessTokenPayload = z.infer<typeof DelegatedAccessTokenPayload>;
@@ -543,8 +547,59 @@ function sortJson(value: unknown): unknown {
 export const SessionTurnStatus = z.enum(["queued", "running", "requires_action", "completed", "failed", "cancelled"]);
 export type SessionTurnStatus = z.infer<typeof SessionTurnStatus>;
 
-export const SessionTurnSource = z.enum(["user", "scheduled_task", "api"]);
+export const SessionTurnSource = z.enum(["user", "scheduled_task", "api", "goal"]);
 export type SessionTurnSource = z.infer<typeof SessionTurnSource>;
+
+export const SessionGoalStatus = z.enum(["active", "paused", "completed"]);
+export type SessionGoalStatus = z.infer<typeof SessionGoalStatus>;
+
+export const SessionGoalCreatedBy = z.enum(["api", "agent", "scheduled_task"]);
+export type SessionGoalCreatedBy = z.infer<typeof SessionGoalCreatedBy>;
+
+export const SessionGoalPausedReason = z.enum([
+  "agent",
+  "user_interrupt",
+  "api",
+  "no_progress",
+  "max_auto_continuations",
+  "limits",
+]);
+export type SessionGoalPausedReason = z.infer<typeof SessionGoalPausedReason>;
+
+export const SessionGoal = z.object({
+  id: z.string().uuid(),
+  accountId: z.string().uuid(),
+  workspaceId: z.string().uuid(),
+  sessionId: z.string().uuid(),
+  status: SessionGoalStatus,
+  text: z.string(),
+  successCriteria: z.string().nullable(),
+  evidence: z.string().nullable(),
+  rationale: z.string().nullable(),
+  pausedReason: z.string().nullable(),
+  createdBy: SessionGoalCreatedBy,
+  version: z.number().int().positive(),
+  autoContinuations: z.number().int().nonnegative(),
+  noProgressStreak: z.number().int().nonnegative(),
+  maxAutoContinuations: z.number().int().positive().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type SessionGoal = z.infer<typeof SessionGoal>;
+
+export const GoalSpec = z.object({
+  text: z.string().min(1),
+  successCriteria: z.string().min(1).optional(),
+  maxAutoContinuations: z.number().int().positive().optional(),
+});
+export type GoalSpec = z.infer<typeof GoalSpec>;
+
+export const UpdateSessionGoalRequest = z.object({
+  status: z.enum(["paused", "active"]),
+  rationale: z.string().min(1).optional(),
+});
+export type UpdateSessionGoalRequest = z.infer<typeof UpdateSessionGoalRequest>;
 
 export const SessionTurn = z.object({
   id: z.string().uuid(),
@@ -677,6 +732,7 @@ export const ScheduledTaskAgentConfig = z.object({
   model: z.string().min(1).optional(),
   reasoningEffort: ReasoningEffort.optional(),
   sandboxBackend: SandboxBackend.optional(),
+  goal: GoalSpec.optional(),
 });
 export type ScheduledTaskAgentConfig = z.infer<typeof ScheduledTaskAgentConfig>;
 
@@ -1042,6 +1098,12 @@ export const SessionEventType = z.enum([
   "sandbox.operation.failed",
   "sandbox.command.output.delta",
   "artifact.created",
+  "goal.set",
+  "goal.updated",
+  "goal.completed",
+  "goal.paused",
+  "goal.resumed",
+  "goal.continuation",
 ]);
 export type SessionEventType = z.infer<typeof SessionEventType>;
 
@@ -1069,6 +1131,7 @@ export const CreateSessionRequest = z.object({
   // Workspace environment attachment is fixed at session creation; follow-up
   // user.message events cannot switch or add one.
   environmentId: z.string().uuid().optional(),
+  goal: GoalSpec.optional(),
   clientEventId: z.string().min(1).optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;

--- a/packages/db/drizzle/0005_session_goals.sql
+++ b/packages/db/drizzle/0005_session_goals.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS "session_goals" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
+  "session_id" uuid NOT NULL REFERENCES "sessions"("id") ON DELETE CASCADE,
+  "status" text NOT NULL DEFAULT 'active',
+  "text" text NOT NULL,
+  "success_criteria" text,
+  "evidence" text,
+  "rationale" text,
+  "paused_reason" text,
+  "created_by" text NOT NULL DEFAULT 'api',
+  "version" integer NOT NULL DEFAULT 1,
+  "auto_continuations" integer NOT NULL DEFAULT 0,
+  "no_progress_streak" integer NOT NULL DEFAULT 0,
+  "max_auto_continuations" integer,
+  "last_continuation_turn_id" uuid,
+  "version_at_last_continuation" integer,
+  "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "session_goals_workspace_session_idx" ON "session_goals" ("workspace_id", "session_id");
+CREATE INDEX IF NOT EXISTS "session_goals_workspace_status_idx" ON "session_goals" ("workspace_id", "status");
+ALTER TABLE "session_goals" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "session_goals" FORCE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'session_goals' AND policyname = 'workspace_isolation'
+  ) THEN
+    DROP POLICY workspace_isolation ON "session_goals";
+  END IF;
+END $$;
+CREATE POLICY workspace_isolation ON "session_goals"
+  USING (opengeni_private.workspace_rls_visible(account_id, workspace_id))
+  WITH CHECK (opengeni_private.workspace_rls_visible(account_id, workspace_id));
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781201200000,
       "tag": "0004_workspace_environments",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1781201800000,
+      "tag": "0005_session_goals",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2023,6 +2023,8 @@ export async function upsertSessionGoal(db: Database, input: CreateSessionGoalIn
       version: existing.version + 1,
       autoContinuations: 0,
       noProgressStreak: 0,
+      lastContinuationTurnId: null,
+      versionAtLastContinuation: null,
       updatedAt: new Date(),
     }).where(eq(schema.sessionGoals.id, existing.id)).returning();
     if (!row) {
@@ -2099,6 +2101,10 @@ export async function setSessionGoalStatus(db: Database, workspaceId: string, se
         pausedReason: null,
         autoContinuations: 0,
         noProgressStreak: 0,
+        // A re-armed goal starts a fresh continuation epoch; stale pointers to
+        // a pre-pause continuation turn must not feed the progress detector.
+        lastContinuationTurnId: null,
+        versionAtLastContinuation: null,
       } : {}),
     }).where(eq(schema.sessionGoals.id, existing.id)).returning();
     if (!row) {
@@ -2120,7 +2126,7 @@ export async function setSessionGoalLastContinuationTurn(db: Database, workspace
 export type GoalContinuationDecision =
   | { decision: "none" }
   | { decision: "queue" }
-  | { decision: "paused"; reason: "no_progress" | "max_auto_continuations"; goal: SessionGoal }
+  | { decision: "paused"; reason: "no_progress" | "max_auto_continuations" | "limits"; goal: SessionGoal }
   | { decision: "continue"; goal: SessionGoal; autoContinuation: number; cap: number };
 
 /**
@@ -2136,6 +2142,10 @@ export async function evaluateGoalContinuation(db: Database, input: {
   sessionId: string;
   defaultMaxAutoContinuations: number;
   noProgressLimit: number;
+  // Caller-computed billing/limits block reason. Applied inside the locked
+  // decision (before the counter bump) so a budget pause never consumes
+  // continuation budget.
+  budgetBlocked?: string | null;
 }): Promise<GoalContinuationDecision> {
   return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => await scopedDb.transaction(async (tx) => {
     const [row] = await tx.select().from(schema.sessionGoals)
@@ -2212,6 +2222,20 @@ export async function evaluateGoalContinuation(db: Database, input: {
         updatedAt: new Date(),
       }).where(eq(schema.sessionGoals.id, row.id)).returning();
       return { decision: "paused", reason: "max_auto_continuations", goal: mapSessionGoal(paused!) } as const;
+    }
+    if (input.budgetBlocked) {
+      // Budget exhaustion pauses the goal visibly without bumping the
+      // continuation counter — no turn is synthesized for this pass.
+      const [paused] = await tx.update(schema.sessionGoals).set({
+        status: "paused",
+        pausedReason: "limits",
+        rationale: input.budgetBlocked,
+        autoContinuations,
+        noProgressStreak,
+        version: row.version + 1,
+        updatedAt: new Date(),
+      }).where(eq(schema.sessionGoals.id, row.id)).returning();
+      return { decision: "paused", reason: "limits", goal: mapSessionGoal(paused!) } as const;
     }
     const [updated] = await tx.update(schema.sessionGoals).set({
       autoContinuations: autoContinuations + 1,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29,6 +29,9 @@ import type {
   Session,
   SessionEvent,
   SessionEventType,
+  SessionGoal,
+  SessionGoalCreatedBy,
+  SessionGoalStatus,
   SessionStatus,
   SessionTurn,
   SessionTurnSource,
@@ -146,6 +149,7 @@ export const allWorkspacePermissions: Permission[] = [
   "api_keys:manage",
   "environments:manage",
   "environments:use",
+  "goals:manage",
 ];
 
 export const allAccountPermissions: Permission[] = [
@@ -1941,6 +1945,305 @@ export async function saveRunState(db: Database, input: {
       pendingApprovals: input.pendingApprovals,
     });
   });
+}
+
+export type CreateSessionGoalInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  text: string;
+  successCriteria?: string | null;
+  maxAutoContinuations?: number | null;
+  createdBy: SessionGoalCreatedBy;
+};
+
+export async function createSessionGoal(db: Database, input: CreateSessionGoalInput): Promise<SessionGoal> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const [row] = await scopedDb.insert(schema.sessionGoals).values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      text: input.text,
+      successCriteria: input.successCriteria ?? null,
+      maxAutoContinuations: input.maxAutoContinuations ?? null,
+      createdBy: input.createdBy,
+    }).returning();
+    if (!row) {
+      throw new Error("Failed to create session goal");
+    }
+    return mapSessionGoal(row);
+  });
+}
+
+export async function getSessionGoal(db: Database, workspaceId: string, sessionId: string): Promise<SessionGoal | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select().from(schema.sessionGoals)
+      .where(and(eq(schema.sessionGoals.workspaceId, workspaceId), eq(schema.sessionGoals.sessionId, sessionId)))
+      .limit(1);
+    return row ? mapSessionGoal(row) : null;
+  });
+}
+
+/**
+ * goal_set semantics: insert, or replace the existing goal in place. A replace
+ * re-activates the goal (even when paused or completed), bumps the version,
+ * and resets the continuation counters — re-stating the objective re-arms the
+ * auto-continuation budget.
+ */
+export async function upsertSessionGoal(db: Database, input: CreateSessionGoalInput): Promise<{ goal: SessionGoal; replaced: boolean }> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const [existing] = await scopedDb.select().from(schema.sessionGoals)
+      .where(and(eq(schema.sessionGoals.workspaceId, input.workspaceId), eq(schema.sessionGoals.sessionId, input.sessionId)))
+      .for("update")
+      .limit(1);
+    if (!existing) {
+      const [row] = await scopedDb.insert(schema.sessionGoals).values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        text: input.text,
+        successCriteria: input.successCriteria ?? null,
+        maxAutoContinuations: input.maxAutoContinuations ?? null,
+        createdBy: input.createdBy,
+      }).returning();
+      if (!row) {
+        throw new Error("Failed to upsert session goal");
+      }
+      return { goal: mapSessionGoal(row), replaced: false };
+    }
+    const [row] = await scopedDb.update(schema.sessionGoals).set({
+      status: "active",
+      text: input.text,
+      successCriteria: input.successCriteria ?? null,
+      maxAutoContinuations: input.maxAutoContinuations ?? null,
+      evidence: null,
+      rationale: null,
+      pausedReason: null,
+      createdBy: input.createdBy,
+      version: existing.version + 1,
+      autoContinuations: 0,
+      noProgressStreak: 0,
+      updatedAt: new Date(),
+    }).where(eq(schema.sessionGoals.id, existing.id)).returning();
+    if (!row) {
+      throw new Error("Failed to upsert session goal");
+    }
+    return { goal: mapSessionGoal(row), replaced: true };
+  });
+}
+
+/**
+ * goal_update semantics: revise text/criteria without changing status. The
+ * version bump counts as progress for the no-progress detector.
+ */
+export async function updateSessionGoal(db: Database, workspaceId: string, sessionId: string, input: {
+  text?: string;
+  successCriteria?: string | null;
+}): Promise<SessionGoal> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.update(schema.sessionGoals).set({
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(input.successCriteria !== undefined ? { successCriteria: input.successCriteria } : {}),
+      version: sql`${schema.sessionGoals.version} + 1`,
+      noProgressStreak: 0,
+      updatedAt: new Date(),
+    }).where(and(eq(schema.sessionGoals.workspaceId, workspaceId), eq(schema.sessionGoals.sessionId, sessionId))).returning();
+    if (!row) {
+      throw new Error(`Session goal not found: ${sessionId}`);
+    }
+    return mapSessionGoal(row);
+  });
+}
+
+/**
+ * Status transition helper. Idempotent: requesting the current status returns
+ * `changed: false` so callers can skip emitting a duplicate event. `completed`
+ * is terminal for transitions; only `upsertSessionGoal` can replace a
+ * completed goal. Resuming to `active` clears the pause fields and resets the
+ * continuation counters.
+ */
+export async function setSessionGoalStatus(db: Database, workspaceId: string, sessionId: string, input: {
+  status: SessionGoalStatus;
+  evidence?: string;
+  rationale?: string;
+  pausedReason?: string;
+}): Promise<{ goal: SessionGoal; changed: boolean }> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [existing] = await scopedDb.select().from(schema.sessionGoals)
+      .where(and(eq(schema.sessionGoals.workspaceId, workspaceId), eq(schema.sessionGoals.sessionId, sessionId)))
+      .for("update")
+      .limit(1);
+    if (!existing) {
+      throw new Error(`Session goal not found: ${sessionId}`);
+    }
+    if (existing.status === input.status) {
+      return { goal: mapSessionGoal(existing), changed: false };
+    }
+    if (existing.status === "completed") {
+      throw new Error("session goal is completed; set a new goal to continue");
+    }
+    const [row] = await scopedDb.update(schema.sessionGoals).set({
+      status: input.status,
+      version: existing.version + 1,
+      updatedAt: new Date(),
+      ...(input.status === "completed" ? {
+        evidence: input.evidence ?? null,
+        pausedReason: null,
+      } : {}),
+      ...(input.status === "paused" ? {
+        rationale: input.rationale ?? null,
+        pausedReason: input.pausedReason ?? null,
+      } : {}),
+      ...(input.status === "active" ? {
+        rationale: null,
+        pausedReason: null,
+        autoContinuations: 0,
+        noProgressStreak: 0,
+      } : {}),
+    }).where(eq(schema.sessionGoals.id, existing.id)).returning();
+    if (!row) {
+      throw new Error(`Session goal not found: ${sessionId}`);
+    }
+    return { goal: mapSessionGoal(row), changed: true };
+  });
+}
+
+export async function setSessionGoalLastContinuationTurn(db: Database, workspaceId: string, sessionId: string, turnId: string): Promise<void> {
+  await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    await scopedDb.update(schema.sessionGoals).set({
+      lastContinuationTurnId: turnId,
+      updatedAt: new Date(),
+    }).where(and(eq(schema.sessionGoals.workspaceId, workspaceId), eq(schema.sessionGoals.sessionId, sessionId)));
+  });
+}
+
+export type GoalContinuationDecision =
+  | { decision: "none" }
+  | { decision: "queue" }
+  | { decision: "paused"; reason: "no_progress" | "max_auto_continuations"; goal: SessionGoal }
+  | { decision: "continue"; goal: SessionGoal; autoContinuation: number; cap: number };
+
+/**
+ * Core continuation decision, taken in one transaction with the goal row
+ * locked. Queued work always wins; any non-terminal turn (queued, running, or
+ * requires_action awaiting a human approval) blocks auto-continuation. The
+ * no-progress and max-continuation guards mutate counters here only, so a
+ * replaying workflow re-reads recorded activity results and never recomputes
+ * them.
+ */
+export async function evaluateGoalContinuation(db: Database, input: {
+  workspaceId: string;
+  sessionId: string;
+  defaultMaxAutoContinuations: number;
+  noProgressLimit: number;
+}): Promise<GoalContinuationDecision> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => await scopedDb.transaction(async (tx) => {
+    const [row] = await tx.select().from(schema.sessionGoals)
+      .where(and(eq(schema.sessionGoals.workspaceId, input.workspaceId), eq(schema.sessionGoals.sessionId, input.sessionId)))
+      .for("update")
+      .limit(1);
+    if (!row || row.status !== "active") {
+      return { decision: "none" } as const;
+    }
+    const [pendingTurn] = await tx.select({ id: schema.sessionTurns.id, status: schema.sessionTurns.status })
+      .from(schema.sessionTurns)
+      .where(and(
+        eq(schema.sessionTurns.workspaceId, input.workspaceId),
+        eq(schema.sessionTurns.sessionId, input.sessionId),
+        inArray(schema.sessionTurns.status, ["queued", "running", "requires_action"]),
+      ))
+      .limit(1);
+    if (pendingTurn) {
+      // "queue" tells the workflow to claim immediately; running/requires_action
+      // turns (e.g. a pending approval on a restarted workflow) must not be
+      // bypassed by a continuation, so they decline instead.
+      return pendingTurn.status === "queued" ? { decision: "queue" } as const : { decision: "none" } as const;
+    }
+    let autoContinuations = row.autoContinuations;
+    let noProgressStreak = row.noProgressStreak;
+    if (row.lastContinuationTurnId) {
+      const [lastFinished] = await tx.select({ id: schema.sessionTurns.id })
+        .from(schema.sessionTurns)
+        .where(and(
+          eq(schema.sessionTurns.workspaceId, input.workspaceId),
+          eq(schema.sessionTurns.sessionId, input.sessionId),
+          sql`${schema.sessionTurns.finishedAt} is not null`,
+        ))
+        .orderBy(desc(schema.sessionTurns.position), desc(schema.sessionTurns.createdAt))
+        .limit(1);
+      if (lastFinished && lastFinished.id !== row.lastContinuationTurnId) {
+        // A user/scheduled turn ran since the last continuation: human
+        // re-engagement re-arms the auto-continuation budget.
+        autoContinuations = 0;
+        noProgressStreak = 0;
+      } else if (lastFinished) {
+        const [{ toolCalls } = { toolCalls: 0 }] = await tx.select({
+          toolCalls: sql<number>`count(*)::int`,
+        }).from(schema.sessionEvents)
+          .where(and(
+            eq(schema.sessionEvents.workspaceId, input.workspaceId),
+            eq(schema.sessionEvents.turnId, row.lastContinuationTurnId),
+            eq(schema.sessionEvents.type, "agent.toolCall.created"),
+          ));
+        const goalRevised = row.versionAtLastContinuation !== null && row.version > row.versionAtLastContinuation;
+        noProgressStreak = Number(toolCalls) > 0 || goalRevised ? 0 : noProgressStreak + 1;
+      }
+    }
+    if (noProgressStreak >= input.noProgressLimit) {
+      const [paused] = await tx.update(schema.sessionGoals).set({
+        status: "paused",
+        pausedReason: "no_progress",
+        autoContinuations,
+        noProgressStreak,
+        version: row.version + 1,
+        updatedAt: new Date(),
+      }).where(eq(schema.sessionGoals.id, row.id)).returning();
+      return { decision: "paused", reason: "no_progress", goal: mapSessionGoal(paused!) } as const;
+    }
+    // The configured default is a hard ceiling; per-goal overrides only lower it.
+    const cap = Math.min(row.maxAutoContinuations ?? input.defaultMaxAutoContinuations, input.defaultMaxAutoContinuations);
+    if (autoContinuations >= cap) {
+      const [paused] = await tx.update(schema.sessionGoals).set({
+        status: "paused",
+        pausedReason: "max_auto_continuations",
+        autoContinuations,
+        noProgressStreak,
+        version: row.version + 1,
+        updatedAt: new Date(),
+      }).where(eq(schema.sessionGoals.id, row.id)).returning();
+      return { decision: "paused", reason: "max_auto_continuations", goal: mapSessionGoal(paused!) } as const;
+    }
+    const [updated] = await tx.update(schema.sessionGoals).set({
+      autoContinuations: autoContinuations + 1,
+      noProgressStreak,
+      versionAtLastContinuation: row.version,
+      updatedAt: new Date(),
+    }).where(eq(schema.sessionGoals.id, row.id)).returning();
+    return { decision: "continue", goal: mapSessionGoal(updated!), autoContinuation: autoContinuations + 1, cap } as const;
+  }));
+}
+
+function mapSessionGoal(row: typeof schema.sessionGoals.$inferSelect): SessionGoal {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    workspaceId: row.workspaceId,
+    sessionId: row.sessionId,
+    status: row.status as SessionGoal["status"],
+    text: row.text,
+    successCriteria: row.successCriteria,
+    evidence: row.evidence,
+    rationale: row.rationale,
+    pausedReason: row.pausedReason,
+    createdBy: row.createdBy as SessionGoal["createdBy"],
+    version: row.version,
+    autoContinuations: row.autoContinuations,
+    noProgressStreak: row.noProgressStreak,
+    maxAutoContinuations: row.maxAutoContinuations,
+    metadata: row.metadata,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
 }
 
 export async function createTurn(db: Database, input: {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -232,6 +232,32 @@ export const sessionTurns = pgTable("session_turns", {
   queue: index("session_turns_workspace_queue_idx").on(table.workspaceId, table.sessionId, table.status, table.position),
 }));
 
+export const sessionGoals = pgTable("session_goals", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),
+  workspaceId: uuid("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  sessionId: uuid("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
+  status: text("status").notNull().default("active"), // active | paused | completed
+  text: text("text").notNull(),
+  successCriteria: text("success_criteria"),
+  evidence: text("evidence"), // set by goal_complete
+  rationale: text("rationale"), // set by goal_pause
+  pausedReason: text("paused_reason"), // agent | user_interrupt | api | no_progress | max_auto_continuations | limits
+  createdBy: text("created_by").notNull().default("api"), // api | agent | scheduled_task
+  version: integer("version").notNull().default(1), // bumped on every set/update; progress signal
+  autoContinuations: integer("auto_continuations").notNull().default(0),
+  noProgressStreak: integer("no_progress_streak").notNull().default(0),
+  maxAutoContinuations: integer("max_auto_continuations"), // per-goal override, clamped to the settings cap
+  lastContinuationTurnId: uuid("last_continuation_turn_id"),
+  versionAtLastContinuation: integer("version_at_last_continuation"),
+  metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  workspaceSession: uniqueIndex("session_goals_workspace_session_idx").on(table.workspaceId, table.sessionId),
+  status: index("session_goals_workspace_status_idx").on(table.workspaceId, table.status),
+}));
+
 export const sessionEvents = pgTable("session_events", {
   id: uuid("id").primaryKey().defaultRandom(),
   accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -200,6 +200,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
       "When the Azure sandbox preparation profile is enabled and service-principal variables are present, the sandbox is pre-authenticated with normal Azure CLI before work starts.",
       "Treat code-changing work as GitOps work: create a focused branch/commit/PR when GitHub credentials are available; otherwise report exact commands and blockers.",
       "Return concise, factual summaries with files changed, commands run, and remaining blockers.",
+      "If the session has a goal, you own it: keep working until you call opengeni__goal_complete with concrete evidence or opengeni__goal_pause with a rationale; revise it with opengeni__goal_update; create one with opengeni__goal_set when given a long-running objective.",
     ].join(" "),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },
@@ -244,6 +245,9 @@ export type PreparedAgentTools = {
 export type PrepareToolsOptions = {
   accountId?: string;
   workspaceId?: string;
+  // Worker-asserted session scope for first-party MCP calls; enables
+  // session-scoped tools such as goal management on the API side.
+  sessionId?: string;
   subjectId?: string;
   subjectLabel?: string;
 };
@@ -297,6 +301,7 @@ async function firstPartyMcpRequestInit(settings: Settings, config: Settings["mc
       subjectId: options.subjectId ?? "worker:first-party-mcp",
       ...(options.subjectLabel ? { subjectLabel: options.subjectLabel } : {}),
       permissions: firstPartyMcpPermissions,
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
       exp: Math.floor(Date.now() / 1000) + 60 * 60,
     })}`;
   }
@@ -316,6 +321,7 @@ const firstPartyMcpPermissions: Permission[] = [
   "documents:search",
   "scheduled_tasks:manage",
   "scheduled_tasks:run",
+  "goals:manage",
 ];
 
 function isFirstPartyMcpServer(settings: Settings, config: Settings["mcpServers"][number]): boolean {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -30,6 +30,8 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     staticUsageLimitsJson: "{}",
     delegationSecret: "test-delegation-secret",
     environmentsEncryptionKey: undefined,
+    goalMaxAutoContinuations: 20,
+    goalNoProgressLimit: 3,
     betterAuthSecret: undefined,
     betterAuthAllowedHosts: "",
     betterAuthCookieDomain: undefined,

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getScheduledTask, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -52,6 +52,158 @@ describe("API component integration", () => {
     expect(workflow.wakeups).toHaveLength(1);
     const events = await listSessionEvents(dbClient.db, workspaceId, session.id);
     expect(events.map((event) => event.type)).toEqual(["session.created", "user.message", "session.status.changed", "turn.queued"]);
+  });
+
+  test("creates sessions with goals and manages the goal lifecycle over the API", async () => {
+    workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        mcpServers: [{ id: "opengeni", name: "OpenGeni", url: "http://127.0.0.1:65530/v1/workspaces/{workspaceId}/mcp", cacheToolsList: true }],
+      }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+
+    const created = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "take repo zero-to-one",
+        model: "scripted-model",
+        goal: { text: "repo deployed to staging", successCriteria: "health probe green", maxAutoContinuations: 7 },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(created.status).toBe(202);
+    const session = await created.json() as { id: string; tools: Array<{ kind: string; id: string }> };
+    // Goal-bearing sessions force the first-party MCP server so goal tools are reachable.
+    expect(session.tools).toContainEqual({ kind: "mcp", id: "opengeni" });
+    const events = await listSessionEvents(dbClient.db, workspaceId, session.id);
+    expect(events.map((event) => event.type)).toEqual(["session.created", "goal.set", "user.message", "session.status.changed", "turn.queued"]);
+
+    const fetched = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/goal`));
+    expect(fetched.status).toBe(200);
+    const goal = await fetched.json() as { id: string; status: string; text: string; maxAutoContinuations: number };
+    expect(goal.status).toBe("active");
+    expect(goal.text).toBe("repo deployed to staging");
+    expect(goal.maxAutoContinuations).toBe(7);
+
+    const paused = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/goal`), {
+      method: "PATCH",
+      body: JSON.stringify({ status: "paused", rationale: "operator hold" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(paused.status).toBe(200);
+    expect(((await paused.json()) as { status: string }).status).toBe("paused");
+
+    const wakeupsBeforeResume = workflow.wakeups.length;
+    const resumed = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/goal`), {
+      method: "PATCH",
+      body: JSON.stringify({ status: "active" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(resumed.status).toBe(200);
+    const resumedGoal = await resumed.json() as { status: string; autoContinuations: number; pausedReason: string | null };
+    expect(resumedGoal.status).toBe("active");
+    expect(resumedGoal.autoContinuations).toBe(0);
+    expect(resumedGoal.pausedReason).toBeNull();
+    // Resume wakes the workflow so an idle session re-enters the goal loop.
+    expect(workflow.wakeups.length).toBe(wakeupsBeforeResume + 1);
+
+    const lifecycleEvents = await listSessionEvents(dbClient.db, workspaceId, session.id);
+    expect(lifecycleEvents.some((event) => event.type === "goal.paused")).toBe(true);
+    expect(lifecycleEvents.some((event) => event.type === "goal.resumed")).toBe(true);
+
+    // Resuming an already-active goal is an invalid transition.
+    const resumeActive = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/goal`), {
+      method: "PATCH",
+      body: JSON.stringify({ status: "active" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(resumeActive.status).toBe(409);
+
+    // Completed goals reject operator transitions.
+    await setSessionGoalStatus(dbClient.db, workspaceId, session.id, { status: "completed", evidence: "done" });
+    const resumeCompleted = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/goal`), {
+      method: "PATCH",
+      body: JSON.stringify({ status: "active" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(resumeCompleted.status).toBe(409);
+
+    // Sessions without goals 404.
+    const plain = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "no goal here", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    const plainSession = await plain.json() as { id: string };
+    const missing = await app.request(workspacePath(workspaceId, `/sessions/${plainSession.id}/goal`));
+    expect(missing.status).toBe(404);
+  });
+
+  test("registers session-scoped goal MCP tools only for session-bound grants", async () => {
+    const settings = testSettings({ databaseUrl: services.databaseUrl });
+    const baseGrant = await bootstrapMcpGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: baseGrant.accountId,
+      workspaceId: baseGrant.workspaceId,
+      initialMessage: "goal tools",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const mcpDeps = {
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by goal MCP tests");
+      },
+    };
+
+    // Without the worker-asserted sessionId claim, goal tools do not exist.
+    const sessionlessMcp = buildOpenGeniMcpServer(mcpDeps, baseGrant);
+    await expect(callMcpTool(sessionlessMcp, "goal_set", { text: "x" })).rejects.toThrow("MCP tool not registered");
+
+    const grant = { ...baseGrant, metadata: { delegated: true, sessionId: session.id } };
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+
+    const setGoal = await callMcpTool<{ id: string; status: string; version: number }>(mcp, "goal_set", {
+      text: "keep CI green",
+      successCriteria: "main pipeline passes",
+    });
+    expect(setGoal.status).toBe("active");
+    expect(setGoal.version).toBe(1);
+
+    const updated = await callMcpTool<{ version: number; text: string }>(mcp, "goal_update", {
+      text: "keep CI green on main",
+      progressNote: "fixed two flaky tests",
+    });
+    expect(updated.version).toBe(2);
+
+    const pausedGoal = await callMcpTool<{ status: string; pausedReason: string }>(mcp, "goal_pause", { rationale: "waiting on upstream fix" });
+    expect(pausedGoal.status).toBe("paused");
+    expect(pausedGoal.pausedReason).toBe("agent");
+
+    const replacedGoal = await callMcpTool<{ status: string }>(mcp, "goal_set", { text: "upstream fixed; finish the job" });
+    expect(replacedGoal.status).toBe("active");
+
+    const completedGoal = await callMcpTool<{ status: string; evidence: string }>(mcp, "goal_complete", { evidence: "CI green for 3 consecutive runs" });
+    expect(completedGoal.status).toBe("completed");
+    expect(completedGoal.evidence).toBe("CI green for 3 consecutive runs");
+    await expect(callMcpTool(mcp, "goal_pause", { rationale: "too late" })).rejects.toThrow("completed");
+
+    const events = await listSessionEvents(dbClient.db, baseGrant.workspaceId, session.id);
+    expect(events.map((event) => event.type)).toEqual(["goal.set", "goal.updated", "goal.paused", "goal.set", "goal.completed"]);
+    expect((await getSessionGoal(dbClient.db, baseGrant.workspaceId, session.id))?.status).toBe("completed");
   });
 
   test("managed email/password auth bootstraps account access and workspace API keys", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -200,6 +200,7 @@ describe("API component integration", () => {
     expect(completedGoal.status).toBe("completed");
     expect(completedGoal.evidence).toBe("CI green for 3 consecutive runs");
     await expect(callMcpTool(mcp, "goal_pause", { rationale: "too late" })).rejects.toThrow("completed");
+    await expect(callMcpTool(mcp, "goal_update", { text: "also too late" })).rejects.toThrow("completed");
 
     const events = await listSessionEvents(dbClient.db, baseGrant.workspaceId, session.id);
     expect(events.map((event) => event.type)).toEqual(["goal.set", "goal.updated", "goal.paused", "goal.set", "goal.completed"]);

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -7,13 +7,21 @@ import {
   createScheduledTaskRun,
   createApiKey,
   createSession,
+  createSessionGoal,
   createTurn,
   dbSql,
   enableCapabilityInstallation,
+  enqueueSessionTurn,
+  evaluateGoalContinuation,
   finishTurn,
   findActiveApiKeyByHash,
   getLatestRunState,
   getSession,
+  getSessionGoal,
+  setSessionGoalLastContinuationTurn,
+  setSessionGoalStatus,
+  updateSessionGoal,
+  upsertSessionGoal,
   listEnabledMcpCapabilityServers,
   listScheduledTaskRuns,
   listScheduledTasks,
@@ -186,6 +194,225 @@ describe("DB integration", () => {
     const runs = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
     expect(runs[0]?.status).toBe("failed");
     expect(runs[0]?.error).toBe("no worker");
+  });
+
+  test("session goal lifecycle: set, revise, complete, replace", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "goal lifecycle",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    expect(await getSessionGoal(dbClient.db, grant.workspaceId, session.id)).toBeNull();
+    const created = await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "ship the deploy pipeline",
+      successCriteria: "CI green on main",
+      createdBy: "api",
+    });
+    expect(created.status).toBe("active");
+    expect(created.version).toBe(1);
+
+    const revised = await updateSessionGoal(dbClient.db, grant.workspaceId, session.id, { text: "ship the deploy pipeline v2" });
+    expect(revised.version).toBe(2);
+    expect(revised.status).toBe("active");
+
+    const paused = await setSessionGoalStatus(dbClient.db, grant.workspaceId, session.id, { status: "paused", rationale: "blocked", pausedReason: "agent" });
+    expect(paused.changed).toBe(true);
+    expect(paused.goal.pausedReason).toBe("agent");
+    const pausedAgain = await setSessionGoalStatus(dbClient.db, grant.workspaceId, session.id, { status: "paused", pausedReason: "agent" });
+    expect(pausedAgain.changed).toBe(false);
+
+    const resumed = await setSessionGoalStatus(dbClient.db, grant.workspaceId, session.id, { status: "active" });
+    expect(resumed.goal.pausedReason).toBeNull();
+    expect(resumed.goal.rationale).toBeNull();
+    expect(resumed.goal.autoContinuations).toBe(0);
+
+    const completed = await setSessionGoalStatus(dbClient.db, grant.workspaceId, session.id, { status: "completed", evidence: "pipeline live, CI green" });
+    expect(completed.goal.evidence).toBe("pipeline live, CI green");
+    await expect(setSessionGoalStatus(dbClient.db, grant.workspaceId, session.id, { status: "active" })).rejects.toThrow("completed");
+
+    const replaced = await upsertSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "now keep it healthy",
+      createdBy: "agent",
+    });
+    expect(replaced.replaced).toBe(true);
+    expect(replaced.goal.status).toBe("active");
+    expect(replaced.goal.evidence).toBeNull();
+    expect(replaced.goal.autoContinuations).toBe(0);
+    expect(replaced.goal.version).toBeGreaterThan(completed.goal.version);
+  });
+
+  test("evaluateGoalContinuation honors queue, approvals, progress, and caps", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "goal loop",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const guards = { defaultMaxAutoContinuations: 5, noProgressLimit: 2 };
+    const enqueueGoalTurn = async () => {
+      const [goalTrigger] = await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "goal.continuation", payload: { text: "continue" } }]);
+      return await enqueueSessionTurn(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: goalTrigger!.id,
+        temporalWorkflowId: "wf-goal-db",
+        source: "goal",
+        prompt: "continue",
+        resources: [],
+        tools: [],
+        model: "scripted-model",
+        reasoningEffort: "low",
+        sandboxBackend: "none",
+        metadata: {},
+      });
+    };
+
+    // No goal yet.
+    expect(await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards })).toEqual({ decision: "none" });
+
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "keep working",
+      createdBy: "api",
+    });
+
+    // Queued work always wins.
+    const [trigger] = await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "user.message", payload: { text: "go" } }]);
+    const queuedUserTurn = await enqueueSessionTurn(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      temporalWorkflowId: "wf-goal-db",
+      source: "user",
+      prompt: "go",
+      resources: [],
+      tools: [],
+      model: "scripted-model",
+      reasoningEffort: "low",
+      sandboxBackend: "none",
+      metadata: {},
+    });
+    expect((await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards })).decision).toBe("queue");
+
+    // A non-terminal requires_action turn (pending approval) blocks continuation.
+    await finishTurn(dbClient.db, grant.workspaceId, queuedUserTurn.id, "requires_action");
+    expect((await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards })).decision).toBe("none");
+    await finishTurn(dbClient.db, grant.workspaceId, queuedUserTurn.id, "completed");
+
+    // First continuation.
+    const first = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(first).toMatchObject({ decision: "continue", autoContinuation: 1, cap: 5 });
+
+    // A continuation turn that finishes without tool calls or a goal revision
+    // increments the no-progress streak; noProgressLimit 2 pauses the goal.
+    for (let round = 1; round <= 2; round += 1) {
+      const continuationTurn = await enqueueGoalTurn();
+      await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, continuationTurn.id);
+      await finishTurn(dbClient.db, grant.workspaceId, continuationTurn.id, "completed");
+      const next = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+      if (round < 2) {
+        expect(next.decision).toBe("continue");
+      } else {
+        expect(next).toMatchObject({ decision: "paused", reason: "no_progress" });
+      }
+    }
+    expect((await getSessionGoal(dbClient.db, grant.workspaceId, session.id))?.pausedReason).toBe("no_progress");
+
+    // Replacing the goal re-arms it; the per-goal cap is enforced.
+    await upsertSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "one more push",
+      maxAutoContinuations: 1,
+      createdBy: "agent",
+    });
+    const capped = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(capped).toMatchObject({ decision: "continue", autoContinuation: 1, cap: 1 });
+    // Mark progress in that continuation so the cap (not no-progress) triggers.
+    const capTurn = await enqueueGoalTurn();
+    await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, capTurn.id);
+    await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "agent.toolCall.created", turnId: capTurn.id, payload: {} }]);
+    await finishTurn(dbClient.db, grant.workspaceId, capTurn.id, "completed");
+    const atCap = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(atCap).toMatchObject({ decision: "paused", reason: "max_auto_continuations" });
+  });
+
+  test("RLS policies isolate session goal rows for a non-owner app role", async () => {
+    const appRoleUrl = await createRlsAppRole(dbClient.db, services.databaseUrl);
+    const appDbClient = createDb(appRoleUrl);
+    try {
+      const grantA = await testGrant(dbClient.db);
+      const grantB = await testGrant(dbClient.db);
+      const sessionB = await createSession(dbClient.db, {
+        accountId: grantB.accountId,
+        workspaceId: grantB.workspaceId,
+        initialMessage: "workspace b goal",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+      });
+      await createSessionGoal(dbClient.db, {
+        accountId: grantB.accountId,
+        workspaceId: grantB.workspaceId,
+        sessionId: sessionB.id,
+        text: "workspace b objective",
+        createdBy: "api",
+      });
+
+      const hidden = await appDbClient.db.execute(dbSql<{ count: string }>`select count(*)::text as count from session_goals`);
+      expect(Number(hidden[0]?.count ?? 0)).toBe(0);
+
+      const sessionA = await createSession(appDbClient.db, {
+        accountId: grantA.accountId,
+        workspaceId: grantA.workspaceId,
+        initialMessage: "workspace a goal",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+      });
+      await createSessionGoal(appDbClient.db, {
+        accountId: grantA.accountId,
+        workspaceId: grantA.workspaceId,
+        sessionId: sessionA.id,
+        text: "workspace a objective",
+        createdBy: "api",
+      });
+      const visible = await withRlsContext(appDbClient.db, grantA, async (db) =>
+        await db.execute(dbSql<{ workspace_id: string }>`select workspace_id::text from session_goals`)
+      );
+      expect(visible.map((row) => row.workspace_id)).toEqual([grantA.workspaceId]);
+
+      await expect(withRlsContext(appDbClient.db, grantA, async (db) => {
+        await db.execute(dbSql`
+          insert into session_goals (account_id, workspace_id, session_id, text)
+          values (${grantA.accountId}, ${grantB.workspaceId}, ${sessionB.id}, 'mismatched goal')
+        `);
+      })).rejects.toThrow();
+    } finally {
+      await appDbClient.close();
+    }
   });
 
   test("RLS policies isolate workspace-owned rows for a non-owner app role", async () => {

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -253,6 +253,128 @@ describe("Temporal workflow integration", () => {
     }
   }, temporalWorkflowTestTimeoutMs);
 
+  test("synthesizes goal continuation turns until the goal declines", async () => {
+    const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+    const scope = workflowScope();
+    const sessionId = crypto.randomUUID();
+    const runs: Array<{ triggerEventId: string }> = [];
+    const goalChecks: unknown[] = [];
+    const queuedTurns = [queuedTurn("event-1")];
+    let continuations = 0;
+    const worker = await testWorker(nativeConnection, taskQueue, {
+      claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
+      markSessionIdle: async () => undefined,
+      runAgentSegment: async (input: { triggerEventId: string }) => {
+        runs.push(input);
+        return { status: "idle" };
+      },
+      failSession: async () => undefined,
+      interruptActiveTurn: async () => undefined,
+      maybeContinueGoal: async (input: unknown) => {
+        goalChecks.push(input);
+        if (continuations < 2) {
+          continuations += 1;
+          queuedTurns.push(queuedTurn(`goal-event-${continuations}`));
+          return { action: "continue" };
+        }
+        return { action: "none" };
+      },
+    });
+    const run = worker.run();
+    try {
+      const client = new Client({ connection });
+      const workflowId = `wf-${crypto.randomUUID()}`;
+      const handle = await client.workflow.start("sessionWorkflow", {
+        taskQueue,
+        workflowId,
+        args: [{ ...scope, sessionId, initialEventId: "event-1" }],
+      });
+      await handle.result();
+      expect(runs.map((input) => input.triggerEventId)).toEqual(["event-1", "goal-event-1", "goal-event-2"]);
+      expect(goalChecks.length).toBeGreaterThanOrEqual(3);
+      expect(goalChecks[0]).toMatchObject({ ...scope, sessionId, workflowId });
+    } finally {
+      worker.shutdown();
+      await run;
+    }
+  }, temporalWorkflowTestTimeoutMs);
+
+  test("idle interrupt pauses the goal before marking the session idle", async () => {
+    const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+    const scope = workflowScope();
+    const sessionId = crypto.randomUUID();
+    const order: string[] = [];
+    const pauses: unknown[] = [];
+    const worker = await testWorker(nativeConnection, taskQueue, {
+      claimNextQueuedTurn: async () => null,
+      markSessionIdle: async () => {
+        order.push("idle");
+      },
+      runAgentSegment: async () => ({ status: "idle" }),
+      failSession: async () => undefined,
+      interruptActiveTurn: async () => undefined,
+      pauseGoalForInterrupt: async (input: unknown) => {
+        order.push("pause");
+        pauses.push(input);
+      },
+    });
+    const run = worker.run();
+    try {
+      const client = new Client({ connection });
+      const handle = await client.workflow.start("sessionWorkflow", {
+        taskQueue,
+        workflowId: `wf-${crypto.randomUUID()}`,
+        args: [{ ...scope, sessionId }],
+      });
+      await handle.signal("interrupt", "interrupt-event");
+      await handle.result();
+      expect(order).toEqual(["pause", "idle"]);
+      expect(pauses).toEqual([{ workspaceId: scope.workspaceId, sessionId }]);
+    } finally {
+      worker.shutdown();
+      await run;
+    }
+  }, temporalWorkflowTestTimeoutMs);
+
+  test("a failing goal continuation check falls back to idle shutdown", async () => {
+    const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+    const scope = workflowScope();
+    const sessionId = crypto.randomUUID();
+    const idleMarks: unknown[] = [];
+    const queuedTurns = [queuedTurn("event-1")];
+    const runs: unknown[] = [];
+    const worker = await testWorker(nativeConnection, taskQueue, {
+      claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
+      markSessionIdle: async (input: unknown) => {
+        idleMarks.push(input);
+      },
+      runAgentSegment: async (input: unknown) => {
+        runs.push(input);
+        return { status: "idle" };
+      },
+      failSession: async () => undefined,
+      interruptActiveTurn: async () => undefined,
+      maybeContinueGoal: async () => {
+        throw new Error("goal store unavailable");
+      },
+    });
+    const run = worker.run();
+    try {
+      const client = new Client({ connection });
+      const handle = await client.workflow.start("sessionWorkflow", {
+        taskQueue,
+        workflowId: `wf-${crypto.randomUUID()}`,
+        args: [{ ...scope, sessionId, initialEventId: "event-1" }],
+      });
+      await handle.result();
+      expect(runs).toHaveLength(1);
+      expect(idleMarks).toEqual([{ workspaceId: scope.workspaceId, sessionId }]);
+    } finally {
+      worker.shutdown();
+      await run;
+    }
+  }, temporalWorkflowTestTimeoutMs);
+
   test("dispatches document index workflow activity", async () => {
     const taskQueue = `workflow-test-${crypto.randomUUID()}`;
     const scope = workflowScope();
@@ -421,6 +543,12 @@ async function testWorker(nativeConnection: NativeConnection, taskQueue: string,
     namespace: "default",
     taskQueue,
     workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
-    activities,
+    activities: {
+      // Goal-less defaults; individual tests override these to exercise the
+      // goal continuation loop.
+      maybeContinueGoal: async () => ({ action: "none" }),
+      pauseGoalForInterrupt: async () => undefined,
+      ...activities,
+    },
   });
 }

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -19,13 +19,17 @@ import {
   createFileUpload,
   createScheduledTask,
   createSession,
+  createSessionGoal,
   createWorkspaceEnvironment,
   encryptEnvironmentValue,
+  enqueueSessionTurn,
   setWorkspaceEnvironmentVariable,
   finishTurn,
   getSession,
+  getSessionGoal,
   getBillingBalance,
   getLatestRunState,
+  listSessionTurns,
   listUsageEvents,
   listSessionEvents,
   listScheduledTaskRuns,
@@ -1562,6 +1566,275 @@ describe("worker activities integration", () => {
     })).rejects.toThrow("scheduled task environment attachment does not match its reusable session");
     const runs = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
     expect(runs[0]?.status).toBe("failed");
+  });
+
+  test("synthesizes billed goal continuation turns and auto-pauses on no progress", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "pursue the goal",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "service deployed and healthy",
+      successCriteria: "probe returns 200",
+      createdBy: "api",
+    });
+    const activities = createActivities({
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        natsUrl: services.natsUrl,
+        goalNoProgressLimit: 1,
+        mcpServers: [{ id: "opengeni", name: "OpenGeni", url: "http://127.0.0.1:65531/v1/workspaces/{workspaceId}/mcp", cacheToolsList: true }],
+      }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+
+    const first = await activities.maybeContinueGoal({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    });
+    expect(first.action).toBe("continue");
+
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id);
+    const continuation = turns.find((turn) => turn.source === "goal");
+    expect(continuation).toBeTruthy();
+    expect(continuation!.status).toBe("queued");
+    expect(continuation!.temporalWorkflowId).toBe(`session-${session.id}`);
+    expect(continuation!.prompt).toContain("[GOAL CONTINUATION 1/20]");
+    expect(continuation!.prompt).toContain("service deployed and healthy");
+    expect(continuation!.prompt).toContain("probe returns 200");
+    // The first-party MCP server is forced onto continuation turns so the
+    // goal_complete/goal_pause escape hatches stay reachable.
+    expect(continuation!.tools).toContainEqual({ kind: "mcp", id: "opengeni" });
+    expect(continuation!.metadata.autoContinuation).toBe(1);
+
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const continuationEvent = events.find((event) => event.type === "goal.continuation");
+    expect(continuationEvent).toBeTruthy();
+    expect(continuation!.triggerEventId).toBe(continuationEvent!.id);
+    expect(events.some((event) => event.type === "turn.queued" && event.turnId === continuation!.id)).toBe(true);
+    const usage = await listUsageEvents(dbClient.db, { accountId: grant.accountId, workspaceId: grant.workspaceId });
+    expect(usage.some((event) => event.eventType === "agent_run.created" && event.sourceResourceId === continuation!.id)).toBe(true);
+
+    // While the continuation turn is queued the queue wins.
+    expect((await activities.maybeContinueGoal({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    })).action).toBe("queue");
+
+    // The continuation finishes without tool calls; goalNoProgressLimit 1
+    // pauses the goal on the next pass with a visible event.
+    await finishTurn(dbClient.db, grant.workspaceId, continuation!.id, "completed");
+    const second = await activities.maybeContinueGoal({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    });
+    expect(second.action).toBe("paused");
+    const goal = await getSessionGoal(dbClient.db, grant.workspaceId, session.id);
+    expect(goal?.status).toBe("paused");
+    expect(goal?.pausedReason).toBe("no_progress");
+    const afterEvents = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const pausedEvent = afterEvents.find((event) => event.type === "goal.paused");
+    expect(pausedEvent).toBeTruthy();
+    expect((pausedEvent!.payload as { reason?: string }).reason).toBe("no_progress");
+  });
+
+  test("user interrupts pause active goals even when no turn is active", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "interrupt me",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "long objective",
+      createdBy: "api",
+    });
+    const [interruptEvent] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.interrupt", payload: {} },
+    ]);
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+
+    // The interrupt landed after the turn cleared activeTurnId; the goal must
+    // still pause so the loop does not auto-continue what the user stopped.
+    await activities.interruptActiveTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: interruptEvent!.id,
+      workflowId: `session-${session.id}`,
+    });
+    const goal = await getSessionGoal(dbClient.db, grant.workspaceId, session.id);
+    expect(goal?.status).toBe("paused");
+    expect(goal?.pausedReason).toBe("user_interrupt");
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const pausedEvents = events.filter((event) => event.type === "goal.paused");
+    expect(pausedEvents).toHaveLength(1);
+    expect((pausedEvents[0]!.payload as { actor?: string }).actor).toBe("user");
+
+    // Idempotent: a second interrupt pause emits no duplicate event.
+    await activities.pauseGoalForInterrupt({ workspaceId: grant.workspaceId, sessionId: session.id });
+    const after = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    expect(after.filter((event) => event.type === "goal.paused")).toHaveLength(1);
+
+    // And a paused goal declines continuation.
+    expect((await activities.maybeContinueGoal({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    })).action).toBe("none");
+  });
+
+  test("scheduled tasks with goals arm and re-arm session goals on dispatch", async () => {
+    const grant = await testGrant(dbClient.db);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "maintain staging",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "skip",
+      agentConfig: {
+        prompt: "keep staging healthy",
+        resources: [],
+        tools: [],
+        metadata: {},
+        goal: { text: "staging healthy", successCriteria: "all probes green" },
+      },
+      metadata: {},
+    });
+    const activities = createActivities({
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        natsUrl: services.natsUrl,
+        mcpServers: [{ id: "opengeni", name: "OpenGeni", url: "http://127.0.0.1:65532/v1/workspaces/{workspaceId}/mcp", cacheToolsList: true }],
+      }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+
+    const firstDispatch = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+    });
+    expect(firstDispatch.action).toBe("start");
+    const goal = await getSessionGoal(dbClient.db, grant.workspaceId, firstDispatch.sessionId);
+    expect(goal?.status).toBe("active");
+    expect(goal?.createdBy).toBe("scheduled_task");
+    expect(goal?.successCriteria).toBe("all probes green");
+    const session = await getSession(dbClient.db, grant.workspaceId, firstDispatch.sessionId);
+    expect(session?.tools).toContainEqual({ kind: "mcp", id: "opengeni" });
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, firstDispatch.sessionId, 0, 50);
+    expect(events.map((event) => event.type).slice(0, 3)).toEqual(["session.created", "goal.set", "user.message"]);
+
+    // The goal paused between fires; the next fire re-arms it.
+    await activities.pauseGoalForInterrupt({ workspaceId: grant.workspaceId, sessionId: firstDispatch.sessionId });
+    const secondDispatch = await activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+    });
+    expect(secondDispatch.action).toBe("signal");
+    expect(secondDispatch.sessionId).toBe(firstDispatch.sessionId);
+    const rearmed = await getSessionGoal(dbClient.db, grant.workspaceId, firstDispatch.sessionId);
+    expect(rearmed?.status).toBe("active");
+    expect(rearmed?.autoContinuations).toBe(0);
+    const rearmEvents = await listSessionEvents(dbClient.db, grant.workspaceId, firstDispatch.sessionId, 0, 100);
+    const goalSetEvents = rearmEvents.filter((event) => event.type === "goal.set");
+    expect(goalSetEvents).toHaveLength(2);
+    expect((goalSetEvents[1]!.payload as { replaced?: boolean }).replaced).toBe(true);
+  });
+
+  test("runs goal continuation turns through the agent with saved context", async () => {
+    const model = new ScriptedModel([
+      { outputText: "initial work", chunks: ["initial ", "work"] },
+      { outputText: "continued work", chunks: ["continued ", "work"] },
+    ]);
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "start",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model }),
+    });
+    const [userTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "start" } },
+    ]);
+    expect((await activities.runAgentSegment({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: userTrigger!.id,
+      workflowId: "workflow-goal-continuation",
+    })).status).toBe("idle");
+
+    const [goalTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "goal.continuation", payload: { text: "[GOAL CONTINUATION 1/20] keep going" } },
+    ]);
+    const turn = await enqueueSessionTurn(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: goalTrigger!.id,
+      temporalWorkflowId: "workflow-goal-continuation",
+      source: "goal",
+      prompt: "[GOAL CONTINUATION 1/20] keep going",
+      resources: [],
+      tools: [],
+      model: "scripted-model",
+      reasoningEffort: "low",
+      sandboxBackend: "none",
+      metadata: {},
+    });
+    const result = await activities.runAgentSegment({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: goalTrigger!.id,
+      workflowId: "workflow-goal-continuation",
+      turnId: turn.id,
+    });
+    expect(result.status).toBe("idle");
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
+    const completions = events.filter((event) => event.type === "turn.completed");
+    expect(completions).toHaveLength(2);
+    expect((completions[1]!.payload as { output?: string }).output).toBe("continued work");
+    // The continuation reused the saved run state from the first turn.
+    expect(JSON.stringify(model.requests[1])).toContain("initial work");
   });
 });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1653,6 +1653,49 @@ describe("worker activities integration", () => {
     expect((pausedEvent!.payload as { reason?: string }).reason).toBe("no_progress");
   });
 
+  test("pauses goals on exhausted budgets without consuming continuation budget", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "budget goal",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "objective beyond the budget",
+      createdBy: "api",
+    });
+    const activities = createActivities({
+      // Managed limits with a zero credit balance block new agent runs.
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl, usageLimitsMode: "managed" }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+    const result = await activities.maybeContinueGoal({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    });
+    expect(result.action).toBe("paused");
+    const goal = await getSessionGoal(dbClient.db, grant.workspaceId, session.id);
+    expect(goal?.status).toBe("paused");
+    expect(goal?.pausedReason).toBe("limits");
+    expect(goal?.rationale).toBe("insufficient OpenGeni credits");
+    // The limits pause happened before the counter bump: no budget consumed,
+    // no continuation turn synthesized.
+    expect(goal?.autoContinuations).toBe(0);
+    expect(await listSessionTurns(dbClient.db, grant.workspaceId, session.id)).toHaveLength(0);
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const pausedEvent = events.find((event) => event.type === "goal.paused");
+    expect((pausedEvent?.payload as { reason?: string } | undefined)?.reason).toBe("limits");
+  });
+
   test("user interrupts pause active goals even when no turn is active", async () => {
     const grant = await testGrant(dbClient.db);
     const session = await createOwnedSession(dbClient.db, grant, {

--- a/test/integration/workspace-isolation.integration.ts
+++ b/test/integration/workspace-isolation.integration.ts
@@ -5,6 +5,7 @@ import {
   bootstrapWorkspace,
   createDb,
   createFileUpload,
+  createSessionGoal,
 } from "@opengeni/db";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
 import { MemoryEventBus, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
@@ -54,6 +55,17 @@ describe("workspace isolation matrix", () => {
     await expectStatus(app, authA, workspacePath(b.workspaceId, `/sessions/${session.id}`), 403);
     await expectStatus(app, authB, workspacePath(b.workspaceId, `/sessions/${session.id}`), 404);
     await expectStatus(app, authA, legacyRoute("sessions", session.id), 404);
+
+    await createSessionGoal(dbClient.db, {
+      accountId: a.accountId,
+      workspaceId: a.workspaceId,
+      sessionId: session.id,
+      text: "workspace A objective",
+      createdBy: "api",
+    });
+    await expectStatus(app, authA, workspacePath(a.workspaceId, `/sessions/${session.id}/goal`), 200);
+    await expectStatus(app, authA, workspacePath(b.workspaceId, `/sessions/${session.id}/goal`), 403);
+    await expectStatus(app, authB, workspacePath(b.workspaceId, `/sessions/${session.id}/goal`), 404);
 
     const fileId = crypto.randomUUID();
     await createFileUpload(dbClient.db, {


### PR DESCRIPTION
## What

Agents stop prematurely. This PR adds **session goals**: a durable, RLS-isolated per-session objective that flips the idle default. While a goal is `active`, a session that finishes a turn with nothing queued does not idle out — the workflow synthesizes a continuation turn ("your goal is not done — keep working, or explicitly complete/pause it"). Stopping becomes an explicit act: `opengeni__goal_complete` (with evidence), `opengeni__goal_pause` (with rationale), or a user interrupt.

## Design highlights

- **Replay-safe by construction**: goal state is one Postgres row (`session_goals`, migration `0005`); the Temporal workflow never holds goal state in memory — all reads/mutations go through activities whose results land in history. The signal-race fix in the idle path is preserved verbatim.
- **Queue always wins, approvals are never bypassed**: the continuation decision is taken in one locked transaction; any non-terminal turn (`queued`/`running`/`requires_action`) blocks auto-continuation, so a restarted workflow cannot side-step a pending human approval.
- **Two runaway guards**: a no-progress detector (continuation turns with zero tool calls and no goal revision; default tolerance 3) and a max-auto-continuation cap (default 20, deployment setting is a hard ceiling over per-goal overrides). Both auto-pause the goal with a visible `goal.paused` timeline event. A user/scheduled turn between continuations re-arms the budget.
- **Continuations are ordinary turns**: they bill, meter (`agent_run.created`), and stream exactly like user turns; saved run state threads through so the agent keeps full conversation context. Budget exhaustion pauses the goal visibly (`reason: "limits"`) instead of failing the session.
- **Interrupts pause goals** in both the idle and mid-turn paths — including the late-interrupt case where the turn already cleared `activeTurnId`.
- **Session-scoped goal tools** (`goal_set`/`goal_update`/`goal_complete`/`goal_pause`) on the first-party MCP server, gated by a worker-asserted (HMAC-signed, never agent-controlled) `sessionId` claim in the delegated token plus a new `goals:manage` permission. Goal-bearing sessions, continuation turns, and scheduled dispatches force-merge the `opengeni` tool ref so the escape hatches are always reachable, even for sessions created with empty tool lists.
- **Known tradeoff (documented)**: if the `maybeContinueGoal` activity itself fails, the workflow falls through to the normal idle shutdown rather than failing the session, so it can complete with an active goal; the next wake retries. See `docs/goals.md`.

## Surface

- `POST /v1/workspaces/:id/sessions` accepts `goal: { text, successCriteria?, maxAutoContinuations? }` (emits `goal.set` after `session.created`).
- `GET`/`PATCH /v1/workspaces/:id/sessions/:sessionId/goal` — read + operator pause/resume; resume resets counters and wakes idle workflows via `signalWithStart`. Invalid transitions 409.
- `ScheduledTaskAgentConfig.goal` arms goals on dispatch; reusable-session fires re-arm (replace text, reactivate, reset counters).
- New timeline events: `goal.set`, `goal.updated`, `goal.completed`, `goal.paused`, `goal.resumed`, `goal.continuation`; new turn source `goal`.
- Settings: `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` (20), `OPENGENI_GOAL_NO_PROGRESS_LIMIT` (3).

## Testing

All local gates green:
- `bun run typecheck` (all packages/apps)
- `bun test` (224 unit tests)
- All integration suites: api (52), db (12), nats (2), workspace-isolation, temporal-workflow (12, incl. new continuation-loop, interrupt-ordering, and failing-goal-check fallback tests against a real Temporal dev server), worker-activity (34, incl. continuation synthesis + billing parity, no-progress auto-pause, interrupt pause idempotency, scheduled-task goal arming/re-arming, and a full continuation turn through the agent with saved context)
- `apps/web` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core session/Temporal workflow behavior, billing for continuation turns, and auth-scoped MCP tools; misconfiguration could cause runaway agent runs or unexpected pauses.
> 
> **Overview**
> Adds **session goals**: durable per-session objectives that keep an active session working via synthesized continuation turns instead of idling out, until the agent completes/pauses the goal, limits kick in, or the user interrupts.
> 
> **Data & contracts:** New `session_goals` table (migration `0005`, RLS), `GoalSpec` on session create and scheduled `agentConfig`, goal timeline events, turn source `goal`, permission `goals:manage`, and optional `sessionId` on delegated access tokens.
> 
> **API & MCP:** `GET`/`PATCH` session goal routes; optional `goal` on `POST` sessions (emits `goal.set`, forces `opengeni` MCP). Session-scoped MCP tools `goal_set` / `goal_update` / `goal_complete` / `goal_pause` only when the grant carries worker-signed `sessionId` + `goals:manage`.
> 
> **Worker loop:** When the queue is empty, `maybeContinueGoal` (locked DB decision) may enqueue a billed continuation turn with saved run state; guards auto-pause on no-progress, max continuations, and billing/usage limits. User interrupts pause active goals; scheduled tasks can arm/re-arm goals on dispatch.
> 
> **Config:** `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` and `OPENGENI_GOAL_NO_PROGRESS_LIMIT` (documented in `docs/goals.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b447108bfa1c4223563f6d88b169f36c012a6673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->