### PR TITLE
Return client errors for invalid checkout requests

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -58,7 +58,11 @@ export function registerBillingRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(404, { message: "stripe billing is not enabled" });
     }
     const context = await requireAccessContext(c, deps);
-    const body = CreateCheckoutRequest.parse(await c.req.json());
+    const parsed = CreateCheckoutRequest.safeParse(await c.req.json());
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: parsed.error.issues[0]?.message ?? "invalid checkout request" });
+    }
+    const body = parsed.data;
     const accountId = requireSelectedAccount(context, body.accountId, "billing:manage");
     const amountCents = usdToCents(body.amountUsd);
     const amountMicros = centsToMicros(amountCents);


### PR DESCRIPTION
## Summary
- validate Stripe checkout requests with safeParse
- return HTTP 400 for invalid flexible top-up amounts instead of surfacing a server error

## Verification
- bun test packages/contracts/test/contracts.test.ts apps/api/test/app.test.ts
- cd apps/web && bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change on a single billing route; valid requests follow the same path as before.
> 
> **Overview**
> **`POST /v1/billing/checkout`** now validates the request body with **`CreateCheckoutRequest.safeParse`** instead of **`parse`**. When validation fails (e.g. invalid or out-of-range flexible top-up **`amountUsd`**), the handler returns **HTTP 400** with the first Zod error message instead of letting a parse exception become a server error.
> 
> Successful checkouts are unchanged: the parsed body still drives account selection, Stripe session creation, and the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c6cf2115c469a281526b7e3f391f044952a338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->