### PR TITLE
Namespace Stripe customer mirrors by mode

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -232,7 +232,7 @@ async function handleStripeWebhookEvent(deps: ApiRouteDeps, stripe: Stripe, even
       return;
     case "customer.created":
     case "customer.updated":
-      await mirrorCustomer(deps, event.data.object as Stripe.Customer);
+      await mirrorCustomer(deps, event, event.data.object as Stripe.Customer);
       return;
     default:
       return;
@@ -249,6 +249,7 @@ async function handleCheckoutSessionCompleted(deps: ApiRouteDeps, event: Stripe.
   if (customerId) {
     await upsertBillingCustomer(deps.db, {
       accountId: credit.accountId,
+      provider: stripeCustomerProvider(event),
       providerCustomerId: customerId,
       email: session.customer_details?.email ?? session.customer_email ?? null,
     });
@@ -274,7 +275,12 @@ async function mirrorPaymentIntentCustomer(deps: ApiRouteDeps, event: Stripe.Eve
   const accountId = intent.metadata?.opengeni_account_id;
   const customerId = typeof intent.customer === "string" ? intent.customer : intent.customer?.id;
   if (accountId && customerId) {
-    await upsertBillingCustomer(deps.db, { accountId, providerCustomerId: customerId, email: null });
+    await upsertBillingCustomer(deps.db, {
+      accountId,
+      provider: stripeCustomerProvider(event),
+      providerCustomerId: customerId,
+      email: null,
+    });
   }
 }
 
@@ -355,13 +361,14 @@ async function releaseDisputedCredits(deps: ApiRouteDeps, stripe: Stripe, event:
   });
 }
 
-async function mirrorCustomer(deps: ApiRouteDeps, customer: Stripe.Customer): Promise<void> {
+async function mirrorCustomer(deps: ApiRouteDeps, event: Stripe.Event, customer: Stripe.Customer): Promise<void> {
   const accountId = customer.metadata?.opengeni_account_id;
   if (!accountId || customer.deleted) {
     return;
   }
   await upsertBillingCustomer(deps.db, {
     accountId,
+    provider: stripeCustomerProvider(event),
     providerCustomerId: customer.id,
     email: typeof customer.email === "string" ? customer.email : null,
   });
@@ -415,7 +422,8 @@ function creditMetadata(metadata: Stripe.Metadata | null | undefined, label: str
 }
 
 async function getOrCreateStripeCustomer(deps: ApiRouteDeps, stripe: Stripe, context: AccessContext, accountId: string): Promise<string> {
-  const existing = await getBillingCustomer(deps.db, accountId);
+  const provider = stripeCustomerProvider(deps);
+  const existing = await getBillingCustomer(deps.db, accountId, provider);
   if (existing) {
     return existing.providerCustomerId;
   }
@@ -432,10 +440,20 @@ async function getOrCreateStripeCustomer(deps: ApiRouteDeps, stripe: Stripe, con
   });
   await upsertBillingCustomer(deps.db, {
     accountId,
+    provider,
     providerCustomerId: customer.id,
     email: customer.email,
   });
   return customer.id;
+}
+
+export function stripeCustomerProvider(input: ApiRouteDeps | Stripe.Event): "stripe:live" | "stripe:test" {
+  if ("livemode" in input) {
+    return input.livemode ? "stripe:live" : "stripe:test";
+  }
+  return input.settings.stripeSecretKey?.startsWith("sk_live_") || input.settings.stripeSecretKey?.startsWith("rk_live_")
+    ? "stripe:live"
+    : "stripe:test";
 }
 
 function requireSelectedAccount(context: AccessContext, requested: string | undefined, permission: Permission): string {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -12,7 +12,7 @@ import {
   workflowIdForSession,
 } from "../src/app";
 import { shouldCreateScheduleAfterUpdateError, temporalOverlapPolicy, temporalScheduleSpec } from "../src/index";
-import { stripeCheckoutSessionCreateParams } from "../src/routes/billing";
+import { stripeCheckoutSessionCreateParams, stripeCustomerProvider } from "../src/routes/billing";
 import { discoverMcpRegistryCapabilities, validateMcpCapabilityConnection } from "../src/domain/capabilities";
 import type { CapabilityCatalogItem, SessionEvent } from "@opengeni/contracts";
 
@@ -200,6 +200,13 @@ describe("API helpers", () => {
       successUrl: "https://evil.example/checkout",
       idempotencyKey: "checkout:test-open-redirect",
     })).toThrow("successUrl must use the OpenGeni public origin");
+  });
+
+  test("namespaces Stripe customer mirrors by live and test mode", () => {
+    expect(stripeCustomerProvider({ livemode: true } as never)).toBe("stripe:live");
+    expect(stripeCustomerProvider({ livemode: false } as never)).toBe("stripe:test");
+    expect(stripeCustomerProvider({ settings: { stripeSecretKey: "rk_live_example" } } as never)).toBe("stripe:live");
+    expect(stripeCustomerProvider({ settings: { stripeSecretKey: "sk_test_example" } } as never)).toBe("stripe:test");
   });
 
   test("discovers public MCP registry servers with bounded latest-version search", async () => {


### PR DESCRIPTION
## Summary\n- namespace Stripe customer mirrors as stripe:live or stripe:test\n- use event livemode for webhook customer mirrors\n- add a focused unit test for live/test provider selection\n\n## Test Plan\n- bun test apps/api/test/app.test.ts\n- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing customer lookup and webhook mirroring; wrong provider selection could attach the wrong Stripe customer to an account, though logic is straightforward and tested.
> 
> **Overview**
> Stripe customer mirrors are now keyed by **live vs test mode** (`stripe:live` / `stripe:test`) instead of a single implicit provider, so the same account can keep separate Stripe customer IDs per mode without overwriting each other.
> 
> A new **`stripeCustomerProvider`** helper picks the provider from webhook **`event.livemode`** or from whether the configured secret key is live (`sk_live_` / `rk_live_`). Checkout completion, payment-intent mirroring, customer webhooks, and **`getOrCreateStripeCustomer`** all pass that provider into **`getBillingCustomer`** / **`upsertBillingCustomer`**. **`mirrorCustomer`** now takes the webhook event for the same reason.
> 
> Unit tests cover live/test selection for both event and API deps shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8801a6b258ef167b09d465df00eb051d88a383a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->