### PR TITLE
Add workspace-registered capability packs

### DIFF
--- a/apps/api/src/domain/capabilities.ts
+++ b/apps/api/src/domain/capabilities.ts
@@ -18,6 +18,7 @@ import {
   getCapabilityCatalogItem,
   getCapabilityInstallation,
   getPackInstallation,
+  getWorkspaceEnvironment,
   listCapabilityCatalogItems,
   listCapabilityInstallations,
   listEnabledMcpCapabilityServers,
@@ -144,6 +145,22 @@ export async function enableCapability(input: {
       throw new HTTPException(422, {
         message: `pack ${packId} requires an environment attachment; enable it through /v1/workspaces/{workspaceId}/packs/${packId}/enable with environmentId`,
       });
+    }
+    if (storedEnvironmentId) {
+      // The stored attachment was authorized at pack-enable time, but the
+      // environment may have been deleted or its variables changed since;
+      // re-validate it like the packs enable endpoint does.
+      const environment = await getWorkspaceEnvironment(input.db, input.workspaceId, storedEnvironmentId);
+      if (!environment) {
+        throw new HTTPException(422, {
+          message: `the stored environment attachment for pack ${packId} no longer exists; re-enable it through /v1/workspaces/{workspaceId}/packs/${packId}/enable with environmentId`,
+        });
+      }
+      const missing = (pack.environment?.requiredVariables ?? [])
+        .filter((name) => !environment.variables.some((variable) => variable.name === name));
+      if (missing.length > 0) {
+        throw new HTTPException(422, { message: `environment is missing required variable(s): ${missing.join(", ")}` });
+      }
     }
     await enablePackInstallation(input.db, {
       accountId: input.accountId,

--- a/apps/api/src/domain/capabilities.ts
+++ b/apps/api/src/domain/capabilities.ts
@@ -17,6 +17,7 @@ import {
   enablePackInstallation,
   getCapabilityCatalogItem,
   getCapabilityInstallation,
+  getPackInstallation,
   listCapabilityCatalogItems,
   listCapabilityInstallations,
   listEnabledMcpCapabilityServers,
@@ -28,7 +29,7 @@ import {
   type EnabledMcpCapabilityServer,
 } from "@opengeni/db";
 import { HTTPException } from "hono/http-exception";
-import { getCapabilityPack, listCapabilityPacks } from "./packs";
+import { listCapabilityPacks, listWorkspaceCapabilityPacks, resolveCapabilityPack } from "./packs";
 
 const officialMcpRegistryUrl = "https://registry.modelcontextprotocol.io";
 const firstPartyMcpServerIds = new Set(["opengeni", "files", "docs"]);
@@ -45,17 +46,20 @@ export async function buildCapabilityCatalog(input: {
     persistedItems,
     capabilityInstallations,
     packInstallations,
+    workspacePacks,
     bundledSkills,
   ] = await Promise.all([
     listCapabilityCatalogItems(input.db, input.workspaceId),
     listCapabilityInstallations(input.db, input.workspaceId),
     listPackInstallations(input.db, input.workspaceId),
+    listWorkspaceCapabilityPacks(input.db, input.workspaceId),
     discoverBundledSkills(),
   ]);
   const capabilityInstallationById = new Map(capabilityInstallations.map((installation) => [installation.capabilityId, installation]));
   const activePackIds = new Set(packInstallations.filter((installation) => installation.status === "active").map((installation) => installation.packId));
+  const builtInPackIds = new Set(listCapabilityPacks().map((pack) => pack.id));
   const builtIns = [
-    ...packCatalogItems(),
+    ...workspacePacks.map((pack) => packCatalogItem(pack, builtInPackIds.has(pack.id) ? "built_in" : "manual")),
     ...configuredMcpCatalogItems(input.settings),
     ...platformApiCatalogItems(),
     ...bundledSkills,
@@ -126,9 +130,20 @@ export async function enableCapability(input: {
   }
   if (item.kind === "pack") {
     const packId = packIdFromCapabilityId(item.id);
-    const pack = getCapabilityPack(packId);
+    const pack = await resolveCapabilityPack(input.db, input.workspaceId, packId);
     if (!pack) {
       throw new HTTPException(404, { message: "pack not found" });
+    }
+    // This generic enable path carries no environment attachment, so packs
+    // that demand one must be enabled through the packs endpoint unless a
+    // previous enable already stored an attachment; a stored attachment is
+    // preserved instead of being overwritten by the fresh metadata.
+    const existing = await getPackInstallation(input.db, input.workspaceId, packId);
+    const storedEnvironmentId = typeof existing?.metadata.environmentId === "string" ? existing.metadata.environmentId : undefined;
+    if (pack.environment?.required && !storedEnvironmentId) {
+      throw new HTTPException(422, {
+        message: `pack ${packId} requires an environment attachment; enable it through /v1/workspaces/{workspaceId}/packs/${packId}/enable with environmentId`,
+      });
     }
     await enablePackInstallation(input.db, {
       accountId: input.accountId,
@@ -137,6 +152,7 @@ export async function enableCapability(input: {
       metadata: {
         ...input.payload.metadata,
         packVersion: pack.version,
+        ...(storedEnvironmentId ? { environmentId: storedEnvironmentId } : {}),
       },
     });
   }
@@ -364,11 +380,11 @@ async function requireCatalogItem(db: Database, workspaceId: string, settings: S
   return item;
 }
 
-function packCatalogItems(): CapabilityCatalogItem[] {
-  return listCapabilityPacks().map((pack) => CapabilityCatalogItem.parse({
+function packCatalogItem(pack: ReturnType<typeof listCapabilityPacks>[number], source: "built_in" | "manual"): CapabilityCatalogItem {
+  return CapabilityCatalogItem.parse({
     id: `pack:${pack.id}`,
     kind: "pack",
-    source: "built_in",
+    source,
     name: pack.name,
     description: pack.description,
     category: pack.category,
@@ -386,7 +402,7 @@ function packCatalogItems(): CapabilityCatalogItem[] {
       scheduledTaskTemplates: pack.scheduledTaskTemplates,
       ...pack.metadata,
     },
-  }));
+  });
 }
 
 function configuredMcpCatalogItems(settings: Settings): CapabilityCatalogItem[] {
@@ -526,15 +542,21 @@ function applyCapabilityEnablement(
   installation: CapabilityInstallation | undefined,
   activePackIds: Set<string>,
 ): CapabilityCatalogItem {
-  if (item.source === "built_in" || item.source === "configured") {
-    const packEnabled = item.kind === "pack" && activePackIds.has(packIdFromCapabilityId(item.id));
-    const enabled = item.kind === "pack" ? packEnabled || installation?.status === "active" : true;
+  if (item.kind === "pack") {
+    // Pack enablement lives in pack_installations regardless of whether the
+    // pack is built in or registered from a workspace manifest.
+    const enabled = activePackIds.has(packIdFromCapabilityId(item.id)) || installation?.status === "active";
     return {
       ...item,
       enabled,
-      enabledReason: enabled
-        ? item.kind === "pack" ? "enabled" : item.source === "configured" ? "configured" : "built in"
-      : null,
+      enabledReason: enabled ? "enabled" : null,
+    };
+  }
+  if (item.source === "built_in" || item.source === "configured") {
+    return {
+      ...item,
+      enabled: true,
+      enabledReason: item.source === "configured" ? "configured" : "built in",
     };
   }
   const activeInstallation = installation?.status === "active";

--- a/apps/api/src/domain/packs.ts
+++ b/apps/api/src/domain/packs.ts
@@ -1,8 +1,9 @@
-import type {
+import {
   CapabilityPack,
-  ScheduledTaskAgentConfig,
-  SocialConnection,
+  type ScheduledTaskAgentConfig,
+  type SocialConnection,
 } from "@opengeni/contracts";
+import { getWorkspacePack, listWorkspacePacks, type Database } from "@opengeni/db";
 
 export const MARKETING_SOCIAL_PACK_ID = "marketing-social-daily-analysis";
 
@@ -121,6 +122,41 @@ export function listCapabilityPacks(): CapabilityPack[] {
 
 export function getCapabilityPack(packId: string): CapabilityPack | null {
   return packs.find((pack) => pack.id === packId) ?? null;
+}
+
+export function isBuiltInCapabilityPack(packId: string): boolean {
+  return getCapabilityPack(packId) !== null;
+}
+
+/**
+ * Built-in packs plus the manifests registered for this workspace. Stored
+ * manifests were validated at registration time; rows that no longer parse
+ * (for example after a contract tightening) are skipped instead of breaking
+ * the whole catalog.
+ */
+export async function listWorkspaceCapabilityPacks(db: Database, workspaceId: string): Promise<CapabilityPack[]> {
+  const registered = await listWorkspacePacks(db, workspaceId);
+  const builtInIds = new Set(packs.map((pack) => pack.id));
+  const registeredPacks = registered
+    .filter((registration) => !builtInIds.has(registration.pack.id))
+    .flatMap((registration) => {
+      const parsed = CapabilityPack.safeParse(registration.pack);
+      return parsed.success ? [parsed.data] : [];
+    });
+  return [...packs, ...registeredPacks];
+}
+
+export async function resolveCapabilityPack(db: Database, workspaceId: string, packId: string): Promise<CapabilityPack | null> {
+  const builtIn = getCapabilityPack(packId);
+  if (builtIn) {
+    return builtIn;
+  }
+  const registration = await getWorkspacePack(db, workspaceId, packId);
+  if (!registration) {
+    return null;
+  }
+  const parsed = CapabilityPack.safeParse(registration.pack);
+  return parsed.success ? parsed.data : null;
 }
 
 export function buildMarketingDailyAnalysisAgentConfig(input: {

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -115,14 +115,16 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
     const payload = EnablePackRequest.parse(await c.req.json());
     // Re-enabling without environmentId keeps the stored attachment instead of
     // silently dropping it; the inherited attachment is re-validated below in
-    // case the environment was deleted or its variables changed since.
+    // case the environment was deleted or its variables changed since. The
+    // inherited attachment was authorized with environments:use when it was
+    // first attached, so only a fresh attachment re-checks that permission.
     const storedEnvironmentId = typeof existing?.metadata.environmentId === "string" ? existing.metadata.environmentId : undefined;
     const environmentId = payload.environmentId ?? storedEnvironmentId;
     if (pack.environment?.required && !environmentId) {
       throw new HTTPException(422, { message: "this pack requires an environment attachment; pass environmentId" });
     }
     if (environmentId) {
-      const environment = await validateEnvironmentAttachment({ settings, db }, grant, workspaceId, environmentId);
+      const environment = await validateEnvironmentAttachment({ settings, db }, grant, workspaceId, environmentId, { preauthorized: !payload.environmentId });
       const missing = (pack.environment?.requiredVariables ?? [])
         .filter((name) => !environment.variables.some((variable) => variable.name === name));
       if (missing.length > 0) {

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -6,7 +6,9 @@ import {
 } from "@opengeni/contracts";
 import {
   deleteWorkspacePack,
+  disableCapabilityInstallation,
   enablePackInstallation,
+  getCapabilityInstallation,
   getPackInstallation,
   getSocialConnection,
   listPackInstallations,
@@ -74,10 +76,16 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(404, { message: "pack not found" });
     }
     // A registration that disappears must not leave an active installation
-    // pointing at a manifest that no longer exists.
+    // pointing at a manifest that no longer exists; the capability
+    // installation row for pack:{packId} would otherwise keep a future
+    // re-registration looking enabled.
     const installation = await getPackInstallation(db, workspaceId, packId);
     if (installation && installation.status === "active") {
       await updatePackInstallationStatus(db, workspaceId, packId, "disabled");
+    }
+    const capabilityInstallation = await getCapabilityInstallation(db, workspaceId, `pack:${packId}`);
+    if (capabilityInstallation && capabilityInstallation.status === "active") {
+      await disableCapabilityInstallation(db, workspaceId, `pack:${packId}`);
     }
     return c.body(null, 204);
   });

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -10,6 +10,7 @@ import {
   enablePackInstallation,
   getCapabilityInstallation,
   getPackInstallation,
+  getWorkspacePack,
   getSocialConnection,
   listPackInstallations,
   listSocialConnections,
@@ -71,14 +72,13 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (isBuiltInCapabilityPack(packId)) {
       throw new HTTPException(409, { message: "built-in packs cannot be unregistered" });
     }
-    const deleted = await deleteWorkspacePack(db, workspaceId, packId);
-    if (!deleted) {
+    if (!await getWorkspacePack(db, workspaceId, packId)) {
       throw new HTTPException(404, { message: "pack not found" });
     }
-    // A registration that disappears must not leave an active installation
-    // pointing at a manifest that no longer exists; the capability
-    // installation row for pack:{packId} would otherwise keep a future
-    // re-registration looking enabled.
+    // Disable installations before deleting the registration so a crash in
+    // between can never orphan an active installation whose manifest is
+    // gone; the capability installation row for pack:{packId} would
+    // otherwise keep a future re-registration looking enabled.
     const installation = await getPackInstallation(db, workspaceId, packId);
     if (installation && installation.status === "active") {
       await updatePackInstallationStatus(db, workspaceId, packId, "disabled");
@@ -87,6 +87,7 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (capabilityInstallation && capabilityInstallation.status === "active") {
       await disableCapabilityInstallation(db, workspaceId, `pack:${packId}`);
     }
+    await deleteWorkspacePack(db, workspaceId, packId);
     return c.body(null, 204);
   });
 

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -1,14 +1,18 @@
 import {
   EnablePackRequest,
   MarketingDailyAnalysisTaskRequest,
+  RegisterCapabilityPackRequest,
   type SocialConnection,
 } from "@opengeni/contracts";
 import {
+  deleteWorkspacePack,
   enablePackInstallation,
   getPackInstallation,
   getSocialConnection,
   listPackInstallations,
   listSocialConnections,
+  registerWorkspacePack,
+  updatePackInstallationStatus,
 } from "@opengeni/db";
 import { getDocumentBase } from "@opengeni/documents";
 import type { Hono } from "hono";
@@ -19,9 +23,10 @@ import type { ApiRouteDeps } from "../dependencies";
 import { validateEnvironmentAttachment } from "../domain/environments";
 import {
   buildMarketingDailyAnalysisAgentConfig,
-  getCapabilityPack,
-  listCapabilityPacks,
+  isBuiltInCapabilityPack,
+  listWorkspaceCapabilityPacks,
   MARKETING_SOCIAL_PACK_ID,
+  resolveCapabilityPack,
 } from "../domain/packs";
 import {
   createValidatedScheduledTask,
@@ -35,9 +40,46 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
     const workspaceId = c.req.param("workspaceId");
     await requireAccessGrant(c, deps, workspaceId, "workspace:read");
     return c.json({
-      packs: listCapabilityPacks(),
+      packs: await listWorkspaceCapabilityPacks(db, workspaceId),
       installations: await listPackInstallations(db, workspaceId),
     });
+  });
+
+  // Registers (or replaces) a workspace-scoped pack from a manifest payload.
+  // Built-in pack ids stay reserved so a registration can never shadow them.
+  app.post("/v1/workspaces/:workspaceId/packs", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+    const manifest = RegisterCapabilityPackRequest.parse(await c.req.json());
+    if (isBuiltInCapabilityPack(manifest.id)) {
+      throw new HTTPException(409, { message: `pack id ${manifest.id} is a built-in pack and cannot be replaced` });
+    }
+    const { pack, created } = await registerWorkspacePack(db, {
+      accountId: grant.accountId,
+      workspaceId,
+      pack: manifest,
+    });
+    return c.json(pack, created ? 201 : 200);
+  });
+
+  app.delete("/v1/workspaces/:workspaceId/packs/:packId", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+    const packId = c.req.param("packId");
+    if (isBuiltInCapabilityPack(packId)) {
+      throw new HTTPException(409, { message: "built-in packs cannot be unregistered" });
+    }
+    const deleted = await deleteWorkspacePack(db, workspaceId, packId);
+    if (!deleted) {
+      throw new HTTPException(404, { message: "pack not found" });
+    }
+    // A registration that disappears must not leave an active installation
+    // pointing at a manifest that no longer exists.
+    const installation = await getPackInstallation(db, workspaceId, packId);
+    if (installation && installation.status === "active") {
+      await updatePackInstallationStatus(db, workspaceId, packId, "disabled");
+    }
+    return c.body(null, 204);
   });
 
   app.get("/v1/workspaces/:workspaceId/packs/installations", async (c) => {
@@ -49,7 +91,7 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.get("/v1/workspaces/:workspaceId/packs/:packId", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     await requireAccessGrant(c, deps, workspaceId, "workspace:read");
-    const pack = requirePack(c.req.param("packId"));
+    const pack = await requirePack(db, workspaceId, c.req.param("packId"));
     return c.json({
       pack,
       installation: await getPackInstallation(db, workspaceId, pack.id),
@@ -59,7 +101,7 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.post("/v1/workspaces/:workspaceId/packs/:packId/enable", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
-    const pack = requirePack(c.req.param("packId"));
+    const pack = await requirePack(db, workspaceId, c.req.param("packId"));
     const existing = await getPackInstallation(db, workspaceId, pack.id);
     const payload = EnablePackRequest.parse(await c.req.json());
     // Re-enabling without environmentId keeps the stored attachment instead of
@@ -94,7 +136,7 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.post("/v1/workspaces/:workspaceId/packs/marketing-social-daily-analysis/scheduled-tasks", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "scheduled_tasks:manage");
-    const pack = requirePack(MARKETING_SOCIAL_PACK_ID);
+    const pack = await requirePack(db, workspaceId, MARKETING_SOCIAL_PACK_ID);
     const installation = await getPackInstallation(db, workspaceId, pack.id);
     if (installation?.status !== "active") {
       throw new HTTPException(409, { message: "enable the marketing social pack before creating its scheduled tasks" });
@@ -150,8 +192,8 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
   });
 }
 
-function requirePack(packId: string) {
-  const pack = getCapabilityPack(packId);
+async function requirePack(db: ApiRouteDeps["db"], workspaceId: string, packId: string) {
+  const pack = await resolveCapabilityPack(db, workspaceId, packId);
   if (!pack) {
     throw new HTTPException(404, { message: "pack not found" });
   }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -835,6 +835,9 @@ export const CapabilityPackScheduledTaskTemplate = z.object({
   defaultSchedule: ScheduledTaskScheduleSpec,
   defaultRunMode: ScheduledTaskRunMode.default("new_session_per_run"),
   defaultOverlapPolicy: ScheduledTaskOverlapPolicy.default("skip"),
+  // Optional default agent prompt so registered pack manifests can ship fully
+  // instantiable templates; built-in packs may instead build prompts in code.
+  prompt: z.string().min(1).optional(),
 });
 export type CapabilityPackScheduledTaskTemplate = z.infer<typeof CapabilityPackScheduledTaskTemplate>;
 
@@ -857,6 +860,20 @@ export const CapabilityPack = z.object({
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 export type CapabilityPack = z.infer<typeof CapabilityPack>;
+
+// Registering a pack stores the manifest itself; the request body is a full
+// CapabilityPack manifest.
+export const RegisterCapabilityPackRequest = CapabilityPack;
+export type RegisterCapabilityPackRequest = z.infer<typeof RegisterCapabilityPackRequest>;
+
+export const WorkspaceRegisteredPack = z.object({
+  accountId: z.string().uuid(),
+  workspaceId: z.string().uuid(),
+  pack: CapabilityPack,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type WorkspaceRegisteredPack = z.infer<typeof WorkspaceRegisteredPack>;
 
 export const PackInstallationStatus = z.enum(["active", "disabled"]);
 export type PackInstallationStatus = z.infer<typeof PackInstallationStatus>;

--- a/packages/db/drizzle/0006_workspace_packs.sql
+++ b/packages/db/drizzle/0006_workspace_packs.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS "workspace_packs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
+  "pack_id" text NOT NULL,
+  "manifest" jsonb NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_packs_workspace_pack_idx" ON "workspace_packs" ("workspace_id", "pack_id");
+ALTER TABLE "workspace_packs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "workspace_packs" FORCE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'workspace_packs' AND policyname = 'workspace_isolation'
+  ) THEN
+    DROP POLICY workspace_isolation ON "workspace_packs";
+  END IF;
+END $$;
+CREATE POLICY workspace_isolation ON "workspace_packs"
+  USING (opengeni_private.workspace_rls_visible(account_id, workspace_id))
+  WITH CHECK (opengeni_private.workspace_rls_visible(account_id, workspace_id));
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781201800000,
       "tag": "0005_session_goals",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1781481600000,
+      "tag": "0006_workspace_packs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,6 +7,7 @@ import type {
   CapabilityInstallation,
   CapabilityInstallationStatus,
   CapabilityKind,
+  CapabilityPack,
   CapabilitySource,
   FileAsset,
   FileStatus,
@@ -46,6 +47,7 @@ import type {
   Workspace,
   WorkspaceEnvironment,
   WorkspaceEnvironmentVariableMetadata,
+  WorkspaceRegisteredPack,
 } from "@opengeni/contracts";
 import { and, asc, desc, eq, gt, gte, inArray, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -869,6 +871,12 @@ export type CreatePackInstallationInput = {
   metadata?: Record<string, unknown>;
 };
 
+export type RegisterWorkspacePackInput = {
+  accountId: string;
+  workspaceId: string;
+  pack: CapabilityPack;
+};
+
 export type CreateSocialConnectionInput = {
   accountId: string;
   workspaceId: string;
@@ -1134,6 +1142,57 @@ export async function updatePackInstallationStatus(db: Database, workspaceId: st
       throw new Error(`Pack installation not found: ${packId}`);
     }
     return mapPackInstallation(row);
+  });
+}
+
+export async function registerWorkspacePack(db: Database, input: RegisterWorkspacePackInput): Promise<{ pack: WorkspaceRegisteredPack; created: boolean }> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const now = new Date();
+    const [row] = await scopedDb.insert(schema.workspacePacks).values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      packId: input.pack.id,
+      manifest: input.pack as unknown as Record<string, unknown>,
+    })
+      .onConflictDoUpdate({
+        target: [schema.workspacePacks.workspaceId, schema.workspacePacks.packId],
+        set: {
+          manifest: input.pack as unknown as Record<string, unknown>,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    if (!row) {
+      throw new Error("Failed to register workspace pack");
+    }
+    return { pack: mapWorkspacePack(row), created: row.createdAt.getTime() === row.updatedAt.getTime() };
+  });
+}
+
+export async function listWorkspacePacks(db: Database, workspaceId: string): Promise<WorkspaceRegisteredPack[]> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.select().from(schema.workspacePacks)
+      .where(eq(schema.workspacePacks.workspaceId, workspaceId))
+      .orderBy(asc(schema.workspacePacks.packId));
+    return rows.map(mapWorkspacePack);
+  });
+}
+
+export async function getWorkspacePack(db: Database, workspaceId: string, packId: string): Promise<WorkspaceRegisteredPack | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select().from(schema.workspacePacks)
+      .where(and(eq(schema.workspacePacks.workspaceId, workspaceId), eq(schema.workspacePacks.packId, packId)))
+      .limit(1);
+    return row ? mapWorkspacePack(row) : null;
+  });
+}
+
+export async function deleteWorkspacePack(db: Database, workspaceId: string, packId: string): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.delete(schema.workspacePacks)
+      .where(and(eq(schema.workspacePacks.workspaceId, workspaceId), eq(schema.workspacePacks.packId, packId)))
+      .returning({ id: schema.workspacePacks.id });
+    return rows.length > 0;
   });
 }
 
@@ -2787,6 +2846,18 @@ function mapPackInstallation(row: typeof schema.packInstallations.$inferSelect):
     status: row.status as PackInstallationStatus,
     metadata: row.metadata,
     enabledAt: row.enabledAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function mapWorkspacePack(row: typeof schema.workspacePacks.$inferSelect): WorkspaceRegisteredPack {
+  return {
+    accountId: row.accountId,
+    workspaceId: row.workspaceId,
+    // Manifests are validated with the CapabilityPack contract at the API
+    // boundary before they are stored.
+    pack: row.manifest as unknown as CapabilityPack,
+    createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -437,6 +437,18 @@ export const packInstallations = pgTable("pack_installations", {
   status: index("pack_installations_workspace_status_idx").on(table.workspaceId, table.status),
 }));
 
+export const workspacePacks = pgTable("workspace_packs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),
+  workspaceId: uuid("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  packId: text("pack_id").notNull(),
+  manifest: jsonb("manifest").$type<Record<string, unknown>>().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  workspacePack: uniqueIndex("workspace_packs_workspace_pack_idx").on(table.workspaceId, table.packId),
+}));
+
 export const capabilityCatalogItems = pgTable("capability_catalog_items", {
   id: text("id").notNull(),
   accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getPackInstallation, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -1490,6 +1490,152 @@ describe("API component integration", () => {
     expect(task.agentConfig.metadata.socialConnectionIds).toEqual([activeConnection.id]);
     expect(task.metadata.socialConnectionIds).not.toContain(disabledConnection.id);
     expect(workflow.synced).toHaveLength(1);
+  });
+
+  test("registers workspace packs from manifests and installs them", async () => {
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl, environmentsEncryptionKey: environmentsTestKey }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const packId = `infra-test-${crypto.randomUUID().slice(0, 8)}`;
+    const manifest = {
+      id: packId,
+      name: "Infra test pack",
+      description: "Registered from a manifest payload in tests.",
+      role: "infrastructure",
+      category: "deployment",
+      version: "0.1.0",
+      scheduledTaskTemplates: [
+        {
+          id: "drift-daily",
+          name: "Daily drift check",
+          description: "Compare expected state against live state.",
+          defaultSchedule: { type: "calendar", timeZone: "UTC", hour: 6, minute: 0 },
+          defaultRunMode: "new_session_per_run",
+          defaultOverlapPolicy: "skip",
+          prompt: "Run the daily drift check.",
+        },
+      ],
+      environment: {
+        description: "Cloud credentials for substrate work.",
+        requiredVariables: ["CLOUD_TOKEN"],
+        required: true,
+      },
+    };
+
+    const registered = await app.request(workspacePath(workspaceId, "/packs"), {
+      method: "POST",
+      body: JSON.stringify(manifest),
+      headers: { "content-type": "application/json" },
+    });
+    expect(registered.status).toBe(201);
+    const registeredBody = await registered.json() as { pack: { id: string; scheduledTaskTemplates: Array<{ prompt?: string }> } };
+    expect(registeredBody.pack.id).toBe(packId);
+    expect(registeredBody.pack.scheduledTaskTemplates[0]?.prompt).toBe("Run the daily drift check.");
+
+    const replaced = await app.request(workspacePath(workspaceId, "/packs"), {
+      method: "POST",
+      body: JSON.stringify({ ...manifest, version: "0.1.1" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(replaced.status).toBe(200);
+
+    const builtInCollision = await app.request(workspacePath(workspaceId, "/packs"), {
+      method: "POST",
+      body: JSON.stringify({ ...manifest, id: "marketing-social-daily-analysis" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(builtInCollision.status).toBe(409);
+
+    const listed = await app.request(workspacePath(workspaceId, "/packs"));
+    expect(listed.status).toBe(200);
+    const listedBody = await listed.json() as { packs: Array<{ id: string; version: string }> };
+    expect(listedBody.packs.map((pack) => pack.id)).toContain(packId);
+    expect(listedBody.packs.find((pack) => pack.id === packId)?.version).toBe("0.1.1");
+
+    const enabledWithoutEnvironment = await app.request(workspacePath(workspaceId, `/packs/${packId}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabledWithoutEnvironment.status).toBe(422);
+
+    const environmentResponse = await app.request(workspacePath(workspaceId, "/environments"), {
+      method: "POST",
+      body: JSON.stringify({
+        name: `cloud-${crypto.randomUUID().slice(0, 8)}`,
+        variables: [{ name: "OTHER_TOKEN", value: "value-1" }],
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(environmentResponse.status).toBe(201);
+    const environment = await environmentResponse.json() as { id: string };
+
+    const enabledMissingVariable = await app.request(workspacePath(workspaceId, `/packs/${packId}/enable`), {
+      method: "POST",
+      body: JSON.stringify({ environmentId: environment.id }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabledMissingVariable.status).toBe(422);
+    expect(await enabledMissingVariable.text()).toContain("CLOUD_TOKEN");
+
+    const capabilityEnableWithoutAttachment = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(`pack:${packId}`)}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(capabilityEnableWithoutAttachment.status).toBe(422);
+
+    const setVariable = await app.request(workspacePath(workspaceId, `/environments/${environment.id}/variables/CLOUD_TOKEN`), {
+      method: "PUT",
+      body: JSON.stringify({ value: "cloud-token-value" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(setVariable.status).toBeLessThan(300);
+
+    const enabled = await app.request(workspacePath(workspaceId, `/packs/${packId}/enable`), {
+      method: "POST",
+      body: JSON.stringify({ environmentId: environment.id }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabled.status).toBe(201);
+    const installation = await enabled.json() as { status: string; metadata: Record<string, unknown> };
+    expect(installation.status).toBe("active");
+    expect(installation.metadata.packVersion).toBe("0.1.1");
+    expect(installation.metadata.environmentId).toBe(environment.id);
+
+    const catalogResponse = await app.request(workspacePath(workspaceId, "/capabilities"));
+    expect(catalogResponse.status).toBe(200);
+    const catalog = await catalogResponse.json() as { items: Array<{ id: string; kind: string; source: string; enabled: boolean }> };
+    expect(catalog.items.find((item) => item.id === `pack:${packId}`)).toMatchObject({
+      kind: "pack",
+      source: "manual",
+      enabled: true,
+    });
+
+    // Re-enabling through the generic capabilities path keeps the stored
+    // environment attachment instead of overwriting it.
+    const capabilityEnable = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(`pack:${packId}`)}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(capabilityEnable.status).toBe(201);
+    const installationAfterCapabilityEnable = await getPackInstallation(dbClient.db, workspaceId, packId);
+    expect(installationAfterCapabilityEnable?.metadata.environmentId).toBe(environment.id);
+
+    const deletedBuiltIn = await app.request(workspacePath(workspaceId, "/packs/marketing-social-daily-analysis"), { method: "DELETE" });
+    expect(deletedBuiltIn.status).toBe(409);
+
+    const deleted = await app.request(workspacePath(workspaceId, `/packs/${packId}`), { method: "DELETE" });
+    expect(deleted.status).toBe(204);
+    const missing = await app.request(workspacePath(workspaceId, `/packs/${packId}`));
+    expect(missing.status).toBe(404);
+    const installationAfterDelete = await getPackInstallation(dbClient.db, workspaceId, packId);
+    expect(installationAfterDelete?.status).toBe("disabled");
   });
 
   test("keeps scheduled task persistence consistent when schedule sync fails", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getPackInstallation, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getPackInstallation, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -1630,12 +1630,28 @@ describe("API component integration", () => {
     const deletedBuiltIn = await app.request(workspacePath(workspaceId, "/packs/marketing-social-daily-analysis"), { method: "DELETE" });
     expect(deletedBuiltIn.status).toBe(409);
 
+    // Once the required variable disappears, the generic enable path
+    // re-validates the stored attachment and refuses.
+    const removeVariable = await app.request(workspacePath(workspaceId, `/environments/${environment.id}/variables/CLOUD_TOKEN`), { method: "DELETE" });
+    expect(removeVariable.status).toBeLessThan(300);
+    const capabilityEnableMissingVariable = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(`pack:${packId}`)}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(capabilityEnableMissingVariable.status).toBe(422);
+    expect(await capabilityEnableMissingVariable.text()).toContain("CLOUD_TOKEN");
+
     const deleted = await app.request(workspacePath(workspaceId, `/packs/${packId}`), { method: "DELETE" });
     expect(deleted.status).toBe(204);
     const missing = await app.request(workspacePath(workspaceId, `/packs/${packId}`));
     expect(missing.status).toBe(404);
     const installationAfterDelete = await getPackInstallation(dbClient.db, workspaceId, packId);
     expect(installationAfterDelete?.status).toBe("disabled");
+    // The capability installation row is disabled too, so a future
+    // re-registration does not inherit stale enablement.
+    const capabilityInstallationAfterDelete = await getCapabilityInstallation(dbClient.db, workspaceId, `pack:${packId}`);
+    expect(capabilityInstallationAfterDelete?.status).toBe("disabled");
   });
 
   test("keeps scheduled task persistence consistent when schedule sync fails", async () => {


### PR DESCRIPTION
## Summary

The capability pack catalog is currently hard-coded: `createCatalogItem` rejects `pack:` ids and pack enable only resolves built-ins, so there is no way to install an externally maintained pack into a workspace. This PR adds the smallest generic mechanism to do that: registering a pack from a manifest payload.

- **POST `/v1/workspaces/:workspaceId/packs`** (`workspace:admin`): validates the body against the `CapabilityPack` contract and upserts it as a workspace-scoped pack (201 create / 200 replace). Built-in pack ids are reserved (409).
- **DELETE `/v1/workspaces/:workspaceId/packs/:packId`**: unregisters and disables any active installation so nothing keeps pointing at a vanished manifest.
- Pack list/lookup/enable resolve built-ins first, then workspace registrations; `environment.required` / `requiredVariables` declared by registered manifests are enforced on enable exactly like for built-ins.
- Registered packs appear in the capability catalog as `kind: pack`, `source: manual`; pack enablement now derives from `pack_installations` for every pack source (previously manual-source packs could never show enabled).
- The generic `/capabilities/:id/enable` path rejects environment-required packs without a stored attachment and preserves a stored attachment on re-enable instead of overwriting it.
- `CapabilityPackScheduledTaskTemplate` gains an optional `prompt` so registered manifests can ship fully instantiable scheduled-task templates (built-ins keep building prompts in code).
- New `workspace_packs` table (RLS `workspace_isolation` policy, unique `(workspace_id, pack_id)`), migration `0006_workspace_packs.sql`.

## Testing

- `bun run typecheck`
- `bun test` (225 unit tests)
- `bun run test:integration` — including a new end-to-end test covering register/replace/built-in-collision, list, environment-required enable (missing attachment and missing variable 422s), catalog surfacing, capabilities-path enable semantics, and unregister-disables-installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pack enablement, environment attachment validation, and capability catalog semantics; mistakes could leave wrong enable state or bypass/ over-block environment use, though behavior is covered by new integration tests.
> 
> **Overview**
> Workspaces can **register custom capability packs** from a full `CapabilityPack` manifest via **POST** `/packs` (upsert, 201/200) and **unregister** via **DELETE**, with built-in pack IDs blocked from override or removal. Manifests persist in a new **`workspace_packs`** table (RLS, unique per workspace + pack id) with DB helpers for register/list/get/delete.
> 
> **List, get, and enable** now resolve **built-ins first**, then workspace registrations (`listWorkspaceCapabilityPacks` / `resolveCapabilityPack`). Registered packs show in the **capability catalog** as `kind: pack`, `source: manual`; **pack enabled state** always comes from `pack_installations` (not “always on” for built-ins).
> 
> **Enable semantics** tighten for environment-required packs: the packs endpoint keeps a stored `environmentId` on re-enable and only re-checks `environments:use` when attaching a new id; generic **`/capabilities/.../enable`** rejects packs that need an environment without a prior attachment, preserves stored attachment, and re-validates existence and **required variables**. Unregister **disables** active pack and `pack:{id}` capability installations first.
> 
> Contracts add **`RegisterCapabilityPackRequest`**, **`WorkspaceRegisteredPack`**, and optional **`prompt`** on scheduled-task templates. Integration test covers register through unregister.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9725dea98fbe8e06bf927e4ee90683cabfb567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->