### PR TITLE
Idle the session when a segment hits the max-turns cap

### DIFF
--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -16,6 +16,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import {
+  maxTurnsExceededRunState,
   modelResponseUsageFromSdkEvent,
   normalizeSdkEvent,
   type SandboxFileDownload,
@@ -265,6 +266,42 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
           await finishTurn(db, input.workspaceId, turnId, "cancelled").catch(() => undefined);
         }
         throw error;
+      }
+      // The SDK's per-segment turn cap is a pacing valve, not a failure: end
+      // the turn gracefully and idle the session so an active goal continues
+      // via a synthesized continuation turn (or a user message resumes work).
+      // The run state captured at the cap keeps full conversation context for
+      // that resumption.
+      const maxTurns = maxTurnsExceededRunState(error);
+      if (maxTurns && publish && turnId && turnStartedPublished) {
+        if (maxTurns.serializedRunState) {
+          await saveRunState(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId,
+            serializedRunState: maxTurns.serializedRunState,
+            pendingApprovals: [],
+          });
+        }
+        await publish([
+          { type: "turn.completed", payload: { output: "", segmentLimit: "max_turns" } },
+          { type: "session.status.changed", payload: { status: "idle" } },
+        ], true);
+        await finishTurn(db, input.workspaceId, turnId, "idle");
+        await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+        await recordUsageEvent(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          eventType: "agent_run.completed",
+          quantity: 1,
+          unit: "run",
+          sourceResourceType: "session_turn",
+          sourceResourceId: turnId,
+          idempotencyKey: `usage:agent_run.completed:${turnId}`,
+        });
+        activityStatus = "idle";
+        return { status: "idle" };
       }
       activityStatus = "failed";
       activityError = error;

--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -275,6 +275,13 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
       const maxTurns = maxTurnsExceededRunState(error);
       if (maxTurns && publish && turnId && turnStartedPublished) {
         await batcher?.flush().catch(() => undefined);
+        // The SDK attaches the run state at the throw site; persisting it lets
+        // the continuation resume with this segment's full context. If capture
+        // ever fails, the continuation falls back to the previous snapshot --
+        // degraded context, flagged on the event, but still strictly better
+        // than a terminal failed session: the sandbox filesystem state
+        // persists independently and the agent re-derives from it.
+        const runStateSaved = Boolean(maxTurns.serializedRunState);
         if (maxTurns.serializedRunState) {
           await saveRunState(db, {
             accountId: input.accountId,
@@ -286,7 +293,7 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
           });
         }
         await publish([
-          { type: "turn.completed", payload: { output: "", segmentLimit: "max_turns" } },
+          { type: "turn.completed", payload: { output: "", segmentLimit: "max_turns", runStateSaved } },
           { type: "session.status.changed", payload: { status: "idle" } },
         ], true);
         await finishTurn(db, input.workspaceId, turnId, "idle");

--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -274,6 +274,7 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
       // that resumption.
       const maxTurns = maxTurnsExceededRunState(error);
       if (maxTurns && publish && turnId && turnStartedPublished) {
+        await batcher?.flush().catch(() => undefined);
         if (maxTurns.serializedRunState) {
           await saveRunState(db, {
             accountId: input.accountId,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -88,6 +88,11 @@ const SettingsSchema = z.object({
   // tolerated before the goal auto-pauses.
   goalMaxAutoContinuations: z.coerce.number().int().positive().default(20),
   goalNoProgressLimit: z.coerce.number().int().positive().default(3),
+  // Per-segment ceiling on agent loop turns (model calls) within a single
+  // session turn. Exceeding it ends the segment gracefully (the session goes
+  // idle and an active goal continues via a synthesized continuation turn);
+  // it is a pacing valve, not a session failure.
+  agentMaxTurnsPerSegment: z.coerce.number().int().positive().default(40),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),
@@ -303,6 +308,7 @@ export function getSettings(): Settings {
     environmentsEncryptionKey: optional("OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY"),
     goalMaxAutoContinuations: optional("OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS"),
     goalNoProgressLimit: optional("OPENGENI_GOAL_NO_PROGRESS_LIMIT"),
+    agentMaxTurnsPerSegment: optional("OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT"),
     authRequired: optional("OPENGENI_AUTH_REQUIRED"),
     accessKey: optional("OPENGENI_ACCESS_KEY"),
     authAllowHealth: optional("OPENGENI_AUTH_ALLOW_HEALTH"),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,6 +4,7 @@ import { signDelegatedAccessToken, type Permission, type ReasoningEffort, type R
 import {
   Agent,
   connectMcpServers,
+  MaxTurnsExceededError,
   MCPServerStreamableHttp,
   RunState,
   isOpenAIResponsesRawModelStreamEvent,
@@ -618,7 +619,7 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       : undefined);
   const runOptions: Parameters<typeof run>[2] = {
     stream: true,
-    maxTurns: 40,
+    maxTurns: settings.agentMaxTurnsPerSegment,
   };
   void settings.disableOpenaiTracing;
   if (client) {
@@ -628,6 +629,26 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     } as SandboxRunConfig;
   }
   return await run(agent, prepared.input, runOptions);
+}
+
+export { MaxTurnsExceededError } from "@openai/agents";
+
+/**
+ * Detects the agents SDK per-segment turn cap. The cap is a pacing valve, not
+ * a session failure: callers should end the segment gracefully (idle) so an
+ * active goal's continuation loop -- or a follow-up user message -- resumes
+ * the work. When the SDK attached the run state at the moment the cap hit,
+ * the serialized form is returned so the resumed turn keeps full context.
+ */
+export function maxTurnsExceededRunState(error: unknown): { serializedRunState: string | null } | null {
+  if (!(error instanceof MaxTurnsExceededError)) {
+    return null;
+  }
+  try {
+    return { serializedRunState: error.state ? error.state.toString() : null };
+  } catch {
+    return { serializedRunState: null };
+  }
 }
 
 export function withManifestRefreshOnResume(client: SandboxClient, targetManifest: Manifest | undefined): SandboxClient {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -32,6 +32,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     environmentsEncryptionKey: undefined,
     goalMaxAutoContinuations: 20,
     goalNoProgressLimit: 3,
+    agentMaxTurnsPerSegment: 40,
     betterAuthSecret: undefined,
     betterAuthAllowedHosts: "",
     betterAuthCookieDomain: undefined,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -310,7 +310,7 @@ describe("worker activities integration", () => {
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     expect(events.some((event) => event.type === "turn.failed")).toBe(false);
     const completed = events.find((event) => event.type === "turn.completed");
-    expect(completed?.payload).toEqual({ output: "", segmentLimit: "max_turns" });
+    expect(completed?.payload).toEqual({ output: "", segmentLimit: "max_turns", runStateSaved: false });
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
     const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id, 10);
     expect(turns.every((turn) => turn.status !== "failed")).toBe(true);

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -43,7 +43,7 @@ import {
 import type { AccessGrant, ResourceRef, SandboxBackend, ScheduledTaskAgentConfig } from "@opengeni/contracts";
 import { createNatsEventBus, type EventBus } from "@opengeni/events";
 import { createObservability } from "@opengeni/observability";
-import { createProductionAgentRuntime, type OpenGeniRuntime } from "@opengeni/runtime";
+import { createProductionAgentRuntime, MaxTurnsExceededError, type OpenGeniRuntime } from "@opengeni/runtime";
 import { createActivities } from "../../apps/worker/src/activities";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "../../apps/worker/src/activities/environment";
 import { ScriptedModel, functionCall, latestStatus, startTestMcpServer, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
@@ -277,6 +277,43 @@ describe("worker activities integration", () => {
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     expect(events.some((event) => event.type === "turn.failed")).toBe(true);
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("failed");
+  });
+
+  test("max turns exceeded idles the session instead of failing it", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "long task",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "long task" } },
+    ]);
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ error: new MaxTurnsExceededError("Max turns (40) exceeded") }]),
+      }),
+    });
+
+    await expect(activities.runAgentSegment({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      workflowId: "workflow-max-turns",
+    })).resolves.toEqual({ status: "idle" });
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    const completed = events.find((event) => event.type === "turn.completed");
+    expect(completed?.payload).toEqual({ output: "", segmentLimit: "max_turns" });
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id, 10);
+    expect(turns.every((turn) => turn.status !== "failed")).toBe(true);
   });
 
   test("classifies provider rate limits as retryable turn failures", async () => {


### PR DESCRIPTION
## Problem

The agents SDK runner caps each session turn at `maxTurns: 40`. A long-running goal-bearing session (observed live: an infrastructure-provisioning session mid `terraform apply`) exceeds the cap mid-work, and the worker's catch-all converts `MaxTurnsExceededError` into `turn.failed` + a **terminal failed session** with the goal still active. The goal auto-continuation loop exists precisely to carry long objectives across turn boundaries, but it never gets the chance because the session hard-fails — and failed sessions reject follow-up user messages, so all progress and context is stranded.

## Change

- **runtime**: `maxTurns` is now the `agentMaxTurnsPerSegment` setting (`OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT`, default 40 — behavior unchanged by default), and a new `maxTurnsExceededRunState()` helper detects the cap error and serializes the run state the SDK attaches at the moment the cap hits. `MaxTurnsExceededError` is re-exported for consumers/tests.
- **worker**: `runAgentSegment` treats the cap as a graceful segment end: save the captured run state, emit `turn.completed` (payload `segmentLimit: "max_turns"`) + `session.status.changed: idle`, finish the turn as idle, and record the usual `agent_run.completed` usage event. With an active goal, `maybeContinueGoal` then synthesizes a continuation turn that resumes from the saved run state with a fresh turn budget (continuations already thread `serializedRunState`). Without a goal the session idles and accepts the next user message.

The existing goal guard rails (max auto-continuations, no-progress streak, budget pause) still bound total work.

## Tests

- New integration test: a scripted model throwing `MaxTurnsExceededError` ends with `{ status: "idle" }`, a `turn.completed` event with `segmentLimit: "max_turns"`, no `turn.failed`, session idle, no failed turns.
- Full unit suite and worker-activity integration suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent run error handling and session lifecycle for long goals; default cap unchanged but mis-handling could strand or over-continue work.
> 
> **Overview**
> **Hitting the agents SDK per-segment turn cap no longer fails the session.** When `MaxTurnsExceededError` is raised, `runAgentSegment` ends the turn as **idle** (not `turn.failed`), optionally persists SDK run state for resume, emits `turn.completed` with `segmentLimit: "max_turns"` and `runStateSaved`, and records `agent_run.completed` so active goals can continue via `maybeContinueGoal` or the user can send another message.
> 
> **Runtime/config:** `maxTurns` is driven by **`agentMaxTurnsPerSegment`** (`OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT`, default **40**). **`maxTurnsExceededRunState()`** detects the cap error and serializes attached run state; **`MaxTurnsExceededError`** is re-exported for tests.
> 
> **Tests:** Integration coverage asserts idle status, no `turn.failed`, and the new `turn.completed` payload when the scripted model throws the cap error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbfa1e30abb8fb77b6e19ea4bcbac7877559ec02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->