### PR TITLE
Idle goal sessions through retryable provider rate limits

### DIFF
--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -6,6 +6,7 @@ import {
   getBillingBalance,
   requireFile,
   getSessionEvent,
+  getSessionGoal,
   getSessionTurn,
   requireSession,
   recordUsageEvent,
@@ -16,6 +17,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import {
+  agentsErrorRunState,
   maxTurnsExceededRunState,
   modelResponseUsageFromSdkEvent,
   normalizeSdkEvent,
@@ -45,6 +47,12 @@ import type {
 } from "./types";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
 import type { ResourceRef } from "@opengeni/contracts";
+
+// How long the session workflow holds the loop after a retryable provider
+// failure before the goal continuation re-enters the model. Azure/OpenAI TPM
+// throttling is minute-granular; anything shorter mostly burns continuation
+// budget against the same window.
+export const PROVIDER_BACKPRESSURE_DELAY_MS = 60_000;
 
 export function createRunAgentSegmentActivity(services: () => Promise<ActivityServices>) {
   return async function runAgentSegment(input: RunAgentSegmentInput): Promise<RunAgentSegmentResult> {
@@ -311,13 +319,52 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
         activityStatus = "idle";
         return { status: "idle" };
       }
+      // A retryable provider failure (rate limit) on a goal-bearing session is
+      // transient backpressure, not a session failure: the in-client retry
+      // budget is already exhausted by the time the error reaches here, so
+      // fail the turn truthfully but idle the session and let the goal
+      // continuation loop resume after a pacing delay. Sessions without an
+      // active goal keep the terminal behavior -- there is no continuation
+      // machinery to resume them, and a failed session is the honest signal
+      // for the user to retry.
+      const failure = agentRunFailurePayload(error);
+      if (failure.retryable && publish && turnId && turnStartedPublished) {
+        const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
+        if (goal && goal.status === "active") {
+          await batcher?.flush().catch(() => undefined);
+          // Provider errors rarely carry SDK run state; a null falls back to
+          // the previous snapshot, same degraded-context contract as the
+          // max-turns path above.
+          const serializedRunState = agentsErrorRunState(error);
+          const runStateSaved = Boolean(serializedRunState);
+          if (serializedRunState) {
+            await saveRunState(db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId,
+              serializedRunState,
+              pendingApprovals: [],
+            });
+          }
+          await publish([
+            { type: "turn.failed", payload: { ...failure, recovery: "goal_continuation", runStateSaved } },
+            { type: "session.status.changed", payload: { status: "idle" } },
+          ], true);
+          await finishTurn(db, input.workspaceId, turnId, "failed");
+          await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+          activityStatus = "idle";
+          activityError = error;
+          return { status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS };
+        }
+      }
       activityStatus = "failed";
       activityError = error;
       if (!publish || !turnId || !turnStartedPublished) {
         throw error;
       }
       await publish([
-        { type: "turn.failed", payload: agentRunFailurePayload(error) },
+        { type: "turn.failed", payload: failure },
         { type: "session.status.changed", payload: { status: "failed" } },
       ], true);
       await finishTurn(db, input.workspaceId, turnId, "failed");

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -79,4 +79,8 @@ export type IndexDocumentInput = {
 
 export type RunAgentSegmentResult = {
   status: "idle" | "requires_action" | "failed" | "cancelled";
+  // Provider backpressure pacing: when set on an idle result, the session
+  // workflow holds the loop this long before admitting the next turn (an
+  // active goal's continuation would otherwise immediately re-hit the limit).
+  continueDelayMs?: number;
 };

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -176,6 +176,14 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         return await runTurn(accountId, workspaceId, sessionId, turnId, approvalEventId);
       }
     }
+
+    if (outcome.result.status === "idle" && outcome.result.continueDelayMs) {
+      // Provider backpressure: hold the loop so an active goal's continuation
+      // does not immediately re-enter the same rate-limit window. An interrupt
+      // or user signal ends the wait early and is handled by the main loop.
+      const seenWakeups = wakeups;
+      await condition(() => interruptedEventId !== null || wakeups !== seenWakeups, outcome.result.continueDelayMs);
+    }
     return true;
   }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -110,6 +110,10 @@ const SettingsSchema = z.object({
   openaiReasoningEffort: ReasoningEffort.default("low"),
   openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
+  // Model-call retry budget for transient provider failures (429s and friends).
+  // The openai client default of 2 retries is too small for sustained TPM
+  // backpressure during long autonomous runs.
+  openaiMaxRetries: z.coerce.number().int().nonnegative().default(5),
   azureOpenaiBaseUrl: z.string().optional(),
   azureOpenaiEndpoint: z.string().optional(),
   azureOpenaiDeployment: z.string().optional(),
@@ -326,6 +330,7 @@ export function getSettings(): Settings {
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),
     openaiAllowedReasoningEfforts: optional("OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"),
     openaiResponsesTransport: optional("OPENGENI_OPENAI_RESPONSES_TRANSPORT"),
+    openaiMaxRetries: optional("OPENGENI_OPENAI_MAX_RETRIES"),
     azureOpenaiBaseUrl: optional("OPENGENI_AZURE_OPENAI_BASE_URL"),
     azureOpenaiEndpoint: optional("OPENGENI_AZURE_OPENAI_ENDPOINT"),
     azureOpenaiDeployment: optional("OPENGENI_AZURE_OPENAI_DEPLOYMENT"),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2255,7 +2255,26 @@ export async function evaluateGoalContinuation(db: Database, input: {
             eq(schema.sessionEvents.type, "agent.toolCall.created"),
           ));
         const goalRevised = row.versionAtLastContinuation !== null && row.version > row.versionAtLastContinuation;
-        noProgressStreak = Number(toolCalls) > 0 || goalRevised ? 0 : noProgressStreak + 1;
+        if (Number(toolCalls) > 0 || goalRevised) {
+          noProgressStreak = 0;
+        } else {
+          // A turn that died on retryable provider backpressure says nothing
+          // about whether the goal can progress; freezing the streak keeps a
+          // sustained rate-limit window from masquerading as a stuck goal.
+          // The auto-continuation cap remains the backstop for a real outage.
+          const [{ backpressureFailures } = { backpressureFailures: 0 }] = await tx.select({
+            backpressureFailures: sql<number>`count(*)::int`,
+          }).from(schema.sessionEvents)
+            .where(and(
+              eq(schema.sessionEvents.workspaceId, input.workspaceId),
+              eq(schema.sessionEvents.turnId, row.lastContinuationTurnId),
+              eq(schema.sessionEvents.type, "turn.failed"),
+              sql`${schema.sessionEvents.payload} ->> 'recovery' = 'goal_continuation'`,
+            ));
+          if (Number(backpressureFailures) === 0) {
+            noProgressStreak = noProgressStreak + 1;
+          }
+        }
       }
     }
     if (noProgressStreak >= input.noProgressLimit) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,6 +3,7 @@ import { collectSandboxEnvironment, parseExposedPorts, sandboxLifecycleHookIds }
 import { signDelegatedAccessToken, type Permission, type ReasoningEffort, type ResourceRef, type SessionEventType, type ToolRef } from "@opengeni/contracts";
 import {
   Agent,
+  AgentsError,
   connectMcpServers,
   MaxTurnsExceededError,
   MCPServerStreamableHttp,
@@ -156,6 +157,7 @@ export function configureOpenAI(settings: Settings): void {
     setDefaultOpenAIClient(new OpenAI({
       apiKey,
       baseURL,
+      maxRetries: settings.openaiMaxRetries,
       defaultQuery: azureOpenAIDefaultQuery(settings, baseURL),
       defaultHeaders: settings.azureOpenaiAdToken && !settings.azureOpenaiApiKey
         ? { Authorization: `Bearer ${settings.azureOpenaiAdToken}` }
@@ -170,6 +172,7 @@ export function configureOpenAI(settings: Settings): void {
     setDefaultOpenAIClient(new OpenAI({
       apiKey: settings.openaiApiKey ?? process.env.OPENAI_API_KEY,
       baseURL: settings.openaiBaseUrl,
+      maxRetries: settings.openaiMaxRetries,
     }));
   }
 }
@@ -648,6 +651,23 @@ export function maxTurnsExceededRunState(error: unknown): { serializedRunState: 
     return { serializedRunState: error.state ? error.state.toString() : null };
   } catch {
     return { serializedRunState: null };
+  }
+}
+
+/**
+ * Serialized run state attached to any agents SDK error, when present.
+ * Provider failures usually surface as raw API errors without state; callers
+ * must treat a null here as "resume from the previous snapshot" rather than
+ * an error.
+ */
+export function agentsErrorRunState(error: unknown): string | null {
+  if (!(error instanceof AgentsError) || !error.state) {
+    return null;
+  }
+  try {
+    return error.state.toString();
+  } catch {
+    return null;
   }
 }
 

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -71,6 +71,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     openaiReasoningEffort: "high",
     openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
     openaiResponsesTransport: "http",
+    openaiMaxRetries: 5,
     azureOpenaiBaseUrl: undefined,
     azureOpenaiEndpoint: undefined,
     azureOpenaiDeployment: undefined,

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -357,6 +357,76 @@ describe("DB integration", () => {
     expect(atCap).toMatchObject({ decision: "paused", reason: "max_auto_continuations" });
   });
 
+  test("provider backpressure turns freeze the no-progress streak", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "goal loop",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const guards = { defaultMaxAutoContinuations: 10, noProgressLimit: 2 };
+    const enqueueGoalTurn = async () => {
+      const [goalTrigger] = await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "goal.continuation", payload: { text: "continue" } }]);
+      return await enqueueSessionTurn(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: goalTrigger!.id,
+        temporalWorkflowId: "wf-goal-backpressure",
+        source: "goal",
+        prompt: "continue",
+        resources: [],
+        tools: [],
+        model: "scripted-model",
+        reasoningEffort: "low",
+        sandboxBackend: "none",
+        metadata: {},
+      });
+    };
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "outlast the rate limiter",
+      createdBy: "api",
+    });
+    const first = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(first).toMatchObject({ decision: "continue", autoContinuation: 1 });
+
+    // Three consecutive rate-limited continuations (no tool calls) exceed
+    // noProgressLimit 2, but backpressure failures must not advance the
+    // streak: the goal keeps continuing instead of pausing as no_progress.
+    for (let round = 1; round <= 3; round += 1) {
+      const turn = await enqueueGoalTurn();
+      await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, turn.id);
+      await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{
+        type: "turn.failed",
+        turnId: turn.id,
+        payload: { code: "provider_rate_limited", retryable: true, recovery: "goal_continuation", runStateSaved: false },
+      }]);
+      await finishTurn(dbClient.db, grant.workspaceId, turn.id, "failed");
+      const next = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+      expect(next).toMatchObject({ decision: "continue", autoContinuation: 1 + round });
+    }
+
+    // Ordinary empty continuations still count: two of them pause the goal.
+    for (let round = 1; round <= 2; round += 1) {
+      const turn = await enqueueGoalTurn();
+      await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, turn.id);
+      await finishTurn(dbClient.db, grant.workspaceId, turn.id, "completed");
+      const next = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+      if (round < 2) {
+        expect(next.decision).toBe("continue");
+      } else {
+        expect(next).toMatchObject({ decision: "paused", reason: "no_progress" });
+      }
+    }
+  });
+
   test("RLS policies isolate session goal rows for a non-owner app role", async () => {
     const appRoleUrl = await createRlsAppRole(dbClient.db, services.databaseUrl);
     const appDbClient = createDb(appRoleUrl);

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -299,6 +299,53 @@ describe("Temporal workflow integration", () => {
     }
   }, temporalWorkflowTestTimeoutMs);
 
+  test("holds the loop for continueDelayMs before the goal continuation check", async () => {
+    const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+    const scope = workflowScope();
+    const sessionId = crypto.randomUUID();
+    const delayMs = 1500;
+    let segmentReturnedAt = 0;
+    let goalCheckedAt = 0;
+    const worker = await testWorker(nativeConnection, taskQueue, {
+      claimNextQueuedTurn: (() => {
+        const queuedTurns = [queuedTurn("event-1")];
+        return async () => queuedTurns.shift() ?? null;
+      })(),
+      markSessionIdle: async () => undefined,
+      runAgentSegment: async () => {
+        segmentReturnedAt = Date.now();
+        // Provider backpressure idle: the workflow must hold the loop before
+        // admitting the goal continuation.
+        return { status: "idle", continueDelayMs: delayMs };
+      },
+      failSession: async () => undefined,
+      interruptActiveTurn: async () => undefined,
+      maybeContinueGoal: async () => {
+        if (!goalCheckedAt) {
+          goalCheckedAt = Date.now();
+        }
+        return { action: "none" };
+      },
+    });
+    const run = worker.run();
+    try {
+      const client = new Client({ connection });
+      const handle = await client.workflow.start("sessionWorkflow", {
+        taskQueue,
+        workflowId: `wf-${crypto.randomUUID()}`,
+        args: [{ ...scope, sessionId, initialEventId: "event-1" }],
+      });
+      await handle.result();
+      expect(segmentReturnedAt).toBeGreaterThan(0);
+      expect(goalCheckedAt).toBeGreaterThan(0);
+      // Generous lower bound to absorb timer scheduling slack.
+      expect(goalCheckedAt - segmentReturnedAt).toBeGreaterThanOrEqual(delayMs - 300);
+    } finally {
+      worker.shutdown();
+      await run;
+    }
+  }, temporalWorkflowTestTimeoutMs);
+
   test("idle interrupt pauses the goal before marking the session idle", async () => {
     const taskQueue = `workflow-test-${crypto.randomUUID()}`;
     const scope = workflowScope();

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -45,6 +45,7 @@ import { createNatsEventBus, type EventBus } from "@opengeni/events";
 import { createObservability } from "@opengeni/observability";
 import { createProductionAgentRuntime, MaxTurnsExceededError, type OpenGeniRuntime } from "@opengeni/runtime";
 import { createActivities } from "../../apps/worker/src/activities";
+import { PROVIDER_BACKPRESSURE_DELAY_MS } from "../../apps/worker/src/activities/agent-segment";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "../../apps/worker/src/activities/environment";
 import { ScriptedModel, functionCall, latestStatus, startTestMcpServer, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
 
@@ -353,6 +354,61 @@ describe("worker activities integration", () => {
       code: "provider_rate_limited",
       retryable: true,
     });
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("failed");
+  });
+
+  test("idles the session on a retryable provider failure when a goal is active", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "rate limit with goal",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "finish the long-running provisioning",
+      createdBy: "api",
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "rate limit with goal" } },
+    ]);
+    const error = new Error("Too Many Requests");
+    Object.assign(error, { status: 429 });
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ error }]),
+      }),
+    });
+
+    await expect(activities.runAgentSegment({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      workflowId: "workflow-rate-limit-goal",
+    })).resolves.toEqual({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const failed = events.find((event) => event.type === "turn.failed");
+    expect(failed?.payload).toEqual({
+      error: "Model provider rate limit hit. Try again in a minute or lower the reasoning effort.",
+      code: "provider_rate_limited",
+      retryable: true,
+      recovery: "goal_continuation",
+      runStateSaved: false,
+    });
+    // The turn is truthfully failed, but the session stays resumable and the
+    // goal remains active for the continuation loop to pick up.
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id, 10);
+    expect(turns.some((turn) => turn.status === "failed")).toBe(true);
+    expect((await getSessionGoal(dbClient.db, grant.workspaceId, session.id))?.status).toBe("active");
   });
 
   test("records worker observability when setup fails before a turn starts", async () => {


### PR DESCRIPTION
## Problem

During an autonomous goal run on managed staging, an Azure OpenAI 429 (TPM backpressure) exhausted the model client's default retry budget (2) and surfaced as a turn failure. `runAgentSegment` converted it into a terminal `session=failed`, killing the run mid-flight even though the failure payload itself said `retryable: true` ("Try again in a minute").

Observed live: session `95a0de54-04f2-4542-856a-cb5f73112a99` (geni-customer-zero workspace) died ~4 minutes into a long provisioning goal on `turn.failed` / `provider_rate_limited`.

## Fix

Follow the established max-turns "pacing valve" pattern (#27) for retryable provider failures on goal-bearing sessions:

- **Model client retry budget**: new `openaiMaxRetries` setting (default 5, env `OPENGENI_OPENAI_MAX_RETRIES`) applied to the Azure and custom-base-URL OpenAI clients, so transient bursts are absorbed in-request with the client's exponential backoff and Retry-After handling.
- **Graceful idle instead of terminal failure**: when the retry budget is still exhausted and the session has an **active goal**, the turn is failed truthfully (`turn.failed` with `recovery: "goal_continuation"`, `runStateSaved`) but the session idles, so the goal continuation loop resumes the work. Run state is saved when the SDK attached it; otherwise the continuation falls back to the previous snapshot — the same degraded-context contract as the max-turns path.
- **Backpressure pacing**: the activity returns `continueDelayMs` (60s) and the session workflow holds the loop (interrupt/user-signal aware) before admitting the continuation, so the goal does not immediately re-enter the same rate-limit window and burn continuation budget.
- Sessions **without** an active goal keep the existing terminal behavior: there is no continuation machinery to resume them, and a failed session is the honest signal for the user to retry.

## Tests

- `worker-activity.integration.ts`: new test — active goal + 429 → `{status: "idle", continueDelayMs: 60000}`, truthful `turn.failed` payload with `recovery`/`runStateSaved`, session idle, goal still active; existing non-goal rate-limit test extended to also assert the terminal session status.
- `temporal-workflow.integration.ts`: new test — workflow holds the loop for `continueDelayMs` before the goal continuation check.
- Full typecheck, unit (225), and integration suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches autonomous session/goal continuation and Temporal pacing on provider errors; behavior change is scoped to retryable failures with active goals but affects long-running production runs.
> 
> **Overview**
> Retryable model provider rate limits (e.g. Azure TPM 429s) no longer **terminate** autonomous sessions that have an **active goal**. The worker raises the OpenAI client retry budget via **`openaiMaxRetries`** (default 5, `OPENGENI_OPENAI_MAX_RETRIES`), and when retries are still exhausted it follows the max-turns pacing pattern: truthful **`turn.failed`** with `recovery: "goal_continuation"`, session set to **idle**, optional run-state save via **`agentsErrorRunState`**, and **`continueDelayMs`** (60s) so the Temporal session workflow waits before the goal loop retries.
> 
> Sessions **without** an active goal still end in **`failed`**. **`evaluateGoalContinuation`** skips advancing the no-progress streak when the last continuation turn failed with that recovery payload, so sustained throttling does not auto-pause the goal as `no_progress`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252c6ed5451f7691936c93aad27f1bab3e8d44f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->