### PR TITLE
Remove run-length limits for multi-day agent runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,10 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Generate with: openssl rand -base64 32
 # OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY=replace-with-base64-32-byte-key
 
-# Session goal guard rails (see docs/goals.md). Defaults shown.
-# OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS=20
+# Session goal guard rails (see docs/goals.md). Goals are uncapped by count
+# by default (agents legitimately run for days); set a max only if a
+# deployment needs a hard ceiling. No-progress detection stays on. Defaults shown.
+# OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS=
 # OPENGENI_GOAL_NO_PROGRESS_LIMIT=3
 
 # Managed mode human auth and transactional email.

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -40,7 +40,7 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
     const decision = await evaluateGoalContinuation(db, {
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
-      defaultMaxAutoContinuations: settings.goalMaxAutoContinuations,
+      defaultMaxAutoContinuations: settings.goalMaxAutoContinuations ?? null,
       noProgressLimit: settings.goalNoProgressLimit,
       budgetBlocked,
     });
@@ -164,9 +164,10 @@ export async function pauseActiveGoalOnInterrupt(db: Database, bus: EventBus, wo
   }
 }
 
-export function goalContinuationPrompt(goal: SessionGoal, autoContinuation: number, cap: number): string {
+export function goalContinuationPrompt(goal: SessionGoal, autoContinuation: number, cap: number | null): string {
+  const counter = cap === null ? `${autoContinuation}` : `${autoContinuation}/${cap}`;
   return [
-    `[GOAL CONTINUATION ${autoContinuation}/${cap}] The session goal is not done. Goal: ${goal.text}.`,
+    `[GOAL CONTINUATION ${counter}] The session goal is not done. Goal: ${goal.text}.`,
     `Success criteria: ${goal.successCriteria ?? "none specified"}.`,
     "Continue working toward the goal now. If it is actually complete, call opengeni__goal_complete with concrete evidence.",
     "If you are blocked or continuing is not productive, call opengeni__goal_pause with your rationale.",

--- a/apps/worker/src/workflows/activities.ts
+++ b/apps/worker/src/workflows/activities.ts
@@ -2,7 +2,10 @@ import { proxyActivities } from "@temporalio/workflow";
 import type * as activities from "../activities";
 
 export const activity = proxyActivities<typeof activities>({
-  startToCloseTimeout: "4 hours",
+  // Agent segments legitimately run for days (goal-bearing infrastructure
+  // sessions). Dead workers are detected by the heartbeat, not this timeout,
+  // so it is deliberately generous rather than a pacing bound.
+  startToCloseTimeout: "30 days",
   heartbeatTimeout: "30 seconds",
   retry: { maximumAttempts: 1 },
 });

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -44,11 +44,15 @@ activity for a decision:
    turn that produced zero tool calls and no goal revision increments a
    no-progress streak (a user/scheduled turn in between resets the streak and
    the budget — human re-engagement re-arms the loop).
-4. Guards: `noProgressStreak >= OPENGENI_GOAL_NO_PROGRESS_LIMIT` (default 3) or
-   `autoContinuations >= cap` auto-pause the goal with a visible `goal.paused`
-   event (`reason: "no_progress" | "max_auto_continuations"`). The cap is
-   `min(goal.maxAutoContinuations, OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS)`
-   (default 20) — the deployment setting is a hard ceiling.
+4. Guards: `noProgressStreak >= OPENGENI_GOAL_NO_PROGRESS_LIMIT` (default 3)
+   auto-pauses the goal with a visible `goal.paused` event
+   (`reason: "no_progress"`). Goals are NOT capped by continuation count by
+   default — runs legitimately span days, so length is governed by progress
+   and budget guards, never by count. If a deployment sets
+   `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` it becomes a hard ceiling
+   (`min(goal.maxAutoContinuations, setting)`, pause reason
+   `"max_auto_continuations"`); a per-goal `maxAutoContinuations` applies on
+   its own even without the deployment setting.
 5. Otherwise a continuation turn is enqueued: a deterministic prompt referencing
    the goal text and success criteria, the session's tool surface plus the
    first-party `opengeni` MCP server (so the goal tools are always reachable),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -83,16 +83,18 @@ const SettingsSchema = z.object({
   staticUsageLimitsJson: z.string().default("{}"),
   delegationSecret: z.string().optional(),
   environmentsEncryptionKey: z.string().optional(),
-  // Session goal guard rails: the hard ceiling on synthesized continuation
-  // turns per goal arming, and the consecutive zero-progress continuations
-  // tolerated before the goal auto-pauses.
-  goalMaxAutoContinuations: z.coerce.number().int().positive().default(20),
+  // Session goal guard rails. Goals are designed for runs that legitimately
+  // span days, so length is bounded by pathology detection (no-progress
+  // streaks, budget exhaustion), never by count. goalMaxAutoContinuations is
+  // therefore UNSET by default (no cap); deployments may configure one, and
+  // it then acts as a hard ceiling that per-goal overrides can only lower.
+  goalMaxAutoContinuations: z.coerce.number().int().positive().optional(),
   goalNoProgressLimit: z.coerce.number().int().positive().default(3),
   // Per-segment ceiling on agent loop turns (model calls) within a single
-  // session turn. Exceeding it ends the segment gracefully (the session goes
-  // idle and an active goal continues via a synthesized continuation turn);
-  // it is a pacing valve, not a session failure.
-  agentMaxTurnsPerSegment: z.coerce.number().int().positive().default(40),
+  // session turn. Effectively unbounded by default for the same reason as
+  // above; the graceful max-turns valve (idle + goal continuation, never a
+  // session failure) remains as inert safety should a deployment set a cap.
+  agentMaxTurnsPerSegment: z.coerce.number().int().positive().default(1_000_000),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2186,7 +2186,7 @@ export type GoalContinuationDecision =
   | { decision: "none" }
   | { decision: "queue" }
   | { decision: "paused"; reason: "no_progress" | "max_auto_continuations" | "limits"; goal: SessionGoal }
-  | { decision: "continue"; goal: SessionGoal; autoContinuation: number; cap: number };
+  | { decision: "continue"; goal: SessionGoal; autoContinuation: number; cap: number | null };
 
 /**
  * Core continuation decision, taken in one transaction with the goal row
@@ -2199,7 +2199,9 @@ export type GoalContinuationDecision =
 export async function evaluateGoalContinuation(db: Database, input: {
   workspaceId: string;
   sessionId: string;
-  defaultMaxAutoContinuations: number;
+  // Optional: when absent (the default posture) goals are uncapped and length
+  // is governed by the no-progress and budget guards only.
+  defaultMaxAutoContinuations?: number | null;
   noProgressLimit: number;
   // Caller-computed billing/limits block reason. Applied inside the locked
   // decision (before the counter bump) so a budget pause never consumes
@@ -2288,9 +2290,13 @@ export async function evaluateGoalContinuation(db: Database, input: {
       }).where(eq(schema.sessionGoals.id, row.id)).returning();
       return { decision: "paused", reason: "no_progress", goal: mapSessionGoal(paused!) } as const;
     }
-    // The configured default is a hard ceiling; per-goal overrides only lower it.
-    const cap = Math.min(row.maxAutoContinuations ?? input.defaultMaxAutoContinuations, input.defaultMaxAutoContinuations);
-    if (autoContinuations >= cap) {
+    // No configured default means uncapped: goal length is bounded by the
+    // no-progress and budget guards above, never by count. When a default is
+    // configured it is a hard ceiling; per-goal overrides can only lower it.
+    const capCandidates = [row.maxAutoContinuations, input.defaultMaxAutoContinuations]
+      .filter((value): value is number => typeof value === "number");
+    const cap = capCandidates.length > 0 ? Math.min(...capCandidates) : null;
+    if (cap !== null && autoContinuations >= cap) {
       const [paused] = await tx.update(schema.sessionGoals).set({
         status: "paused",
         pausedReason: "max_auto_continuations",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -247,7 +247,7 @@ export const sessionGoals = pgTable("session_goals", {
   version: integer("version").notNull().default(1), // bumped on every set/update; progress signal
   autoContinuations: integer("auto_continuations").notNull().default(0),
   noProgressStreak: integer("no_progress_streak").notNull().default(0),
-  maxAutoContinuations: integer("max_auto_continuations"), // per-goal override, clamped to the settings cap
+  maxAutoContinuations: integer("max_auto_continuations"), // per-goal override; a configured settings cap (if any) remains the hard ceiling
   lastContinuationTurnId: uuid("last_continuation_turn_id"),
   versionAtLastContinuation: integer("version_at_last_continuation"),
   metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -427,6 +427,75 @@ describe("DB integration", () => {
     }
   });
 
+  test("goals are uncapped by count when no default cap is configured", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "multi-day goal",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // No deployment default: length is governed by progress/budget guards only.
+    const guards = { defaultMaxAutoContinuations: null, noProgressLimit: 2 };
+    const enqueueGoalTurn = async () => {
+      const [goalTrigger] = await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "goal.continuation", payload: { text: "continue" } }]);
+      return await enqueueSessionTurn(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: goalTrigger!.id,
+        temporalWorkflowId: "wf-goal-uncapped",
+        source: "goal",
+        prompt: "continue",
+        resources: [],
+        tools: [],
+        model: "scripted-model",
+        reasoningEffort: "low",
+        sandboxBackend: "none",
+        metadata: {},
+      });
+    };
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "keep going for days",
+      createdBy: "api",
+    });
+    // Run well past the old default cap of 20; with progress every round the
+    // loop must keep continuing, with a null cap throughout.
+    let decision = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(decision).toMatchObject({ decision: "continue", autoContinuation: 1, cap: null });
+    for (let round = 2; round <= 25; round += 1) {
+      const turn = await enqueueGoalTurn();
+      await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, turn.id);
+      await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "agent.toolCall.created", turnId: turn.id, payload: {} }]);
+      await finishTurn(dbClient.db, grant.workspaceId, turn.id, "completed");
+      decision = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+      expect(decision).toMatchObject({ decision: "continue", autoContinuation: round, cap: null });
+    }
+    // A per-goal cap still applies on its own, without any deployment default.
+    await upsertSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "bounded push",
+      maxAutoContinuations: 1,
+      createdBy: "agent",
+    });
+    const bounded = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(bounded).toMatchObject({ decision: "continue", autoContinuation: 1, cap: 1 });
+    const boundedTurn = await enqueueGoalTurn();
+    await setSessionGoalLastContinuationTurn(dbClient.db, grant.workspaceId, session.id, boundedTurn.id);
+    await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [{ type: "agent.toolCall.created", turnId: boundedTurn.id, payload: {} }]);
+    await finishTurn(dbClient.db, grant.workspaceId, boundedTurn.id, "completed");
+    const atCap = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
+    expect(atCap).toMatchObject({ decision: "paused", reason: "max_auto_continuations" });
+  });
+
   test("RLS policies isolate session goal rows for a non-owner app role", async () => {
     const appRoleUrl = await createRlsAppRole(dbClient.db, services.databaseUrl);
     const appDbClient = createDb(appRoleUrl);


### PR DESCRIPTION
## Summary
- Goals are no longer capped by continuation count by default: `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` is unset out of the box (uncapped); when configured it remains a hard ceiling, and per-goal `maxAutoContinuations` applies on its own either way.
- `OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT` default 40 → 1,000,000 (effectively unbounded). The graceful max-turns valve from #27 remains as inert safety for deployments that configure a cap.
- Agent activity `startToCloseTimeout` 4h → 30 days. Dead-worker detection is the existing 30s heartbeat; `retry.maximumAttempts` stays 1 so side-effectful segments never auto-rerun.

## Why
The platform is built for agents that legitimately run for many days (goal-driven infrastructure sessions). Count/duration limits interrupt or kill healthy long runs — attempt diagnostics showed exactly this in production-like use. Pathology detection stays symptom-based: the no-progress streak and budget-exhaustion pauses are untouched and remain the real guards.

## Verification
- `bun run typecheck` green across workspaces
- `bun test test/integration/db.integration.ts` 14/14, including a new test: an uncapped goal continues past the old default (25 rounds, `cap: null`), and a per-goal cap still pauses with `max_auto_continuations` without any deployment default
- `bun test test/integration/worker-activity.integration.ts test/integration/temporal-workflow.integration.ts` 50/50
- `bun run test:unit` 225/225
- Docs/.env.example updated to the new posture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default guardrails and Temporal activity lifetime for core session/goal workflows; misconfiguration could allow very long runs and higher cost, though no-progress and budget pauses remain.
> 
> **Overview**
> **Enables multi-day goal-driven agent sessions** by removing artificial run-length ceilings while keeping pathology guards (no-progress streak, budget/limits pauses).
> 
> **Goal continuation count** is **uncapped by default**: `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` is optional with no default; `evaluateGoalContinuation` only applies a max-continuations pause when a cap exists (`min` of per-goal override and deployment setting, or per-goal alone). Continuation prompts and events use a nullable `cap` (counter shows `N` vs `N/M`). Worker passes `settings.goalMaxAutoContinuations ?? null`.
> 
> **Per-segment agent loop** default rises from 40 to **1,000,000** model-call turns (`OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT`); configured caps still trigger the graceful idle + goal-continuation valve.
> 
> **Temporal** agent activity `startToCloseTimeout` goes from **4 hours to 30 days** (heartbeat still 30s; retries stay at 1).
> 
> Docs/`.env.example` describe the new posture; integration test asserts 25+ continuation rounds with `cap: null` and that per-goal `maxAutoContinuations` still pauses without a deployment default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cbe8831776b01f58a59acd9750dddd03841e0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->