### PR TITLE
Budget exhaustion idles the turn instead of failing the session

### DIFF
--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -191,7 +191,23 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
               usage: responseUsage.usage,
               sourceKey: responseUsage.responseId ?? `response-${responseUsageCount}`,
             });
-            await ensureRunAllowed(settings, db, input.accountId, input.workspaceId);
+            try {
+              await ensureRunAllowed(settings, db, input.accountId, input.workspaceId);
+            } catch (limitError) {
+              // Capture the run state at the boundary so the budget valve in
+              // the outer catch can end this segment gracefully with full
+              // conversation context preserved for the post-top-up resume.
+              let serializedRunState: string | null = null;
+              try {
+                serializedRunState = stream.state.toString();
+              } catch {
+                serializedRunState = null;
+              }
+              throw new BudgetExhaustedError(
+                limitError instanceof Error ? limitError.message : String(limitError),
+                serializedRunState,
+              );
+            }
           }
           const normalized = normalizeSdkEvent(next.value);
           for (const event of normalized) {
@@ -319,6 +335,43 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
         activityStatus = "idle";
         return { status: "idle" };
       }
+      // Budget/limit exhaustion between model calls is account state, not an
+      // agent failure: idle the session for goal-bearing and goal-less runs
+      // alike (a failed session would reject the user's next message after a
+      // top-up). An active goal pauses visibly with reason "limits" at the
+      // next continuation evaluation, without consuming continuation budget.
+      if (error instanceof BudgetExhaustedError && publish && turnId && turnStartedPublished) {
+        await batcher?.flush().catch(() => undefined);
+        const runStateSaved = Boolean(error.serializedRunState);
+        if (error.serializedRunState) {
+          await saveRunState(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId,
+            serializedRunState: error.serializedRunState,
+            pendingApprovals: [],
+          });
+        }
+        await publish([
+          { type: "turn.completed", payload: { output: "", segmentLimit: "budget_exhausted", detail: error.message, runStateSaved } },
+          { type: "session.status.changed", payload: { status: "idle" } },
+        ], true);
+        await finishTurn(db, input.workspaceId, turnId, "idle");
+        await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+        await recordUsageEvent(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          eventType: "agent_run.completed",
+          quantity: 1,
+          unit: "run",
+          sourceResourceType: "session_turn",
+          sourceResourceId: turnId,
+          idempotencyKey: `usage:agent_run.completed:${turnId}`,
+        });
+        activityStatus = "idle";
+        return { status: "idle" };
+      }
       // A retryable provider failure (rate limit) on a goal-bearing session is
       // transient backpressure, not a session failure: the in-client retry
       // budget is already exhausted by the time the error reaches here, so
@@ -411,6 +464,21 @@ export function agentRunFailurePayload(error: unknown): { error: string; code?: 
     };
   }
   return { error: message };
+}
+
+/**
+ * Budget/limit exhaustion detected between model calls. This is account
+ * state, not an agent failure: the segment ends gracefully (session idles,
+ * run state preserved) so a top-up or limit reset lets the same session
+ * continue — a failed session would reject the user's next message. An
+ * active goal pauses visibly (reason "limits") at the next continuation
+ * evaluation without consuming continuation budget.
+ */
+class BudgetExhaustedError extends Error {
+  constructor(message: string, readonly serializedRunState: string | null) {
+    super(message);
+    this.name = "BudgetExhaustedError";
+  }
 }
 
 async function ensureRunAllowed(settings: Settings, db: ActivityServices["db"], accountId: string, workspaceId: string): Promise<void> {

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -898,7 +898,14 @@ describe("worker activities integration", () => {
       workflowId: "workflow-capped-model-debit",
     });
 
-    expect(result.status).toBe("failed");
+    // Budget exhaustion is account state, not an agent failure: the segment
+    // ends gracefully so the session accepts new messages after a top-up.
+    expect(result.status).toBe("idle");
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    const completed = events.find((event) => event.type === "turn.completed");
+    expect(completed?.payload).toMatchObject({ segmentLimit: "budget_exhausted", detail: "insufficient OpenGeni credits" });
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
     const balance = await getBillingBalance(dbClient.db, grant.accountId);
     expect(balance.balanceMicros).toBe(0);
     const usage = await listUsageEvents(dbClient.db, { accountId: grant.accountId, workspaceId: grant.workspaceId, limit: 20 });


### PR DESCRIPTION
## Summary
- The per-model-call budget/limit check (`ensureRunAllowed`, already executed after every per-response debit) now ends the turn gracefully instead of terminally failing the session: the session idles, `turn.completed` carries `segmentLimit: budget_exhausted` + a human-readable `detail`, and the turn-end run state is saved exactly as the natural turn-end path does.
- Applies to goal-bearing and goal-less sessions alike: a failed session rejects subsequent user messages, which stranded sessions precisely when a top-up would let them continue. An active goal still pauses visibly (`reason: limits`) at the next continuation evaluation via the existing `goalRunBudgetBlocked` path, without consuming continuation budget.

## Why
Same defect class as #27/#28: a recoverable condition (account state) treated as terminal for long-running autonomous sessions. The check itself already ran per model call — only its failure mode was wrong.

## Verification
- `bun run typecheck` clean
- `bun test test/integration/worker-activity.integration.ts` 37/37 — the existing "caps model usage debits at the prepaid balance" test now asserts the graceful path (idle, no `turn.failed`, `budget_exhausted` payload, exact zero balance, debit still capped)
- `bun run test:unit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing/limit enforcement outcomes in runAgentSegment (session lifecycle and events), aligned with existing max-turns handling but affecting when users can send messages after credits hit zero.
> 
> **Overview**
> When **`ensureRunAllowed`** fails after a per-response model debit (credits or usage limits), the worker no longer treats that as a terminal agent failure.
> 
> Failures are wrapped in **`BudgetExhaustedError`** with serialized SDK run state when available. The outer catch follows the same graceful path as **max turns**: flush events, optionally **`saveRunState`**, emit **`turn.completed`** with **`segmentLimit: "budget_exhausted"`** and **`detail`**, idle the session and turn, and record **`agent_run.completed`** — no **`turn.failed`**.
> 
> Integration test **"caps model usage debits at the prepaid balance"** now expects **`idle`**, no **`turn.failed`**, and the **`budget_exhausted`** payload instead of **`failed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e0e8d92ab159ea5cd54807a990f6ea5cc76c111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->