### PR TITLE
Use workspace-scoped TanStack Router web routes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@tailwindcss/vite": "^4.2.4",
+    "@tanstack/react-router": "^1.170.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
@@ -25,6 +26,8 @@
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
+    "@tanstack/react-router-devtools": "^1.167.0",
+    "@tanstack/router-plugin": "^1.168.18",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -14,8 +14,21 @@ import {
   scheduleFromFormState,
   selectedAvailableCapabilityToolIds,
   summarizePackContents,
+  workspaceAgentPath,
+  workspaceSessionPath,
 } from "./App";
 import type { CapabilityCatalogItem, GitHubRepository, ResourceRef, ScheduledTask, ScheduledTaskScheduleSpec, Session, SessionEvent } from "./types";
+
+describe("workspace route helpers", () => {
+  test("builds canonical workspace-scoped console URLs", () => {
+    expect(workspaceAgentPath("workspace-1")).toBe("/workspaces/workspace-1/agent");
+    expect(workspaceSessionPath("workspace-1", "session-1")).toBe("/workspaces/workspace-1/sessions/session-1");
+  });
+
+  test("does not build legacy unscoped session URLs", () => {
+    expect(workspaceSessionPath("workspace-1", "session-1")).not.toBe("/sessions/session-1");
+  });
+});
 
 describe("projectConversation", () => {
   test("keeps assistant messages and activity groups in event order", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -387,6 +387,7 @@ function RootRouteComponent() {
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(() => new Set());
   const previousCapabilityToolIds = useRef<Set<string>>(new Set());
   const githubRefreshId = useRef(0);
+  const mcpRefreshId = useRef(0);
   const [busy, setBusy] = useState(false);
   const [repoBusy, setRepoBusy] = useState(false);
   const [githubAppBusy, setGithubAppBusy] = useState(false);
@@ -548,8 +549,10 @@ function RootRouteComponent() {
   }
 
   async function refreshWorkspaceMcpServers(workspaceId: string, signal?: AbortSignal) {
+    const refreshId = mcpRefreshId.current + 1;
+    mcpRefreshId.current = refreshId;
     const catalog = await fetchCapabilities(workspaceId, signal);
-    if (signal?.aborted) {
+    if (signal?.aborted || mcpRefreshId.current !== refreshId) {
       return;
     }
     setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
@@ -838,13 +841,17 @@ function WorkspaceShellRoute() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
   const isSessionRoute = pathname.includes(`/workspaces/${workspaceId}/sessions/`);
+  const previousWorkspaceId = useRef<string | null>(null);
 
   useEffect(() => {
     if (!activeWorkspace) {
       return;
     }
     const abortController = new AbortController();
-    context.resetSessionView();
+    if (previousWorkspaceId.current !== workspaceId) {
+      context.resetSessionView();
+    }
+    previousWorkspaceId.current = workspaceId;
     context.resetWorkspaceIntegrations();
     context.setSelectedRepoIds(new Set());
     context.setSelectedRepoRefs({});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -264,14 +264,15 @@ type AppContextValue = {
   addManualRepository: () => void;
   forgetAccessKey: () => void;
   handleManagedSignOut: () => Promise<void>;
-  refreshGitHub: (workspaceId: string) => Promise<void>;
-  refreshWorkspaceMcpServers: (workspaceId: string) => Promise<void>;
+  refreshGitHub: (workspaceId: string, signal?: AbortSignal) => Promise<void>;
+  refreshWorkspaceMcpServers: (workspaceId: string, signal?: AbortSignal) => Promise<void>;
   startGitHubAppManifestFlow: (workspaceId: string) => Promise<void>;
   toggleGitHubRepository: (repo: GitHubRepository) => void;
   startSession: (workspaceId: string, submission: TurnSubmission) => Promise<Session | null>;
   submitFollowUp: (workspaceId: string, sessionId: string, submission: TurnSubmission) => Promise<void>;
   interruptSession: (workspaceId: string, sessionId: string) => Promise<void>;
   resetSessionView: () => void;
+  resetWorkspaceIntegrations: () => void;
 };
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -511,25 +512,43 @@ function RootRouteComponent() {
     previousCapabilityToolIds.current = new Set(availableIds);
   }, [clientConfig, customMcpServers]);
 
-  async function refreshGitHub(workspaceId: string) {
+  async function refreshGitHub(workspaceId: string, signal?: AbortSignal) {
     setRepoBusy(true);
     try {
-      const status = await fetchGitHubStatus(workspaceId);
+      const status = await fetchGitHubStatus(workspaceId, signal);
+      if (signal?.aborted) {
+        return;
+      }
       setGithubStatus(status);
       setGithubAppOpen(!status.configured);
       if (status.configured) {
-        setGithubRepos(await fetchGitHubRepositories(workspaceId));
+        const repositories = await fetchGitHubRepositories(workspaceId, signal);
+        if (signal?.aborted) {
+          return;
+        }
+        setGithubRepos(repositories);
+      } else {
+        setGithubRepos([]);
       }
     } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
       setGithubStatus({ configured: false, missing: [], installUrl: null });
+      setGithubRepos([]);
       toast.error("GitHub status unavailable", { description: String(error) });
     } finally {
-      setRepoBusy(false);
+      if (!signal?.aborted) {
+        setRepoBusy(false);
+      }
     }
   }
 
-  async function refreshWorkspaceMcpServers(workspaceId: string) {
-    const catalog = await fetchCapabilities(workspaceId);
+  async function refreshWorkspaceMcpServers(workspaceId: string, signal?: AbortSignal) {
+    const catalog = await fetchCapabilities(workspaceId, signal);
+    if (signal?.aborted) {
+      return;
+    }
     setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
   }
 
@@ -687,6 +706,12 @@ function RootRouteComponent() {
     setConnectionState("closed");
   }
 
+  function resetWorkspaceIntegrations() {
+    setGithubStatus(null);
+    setGithubRepos([]);
+    setWorkspaceMcpServers([]);
+  }
+
   const appContext = clientConfig && accessContext ? {
     clientConfig,
     authSession: authSession ?? null,
@@ -744,6 +769,7 @@ function RootRouteComponent() {
     submitFollowUp,
     interruptSession,
     resetSessionView,
+    resetWorkspaceIntegrations,
   } satisfies AppContextValue : null;
 
   return (
@@ -814,12 +840,19 @@ function WorkspaceShellRoute() {
     if (!activeWorkspace) {
       return;
     }
+    const abortController = new AbortController();
     context.resetSessionView();
+    context.resetWorkspaceIntegrations();
     context.setSelectedRepoIds(new Set());
     context.setSelectedRepoRefs({});
-    void context.refreshGitHub(workspaceId);
-    void context.refreshWorkspaceMcpServers(workspaceId)
-      .catch((error) => toast.error("Failed to load workspace MCP tools", { description: String(error) }));
+    void context.refreshGitHub(workspaceId, abortController.signal);
+    void context.refreshWorkspaceMcpServers(workspaceId, abortController.signal)
+      .catch((error) => {
+        if (!isAbortError(error)) {
+          toast.error("Failed to load workspace MCP tools", { description: String(error) });
+        }
+      });
+    return () => abortController.abort();
   }, [workspaceId, context.accessKeyVersion, activeWorkspace?.id]);
 
   if (!activeWorkspace) {
@@ -5379,6 +5412,10 @@ function scheduleLabel(schedule: ScheduledTaskScheduleSpec): string {
 
 function isUiReasoningEffort(value: ReasoningEffort): value is IntelligenceEffort {
   return value === "low" || value === "medium" || value === "high" || value === "xhigh";
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function labelEffort(value: IntelligenceEffort): string {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -366,6 +366,7 @@ function RootRouteComponent() {
   const [accessContext, setAccessContext] = useState<AccessContext | null>(null);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [accessLoading, setAccessLoading] = useState(false);
+  const [accessError, setAccessError] = useState<string | null>(null);
   const [model, setModel] = useState("gpt-5.5");
   const [reasoningEffort, setReasoningEffort] = useState<IntelligenceEffort>("low");
   const [inspectorOpen, setInspectorOpen] = useState(true);
@@ -456,10 +457,12 @@ function RootRouteComponent() {
       setAccessContext(null);
       setWorkspaces([]);
       setAccessLoading(false);
+      setAccessError(null);
       return;
     }
     let cancelled = false;
     setAccessLoading(true);
+    setAccessError(null);
     void Promise.all([fetchAccessContext(), fetchWorkspaces()])
       .then(([context, nextWorkspaces]) => {
         if (cancelled) {
@@ -475,6 +478,7 @@ function RootRouteComponent() {
         toast.error("Failed to load workspace access", { description: String(error) });
         setAccessContext(null);
         setWorkspaces([]);
+        setAccessError(error instanceof Error ? error.message : String(error));
       })
       .finally(() => {
         if (!cancelled) {
@@ -636,6 +640,7 @@ function RootRouteComponent() {
     setStoredAccessKey(key);
     setHasAccessKey(true);
     setAccessKeyDraft("");
+    setAccessError(null);
     setAccessKeyVersion((version) => version + 1);
   }
 
@@ -646,6 +651,7 @@ function RootRouteComponent() {
     setEvents([]);
     setAccessContext(null);
     setWorkspaces([]);
+    setAccessError(null);
     setAccessKeyVersion((version) => version + 1);
   }
 
@@ -670,6 +676,7 @@ function RootRouteComponent() {
     setWorkspaces([]);
     setSession(null);
     setEvents([]);
+    setAccessError(null);
     setAccessKeyVersion((version) => version + 1);
     await navigate({ to: "/", replace: true });
   }
@@ -757,6 +764,16 @@ function RootRouteComponent() {
         <LoadingPanel label="Checking session" />
       ) : managedAuthRequired && !authSession ? (
         <ManagedAuthPanel onSubmit={handleManagedAuth} />
+      ) : accessError && !accessLoading ? (
+        <ProblemPanel
+          title="Workspace access unavailable"
+          description={accessError}
+          action={(
+            <Button type="button" variant="secondary" onClick={() => setAccessKeyVersion((version) => version + 1)}>
+              Retry
+            </Button>
+          )}
+        />
       ) : accessLoading || !appContext ? (
         <LoadingPanel label="Loading workspace access" />
       ) : !defaultWorkspaceId ? (
@@ -1027,7 +1044,9 @@ function SessionRoute() {
         context.setEvents([]);
         context.setConnectionState("closed");
         setLoadError(error);
-        if (!isApiErrorStatus(error, 404)) {
+        if (isApiErrorStatus(error, 404)) {
+          forgetSession(workspaceId, sessionId);
+        } else {
           toast.error("Failed to load session", { description: String(error) });
         }
       } finally {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -386,6 +386,7 @@ function RootRouteComponent() {
   const [workspaceMcpServers, setWorkspaceMcpServers] = useState<McpServerOption[]>([]);
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(() => new Set());
   const previousCapabilityToolIds = useRef<Set<string>>(new Set());
+  const githubRefreshId = useRef(0);
   const [busy, setBusy] = useState(false);
   const [repoBusy, setRepoBusy] = useState(false);
   const [githubAppBusy, setGithubAppBusy] = useState(false);
@@ -513,17 +514,19 @@ function RootRouteComponent() {
   }, [clientConfig, customMcpServers]);
 
   async function refreshGitHub(workspaceId: string, signal?: AbortSignal) {
+    const refreshId = githubRefreshId.current + 1;
+    githubRefreshId.current = refreshId;
     setRepoBusy(true);
     try {
       const status = await fetchGitHubStatus(workspaceId, signal);
-      if (signal?.aborted) {
+      if (signal?.aborted || githubRefreshId.current !== refreshId) {
         return;
       }
       setGithubStatus(status);
       setGithubAppOpen(!status.configured);
       if (status.configured) {
         const repositories = await fetchGitHubRepositories(workspaceId, signal);
-        if (signal?.aborted) {
+        if (signal?.aborted || githubRefreshId.current !== refreshId) {
           return;
         }
         setGithubRepos(repositories);
@@ -531,14 +534,14 @@ function RootRouteComponent() {
         setGithubRepos([]);
       }
     } catch (error) {
-      if (isAbortError(error)) {
+      if (isAbortError(error) || signal?.aborted || githubRefreshId.current !== refreshId) {
         return;
       }
       setGithubStatus({ configured: false, missing: [], installUrl: null });
       setGithubRepos([]);
       toast.error("GitHub status unavailable", { description: String(error) });
     } finally {
-      if (!signal?.aborted) {
+      if (githubRefreshId.current === refreshId) {
         setRepoBusy(false);
       }
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,7 +34,29 @@ import {
   WrenchIcon,
   XIcon,
 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Link,
+  Navigate,
+  Outlet,
+  RouterProvider,
+  createRoute,
+  createRootRoute,
+  createRouter,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router";
+import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Toaster, toast } from "sonner";
 
 import { Composer } from "@/components/Composer";
@@ -193,16 +215,157 @@ type ConversationActivityTurn = {
 
 type ConversationTurn = ConversationUserTurn | ConversationAssistantTurn | ConversationActivityTurn;
 
+type AppContextValue = {
+  clientConfig: ClientConfig;
+  authSession: AuthSession | null;
+  accessContext: AccessContext;
+  workspaces: Workspace[];
+  accessKeyVersion: number;
+  keyAuthRequired: boolean;
+  model: string;
+  setModel: Dispatch<SetStateAction<string>>;
+  reasoningEffort: IntelligenceEffort;
+  setReasoningEffort: Dispatch<SetStateAction<IntelligenceEffort>>;
+  inspectorOpen: boolean;
+  setInspectorOpen: Dispatch<SetStateAction<boolean>>;
+  session: Session | null;
+  setSession: Dispatch<SetStateAction<Session | null>>;
+  events: SessionEvent[];
+  setEvents: Dispatch<SetStateAction<SessionEvent[]>>;
+  connectionState: ConnectionState;
+  setConnectionState: Dispatch<SetStateAction<ConnectionState>>;
+  manualRepos: RepoDraft[];
+  setManualRepos: Dispatch<SetStateAction<RepoDraft[]>>;
+  manualReposOpen: boolean;
+  setManualReposOpen: Dispatch<SetStateAction<boolean>>;
+  selectedRepoIds: Set<number>;
+  setSelectedRepoIds: Dispatch<SetStateAction<Set<number>>>;
+  selectedRepoRefs: Record<number, string>;
+  setSelectedRepoRefs: Dispatch<SetStateAction<Record<number, string>>>;
+  githubRepos: GitHubRepository[];
+  githubStatus: { configured: boolean; missing: string[]; installUrl: string | null } | null;
+  githubAppOpen: boolean;
+  setGithubAppOpen: Dispatch<SetStateAction<boolean>>;
+  githubOrg: string;
+  setGithubOrg: Dispatch<SetStateAction<string>>;
+  openGeniToolEnabled: boolean;
+  setOpenGeniToolEnabled: Dispatch<SetStateAction<boolean>>;
+  documentSearchEnabled: boolean;
+  setDocumentSearchEnabled: Dispatch<SetStateAction<boolean>>;
+  selectedCapabilityToolIds: Set<string>;
+  setSelectedCapabilityToolIds: Dispatch<SetStateAction<Set<string>>>;
+  busy: boolean;
+  repoBusy: boolean;
+  githubAppBusy: boolean;
+  selectedInstallationId: number | null;
+  repositoryGroups: ReturnType<typeof groupRepositories>;
+  customMcpServers: McpServerOption[];
+  currentResources: ResourceRef[];
+  addManualRepository: () => void;
+  forgetAccessKey: () => void;
+  handleManagedSignOut: () => Promise<void>;
+  refreshGitHub: (workspaceId: string) => Promise<void>;
+  refreshWorkspaceMcpServers: (workspaceId: string) => Promise<void>;
+  startGitHubAppManifestFlow: (workspaceId: string) => Promise<void>;
+  toggleGitHubRepository: (repo: GitHubRepository) => void;
+  startSession: (workspaceId: string, submission: TurnSubmission) => Promise<Session | null>;
+  submitFollowUp: (workspaceId: string, sessionId: string, submission: TurnSubmission) => Promise<void>;
+  interruptSession: (workspaceId: string, sessionId: string) => Promise<void>;
+  resetSessionView: () => void;
+};
+
+const AppContext = createContext<AppContextValue | null>(null);
+
+const rootRoute = createRootRoute({
+  component: RootRouteComponent,
+  notFoundComponent: NotFoundRoute,
+});
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: RootIndexRoute,
+});
+const workspaceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "workspaces/$workspaceId",
+  component: WorkspaceShellRoute,
+});
+const workspaceIndexRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "/",
+  component: WorkspaceIndexRoute,
+});
+const workspaceAgentRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "agent",
+  component: AgentHomeRoute,
+});
+const workspaceSessionRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "sessions/$sessionId",
+  component: SessionRoute,
+});
+const workspaceDocumentsRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "documents",
+  component: DocumentsRoute,
+});
+const workspaceCapabilitiesRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "capabilities",
+  component: CapabilitiesRoute,
+});
+const workspaceSchedulesRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "schedules",
+  component: SchedulesRoute,
+});
+const workspaceAccountRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "account",
+  component: AccountRoute,
+});
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  workspaceRoute.addChildren([
+    workspaceIndexRoute,
+    workspaceAgentRoute,
+    workspaceSessionRoute,
+    workspaceDocumentsRoute,
+    workspaceCapabilitiesRoute,
+    workspaceSchedulesRoute,
+    workspaceAccountRoute,
+  ]),
+]);
+const router = createRouter({ routeTree });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
 export function App() {
-  const [sessionId, setSessionId] = useState(() => sessionIdFromPath());
-  const [activeView, setActiveView] = useState<"agent" | "documents" | "capabilities" | "account">("agent");
+  return <RouterProvider router={router} />;
+}
+
+export function workspaceAgentPath(workspaceId: string): string {
+  return `/workspaces/${encodeURIComponent(workspaceId)}/agent`;
+}
+
+export function workspaceSessionPath(workspaceId: string, sessionId: string): string {
+  return `/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`;
+}
+
+function RootRouteComponent() {
   const [session, setSession] = useState<Session | null>(null);
   const [events, setEvents] = useState<SessionEvent[]>([]);
   const [clientConfig, setClientConfig] = useState<ClientConfig | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
   const [authSession, setAuthSession] = useState<AuthSession | null | undefined>(undefined);
   const [accessContext, setAccessContext] = useState<AccessContext | null>(null);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const [accessLoading, setAccessLoading] = useState(false);
   const [model, setModel] = useState("gpt-5.5");
   const [reasoningEffort, setReasoningEffort] = useState<IntelligenceEffort>("low");
   const [inspectorOpen, setInspectorOpen] = useState(true);
@@ -227,138 +390,112 @@ export function App() {
   const [hasAccessKey, setHasAccessKey] = useState(() => getStoredAccessKey() !== null);
   const [accessKeyDraft, setAccessKeyDraft] = useState("");
   const [accessKeyVersion, setAccessKeyVersion] = useState(0);
-  const lastSequence = useMemo(() => events.reduce((max, event) => Math.max(max, event.sequence), 0), [events]);
   const keyAuthRequired = clientConfig?.auth.mode === "deploymentKey" || clientConfig?.auth.mode === "configuredToken";
   const managedAuthRequired = clientConfig?.auth.mode === "managedSession";
   const keyAuthReady = !keyAuthRequired || hasAccessKey;
-  const managedAuthReady = !managedAuthRequired || authSession !== null;
+  const managedAuthReady = !managedAuthRequired || Boolean(authSession);
   const authReady = keyAuthReady && managedAuthReady;
-  const workspaceId = selectedWorkspaceId ?? accessContext?.defaultWorkspaceId ?? workspaces[0]?.id ?? null;
-  const activeWorkspace = workspaceId ? workspaces.find((workspace) => workspace.id === workspaceId) ?? null : null;
-  const workspaceReady = authReady && workspaceId !== null;
+  const defaultWorkspaceId = accessContext?.defaultWorkspaceId ?? workspaces[0]?.id ?? accessContext?.workspaceGrants[0]?.workspaceId ?? null;
+  const navigate = useNavigate();
 
   useEffect(() => {
+    let cancelled = false;
     void fetchClientConfig()
       .then((config) => {
+        if (cancelled) {
+          return;
+        }
         setClientConfig(config);
+        setConfigError(null);
         setModel(config.defaultModel);
         if (isUiReasoningEffort(config.defaultReasoningEffort)) {
           setReasoningEffort(config.defaultReasoningEffort);
         }
       })
-      .catch((error) => toast.error("Failed to load client config", { description: String(error) }));
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        setConfigError(message);
+        toast.error("Failed to load client config", { description: message });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
-    if (clientConfig?.auth.mode !== "managedSession") {
+    if (!clientConfig) {
+      return;
+    }
+    if (clientConfig.auth.mode !== "managedSession") {
       setAuthSession(null);
       return;
     }
+    let cancelled = false;
+    setAuthSession(undefined);
     void fetchAuthSession()
-      .then(setAuthSession)
-      .catch(() => setAuthSession(null));
+      .then((nextSession) => {
+        if (!cancelled) {
+          setAuthSession(nextSession);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthSession(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [clientConfig]);
 
   useEffect(() => {
     if (!clientConfig || !authReady) {
-      return;
-    }
-    void Promise.all([fetchAccessContext(), fetchWorkspaces()])
-      .then(([context, nextWorkspaces]) => {
-        setAccessContext(context);
-        setWorkspaces(nextWorkspaces);
-        setSelectedWorkspaceId((current) => {
-          if (current && nextWorkspaces.some((workspace) => workspace.id === current)) {
-            return current;
-          }
-          return context.defaultWorkspaceId ?? nextWorkspaces[0]?.id ?? context.workspaceGrants[0]?.workspaceId ?? null;
-        });
-      })
-      .catch((error) => toast.error("Failed to load workspace access", { description: String(error) }));
-  }, [clientConfig, authReady, accessKeyVersion]);
-
-  useEffect(() => {
-    if (!clientConfig || !workspaceReady || !workspaceId) {
-      return;
-    }
-    void refreshGitHub();
-  }, [clientConfig, workspaceReady, workspaceId, accessKeyVersion]);
-
-  useEffect(() => {
-    if (!workspaceReady || !workspaceId) {
-      setWorkspaceMcpServers([]);
-      return;
-    }
-    void refreshWorkspaceMcpServers()
-      .catch((error) => toast.error("Failed to load workspace MCP tools", { description: String(error) }));
-  }, [workspaceReady, workspaceId, accessKeyVersion]);
-
-  useEffect(() => {
-    if (!workspaceReady || !workspaceId) {
-      return;
-    }
-    if (!sessionId) {
-      setSession(null);
-      setEvents([]);
-      setConnectionState("closed");
+      setAccessContext(null);
+      setWorkspaces([]);
+      setAccessLoading(false);
       return;
     }
     let cancelled = false;
-    setSession(null);
-    setEvents([]);
-    void (async () => {
-      try {
-        const [nextSession, nextEvents] = await Promise.all([
-          fetchSession(workspaceId, sessionId),
-          fetchEvents(workspaceId, sessionId),
-        ]);
+    setAccessLoading(true);
+    void Promise.all([fetchAccessContext(), fetchWorkspaces()])
+      .then(([context, nextWorkspaces]) => {
         if (cancelled) {
           return;
         }
-        setSession(nextSession);
-        setEvents(nextEvents);
-        if (isTerminalSessionStatus(nextSession.status)) {
-          forgetSession(workspaceId, nextSession.id);
-        }
-      } catch (error) {
+        setAccessContext(context);
+        setWorkspaces(nextWorkspaces);
+      })
+      .catch((error) => {
         if (cancelled) {
           return;
         }
-        setSession(null);
-        setEvents([]);
-        setConnectionState("closed");
-        if (isApiErrorStatus(error, 404)) {
-          forgetSession(workspaceId, sessionId);
-          setSessionId(null);
-          if (sessionIdFromPath() === sessionId) {
-            window.history.replaceState({}, "", "/");
-          }
-          toast.error("Session no longer exists", { description: "It was removed from recent sessions." });
-          return;
+        toast.error("Failed to load workspace access", { description: String(error) });
+        setAccessContext(null);
+        setWorkspaces([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setAccessLoading(false);
         }
-        toast.error("Failed to load session", { description: String(error) });
-      }
-    })();
+      });
     return () => {
       cancelled = true;
     };
-  }, [sessionId, workspaceReady, workspaceId, accessKeyVersion]);
-
-  useSessionStream(workspaceReady ? workspaceId : null, workspaceReady ? sessionId : null, lastSequence, accessKeyVersion, (incoming) => {
-    setEvents((current) => mergeEvents(current, incoming));
-    setSession((current) => current ? applySessionStatusEvents(current, incoming) : current);
-  }, setConnectionState);
+  }, [clientConfig, authReady, accessKeyVersion]);
 
   const selectedInstalledRepositories = githubRepos.filter((repo) => selectedRepoIds.has(repo.id));
   const selectedInstallationId = selectedInstalledRepositories[0]?.installationId ?? null;
   const repositoryGroups = useMemo(() => groupRepositories(githubRepos), [githubRepos]);
-  const conversation = useMemo(() => session ? projectConversation(session, events) : [], [session, events]);
-  const approvals = events.flatMap((event) => event.type === "session.requiresAction" ? approvalItems(event.payload) : []);
-  const canSendFollowUp = session?.status === "idle";
-  const sessionRunning = session?.status === "running" || session?.status === "queued";
   const customMcpServers = useMemo(
     () => mergeMcpServerOptions(enabledCustomMcpServers(clientConfig), workspaceMcpServers),
     [clientConfig, workspaceMcpServers],
+  );
+  const currentResources = useMemo(
+    () => buildResources(manualRepos, githubRepos, selectedRepoIds, selectedRepoRefs),
+    [manualRepos, githubRepos, selectedRepoIds, selectedRepoRefs],
   );
 
   useEffect(() => {
@@ -370,10 +507,7 @@ export function App() {
     previousCapabilityToolIds.current = new Set(availableIds);
   }, [clientConfig, customMcpServers]);
 
-  async function refreshGitHub() {
-    if (!workspaceId) {
-      return;
-    }
+  async function refreshGitHub(workspaceId: string) {
     setRepoBusy(true);
     try {
       const status = await fetchGitHubStatus(workspaceId);
@@ -390,77 +524,50 @@ export function App() {
     }
   }
 
-  async function refreshClientConfig() {
-    const config = await fetchClientConfig();
-    setClientConfig(config);
-    setModel((current) => config.allowedModels.includes(current) ? current : config.defaultModel);
-    if (isUiReasoningEffort(config.defaultReasoningEffort)) {
-      setReasoningEffort((current) => config.allowedReasoningEfforts.includes(current) ? current : config.defaultReasoningEffort as IntelligenceEffort);
-    }
-  }
-
-  async function refreshWorkspaceMcpServers() {
-    if (!workspaceId) {
-      return;
-    }
+  async function refreshWorkspaceMcpServers(workspaceId: string) {
     const catalog = await fetchCapabilities(workspaceId);
     setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
   }
 
-  async function submitInitial(submission: TurnSubmission) {
-    if (!workspaceId) {
-      toast.error("Select a workspace before starting a session");
-      return;
-    }
+  async function startSession(workspaceId: string, submission: TurnSubmission): Promise<Session | null> {
     setBusy(true);
     try {
-      const selectedResources = buildResources(manualRepos, githubRepos, selectedRepoIds, selectedRepoRefs);
       const selectedTools = buildTools(submission.tools, documentSearchEnabled, openGeniToolEnabled, [...selectedCapabilityToolIds]);
       const created = await createSession({
         workspaceId,
         initialMessage: submission.text,
-        resources: [...selectedResources, ...(submission.resources ?? [])],
+        resources: [...currentResources, ...(submission.resources ?? [])],
         tools: selectedTools,
         model,
         reasoningEffort,
       });
       rememberSession(created);
       setSession(created);
-      setSessionId(created.id);
-      window.history.pushState({}, "", `/sessions/${created.id}`);
+      setEvents([]);
+      setConnectionState("closed");
+      return created;
     } catch (error) {
       toast.error("Failed to start session", { description: error instanceof Error ? error.message : String(error) });
+      return null;
     } finally {
       setBusy(false);
     }
   }
 
-  function selectSession(id: string) {
-    setActiveView("agent");
-    setSessionId(id);
-    window.history.pushState({}, "", `/sessions/${id}`);
-  }
-
-  function goHome() {
-    setActiveView("agent");
-    setSessionId(null);
-    window.history.pushState({}, "", "/");
-  }
-
-  async function submitFollowUp(submission: TurnSubmission) {
-    if (!workspaceId || !session || !submission.text.trim()) {
+  async function submitFollowUp(workspaceId: string, sessionId: string, submission: TurnSubmission) {
+    if (!submission.text.trim()) {
       return;
     }
     setBusy(true);
     try {
-      await sendUserMessage(workspaceId, session.id, {
+      await sendUserMessage(workspaceId, sessionId, {
         ...submission,
         text: submission.text.trim(),
         tools: buildTools(submission.tools, documentSearchEnabled, openGeniToolEnabled, [...selectedCapabilityToolIds]),
         model,
         reasoningEffort,
       });
-      setSession(await fetchSession(workspaceId, session.id));
+      setSession(await fetchSession(workspaceId, sessionId));
     } catch (error) {
       toast.error("Failed to send follow-up", { description: error instanceof Error ? error.message : String(error) });
     } finally {
@@ -468,14 +575,15 @@ export function App() {
     }
   }
 
-  async function interruptSession() {
-    if (!workspaceId || !session || !sessionRunning) {
+  async function interruptSession(workspaceId: string, sessionId: string) {
+    const current = session?.id === sessionId ? session : null;
+    if (!current || (current.status !== "running" && current.status !== "queued")) {
       return;
     }
     setBusy(true);
     try {
-      await sendInterrupt(workspaceId, session.id, "user requested cancellation");
-      setSession(await fetchSession(workspaceId, session.id));
+      await sendInterrupt(workspaceId, sessionId, "user requested cancellation");
+      setSession(await fetchSession(workspaceId, sessionId));
     } catch (error) {
       toast.error("Failed to interrupt session", { description: error instanceof Error ? error.message : String(error) });
     } finally {
@@ -483,11 +591,7 @@ export function App() {
     }
   }
 
-  async function startGitHubAppManifestFlow() {
-    if (!workspaceId) {
-      toast.error("Select a workspace before setting up GitHub");
-      return;
-    }
+  async function startGitHubAppManifestFlow(workspaceId: string) {
     setGithubAppBusy(true);
     try {
       const result = await startGitHubManifest(workspaceId, githubOrg.trim() || undefined);
@@ -540,6 +644,8 @@ export function App() {
     setHasAccessKey(false);
     setSession(null);
     setEvents([]);
+    setAccessContext(null);
+    setWorkspaces([]);
     setAccessKeyVersion((version) => version + 1);
   }
 
@@ -562,340 +668,647 @@ export function App() {
     setAuthSession(null);
     setAccessContext(null);
     setWorkspaces([]);
-    setSelectedWorkspaceId(null);
     setSession(null);
     setEvents([]);
-    setSessionId(null);
     setAccessKeyVersion((version) => version + 1);
-    window.history.pushState({}, "", "/");
+    await navigate({ to: "/", replace: true });
   }
+
+  function resetSessionView() {
+    setSession(null);
+    setEvents([]);
+    setConnectionState("closed");
+  }
+
+  const appContext = clientConfig && accessContext ? {
+    clientConfig,
+    authSession: authSession ?? null,
+    accessContext,
+    workspaces,
+    accessKeyVersion,
+    keyAuthRequired: keyAuthRequired === true,
+    model,
+    setModel,
+    reasoningEffort,
+    setReasoningEffort,
+    inspectorOpen,
+    setInspectorOpen,
+    session,
+    setSession,
+    events,
+    setEvents,
+    connectionState,
+    setConnectionState,
+    manualRepos,
+    setManualRepos,
+    manualReposOpen,
+    setManualReposOpen,
+    selectedRepoIds,
+    setSelectedRepoIds,
+    selectedRepoRefs,
+    setSelectedRepoRefs,
+    githubRepos,
+    githubStatus,
+    githubAppOpen,
+    setGithubAppOpen,
+    githubOrg,
+    setGithubOrg,
+    openGeniToolEnabled,
+    setOpenGeniToolEnabled,
+    documentSearchEnabled,
+    setDocumentSearchEnabled,
+    selectedCapabilityToolIds,
+    setSelectedCapabilityToolIds,
+    busy,
+    repoBusy,
+    githubAppBusy,
+    selectedInstallationId,
+    repositoryGroups,
+    customMcpServers,
+    currentResources,
+    addManualRepository,
+    forgetAccessKey,
+    handleManagedSignOut,
+    refreshGitHub,
+    refreshWorkspaceMcpServers,
+    startGitHubAppManifestFlow,
+    toggleGitHubRepository,
+    startSession,
+    submitFollowUp,
+    interruptSession,
+    resetSessionView,
+  } satisfies AppContextValue : null;
 
   return (
     <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-[color:var(--color-bg)] text-[color:var(--color-fg)]">
       <Toaster richColors theme="dark" />
-      <header className="sticky top-0 z-40 flex h-14 items-center gap-3 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)]/75 px-4 backdrop-blur sm:px-6">
-        <button
-          type="button"
-          onClick={goHome}
-          className="flex shrink-0 items-center gap-2 rounded-md px-1.5 py-1 text-[15px] font-medium text-[color:var(--color-fg)] hover:bg-[color:var(--color-surface-2)]"
-        >
-          <span className="flex size-6 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
-            <SparkleIcon className="size-3.5" />
-          </span>
-          <span>OpenGeni Agent</span>
-        </button>
-
-        <nav className="flex items-center gap-1 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-1">
-          <Button
-            type="button"
-            variant={activeView === "agent" ? "secondary" : "ghost"}
-            size="sm"
-            onClick={() => setActiveView("agent")}
-            className="h-8 px-2.5 text-xs"
-          >
-            <BotIcon className="size-3.5" />
-            <span className="hidden sm:inline">Agent</span>
-          </Button>
-          <Button
-            type="button"
-            variant={activeView === "documents" ? "secondary" : "ghost"}
-            size="sm"
-            onClick={() => setActiveView("documents")}
-            className="h-8 px-2.5 text-xs"
-          >
-            <FileSearchIcon className="size-3.5" />
-            <span className="hidden sm:inline">Documents</span>
-          </Button>
-          <Button
-            type="button"
-            variant={activeView === "capabilities" ? "secondary" : "ghost"}
-            size="sm"
-            onClick={() => setActiveView("capabilities")}
-            className="h-8 px-2.5 text-xs"
-          >
-            <PlugIcon className="size-3.5" />
-            <span className="hidden sm:inline">Capabilities</span>
-          </Button>
-          <Button
-            type="button"
-            variant={activeView === "account" ? "secondary" : "ghost"}
-            size="sm"
-            onClick={() => setActiveView("account")}
-            className="h-8 px-2.5 text-xs"
-          >
-            <UserIcon className="size-3.5" />
-            <span className="hidden sm:inline">Account</span>
-          </Button>
-        </nav>
-
-        {session && activeView === "agent" ? (
-          <div className="flex min-w-0 items-center gap-2">
-            <Button type="button" variant="ghost" size="icon-sm" onClick={goHome} aria-label="Back to sessions">
-              <ArrowLeftIcon className="size-4" />
-            </Button>
-            <div className="hidden min-w-0 sm:block">
-              <div className="truncate text-sm font-medium">{session.initialMessage}</div>
-              <div className="truncate text-xs text-[color:var(--color-fg-subtle)]">
-                {session.model} · {String(session.metadata.reasoningEffort ?? "low")} · {session.sandboxBackend}
-              </div>
-            </div>
-          </div>
-        ) : null}
-
-        {workspaces.length > 1 ? (
-          <label className="hidden min-w-0 items-center gap-2 sm:flex">
-            <span className="sr-only">Workspace</span>
-            <select
-              value={workspaceId ?? ""}
-              onChange={(event) => {
-                const nextWorkspaceId = event.target.value || null;
-                setSelectedWorkspaceId(nextWorkspaceId);
-                setSession(null);
-                setEvents([]);
-                setSessionId(null);
-                window.history.pushState({}, "", "/");
-              }}
-              className="h-8 max-w-52 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 text-xs text-[color:var(--color-fg)]"
-            >
-              {workspaces.map((workspace) => (
-                <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
-              ))}
-            </select>
-          </label>
-        ) : activeWorkspace ? (
-          <div className="hidden max-w-52 truncate rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1.5 text-xs text-[color:var(--color-fg-muted)] sm:block">
-            {activeWorkspace.name}
-          </div>
-        ) : null}
-
-        <div className="ml-auto flex items-center gap-2">
-          {keyAuthRequired ? (
-            <Button type="button" variant="ghost" size="icon-sm" onClick={forgetAccessKey} aria-label="Clear access key">
-              <LockIcon className="size-4" />
-            </Button>
-          ) : null}
-          {session && activeView === "agent" ? <ConnectionPill state={connectionState} /> : null}
-          {session && activeView === "agent" ? <StatusBadge status={session.status} /> : null}
-          {session && activeView === "agent" ? (
-            <Button
-              type="button"
-              variant={inspectorOpen ? "secondary" : "ghost"}
-              size="icon-sm"
-              onClick={() => setInspectorOpen((open) => !open)}
-              aria-label="Toggle debug inspector"
-            >
-              <PanelRightIcon className="size-4" />
-            </Button>
-          ) : null}
-        </div>
-      </header>
-
-      {keyAuthRequired && !hasAccessKey ? (
-        <section className="flex flex-1 items-center justify-center px-4">
-          <form
-            className="w-full max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 shadow-sm"
-            onSubmit={(event) => {
-              event.preventDefault();
-              saveAccessKey();
-            }}
-          >
-            <div className="mb-4 flex items-center gap-3">
-              <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
-                <LockIcon className="size-4" />
-              </span>
-              <div>
-                <h1 className="text-base font-semibold">Access key required</h1>
-                <p className="text-sm text-[color:var(--color-fg-subtle)]">
-                  Enter the {clientConfig?.auth.mode === "configuredToken" ? "configured bearer token" : "deployment key"} for this OpenGeni instance.
-                </p>
-              </div>
-            </div>
-            <Label htmlFor="access-key">Access key</Label>
-            <Input
-              id="access-key"
-              type="password"
-              value={accessKeyDraft}
-              onChange={(event) => setAccessKeyDraft(event.target.value)}
-              autoComplete="current-password"
-              className="mt-2"
-              autoFocus
-            />
-            <Button type="submit" className="mt-4 w-full">
-              <CheckIcon className="size-4" />
-              Continue
-            </Button>
-          </form>
-        </section>
+      {!clientConfig && !configError ? (
+        <LoadingPanel label="Loading OpenGeni" />
+      ) : configError ? (
+        <ProblemPanel title="Client configuration unavailable" description={configError} />
+      ) : keyAuthRequired && !hasAccessKey ? (
+        <AccessKeyPanel
+          authMode={clientConfig?.auth.mode}
+          accessKeyDraft={accessKeyDraft}
+          setAccessKeyDraft={setAccessKeyDraft}
+          onSubmit={saveAccessKey}
+        />
       ) : managedAuthRequired && authSession === undefined ? (
-        <section className="grid flex-1 place-items-center px-4 text-center">
-          <div className="max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 text-sm text-[color:var(--color-fg-muted)]">
-            <Loader2Icon className="mx-auto mb-3 size-5 animate-spin text-[color:var(--color-fg)]" />
-            Checking session
-          </div>
-        </section>
+        <LoadingPanel label="Checking session" />
       ) : managedAuthRequired && !authSession ? (
         <ManagedAuthPanel onSubmit={handleManagedAuth} />
-      ) : !workspaceReady ? (
-        <section className="grid flex-1 place-items-center px-4 text-center">
-          <div className="max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 text-sm text-[color:var(--color-fg-muted)]">
-            <Loader2Icon className="mx-auto mb-3 size-5 animate-spin text-[color:var(--color-fg)]" />
-            Loading workspace
-          </div>
-        </section>
+      ) : accessLoading || !appContext ? (
+        <LoadingPanel label="Loading workspace access" />
+      ) : !defaultWorkspaceId ? (
+        <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />
       ) : (
-        <>
-
-      {activeView === "account" ? (
-        <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
-          <AccountConsole
-            workspaceId={workspaceId ?? ""}
-            accountId={accessContext?.defaultAccountId ?? activeWorkspace?.accountId ?? ""}
-            authSession={authSession ?? null}
-            accessContext={accessContext}
-            clientConfig={clientConfig}
-            onSignOut={() => void handleManagedSignOut().catch((error) => toast.error("Sign out failed", { description: String(error) }))}
-          />
-        </div>
-      ) : activeView === "capabilities" ? (
-        <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
-          <CapabilitiesWorkspace workspaceId={workspaceId ?? ""} onRuntimeChanged={() => void refreshWorkspaceMcpServers()} />
-        </div>
-      ) : activeView === "documents" ? (
-        <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
-          <DocumentsWorkspace workspaceId={workspaceId ?? ""} fileUploadsEnabled={clientConfig?.fileUploads.enabled === true} />
-        </div>
-      ) : !session ? (
-        <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 pt-10 pb-16 sm:px-6 sm:pt-16">
-          <section className="flex flex-col items-center gap-2 text-center">
-            <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
-              What should the agent do?
-            </h1>
-            <p className="max-w-md text-sm text-[color:var(--color-fg-muted)]">
-              Start a durable sandbox session with live streams, approvals, interrupts, and follow-ups.
-            </p>
-          </section>
-
-          <div className="mt-8">
-            <Composer
-              workspaceId={workspaceId ?? ""}
-              autoFocus
-              pending={busy}
-              fileUploadsEnabled={clientConfig?.fileUploads.enabled === true}
-              placeholder="Describe a task for the agent..."
-              submitLabel={busy ? "Starting" : "Send"}
-              examples={examples}
-              controlsStart={
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <ModelPicker
-                    config={clientConfig}
-                    model={model}
-                    effort={reasoningEffort}
-                    disabled={busy}
-                    onModelChange={setModel}
-                    onEffortChange={setReasoningEffort}
-                  />
-                  <RepositoryContextPicker
-                    configured={githubStatus?.configured === true}
-                    installUrl={githubStatus?.installUrl ?? null}
-                    repositories={githubRepos}
-                    groups={repositoryGroups}
-                    selectedRepoIds={selectedRepoIds}
-                    selectedRepoRefs={selectedRepoRefs}
-                    selectedInstallationId={selectedInstallationId}
-                    manualRepos={manualRepos}
-                    manualOpen={manualReposOpen}
-                    githubAppOpen={githubAppOpen}
-                    org={githubOrg}
-                    pending={busy}
-                    repoBusy={repoBusy}
-                    githubAppBusy={githubAppBusy}
-                    onRefresh={refreshGitHub}
-                    onToggleRepo={toggleGitHubRepository}
-                    onRefChange={(repoId, ref) => setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref }))}
-                    onManualOpenChange={setManualReposOpen}
-                    onManualAdd={addManualRepository}
-                    onManualUpdate={(id, patch) => setManualRepos((current) => current.map((repo) => repo.id === id ? { ...repo, ...patch } : repo))}
-                    onManualRemove={(id) => setManualRepos((current) => current.filter((repo) => repo.id !== id))}
-                    onGitHubAppOpenChange={setGithubAppOpen}
-                    onOrgChange={setGithubOrg}
-                    onStartGitHubApp={startGitHubAppManifestFlow}
-                  />
-                  <DocumentSearchToolToggle
-                    enabled={documentSearchEnabled}
-                    disabled={busy}
-                    onToggle={() => setDocumentSearchEnabled((enabled) => !enabled)}
-                  />
-                  <OpenGeniToolToggle
-                    enabled={openGeniToolEnabled}
-                    disabled={busy}
-                    onToggle={() => setOpenGeniToolEnabled((enabled) => !enabled)}
-                  />
-                  <EnabledMcpToolPicker
-                    servers={customMcpServers}
-                    selectedIds={selectedCapabilityToolIds}
-                    disabled={busy}
-                    onChange={setSelectedCapabilityToolIds}
-                  />
-                </div>
-              }
-              onSubmit={submitInitial}
-            />
-            <RecentSessions workspaceId={workspaceId} onSelect={selectSession} />
-            <ScheduledTasksPanel
-              workspaceId={workspaceId ?? ""}
-              clientConfig={clientConfig}
-              resources={buildResources(manualRepos, githubRepos, selectedRepoIds, selectedRepoRefs)}
-              githubConfigured={githubStatus?.configured === true}
-              githubRepos={githubRepos}
-              repositoryGroups={repositoryGroups}
-              repoBusy={repoBusy}
-              onRefreshRepositories={refreshGitHub}
-              model={model}
-              reasoningEffort={reasoningEffort}
-              onSelectSession={selectSession}
-            />
-          </div>
-        </div>
-      ) : (
-        <div className={cn("grid min-h-0 w-full min-w-0 flex-1 grid-cols-1 overflow-hidden", inspectorOpen && "lg:grid-cols-[minmax(0,1fr)_minmax(0,390px)]")}>
-          <SessionChatPane
-            conversation={conversation}
-            approvals={approvals}
-            busy={busy}
-            canSendFollowUp={canSendFollowUp}
-            session={session}
-            sessionRunning={sessionRunning}
-            fileUploadsEnabled={clientConfig?.fileUploads.enabled === true}
-            documentSearchEnabled={documentSearchEnabled}
-            openGeniToolEnabled={openGeniToolEnabled}
-            customMcpServers={customMcpServers}
-            selectedCapabilityToolIds={selectedCapabilityToolIds}
-            clientConfig={clientConfig}
-            model={model}
-            reasoningEffort={reasoningEffort}
-            onDocumentSearchToggle={() => setDocumentSearchEnabled((enabled) => !enabled)}
-            onOpenGeniToolToggle={() => setOpenGeniToolEnabled((enabled) => !enabled)}
-            onCapabilityToolIdsChange={setSelectedCapabilityToolIds}
-            onModelChange={setModel}
-            onReasoningEffortChange={setReasoningEffort}
-            onSubmit={submitFollowUp}
-            onInterrupt={interruptSession}
-            onNewSession={goHome}
-            onApprove={(approvalId) => workspaceId ? void sendApproval(workspaceId, session.id, approvalId, "approve") : undefined}
-            onReject={(approvalId) => workspaceId ? void sendApproval(workspaceId, session.id, approvalId, "reject") : undefined}
-          />
-
-          {inspectorOpen ? (
-            <aside className="min-h-0 w-full min-w-0 overflow-hidden border-t border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 lg:border-t-0 lg:border-l">
-              <SessionInspector session={session} events={events} connectionState={connectionState} />
-            </aside>
-          ) : null}
-        </div>
-      )}
-        </>
+        <AppContext.Provider value={appContext}>
+          <Outlet />
+          {import.meta.env.DEV ? <TanStackRouterDevtools position="bottom-right" /> : null}
+        </AppContext.Provider>
       )}
     </main>
   );
+}
+
+function RootIndexRoute() {
+  const context = useAppContext();
+  const workspaceId = context.accessContext.defaultWorkspaceId ?? context.workspaces[0]?.id ?? context.accessContext.workspaceGrants[0]?.workspaceId;
+  if (!workspaceId) {
+    return <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />;
+  }
+  return <Navigate to="/workspaces/$workspaceId/agent" params={{ workspaceId }} replace />;
+}
+
+function WorkspaceIndexRoute() {
+  const { workspaceId } = workspaceRoute.useParams();
+  return <Navigate to="/workspaces/$workspaceId/agent" params={{ workspaceId }} replace />;
+}
+
+function WorkspaceShellRoute() {
+  const context = useAppContext();
+  const navigate = useNavigate();
+  const { workspaceId } = workspaceRoute.useParams();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
+  const isSessionRoute = pathname.includes(`/workspaces/${workspaceId}/sessions/`);
+
+  useEffect(() => {
+    if (!activeWorkspace) {
+      return;
+    }
+    context.resetSessionView();
+    context.setSelectedRepoIds(new Set());
+    context.setSelectedRepoRefs({});
+    void context.refreshGitHub(workspaceId);
+    void context.refreshWorkspaceMcpServers(workspaceId)
+      .catch((error) => toast.error("Failed to load workspace MCP tools", { description: String(error) }));
+  }, [workspaceId, context.accessKeyVersion, activeWorkspace?.id]);
+
+  if (!activeWorkspace) {
+    return (
+      <>
+        <WorkspaceHeader workspaceId={workspaceId} activeWorkspace={null} isSessionRoute={false} onChangeWorkspace={changeWorkspace} />
+        <ProblemPanel
+          title="Workspace unavailable"
+          description="The URL workspace is not available to this subject."
+          action={<Button asChild type="button" variant="secondary"><Link to="/">Open default workspace</Link></Button>}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <WorkspaceHeader workspaceId={workspaceId} activeWorkspace={activeWorkspace} isSessionRoute={isSessionRoute} onChangeWorkspace={changeWorkspace} />
+      <Outlet />
+    </>
+  );
+
+  async function changeWorkspace(nextWorkspaceId: string) {
+    context.resetSessionView();
+    await navigate({ to: "/workspaces/$workspaceId/agent", params: { workspaceId: nextWorkspaceId } });
+  }
+}
+
+function WorkspaceHeader(props: {
+  workspaceId: string;
+  activeWorkspace: Workspace | null;
+  isSessionRoute: boolean;
+  onChangeWorkspace: (workspaceId: string) => void;
+}) {
+  const context = useAppContext();
+  return (
+    <header className="sticky top-0 z-40 flex h-14 items-center gap-2 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)]/75 px-3 backdrop-blur sm:gap-3 sm:px-6">
+      <Button asChild type="button" variant="ghost" size="sm" className="h-9 shrink-0 px-1.5 text-[15px] font-medium">
+        <Link to="/workspaces/$workspaceId/agent" params={{ workspaceId: props.workspaceId }}>
+          <span className="flex size-6 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+            <SparkleIcon className="size-3.5" />
+          </span>
+          <span className="hidden sm:inline">OpenGeni Agent</span>
+        </Link>
+      </Button>
+
+      <nav className="flex min-w-0 items-center gap-1 overflow-x-auto rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-1">
+        <NavButton to="/workspaces/$workspaceId/agent" workspaceId={props.workspaceId} icon={<BotIcon className="size-3.5" />} label="Agent" />
+        <NavButton to="/workspaces/$workspaceId/documents" workspaceId={props.workspaceId} icon={<FileSearchIcon className="size-3.5" />} label="Documents" />
+        <NavButton to="/workspaces/$workspaceId/capabilities" workspaceId={props.workspaceId} icon={<PlugIcon className="size-3.5" />} label="Capabilities" />
+        <NavButton to="/workspaces/$workspaceId/schedules" workspaceId={props.workspaceId} icon={<CalendarClockIcon className="size-3.5" />} label="Schedules" />
+        <NavButton to="/workspaces/$workspaceId/account" workspaceId={props.workspaceId} icon={<UserIcon className="size-3.5" />} label="Account" />
+      </nav>
+
+      {context.session && props.isSessionRoute ? (
+        <div className="hidden min-w-0 items-center gap-2 lg:flex">
+          <Button asChild type="button" variant="ghost" size="icon-sm" aria-label="Back to agent">
+            <Link to="/workspaces/$workspaceId/agent" params={{ workspaceId: props.workspaceId }}>
+              <ArrowLeftIcon className="size-4" />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium">{context.session.initialMessage}</div>
+            <div className="truncate text-xs text-[color:var(--color-fg-subtle)]">
+              {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")} · {context.session.sandboxBackend}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <label className="ml-auto flex min-w-28 max-w-44 items-center gap-2 sm:min-w-40 sm:max-w-64">
+        <span className="sr-only">Workspace</span>
+        <select
+          value={props.activeWorkspace?.id ?? props.workspaceId}
+          onChange={(event) => props.onChangeWorkspace(event.target.value)}
+          className="h-8 w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 text-xs text-[color:var(--color-fg)]"
+        >
+          {context.workspaces.map((workspace) => (
+            <option key={workspace.id} value={workspace.id}>{workspaceLabel(workspace, context.workspaces)}</option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {context.keyAuthRequired ? (
+          <Button type="button" variant="ghost" size="icon-sm" onClick={context.forgetAccessKey} aria-label="Clear access key">
+            <LockIcon className="size-4" />
+          </Button>
+        ) : null}
+        {context.session && props.isSessionRoute ? <ConnectionPill state={context.connectionState} /> : null}
+        {context.session && props.isSessionRoute ? <StatusBadge status={context.session.status} /> : null}
+        {context.session && props.isSessionRoute ? (
+          <Button
+            type="button"
+            variant={context.inspectorOpen ? "secondary" : "ghost"}
+            size="icon-sm"
+            onClick={() => context.setInspectorOpen((open) => !open)}
+            aria-label="Toggle debug inspector"
+          >
+            <PanelRightIcon className="size-4" />
+          </Button>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function NavButton(props: {
+  to:
+    | "/workspaces/$workspaceId/agent"
+    | "/workspaces/$workspaceId/documents"
+    | "/workspaces/$workspaceId/capabilities"
+    | "/workspaces/$workspaceId/schedules"
+    | "/workspaces/$workspaceId/account";
+  workspaceId: string;
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <Link
+      to={props.to}
+      params={{ workspaceId: props.workspaceId }}
+      activeProps={{ "data-active": "true" }}
+      className={cn(
+        "inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2.5 text-xs font-medium text-[color:var(--color-fg-muted)] transition-colors hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
+        "data-[active=true]:bg-[color:var(--color-surface-2)] data-[active=true]:text-[color:var(--color-fg)]",
+      )}
+    >
+      {props.icon}
+      <span className="hidden sm:inline">{props.label}</span>
+    </Link>
+  );
+}
+
+function AgentHomeRoute() {
+  const context = useAppContext();
+  const navigate = useNavigate();
+  const { workspaceId } = workspaceAgentRoute.useParams();
+
+  useEffect(() => {
+    context.resetSessionView();
+  }, [workspaceId]);
+
+  async function submitInitial(submission: TurnSubmission) {
+    const created = await context.startSession(workspaceId, submission);
+    if (created) {
+      await navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: created.id } });
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 pt-10 pb-16 sm:px-6 sm:pt-16">
+      <section className="flex flex-col items-center gap-2 text-center">
+        <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
+          What should the agent do?
+        </h1>
+        <p className="max-w-md text-sm text-[color:var(--color-fg-muted)]">
+          Start a durable sandbox session with live streams, approvals, interrupts, and follow-ups.
+        </p>
+      </section>
+
+      <div className="mt-8">
+        <Composer
+          workspaceId={workspaceId}
+          autoFocus
+          pending={context.busy}
+          fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
+          placeholder="Describe a task for the agent..."
+          submitLabel={context.busy ? "Starting" : "Send"}
+          examples={examples}
+          controlsStart={<AgentControlStrip workspaceId={workspaceId} />}
+          onSubmit={(submission) => void submitInitial(submission)}
+        />
+        <RecentSessions
+          workspaceId={workspaceId}
+          onSelect={(id) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: id } })}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SessionRoute() {
+  const context = useAppContext();
+  const { workspaceId, sessionId } = workspaceSessionRoute.useParams();
+  const navigate = useNavigate();
+  const [loadError, setLoadError] = useState<unknown>(null);
+  const [loading, setLoading] = useState(true);
+  const lastSequence = useMemo(() => context.events.reduce((max, event) => Math.max(max, event.sequence), 0), [context.events]);
+  const session = context.session?.workspaceId === workspaceId && context.session.id === sessionId ? context.session : null;
+  const conversation = useMemo(() => session ? projectConversation(session, context.events) : [], [session, context.events]);
+  const approvals = context.events.flatMap((event) => event.type === "session.requiresAction" ? approvalItems(event.payload) : []);
+  const canSendFollowUp = session?.status === "idle";
+  const sessionRunning = session?.status === "running" || session?.status === "queued";
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    context.setSession(null);
+    context.setEvents([]);
+    context.setConnectionState("closed");
+    void (async () => {
+      try {
+        const [nextSession, nextEvents] = await Promise.all([
+          fetchSession(workspaceId, sessionId),
+          fetchEvents(workspaceId, sessionId),
+        ]);
+        if (cancelled) {
+          return;
+        }
+        context.setSession(nextSession);
+        context.setEvents(nextEvents);
+        if (isTerminalSessionStatus(nextSession.status)) {
+          forgetSession(workspaceId, nextSession.id);
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        context.setSession(null);
+        context.setEvents([]);
+        context.setConnectionState("closed");
+        setLoadError(error);
+        if (!isApiErrorStatus(error, 404)) {
+          toast.error("Failed to load session", { description: String(error) });
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, sessionId, context.accessKeyVersion]);
+
+  useSessionStream(session ? workspaceId : null, session ? sessionId : null, lastSequence, context.accessKeyVersion, (incoming) => {
+    context.setEvents((current) => mergeEvents(current, incoming));
+    context.setSession((current) => current ? applySessionStatusEvents(current, incoming) : current);
+  }, context.setConnectionState);
+
+  if (loading || !session) {
+    if (loadError) {
+      return isApiErrorStatus(loadError, 404) ? (
+        <ProblemPanel
+          title="Session not found in this workspace"
+          description="The session ID is not available under the workspace in the URL."
+          action={<Button asChild type="button" variant="secondary"><Link to="/workspaces/$workspaceId/agent" params={{ workspaceId }}>Back to agent</Link></Button>}
+        />
+      ) : (
+        <ProblemPanel
+          title="Unable to open session"
+          description={loadError instanceof Error ? loadError.message : String(loadError)}
+          action={<Button asChild type="button" variant="secondary"><Link to="/workspaces/$workspaceId/agent" params={{ workspaceId }}>Back to agent</Link></Button>}
+        />
+      );
+    }
+    return <LoadingPanel label="Opening session" />;
+  }
+
+  return (
+    <div className={cn("grid min-h-0 w-full min-w-0 flex-1 grid-cols-1 overflow-hidden", context.inspectorOpen && "lg:grid-cols-[minmax(0,1fr)_minmax(0,390px)]")}>
+      <SessionChatPane
+        conversation={conversation}
+        approvals={approvals}
+        busy={context.busy}
+        canSendFollowUp={canSendFollowUp}
+        session={session}
+        sessionRunning={sessionRunning}
+        fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
+        documentSearchEnabled={context.documentSearchEnabled}
+        openGeniToolEnabled={context.openGeniToolEnabled}
+        customMcpServers={context.customMcpServers}
+        selectedCapabilityToolIds={context.selectedCapabilityToolIds}
+        clientConfig={context.clientConfig}
+        model={context.model}
+        reasoningEffort={context.reasoningEffort}
+        onDocumentSearchToggle={() => context.setDocumentSearchEnabled((enabled) => !enabled)}
+        onOpenGeniToolToggle={() => context.setOpenGeniToolEnabled((enabled) => !enabled)}
+        onCapabilityToolIdsChange={context.setSelectedCapabilityToolIds}
+        onModelChange={context.setModel}
+        onReasoningEffortChange={context.setReasoningEffort}
+        onSubmit={(submission) => void context.submitFollowUp(workspaceId, session.id, submission)}
+        onInterrupt={() => void context.interruptSession(workspaceId, session.id)}
+        onNewSession={() => void navigate({ to: "/workspaces/$workspaceId/agent", params: { workspaceId } })}
+        onApprove={(approvalId) => void sendApproval(workspaceId, session.id, approvalId, "approve")}
+        onReject={(approvalId) => void sendApproval(workspaceId, session.id, approvalId, "reject")}
+      />
+
+      {context.inspectorOpen ? (
+        <aside className="min-h-0 w-full min-w-0 overflow-hidden border-t border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 lg:border-t-0 lg:border-l">
+          <SessionInspector session={session} events={context.events} connectionState={context.connectionState} />
+        </aside>
+      ) : null}
+    </div>
+  );
+}
+
+function DocumentsRoute() {
+  const context = useAppContext();
+  const { workspaceId } = workspaceDocumentsRoute.useParams();
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+      <DocumentsWorkspace workspaceId={workspaceId} fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true} />
+    </div>
+  );
+}
+
+function CapabilitiesRoute() {
+  const context = useAppContext();
+  const { workspaceId } = workspaceCapabilitiesRoute.useParams();
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+      <CapabilitiesWorkspace workspaceId={workspaceId} onRuntimeChanged={() => void context.refreshWorkspaceMcpServers(workspaceId)} />
+    </div>
+  );
+}
+
+function SchedulesRoute() {
+  const context = useAppContext();
+  const navigate = useNavigate();
+  const { workspaceId } = workspaceSchedulesRoute.useParams();
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+      <ScheduledTasksPanel
+        workspaceId={workspaceId}
+        clientConfig={context.clientConfig}
+        resources={context.currentResources}
+        githubConfigured={context.githubStatus?.configured === true}
+        githubRepos={context.githubRepos}
+        repositoryGroups={context.repositoryGroups}
+        repoBusy={context.repoBusy}
+        onRefreshRepositories={() => context.refreshGitHub(workspaceId)}
+        model={context.model}
+        reasoningEffort={context.reasoningEffort}
+        onSelectSession={(id) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: id } })}
+      />
+    </div>
+  );
+}
+
+function AccountRoute() {
+  const context = useAppContext();
+  const { workspaceId } = workspaceAccountRoute.useParams();
+  const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+      <AccountConsole
+        workspaceId={workspaceId}
+        accountId={activeWorkspace?.accountId ?? ""}
+        authSession={context.authSession}
+        accessContext={context.accessContext}
+        clientConfig={context.clientConfig}
+        onSignOut={() => void context.handleManagedSignOut().catch((error) => toast.error("Sign out failed", { description: String(error) }))}
+      />
+    </div>
+  );
+}
+
+function AgentControlStrip({ workspaceId }: { workspaceId: string }) {
+  const context = useAppContext();
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <ModelPicker
+        config={context.clientConfig}
+        model={context.model}
+        effort={context.reasoningEffort}
+        disabled={context.busy}
+        onModelChange={context.setModel}
+        onEffortChange={context.setReasoningEffort}
+      />
+      <RepositoryContextPicker
+        configured={context.githubStatus?.configured === true}
+        installUrl={context.githubStatus?.installUrl ?? null}
+        repositories={context.githubRepos}
+        groups={context.repositoryGroups}
+        selectedRepoIds={context.selectedRepoIds}
+        selectedRepoRefs={context.selectedRepoRefs}
+        selectedInstallationId={context.selectedInstallationId}
+        manualRepos={context.manualRepos}
+        manualOpen={context.manualReposOpen}
+        githubAppOpen={context.githubAppOpen}
+        org={context.githubOrg}
+        pending={context.busy}
+        repoBusy={context.repoBusy}
+        githubAppBusy={context.githubAppBusy}
+        onRefresh={() => context.refreshGitHub(workspaceId)}
+        onToggleRepo={context.toggleGitHubRepository}
+        onRefChange={(repoId, ref) => context.setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref }))}
+        onManualOpenChange={context.setManualReposOpen}
+        onManualAdd={context.addManualRepository}
+        onManualUpdate={(id, patch) => context.setManualRepos((current) => current.map((repo) => repo.id === id ? { ...repo, ...patch } : repo))}
+        onManualRemove={(id) => context.setManualRepos((current) => current.filter((repo) => repo.id !== id))}
+        onGitHubAppOpenChange={context.setGithubAppOpen}
+        onOrgChange={context.setGithubOrg}
+        onStartGitHubApp={() => void context.startGitHubAppManifestFlow(workspaceId)}
+      />
+      <DocumentSearchToolToggle
+        enabled={context.documentSearchEnabled}
+        disabled={context.busy}
+        onToggle={() => context.setDocumentSearchEnabled((enabled) => !enabled)}
+      />
+      <OpenGeniToolToggle
+        enabled={context.openGeniToolEnabled}
+        disabled={context.busy}
+        onToggle={() => context.setOpenGeniToolEnabled((enabled) => !enabled)}
+      />
+      <EnabledMcpToolPicker
+        servers={context.customMcpServers}
+        selectedIds={context.selectedCapabilityToolIds}
+        disabled={context.busy}
+        onChange={context.setSelectedCapabilityToolIds}
+      />
+    </div>
+  );
+}
+
+function AccessKeyPanel(props: {
+  authMode: ClientConfig["auth"]["mode"] | undefined;
+  accessKeyDraft: string;
+  setAccessKeyDraft: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <section className="flex flex-1 items-center justify-center px-4">
+      <form
+        className="w-full max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 shadow-sm"
+        onSubmit={(event) => {
+          event.preventDefault();
+          props.onSubmit();
+        }}
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+            <LockIcon className="size-4" />
+          </span>
+          <div>
+            <h1 className="text-base font-semibold">Access key required</h1>
+            <p className="text-sm text-[color:var(--color-fg-subtle)]">
+              Enter the {props.authMode === "configuredToken" ? "configured bearer token" : "deployment key"} for this OpenGeni instance.
+            </p>
+          </div>
+        </div>
+        <Label htmlFor="access-key">Access key</Label>
+        <Input
+          id="access-key"
+          type="password"
+          value={props.accessKeyDraft}
+          onChange={(event) => props.setAccessKeyDraft(event.target.value)}
+          autoComplete="current-password"
+          className="mt-2"
+          autoFocus
+        />
+        <Button type="submit" className="mt-4 w-full">
+          <CheckIcon className="size-4" />
+          Continue
+        </Button>
+      </form>
+    </section>
+  );
+}
+
+function LoadingPanel({ label }: { label: string }) {
+  return (
+    <section className="grid flex-1 place-items-center px-4 text-center">
+      <div className="max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 text-sm text-[color:var(--color-fg-muted)]">
+        <Loader2Icon className="mx-auto mb-3 size-5 animate-spin text-[color:var(--color-fg)]" />
+        {label}
+      </div>
+    </section>
+  );
+}
+
+function ProblemPanel(props: { title: string; description: string; action?: ReactNode }) {
+  return (
+    <section className="grid flex-1 place-items-center px-4 text-center">
+      <div className="w-full max-w-md rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5">
+        <AlertTriangleIcon className="mx-auto mb-3 size-5 text-amber-300" />
+        <h1 className="text-base font-semibold">{props.title}</h1>
+        <p className="mt-2 text-sm leading-5 text-[color:var(--color-fg-muted)]">{props.description}</p>
+        {props.action ? <div className="mt-4 flex justify-center">{props.action}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+function NotFoundRoute() {
+  return <ProblemPanel title="Page not found" description="This OpenGeni console route does not exist. Workspace-scoped URLs are required." />;
+}
+
+function useAppContext(): AppContextValue {
+  const value = useContext(AppContext);
+  if (!value) {
+    throw new Error("OpenGeni app context is not ready");
+  }
+  return value;
+}
+
+function workspaceLabel(workspace: Workspace, workspaces: Workspace[]): string {
+  const hasMultipleAccounts = new Set(workspaces.map((candidate) => candidate.accountId)).size > 1;
+  if (!hasMultipleAccounts) {
+    return workspace.name;
+  }
+  return `${workspace.name} / ${workspace.accountId.slice(0, 8)}`;
 }
 
 function submitGitHubManifest(actionUrl: string, manifest: Record<string, unknown>): void {
@@ -4839,11 +5252,6 @@ function mergeEvents(current: SessionEvent[], incoming: SessionEvent[]): Session
     byId.set(event.id, event);
   }
   return [...byId.values()].sort((a, b) => a.sequence - b.sequence);
-}
-
-function sessionIdFromPath(): string | null {
-  const match = window.location.pathname.match(/^\/sessions\/([0-9a-f-]+)/i);
-  return match?.[1] ?? null;
 }
 
 function statusTone(status: SessionStatus): string {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -212,8 +212,8 @@ export function fetchAccessContext(): Promise<AccessContext> {
   return request<AccessContext>("/v1/access/me");
 }
 
-export function fetchCapabilities(workspaceId: string): Promise<CapabilityCatalogResponse> {
-  return request<CapabilityCatalogResponse>(workspacePath(workspaceId, "/capabilities"));
+export function fetchCapabilities(workspaceId: string, signal?: AbortSignal): Promise<CapabilityCatalogResponse> {
+  return request<CapabilityCatalogResponse>(workspacePath(workspaceId, "/capabilities"), { signal });
 }
 
 export function createCapability(workspaceId: string, input: CreateCapabilityInput): Promise<CapabilityCatalogItem> {
@@ -554,12 +554,12 @@ function parseSseEvent(block: string): SessionEvent | null {
   return data ? JSON.parse(data) as SessionEvent : null;
 }
 
-export async function fetchGitHubStatus(workspaceId: string): Promise<{ configured: boolean; missing: string[]; installUrl: string | null }> {
-  return await request(workspacePath(workspaceId, "/github/app"));
+export async function fetchGitHubStatus(workspaceId: string, signal?: AbortSignal): Promise<{ configured: boolean; missing: string[]; installUrl: string | null }> {
+  return await request(workspacePath(workspaceId, "/github/app"), { signal });
 }
 
-export async function fetchGitHubRepositories(workspaceId: string): Promise<GitHubRepository[]> {
-  const payload = await request<{ repositories: GitHubRepository[] }>(workspacePath(workspaceId, "/github/repositories"));
+export async function fetchGitHubRepositories(workspaceId: string, signal?: AbortSignal): Promise<GitHubRepository[]> {
+  const payload = await request<{ repositories: GitHubRepository[] }>(workspacePath(workspaceId, "/github/repositories"), { signal });
   return payload.repositories;
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
+import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
@@ -25,5 +26,9 @@ export default defineConfig({
       "@": path.resolve(dirname, "src"),
     },
   },
-  plugins: [viteReact(), tailwindcss()],
+  plugins: [
+    tanstackRouter({ target: "react", enableRouteGeneration: false }),
+    viteReact(),
+    tailwindcss(),
+  ],
 });

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@tailwindcss/vite": "^4.2.4",
+        "@tanstack/react-router": "^1.170.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -71,6 +72,8 @@
         "tailwindcss": "^4.2.4",
       },
       "devDependencies": {
+        "@tanstack/react-router-devtools": "^1.167.0",
+        "@tanstack/router-plugin": "^1.168.18",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -355,6 +358,38 @@
     "@azure/storage-blob": ["@azure/storage-blob@12.31.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.3", "@azure/core-http-compat": "^2.2.0", "@azure/core-lro": "^2.2.0", "@azure/core-paging": "^1.6.2", "@azure/core-rest-pipeline": "^1.19.1", "@azure/core-tracing": "^1.2.0", "@azure/core-util": "^1.11.0", "@azure/core-xml": "^1.4.5", "@azure/logger": "^1.1.4", "@azure/storage-common": "^12.3.0", "events": "^3.0.0", "tslib": "^2.8.1" } }, "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg=="],
 
     "@azure/storage-common": ["@azure/storage-common@12.3.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-http-compat": "^2.2.0", "@azure/core-rest-pipeline": "^1.19.1", "@azure/core-tracing": "^1.2.0", "@azure/core-util": "^1.11.0", "@azure/logger": "^1.1.4", "events": "^3.3.0", "tslib": "^2.8.1" } }, "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@better-auth/core": ["@better-auth/core@1.6.14", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-12cA7tnR4Wyb3nLpPmeq/Id7QNB+4OhjbzuX7sIhqglgXGjyT5iiNpe2lx/8FF532sHC450Yx1850salCYbkzw=="],
 
@@ -980,6 +1015,28 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
 
+    "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
+
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg=="],
+
+    "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.0", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.0" }, "peerDependencies": { "@tanstack/react-router": "^1.170.0", "@tanstack/router-core": "^1.170.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w=="],
+
+    "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
+
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
+
+    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.0", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.170.0", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg=="],
+
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.167.17", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.13", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA=="],
+
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.18", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.13", "@tanstack/router-generator": "1.167.17", "@tanstack/router-utils": "1.162.2", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.15", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-MofS28/axfnfnhOD2RSgJEaU882aX5RsAzhGz5Vc4XhAmvCjy919u9JrNs4QsTWFbTD1P7IJ8WFlFVsrg0pStg=="],
+
+    "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
+
+    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
+
     "@temporalio/activity": ["@temporalio/activity@1.17.0", "", { "dependencies": { "@temporalio/client": "1.17.0", "@temporalio/common": "1.17.0", "abort-controller": "^3.0.0" } }, "sha512-jjF38/VX7c9eyAb9g4oP4CAAYO3oWNIPIks5R5z0yszoDGBq+29UwsHYd6WrMviGt63NvLhWJWEOyeyGdA6L1g=="],
 
     "@temporalio/client": ["@temporalio/client@1.17.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.17.0", "@temporalio/proto": "1.17.0", "abort-controller": "^3.0.0", "long": "^5.2.3", "uuid": "^11.1.0" } }, "sha512-mc1VHfuVjT7D/QprjEGQFpbePMvuA0/kqIWhrEN+D1VYkLdhaMkuMgVjPtsxXjvACR20+qEsDg5m0a1qjllEoA=="],
@@ -1172,6 +1229,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
@@ -1181,6 +1240,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+
+    "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -1234,6 +1295,8 @@
 
     "chevrotain-allstar": ["chevrotain-allstar@0.4.3", "", { "dependencies": { "lodash-es": "^4.18.1" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ=="],
 
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
@@ -1256,7 +1319,11 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -1362,6 +1429,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
     "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
@@ -1464,6 +1533,8 @@
 
     "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
@@ -1477,6 +1548,8 @@
     "glob-to-regex.js": ["glob-to-regex.js@1.2.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "goober": ["goober@2.1.19", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg=="],
 
     "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
@@ -1568,6 +1641,8 @@
 
     "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
 
+    "isbot": ["isbot@5.1.42", "", {}, "sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jest-worker": ["jest-worker@27.5.1", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg=="],
@@ -1576,11 +1651,17 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -1629,6 +1710,8 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
@@ -1802,6 +1885,8 @@
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "pg": ["pg@8.21.0", "", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
 
     "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
@@ -1846,6 +1931,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proto3-json-serializer": ["proto3-json-serializer@2.0.2", "", { "dependencies": { "protobufjs": "^7.2.5" } }, "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ=="],
@@ -1875,6 +1962,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
 
@@ -1931,6 +2020,10 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -2072,6 +2165,8 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
@@ -2118,6 +2213,8 @@
 
     "webpack-sources": ["webpack-sources@3.4.1", "", {}, "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A=="],
 
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -2131,6 +2228,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -2151,6 +2250,10 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/test/e2e/browser.e2e.ts
+++ b/test/e2e/browser.e2e.ts
@@ -65,7 +65,7 @@ describe("browser e2e", () => {
     await pageA.keyboard.press("Escape");
     await pageA.getByPlaceholder("Describe a task for the agent...").fill("run a slow browser e2e session");
     await pageA.getByRole("button", { name: "Send" }).click();
-    await waitFor(() => pageA.url().includes("/sessions/"), { timeoutMs: 15_000 });
+    await waitFor(() => /\/workspaces\/[^/]+\/sessions\/[^/]+$/.test(pageA.url()), { timeoutMs: 15_000 });
 
     await pageB.goto(pageA.url());
     await pageA.getByTestId("session-timeline").getByText("slow stream", { exact: false }).waitFor({ timeout: 20_000 });


### PR DESCRIPTION
## Summary
- add TanStack Router to the Vite web app
- make workspace-scoped console routes canonical
- remove legacy unscoped /sessions/:id web routing
- fix direct session deep links, workspace switching, schedules/account routes, and refresh/replay behavior

## Verification
- bun run typecheck
- bun test
- bun scripts/check-workspace-billing-static.ts
- cd apps/web && bun run typecheck
- cd apps/web && bun run build
- bun test apps/web/src/App.test.ts apps/web/src/api.test.ts
- bun scripts/run-browser-e2e.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large front-end routing refactor changes deep links, bookmarks, and workspace/session navigation; session streaming and integration refresh behavior moved across routes but APIs are unchanged.
> 
> **Overview**
> Replaces the single-page **view state** and **`window.history`** session URLs with **TanStack Router**, so the OpenGeni web console is driven by real routes instead of in-memory tabs.
> 
> **Canonical URLs** are now workspace-scoped: `/workspaces/:workspaceId/agent`, `.../sessions/:sessionId`, plus dedicated routes for documents, capabilities, **schedules**, and account. `/` redirects into the default workspace agent home. Legacy unscoped `/sessions/:id` routing and `sessionIdFromPath` are removed; helpers `workspaceAgentPath` / `workspaceSessionPath` encode the new shape.
> 
> Shared console state (auth, workspaces, session stream, GitHub/MCP picks, etc.) lives in a root **`AppContext`** after config and access load; route components consume it for navigation, session load/stream on `SessionRoute`, and workspace-switch resets. GitHub and capability fetches accept **`AbortSignal`** with refresh IDs to avoid stale updates when switching workspaces.
> 
> Vite wires **`@tanstack/router-plugin`**; devtools appear in development. Unit tests cover URL helpers; browser e2e expects workspace-scoped session URLs after starting a run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b840f1b6909b219700a1210661b14b5a9b42049e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->