### PR TITLE
Surface attached workspace environment metadata in agent instructions

### DIFF
--- a/apps/worker/src/activities/agent-segment.ts
+++ b/apps/worker/src/activities/agent-segment.ts
@@ -156,6 +156,15 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
         sandboxEnvironment,
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
+        ...(workspaceEnvironment
+          ? {
+            workspaceEnvironment: {
+              name: workspaceEnvironment.name,
+              description: workspaceEnvironment.description,
+              variableNames: Object.keys(workspaceEnvironment.values),
+            },
+          }
+          : {}),
       });
       const runInput = await segmentInput(db, runtime, agent, trigger);
       let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>>;

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -18,6 +18,7 @@ import {
 export type WorkspaceEnvironmentForRun = {
   id: string;
   name: string;
+  description: string | null;
   values: Record<string, string>;
 };
 
@@ -54,7 +55,12 @@ export async function loadWorkspaceEnvironmentForRun(
       throw new Error(`failed to decrypt workspace environment variable ${name}: ${reason}`);
     }
   }
-  return { id: stored.environment.id, name: stored.environment.name, values };
+  return {
+    id: stored.environment.id,
+    name: stored.environment.name,
+    description: stored.environment.description,
+    values,
+  };
 }
 
 export async function sandboxEnvironmentForRun(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1807,13 +1807,14 @@ export async function deleteWorkspaceEnvironmentVariable(db: Database, workspace
  * environment attachment. Do not call from API routes: values are write-only.
  */
 export async function getWorkspaceEnvironmentValuesForRun(db: Database, workspaceId: string, environmentId: string): Promise<{
-  environment: { id: string; name: string };
+  environment: { id: string; name: string; description: string | null };
   values: Record<string, string>;
 } | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [environment] = await scopedDb.select({
       id: schema.workspaceEnvironments.id,
       name: schema.workspaceEnvironments.name,
+      description: schema.workspaceEnvironments.description,
     }).from(schema.workspaceEnvironments)
       .where(and(eq(schema.workspaceEnvironments.workspaceId, workspaceId), eq(schema.workspaceEnvironments.id, environmentId)))
       .limit(1);
@@ -1829,7 +1830,7 @@ export async function getWorkspaceEnvironmentValuesForRun(db: Database, workspac
         eq(schema.workspaceEnvironmentVariables.environmentId, environmentId),
       ));
     return {
-      environment: { id: environment.id, name: environment.name },
+      environment: { id: environment.id, name: environment.name, description: environment.description },
       values: Object.fromEntries(rows.map((row) => [row.name, row.valueEncrypted])),
     };
   });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -183,7 +183,37 @@ export type BuildAgentOptions = {
   sandboxEnvironment?: Record<string, string>;
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
+  workspaceEnvironment?: WorkspaceEnvironmentContext;
 };
+
+/**
+ * Operator-facing metadata for the workspace environment attached to a run.
+ * Surfaced verbatim in the agent instructions: the description is where
+ * operators document how the exported credentials are meant to be used
+ * (e.g. which variable holds a deploy key and how to clone with it), so an
+ * agent must not have to rediscover that by enumerating `env` and guessing.
+ * Only metadata belongs here — never variable values.
+ */
+export type WorkspaceEnvironmentContext = {
+  name: string;
+  description?: string | null;
+  variableNames?: string[];
+};
+
+export function workspaceEnvironmentInstructions(environment: WorkspaceEnvironmentContext): string[] {
+  const lines = [
+    `A workspace environment named "${environment.name}" is attached to this session; its variables are exported in the sandbox shell environment.`,
+  ];
+  const variableNames = (environment.variableNames ?? []).filter((name) => name.length > 0);
+  if (variableNames.length > 0) {
+    lines.push(`Exported environment variables: ${[...variableNames].sort().join(", ")}.`);
+  }
+  const description = environment.description?.trim();
+  if (description) {
+    lines.push(`Environment notes from the operator: ${description}`);
+  }
+  return lines;
+}
 
 const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
@@ -205,6 +235,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
       "Treat code-changing work as GitOps work: create a focused branch/commit/PR when GitHub credentials are available; otherwise report exact commands and blockers.",
       "Return concise, factual summaries with files changed, commands run, and remaining blockers.",
       "If the session has a goal, you own it: keep working until you call opengeni__goal_complete with concrete evidence or opengeni__goal_pause with a rationale; revise it with opengeni__goal_update; create one with opengeni__goal_set when given a long-running objective.",
+      ...(options.workspaceEnvironment ? workspaceEnvironmentInstructions(options.workspaceEnvironment) : []),
     ].join(" "),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -287,6 +287,31 @@ describe("runtime event normalization", () => {
     expect(agent.instructions).toContain("Attached files are mounted read-only; copy them before modifying.");
   });
 
+  test("surfaces attached workspace environment metadata in agent instructions", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      workspaceEnvironment: {
+        name: "azure-prod",
+        description: "Clone the journal repo over SSH with JOURNAL_DEPLOY_KEY.",
+        variableNames: ["JOURNAL_DEPLOY_KEY", "ARM_CLIENT_ID"],
+      },
+    });
+    expect(agent.instructions).toContain('A workspace environment named "azure-prod" is attached to this session');
+    expect(agent.instructions).toContain("Exported environment variables: ARM_CLIENT_ID, JOURNAL_DEPLOY_KEY.");
+    expect(agent.instructions).toContain("Environment notes from the operator: Clone the journal repo over SSH with JOURNAL_DEPLOY_KEY.");
+  });
+
+  test("omits workspace environment instructions when no environment is attached or metadata is empty", () => {
+    const detached = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    expect(detached.instructions).not.toContain("A workspace environment named");
+
+    const minimal = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      workspaceEnvironment: { name: "bare", description: "  ", variableNames: [] },
+    });
+    expect(minimal.instructions).toContain('A workspace environment named "bare" is attached to this session');
+    expect(minimal.instructions).not.toContain("Exported environment variables:");
+    expect(minimal.instructions).not.toContain("Environment notes from the operator:");
+  });
+
   test("builds native S3 mount entries for file resources", () => {
     const fileId = "00000000-0000-4000-8000-000000000010";
     const manifest = buildManifest(testSettings({

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1460,11 +1460,15 @@ describe("worker activities integration", () => {
     const environment = await seedWorkspaceEnvironment(dbClient.db, grant, {
       API_TOKEN: "worker-secret-token-1234",
       DB_PASSWORD: "worker-secret-pass-5678",
-    });
+    }, "Operator notes: API_TOKEN authenticates the worker against the test API.");
 
     expect(await loadWorkspaceEnvironmentForRun(dbClient.db, settings, grant.workspaceId, null)).toBeNull();
     const loaded = await loadWorkspaceEnvironmentForRun(dbClient.db, settings, grant.workspaceId, environment.id);
-    expect(loaded).toMatchObject({ id: environment.id, name: environment.name });
+    expect(loaded).toMatchObject({
+      id: environment.id,
+      name: environment.name,
+      description: "Operator notes: API_TOKEN authenticates the worker against the test API.",
+    });
     expect(loaded?.values).toEqual({
       API_TOKEN: "worker-secret-token-1234",
       DB_PASSWORD: "worker-secret-pass-5678",
@@ -1985,12 +1989,13 @@ type TestDb = ReturnType<typeof createDb>["db"];
 
 const workerEnvironmentsKey = Buffer.alloc(32, 8).toString("base64");
 
-async function seedWorkspaceEnvironment(db: TestDb, grant: AccessGrant, values: Record<string, string>): Promise<{ id: string; name: string }> {
+async function seedWorkspaceEnvironment(db: TestDb, grant: AccessGrant, values: Record<string, string>, description?: string): Promise<{ id: string; name: string }> {
   const key = new Uint8Array(Buffer.from(workerEnvironmentsKey, "base64"));
   const environment = await createWorkspaceEnvironment(db, {
     accountId: grant.accountId,
     workspaceId: grant.workspaceId,
     name: `worker-env-${crypto.randomUUID()}`,
+    ...(description !== undefined ? { description } : {}),
   });
   for (const [name, value] of Object.entries(values)) {
     await setWorkspaceEnvironmentVariable(db, {


### PR DESCRIPTION
## Problem

When a session runs with a workspace environment attached, the worker exports the environment's variables into the sandbox — but the agent is told nothing about them. The environment's name, its variable names, and especially its operator-authored **description** never reach the agent's instructions.

The description is exactly where operators document how the exported credentials are meant to be used (e.g. which variable holds a repo deploy key and how to clone with it). Today an agent only finds that out if it happens to enumerate `env` and guess intent from variable names. Observed live on a goal session: the agent checked `gh auth status`, `GH_TOKEN`, `GITHUB_TOKEN`, found nothing, and paused its goal as "no GitHub credentials available" — while a documented SSH deploy key sat in its own process environment the whole time.

## Change

- `getWorkspaceEnvironmentValuesForRun` (db) also selects the environment `description` (metadata only — values remain write-only outside the decrypt path).
- `loadWorkspaceEnvironmentForRun` (worker) carries the description through.
- `buildOpenGeniAgent` (runtime) accepts an optional `workspaceEnvironment` context — name, description, variable names, never values — and appends it to the agent instructions:
  - environment name + the fact that its variables are exported in the sandbox shell
  - sorted variable names
  - the operator description verbatim as "Environment notes from the operator"
- `agent-segment` passes the context only when an environment is attached; detached sessions produce byte-identical instructions to before.

## Tests

- runtime unit tests: metadata surfaced; empty/absent metadata omitted; detached agents unchanged.
- worker integration test extended: description round-trips through `loadWorkspaceEnvironmentForRun`.
- `bun run typecheck`, `bun test` (227 pass), and `test/integration/worker-activity.integration.ts` (37 pass) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only prompt changes with no new secret exposure; detached sessions and the write-only values API path stay the same.
> 
> **Overview**
> When a session has a workspace environment attached, the agent now receives **metadata-only** context in its instructions—not secret values.
> 
> The worker loads the environment **description** from the DB (alongside existing decrypt path for values) and passes **name**, **description**, and **sorted variable names** into `buildOpenGeniAgent` via a new `workspaceEnvironment` option. Runtime adds `workspaceEnvironmentInstructions()` so instructions state that variables are exported in the sandbox shell, list exported names, and include operator notes verbatim. Sessions without an attached environment are unchanged.
> 
> Tests cover instruction text for full vs empty metadata and description round-trip through `loadWorkspaceEnvironmentForRun`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11187aed87823a0895097fb294fa879d60e10f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->