### PR TITLE
Upgrade @openai/agents to 0.11.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -194,8 +194,8 @@
       "name": "@opengeni/runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@openai/agents": "^0.9.1",
-        "@openai/agents-extensions": "^0.9.1",
+        "@openai/agents": "^0.11.6",
+        "@openai/agents-extensions": "^0.11.6",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
         "modal": "^0.7.4",
@@ -225,7 +225,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/agents": "^0.9.1",
+        "@openai/agents": "^0.11.6",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -604,15 +604,15 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
-    "@openai/agents": ["@openai/agents@0.9.1", "", { "dependencies": { "@openai/agents-core": "0.9.1", "@openai/agents-openai": "0.9.1", "@openai/agents-realtime": "0.9.1", "debug": "^4.4.0", "openai": "^6.26.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-IxVlkr3ixeE1vxTp6Gaj1nn9I+J+Lwf+ZhHWKOVC2/SKV//B1KVBllWkX0bj4OKZO1VyO+NHA0eDVLLZxQIqIw=="],
+    "@openai/agents": ["@openai/agents@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@openai/agents-openai": "0.11.6", "@openai/agents-realtime": "0.11.6", "debug": "^4.4.0", "openai": "^6.35.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-YLwycYJQ65ETEq1SzjdFO6U9VhWHOKKIVh6wZCd/FmTZoqYq9UF/5uvX+wF8cZ58J+wIyyLynPdCmzEEov2rhw=="],
 
-    "@openai/agents-core": ["@openai/agents-core@0.9.1", "", { "dependencies": { "debug": "^4.4.0", "openai": "^6.26.0" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.26.0" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-WSH7S46qopzNCGfHrJxeDVeZCKU0pK9gqhVevRfHdlrcWUcjm7Sj58SiTdGi3v/v1sw2xKDzVN08C4K8qxjNoQ=="],
+    "@openai/agents-core": ["@openai/agents-core@0.11.6", "", { "dependencies": { "debug": "^4.4.0", "openai": "^6.35.0" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.26.0" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-jWeo4mF+zjp9R80OPg+9prAnwF53dIpok2ymp9OkC3DpK2qcqBO8CfoEgocNp+E5HXXFW4uvCaY0olNCCcmTFw=="],
 
-    "@openai/agents-extensions": ["@openai/agents-extensions@0.9.1", "", { "dependencies": { "@openai/agents-core": "0.9.1", "@types/ws": "^8.18.1", "debug": "^4.4.0" }, "peerDependencies": { "@ai-sdk/provider": "^2.0.0 || ^3.0.0", "@blaxel/core": "^0.2.78", "@daytonaio/sdk": "^0.162.0", "@e2b/code-interpreter": "^2.3.3", "@openai/agents": ">=0.0.0", "@openai/codex-sdk": ">=0.86.0", "@runloop/api-client": "^1.16.2", "@vercel/sandbox": "^1.9.3", "ai": "^6.0.0", "e2b": "^2.14.1", "modal": "^0.7.4", "ws": "^8.18.1", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@blaxel/core", "@daytonaio/sdk", "@e2b/code-interpreter", "@openai/codex-sdk", "@runloop/api-client", "@vercel/sandbox", "ai", "e2b", "modal"] }, "sha512-7wsMI18FgQlHFcoG04QjUqkc2IrderGju/xz0cEmuyBac+3IxUxLh4CsJUthZxaLwR7IdLrvxYmww1jLQF1apQ=="],
+    "@openai/agents-extensions": ["@openai/agents-extensions@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@types/ws": "^8.18.1", "debug": "^4.4.0" }, "peerDependencies": { "@ai-sdk/provider": "^2.0.0 || ^3.0.0", "@blaxel/core": "^0.2.82", "@daytonaio/sdk": "^0.162.0", "@e2b/code-interpreter": "^2.3.3", "@openai/agents": ">=0.0.0", "@openai/codex-sdk": ">=0.86.0", "@runloop/api-client": "^1.16.2", "@vercel/sandbox": "^1.9.3", "ai": "^6.0.0", "e2b": "^2.14.1", "modal": "^0.7.4", "ws": "^8.18.1", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@blaxel/core", "@daytonaio/sdk", "@e2b/code-interpreter", "@openai/codex-sdk", "@runloop/api-client", "@vercel/sandbox", "ai", "e2b", "modal"] }, "sha512-lTWr0kFos15PXEqs/gbTPLjVHblFvYx/YKVYy3fK89g56vdW78Tusgvjh9enIFLdmqnzPacTBA3GB2V8V7pr7g=="],
 
-    "@openai/agents-openai": ["@openai/agents-openai@0.9.1", "", { "dependencies": { "@openai/agents-core": "0.9.1", "debug": "^4.4.0", "openai": "^6.26.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-UqyYCuTh5dQgFY2R73UlH+n1P0gBatQ/hlcGZwca7f4N6+2xMy1wBkFJo7x9SMW9cN2XYlWl96sQYMqh+X+v7w=="],
+    "@openai/agents-openai": ["@openai/agents-openai@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "debug": "^4.4.0", "openai": "^6.35.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A=="],
 
-    "@openai/agents-realtime": ["@openai/agents-realtime@0.9.1", "", { "dependencies": { "@openai/agents-core": "0.9.1", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.18.1" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-INUkmYtSRupNxUAIb85zt1DTwVLsKHyCbIi9PZq3rfAFuldpaD39Fqo1F7pmY47+Tt773+sGBTMVxqqW7PxTZw=="],
+    "@openai/agents-realtime": ["@openai/agents-realtime@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.18.1" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-jw4lLO6B2xyCBtgLtAXZmqhjEAqSLO1EtJzfwfrZuzGpPgs4nJBQ+O7ybtdPPKt8iWdIOlrYRDqxhBHv7Qqo7w=="],
 
     "@opengeni/api": ["@opengeni/api@workspace:apps/api"],
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@opengeni/config": "workspace:*",
     "@opengeni/contracts": "workspace:*",
-    "@openai/agents": "^0.9.1",
-    "@openai/agents-extensions": "^0.9.1",
+    "@openai/agents": "^0.11.6",
+    "@openai/agents-extensions": "^0.11.6",
     "modal": "^0.7.4",
     "openai": "6.36.0"
   },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -732,10 +732,15 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
   if (Object.keys(entries).length === 0 && !environmentChanged) {
     return;
   }
+  // Carry path grants through manifest rebuilds: since @openai/agents 0.11.0
+  // they gate local source materialization, and run states saved before the
+  // upgrade have manifests without grants.
+  const extraPathGrants = mergePathGrants(currentManifest.extraPathGrants, target.extraPathGrants);
   const delta = new Manifest({
     root: currentManifest.root,
     entries,
     environment: target.environment,
+    ...(extraPathGrants.length ? { extraPathGrants } : {}),
   });
   if (session.applyManifest) {
     await session.applyManifest(delta);
@@ -751,7 +756,19 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
       ...currentManifest.entries,
       ...entries,
     },
+    ...(extraPathGrants.length ? { extraPathGrants } : {}),
   });
+}
+
+function mergePathGrants(
+  current: Manifest["extraPathGrants"] | undefined,
+  target: Manifest["extraPathGrants"] | undefined,
+): Manifest["extraPathGrants"] {
+  const merged = new Map<string, Manifest["extraPathGrants"][number]>();
+  for (const grant of [...(current ?? []), ...(target ?? [])]) {
+    merged.set(grant.path, grant);
+  }
+  return [...merged.values()];
 }
 
 export function withSandboxFileDownloads(
@@ -843,7 +860,7 @@ export function sandboxFileDownloadsForAgent(agent: unknown): SandboxFileDownloa
     : [];
 }
 
-function ensureManifest(manifest: Manifest | { root?: string; entries?: Record<string, any>; environment?: Record<string, any> }): Manifest {
+function ensureManifest(manifest: Manifest | { root?: string; entries?: Record<string, any>; environment?: Record<string, any>; extraPathGrants?: any[] }): Manifest {
   if (manifest instanceof Manifest && typeof manifest.mountTargetsForMaterialization === "function") {
     return manifest;
   }
@@ -851,6 +868,7 @@ function ensureManifest(manifest: Manifest | { root?: string; entries?: Record<s
     ...(manifest.root ? { root: manifest.root } : {}),
     entries: manifest.entries ?? {},
     environment: manifest.environment ?? {},
+    ...(manifest.extraPathGrants?.length ? { extraPathGrants: manifest.extraPathGrants } : {}),
   });
 }
 
@@ -1021,6 +1039,16 @@ export function buildManifest(
     root: "/workspace",
     entries,
     environment,
+    // Since @openai/agents 0.11.0, local sandbox sources (including the lazy
+    // bundled-skills source) must stay within the SDK process working
+    // directory unless granted here. The bundled skills ship inside the
+    // runtime package, which is outside the worker's cwd in production, so
+    // grant it explicitly to preserve pre-0.11 behavior.
+    extraPathGrants: [{
+      path: bundledSkillsDir(),
+      readOnly: true,
+      description: "OpenGeni bundled skills",
+    }],
   });
 }
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,7 +16,7 @@
     "@opengeni/runtime": "workspace:*",
     "@opengeni/worker": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/agents": "^0.9.1",
+    "@openai/agents": "^0.11.6",
     "@temporalio/client": "^1.17.0",
     "nats": "^2.29.3",
     "playwright": "^1.57.0",


### PR DESCRIPTION
Upgrades `@openai/agents` and `@openai/agents-extensions` from 0.9.1 to 0.11.6 (kept in lockstep) in `packages/runtime` and `packages/testing`. Mechanical migration; no design decisions were made — where the SDK forced a behavioral choice, the change preserves pre-upgrade behavior exactly (flagged below).

## Breaking changes encountered (0.9.1 → 0.11.6)

1. **0.11.0 — sandbox local-source boundary** (the only change requiring code): `LocalFile.src` / `LocalDir.src` (including `localDirLazySkillSource`) must now resolve within the SDK process working directory unless covered by `Manifest.extraPathGrants`. OpenGeni loads bundled skills from `packages/runtime/src/bundled_hashicorp_terraform_skills` via an absolute path that is **outside** the worker's cwd in production (`apps/worker` / container), so without a grant the skill index would silently resolve empty and skill materialization would throw. **Adaptation:** `buildManifest` now adds a read-only `extraPathGrants` entry for the bundled skills dir, and `ensureManifest` / `applyMissingManifestEntries` carry grants through manifest rebuilds on sandbox resume (merged by path, target wins).
2. **0.10.0 — default model changed `gpt-4.1` → `gpt-5.4-mini`**: not applicable; OpenGeni always sets the model explicitly (`options.model ?? settings.openaiModel`, which defaults to `gpt-5.5` in `@opengeni/config`). No change.
3. **0.10.0 — `maxTurns: null` now disables the turn limit**: not applicable; `runAgentStream` always passes `settings.agentMaxTurnsPerSegment` (number). Omitted default (`10`) unchanged. The max-turns graceful-idle valve (#27) behavior is unchanged and covered by the integration suites.
4. **0.11.0 — RealtimeAgent default is `gpt-realtime-2`**: not applicable; no realtime usage.
5. **0.10.0 — `MCPConfig.includeServerInToolNames`**: new opt-in that overlaps with OpenGeni's own `PrefixedMcpServer`; left **off** (default) to keep the existing `<registryId>__<tool>` naming exactly. `MCPServer` interface is otherwise unchanged — the custom wrapper still typechecks against 0.11.6.

Everything else in 0.10.x/0.11.x (tracing lifecycle helpers, chat-completions strict validation, sandbox archive extraction limits, GitRepo subpath validation, Usage JSON helpers) required no adaptation: `maxTurnsExceededRunState()` / `agentsErrorRunState()` (`error.state`), per-response usage extraction (`response_done` / `response.completed` shapes), `ModalImageSelector.fromTag`, and the streaming event handling all typecheck and pass tests unchanged.

## Run-state compatibility

OpenGeni durably persists serialized run states in `agent_run_states` (`saveRunState` / `getLatestRunState`) for goal continuations, approvals, and the graceful-idle valves. RunState schema: 0.9.1 writes `$schemaVersion: "1.10"`; 0.11.6 accepts `1.0`–`1.12` and **preserves** `1.10` on round-trip. Verified empirically: a RunState serialized by an actual 0.9.1 install deserializes cleanly via `RunState.fromString` under 0.11.6. **No format guard was added** — in-flight saved states from 0.9.1 remain loadable. (Note: states written by 0.11.6 at `1.12` would not load if the deployment were rolled back to 0.9.1.)

## Flags (behavior-preserving choices to be aware of)

- The `extraPathGrants` carry-through in `applyMissingManifestEntries` only runs when there are new entries or an environment change (the pre-existing early-return is untouched). A sandbox session created on 0.9.1 and resumed on 0.11.6 with zero manifest delta keeps a grant-less stored manifest; lazily loading a not-yet-materialized bundled skill in that exact case would resolve empty rather than throw. Skills already materialized in the workspace are unaffected.
- `mergePathGrants` dedupes by literal `path` string with target-manifest grants winning.

## Verification

- [x] `bun run typecheck` — all 14 workspaces pass
- [x] `bun run test:unit` — 225 pass / 0 fail
- [x] `bun test --timeout 30000 ./test/integration/db.integration.ts` — 14 pass / 0 fail
- [x] `bun test --timeout 30000 ./test/integration/worker-activity.integration.ts` — 37 pass / 0 fail (includes max-turns and provider-rate-limit graceful-idle valves from #27/#28)
- [x] `bun test --timeout 30000 ./test/integration/temporal-workflow.integration.ts` — 13 pass / 0 fail
- [x] Combined gate run of all three integration files — 64 pass / 0 fail
- [x] Cross-version run-state deserialization (0.9.1 → 0.11.6) verified with a real 0.9.1-serialized state
- [x] gitleaks over the diff — no leaks

Note on flakiness: under heavy host load, individual temporal-workflow tests can hit the 30s timeout; this reproduces identically on unmodified `main` with 0.9.1 (verified via a baseline worktree) and is unrelated to this upgrade. All suites pass cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent runtime and sandbox manifest materialization; a narrow edge case remains when resuming a 0.9.1 sandbox with zero manifest delta and lazily loading an unmaterialized bundled skill.
> 
> **Overview**
> Bumps **`@openai/agents`** and **`@openai/agents-extensions`** from **0.9.1** to **0.11.6** in `packages/runtime` and `packages/testing`, with lockfile updates.
> 
> The only application change is for the **0.11.0 sandbox local-source boundary**: local paths must sit under the SDK cwd or appear on **`Manifest.extraPathGrants`**. **`buildManifest`** now grants read-only access to the bundled skills directory (outside the worker cwd in production). **`mergePathGrants`**, **`ensureManifest`**, and **`applyMissingManifestEntries`** preserve and merge grants when manifests are rebuilt on sandbox resume so behavior matches pre-upgrade skill loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bdf0fde8345c2a4c5b1eb0c27ce834d41ce403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->