### PR TITLE
Retire the segment vocabulary: a segment was always just a turn

### DIFF
--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -5,7 +5,7 @@ import { createNatsEventBus } from "@opengeni/events";
 import { createObservability } from "@opengeni/observability";
 import { createProductionAgentRuntime } from "@opengeni/runtime";
 import { createObjectStorage } from "@opengeni/storage";
-import { createRunAgentSegmentActivity } from "./activities/agent-segment";
+import { createRunAgentTurnActivity } from "./activities/agent-turn";
 import { createDocumentActivities } from "./activities/documents";
 import { createGoalActivities } from "./activities/goals";
 import { createScheduledTaskActivities } from "./activities/scheduled-tasks";
@@ -20,8 +20,8 @@ export type {
   MaybeContinueGoalInput,
   MaybeContinueGoalResult,
   PauseGoalForInterruptInput,
-  RunAgentSegmentInput,
-  RunAgentSegmentResult,
+  RunAgentTurnInput,
+  RunAgentTurnResult,
 } from "./activities/types";
 
 export function createActivities(dependencies: ActivityDependencies = {}) {
@@ -44,8 +44,15 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
     return servicesPromise;
   }
 
+  const runAgentTurn = createRunAgentTurnActivity(services);
   return {
-    runAgentSegment: createRunAgentSegmentActivity(services),
+    runAgentTurn,
+    // Legacy Temporal activity name. In-flight session workflows (which can
+    // legitimately live for days) recorded ScheduleActivityTask events as
+    // "runAgentSegment"; the name must keep resolving until those histories
+    // drain. New workflow code must use runAgentTurn; migrate the session
+    // workflow call site via patched() before removing this alias.
+    runAgentSegment: runAgentTurn,
     ...createDocumentActivities(services),
     ...createSessionStateActivities(services),
     ...createScheduledTaskActivities(services),
@@ -55,6 +62,7 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
 
 const defaultActivities = createActivities();
 
+export const runAgentTurn = defaultActivities.runAgentTurn;
 export const runAgentSegment = defaultActivities.runAgentSegment;
 export const indexDocument = defaultActivities.indexDocument;
 export const failSession = defaultActivities.failSession;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -33,7 +33,7 @@ import {
 } from "./common";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
 import { createSecretRedactor, identityRedactor } from "./redaction";
-import { segmentInput } from "./run-input";
+import { turnInput } from "./run-input";
 import {
   createRuntimeBatcher,
   currentActivityContext,
@@ -42,8 +42,8 @@ import {
 } from "./streaming";
 import type {
   ActivityServices,
-  RunAgentSegmentInput,
-  RunAgentSegmentResult,
+  RunAgentTurnInput,
+  RunAgentTurnResult,
 } from "./types";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
 import type { ResourceRef } from "@opengeni/contracts";
@@ -54,8 +54,8 @@ import type { ResourceRef } from "@opengeni/contracts";
 // budget against the same window.
 export const PROVIDER_BACKPRESSURE_DELAY_MS = 60_000;
 
-export function createRunAgentSegmentActivity(services: () => Promise<ActivityServices>) {
-  return async function runAgentSegment(input: RunAgentSegmentInput): Promise<RunAgentSegmentResult> {
+export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
+  return async function runAgentTurn(input: RunAgentTurnInput): Promise<RunAgentTurnResult> {
     const { settings, db, bus, runtime, objectStorage, observability } = await services();
     const activityStarted = performance.now();
     const activitySpan = observability.startSpan("worker.run_agent_segment", {
@@ -166,7 +166,7 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
           }
           : {}),
       });
-      const runInput = await segmentInput(db, runtime, agent, trigger);
+      const runInput = await turnInput(db, runtime, agent, trigger);
       let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>>;
       let responseUsageCount = 0;
       stream = await runtime.runStream(agent, runInput, runSettings, {
@@ -435,7 +435,7 @@ export function createRunAgentSegmentActivity(services: () => Promise<ActivitySe
     } finally {
       const durationSeconds = (performance.now() - activityStarted) / 1000;
       observability.recordWorkerActivity({
-        activity: "runAgentSegment",
+        activity: "runAgentTurn",
         status: activityStatus,
         durationSeconds,
       });

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -7,7 +7,7 @@ import {
 } from "@opengeni/db";
 import type { OpenGeniRuntime } from "@opengeni/runtime";
 
-export async function segmentInput(
+export async function turnInput(
   db: Database,
   runtime: OpenGeniRuntime,
   agent: any,

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -11,11 +11,11 @@ import type {
   ActivityServices,
   ClaimNextQueuedTurnInput,
   MarkSessionIdleInput,
-  RunAgentSegmentInput,
+  RunAgentTurnInput,
 } from "./types";
 
 export function createSessionStateActivities(services: () => Promise<ActivityServices>) {
-  async function failSession(input: RunAgentSegmentInput & { error?: string }): Promise<void> {
+  async function failSession(input: RunAgentTurnInput & { error?: string }): Promise<void> {
     const { db, bus } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
     const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
@@ -42,7 +42,7 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
     await setSessionStatus(db, input.workspaceId, input.sessionId, "failed", null);
   }
 
-  async function interruptActiveTurn(input: RunAgentSegmentInput): Promise<void> {
+  async function interruptActiveTurn(input: RunAgentTurnInput): Promise<void> {
     const { db, bus } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
     // Pause an active goal before the early return below: an interrupt can

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -19,7 +19,7 @@ export type ActivityServices = {
 
 export type ActivityDependencies = Partial<ActivityServices>;
 
-export type RunAgentSegmentInput = {
+export type RunAgentTurnInput = {
   accountId: string;
   workspaceId: string;
   sessionId: string;
@@ -77,7 +77,7 @@ export type IndexDocumentInput = {
   documentId: string;
 };
 
-export type RunAgentSegmentResult = {
+export type RunAgentTurnResult = {
   status: "idle" | "requires_action" | "failed" | "cancelled";
   // Provider backpressure pacing: when set on an idle result, the session
   // workflow holds the loop this long before admitting the next turn (an

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -113,7 +113,12 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
 
     const scope = new CancellationScope();
     const workflowId = workflowInfo().workflowId;
-    const segment: Promise<activities.RunAgentSegmentResult> = scope.run(() => activity.runAgentSegment({
+    // Deliberately schedules the LEGACY activity name: in-flight session
+    // workflows (multi-day by design) recorded this name in their histories,
+    // and scheduling a different activity type at the same position is a
+    // non-deterministic change on replay. Migrate to runAgentTurn with
+    // patched() once pre-rename sessions have drained.
+    const turn: Promise<activities.RunAgentTurnResult> = scope.run(() => activity.runAgentSegment({
       accountId,
       workspaceId,
       sessionId,
@@ -121,9 +126,9 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       workflowId,
       turnId,
     }));
-    const outcome: { kind: "result"; result: activities.RunAgentSegmentResult } | { kind: "interrupt" } | { kind: "failure"; error: unknown } = await Promise.race([
-      segment.then(
-        (result: activities.RunAgentSegmentResult) => ({ kind: "result" as const, result }),
+    const outcome: { kind: "result"; result: activities.RunAgentTurnResult } | { kind: "interrupt" } | { kind: "failure"; error: unknown } = await Promise.race([
+      turn.then(
+        (result: activities.RunAgentTurnResult) => ({ kind: "result" as const, result }),
         (error: unknown) => ({ kind: "failure" as const, error }),
       ),
       condition(() => interruptedEventId !== null).then(() => ({ kind: "interrupt" as const })),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -94,7 +94,7 @@ const SettingsSchema = z.object({
   // session turn. Effectively unbounded by default for the same reason as
   // above; the graceful max-turns valve (idle + goal continuation, never a
   // session failure) remains as inert safety should a deployment set a cap.
-  agentMaxTurnsPerSegment: z.coerce.number().int().positive().default(1_000_000),
+  agentMaxModelCallsPerTurn: z.coerce.number().int().positive().default(1_000_000),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),
@@ -314,7 +314,7 @@ export function getSettings(): Settings {
     environmentsEncryptionKey: optional("OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY"),
     goalMaxAutoContinuations: optional("OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS"),
     goalNoProgressLimit: optional("OPENGENI_GOAL_NO_PROGRESS_LIMIT"),
-    agentMaxTurnsPerSegment: optional("OPENGENI_AGENT_MAX_TURNS_PER_SEGMENT"),
+    agentMaxModelCallsPerTurn: optional("OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN"),
     authRequired: optional("OPENGENI_AUTH_REQUIRED"),
     accessKey: optional("OPENGENI_ACCESS_KEY"),
     authAllowHealth: optional("OPENGENI_AUTH_ALLOW_HEALTH"),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -653,7 +653,7 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       : undefined);
   const runOptions: Parameters<typeof run>[2] = {
     stream: true,
-    maxTurns: settings.agentMaxTurnsPerSegment,
+    maxTurns: settings.agentMaxModelCallsPerTurn,
   };
   void settings.disableOpenaiTracing;
   if (client) {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -32,7 +32,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     environmentsEncryptionKey: undefined,
     goalMaxAutoContinuations: 20,
     goalNoProgressLimit: 3,
-    agentMaxTurnsPerSegment: 40,
+    agentMaxModelCallsPerTurn: 40,
     betterAuthSecret: undefined,
     betterAuthAllowedHosts: "",
     betterAuthCookieDomain: undefined,

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -30,7 +30,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         calls.push(input);
         return { status: "idle" };
       },
@@ -63,7 +63,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         calls.push(input);
         return { status: calls.length === 1 ? "requires_action" : "idle" };
       },
@@ -98,7 +98,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async () => {
+      runAgentTurn: async () => {
         attempts += 1;
         throw new Error("boom");
       },
@@ -134,7 +134,7 @@ describe("Temporal workflow integration", () => {
       markSessionIdle: async (input: unknown) => {
         idleMarks.push(input);
       },
-      runAgentSegment: async () => ({ status: "idle" }),
+      runAgentTurn: async () => ({ status: "idle" }),
       failSession: async () => undefined,
       interruptActiveTurn: async (input: unknown) => {
         interrupts.push(input);
@@ -173,7 +173,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         runs.push(input);
         if (runs.length === 1) {
           while (!allowFirstRunToFinish) {
@@ -223,7 +223,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         runs.push(input);
         return { status: runs.length === 1 ? "requires_action" : "idle" };
       },
@@ -264,7 +264,7 @@ describe("Temporal workflow integration", () => {
     const worker = await testWorker(nativeConnection, taskQueue, {
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: { triggerEventId: string }) => {
+      runAgentTurn: async (input: { triggerEventId: string }) => {
         runs.push(input);
         return { status: "idle" };
       },
@@ -312,7 +312,7 @@ describe("Temporal workflow integration", () => {
         return async () => queuedTurns.shift() ?? null;
       })(),
       markSessionIdle: async () => undefined,
-      runAgentSegment: async () => {
+      runAgentTurn: async () => {
         segmentReturnedAt = Date.now();
         // Provider backpressure idle: the workflow must hold the loop before
         // admitting the goal continuation.
@@ -357,7 +357,7 @@ describe("Temporal workflow integration", () => {
       markSessionIdle: async () => {
         order.push("idle");
       },
-      runAgentSegment: async () => ({ status: "idle" }),
+      runAgentTurn: async () => ({ status: "idle" }),
       failSession: async () => undefined,
       interruptActiveTurn: async () => undefined,
       pauseGoalForInterrupt: async (input: unknown) => {
@@ -395,7 +395,7 @@ describe("Temporal workflow integration", () => {
       markSessionIdle: async (input: unknown) => {
         idleMarks.push(input);
       },
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         runs.push(input);
         return { status: "idle" };
       },
@@ -442,7 +442,7 @@ describe("Temporal workflow integration", () => {
           updatedAt: new Date().toISOString(),
         };
       },
-      runAgentSegment: async () => ({ status: "idle" }),
+      runAgentTurn: async () => ({ status: "idle" }),
       failSession: async () => undefined,
       interruptActiveTurn: async () => undefined,
     });
@@ -487,7 +487,7 @@ describe("Temporal workflow integration", () => {
       },
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         runs.push(input);
         return { status: "idle" };
       },
@@ -539,7 +539,7 @@ describe("Temporal workflow integration", () => {
       },
       claimNextQueuedTurn: async () => queuedTurns.shift() ?? null,
       markSessionIdle: async () => undefined,
-      runAgentSegment: async (input: unknown) => {
+      runAgentTurn: async (input: unknown) => {
         calls.push(input);
         return { status: "idle" };
       },
@@ -596,6 +596,10 @@ async function testWorker(nativeConnection: NativeConnection, taskQueue: string,
       maybeContinueGoal: async () => ({ action: "none" }),
       pauseGoalForInterrupt: async () => undefined,
       ...activities,
+      // Mirror production registration: the session workflow schedules the
+      // LEGACY activity name (replay safety for in-flight multi-day sessions),
+      // so the turn mock must answer to it as well.
+      ...(activities.runAgentTurn ? { runAgentSegment: activities.runAgentTurn } : {}),
     },
   });
 }

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -45,7 +45,7 @@ import { createNatsEventBus, type EventBus } from "@opengeni/events";
 import { createObservability } from "@opengeni/observability";
 import { createProductionAgentRuntime, MaxTurnsExceededError, type OpenGeniRuntime } from "@opengeni/runtime";
 import { createActivities } from "../../apps/worker/src/activities";
-import { PROVIDER_BACKPRESSURE_DELAY_MS } from "../../apps/worker/src/activities/agent-segment";
+import { PROVIDER_BACKPRESSURE_DELAY_MS } from "../../apps/worker/src/activities/agent-turn";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "../../apps/worker/src/activities/environment";
 import { ScriptedModel, functionCall, latestStatus, startTestMcpServer, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
 
@@ -88,7 +88,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -126,7 +126,7 @@ describe("worker activities integration", () => {
     const [firstTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "first question" } },
     ]);
-    await activities.runAgentSegment({
+    await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -136,7 +136,7 @@ describe("worker activities integration", () => {
     const [secondTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "second question" } },
     ]);
-    await activities.runAgentSegment({
+    await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -184,7 +184,7 @@ describe("worker activities integration", () => {
       runtime: createProductionAgentRuntime({ model }),
     });
 
-    await activities.runAgentSegment({
+    await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -233,7 +233,7 @@ describe("worker activities integration", () => {
       runtime: createProductionAgentRuntime({ model }),
     });
 
-    await activities.runAgentSegment({
+    await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -268,7 +268,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -301,7 +301,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -340,7 +340,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -387,7 +387,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -435,7 +435,7 @@ describe("worker activities integration", () => {
       observability,
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: crypto.randomUUID(),
@@ -500,7 +500,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -578,7 +578,7 @@ describe("worker activities integration", () => {
       runtime,
     });
 
-    await expect(activities.runAgentSegment({
+    await expect(activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -680,7 +680,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -742,7 +742,7 @@ describe("worker activities integration", () => {
         runtime: createProductionAgentRuntime({ model }),
       });
 
-      const result = await activities.runAgentSegment({
+      const result = await activities.runAgentTurn({
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
@@ -824,7 +824,7 @@ describe("worker activities integration", () => {
         runtime: createProductionAgentRuntime({ model }),
       });
 
-      const result = await activities.runAgentSegment({
+      const result = await activities.runAgentTurn({
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
@@ -890,7 +890,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -1130,7 +1130,7 @@ describe("worker activities integration", () => {
       }),
     });
 
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -1193,7 +1193,7 @@ describe("worker activities integration", () => {
         runtime: createProductionAgentRuntime({ model }),
       });
 
-      const result = await activities.runAgentSegment({
+      const result = await activities.runAgentTurn({
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
@@ -1543,7 +1543,7 @@ describe("worker activities integration", () => {
         }]),
       }),
     });
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -1579,7 +1579,7 @@ describe("worker activities integration", () => {
       bus,
       runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "never reached" }]) }),
     });
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -1941,7 +1941,7 @@ describe("worker activities integration", () => {
     const [userTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "start" } },
     ]);
-    expect((await activities.runAgentSegment({
+    expect((await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
@@ -1967,7 +1967,7 @@ describe("worker activities integration", () => {
       sandboxBackend: "none",
       metadata: {},
     });
-    const result = await activities.runAgentSegment({
+    const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,


### PR DESCRIPTION
## Summary
- `runAgentSegment` → `runAgentTurn` (file, factory, types, call sites). With the model-call cap effectively unbounded (#29) nothing distinguishes a segment from a turn — and nothing ever did: even under the old cap, the valve ended the *turn* and a goal continuation started a *new turn*.
- `agentMaxTurnsPerSegment` → `agentMaxModelCallsPerTurn` (env `OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN`): what the SDK counts are model calls; a product turn is one input → natural completion.
- `segmentInput` → `turnInput`; comments/docs moved to the turn/model-call vocabulary.

## Temporal replay safety (deliberate)
- The activity registers under **both** names; the session workflow **keeps scheduling the legacy `runAgentSegment` name**: in-flight multi-day sessions recorded it in their histories, and scheduling a different activity type at the same position is a non-deterministic replay break. Migration path: `patched()` once pre-rename sessions drain, then drop the alias.
- The `turn.completed` payload key `segmentLimit` stays on the wire for deployed consumers.
- The test harness mirrors production registration (mock answers to both names).

## Verification
- typecheck clean across workspaces; unit 225/225; temporal-workflow 13/13 + worker-activity 37/37 + db green after rebase onto #33 (SDK 0.11.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session worker activities and Temporal workflow scheduling; replay safety relies on keeping the legacy activity name until histories drain, and deployments must adopt the renamed config env var.
> 
> **Overview**
> Renames the worker **segment** vocabulary to **turn** so it matches product semantics: one user/goal trigger maps to one `runAgentTurn` activity (`RunAgentTurnInput` / `RunAgentTurnResult`, `turnInput`, `agent-turn.ts`).
> 
> Config is aligned with SDK wording: **`agentMaxTurnsPerSegment`** becomes **`agentMaxModelCallsPerTurn`** (`OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN`), wired through runtime `maxTurns` and test defaults.
> 
> **Temporal replay** is preserved on purpose: the worker registers **`runAgentSegment` as an alias** to the same implementation, **`sessionWorkflow` still schedules `runAgentSegment`**, and integration tests mirror that dual registration. New code should use `runAgentTurn`; migration to `patched()` is documented before dropping the legacy name. The `turn.completed` **`segmentLimit`** payload key is unchanged for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd4e1129d24b0e96cc95f653af70f82d4585438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->