### PR TITLE
Stage bundled skills inside the worker cwd instead of granting extra paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ bun.lockb
 terraform.tfvars
 terraform.tfvars.json
 .agent/
+# Staged bundled-skills copy created at runtime (packages/runtime bundledSkillsDir)
+.opengeni/

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -42,8 +42,9 @@ import {
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy, ModalImageSelector, ModalSandboxClient } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
+import { cpSync, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { userInfo } from "node:os";
-import { dirname, join, posix as posixPath } from "node:path";
+import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 ensureReadableStreamFrom();
@@ -1066,20 +1067,15 @@ export function buildManifest(
         : objectStorageFileMount(settings, `files/${resource.fileId}/original`);
     }
   }
+  // No extraPathGrants here: remote sandbox clients (Modal) reject manifests
+  // that carry them at create/apply time, which broke every Modal session.
+  // The lazy bundled-skills source no longer needs a grant because
+  // bundledSkillsDir() stages the skills inside the process working directory
+  // whenever the packaged copy lives outside it.
   return new Manifest({
     root: "/workspace",
     entries,
     environment,
-    // Since @openai/agents 0.11.0, local sandbox sources (including the lazy
-    // bundled-skills source) must stay within the SDK process working
-    // directory unless granted here. The bundled skills ship inside the
-    // runtime package, which is outside the worker's cwd in production, so
-    // grant it explicitly to preserve pre-0.11 behavior.
-    extraPathGrants: [{
-      path: bundledSkillsDir(),
-      readOnly: true,
-      description: "OpenGeni bundled skills",
-    }],
   });
 }
 
@@ -1660,8 +1656,47 @@ export function azureOpenAIDefaultQuery(
   return { "api-version": settings.azureOpenaiApiVersion };
 }
 
+// Since @openai/agents 0.11.0 local sandbox sources (including the lazy
+// bundled-skills source) must stay within the SDK process working directory:
+// reads outside it require manifest.extraPathGrants, and remote sandbox
+// clients such as Modal reject manifests that carry extra path grants. The
+// packaged skills live inside the runtime package — outside the worker's cwd
+// in production — so stage a copy under the working directory once per
+// process instead of granting the packaged path.
+let stagedBundledSkillsDir: string | null = null;
+
 function bundledSkillsDir(): string {
-  return join(dirname(fileURLToPath(import.meta.url)), "bundled_hashicorp_terraform_skills");
+  const packaged = join(dirname(fileURLToPath(import.meta.url)), "bundled_hashicorp_terraform_skills");
+  if (isPathWithin(process.cwd(), packaged)) {
+    return packaged;
+  }
+  if (!stagedBundledSkillsDir) {
+    stagedBundledSkillsDir = stageBundledSkills(packaged, join(process.cwd(), ".opengeni", "bundled_hashicorp_terraform_skills"));
+  }
+  return stagedBundledSkillsDir;
+}
+
+function stageBundledSkills(packaged: string, target: string): string {
+  const tmp = `${target}.tmp-${process.pid}`;
+  rmSync(tmp, { recursive: true, force: true });
+  mkdirSync(dirname(tmp), { recursive: true });
+  cpSync(packaged, tmp, { recursive: true });
+  rmSync(target, { recursive: true, force: true });
+  try {
+    renameSync(tmp, target);
+  } catch (error) {
+    // Another process staged the same content between our rm and rename.
+    rmSync(tmp, { recursive: true, force: true });
+    if (!existsSync(target)) {
+      throw error;
+    }
+  }
+  return target;
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -513,6 +513,20 @@ describe("runtime event normalization", () => {
     expect(serialized).not.toContain("x-access-token");
   });
 
+  test("emits manifests without extra path grants so remote sandbox clients accept them", () => {
+    // Modal's sandbox client rejects any manifest carrying extraPathGrants at
+    // create/apply time; the bundled-skills source must not reintroduce one.
+    const modalManifest = buildManifest(testSettings({ sandboxBackend: "modal" }), [{
+      kind: "repository",
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }]);
+    expect(modalManifest.extraPathGrants).toEqual([]);
+    expect(buildManifest(testSettings(), []).extraPathGrants).toEqual([]);
+  });
+
   test("clones repository resources inside the sandbox without embedding credentials", () => {
     const command = repositoryCloneCommand([{
       kind: "repository",


### PR DESCRIPTION
## Problem

Since the @openai/agents 0.11.6 upgrade (#33), `buildManifest` adds an `extraPathGrants` entry for the packaged bundled-skills directory to every sandbox manifest. The Modal sandbox client rejects manifests that carry extra path grants:

```
ModalSandboxClient does not support extra path grants yet.
```

so any Modal session whose manifest is applied (e.g. any session with a repository or file resource attached) fails immediately at sandbox creation. First observed live on a staging Modal session with a GitHub App repository resource; the turn failed ~4s in with the error above.

## Fix

Local sandbox sources only require a grant when they live outside the SDK process working directory. Instead of granting the packaged path:

- `bundledSkillsDir()` now stages a copy of the bundled skills under `process.cwd()/.opengeni/bundled_hashicorp_terraform_skills` once per process when the packaged copy lives outside cwd (in production the worker runs with `--cwd apps/worker` while the skills ship inside `packages/runtime`), and returns the packaged path unchanged when it is already inside cwd.
- `buildManifest` no longer emits `extraPathGrants`, so Modal accepts the manifests again and lazy bundled-skill discovery/materialization still passes the SDK path policy (everything is inside cwd).
- The resumed-session grant carry in `applyMissingManifestEntries` stays: run states saved by builds that recorded grants keep materializing on backends that support them.
- `.opengeni/` is gitignored for dev runs.

## Tests

- New regression test: manifests (Modal and default) carry no `extraPathGrants`.
- `bun test` (230 pass) and full `bun run typecheck` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox manifest construction and filesystem staging on every sandbox run; wrong paths could break lazy skill loading, though Modal session breakage is the targeted fix.
> 
> **Overview**
> Fixes **Modal sandbox sessions failing at create/apply** because `ModalSandboxClient` rejects manifests with `extraPathGrants` (introduced after the agents 0.11 upgrade for bundled Terraform skills).
> 
> **`buildManifest` no longer emits `extraPathGrants`.** Instead, **`bundledSkillsDir()`** copies packaged skills into **`process.cwd()/.opengeni/bundled_hashicorp_terraform_skills`** once per process when the runtime package path sits outside the worker cwd (production layout), and keeps using the packaged path when it is already under cwd. Staging uses a pid-scoped temp dir and atomic rename, with a race fallback if another process wins.
> 
> **`.opengeni/`** is added to **`.gitignore`** for local dev artifacts. **`applyMissingManifestEntries`** still merges grants from resumed run state for backends that support them.
> 
> A regression test asserts Modal and default manifests have **empty `extraPathGrants`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e39db4cabaebd2decee094088d7eb2d608c721e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->