### PR TITLE
Conversation truth as history items; RunState shrinks toward approvals-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS=
 # OPENGENI_GOAL_NO_PROGRESS_LIMIT=3
 
+# Conversation-history source (issue #35). Items + the sandbox envelope are
+# dual-written unconditionally; this flips the READ path only (safe to toggle
+# both ways at any time). "items" reads SDK-native history items from the DB;
+# unset/"run_state" reads the legacy serialized RunState blob.
+# OPENGENI_SESSION_HISTORY_SOURCE=items
+
 # Managed mode human auth and transactional email.
 # OPENGENI_BETTER_AUTH_SECRET=replace-with-long-random-better-auth-secret
 # OPENGENI_BETTER_AUTH_TRUSTED_ORIGINS=https://app.opengeni.ai,https://staging.app.opengeni.ai

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -10,13 +10,17 @@ import {
   getSessionTurn,
   requireSession,
   recordUsageEvent,
+  appendSessionHistoryItems,
+  countSessionHistoryItems,
   saveRunState,
+  upsertSandboxSessionEnvelope,
   setSessionStatus,
   sumUsageQuantity,
   type AppendEventInput,
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import {
+  sandboxStateEntryFromRunState,
   agentsErrorRunState,
   maxTurnsExceededRunState,
   modelResponseUsageFromSdkEvent,
@@ -71,6 +75,46 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let preparedTools: Awaited<ReturnType<OpenGeniRuntime["prepareTools"]>> | null = null;
     let publish: ((events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>, immediate?: boolean) => Promise<void>) | null = null;
     let turnStartedPublished = false;
+    let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>> | undefined;
+    // Dual-write of conversation truth (issue #35): completed items are
+    // reconciled into session_history_items after every model response and at
+    // every turn-end path (idempotent on position, watermark-sliced), and the
+    // sandbox recovery envelope is upserted alongside. Best-effort by design:
+    // persistence problems must never fail the run.
+    let persistedHistoryCount = 0;
+    const reconcileConversationTruth = async () => {
+      if (!stream || !turnId) {
+        return;
+      }
+      try {
+        const history = (stream.state as { history?: unknown[] }).history;
+        if (Array.isArray(history) && history.length > persistedHistoryCount) {
+          const rows = history.slice(persistedHistoryCount).map((item, offset) => ({
+            position: persistedHistoryCount + offset,
+            item: item as Record<string, unknown>,
+          }));
+          await appendSessionHistoryItems(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId,
+            items: rows,
+          });
+          persistedHistoryCount = history.length;
+        }
+        const envelope = sandboxStateEntryFromRunState(stream.state);
+        if (envelope) {
+          await upsertSandboxSessionEnvelope(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            envelope,
+          });
+        }
+      } catch (persistError) {
+        console.error("session history dual-write failed (run unaffected)", persistError);
+      }
+    };
     // Reassigned after the workspace environment loads; the publish closure is
     // created (and used for turn.started) before the environment is available.
     let redact: (payload: unknown) => unknown = identityRedactor;
@@ -166,8 +210,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           }
           : {}),
       });
-      const runInput = await turnInput(db, runtime, agent, trigger);
-      let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>>;
+      const runInput = await turnInput(db, runtime, agent, trigger, runSettings);
+      persistedHistoryCount = await countSessionHistoryItems(db, input.workspaceId, input.sessionId);
       let responseUsageCount = 0;
       stream = await runtime.runStream(agent, runInput, runSettings, {
         sandboxEnvironment,
@@ -200,6 +244,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               usage: responseUsage.usage,
               sourceKey: responseUsage.responseId ?? `response-${responseUsageCount}`,
             });
+            await reconcileConversationTruth();
             try {
               await ensureRunAllowed(settings, db, input.accountId, input.workspaceId);
             } catch (limitError) {
@@ -243,6 +288,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       }
 
       if (stream.interruptions.length > 0) {
+        await reconcileConversationTruth();
         const approvals = runtime.serializeApprovals(stream.interruptions);
         await saveRunState(db, {
           accountId: input.accountId,
@@ -263,14 +309,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       }
 
       const finalOutput = String(stream.finalOutput ?? "");
-      await saveRunState(db, {
-        accountId: input.accountId,
-        workspaceId: input.workspaceId,
-        sessionId: input.sessionId,
-        turnId,
-        serializedRunState: stream.state.toString(),
-        pendingApprovals: [],
-      });
+      await reconcileConversationTruth();
+      if (settings.sessionHistorySource !== "items") {
+        // Legacy conversation memory; in items mode the blob is only written
+        // for requires_action pauses (the one RunState-only resume path).
+        await saveRunState(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          turnId,
+          serializedRunState: stream.state.toString(),
+          pendingApprovals: [],
+        });
+      }
       await publish([
         { type: "agent.message.completed", payload: { text: finalOutput } },
         { type: "turn.completed", payload: { output: finalOutput } },
@@ -314,8 +365,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // degraded context, flagged on the event, but still strictly better
         // than a terminal failed session: the sandbox filesystem state
         // persists independently and the agent re-derives from it.
-        const runStateSaved = Boolean(maxTurns.serializedRunState);
-        if (maxTurns.serializedRunState) {
+        await reconcileConversationTruth();
+        const runStateSaved = Boolean(maxTurns.serializedRunState) && settings.sessionHistorySource !== "items";
+        if (maxTurns.serializedRunState && settings.sessionHistorySource !== "items") {
           await saveRunState(db, {
             accountId: input.accountId,
             workspaceId: input.workspaceId,
@@ -351,8 +403,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // next continuation evaluation, without consuming continuation budget.
       if (error instanceof BudgetExhaustedError && publish && turnId && turnStartedPublished) {
         await batcher?.flush().catch(() => undefined);
-        const runStateSaved = Boolean(error.serializedRunState);
-        if (error.serializedRunState) {
+        await reconcileConversationTruth();
+        const runStateSaved = Boolean(error.serializedRunState) && settings.sessionHistorySource !== "items";
+        if (error.serializedRunState && settings.sessionHistorySource !== "items") {
           await saveRunState(db, {
             accountId: input.accountId,
             workspaceId: input.workspaceId,
@@ -397,9 +450,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // Provider errors rarely carry SDK run state; a null falls back to
           // the previous snapshot, same degraded-context contract as the
           // max-turns path above.
+          await reconcileConversationTruth();
           const serializedRunState = agentsErrorRunState(error);
-          const runStateSaved = Boolean(serializedRunState);
-          if (serializedRunState) {
+          const runStateSaved = Boolean(serializedRunState) && settings.sessionHistorySource !== "items";
+          if (serializedRunState && settings.sessionHistorySource !== "items") {
             await saveRunState(db, {
               accountId: input.accountId,
               workspaceId: input.workspaceId,

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -1,7 +1,10 @@
+import type { Settings } from "@opengeni/config";
 import type { FileAsset, ResourceRef } from "@opengeni/contracts";
 import {
   getLatestRunState,
+  getSandboxSessionEnvelope,
   getSessionEvent,
+  getSessionHistoryItems,
   requireFile,
   type Database,
 } from "@opengeni/db";
@@ -12,6 +15,7 @@ export async function turnInput(
   runtime: OpenGeniRuntime,
   agent: any,
   trigger: Awaited<ReturnType<typeof getSessionEvent>>,
+  settings?: Settings,
 ) {
   if (!trigger) {
     throw new Error("Missing trigger event");
@@ -27,26 +31,16 @@ export async function turnInput(
       payload.text,
       Array.isArray(payload.resources) ? payload.resources as ResourceRef[] : [],
     );
-    const latestState = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
-    return await runtime.prepareInput(agent, {
-      kind: "message",
-      text,
-      serializedRunState: latestState?.serializedRunState ?? null,
-    });
+    return await messageInput(db, runtime, agent, trigger, text, settings);
   }
   if (trigger.type === "goal.continuation") {
     const payload = trigger.payload as { text?: unknown };
     if (typeof payload.text !== "string" || payload.text.trim().length === 0) {
       throw new Error("goal.continuation payload is missing text");
     }
-    // Threading serializedRunState keeps the agent's full conversation context
-    // across continuations — this is what makes "keep working" coherent.
-    const latestState = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
-    return await runtime.prepareInput(agent, {
-      kind: "message",
-      text: payload.text,
-      serializedRunState: latestState?.serializedRunState ?? null,
-    });
+    // Threading the stored conversation keeps the agent's full context across
+    // continuations — this is what makes "keep working" coherent.
+    return await messageInput(db, runtime, agent, trigger, payload.text, settings);
   }
   if (trigger.type === "user.approvalDecision") {
     const payload = trigger.payload as {
@@ -54,6 +48,8 @@ export async function turnInput(
       decision?: unknown;
       message?: unknown;
     };
+    // Approvals are the one path that legitimately requires the RunState blob:
+    // a turn frozen mid-flight cannot be represented as plain history items.
     const state = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
     if (!state) {
       throw new Error("No saved run state is available for approval decision");
@@ -67,6 +63,42 @@ export async function turnInput(
     });
   }
   throw new Error(`Unsupported trigger event type: ${trigger.type}`);
+}
+
+/**
+ * Build a message/continuation turn input from the configured history source.
+ * Items mode reads conversation truth from session_history_items and the
+ * sandbox envelope from its own store; a session with no stored items yet
+ * (created before dual-write, or its first turn) falls back to the RunState
+ * blob for this turn — the turn-end reconciliation then backfills its items,
+ * so the fallback is self-eliminating (issue #35).
+ */
+async function messageInput(
+  db: Database,
+  runtime: OpenGeniRuntime,
+  agent: any,
+  trigger: NonNullable<Awaited<ReturnType<typeof getSessionEvent>>>,
+  text: string,
+  settings?: Settings,
+) {
+  if (settings?.sessionHistorySource === "items") {
+    const stored = await getSessionHistoryItems(db, trigger.workspaceId, trigger.sessionId);
+    if (stored.length > 0) {
+      const envelope = await getSandboxSessionEnvelope(db, trigger.workspaceId, trigger.sessionId);
+      return await runtime.prepareInput(agent, {
+        kind: "message",
+        text,
+        historyItems: stored.map((row) => row.item) as any,
+        sandboxEnvelope: envelope,
+      });
+    }
+  }
+  const latestState = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
+  return await runtime.prepareInput(agent, {
+    kind: "message",
+    text,
+    serializedRunState: latestState?.serializedRunState ?? null,
+  });
 }
 
 export async function userMessageTextWithAttachments(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -95,6 +95,12 @@ const SettingsSchema = z.object({
   // above; the graceful max-turns valve (idle + goal continuation, never a
   // session failure) remains as inert safety should a deployment set a cap.
   agentMaxModelCallsPerTurn: z.coerce.number().int().positive().default(1_000_000),
+  // Where turn-input conversation history comes from (issue #35):
+  // "run_state" = legacy serialized RunState blob; "items" = the
+  // session_history_items table (SDK-native, version-stable). Items and the
+  // sandbox envelope are dual-written unconditionally; this flag governs the
+  // read path only, so flipping (and flipping back) is safe at any time.
+  sessionHistorySource: z.enum(["run_state", "items"]).default("run_state"),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),
@@ -315,6 +321,7 @@ export function getSettings(): Settings {
     goalMaxAutoContinuations: optional("OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS"),
     goalNoProgressLimit: optional("OPENGENI_GOAL_NO_PROGRESS_LIMIT"),
     agentMaxModelCallsPerTurn: optional("OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN"),
+    sessionHistorySource: optional("OPENGENI_SESSION_HISTORY_SOURCE"),
     authRequired: optional("OPENGENI_AUTH_REQUIRED"),
     accessKey: optional("OPENGENI_ACCESS_KEY"),
     authAllowHealth: optional("OPENGENI_AUTH_ALLOW_HEALTH"),

--- a/packages/db/drizzle/0007_session_history_items.sql
+++ b/packages/db/drizzle/0007_session_history_items.sql
@@ -1,0 +1,66 @@
+-- Conversation truth as ordered, verbatim SDK input items (issue #35).
+-- The model-facing memory store: unredacted, replay-ready AgentInputItem JSON.
+-- session_events stays the redacted human/audit timeline; agent_run_states
+-- shrinks to mid-turn approval resume.
+CREATE TABLE IF NOT EXISTS "session_history_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
+  "session_id" uuid NOT NULL REFERENCES "sessions"("id") ON DELETE CASCADE,
+  "turn_id" uuid REFERENCES "session_turns"("id") ON DELETE SET NULL,
+  "position" integer NOT NULL,
+  "item" jsonb NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "session_history_items_position_idx"
+  ON "session_history_items" ("workspace_id", "session_id", "position");
+ALTER TABLE "session_history_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "session_history_items" FORCE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'session_history_items' AND policyname = 'workspace_isolation'
+  ) THEN
+    DROP POLICY workspace_isolation ON "session_history_items";
+  END IF;
+END $$;
+CREATE POLICY workspace_isolation ON "session_history_items"
+  USING (opengeni_private.workspace_rls_visible(account_id, workspace_id))
+  WITH CHECK (opengeni_private.workspace_rls_visible(account_id, workspace_id));
+
+-- Sandbox recovery descriptor, decoupled from the RunState blob: the small
+-- versioned envelope (provider handle / snapshot ref / manifest) needed to
+-- reattach, restore, or rebuild the sandbox for a session's next turn.
+CREATE TABLE IF NOT EXISTS "sandbox_session_envelopes" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
+  "session_id" uuid NOT NULL REFERENCES "sessions"("id") ON DELETE CASCADE,
+  "envelope" jsonb NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "sandbox_session_envelopes_session_idx"
+  ON "sandbox_session_envelopes" ("workspace_id", "session_id");
+ALTER TABLE "sandbox_session_envelopes" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "sandbox_session_envelopes" FORCE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'sandbox_session_envelopes' AND policyname = 'workspace_isolation'
+  ) THEN
+    DROP POLICY workspace_isolation ON "sandbox_session_envelopes";
+  END IF;
+END $$;
+CREATE POLICY workspace_isolation ON "sandbox_session_envelopes"
+  USING (opengeni_private.workspace_rls_visible(account_id, workspace_id))
+  WITH CHECK (opengeni_private.workspace_rls_visible(account_id, workspace_id));
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781481600000,
       "tag": "0006_workspace_packs",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781568000000,
+      "tag": "0007_session_history_items",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1983,6 +1983,92 @@ export async function getLatestRunState(db: Database, workspaceId: string, sessi
   });
 }
 
+/**
+ * Append conversation items (verbatim SDK AgentInputItems) to the session's
+ * history. Idempotent on (workspace, session, position): concurrent or
+ * repeated writers (streaming writes + turn-end reconciliation) converge
+ * instead of duplicating.
+ */
+export async function appendSessionHistoryItems(db: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  turnId?: string | null;
+  items: Array<{ position: number; item: Record<string, unknown> }>;
+}): Promise<void> {
+  if (input.items.length === 0) {
+    return;
+  }
+  await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    await scopedDb.insert(schema.sessionHistoryItems).values(input.items.map((entry) => ({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      turnId: input.turnId ?? null,
+      position: entry.position,
+      item: entry.item,
+    }))).onConflictDoNothing({
+      target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
+    });
+  });
+}
+
+export async function getSessionHistoryItems(db: Database, workspaceId: string, sessionId: string): Promise<Array<{ position: number; item: Record<string, unknown> }>> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.select({
+      position: schema.sessionHistoryItems.position,
+      item: schema.sessionHistoryItems.item,
+    }).from(schema.sessionHistoryItems)
+      .where(and(eq(schema.sessionHistoryItems.workspaceId, workspaceId), eq(schema.sessionHistoryItems.sessionId, sessionId)))
+      .orderBy(schema.sessionHistoryItems.position);
+    return rows;
+  });
+}
+
+export async function countSessionHistoryItems(db: Database, workspaceId: string, sessionId: string): Promise<number> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select({
+      count: sql<number>`count(*)`,
+    }).from(schema.sessionHistoryItems)
+      .where(and(eq(schema.sessionHistoryItems.workspaceId, workspaceId), eq(schema.sessionHistoryItems.sessionId, sessionId)));
+    return Number(row?.count ?? 0);
+  });
+}
+
+/**
+ * Persist the session's sandbox recovery descriptor (the small versioned
+ * envelope used to reattach / snapshot-restore / rebuild the sandbox),
+ * decoupled from the RunState blob.
+ */
+export async function upsertSandboxSessionEnvelope(db: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  envelope: Record<string, unknown>;
+}): Promise<void> {
+  await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    await scopedDb.insert(schema.sandboxSessionEnvelopes).values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      envelope: input.envelope,
+    }).onConflictDoUpdate({
+      target: [schema.sandboxSessionEnvelopes.workspaceId, schema.sandboxSessionEnvelopes.sessionId],
+      set: { envelope: input.envelope, updatedAt: new Date() },
+    });
+  });
+}
+
+export async function getSandboxSessionEnvelope(db: Database, workspaceId: string, sessionId: string): Promise<Record<string, unknown> | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select({ envelope: schema.sandboxSessionEnvelopes.envelope })
+      .from(schema.sandboxSessionEnvelopes)
+      .where(and(eq(schema.sandboxSessionEnvelopes.workspaceId, workspaceId), eq(schema.sandboxSessionEnvelopes.sessionId, sessionId)))
+      .limit(1);
+    return row?.envelope ?? null;
+  });
+}
+
 export async function saveRunState(db: Database, input: {
   accountId: string;
   workspaceId: string;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -291,6 +291,37 @@ export const agentRunStates = pgTable("agent_run_states", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Conversation truth: ordered, verbatim SDK input items (issue #35). The
+// model-facing memory store — unredacted and replay-ready. session_events
+// remains the redacted human/audit timeline.
+export const sessionHistoryItems = pgTable("session_history_items", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),
+  workspaceId: uuid("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  sessionId: uuid("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
+  turnId: uuid("turn_id").references(() => sessionTurns.id, { onDelete: "set null" }),
+  position: integer("position").notNull(),
+  item: jsonb("item").$type<Record<string, unknown>>().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  positionIdx: uniqueIndex("session_history_items_position_idx").on(table.workspaceId, table.sessionId, table.position),
+}));
+
+// Sandbox recovery descriptor, decoupled from the RunState blob: the small
+// versioned envelope (provider handle / snapshot ref / manifest) needed to
+// reattach, restore, or rebuild the session's sandbox on its next turn.
+export const sandboxSessionEnvelopes = pgTable("sandbox_session_envelopes", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),
+  workspaceId: uuid("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  sessionId: uuid("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
+  envelope: jsonb("envelope").$type<Record<string, unknown>>().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  sessionIdx: uniqueIndex("sandbox_session_envelopes_session_idx").on(table.workspaceId, table.sessionId),
+}));
+
 export const scheduledTasks = pgTable("scheduled_tasks", {
   id: uuid("id").primaryKey().defaultRandom(),
   accountId: uuid("account_id").notNull().references(() => managedAccounts.id, { onDelete: "cascade" }),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -99,7 +99,16 @@ export function ensureReadableStreamFrom(): void {
 }
 
 export type AgentSegmentInput =
-  | { kind: "message"; text: string; serializedRunState?: string | null }
+  | {
+    kind: "message";
+    text: string;
+    serializedRunState?: string | null;
+    // Items-mode conversation truth (issue #35): when provided, turn input is
+    // built from these verbatim AgentInputItems and the stored sandbox
+    // envelope — no RunState deserialization, no SDK-version coupling.
+    historyItems?: AgentInputItem[] | null;
+    sandboxEnvelope?: Record<string, unknown> | null;
+  }
   | { kind: "approval"; serializedRunState: string; approvalId: string; decision: "approve" | "reject"; message?: string };
 
 export type PreparedAgentInput = {
@@ -584,6 +593,25 @@ export type PrepareInputOptions = {
 
 export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmentInput, options: PrepareInputOptions = {}): Promise<PreparedAgentInput> {
   if (input.kind === "message") {
+    if (input.historyItems && input.historyItems.length > 0) {
+      // Items mode: conversation truth comes from the database, the sandbox
+      // recovery descriptor from its own store. The RunState blob is not
+      // touched at all on this path.
+      const sandboxSessionState = input.sandboxEnvelope
+        ? await restoredSandboxSessionStateFromEntry(input.sandboxEnvelope, options.sandboxClient)
+        : undefined;
+      return {
+        input: [
+          ...input.historyItems,
+          {
+            type: "message",
+            role: "user",
+            content: input.text,
+          } as AgentInputItem,
+        ],
+        ...(sandboxSessionState ? { sandboxSessionState } : {}),
+      };
+    }
     if (!input.serializedRunState) {
       return { input: input.text };
     }
@@ -1273,6 +1301,46 @@ async function restoredSandboxSessionState(state: RunState<any, any>, client: un
   }
   if ((client as SandboxClient).backendId !== entry.backendId) {
     throw new Error("RunState sandbox backend does not match the configured sandbox client");
+  }
+  return await deserializeSandboxSessionStateEnvelope(client as SandboxClient, entry.sessionState);
+}
+
+/**
+ * Extract the sandbox recovery entry from a run state as a plain JSON record,
+ * for storage decoupled from the RunState blob (issue #35). Encapsulates the
+ * underscore-internal `_sandbox` read in exactly one place.
+ */
+export function sandboxStateEntryFromRunState(state: unknown): Record<string, unknown> | null {
+  const sandboxState = (state as any)?._sandbox;
+  if (!sandboxState) {
+    return null;
+  }
+  const entry = sandboxState.sessionsByAgent?.[sandboxState.currentAgentKey]
+    ?? (sandboxState.currentAgentKey && sandboxState.sessionState
+      ? {
+        backendId: sandboxState.backendId,
+        currentAgentKey: sandboxState.currentAgentKey,
+        currentAgentName: sandboxState.currentAgentName,
+        sessionState: sandboxState.sessionState,
+      }
+      : null);
+  if (!entry || !entry.sessionState) {
+    return null;
+  }
+  return entry as Record<string, unknown>;
+}
+
+/**
+ * Items-mode counterpart of restoredSandboxSessionState: rebuild the live
+ * sandbox session state from a stored entry (as produced by
+ * sandboxStateEntryFromRunState) instead of from a RunState blob.
+ */
+export async function restoredSandboxSessionStateFromEntry(entry: Record<string, unknown>, client: unknown): Promise<SandboxSessionState | undefined> {
+  if (!client || !entry || typeof entry !== "object" || !("sessionState" in entry)) {
+    return undefined;
+  }
+  if (entry.backendId && (client as SandboxClient).backendId !== entry.backendId) {
+    throw new Error("Stored sandbox envelope backend does not match the configured sandbox client");
   }
   return await deserializeSandboxSessionStateEnvelope(client as SandboxClient, entry.sessionState);
 }

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -33,6 +33,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     goalMaxAutoContinuations: 20,
     goalNoProgressLimit: 3,
     agentMaxModelCallsPerTurn: 40,
+    sessionHistorySource: "run_state",
     betterAuthSecret: undefined,
     betterAuthAllowedHosts: "",
     betterAuthCookieDomain: undefined,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -29,6 +29,7 @@ import {
   getSessionGoal,
   getBillingBalance,
   getLatestRunState,
+  getSessionHistoryItems,
   listSessionTurns,
   listUsageEvents,
   listSessionEvents,
@@ -911,6 +912,71 @@ describe("worker activities integration", () => {
     const usage = await listUsageEvents(dbClient.db, { accountId: grant.accountId, workspaceId: grant.workspaceId, limit: 20 });
     const cost = usage.find((event) => event.eventType === "model.cost" && event.sourceResourceId?.endsWith("expensive-response"));
     expect(cost?.quantity).toBeGreaterThan(1);
+  });
+
+  test("dual-writes conversation items and resumes turns from them in items mode", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "remember the codeword zebra",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const model = new ScriptedModel([
+      { id: "items-t1", outputText: "noted: zebra", chunks: ["noted: zebra"] },
+      { id: "items-t2", outputText: "the codeword is zebra", chunks: ["the codeword is zebra"] },
+    ]);
+    // Turn 1 runs in legacy run_state mode: items must be dual-written anyway.
+    const runStateActivities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model }),
+    });
+    const [trigger1] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "remember the codeword zebra" } },
+    ]);
+    await expect(runStateActivities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger1!.id,
+      workflowId: "workflow-items-turn-1",
+    })).resolves.toEqual({ status: "idle" });
+    const itemsAfterTurn1 = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(itemsAfterTurn1.length).toBeGreaterThanOrEqual(2);
+    expect(itemsAfterTurn1.map((row) => row.position)).toEqual(itemsAfterTurn1.map((_, index) => index));
+    expect(JSON.stringify(itemsAfterTurn1[0]?.item)).toContain("remember the codeword zebra");
+    const blobAfterTurn1 = await getLatestRunState(dbClient.db, grant.workspaceId, session.id);
+    expect(blobAfterTurn1).not.toBeNull();
+
+    // Turn 2 reads conversation truth from the items table (items mode) and
+    // writes no new blob: the model must still see the full prior turn.
+    const itemsActivities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl, sessionHistorySource: "items" }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model }),
+    });
+    const [trigger2] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "what is the codeword?" } },
+    ]);
+    await expect(itemsActivities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger2!.id,
+      workflowId: "workflow-items-turn-2",
+    })).resolves.toEqual({ status: "idle" });
+    const lastRequestInput = JSON.stringify((model.requests.at(-1) as { input?: unknown })?.input ?? "");
+    expect(lastRequestInput).toContain("remember the codeword zebra");
+    expect(lastRequestInput).toContain("noted: zebra");
+    expect(lastRequestInput).toContain("what is the codeword?");
+    const itemsAfterTurn2 = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(itemsAfterTurn2.length).toBeGreaterThan(itemsAfterTurn1.length);
+    const blobAfterTurn2 = await getLatestRunState(dbClient.db, grant.workspaceId, session.id);
+    expect(blobAfterTurn2?.id).toBe(blobAfterTurn1?.id);
   });
 
   test("blocks async document embeddings when managed credits are empty", async () => {


### PR DESCRIPTION
Implements the dual-write + flagged-read phases of #35 (design confirmed there).

## Summary
- `session_history_items`: ordered, verbatim `AgentInputItem` JSON — the model-facing conversation truth (RLS-scoped). `session_events` remains the redacted human/audit timeline.
- `sandbox_session_envelopes`: the sandbox recovery descriptor decoupled from the RunState blob; the `_sandbox` internal read is encapsulated in exactly one helper.
- **Dual-write unconditional**: items reconciled after every model response (crash window = one in-flight model call) and on every turn-end path including the max-calls/budget/provider valves; envelope upserted alongside; best-effort so persistence can never fail a run.
- **Read path flagged** (`OPENGENI_SESSION_HISTORY_SOURCE=items`): turn input = stored items + new message, sandbox state from its own store, zero RunState deserialization. Blob-less except `requires_action` (the one documented RunState-only resume). Lazy migration: a session without items reads the blob once and is backfilled by reconciliation.
- Flag default stays `run_state`; the staging flip is an env change after live soak, reversible both ways at any time.

## Verification
- typecheck clean; unit 229/229; db + temporal-workflow 27/27; worker-activity 38/38 including a new end-to-end test: turn 1 in run_state mode dual-writes items; turn 2 in items mode **proves via the scripted model's captured request** that the model received the full prior conversation from the items table, while writing no new blob row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent turn memory and resume behavior across worker, runtime, and DB; mitigated by default `run_state`, reversible flag, RunState fallback when items are empty, and approval-only blob path.
> 
> **Overview**
> Adds **SDK-native conversation persistence** (#35): new `session_history_items` and `sandbox_session_envelopes` tables, DB helpers, and a migration with workspace RLS.
> 
> The worker **dual-writes** on every run: after each model response and on all turn-end paths it appends new history items (position-idempotent) and upserts the sandbox envelope—**best-effort** so DB failures never fail the turn. **`OPENGENI_SESSION_HISTORY_SOURCE`** (`run_state` default, `items` optional) only switches the **read** path: in `items` mode, `turnInput` loads stored items + envelope instead of deserializing RunState; legacy blob writes are skipped except **`requires_action`** approvals. Runtime `prepareRunInput` gains an items-based branch; RunState blob use shrinks toward approvals-only.
> 
> Integration test covers dual-write under `run_state`, then multi-turn resume from items without a new blob row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9db083f7935f3fcfd6bdeec699794f8ca0e583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->