### PR TITLE
List workspace sessions in the web console

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -13,6 +13,7 @@ import {
   getSession,
   getSessionGoal,
   listSessionEvents,
+  listSessions,
   listSessionTurns,
   reorderQueuedSessionTurns,
   requireSession,
@@ -103,6 +104,12 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       idempotencyKey: `agent_run.created:${workspaceId}:${session.id}`,
     });
     return c.json(session, 202);
+  });
+
+  app.get("/v1/workspaces/:workspaceId/sessions", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "sessions:read");
+    return c.json(await listSessions(db, workspaceId, boundedLimit(c.req.query("limit"))));
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId", async (c) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -51,6 +51,7 @@ import {
   type Dispatch,
   type ReactNode,
   type SetStateAction,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -110,6 +111,7 @@ import {
   createBillingCheckout,
   reindexDocument,
   fetchSession,
+  fetchSessions,
   pauseScheduledTask,
   resumeScheduledTask,
   sendApproval,
@@ -570,7 +572,6 @@ function RootRouteComponent() {
         model,
         reasoningEffort,
       });
-      rememberSession(created);
       setSession(created);
       setEvents([]);
       setConnectionState("closed");
@@ -1036,8 +1037,9 @@ function AgentHomeRoute() {
           controlsStart={<AgentControlStrip workspaceId={workspaceId} />}
           onSubmit={(submission) => void submitInitial(submission)}
         />
-        <RecentSessions
+        <WorkspaceSessions
           workspaceId={workspaceId}
+          accessKeyVersion={context.accessKeyVersion}
           onSelect={(id) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: id } })}
         />
       </div>
@@ -1076,9 +1078,6 @@ function SessionRoute() {
         }
         context.setSession(nextSession);
         context.setEvents(nextEvents);
-        if (isTerminalSessionStatus(nextSession.status)) {
-          forgetSession(workspaceId, nextSession.id);
-        }
       } catch (error) {
         if (cancelled) {
           return;
@@ -1087,9 +1086,7 @@ function SessionRoute() {
         context.setEvents([]);
         context.setConnectionState("closed");
         setLoadError(error);
-        if (isApiErrorStatus(error, 404)) {
-          forgetSession(workspaceId, sessionId);
-        } else {
+        if (!isApiErrorStatus(error, 404)) {
           toast.error("Failed to load session", { description: String(error) });
         }
       } finally {
@@ -3906,19 +3903,71 @@ function ConnectionPill({ state }: { state: ConnectionState }) {
   );
 }
 
-function RecentSessions({ workspaceId, onSelect }: { workspaceId: string | null; onSelect: (id: string) => void }) {
-  const sessions = workspaceId ? recentSessions(workspaceId) : [];
-  if (sessions.length === 0) {
-    return null;
-  }
+function WorkspaceSessions({
+  workspaceId,
+  accessKeyVersion,
+  onSelect,
+}: {
+  workspaceId: string;
+  accessKeyVersion: number;
+  onSelect: (id: string) => void;
+}) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  const loadSessions = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const nextSessions = await fetchSessions(workspaceId, 50);
+      if (!signal?.aborted) {
+        setSessions(nextSessions);
+      }
+    } catch (nextError) {
+      if (!signal?.aborted) {
+        setError(nextError);
+        setSessions([]);
+      }
+    } finally {
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadSessions(controller.signal);
+    return () => controller.abort();
+  }, [loadSessions, accessKeyVersion]);
+
   return (
     <section className="mt-12">
-      <h2 className="text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">Recent sessions</h2>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">Workspace sessions</h2>
+        {error ? (
+          <Button type="button" variant="ghost" size="sm" onClick={() => void loadSessions()}>
+            <RefreshCwIcon className="size-4" />
+            Retry
+          </Button>
+        ) : null}
+      </div>
       <div className="mt-3 grid gap-2">
-        {sessions.map((item) => (
+        {loading ? (
+          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">Loading sessions...</div>
+        ) : error ? (
+          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">Session history is unavailable.</div>
+        ) : sessions.length === 0 ? (
+          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">No sessions in this workspace yet.</div>
+        ) : sessions.map((item) => (
           <button key={item.id} type="button" onClick={() => onSelect(item.id)} className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-left text-sm hover:bg-[color:var(--color-surface-2)]">
-            <div className="truncate font-medium">{item.prompt}</div>
-            <div className="mt-1 text-xs text-[color:var(--color-fg-subtle)]">{new Date(item.createdAt).toLocaleString()}</div>
+            <div className="truncate font-medium">{item.initialMessage}</div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[color:var(--color-fg-subtle)]">
+              <span>{new Date(item.createdAt).toLocaleString()}</span>
+              <span>{item.status}</span>
+              <span>{displayModel(item.model)}</span>
+            </div>
           </button>
         ))}
       </div>
@@ -5453,27 +5502,4 @@ function labelEffort(value: IntelligenceEffort): string {
 
 function displayModel(value: string): string {
   return value.startsWith("gpt-") ? value.replace("gpt-", "").toUpperCase() : value;
-}
-
-function rememberSession(session: Session) {
-  const items = [{ id: session.id, prompt: session.initialMessage, createdAt: session.createdAt }, ...recentSessions(session.workspaceId).filter((item) => item.id !== session.id)].slice(0, 8);
-  localStorage.setItem(recentSessionsStorageKey(session.workspaceId), JSON.stringify(items));
-}
-
-function forgetSession(workspaceId: string, sessionId: string) {
-  const items = recentSessions(workspaceId).filter((item) => item.id !== sessionId);
-  localStorage.setItem(recentSessionsStorageKey(workspaceId), JSON.stringify(items));
-}
-
-function recentSessions(workspaceId: string): Array<{ id: string; prompt: string; createdAt: string }> {
-  try {
-    const parsed = JSON.parse(localStorage.getItem(recentSessionsStorageKey(workspaceId)) ?? "[]");
-    return Array.isArray(parsed) ? parsed.filter((item) => item?.id && item?.prompt && item?.createdAt) : [];
-  } catch {
-    return [];
-  }
-}
-
-function recentSessionsStorageKey(workspaceId: string): string {
-  return `opengeni-recent-sessions:${workspaceId}`;
 }

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { authHeadersForAccessKey, resolveApiBaseUrl, sendVerificationEmail, shouldReloadForDeploymentRevision, streamSessionEvents } from "./api";
+import { authHeadersForAccessKey, fetchSessions, resolveApiBaseUrl, sendVerificationEmail, shouldReloadForDeploymentRevision, streamSessionEvents } from "./api";
 import type { SessionEvent } from "./types";
 
 describe("web API auth helpers", () => {
@@ -50,6 +50,26 @@ describe("web API auth helpers", () => {
     expect(request!.init?.method).toBe("POST");
     expect(request!.init?.credentials).toBe("include");
     expect(JSON.parse(String(request!.init?.body))).toEqual({ email: "user@example.com" });
+  });
+
+  test("fetches workspace sessions from the canonical workspace route", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ input: Parameters<typeof fetch>[0]; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      requests.push({ input, init });
+      return Response.json([]);
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(fetchSessions("workspace-id", 25)).resolves.toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const request = requests[0];
+    expect(request).toBeDefined();
+    expect(String(request!.input)).toBe("/v1/workspaces/workspace-id/sessions?limit=25");
+    expect(request!.init?.credentials).toBe("include");
   });
 });
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -260,6 +260,11 @@ export function fetchSession(workspaceId: string, sessionId: string): Promise<Se
   return request<Session>(workspacePath(workspaceId, `/sessions/${sessionId}`));
 }
 
+export function fetchSessions(workspaceId: string, limit = 50): Promise<Session[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return request<Session[]>(workspacePath(workspaceId, `/sessions?${params}`));
+}
+
 export async function fetchEvents(workspaceId: string, sessionId: string, after = 0): Promise<SessionEvent[]> {
   const limit = 500;
   const events: SessionEvent[] = [];

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1940,6 +1940,16 @@ export async function getSession(db: Database, workspaceId: string, sessionId: s
   });
 }
 
+export async function listSessions(db: Database, workspaceId: string, limit = 50): Promise<Session[]> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.select().from(schema.sessions)
+      .where(eq(schema.sessions.workspaceId, workspaceId))
+      .orderBy(desc(schema.sessions.createdAt), desc(schema.sessions.id))
+      .limit(limit);
+    return rows.map(mapSession);
+  });
+}
+
 export async function requireSession(db: Database, workspaceId: string, sessionId: string): Promise<Session> {
   const session = await getSession(db, workspaceId, sessionId);
   if (!session) {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -52,6 +52,11 @@ describe("API component integration", () => {
     expect(workflow.wakeups).toHaveLength(1);
     const events = await listSessionEvents(dbClient.db, workspaceId, session.id);
     expect(events.map((event) => event.type)).toEqual(["session.created", "user.message", "session.status.changed", "turn.queued"]);
+
+    const listed = await app.request(workspacePath(workspaceId, "/sessions?limit=10"));
+    expect(listed.status).toBe(200);
+    const sessions = await listed.json() as Array<{ id: string; workspaceId: string; initialMessage: string }>;
+    expect(sessions.some((item) => item.id === session.id && item.workspaceId === workspaceId && item.initialMessage === "hello")).toBe(true);
   });
 
   test("creates sessions with goals and manages the goal lifecycle over the API", async () => {

--- a/test/integration/workspace-isolation.integration.ts
+++ b/test/integration/workspace-isolation.integration.ts
@@ -52,6 +52,14 @@ describe("workspace isolation matrix", () => {
     expect(createdSession.status).toBe(202);
     const session = await createdSession.json() as { id: string };
 
+    const listA = await app.request(workspacePath(a.workspaceId, "/sessions"), { headers: authA });
+    expect(listA.status).toBe(200);
+    expect((await listA.json() as Array<{ id: string }>).some((item) => item.id === session.id)).toBe(true);
+    await expectStatus(app, authA, workspacePath(b.workspaceId, "/sessions"), 403);
+    const listB = await app.request(workspacePath(b.workspaceId, "/sessions"), { headers: authB });
+    expect(listB.status).toBe(200);
+    expect((await listB.json() as Array<{ id: string }>).some((item) => item.id === session.id)).toBe(false);
+
     await expectStatus(app, authA, workspacePath(b.workspaceId, `/sessions/${session.id}`), 403);
     await expectStatus(app, authB, workspacePath(b.workspaceId, `/sessions/${session.id}`), 404);
     await expectStatus(app, authA, legacyRoute("sessions", session.id), 404);


### PR DESCRIPTION
## Summary
- add `GET /v1/workspaces/:workspaceId/sessions` backed by workspace-scoped DB/RLS access
- replace browser-local recent sessions with server-backed workspace session history on the agent home route
- cover the list route in API, web API, and workspace isolation tests

## Tests
- `bun run typecheck`
- `bun test apps/web/src/api.test.ts apps/web/src/App.test.ts`
- `bun test ./test/integration/api.integration.ts`
- `bun test ./test/integration/workspace-isolation.integration.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new workspace data read path; risk is mitigated by existing access grants and RLS, but incorrect scoping would leak session metadata across workspaces.
> 
> **Overview**
> Adds **`GET /v1/workspaces/:workspaceId/sessions`** with `sessions:read` and a bounded `limit`, backed by new **`listSessions`** (workspace RLS, newest first).
> 
> The web agent home **replaces browser `localStorage` “recent sessions”** with **`WorkspaceSessions`**, which loads up to 50 sessions via **`fetchSessions`**, shows loading/error/retry UI, and refreshes when the access key changes. Session rows now use **`initialMessage`**, **status**, and **model** from the API. Creating or loading a session no longer writes or prunes local recent-session entries.
> 
> Coverage: web API unit test for the list URL, integration tests for listing and **workspace isolation** on the list route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64946265a438ad40fb53bc6b7e038c2b05e613d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->