### PR TITLE
Items as default conversation memory + contributor doc sync (#35)

### DIFF
--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -31,6 +31,8 @@ Then open the smallest source files that answer the question:
 - API routes: `apps/api/src/routes/`, plus `apps/api/src/app.ts` and `apps/api/src/index.ts`.
 - Public shapes: `packages/contracts/src/index.ts`, especially workspace, access, billing, usage, session, file, document, schedule, and MCP contracts.
 - Config/env: `packages/config/src/index.ts`, `.env.example`, `README.md`, `AGENTS.md`.
+- Run lifecycle / goals / memory: `docs/run-lifecycle.md`, `docs/goals.md`, plus `apps/worker/src/workflows/session.ts` and `apps/worker/src/activities/agent-turn.ts`.
+- Feature subsystems: `docs/environments.md` (workspace secrets), `docs/packs.md` and `docs/capabilities.md` (capability packs / MCP catalog).
 - Database/state: `packages/db/src/schema.ts`, `packages/db/src/index.ts`, `packages/db/drizzle/`.
 - Event bus/SSE: `packages/events/src/index.ts`, `apps/api/src/http/sse.ts`.
 - Worker/orchestration: `apps/worker/src/workflows/`, `apps/worker/src/activities/`.
@@ -44,7 +46,7 @@ Then open the smallest source files that answer the question:
 If paths have moved, find concepts by symbol name, not by old paths:
 
 ```bash
-rg -n "CreateSessionRequest|ClientSessionEvent|sessionWorkflow|runAgentSegment|createSandboxClient|buildManifest|createObjectStorage|build.*McpServer|getSettings"
+rg -n "CreateSessionRequest|ClientSessionEvent|sessionWorkflow|runAgentTurn|createSandboxClient|buildManifest|createObjectStorage|build.*McpServer|getSettings"
 ```
 
 ## Client Integration
@@ -71,7 +73,10 @@ Keep these concepts straight while working:
 - **Workspace**: operational data boundary for sessions, events, files, documents, schedules, GitHub installations, usage, and first-party MCP.
 - **Access grant**: resolved subject plus permissions for one workspace. Route code should depend on grants and permissions, not on the caller's auth mechanism.
 - **Session**: durable user-facing work container. It owns status, resources, selected tools, model/sandbox settings, event cursor, and active turn.
-- **Turn**: one queued/running unit of agent work inside a session. Follow-ups and scheduled task firings become turns.
+- **Turn**: one queued/running unit of agent work inside a session, run as one non-retryable Temporal activity (`runAgentTurn`). Follow-ups, goal continuations, and scheduled task firings become turns. Inside a turn the SDK makes as many model/tool calls as the work needs; run length is bounded by symptoms (no-progress, budget), not by counts or clocks. See `docs/run-lifecycle.md`.
+- **Goal**: optional durable per-session objective that flips "stop" into an explicit act — while active, the session workflow synthesizes continuation turns until the agent calls `goal_complete`/`goal_pause` or a user interrupts. The mechanism behind long-running autonomous runs. See `docs/goals.md`.
+- **Session memory (three stores, three jobs)**: `session_history_items` is the conversation truth fed to the model (default read path); `agent_run_states` is the serialized RunState blob, used only to resume a turn paused for a human approval; `session_events` is the redacted/lossy human-audit timeline and is never fed back to the model. Sandbox recovery state lives separately in `sandbox_session_envelopes`. See `docs/run-lifecycle.md`.
+- **Workspace environment**: named per-workspace set of secret env vars, attached to a session/scheduled-task/pack and injected into the sandbox at run time; values are write-only. See `docs/environments.md`.
 - **Event log**: append-only session timeline with per-session sequence numbers. It supports replay, SSE reconnect, UI timeline projection, and auditing.
 - **SSE/NATS split**: Postgres is replay/source of truth. NATS is live fanout. If live events are missed, API should backfill from Postgres by sequence.
 - **Temporal**: orchestration, signals, timers, schedules, and worker dispatch. Token streams/tool output should not be pushed through workflow history unless the code intentionally changes that design.
@@ -214,7 +219,8 @@ Avoid absolute claims until verified in current code:
 Update this skill in the same change whenever the repo changes any of these:
 
 - Core architecture: API/worker/runtime/storage/event-bus boundaries.
-- Terminology: session, turn, event, resource, tool, schedule, sandbox, activity.
+- Terminology: session, turn, goal, event, resource, tool, schedule, sandbox, activity, workspace environment.
+- Run lifecycle: the goal continuation loop, the no-run-length-limits principle, and the three-store session memory model (history items / run-state blob / event log).
 - Public workflow: how to create sessions, stream events, upload files, attach resources, approve/interrupt, schedule tasks.
 - Pluggability model: sandbox backend contract, MCP tool config, model provider config, object storage, GitHub integration.
 - Source layout: if important files move or names change.

--- a/.env.example
+++ b/.env.example
@@ -64,11 +64,11 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS=
 # OPENGENI_GOAL_NO_PROGRESS_LIMIT=3
 
-# Conversation-history source (issue #35). Items + the sandbox envelope are
-# dual-written unconditionally; this flips the READ path only (safe to toggle
-# both ways at any time). "items" reads SDK-native history items from the DB;
-# unset/"run_state" reads the legacy serialized RunState blob.
-# OPENGENI_SESSION_HISTORY_SOURCE=items
+# Conversation-history source (issue #35; see docs/run-lifecycle.md). Items +
+# the sandbox envelope are dual-written unconditionally; this flips the READ
+# path only. Default is "items" (SDK-native history items from the DB); set
+# "run_state" to fall back to the legacy serialized RunState blob.
+# OPENGENI_SESSION_HISTORY_SOURCE=run_state
 
 # Managed mode human auth and transactional email.
 # OPENGENI_BETTER_AUTH_SECRET=replace-with-long-random-better-auth-secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,21 @@ MinIO is the local S3-compatible object storage default for Docker Compose and o
 - Postgres is the durable event store and replay source.
 - Temporal is orchestration only. Token streams do not go through workflow history.
 - OpenAI Agents SDK execution happens inside non-retryable worker activities.
-- Agent activities are side-effectful. Do not add automatic Temporal retries around full agent segments unless each model/tool/sandbox boundary has been made idempotent.
+- Agent activities are side-effectful. Do not add automatic Temporal retries around full agent turns unless each model/tool/sandbox boundary has been made idempotent.
+
+## Run Lifecycle (read `docs/run-lifecycle.md` before changing the session workflow, the agent turn activity, or memory)
+
+Three principles here are load-bearing and easy to break by accident:
+
+- **No run-length limits, by design.** OpenGeni runs agents that legitimately work for days. Run length is bounded by symptoms (no-progress detection, budget exhaustion), never by counts or clocks. Do not add or lower caps on model calls per turn, continuation count, or activity timeout as a way to "be safe" — fix the pathology instead. See `docs/run-lifecycle.md` and `docs/goals.md`.
+- **Three memory stores, three jobs.** `session_history_items` is conversation truth fed to the model (default read path). `agent_run_states` is the serialized RunState blob, used *only* to resume a turn paused for a human approval — never as conversation memory. `session_events` is the redacted, lossy human/audit timeline and must never be fed back to the model. Sandbox recovery state is separate again in `sandbox_session_envelopes`.
+- **Goals drive long runs.** An active goal turns "stop" into an explicit act; the continuation loop is replay-safe and lives in the session workflow. See `docs/goals.md`.
+
+The agent turn activity is `runAgentTurn`, also registered under the legacy alias `runAgentSegment` for in-flight workflow histories — schedule `runAgentTurn` in new code.
+
+## Keeping these notes current
+
+If a change alters architecture, terminology, the run lifecycle, the memory model, or a "do not" guardrail above, update this file and the relevant `docs/*.md` in the same change. An out-of-date AGENTS.md or doc is a bug, not a nicety.
 
 ## Sandbox Notes
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart LR
 
   subgraph Managed["Managed agent service"]
     API["Hono API<br/>public contract"]
-    DB["Postgres<br/>sessions, events, run state"]
+    DB["Postgres<br/>sessions, events, history items, run state"]
     Temporal["Temporal<br/>orchestration and signals"]
     Worker["Worker<br/>OpenAI Agents SDK harness"]
     NATS["NATS Core<br/>live fanout"]
@@ -309,7 +309,7 @@ Integration and E2E tests use Bun's test runner. Deterministic SDK-level tests u
 
 - Public clients should treat the API as the source of truth.
 - Browser streaming uses `GET /v1/workspaces/:workspaceId/sessions/:id/events/stream`.
-- Agent activities are side-effectful. Do not add automatic Temporal retries around full agent segments unless each model, tool, and sandbox boundary has been made idempotent.
+- Agent activities are side-effectful. Do not add automatic Temporal retries around full agent turns unless each model, tool, and sandbox boundary has been made idempotent.
 - Docker sandbox file resources from local S3-compatible storage are materialized into the sandbox before the run. Attach file resources before the first run when using the Docker backend.
 - Sandbox preparation profiles are explicit. Model provider credentials are not automatically exposed inside sandboxes unless configured.
 

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -56,8 +56,10 @@ activity for a decision:
 5. Otherwise a continuation turn is enqueued: a deterministic prompt referencing
    the goal text and success criteria, the session's tool surface plus the
    first-party `opengeni` MCP server (so the goal tools are always reachable),
-   and the session's saved run state — the agent keeps its full conversation
-   context.
+   and the session's stored conversation — the agent keeps its full context.
+   By default that conversation comes from `session_history_items` (the
+   SDK-native memory store; see `docs/run-lifecycle.md`); the legacy run-state
+   blob path remains available behind `OPENGENI_SESSION_HISTORY_SOURCE`.
 
 Continuation turns are ordinary turns: they bill, meter (`agent_run.created`
 with source `session_turn`), and stream exactly like user turns. If billing or
@@ -117,5 +119,6 @@ reachable even when the session was created with an empty tool list.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` | `20` | Hard ceiling on synthesized continuation turns per goal arming. |
+| `OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS` | _(unset — no cap)_ | Optional hard ceiling on synthesized continuation turns per goal arming. Unset by default: goals are bounded by the progress and budget guards, not by count, so a run can legitimately span days. When set, it is a ceiling that a per-goal `maxAutoContinuations` can only lower. |
 | `OPENGENI_GOAL_NO_PROGRESS_LIMIT` | `3` | Consecutive zero-progress continuations tolerated before auto-pause. |
+| `OPENGENI_SESSION_HISTORY_SOURCE` | `items` | Conversation-memory read path: `items` (SDK-native `session_history_items`) or `run_state` (legacy blob). See `docs/run-lifecycle.md`. |

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1,0 +1,72 @@
+# Run lifecycle: turns, goals, and memory
+
+This is the orientation for how an OpenGeni agent run actually executes over
+time. It ties together three subsystems a contributor touching the session
+workflow, the worker activity, or the runtime must keep straight. Code wins
+over this doc; the canonical sources are `apps/worker/src/workflows/session.ts`,
+`apps/worker/src/activities/agent-turn.ts`, and `packages/runtime/src/index.ts`.
+
+## Turns
+
+A **turn** is one unit of agent work inside a session: an input (a user message,
+a goal continuation, or an approval decision) is processed until the agent
+reaches a natural stopping point. One turn runs as one non-retryable Temporal
+activity (`runAgentTurn`; the activity is also registered under its former name
+`runAgentSegment` for in-flight workflow-history compatibility — do not schedule
+the old name in new code). Inside that activity the OpenAI Agents SDK loop makes
+as many model calls and tool calls as the work needs.
+
+**Runs have no length limits, by design.** What the SDK calls "turns" are model
+calls; `OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN` exists but defaults to
+effectively unbounded. There is no continuation cap and the agent activity's
+Temporal timeout is measured in days, not hours. OpenGeni is built for agents
+that legitimately run for a very long time, so **run length is bounded by
+symptoms, never by counts**: the no-progress detector and budget exhaustion are
+the real guards. Do not reintroduce count- or duration-based caps on legitimate
+run length; if a run is misbehaving, detect the pathology, do not cap the clock.
+
+Two recoverable conditions end a turn gracefully (idle the session, keep the
+context) instead of failing it, so a long run survives them: hitting the
+model-call cap (if one is configured) and provider rate-limit backpressure on a
+goal-bearing session. A budget/credit exhaustion between model calls likewise
+idles the turn rather than failing the session, so a top-up lets the same
+session continue.
+
+## Goals — what makes long runs continue
+
+Agents stop prematurely. A **goal** flips the default so that finishing a turn
+with nothing queued does not idle the session out — the workflow synthesizes a
+continuation turn and the agent must explicitly `goal_complete` or `goal_pause`
+to stop. This is the mechanism behind every multi-day autonomous run. Full
+detail in `docs/goals.md`; the one-line model: queued user input always wins
+over a continuation, and goals are bounded by progress/budget guards, not counts.
+
+## Memory — three stores, three jobs
+
+A session's content lives in three places. Keep them straight; reaching for the
+wrong one is the classic mistake.
+
+1. **`session_history_items` — conversation truth (the model-facing store).**
+   Ordered, verbatim SDK `AgentInputItem` JSON, unredacted, RLS-scoped. This is
+   what a new turn's input is built from. It is dual-written as the agent
+   streams (reconciled after every model response and at every turn-end path)
+   so a crash loses at most the single in-flight model call. The read path is
+   selected by `OPENGENI_SESSION_HISTORY_SOURCE` (default `items`).
+2. **`agent_run_states` — approval resume only.** The serialized SDK `RunState`
+   blob is an opaque, SDK-version-gated process checkpoint. Its one legitimate
+   job is resuming a turn that paused mid-flight for a human approval
+   (`requires_action`); a half-finished tool approval cannot be represented as
+   plain history items. In items mode the blob is written only for that case.
+   Do not use it as conversation memory.
+3. **`session_events` — the redacted human/audit timeline.** Append-only,
+   per-session sequence numbers, drives replay/SSE/UI. It is **secret-redacted
+   and lossy** (reasoning items and several item types are dropped), so it is
+   correct for humans and auditing and must never be fed back to the model.
+
+Sandbox recovery state is persisted separately again, in
+`sandbox_session_envelopes`: the small versioned descriptor (provider handle /
+snapshot reference / manifest) used to reattach, snapshot-restore, or rebuild
+the session's sandbox on its next turn — decoupled from the RunState blob.
+
+See issue #35 for the rationale and the dual-write → flagged-read → default-flip
+migration history.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -96,11 +96,12 @@ const SettingsSchema = z.object({
   // session failure) remains as inert safety should a deployment set a cap.
   agentMaxModelCallsPerTurn: z.coerce.number().int().positive().default(1_000_000),
   // Where turn-input conversation history comes from (issue #35):
-  // "run_state" = legacy serialized RunState blob; "items" = the
-  // session_history_items table (SDK-native, version-stable). Items and the
-  // sandbox envelope are dual-written unconditionally; this flag governs the
-  // read path only, so flipping (and flipping back) is safe at any time.
-  sessionHistorySource: z.enum(["run_state", "items"]).default("run_state"),
+  // "items" (default) = the session_history_items table (SDK-native,
+  // version-stable conversation truth); "run_state" = the legacy serialized
+  // RunState blob. Items and the sandbox envelope are dual-written
+  // unconditionally; this flag governs the read path only, so flipping back to
+  // "run_state" remains a safe rollback at any time.
+  sessionHistorySource: z.enum(["run_state", "items"]).default("items"),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),


### PR DESCRIPTION
Completes the #35 switchover and fixes the contributor guidance that drifted across today's run-architecture work.

## Switchover
- `OPENGENI_SESSION_HISTORY_SOURCE` defaults to `items`. Conversation truth = `session_history_items`; the RunState blob is written only for `requires_action` approval resume; `run_state` stays available as a documented rollback (read-path flag only, dual-write unchanged).

## Doc sync
- **New `docs/run-lifecycle.md`** — turns, the no-run-length-limits principle, goals, and the three-store memory model in one place.
- `AGENTS.md` / `README.md`: "agent segments" → "agent turns"; AGENTS.md gains a Run Lifecycle section + a doc-currency rule.
- `docs/goals.md`: fixed the Settings table still claiming a default continuation cap of 20 (the body dropped it in #29 — a live contradiction); corrected the run-state memory line.
- opengeni skill: `runAgentSegment`→`runAgentTurn` greps; Goal / Session-memory / Workspace-environment mental-model entries; pointers to the new + post-PR-11 docs; extended currency watch list.

## Verification
- typecheck clean; unit 230/230; worker-activity + db + temporal-workflow 65/65 (both memory modes covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flipping the default conversation read path affects all new deployments and session continuity semantics; rollback via `OPENGENI_SESSION_HISTORY_SOURCE=run_state` is documented but behavior change is operationally significant.
> 
> **Overview**
> Completes **#35** by defaulting **`OPENGENI_SESSION_HISTORY_SOURCE`** to **`items`**, so new turns build model input from **`session_history_items`**; dual-write is unchanged and **`run_state`** remains a read-path rollback only (RunState blob still written for approval resume in items mode).
> 
> Adds **`docs/run-lifecycle.md`** and aligns contributor docs: **agent segments → agent turns**, a **Run Lifecycle** section in **`AGENTS.md`**, the three-store memory model, **`runAgentTurn`** discovery in the opengeni skill, and fixes **`docs/goals.md`** / **`.env.example`** where goal continuation caps and history defaults still contradicted current behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf348898773ae1620805c135b9680d2b74fcd40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->