### PR TITLE
Manager MCP tools: workspace orchestration, environment management, github

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -181,7 +181,7 @@ export function createApp(deps: AppDependencies): Hono {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, routeDeps, workspaceId, "workspace:read");
     const transport = new WebStandardStreamableHTTPServerTransport({ enableJsonResponse: true });
-    const mcp = buildOpenGeniMcpServer(routeDeps, grant);
+    const mcp = buildOpenGeniMcpServer(routeDeps, grant, { requestOrigin: new URL(c.req.url).origin });
     await mcp.connect(transport);
     return await transport.handleRequest(c.req.raw);
   });

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -1,12 +1,18 @@
 import type { Settings } from "@opengeni/config";
 import {
+  CreateSessionRequest,
   reasoningEffortForMetadata,
+  type AccessGrant,
   type GoalSpec,
+  type ReasoningEffort,
   type ResourceRef,
+  type Session,
+  type SessionEvent,
   type SessionTurn,
   type ToolRef,
 } from "@opengeni/contracts";
 import {
+  appendSessionEventsWithLockedSessionUpdate,
   createSession,
   createSessionGoal,
   enqueueSessionTurn,
@@ -17,7 +23,19 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
-import type { SessionWorkflowClient } from "../dependencies";
+import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
+import type { ApiRouteDeps, SessionWorkflowClient } from "../dependencies";
+import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
+import { validateEnvironmentAttachment } from "./environments";
+import {
+  mergeResourceRefs,
+  mergeToolRefs,
+  normalizeResources,
+  validateFileResources,
+  validateGitHubRepositorySelection,
+  validateToolRefs,
+  withDefaultEnabledCapabilityMcpTools,
+} from "./resources";
 
 export async function createAndStartSession(input: {
   db: Database;
@@ -143,4 +161,236 @@ export async function requireQueuedTurnForApi(db: Database, workspaceId: string,
 
 export function reasoningEffortForSession(metadata: Record<string, unknown>, fallback: Settings["openaiReasoningEffort"]): Settings["openaiReasoningEffort"] {
   return reasoningEffortForMetadata(metadata, fallback);
+}
+
+/**
+ * Appends a `user.message` to an existing session and enqueues the resulting
+ * turn, merging requested resources/tools into the session and waking the
+ * workflow. Shared by the public events route and the first-party MCP
+ * `session_send_message` tool so the two surfaces cannot drift. Callers own
+ * resource/tool validation and the per-message usage limit before calling.
+ */
+export async function postUserMessageTurn(input: {
+  db: Database;
+  bus: EventBus;
+  workflowClient: SessionWorkflowClient;
+  settings: Settings;
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  text: string;
+  resources: ResourceRef[];
+  tools: ToolRef[];
+  model?: string | null;
+  reasoningEffort?: Settings["openaiReasoningEffort"] | null;
+  clientEventId?: string;
+}): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
+  const { db, bus, workflowClient, settings, accountId, workspaceId, sessionId } = input;
+  const requestedModel = input.model ?? null;
+  const requestedReasoningEffort = input.reasoningEffort ?? null;
+  const appended = await appendSessionEventsWithLockedSessionUpdate(db, workspaceId, sessionId, (lockedSession) => {
+    if (lockedSession.status === "failed" || lockedSession.status === "cancelled") {
+      throw new HTTPException(409, { message: `session is ${lockedSession.status}; cannot accept a new user message` });
+    }
+    const nextResources = mergeResourceRefs(lockedSession.resources, input.resources);
+    const nextTools = mergeToolRefs(lockedSession.tools, input.tools);
+    const shouldQueueSession = lockedSession.status === "idle";
+    return {
+      events: [
+        {
+          type: "user.message",
+          payload: {
+            text: input.text,
+            ...(input.resources.length ? { resources: input.resources } : {}),
+            ...(input.tools.length ? { tools: input.tools } : {}),
+            ...(requestedModel ? { model: requestedModel } : {}),
+            ...(requestedReasoningEffort ? { reasoningEffort: requestedReasoningEffort } : {}),
+          },
+          ...(input.clientEventId ? { clientEventId: input.clientEventId } : {}),
+        },
+        ...(shouldQueueSession ? [{ type: "session.status.changed" as const, payload: { status: "queued" } }] : []),
+      ],
+      update: {
+        resources: nextResources,
+        tools: nextTools,
+        ...(shouldQueueSession ? { status: "queued" as const, activeTurnId: null } : {}),
+      },
+    };
+  }).then(async (events) => {
+    await bus.publish(workspaceId, sessionId, events);
+    return events;
+  });
+  const accepted = appended[0];
+  if (!accepted) {
+    throw new HTTPException(500, { message: "failed to append client event" });
+  }
+  const workflowId = workflowIdForSession(sessionId);
+  const session = await requireSession(db, workspaceId, sessionId);
+  const turn = await enqueueSessionTurn(db, {
+    accountId,
+    workspaceId,
+    sessionId,
+    triggerEventId: accepted.id,
+    temporalWorkflowId: workflowId,
+    source: "user",
+    prompt: input.text,
+    resources: input.resources,
+    tools: input.tools,
+    model: requestedModel ?? session.model,
+    reasoningEffort: requestedReasoningEffort ?? reasoningEffortForSession(session.metadata, settings.openaiReasoningEffort),
+    sandboxBackend: session.sandboxBackend,
+    metadata: {},
+  });
+  await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+    type: "turn.queued",
+    turnId: turn.id,
+    payload: { turnId: turn.id, triggerEventId: accepted.id, source: turn.source },
+  }]);
+  await workflowClient.wakeSessionWorkflow({ accountId, workspaceId, sessionId, workflowId });
+  return { accepted, turn };
+}
+
+/**
+ * Full create-session flow shared by `POST /sessions` and the first-party MCP
+ * `session_create` tool: payload validation, resource/tool/environment
+ * checks, usage limits, session start, and usage recording. `rawPayload` is
+ * the unparsed request body so absent-vs-empty `tools` keeps its meaning
+ * (absent applies the workspace's default capability MCP tools).
+ */
+export async function createSessionForRequest(
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  workspaceId: string,
+  rawPayload: unknown,
+): Promise<Session> {
+  const { settings, db, bus, workflowClient, objectStorage } = deps;
+  const payload = CreateSessionRequest.parse(rawPayload);
+  const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
+  const resources = normalizeResources(payload.resources);
+  const requestedTools = validateToolRefs(payload.tools, runtimeSettings);
+  const defaultedTools = hasOwnProperty(rawPayload, "tools")
+    ? requestedTools
+    : withDefaultEnabledCapabilityMcpTools(requestedTools, settings, runtimeSettings);
+  // Goal-bearing sessions force the first-party MCP server so the goal
+  // tools the continuation prompt references are reachable.
+  const tools = payload.goal ? withFirstPartyGoalTools(defaultedTools, runtimeSettings) : defaultedTools;
+  await validateGitHubRepositorySelection(db, workspaceId, resources);
+  if (resources.some((resource) => resource.kind === "file") && !objectStorage) {
+    throw new HTTPException(503, { message: "object storage is not configured" });
+  }
+  await validateFileResources(db, workspaceId, resources);
+  // Environment attachment requires environments:use on the calling grant
+  // (validateEnvironmentAttachment enforces it), preserving the invariant
+  // that sandboxed agents cannot self-attach workspace secrets.
+  const environment = payload.environmentId
+    ? await validateEnvironmentAttachment({ settings, db }, grant, workspaceId, payload.environmentId)
+    : null;
+  const model = payload.model ?? settings.openaiModel;
+  const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
+  await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
+  const session = await createAndStartSession({
+    db,
+    bus,
+    workflowClient,
+    accountId: grant.accountId,
+    workspaceId,
+    initialMessage: payload.initialMessage,
+    resources,
+    tools,
+    ...(payload.clientEventId ? { clientEventId: payload.clientEventId } : {}),
+    model,
+    reasoningEffort,
+    sandboxBackend: payload.sandboxBackend ?? settings.sandboxBackend,
+    metadata: payload.metadata,
+    environment: environment ? { id: environment.id, name: environment.name } : null,
+    goal: payload.goal ?? null,
+  });
+  await recordWorkspaceUsage(deps, {
+    accountId: grant.accountId,
+    workspaceId,
+    subjectId: grant.subjectId,
+    eventType: "agent_run.created",
+    quantity: 1,
+    unit: "run",
+    sourceResourceType: "session",
+    sourceResourceId: session.id,
+    idempotencyKey: `agent_run.created:${workspaceId}:${session.id}`,
+  });
+  return session;
+}
+
+/**
+ * Full accept-user-message flow shared by the `user.message` branch of
+ * `POST /sessions/:id/events` and the first-party MCP `session_send_message`
+ * tool: resource/tool validation, usage limits, the locked append + turn
+ * enqueue, and usage recording. `toolsProvided: false` applies the
+ * workspace's default capability MCP tools, matching an absent `tools` key.
+ */
+export async function acceptSessionUserMessage(
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  workspaceId: string,
+  sessionId: string,
+  input: {
+    text: string;
+    resources?: ResourceRef[];
+    tools?: ToolRef[];
+    toolsProvided: boolean;
+    model?: string | null;
+    reasoningEffort?: ReasoningEffort | null;
+    clientEventId?: string;
+  },
+): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
+  const { settings, db, bus, workflowClient, objectStorage } = deps;
+  const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
+  const requestedResources = normalizeResources(input.resources ?? []);
+  const validatedTools = validateToolRefs(input.tools ?? [], runtimeSettings);
+  const requestedTools = input.toolsProvided
+    ? validatedTools
+    : withDefaultEnabledCapabilityMcpTools(validatedTools, settings, runtimeSettings);
+  await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
+  if (requestedResources.some((resource) => resource.kind === "file") && !objectStorage) {
+    throw new HTTPException(503, { message: "object storage is not configured" });
+  }
+  await validateFileResources(db, workspaceId, requestedResources);
+  const existingSession = await requireSession(db, workspaceId, sessionId);
+  await validateGitHubRepositorySelection(db, workspaceId, [...existingSession.resources, ...requestedResources]);
+  const { accepted, turn } = await postUserMessageTurn({
+    db,
+    bus,
+    workflowClient,
+    settings,
+    accountId: grant.accountId,
+    workspaceId,
+    sessionId,
+    text: input.text,
+    resources: requestedResources,
+    tools: requestedTools,
+    model: input.model ?? null,
+    reasoningEffort: input.reasoningEffort ?? null,
+    ...(input.clientEventId ? { clientEventId: input.clientEventId } : {}),
+  });
+  await recordWorkspaceUsage(deps, {
+    accountId: grant.accountId,
+    workspaceId,
+    subjectId: grant.subjectId,
+    eventType: "agent_run.created",
+    quantity: 1,
+    unit: "run",
+    sourceResourceType: "session_turn",
+    sourceResourceId: turn.id,
+    idempotencyKey: `agent_run.created:${workspaceId}:${turn.id}`,
+  });
+  return { accepted, turn };
+}
+
+function withFirstPartyGoalTools(tools: ToolRef[], runtimeSettings: { mcpServers: Array<{ id: string }> }): ToolRef[] {
+  if (!runtimeSettings.mcpServers.some((server) => server.id === "opengeni")) {
+    return tools;
+  }
+  return mergeToolRefs(tools, [{ kind: "mcp", id: "opengeni" }]);
+}
+
+function hasOwnProperty(value: unknown, key: string): boolean {
+  return Boolean(value && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key));
 }

--- a/apps/api/src/http/auth.ts
+++ b/apps/api/src/http/auth.ts
@@ -1,6 +1,8 @@
 import type { Settings } from "@opengeni/config";
 import type { Context, MiddlewareHandler } from "hono";
 
+const githubConnectPathPattern = /^\/v1\/workspaces\/[^/]+\/github\/connect$/;
+
 export function requireAccessKey(settings: Settings): MiddlewareHandler {
   return async (c, next) => {
     if (!settings.authRequired || isAuthExempt(c, settings)) {
@@ -35,6 +37,12 @@ function isAuthExempt(c: Context, settings: Settings): boolean {
     path === "/v1/github/oauth/callback" ||
     path === "/v1/github/app-manifest/callback"
   ) {
+    return true;
+  }
+  // Browser entry for MCP-issued GitHub install links: opened in a browser
+  // that holds no API credentials, like the callbacks above. The route itself
+  // verifies the signed workspace-bound state before doing anything.
+  if (githubConnectPathPattern.test(path)) {
     return true;
   }
   if (settings.authAllowHealth && path === "/healthz") {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1,30 +1,45 @@
 import {
   CreateScheduledTaskRequest,
+  WorkspaceEnvironmentVariableName,
   type AccessGrant,
   type GitHubRepository,
+  type Permission,
   type ResourceRef,
   UpdateScheduledTaskRequest,
 } from "@opengeni/contracts";
 import {
+  countWorkspaceEnvironments,
+  createWorkspaceEnvironment,
   deleteScheduledTask,
+  encryptEnvironmentValue,
+  getSession,
   getSessionGoal,
+  getWorkspaceEnvironment,
+  getWorkspaceEnvironmentByName,
   listGitHubInstallationIdsForWorkspace,
   listScheduledTaskRuns,
   listScheduledTasks,
+  listSessionEvents,
+  listSessions,
   listSocialConnections,
   listSocialPosts,
+  listWorkspaceEnvironments,
   requireFile,
   requireScheduledTask,
   requireSession,
   setSessionGoalStatus,
+  setWorkspaceEnvironmentVariable,
   updateScheduledTask,
   updateSessionGoal,
   upsertSessionGoal,
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import {
+  createSignedState,
   GitHubAppConfigurationError,
+  githubAppMissingSettings,
   listGitHubAppRepositories,
+  stateMaxAgeSeconds,
 } from "@opengeni/github";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z4 from "zod/v4";
@@ -32,25 +47,54 @@ import { hasPermission } from "../access";
 import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
 import type { ApiRouteDeps } from "../dependencies";
 import {
+  assertAllowedEnvironmentVariableName,
+  MAX_ENVIRONMENTS_PER_WORKSPACE,
+  MAX_VARIABLES_PER_ENVIRONMENT,
+  recordEnvironmentAuditEvent,
+  requireEnvironmentEncryption,
+} from "../domain/environments";
+import {
   createValidatedScheduledTask,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
 } from "../domain/scheduled-tasks";
+import { acceptSessionUserMessage, createSessionForRequest } from "../domain/sessions";
 
-export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant): McpServer {
+export type McpServerOptions = {
+  // Origin of the HTTP request that reached the MCP route; last-resort base
+  // for links the server mints (github_connect_link) when neither
+  // OPENGENI_PUBLIC_BASE_URL nor the manifest base URL is configured.
+  requestOrigin?: string | null;
+};
+
+export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, options: McpServerOptions = {}): McpServer {
   const server = new McpServer({
     name: "opengeni",
     version: "1.0.0",
   });
   const json = (value: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] });
+  const can = (permission: Permission) => hasPermission(grant.permissions, permission);
 
   // Goal tools are session-scoped: they are only registered when the grant
   // carries the worker-asserted sessionId claim (signed into the delegated
   // token by the worker, never agent-controlled) plus goals:manage.
   const goalSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
-  if (goalSessionId !== null && hasPermission(grant.permissions, "goals:manage")) {
+  if (goalSessionId !== null && can("goals:manage")) {
     registerGoalTools(server, deps, grant, goalSessionId, json);
+  }
+
+  // Orchestration, environment, and GitHub-connect tools are permission-gated
+  // at registration: a grant without the permission does not see the tool.
+  // Sandboxed workers reach this server with the fixed first-party delegated
+  // permission set (firstPartyMcpPermissions in @opengeni/runtime), which
+  // carries none of sessions:*, environments:*, or github:use — so agents
+  // cannot spawn or read sessions, touch workspace secrets, or mint GitHub
+  // install links unless the operator hands them a grant that says so.
+  registerWorkspaceOrchestrationTools(server, deps, grant, can, json);
+  registerEnvironmentTools(server, deps, grant, can, json);
+  if (can("github:use")) {
+    registerGitHubConnectTool(server, deps, grant, options, json);
   }
 
   server.registerTool("files_get_download_url", {
@@ -412,6 +456,202 @@ function registerGoalTools(
       }]);
     }
     return json(goal);
+  });
+}
+
+type JsonResult = (value: unknown) => { content: Array<{ type: "text"; text: string }> };
+
+// Workspace orchestration for manager-style agents: sessions are listed,
+// inspected, spawned, and steered with the same domain functions the REST
+// routes use, so limits, validation, and usage metering cannot drift.
+function registerWorkspaceOrchestrationTools(
+  server: McpServer,
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  can: (permission: Permission) => boolean,
+  json: JsonResult,
+): void {
+  if (can("sessions:read")) {
+    server.registerTool("sessions_list", {
+      description: "List sessions in this workspace, newest first.",
+      inputSchema: { limit: z4.number().int().positive().optional() },
+    }, async ({ limit }) => json({ sessions: await listSessions(deps.db, grant.workspaceId, boundedMcpLimit(limit)) }));
+
+    server.registerTool("session_get", {
+      description: "Get one session: status, goal-bearing metadata, resources, tools, and environment attachment (names/ids only, never variable values).",
+      inputSchema: { sessionId: z4.string().uuid() },
+    }, async ({ sessionId }) => {
+      const session = await getSession(deps.db, grant.workspaceId, sessionId);
+      if (!session) {
+        throw new Error("session not found");
+      }
+      return json(session);
+    });
+
+    server.registerTool("session_events", {
+      description: "Read a session's event timeline (oldest first). Pass `after` = the highest event `sequence` already seen to page forward; the response's `nextAfter` is that cursor. Use it to monitor another session's progress.",
+      inputSchema: {
+        sessionId: z4.string().uuid(),
+        after: z4.number().int().nonnegative().optional(),
+        limit: z4.number().int().positive().optional(),
+      },
+    }, async ({ sessionId, after, limit }) => {
+      await requireSession(deps.db, grant.workspaceId, sessionId);
+      const events = await listSessionEvents(deps.db, grant.workspaceId, sessionId, after ?? 0, boundedMcpLimit(limit));
+      const last = events[events.length - 1];
+      return json({ events, nextAfter: last ? last.sequence : after ?? 0 });
+    });
+  }
+
+  if (can("sessions:create")) {
+    server.registerTool("session_create", {
+      description: "Spawn a new agent session (a worker) with an initial message and optional goal, resources (e.g. repositories from github_repositories_list), tools, and workspace environment attachment. Environment attachment happens at creation only — it cannot be added to a running session — and requires the environments:use permission.",
+      inputSchema: {
+        initialMessage: z4.string().min(1),
+        goal: z4.unknown().optional(),
+        resources: z4.array(z4.unknown()).optional(),
+        tools: z4.array(z4.unknown()).optional(),
+        environmentId: z4.string().uuid().optional(),
+        model: z4.string().min(1).optional(),
+        reasoningEffort: z4.string().optional(),
+        metadata: z4.record(z4.string(), z4.unknown()).optional(),
+      },
+    }, async (args) => json(await createSessionForRequest(deps, grant, grant.workspaceId, args)));
+  }
+
+  if (can("sessions:control")) {
+    server.registerTool("session_send_message", {
+      description: "Post a user message into an existing session; the session queues a turn and resumes if idle.",
+      inputSchema: {
+        sessionId: z4.string().uuid(),
+        text: z4.string().min(1),
+      },
+    }, async ({ sessionId, text }) => {
+      const { accepted, turn } = await acceptSessionUserMessage(deps, grant, grant.workspaceId, sessionId, {
+        text,
+        toolsProvided: false,
+      });
+      return json({ event: accepted, turnId: turn.id });
+    });
+  }
+}
+
+// Environment management for manager-style agents. v1 deliberately accepts
+// variable VALUES in plain tool arguments: the calling model is trusted with
+// the secrets it is persisting (see docs/environments.md). Reads stay
+// write-only — responses carry names and metadata, never values.
+function registerEnvironmentTools(
+  server: McpServer,
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  can: (permission: Permission) => boolean,
+  json: JsonResult,
+): void {
+  if (can("environments:use")) {
+    server.registerTool("environment_list", {
+      description: "List workspace environments with variable names and metadata (versions, timestamps). Values are write-only and never returned.",
+      inputSchema: {},
+    }, async () => json({ environments: await listWorkspaceEnvironments(deps.db, grant.workspaceId) }));
+  }
+
+  if (can("environments:manage")) {
+    server.registerTool("environment_set_variable", {
+      description: "Set or rotate one variable in a workspace environment. Target by environmentId, or by environmentName (created if it does not exist). The value is encrypted at rest and injected into sandboxes of sessions the environment is attached to; it is never readable back through any API.",
+      inputSchema: {
+        environmentId: z4.string().uuid().optional(),
+        environmentName: z4.string().min(1).optional(),
+        name: z4.string().min(1),
+        value: z4.string().min(1).max(32768),
+      },
+    }, async ({ environmentId, environmentName, name, value }) => {
+      const key = requireEnvironmentEncryption(deps.settings);
+      const parsedName = WorkspaceEnvironmentVariableName.safeParse(name);
+      if (!parsedName.success) {
+        throw new Error("environment variable names must match ^[A-Z][A-Z0-9_]*$");
+      }
+      assertAllowedEnvironmentVariableName(parsedName.data);
+      if ((environmentId === undefined) === (environmentName === undefined)) {
+        throw new Error("provide exactly one of environmentId or environmentName");
+      }
+      const trimmedEnvironmentName = environmentName?.trim();
+      if (environmentName !== undefined && !trimmedEnvironmentName) {
+        throw new Error("environment name is required");
+      }
+      let created = false;
+      let environment = environmentId !== undefined
+        ? await getWorkspaceEnvironment(deps.db, grant.workspaceId, environmentId)
+        : await getWorkspaceEnvironmentByName(deps.db, grant.workspaceId, trimmedEnvironmentName!);
+      if (!environment && environmentId !== undefined) {
+        throw new Error("environment not found");
+      }
+      if (!environment) {
+        if (await countWorkspaceEnvironments(deps.db, grant.workspaceId) >= MAX_ENVIRONMENTS_PER_WORKSPACE) {
+          throw new Error(`a workspace supports at most ${MAX_ENVIRONMENTS_PER_WORKSPACE} environments`);
+        }
+        environment = await createWorkspaceEnvironment(deps.db, {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId,
+          name: trimmedEnvironmentName!,
+        });
+        created = true;
+        await recordEnvironmentAuditEvent(deps.db, { grant, action: "environment.created", environmentId: environment.id });
+      }
+      const exists = environment.variables.some((variable) => variable.name === parsedName.data);
+      if (!exists && environment.variables.length >= MAX_VARIABLES_PER_ENVIRONMENT) {
+        throw new Error(`an environment supports at most ${MAX_VARIABLES_PER_ENVIRONMENT} variables`);
+      }
+      const metadata = await setWorkspaceEnvironmentVariable(deps.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        environmentId: environment.id,
+        name: parsedName.data,
+        valueEncrypted: encryptEnvironmentValue(key, value),
+      });
+      await recordEnvironmentAuditEvent(deps.db, { grant, action: "environment.variable.set", environmentId: environment.id, variableName: parsedName.data });
+      return json({
+        environment: { id: environment.id, name: environment.name, created },
+        variable: metadata,
+      });
+    });
+  }
+}
+
+// GitHub connect link for manager-style agents: mirrors GET .../github/app but
+// returns a browser entry URL (.../github/connect) that plants the CSRF state
+// cookie before forwarding to GitHub, because an MCP-issued link is opened in
+// a browser that never called the API directly.
+function registerGitHubConnectTool(
+  server: McpServer,
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  options: McpServerOptions,
+  json: JsonResult,
+): void {
+  server.registerTool("github_connect_link", {
+    description: "Create a workspace-bound GitHub App install link to share with a human. Opening it redirects to GitHub to install the app and select repositories for this workspace; completing the connection requires the person to be signed in to this OpenGeni deployment with github:manage. The link expires.",
+    inputSchema: {},
+  }, async () => {
+    const { settings } = deps;
+    const missing = githubAppMissingSettings(settings);
+    const slug = settings.githubAppSlug?.trim() || null;
+    if (missing.length > 0 || !slug) {
+      return json({ configured: false, appSlug: slug, installUrl: null, missing });
+    }
+    const base = (settings.publicBaseUrl ?? settings.githubAppManifestBaseUrl ?? options.requestOrigin ?? "").replace(/\/+$/, "");
+    if (!base) {
+      throw new Error("github_connect_link requires OPENGENI_PUBLIC_BASE_URL (or OPENGENI_GITHUB_APP_MANIFEST_BASE_URL) so the install link can route through this deployment");
+    }
+    const state = createSignedState(deps.githubStateSecret, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+    });
+    return json({
+      configured: true,
+      appSlug: slug,
+      installUrl: `${base}/v1/workspaces/${grant.workspaceId}/github/connect?state=${encodeURIComponent(state)}`,
+      expiresInSeconds: stateMaxAgeSeconds,
+      missing: [],
+    });
   });
 }
 

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -51,6 +51,31 @@ export function registerGitHubRoutes(app: Hono, deps: ApiRouteDeps): void {
     });
   });
 
+  // Browser entry point for install links issued outside a browser context
+  // (the first-party MCP github_connect_link tool): it plants the CSRF state
+  // cookie the install/OAuth callbacks require and forwards to GitHub.
+  // Deliberately unauthenticated: the signed state is only ever minted for
+  // grants holding github:use, expires after stateMaxAgeSeconds, and is bound
+  // to this workspace; completing the installation binding still requires an
+  // authenticated github:manage grant in the same browser at the callback.
+  app.get("/v1/workspaces/:workspaceId/github/connect", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const state = c.req.query("state");
+    if (!state) {
+      throw new HTTPException(400, { message: "missing GitHub installation state" });
+    }
+    const statePayload = readSignedState(state, githubStateSecret);
+    if (!statePayload || statePayload.workspaceId !== workspaceId) {
+      throw new HTTPException(400, { message: "invalid or expired GitHub installation state" });
+    }
+    const slug = settings.githubAppSlug?.trim();
+    if (!slug) {
+      throw new HTTPException(409, { message: JSON.stringify({ message: "GitHub App is not configured", missing: githubAppMissingSettings(settings) }) });
+    }
+    setGitHubStateCookie(c, deps, state);
+    return c.redirect(`https://github.com/apps/${slug}/installations/new?state=${encodeURIComponent(state)}`);
+  });
+
   app.get("/v1/workspaces/:workspaceId/github/repositories", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     await requireAccessGrant(c, deps, workspaceId, "github:use");

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,15 +1,11 @@
 import {
   ClientSessionEvent,
-  CreateSessionRequest,
   ReorderSessionTurnsRequest,
   UpdateSessionGoalRequest,
   UpdateSessionTurnRequest,
-  type ToolRef,
 } from "@opengeni/contracts";
 import {
-  appendSessionEventsWithLockedSessionUpdate,
   cancelQueuedSessionTurn,
-  enqueueSessionTurn,
   getSession,
   getSessionGoal,
   listSessionEvents,
@@ -25,22 +21,17 @@ import { appendAndPublishEvents } from "@opengeni/events";
 import type { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { requireAccessGrant } from "../access";
-import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
 import type { ApiRouteDeps } from "../dependencies";
 import { settingsWithEnabledCapabilityMcpServers } from "../domain/capabilities";
-import { validateEnvironmentAttachment } from "../domain/environments";
 import {
-  mergeResourceRefs,
-  mergeToolRefs,
   normalizeResources,
   validateFileResources,
   validateGitHubRepositorySelection,
   validateToolRefs,
-  withDefaultEnabledCapabilityMcpTools,
 } from "../domain/resources";
 import {
-  createAndStartSession,
-  reasoningEffortForSession,
+  acceptSessionUserMessage,
+  createSessionForRequest,
   requireQueuedTurnForApi,
   workflowIdForSession,
 } from "../domain/sessions";
@@ -53,56 +44,7 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.post("/v1/workspaces/:workspaceId/sessions", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:create");
-    const rawPayload = await c.req.json();
-    const payload = CreateSessionRequest.parse(rawPayload);
-    const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
-    const resources = normalizeResources(payload.resources);
-    const requestedTools = validateToolRefs(payload.tools, runtimeSettings);
-    const defaultedTools = hasOwnProperty(rawPayload, "tools")
-      ? requestedTools
-      : withDefaultEnabledCapabilityMcpTools(requestedTools, settings, runtimeSettings);
-    // Goal-bearing sessions force the first-party MCP server so the goal
-    // tools the continuation prompt references are reachable.
-    const tools = payload.goal ? withFirstPartyGoalTools(defaultedTools, runtimeSettings) : defaultedTools;
-    await validateGitHubRepositorySelection(db, workspaceId, resources);
-    if (resources.some((resource) => resource.kind === "file") && !objectStorage) {
-      throw new HTTPException(503, { message: "object storage is not configured" });
-    }
-    await validateFileResources(db, workspaceId, resources);
-    const environment = payload.environmentId
-      ? await validateEnvironmentAttachment({ settings, db }, grant, workspaceId, payload.environmentId)
-      : null;
-    const model = payload.model ?? settings.openaiModel;
-    const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
-    await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
-    const session = await createAndStartSession({
-      db,
-      bus,
-      workflowClient,
-      accountId: grant.accountId,
-      workspaceId,
-      initialMessage: payload.initialMessage,
-      resources,
-      tools,
-      ...(payload.clientEventId ? { clientEventId: payload.clientEventId } : {}),
-      model,
-      reasoningEffort,
-      sandboxBackend: payload.sandboxBackend ?? settings.sandboxBackend,
-      metadata: payload.metadata,
-      environment: environment ? { id: environment.id, name: environment.name } : null,
-      goal: payload.goal ?? null,
-    });
-    await recordWorkspaceUsage(deps, {
-      accountId: grant.accountId,
-      workspaceId,
-      subjectId: grant.subjectId,
-      eventType: "agent_run.created",
-      quantity: 1,
-      unit: "run",
-      sourceResourceType: "session",
-      sourceResourceId: session.id,
-      idempotencyKey: `agent_run.created:${workspaceId}:${session.id}`,
-    });
+    const session = await createSessionForRequest(deps, grant, workspaceId, await c.req.json());
     return c.json(session, 202);
   });
 
@@ -292,93 +234,17 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     const rawEvent = await c.req.json();
     const event = ClientSessionEvent.parse(rawEvent);
     if (event.type === "user.message") {
-      const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
-      const requestedResources = normalizeResources(event.payload.resources ?? []);
-      const validatedTools = validateToolRefs(event.payload.tools ?? [], runtimeSettings);
-      const requestedTools = userMessagePayloadHasOwnProperty(rawEvent, "tools")
-        ? validatedTools
-        : withDefaultEnabledCapabilityMcpTools(validatedTools, settings, runtimeSettings);
-      const requestedModel = event.payload.model ?? null;
-      const requestedReasoningEffort = event.payload.reasoningEffort ?? null;
-      await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
-      if (requestedResources.some((resource) => resource.kind === "file") && !objectStorage) {
-        throw new HTTPException(503, { message: "object storage is not configured" });
-      }
-      await validateFileResources(db, workspaceId, requestedResources);
-      const existingSession = await requireSession(db, workspaceId, sessionId);
-      await validateGitHubRepositorySelection(db, workspaceId, [...existingSession.resources, ...requestedResources]);
-      const appended = await appendSessionEventsWithLockedSessionUpdate(db, workspaceId, sessionId, (lockedSession) => {
-        if (lockedSession.status === "failed" || lockedSession.status === "cancelled") {
-          throw new HTTPException(409, { message: `session is ${lockedSession.status}; cannot accept a new user message` });
-        }
-        const nextResources = mergeResourceRefs(lockedSession.resources, requestedResources);
-        const nextTools = mergeToolRefs(lockedSession.tools, requestedTools);
-        const shouldQueueSession = lockedSession.status === "idle";
-        return {
-          events: [
-            {
-              type: event.type,
-              payload: {
-                text: event.payload.text,
-                ...(requestedResources.length ? { resources: requestedResources } : {}),
-                ...(requestedTools.length ? { tools: requestedTools } : {}),
-                ...(requestedModel ? { model: requestedModel } : {}),
-                ...(requestedReasoningEffort ? { reasoningEffort: requestedReasoningEffort } : {}),
-              },
-              ...(event.clientEventId ? { clientEventId: event.clientEventId } : {}),
-            },
-            ...(shouldQueueSession ? [{ type: "session.status.changed" as const, payload: { status: "queued" } }] : []),
-          ],
-          update: {
-            resources: nextResources,
-            tools: nextTools,
-            ...(shouldQueueSession ? { status: "queued" as const, activeTurnId: null } : {}),
-          },
-        };
-      }).then(async (events) => {
-        await bus.publish(workspaceId, sessionId, events);
-        return events;
+      const { accepted } = await acceptSessionUserMessage(deps, grant, workspaceId, sessionId, {
+        text: event.payload.text,
+        resources: event.payload.resources ?? [],
+        tools: event.payload.tools ?? [],
+        toolsProvided: userMessagePayloadHasOwnProperty(rawEvent, "tools"),
+        model: event.payload.model ?? null,
+        reasoningEffort: event.payload.reasoningEffort ?? null,
+        ...(event.clientEventId ? { clientEventId: event.clientEventId } : {}),
       });
-      const accepted = appended[0];
-      if (!accepted) {
-        throw new HTTPException(500, { message: "failed to append client event" });
-      }
-      const workflowId = workflowIdForSession(sessionId);
-      const session = await requireSession(db, workspaceId, sessionId);
-      const turn = await enqueueSessionTurn(db, {
-        accountId: grant.accountId,
-        workspaceId,
-        sessionId,
-        triggerEventId: accepted.id,
-        temporalWorkflowId: workflowId,
-        source: "user",
-        prompt: event.payload.text,
-        resources: requestedResources,
-        tools: requestedTools,
-        model: requestedModel ?? session.model,
-        reasoningEffort: requestedReasoningEffort ?? reasoningEffortForSession(session.metadata, settings.openaiReasoningEffort),
-        sandboxBackend: session.sandboxBackend,
-        metadata: {},
-      });
-      await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
-        type: "turn.queued",
-        turnId: turn.id,
-        payload: { turnId: turn.id, triggerEventId: accepted.id, source: turn.source },
-      }]);
-	      await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId });
-	      await recordWorkspaceUsage(deps, {
-	        accountId: grant.accountId,
-	        workspaceId,
-	        subjectId: grant.subjectId,
-	        eventType: "agent_run.created",
-	        quantity: 1,
-	        unit: "run",
-	        sourceResourceType: "session_turn",
-	        sourceResourceId: turn.id,
-	        idempotencyKey: `agent_run.created:${workspaceId}:${turn.id}`,
-	      });
-	      return c.json(accepted, 202);
-	    }
+      return c.json(accepted, 202);
+    }
 
     const session = await requireSession(db, workspaceId, sessionId);
     if (event.type === "user.approvalDecision" && session.status !== "requires_action") {
@@ -402,13 +268,6 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     }
     return c.json(accepted, 202);
   });
-}
-
-function withFirstPartyGoalTools(tools: ToolRef[], runtimeSettings: { mcpServers: Array<{ id: string }> }): ToolRef[] {
-  if (!runtimeSettings.mcpServers.some((server) => server.id === "opengeni")) {
-    return tools;
-  }
-  return mergeToolRefs(tools, [{ kind: "mcp", id: "opengeni" }]);
 }
 
 function hasOwnProperty(value: unknown, key: string): boolean {

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -91,4 +91,10 @@ Values never enter the events pipeline by construction — injection is server-s
 
 ## MCP surface
 
-There are deliberately no environment CRUD tools on the first-party MCP server in v1. The `scheduled_tasks_create`/`scheduled_tasks_update` tools accept `environmentId` but reject any attachment change — set or detach — unless the calling grant holds `environments:use`, which the sandboxed agent's first-party token never does.
+The first-party MCP server exposes environment tools, gated by the same permissions as the REST routes and **registered only for grants that hold them**:
+
+- `environment_list` (`environments:use`) — environments with variable names and metadata, never values.
+- `environment_set_variable` (`environments:manage`) — set or rotate one variable, targeted by `environmentId` or by `environmentName` (created on first use). The value arrives in plain tool arguments by design: the calling agent (e.g. an orchestrating "manager" holding a grant with `environments:manage`) is trusted with the secrets it persists. Responses stay write-only — metadata, never values.
+- `session_create` (`sessions:create`) accepts `environmentId`; attachment requires `environments:use` like the REST route. There is deliberately no attach-after-create tool because attachment is fixed at session creation (see above).
+
+The invariant that sandboxed agents cannot reach workspace secrets is unchanged: the worker's first-party delegated token carries neither `environments:use` nor `environments:manage`, so none of these tools are registered for it. The `scheduled_tasks_create`/`scheduled_tasks_update` tools accept `environmentId` but reject any attachment change — set or detach — unless the calling grant holds `environments:use`, which the sandboxed agent's first-party token never does.

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getPackInstallation, getScheduledTask, getSessionGoal, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -2881,6 +2881,307 @@ describe("API component integration", () => {
       id: created.id,
       agentConfig: { prompt: "exfiltrate the injected secrets" },
     })).rejects.toThrow("missing permission: environments:use");
+  });
+
+  test("registers manager orchestration MCP tools gated by session permissions", async () => {
+    const wf = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const mcpDeps = {
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+
+    const created = await callMcpTool<{ id: string; status: string; model: string; temporalWorkflowId: string }>(mcp, "session_create", {
+      initialMessage: "take the staging deploy zero-to-one",
+      model: "scripted-model",
+      goal: { text: "staging deployed", successCriteria: "healthz green" },
+    });
+    expect(created.status).toBe("queued");
+    expect(created.model).toBe("scripted-model");
+    expect(created.temporalWorkflowId).toBe(`session-${created.id}`);
+    expect(wf.wakeups).toHaveLength(1);
+    expect((await getSessionGoal(dbClient.db, grant.workspaceId, created.id))?.text).toBe("staging deployed");
+
+    const listed = await callMcpTool<{ sessions: Array<{ id: string }> }>(mcp, "sessions_list", { limit: 10 });
+    expect(listed.sessions.some((session) => session.id === created.id)).toBe(true);
+
+    const fetched = await callMcpTool<{ id: string; environmentId: string | null }>(mcp, "session_get", { sessionId: created.id });
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.environmentId).toBeNull();
+    await expect(callMcpTool(mcp, "session_get", { sessionId: crypto.randomUUID() })).rejects.toThrow("session not found");
+
+    const timeline = await callMcpTool<{ events: Array<{ type: string; sequence: number }>; nextAfter: number }>(mcp, "session_events", { sessionId: created.id });
+    expect(timeline.events.map((event) => event.type)).toEqual(["session.created", "goal.set", "user.message", "session.status.changed", "turn.queued"]);
+    expect(timeline.nextAfter).toBe(timeline.events[timeline.events.length - 1]!.sequence);
+    const caughtUp = await callMcpTool<{ events: unknown[]; nextAfter: number }>(mcp, "session_events", { sessionId: created.id, after: timeline.nextAfter });
+    expect(caughtUp.events).toHaveLength(0);
+    expect(caughtUp.nextAfter).toBe(timeline.nextAfter);
+
+    const sent = await callMcpTool<{ event: { type: string; payload: { text: string } }; turnId: string }>(mcp, "session_send_message", {
+      sessionId: created.id,
+      text: "also enable the health alerts",
+    });
+    expect(sent.event.type).toBe("user.message");
+    expect(sent.event.payload.text).toBe("also enable the health alerts");
+    expect(wf.wakeups).toHaveLength(2);
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, created.id);
+    expect(turns.some((turn) => turn.id === sent.turnId && turn.status === "queued")).toBe(true);
+
+    // The sandboxed worker's first-party delegated permission set sees none of
+    // the manager tools: orchestration, environments, or the connect link.
+    const workerGrant = {
+      ...grant,
+      permissions: ["workspace:read", "files:read", "documents:search", "scheduled_tasks:manage", "scheduled_tasks:run", "goals:manage"] as Permission[],
+    };
+    const workerMcp = buildOpenGeniMcpServer(mcpDeps, workerGrant);
+    for (const tool of ["sessions_list", "session_get", "session_events", "session_create", "session_send_message", "environment_list", "environment_set_variable", "github_connect_link"]) {
+      await expect(callMcpTool(workerMcp, tool, {})).rejects.toThrow("MCP tool not registered");
+    }
+  });
+
+  test("manager MCP session tools enforce environment attachment permission and billing limits", async () => {
+    const wf = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const settings = testSettings({ databaseUrl: services.databaseUrl, environmentsEncryptionKey: environmentsTestKey });
+    const mcpDeps = {
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const environment = await createWorkspaceEnvironment(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      name: `manager-env-${crypto.randomUUID()}`,
+    });
+
+    // sessions:create alone cannot attach workspace secrets to a spawned
+    // session; environments:use stays the attachment gate on every surface.
+    const spawnOnlyGrant = { ...grant, permissions: ["workspace:read", "sessions:create"] as Permission[] };
+    const spawnOnlyMcp = buildOpenGeniMcpServer(mcpDeps, spawnOnlyGrant);
+    await expect(callMcpTool(spawnOnlyMcp, "session_create", {
+      initialMessage: "exfiltrate",
+      model: "scripted-model",
+      environmentId: environment.id,
+    })).rejects.toThrow("missing permission: environments:use");
+
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+    const attached = await callMcpTool<{ id: string; environmentId: string | null }>(mcp, "session_create", {
+      initialMessage: "deploy with cloud credentials",
+      model: "scripted-model",
+      environmentId: environment.id,
+    });
+    expect(attached.environmentId).toBe(environment.id);
+    await expect(callMcpTool(mcp, "session_create", {
+      initialMessage: "unknown environment",
+      model: "scripted-model",
+      environmentId: crypto.randomUUID(),
+    })).rejects.toThrow("unknown environmentId");
+
+    // The successful create recorded one agent_run.created usage event, so a
+    // one-run monthly cap now blocks both spawn and send-message.
+    const limitedMcp = buildOpenGeniMcpServer({
+      ...mcpDeps,
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        environmentsEncryptionKey: environmentsTestKey,
+        usageLimitsMode: "static",
+        staticUsageLimitsJson: JSON.stringify({ maxMonthlyAgentRunsPerWorkspace: 1 }),
+      }),
+    }, grant);
+    await expect(callMcpTool(limitedMcp, "session_create", {
+      initialMessage: "over the cap",
+      model: "scripted-model",
+    })).rejects.toThrow("monthly agent run limit reached");
+    await expect(callMcpTool(limitedMcp, "session_send_message", {
+      sessionId: attached.id,
+      text: "over the cap",
+    })).rejects.toThrow("monthly agent run limit reached");
+  });
+
+  test("manager MCP environment tools set variables write-only and create environments by name", async () => {
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const mcpDeps = {
+      settings: testSettings({ databaseUrl: services.databaseUrl, environmentsEncryptionKey: environmentsTestKey }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+    const environmentName = `geni-cloud-${crypto.randomUUID()}`;
+    const secretValue = `super-secret-${crypto.randomUUID()}`;
+
+    const first = await callMcpTool<{ environment: { id: string; name: string; created: boolean }; variable: { name: string; version: number } }>(mcp, "environment_set_variable", {
+      environmentName,
+      name: "AZURE_CLIENT_SECRET",
+      value: secretValue,
+    });
+    expect(first.environment.created).toBe(true);
+    expect(first.environment.name).toBe(environmentName);
+    expect(first.variable).toMatchObject({ name: "AZURE_CLIENT_SECRET", version: 1 });
+
+    const rotatedValue = `rotated-${crypto.randomUUID()}`;
+    const rotated = await callMcpTool<{ environment: { id: string; created: boolean }; variable: { version: number } }>(mcp, "environment_set_variable", {
+      environmentId: first.environment.id,
+      name: "AZURE_CLIENT_SECRET",
+      value: rotatedValue,
+    });
+    expect(rotated.environment.created).toBe(false);
+    expect(rotated.variable.version).toBe(2);
+
+    // The stored value round-trips through the operator key, proving the MCP
+    // write path encrypts exactly like the REST route.
+    const stored = await getWorkspaceEnvironmentValuesForRun(dbClient.db, grant.workspaceId, first.environment.id);
+    const key = new Uint8Array(Buffer.from(environmentsTestKey, "base64"));
+    expect(decryptEnvironmentValue(key, stored!.values["AZURE_CLIENT_SECRET"]!)).toBe(rotatedValue);
+
+    const listedEnvironments = await callMcpTool<{ environments: Array<{ id: string; name: string; variables: Array<{ name: string; version: number }> }> }>(mcp, "environment_list", {});
+    const listedEnvironment = listedEnvironments.environments.find((candidate) => candidate.id === first.environment.id);
+    expect(listedEnvironment?.variables).toEqual([expect.objectContaining({ name: "AZURE_CLIENT_SECRET", version: 2 })]);
+    // Write-only invariant: no response carries a variable value.
+    expect(JSON.stringify(listedEnvironments)).not.toContain(rotatedValue);
+    expect(JSON.stringify(rotated)).not.toContain(rotatedValue);
+
+    await expect(callMcpTool(mcp, "environment_set_variable", {
+      environmentName,
+      name: "GH_TOKEN",
+      value: "nope",
+    })).rejects.toThrow("reserved environment variable name");
+    await expect(callMcpTool(mcp, "environment_set_variable", {
+      environmentName,
+      name: "lowercase",
+      value: "nope",
+    })).rejects.toThrow("environment variable names must match");
+    await expect(callMcpTool(mcp, "environment_set_variable", {
+      environmentId: first.environment.id,
+      environmentName,
+      name: "AMBIGUOUS",
+      value: "nope",
+    })).rejects.toThrow("exactly one of environmentId or environmentName");
+    await expect(callMcpTool(mcp, "environment_set_variable", {
+      environmentId: crypto.randomUUID(),
+      name: "MISSING_TARGET",
+      value: "nope",
+    })).rejects.toThrow("environment not found");
+
+    // environments:use lists but cannot write; environments:manage is the
+    // write gate, mirroring the REST routes.
+    const useOnlyGrant = { ...grant, permissions: ["workspace:read", "environments:use"] as Permission[] };
+    const useOnlyMcp = buildOpenGeniMcpServer(mcpDeps, useOnlyGrant);
+    const useOnlyList = await callMcpTool<{ environments: Array<{ id: string }> }>(useOnlyMcp, "environment_list", {});
+    expect(useOnlyList.environments.some((candidate) => candidate.id === first.environment.id)).toBe(true);
+    await expect(callMcpTool(useOnlyMcp, "environment_set_variable", {
+      environmentName,
+      name: "BLOCKED",
+      value: "nope",
+    })).rejects.toThrow("MCP tool not registered");
+  });
+
+  test("manager MCP github_connect_link mints a browser entry link that plants the CSRF state cookie", async () => {
+    const stateSecret = "test-github-connect-state-secret";
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const configuredGitHub = {
+      githubAppId: "12345",
+      githubClientId: "test-client-id",
+      githubClientSecret: "test-client-secret",
+      githubAppSlug: "opengeni-test-app",
+      githubAppPrivateKey: "test-private-key",
+    };
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      publicBaseUrl: "https://api.opengeni.test",
+      ...configuredGitHub,
+    });
+    const mcpDeps = {
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      objectStorage: null,
+      githubStateSecret: stateSecret,
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+    const link = await callMcpTool<{ configured: boolean; appSlug: string; installUrl: string; expiresInSeconds: number }>(mcp, "github_connect_link", {});
+    expect(link.configured).toBe(true);
+    expect(link.appSlug).toBe("opengeni-test-app");
+    expect(link.expiresInSeconds).toBeGreaterThan(0);
+    const installUrl = new URL(link.installUrl);
+    expect(installUrl.origin).toBe("https://api.opengeni.test");
+    expect(installUrl.pathname).toBe(`/v1/workspaces/${grant.workspaceId}/github/connect`);
+    const state = installUrl.searchParams.get("state");
+    expect(readSignedState(state!, stateSecret)).toMatchObject({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+    });
+
+    // Opening the link plants the CSRF state cookie the install/OAuth
+    // callbacks require and forwards the same state to GitHub.
+    const app = createApp({
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      githubStateSecret: stateSecret,
+    });
+    const redirect = await app.request(`${installUrl.pathname}${installUrl.search}`);
+    expect(redirect.status).toBe(302);
+    const location = new URL(redirect.headers.get("location")!);
+    expect(`${location.origin}${location.pathname}`).toBe("https://github.com/apps/opengeni-test-app/installations/new");
+    expect(location.searchParams.get("state")).toBe(state);
+    expect(redirect.headers.get("set-cookie")).toContain(`opengeni_github_state=${state}`);
+
+    expect((await app.request(`/v1/workspaces/${grant.workspaceId}/github/connect`)).status).toBe(400);
+    expect((await app.request(`/v1/workspaces/${grant.workspaceId}/github/connect?state=tampered`)).status).toBe(400);
+    // A state minted for one workspace cannot start the flow for another.
+    expect((await app.request(`/v1/workspaces/${crypto.randomUUID()}/github/connect${installUrl.search}`)).status).toBe(400);
+
+    // Unconfigured deployments report what is missing instead of minting links.
+    const unconfiguredMcp = buildOpenGeniMcpServer({
+      ...mcpDeps,
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+    }, grant);
+    const unconfigured = await callMcpTool<{ configured: boolean; installUrl: string | null; missing: string[] }>(unconfiguredMcp, "github_connect_link", {});
+    expect(unconfigured.configured).toBe(false);
+    expect(unconfigured.installUrl).toBeNull();
+    expect(unconfigured.missing.length).toBeGreaterThan(0);
+
+    // Without a configured base URL the request origin is the fallback.
+    const originMcp = buildOpenGeniMcpServer({
+      ...mcpDeps,
+      settings: testSettings({ databaseUrl: services.databaseUrl, publicBaseUrl: undefined, ...configuredGitHub }),
+    }, grant, { requestOrigin: "http://127.0.0.1:8000" });
+    const originLink = await callMcpTool<{ installUrl: string }>(originMcp, "github_connect_link", {});
+    expect(originLink.installUrl.startsWith(`http://127.0.0.1:8000/v1/workspaces/${grant.workspaceId}/github/connect?state=`)).toBe(true);
+    const noBaseMcp = buildOpenGeniMcpServer({
+      ...mcpDeps,
+      settings: testSettings({ databaseUrl: services.databaseUrl, publicBaseUrl: undefined, ...configuredGitHub }),
+    }, grant);
+    await expect(callMcpTool(noBaseMcp, "github_connect_link", {})).rejects.toThrow("OPENGENI_PUBLIC_BASE_URL");
   });
 
   test("pack enable validates and stores environment attachments", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3160,6 +3160,27 @@ describe("API component integration", () => {
     // A state minted for one workspace cannot start the flow for another.
     expect((await app.request(`/v1/workspaces/${crypto.randomUUID()}/github/connect${installUrl.search}`)).status).toBe(400);
 
+    // The browser entry stays reachable when deployment-level access-key auth
+    // is enabled (the browser opening the link holds no API credentials), like
+    // the install/OAuth callbacks it feeds; the signed state is the gate.
+    const lockedApp = createApp({
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        publicBaseUrl: "https://api.opengeni.test",
+        ...configuredGitHub,
+        authRequired: true,
+        accessKey: "test-deployment-access-key",
+      }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      githubStateSecret: stateSecret,
+    });
+    expect((await lockedApp.request(`/v1/workspaces/${grant.workspaceId}/github/repositories`)).status).toBe(401);
+    const lockedRedirect = await lockedApp.request(`${installUrl.pathname}${installUrl.search}`);
+    expect(lockedRedirect.status).toBe(302);
+    expect(lockedRedirect.headers.get("set-cookie")).toContain(`opengeni_github_state=${state}`);
+
     // Unconfigured deployments report what is missing instead of minting links.
     const unconfiguredMcp = buildOpenGeniMcpServer({
       ...mcpDeps,


### PR DESCRIPTION
## What

Adds the workspace-scoped, permission-gated tools an orchestrating agent (a "manager") needs to the first-party `opengeni` MCP server, registered alongside the existing goal/scheduled-task tools:

**Orchestration**
- `sessions_list`, `session_get`, `session_events` (gated `sessions:read`) — list/inspect sessions and read another session's event timeline with a `sequence` cursor (`after`/`nextAfter`).
- `session_create` (gated `sessions:create`) — spawn a worker session with initial message + optional goal, resources, tools, model, and workspace environment attachment.
- `session_send_message` (gated `sessions:control`) — post a user message into a session; queues a turn and wakes the workflow.
- `scheduled_tasks_list` and `github_repositories_list` already existed and are unchanged.

**Environment management**
- `environment_list` (gated `environments:use`) — names + variable metadata only; values stay write-only.
- `environment_set_variable` (gated `environments:manage`) — set/rotate one variable, targeted by `environmentId` or by `environmentName` (environment created on first use, within existing caps). The VALUE arrives in plain tool arguments **by design**: v1 trusts the calling model with secrets it persists (same reserved-name validation, encryption, and audit events as the REST route).
- **Attach-after-create is deliberately not a tool**: environment attachment is fixed at session creation across the whole runtime (`docs/environments.md` invariant), so attachment is supported via `session_create`'s `environmentId` parameter instead, and the tool description says so. Attachment still requires `environments:use` on the calling grant.

**GitHub**
- `github_connect_link` (gated `github:use`) — returns a workspace-bound install link. It routes through a new unauthenticated browser entry route `GET /v1/workspaces/:id/github/connect?state=...` that verifies the signed workspace-bound state, plants the CSRF state cookie the install/OAuth callbacks require, and 302s to GitHub. This is necessary because an MCP-issued link is opened in a browser that never called the API, so the raw GitHub install URL would fail the callback's cookie check. Completing the binding still requires an authenticated `github:manage` grant in the same browser, so the CSRF property is preserved.

## How it's wired

- The `POST /sessions` and `user.message` flows are extracted into shared domain functions (`createSessionForRequest`, `acceptSessionUserMessage`, `postUserMessageTurn` in `apps/api/src/domain/sessions.ts`) used by both the REST routes and the MCP tools — validation, billing limits (`agent_run:create`), and usage metering cannot drift between surfaces.
- Tools are gated **at registration** (like the session-scoped goal tools): a grant without the permission does not see the tool. The sandboxed worker's first-party delegated token (`firstPartyMcpPermissions`) carries none of `sessions:*`, `environments:*`, or `github:use`, so workers cannot spawn/read sessions, touch workspace secrets, or mint install links. The agents-cannot-self-attach invariant is unchanged and re-tested (`session_create` with `environmentId` on a grant without `environments:use` fails with `missing permission: environments:use`).
- `docs/environments.md` MCP-surface section updated to describe the new tools and the preserved invariant.

## Tests

Four new integration tests in `test/integration/api.integration.ts` (repo style: `buildOpenGeniMcpServer` + `callMcpTool`):
- orchestration tools end-to-end (create with goal, list/get/events cursor, send message, workflow wakeups) + worker-shaped grant sees none of the new tools;
- environment attachment permission + billing-limit parity for `session_create`/`session_send_message`;
- environment tools: create-by-name, rotation (version bump), encrypted round-trip via the operator key, write-only responses, reserved/invalid names, `environments:use` vs `environments:manage` gating;
- `github_connect_link`: state round-trip, the connect route's 302 + CSRF cookie, wrong-workspace/tampered-state 400s, unconfigured-app reporting, and base-URL fallback (`OPENGENI_PUBLIC_BASE_URL` → manifest base → request origin).

Gate: `bun run typecheck`, `bun run test` (231 pass), `bun run test:integration` (all suites green). gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches session creation/messaging, environment secret writes via MCP, and a new unauthenticated GitHub connect route—security-critical paths with broad integration test coverage but meaningful blast radius if validation drifts.
> 
> **Overview**
> Adds **permission-gated manager tools** on the first-party `opengeni` MCP server so orchestrating agents can list/inspect/spawn/steer sessions, manage workspace environments (write-only secrets), and mint GitHub install links—without duplicating REST behavior.
> 
> **Session flows** are centralized in `createSessionForRequest`, `acceptSessionUserMessage`, and `postUserMessageTurn`; `POST /sessions` and `user.message` events now call these shared helpers so validation, billing limits, and usage metering stay aligned with MCP `session_create` / `session_send_message`.
> 
> **MCP tools** register only when the grant has the matching permission (`sessions:*`, `environments:*`, `github:use`); sandbox worker delegated tokens still omit those permissions so workers cannot see orchestration, secret, or connect tools.
> 
> **GitHub**: new `github_connect_link` MCP tool and unauthenticated `GET .../github/connect` browser entry (auth-exempt like other GitHub callbacks) that validates signed workspace state, sets the CSRF cookie, and redirects to GitHub; MCP route passes `requestOrigin` as a fallback base URL for link minting.
> 
> Docs and integration tests cover orchestration, environment gating/encryption, connect flow, and worker grant isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64bafbe28367d4bc0d00a2e18edbfe4340547b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->