### PR TITLE
Per-session first-party MCP permissions for manager sessions

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -297,6 +297,11 @@ export async function createSessionForRequest(
   // but never one out-ranking its creator: every requested permission must be
   // held by the creating grant.
   const firstPartyMcpPermissions = payload.firstPartyMcpPermissions ?? null;
+  if (firstPartyMcpPermissions && firstPartyMcpPermissions.length === 0) {
+    // An empty set would sign an unusable zero-permission token; the default
+    // worker set is expressed by omitting the field.
+    throw new HTTPException(422, { message: "firstPartyMcpPermissions must not be empty; omit it for the default worker permission set" });
+  }
   for (const permission of firstPartyMcpPermissions ?? []) {
     if (!hasPermission(grant.permissions, permission)) {
       throw new HTTPException(403, { message: `cannot grant first-party MCP permission beyond the creating grant: ${permission}` });

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -4,6 +4,7 @@ import {
   reasoningEffortForMetadata,
   type AccessGrant,
   type GoalSpec,
+  type Permission,
   type ReasoningEffort,
   type ResourceRef,
   type Session,
@@ -23,6 +24,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
+import { hasPermission } from "../access";
 import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
 import type { ApiRouteDeps, SessionWorkflowClient } from "../dependencies";
 import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
@@ -54,6 +56,8 @@ export async function createAndStartSession(input: {
   // Names/ids only; the session.created payload never carries variable values.
   environment?: { id: string; name: string } | null;
   goal?: GoalSpec | null;
+  // Validated against the creating grant before this is called.
+  firstPartyMcpPermissions?: Permission[] | null;
 }) {
   const session = await createSession(input.db, {
     accountId: input.accountId,
@@ -69,6 +73,7 @@ export async function createAndStartSession(input: {
     model: input.model,
     sandboxBackend: input.sandboxBackend,
     environmentId: input.environment?.id ?? null,
+    firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
   });
   // The goal row is durable session state; the workflow picks it up from the
   // database once the first turn completes — no extra workflow plumbing here.
@@ -287,6 +292,16 @@ export async function createSessionForRequest(
     : null;
   const model = payload.model ?? settings.openaiModel;
   const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
+  // A session's first-party MCP token can carry a non-default permission set
+  // (how an operator hands a manager-style session the orchestration tools),
+  // but never one out-ranking its creator: every requested permission must be
+  // held by the creating grant.
+  const firstPartyMcpPermissions = payload.firstPartyMcpPermissions ?? null;
+  for (const permission of firstPartyMcpPermissions ?? []) {
+    if (!hasPermission(grant.permissions, permission)) {
+      throw new HTTPException(403, { message: `cannot grant first-party MCP permission beyond the creating grant: ${permission}` });
+    }
+  }
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
   const session = await createAndStartSession({
     db,
@@ -304,6 +319,7 @@ export async function createSessionForRequest(
     metadata: payload.metadata,
     environment: environment ? { id: environment.id, name: environment.name } : null,
     goal: payload.goal ?? null,
+    firstPartyMcpPermissions,
   });
   await recordWorkspaceUsage(deps, {
     accountId: grant.accountId,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -515,6 +515,9 @@ function registerWorkspaceOrchestrationTools(
         model: z4.string().min(1).optional(),
         reasoningEffort: z4.string().optional(),
         metadata: z4.record(z4.string(), z4.unknown()).optional(),
+        // First-party MCP token permissions for the spawned session; every
+        // permission must be held by this grant (validated in the domain).
+        firstPartyMcpPermissions: z4.array(z4.string()).optional(),
       },
     }, async (args) => json(await createSessionForRequest(deps, grant, grant.workspaceId, args)));
   }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -514,6 +514,7 @@ function registerWorkspaceOrchestrationTools(
         environmentId: z4.string().uuid().optional(),
         model: z4.string().min(1).optional(),
         reasoningEffort: z4.string().optional(),
+        sandboxBackend: z4.string().optional(),
         metadata: z4.record(z4.string(), z4.unknown()).optional(),
         // First-party MCP token permissions for the spawned session; every
         // permission must be held by this grant (validated in the domain).

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -241,6 +241,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         sessionId: input.sessionId,
         subjectId: "worker:first-party-mcp",
         subjectLabel: "OpenGeni worker",
+        // Manager-style sessions carry a creation-validated permission set
+        // for their first-party MCP token; null keeps the fixed default.
+        ...(session.firstPartyMcpPermissions ? { firstPartyPermissions: session.firstPartyMcpPermissions } : {}),
       });
       const agent = runtime.buildAgent(runSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -243,7 +243,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         subjectLabel: "OpenGeni worker",
         // Manager-style sessions carry a creation-validated permission set
         // for their first-party MCP token; null keeps the fixed default.
-        ...(session.firstPartyMcpPermissions ? { firstPartyPermissions: session.firstPartyMcpPermissions } : {}),
+        ...(session.firstPartyMcpPermissions?.length ? { firstPartyPermissions: session.firstPartyMcpPermissions } : {}),
       });
       const agent = runtime.buildAgent(runSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -6,7 +6,7 @@ A workspace owns named **environments**: sets of environment variables whose val
 
 1. **Write-only values.** No API response, session event, log, span, or audit record ever contains a variable value. Reads return names and metadata (version, timestamps) only; there is no read-back even at create time. Rotation is `PUT` with a new value.
 2. **No attachment, no injection.** A run whose session has `environmentId = null` gets exactly the pre-existing behavior: the deployment env allowlist, git identity, and run-scoped GitHub auth. Nothing more.
-3. **Agents cannot self-attach.** The worker's first-party MCP delegated token never carries `environments:use`, and the MCP scheduled-task tools reject attachment changes (set **or** detach) and instruction edits to environment-attached tasks for grants without it.
+3. **Agents cannot self-attach.** The worker's **default** first-party MCP delegated token never carries `environments:use`, and the MCP scheduled-task tools reject attachment changes (set **or** detach) and instruction edits to environment-attached tasks for grants without it. A session only holds a stronger first-party token when its creator explicitly granted one at creation (`firstPartyMcpPermissions`, capped by the creating grant) — agents can never escalate themselves.
 4. **Workspace isolation.** Both tables are protected by the same forced row-level-security policy as every other workspace table.
 5. **Encryption at rest.** Values are AES-256-GCM encrypted with an operator key (`OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`) held outside Postgres. A database dump alone does not reveal values.
 
@@ -97,4 +97,11 @@ The first-party MCP server exposes environment tools, gated by the same permissi
 - `environment_set_variable` (`environments:manage`) — set or rotate one variable, targeted by `environmentId` or by `environmentName` (created on first use). The value arrives in plain tool arguments by design: the calling agent (e.g. an orchestrating "manager" holding a grant with `environments:manage`) is trusted with the secrets it persists. Responses stay write-only — metadata, never values.
 - `session_create` (`sessions:create`) accepts `environmentId`; attachment requires `environments:use` like the REST route. There is deliberately no attach-after-create tool because attachment is fixed at session creation (see above).
 
-The invariant that sandboxed agents cannot reach workspace secrets is unchanged: the worker's first-party delegated token carries neither `environments:use` nor `environments:manage`, so none of these tools are registered for it. The `scheduled_tasks_create`/`scheduled_tasks_update` tools accept `environmentId` but reject any attachment change — set or detach — unless the calling grant holds `environments:use`, which the sandboxed agent's first-party token never does.
+The invariant that sandboxed agents cannot reach workspace secrets is unchanged: the worker's **default** first-party delegated token carries neither `environments:use` nor `environments:manage`, so none of these tools are registered for it. The `scheduled_tasks_create`/`scheduled_tasks_update` tools accept `environmentId` but reject any attachment change — set or detach — unless the calling grant holds `environments:use`, which the sandboxed agent's default first-party token never does.
+
+### Manager sessions: per-session first-party MCP permissions
+
+`CreateSessionRequest.firstPartyMcpPermissions` (REST `POST /sessions` and the MCP `session_create` tool) lets an operator create a session whose first-party MCP token carries a **non-default permission set** — this is how a manager-style session sees the orchestration (`sessions:*`), environment, and `github:use` tools. Two rules keep this safe:
+
+1. **Capped at creation.** Every requested permission must be held by the creating grant (`workspace:admin` covers all); otherwise the request is rejected with 403. A session can never out-rank its creator, and a manager spawning workers via `session_create` can only delegate a subset of what it was itself granted.
+2. **Fixed for the session's lifetime.** Like environment attachment, the permission set is fixed at creation; there is no way for a running agent to widen its own token.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1086,6 +1086,9 @@ export const Session = z.object({
   model: z.string(),
   sandboxBackend: SandboxBackend,
   environmentId: z.string().uuid().nullable(),
+  // Non-default first-party MCP token permissions (manager-style sessions);
+  // null means the fixed worker default set.
+  firstPartyMcpPermissions: z.array(Permission).nullable(),
   temporalWorkflowId: z.string().nullable(),
   activeTurnId: z.string().uuid().nullable(),
   lastSequence: z.number().int().nonnegative(),
@@ -1154,6 +1157,11 @@ export const CreateSessionRequest = z.object({
   environmentId: z.string().uuid().optional(),
   goal: GoalSpec.optional(),
   clientEventId: z.string().min(1).optional(),
+  // Permissions the session's first-party MCP token should carry instead of
+  // the fixed worker default — how an operator hands a manager-style session
+  // the orchestration/environment/github tools. Capped at creation: every
+  // requested permission must be held by the creating grant (no escalation).
+  firstPartyMcpPermissions: z.array(Permission).optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 

--- a/packages/db/drizzle/0008_session_first_party_mcp_permissions.sql
+++ b/packages/db/drizzle/0008_session_first_party_mcp_permissions.sql
@@ -1,0 +1,5 @@
+-- Per-session first-party MCP token permissions (manager-style sessions).
+-- NULL means the fixed worker default permission set in @opengeni/runtime.
+-- Values are validated at session creation: every permission must be held by
+-- the creating grant, so a session can never out-rank its creator.
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "first_party_mcp_permissions" jsonb;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1912,6 +1912,7 @@ export async function createSession(db: Database, input: {
   model: string;
   sandboxBackend: SandboxBackend;
   environmentId?: string | null;
+  firstPartyMcpPermissions?: Permission[] | null;
 }): Promise<Session> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
     const [row] = await scopedDb.insert(schema.sessions).values({
@@ -1924,6 +1925,7 @@ export async function createSession(db: Database, input: {
       model: input.model,
       sandboxBackend: input.sandboxBackend,
       environmentId: input.environmentId ?? null,
+      firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
       status: "queued",
     }).returning();
     if (!row) {
@@ -2826,6 +2828,7 @@ function mapSession(row: typeof schema.sessions.$inferSelect): Session {
     model: row.model,
     sandboxBackend: row.sandboxBackend as SandboxBackend,
     environmentId: row.environmentId,
+    firstPartyMcpPermissions: (row.firstPartyMcpPermissions as Permission[] | null) ?? null,
     temporalWorkflowId: row.temporalWorkflowId,
     activeTurnId: row.activeTurnId,
     lastSequence: row.lastSequence,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -113,6 +113,9 @@ export const sessions = pgTable("sessions", {
   model: text("model").notNull(),
   sandboxBackend: text("sandbox_backend").notNull(),
   environmentId: uuid("environment_id").references(() => workspaceEnvironments.id, { onDelete: "set null" }),
+  // Non-default first-party MCP token permissions (manager-style sessions);
+  // null means the fixed worker default set in @opengeni/runtime.
+  firstPartyMcpPermissions: jsonb("first_party_mcp_permissions").$type<string[]>(),
   temporalWorkflowId: text("temporal_workflow_id"),
   activeTurnId: uuid("active_turn_id"),
   lastSequence: integer("last_sequence").notNull().default(0),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -295,6 +295,10 @@ export type PrepareToolsOptions = {
   sessionId?: string;
   subjectId?: string;
   subjectLabel?: string;
+  // Overrides the fixed first-party MCP permission set for this session's
+  // delegated token (manager-style sessions). The caller is responsible for
+  // having validated the set against the session creator's grant.
+  firstPartyPermissions?: Permission[];
 };
 
 export async function prepareAgentTools(settings: Settings, tools: ToolRef[], options: PrepareToolsOptions = {}): Promise<PreparedAgentTools> {
@@ -345,7 +349,7 @@ async function firstPartyMcpRequestInit(settings: Settings, config: Settings["mc
       workspaceId: options.workspaceId,
       subjectId: options.subjectId ?? "worker:first-party-mcp",
       ...(options.subjectLabel ? { subjectLabel: options.subjectLabel } : {}),
-      permissions: firstPartyMcpPermissions,
+      permissions: options.firstPartyPermissions ?? firstPartyMcpPermissions,
       ...(options.sessionId ? { sessionId: options.sessionId } : {}),
       exp: Math.floor(Date.now() / 1000) + 60 * 60,
     })}`;

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3027,12 +3027,14 @@ describe("API component integration", () => {
       model: "scripted-model",
       firstPartyMcpPermissions: ["environments:manage"],
     })).rejects.toThrow("cannot grant first-party MCP permission beyond the creating grant");
-    const spawned = await callMcpTool<{ id: string; firstPartyMcpPermissions: string[] | null }>(managerMcp, "session_create", {
+    const spawned = await callMcpTool<{ id: string; firstPartyMcpPermissions: string[] | null; sandboxBackend: string }>(managerMcp, "session_create", {
       initialMessage: "spawn a delegated worker",
       model: "scripted-model",
+      sandboxBackend: "none",
       firstPartyMcpPermissions: ["sessions:read"],
     });
     expect(spawned.firstPartyMcpPermissions).toEqual(["sessions:read"]);
+    expect(spawned.sandboxBackend).toBe("none");
 
     // The delegated token the runtime mints for a session's first-party MCP
     // connection carries the session's permission set, which gates manager

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3006,6 +3006,20 @@ describe("API component integration", () => {
     expect(escalation.status).toBe(403);
     expect(await escalation.text()).toContain("cannot grant first-party MCP permission beyond the creating grant: environments:manage");
 
+    // An empty set would sign an unusable zero-permission token; omit the
+    // field for the default worker set instead.
+    const emptySet = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "empty permission set",
+        model: "scripted-model",
+        firstPartyMcpPermissions: [],
+      }),
+      headers: { "content-type": "application/json", authorization: `Bearer ${managerToken}` },
+    });
+    expect(emptySet.status).toBe(422);
+    expect(await emptySet.text()).toContain("firstPartyMcpPermissions must not be empty");
+
     // Same rule through the MCP session_create tool: a manager can only
     // delegate a subset of what it was itself granted.
     const mcpDeps = {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getSession, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -2945,6 +2945,136 @@ describe("API component integration", () => {
     const workerMcp = buildOpenGeniMcpServer(mcpDeps, workerGrant);
     for (const tool of ["sessions_list", "session_get", "session_events", "session_create", "session_send_message", "environment_list", "environment_set_variable", "github_connect_link"]) {
       await expect(callMcpTool(workerMcp, tool, {})).rejects.toThrow("MCP tool not registered");
+    }
+  });
+
+  test("per-session first-party MCP permissions are capped by the creator and gate the manager tools", async () => {
+    const wf = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const delegationSecret = "test-delegation-secret";
+    // Configured access mode: every request authenticates with a delegated
+    // bearer token, so the grant the MCP endpoint sees is exactly the token's
+    // permission set - the same shape the worker runtime uses live.
+    const appSettings = testSettings({
+      databaseUrl: services.databaseUrl,
+      productAccessMode: "configured",
+      delegationSecret,
+    });
+    const app = createApp({
+      settings: appSettings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+    });
+    const signToken = async (permissions: Permission[]) => await signDelegatedAccessToken(delegationSecret, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      subjectId: "test:first-party-mcp-permissions",
+      permissions,
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+
+    // REST create: the permission set is stored and echoed; the creator must
+    // hold every requested permission.
+    const managerToken = await signToken(["workspace:read", "sessions:create", "sessions:read", "goals:manage"]);
+    const createResponse = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "orchestrate the fleet",
+        model: "scripted-model",
+        firstPartyMcpPermissions: ["workspace:read", "sessions:read", "sessions:create", "goals:manage"],
+      }),
+      headers: { "content-type": "application/json", authorization: `Bearer ${managerToken}` },
+    });
+    expect(createResponse.status).toBe(202);
+    const managerSession = await createResponse.json() as { id: string; firstPartyMcpPermissions: string[] | null };
+    expect(managerSession.firstPartyMcpPermissions).toEqual(["workspace:read", "sessions:read", "sessions:create", "goals:manage"]);
+    expect((await getSession(dbClient.db, grant.workspaceId, managerSession.id))?.firstPartyMcpPermissions)
+      .toEqual(["workspace:read", "sessions:read", "sessions:create", "goals:manage"] as Permission[]);
+
+    // No escalation: a creator without the permission cannot mint it.
+    const limitedToken = await signToken(["workspace:read", "sessions:create"]);
+    const escalation = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "try to escalate",
+        model: "scripted-model",
+        firstPartyMcpPermissions: ["environments:manage"],
+      }),
+      headers: { "content-type": "application/json", authorization: `Bearer ${limitedToken}` },
+    });
+    expect(escalation.status).toBe(403);
+    expect(await escalation.text()).toContain("cannot grant first-party MCP permission beyond the creating grant: environments:manage");
+
+    // Same rule through the MCP session_create tool: a manager can only
+    // delegate a subset of what it was itself granted.
+    const mcpDeps = {
+      settings: appSettings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const managerGrant = { ...grant, permissions: ["workspace:read", "sessions:create", "sessions:read"] as Permission[] };
+    const managerMcp = buildOpenGeniMcpServer(mcpDeps, managerGrant);
+    await expect(callMcpTool(managerMcp, "session_create", {
+      initialMessage: "spawn an over-privileged worker",
+      model: "scripted-model",
+      firstPartyMcpPermissions: ["environments:manage"],
+    })).rejects.toThrow("cannot grant first-party MCP permission beyond the creating grant");
+    const spawned = await callMcpTool<{ id: string; firstPartyMcpPermissions: string[] | null }>(managerMcp, "session_create", {
+      initialMessage: "spawn a delegated worker",
+      model: "scripted-model",
+      firstPartyMcpPermissions: ["sessions:read"],
+    });
+    expect(spawned.firstPartyMcpPermissions).toEqual(["sessions:read"]);
+
+    // The delegated token the runtime mints for a session's first-party MCP
+    // connection carries the session's permission set, which gates manager
+    // tool visibility end to end; the default set stays worker-shaped.
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: app.fetch });
+    let managerPrepared: Awaited<ReturnType<typeof prepareAgentTools>> | null = null;
+    let workerPrepared: Awaited<ReturnType<typeof prepareAgentTools>> | null = null;
+    try {
+      const runtimeSettings = {
+        ...appSettings,
+        mcpServers: [{
+          id: "opengeni",
+          name: "OpenGeni",
+          url: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
+          timeoutMs: undefined,
+          cacheToolsList: false,
+        }],
+      };
+      managerPrepared = await prepareAgentTools(runtimeSettings, [{ kind: "mcp", id: "opengeni" }], {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: managerSession.id,
+        firstPartyPermissions: ["workspace:read", "sessions:read", "sessions:create", "goals:manage"],
+      });
+      const managerTools = (await managerPrepared.mcpServers[0]!.listTools()).map((tool) => tool.name);
+      expect(managerTools).toContain("opengeni__sessions_list");
+      expect(managerTools).toContain("opengeni__session_create");
+      expect(managerTools).not.toContain("opengeni__environment_set_variable");
+
+      workerPrepared = await prepareAgentTools(runtimeSettings, [{ kind: "mcp", id: "opengeni" }], {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: managerSession.id,
+      });
+      const workerTools = (await workerPrepared.mcpServers[0]!.listTools()).map((tool) => tool.name);
+      expect(workerTools).not.toContain("opengeni__sessions_list");
+      expect(workerTools).not.toContain("opengeni__session_create");
+      expect(workerTools).toContain("opengeni__scheduled_tasks_list");
+    } finally {
+      await managerPrepared?.close().catch(() => undefined);
+      await workerPrepared?.close().catch(() => undefined);
+      server.stop(true);
     }
   });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -46,6 +46,7 @@ import { createNatsEventBus, type EventBus } from "@opengeni/events";
 import { createObservability } from "@opengeni/observability";
 import { createProductionAgentRuntime, MaxTurnsExceededError, type OpenGeniRuntime } from "@opengeni/runtime";
 import { createActivities } from "../../apps/worker/src/activities";
+import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
 import { PROVIDER_BACKPRESSURE_DELAY_MS } from "../../apps/worker/src/activities/agent-turn";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "../../apps/worker/src/activities/environment";
 import { ScriptedModel, functionCall, latestStatus, startTestMcpServer, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
@@ -103,6 +104,89 @@ describe("worker activities integration", () => {
     expect(latestStatus(events)).toBe("idle");
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
     expect(await getLatestRunState(dbClient.db, grant.workspaceId, session.id)).not.toBeNull();
+  });
+
+  test("manager session's first-party MCP token carries its granted permissions end to end", async () => {
+    // A manager-style session (created with firstPartyMcpPermissions) calls
+    // the workspace-orchestration tools through its own first-party MCP
+    // connection - the exact wiring the live manager probe uses.
+    const noopWorkflowClient: SessionWorkflowClient = {
+      signalUserMessage: async () => undefined,
+      wakeSessionWorkflow: async () => undefined,
+      signalApprovalDecision: async () => undefined,
+      signalInterrupt: async () => undefined,
+      syncScheduledTask: async () => undefined,
+      deleteScheduledTaskSchedule: async () => undefined,
+      triggerScheduledTask: async () => undefined,
+    };
+    const grant = await testGrant(dbClient.db);
+    const delegationSecret = "test-delegation-secret";
+    const apiSettings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      productAccessMode: "configured",
+      delegationSecret,
+    });
+    const app = createApp({
+      settings: apiSettings,
+      db: dbClient.db,
+      bus,
+      workflowClient: noopWorkflowClient,
+    });
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: app.fetch });
+    try {
+      const settings = {
+        ...apiSettings,
+        mcpServers: [{
+          id: "opengeni",
+          name: "OpenGeni",
+          url: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
+          timeoutMs: undefined,
+          cacheToolsList: false,
+        }],
+      };
+      const model = new ScriptedModel([
+        { id: "manager-call-1", output: [functionCall("opengeni__sessions_list", { limit: 10 }, "call-manager-1")] },
+        { id: "manager-call-2", outputText: "fleet listed", chunks: ["fleet ", "listed"] },
+      ]);
+      const session = await createOwnedSession(dbClient.db, grant, {
+        initialMessage: "list the fleet",
+        resources: [],
+        tools: [{ kind: "mcp", id: "opengeni" }],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        firstPartyMcpPermissions: ["workspace:read", "sessions:read", "sessions:create"],
+      });
+      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+        { type: "user.message", payload: { text: "list the fleet" } },
+      ]);
+      const activities = createActivities({
+        settings,
+        db: dbClient.db,
+        bus,
+        runtime: createProductionAgentRuntime({ model }),
+      });
+      const result = await activities.runAgentTurn({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: trigger!.id,
+        workflowId: "workflow-manager-mcp",
+      });
+      expect(result.status).toBe("idle");
+      // The sessions_list result (containing this very session) was fed back
+      // to the model: the tool call resolved against the live MCP endpoint
+      // with a token carrying the session's permission set.
+      expect(model.calls).toBe(2);
+      const followupInput = JSON.stringify((model.requests.at(-1) as { input?: unknown })?.input ?? "");
+      expect(followupInput).toContain(session.id);
+      const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
+      expect(events.some((event) => event.type === "turn.completed")).toBe(true);
+      expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    } finally {
+      server.stop(true);
+    }
   });
 
   test("uses saved SDK history for follow-up turns", async () => {


### PR DESCRIPTION
## Why

The manager MCP tools (#40) are permission-gated at registration — but every session's first-party MCP token carries the fixed worker permission set (`firstPartyMcpPermissions` in `@opengeni/runtime`), which holds none of `sessions:*`, `environments:*`, or `github:use`. So no session running on the platform could actually *see* the orchestration tools: the manager→worker keystone (a manager session spawning and steering workers via MCP) was unreachable. The design docs anticipated exactly this gap ("per-workspace MCP auth … if unsupported, build it as a generic OpenGeni feature").

## What

`CreateSessionRequest.firstPartyMcpPermissions` (REST `POST /sessions` and the MCP `session_create` tool) stores a per-session permission set on the session row; the worker signs it into that session's first-party delegated token instead of the fixed default.

Safety model:
- **Capped at creation.** Every requested permission must be held by the creating grant (`workspace:admin` covers all); otherwise 403. A session can never out-rank its creator, and a manager spawning workers via `session_create` can only delegate a subset of what it was itself granted.
- **Fixed for the session's lifetime**, like environment attachment — a running agent cannot widen its own token. Default (`null`) keeps the existing fixed worker set, so sandboxed workers see exactly what they saw before.

## Tests

- End-to-end worker-activity integration test: a manager session created with `firstPartyMcpPermissions` calls `opengeni__sessions_list` through its own first-party MCP connection against a live API instance (configured access mode, real delegated token), and the result reaches the model.
- API integration: the cap enforced on both surfaces (REST 403 + MCP `session_create` rejection), storage/echo of the set, and token-gated tool visibility (manager token sees `sessions_list`/`session_create`; default worker token does not).
- New migration `0008_session_first_party_mcp_permissions.sql` (nullable jsonb column).

`docs/environments.md` invariants updated: agents still cannot self-attach or self-escalate; only a creator already holding a permission can mint a session that carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes delegated MCP authentication and permission delegation at session creation; incorrect validation could allow privilege escalation, though the creator-grant cap is enforced in domain code and tested.
> 
> **Overview**
> Adds **`firstPartyMcpPermissions`** on session create (REST and MCP `session_create`) so a session can use a **custom first-party MCP delegated token** instead of the fixed worker default—enabling manager-style sessions to see orchestration tools (`sessions:*`, etc.).
> 
> The set is stored on the session row (migration `0008`, nullable jsonb), validated so **every permission must already be on the creating grant** (403 on escalation, 422 on empty array), and **fixed for the session lifetime**. The worker passes the stored set into `prepareAgentTools` / runtime token signing; `null` keeps prior worker behavior.
> 
> Docs clarify default vs explicit manager tokens; integration tests cover REST/MCP caps, tool visibility, and end-to-end `sessions_list` from a manager session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d52432015c12672d1e07ab681cea6666918ccca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->