### PR TITLE
Support per-workspace credential headers for capability MCP servers

### DIFF
--- a/apps/api/src/domain/capabilities.ts
+++ b/apps/api/src/domain/capabilities.ts
@@ -131,9 +131,11 @@ export async function enableCapability(input: {
     throw new HTTPException(422, { message: "MCP capabilities need a remote streamable HTTP endpoint before they can be enabled" });
   }
   let installationMetadata = input.payload.metadata;
-  // Credential-header ciphertext is written exclusively by this flow; strip
-  // any caller-provided values so the stored shape stays trustworthy.
+  // Credential-header storage is written exclusively by this flow; strip the
+  // reserved keys from caller-provided config so the stored shape stays
+  // trustworthy and no plaintext credentials sneak in through config.headers.
   const installationConfig: Record<string, unknown> = { ...input.payload.config };
+  delete installationConfig.headers;
   delete installationConfig.headersEncrypted;
   delete installationConfig.headerNames;
   if (item.kind === "mcp") {
@@ -256,8 +258,10 @@ function normalizedMcpCredentialHeaders(headers: Record<string, string>): Record
     if (value.length === 0 || value.length > maxMcpCredentialHeaderValueLength) {
       throw new HTTPException(422, { message: `credential header ${name} must be 1-${maxMcpCredentialHeaderValueLength} characters` });
     }
+    // RFC 9110 §5.5: field values are HTAB / printable characters — reject
+    // all other control characters (they would also fail at the HTTP client).
     // eslint-disable-next-line no-control-regex
-    if (/[\r\n\0]/.test(value)) {
+    if (/[\u0000-\u0008\u000A-\u001F\u007F]/.test(value)) {
       throw new HTTPException(422, { message: `credential header ${name} contains forbidden control characters` });
     }
   }

--- a/apps/api/src/domain/capabilities.ts
+++ b/apps/api/src/domain/capabilities.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { Settings } from "@opengeni/config";
+import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
 import {
   CapabilityCatalogItem,
   type CapabilityCatalogResponse,
@@ -12,12 +12,16 @@ import {
   type EnableCapabilityRequest,
 } from "@opengeni/contracts";
 import {
+  decryptEnvironmentValue,
+  decryptedCapabilityHeaders,
   disableCapabilityInstallation,
   enableCapabilityInstallation,
   enablePackInstallation,
+  encryptEnvironmentValue,
   getCapabilityCatalogItem,
   getCapabilityInstallation,
   getPackInstallation,
+  getStoredCapabilityHeaderCiphertext,
   getWorkspaceEnvironment,
   listCapabilityCatalogItems,
   listCapabilityInstallations,
@@ -37,6 +41,10 @@ const firstPartyMcpServerIds = new Set(["opengeni", "files", "docs"]);
 const mcpRegistryFetchTimeoutMs = 15000;
 const mcpRegistryMaxPages = 3;
 const mcpCapabilityProbeTimeoutMs = 15000;
+const maxMcpCredentialHeaders = 16;
+const maxMcpCredentialHeaderValueLength = 4096;
+// RFC 9110 field-name token characters.
+const mcpCredentialHeaderName = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
 export async function buildCapabilityCatalog(input: {
   db: Database;
@@ -123,11 +131,24 @@ export async function enableCapability(input: {
     throw new HTTPException(422, { message: "MCP capabilities need a remote streamable HTTP endpoint before they can be enabled" });
   }
   let installationMetadata = input.payload.metadata;
+  // Credential-header ciphertext is written exclusively by this flow; strip
+  // any caller-provided values so the stored shape stays trustworthy.
+  const installationConfig: Record<string, unknown> = { ...input.payload.config };
+  delete installationConfig.headersEncrypted;
+  delete installationConfig.headerNames;
   if (item.kind === "mcp") {
+    const headers = await resolveMcpCredentialHeaders(input, item);
+    assertRequiredMcpCredentialHeaders(item, headers);
     installationMetadata = {
       ...installationMetadata,
-      ...await validateMcpCapabilityConnection(item, input.probeMcpServer),
+      ...await validateMcpCapabilityConnection(item, input.probeMcpServer, headers ?? undefined),
     };
+    if (headers) {
+      const key = requireCapabilityHeaderEncryption(input.settings);
+      installationConfig.headersEncrypted = Object.fromEntries(
+        Object.entries(headers).map(([name, value]) => [name, encryptEnvironmentValue(key, value)]),
+      );
+    }
   }
   if (item.kind === "pack") {
     const packId = packIdFromCapabilityId(item.id);
@@ -178,9 +199,101 @@ export async function enableCapability(input: {
     workspaceId: input.workspaceId,
     capabilityId: item.id,
     kind: item.kind,
-    config: input.payload.config,
+    config: installationConfig,
     metadata: installationMetadata,
   });
+}
+
+/**
+ * Resolves the plaintext credential headers an MCP enable should use: the
+ * validated headers from the request when provided, otherwise headers stored
+ * encrypted by a previous enable (so re-enabling never requires re-pasting
+ * credentials). Returns null when neither exists.
+ */
+async function resolveMcpCredentialHeaders(
+  input: { db: Database; workspaceId: string; settings: Settings; payload: EnableCapabilityRequest },
+  item: CapabilityCatalogItem,
+): Promise<Record<string, string> | null> {
+  const provided = normalizedMcpCredentialHeaders(input.payload.headers);
+  if (provided) {
+    // Validate the key is configured before probing so a misconfigured
+    // deployment fails fast instead of after a successful remote probe.
+    requireCapabilityHeaderEncryption(input.settings);
+    return provided;
+  }
+  const storedCiphertext = await getStoredCapabilityHeaderCiphertext(input.db, input.workspaceId, item.id);
+  if (!storedCiphertext) {
+    return null;
+  }
+  const key = requireCapabilityHeaderEncryption(input.settings);
+  try {
+    return Object.fromEntries(Object.entries(storedCiphertext).map(([name, value]) => [name, decryptEnvironmentValue(key, value)]));
+  } catch {
+    throw new HTTPException(422, {
+      message: `stored credential headers for "${item.name}" could not be decrypted; supply them again in the enable request "headers" field`,
+    });
+  }
+}
+
+function normalizedMcpCredentialHeaders(headers: Record<string, string>): Record<string, string> | null {
+  const entries = Object.entries(headers).map(([name, value]) => [name.trim(), value] as const).filter(([name]) => name.length > 0);
+  if (entries.length === 0) {
+    return null;
+  }
+  if (entries.length > maxMcpCredentialHeaders) {
+    throw new HTTPException(422, { message: `an MCP capability supports at most ${maxMcpCredentialHeaders} credential headers` });
+  }
+  const seen = new Set<string>();
+  for (const [name, value] of entries) {
+    if (!mcpCredentialHeaderName.test(name)) {
+      throw new HTTPException(422, { message: `invalid credential header name: ${name}` });
+    }
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) {
+      throw new HTTPException(422, { message: `duplicate credential header name: ${name}` });
+    }
+    seen.add(lower);
+    if (value.length === 0 || value.length > maxMcpCredentialHeaderValueLength) {
+      throw new HTTPException(422, { message: `credential header ${name} must be 1-${maxMcpCredentialHeaderValueLength} characters` });
+    }
+    // eslint-disable-next-line no-control-regex
+    if (/[\r\n\0]/.test(value)) {
+      throw new HTTPException(422, { message: `credential header ${name} contains forbidden control characters` });
+    }
+  }
+  return Object.fromEntries(entries);
+}
+
+function assertRequiredMcpCredentialHeaders(item: CapabilityCatalogItem, headers: Record<string, string> | null): void {
+  const required = requiredCapabilityHeaders(item.metadata);
+  const names = new Set(Object.keys(headers ?? {}).map((name) => name.toLowerCase()));
+  const missing = required.filter((name) => !names.has(name.toLowerCase()));
+  if (missing.length > 0) {
+    throw new HTTPException(422, {
+      message: `MCP capability "${item.name}" requires credential header(s) ${missing.join(", ")}; pass them in the enable request "headers" field`,
+    });
+  }
+  if (item.authModel && names.size === 0) {
+    throw new HTTPException(422, {
+      message: `MCP capability "${item.name}" requires credentials; pass them in the enable request "headers" field`,
+    });
+  }
+}
+
+function requiredCapabilityHeaders(metadata: Record<string, unknown>): string[] {
+  const value = metadata.requiredHeaders;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((name): name is string => typeof name === "string" && name.trim().length > 0).map((name) => name.trim());
+}
+
+function requireCapabilityHeaderEncryption(settings: Settings): Uint8Array {
+  const key = environmentsEncryptionKeyBytes(settings);
+  if (!key) {
+    throw new HTTPException(503, { message: "MCP credential headers require OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY" });
+  }
+  return key;
 }
 
 export type McpCapabilityProbeInput = {
@@ -188,6 +301,7 @@ export type McpCapabilityProbeInput = {
   name: string;
   url: string;
   timeoutMs: number;
+  headers?: Record<string, string>;
 };
 
 export type McpCapabilityProbeResult = {
@@ -199,6 +313,7 @@ export type McpCapabilityProbe = (input: McpCapabilityProbeInput) => Promise<Mcp
 export async function validateMcpCapabilityConnection(
   item: CapabilityCatalogItem,
   probe: McpCapabilityProbe = probeStreamableHttpMcpServer,
+  headers?: Record<string, string>,
 ): Promise<Record<string, unknown>> {
   if (item.kind !== "mcp") {
     return {};
@@ -212,6 +327,7 @@ export async function validateMcpCapabilityConnection(
       name: item.name,
       url: item.endpointUrl,
       timeoutMs: mcpCapabilityProbeTimeoutMs,
+      ...(headers ? { headers } : {}),
     });
     return {
       mcpConnectivity: {
@@ -233,7 +349,10 @@ async function probeStreamableHttpMcpServer(input: McpCapabilityProbeInput): Pro
   const client = new Client({ name: "opengeni-capability-probe", version: "0.1.0" }, { capabilities: {} });
   try {
     const transport = new StreamableHTTPClientTransport(new URL(input.url), {
-      requestInit: { signal: controller.signal },
+      requestInit: {
+        signal: controller.signal,
+        ...(input.headers ? { headers: input.headers } : {}),
+      },
     });
     await client.connect(transport as unknown as Transport, { timeout: input.timeoutMs, maxTotalTimeout: input.timeoutMs });
     const tools = await client.listTools(undefined, { timeout: input.timeoutMs, maxTotalTimeout: input.timeoutMs });
@@ -287,17 +406,27 @@ export function settingsWithMcpCapabilityServers(settings: Settings, enabled: En
   if (enabled.length === 0) {
     return settings;
   }
+  const encryptionKey = environmentsEncryptionKeyBytes(settings);
   const existingIds = new Set(settings.mcpServers.map((server) => server.id));
   const dynamicServers = enabled
     .filter((server) => !existingIds.has(server.id))
-    .map((server) => ({
-      id: server.id,
-      name: server.name,
-      url: server.url,
-      ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
-      ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
-      cacheToolsList: server.cacheToolsList ?? false,
-    }));
+    .flatMap((server) => {
+      const headers = decryptedCapabilityHeaders(server, encryptionKey);
+      if (headers === "unavailable") {
+        // Without its credential headers this server can only fail auth at
+        // connect time and break agent turns; leave it out of the run.
+        return [];
+      }
+      return [{
+        id: server.id,
+        name: server.name,
+        url: server.url,
+        ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
+        ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
+        cacheToolsList: server.cacheToolsList ?? false,
+        ...(headers ? { headers } : {}),
+      }];
+    });
   return dynamicServers.length ? { ...settings, mcpServers: [...settings.mcpServers, ...dynamicServers] } : settings;
 }
 
@@ -701,7 +830,6 @@ function mcpRegistryEntryToCatalogItem(entry: McpRegistryEntry): CapabilityCatal
   const id = publicRegistryCapabilityId(server.name, version, endpointUrl);
   const homepageUrl = validUrl(server.websiteUrl) ?? validUrl(server.repository?.url);
   const requiredHeaders = requiredRemoteHeaders(remote);
-  const runtimeAvailable = requiredHeaders.length === 0;
   const mcpServerId = mcpServerIdForCapability(id, {});
   return CapabilityCatalogItem.parse({
     id,
@@ -715,14 +843,14 @@ function mcpRegistryEntryToCatalogItem(entry: McpRegistryEntry): CapabilityCatal
     endpointUrl,
     installUrl: homepageUrl,
     authModel: requiredHeaders.length ? "credential_ref" : null,
-    tools: runtimeAvailable ? [{ kind: "mcp", id: mcpServerId }] : [],
+    tools: [{ kind: "mcp", id: mcpServerId }],
     runtime: {
-      available: runtimeAvailable,
-      ...(runtimeAvailable ? { mcpServerId } : {}),
+      available: true,
+      mcpServerId,
       transport: "streamable-http",
-      notes: runtimeAvailable
+      notes: requiredHeaders.length === 0
         ? "Remote MCP server from the official MCP Registry."
-        : "This MCP declares required remote headers. Capability credential injection is not implemented yet.",
+        : `This MCP requires credential header(s) ${requiredHeaders.join(", ")} supplied in the enable request.`,
     },
     metadata: {
       registry: "official_mcp_registry",
@@ -773,9 +901,29 @@ function capabilityInstallationRuntimeReady(
   if (!installation || item.kind !== "mcp") {
     return !!installation;
   }
-  if (!item.runtime.available || item.authModel) {
+  if (!item.runtime.available) {
+    return false;
+  }
+  if (!storedCredentialHeadersSatisfy(item, installation)) {
     return false;
   }
   const connectivity = installation.metadata.mcpConnectivity;
   return !!connectivity && typeof connectivity === "object" && "status" in connectivity && connectivity.status === "ok";
+}
+
+/**
+ * Checks the redacted installation config (header names only) against the
+ * capability's declared credential requirements.
+ */
+function storedCredentialHeadersSatisfy(item: CapabilityCatalogItem, installation: CapabilityInstallation): boolean {
+  const storedNames = new Set(
+    (Array.isArray(installation.config.headerNames) ? installation.config.headerNames : [])
+      .filter((name): name is string => typeof name === "string")
+      .map((name) => name.toLowerCase()),
+  );
+  const required = requiredCapabilityHeaders(item.metadata);
+  if (required.some((name) => !storedNames.has(name.toLowerCase()))) {
+    return false;
+  }
+  return !item.authModel || storedNames.size > 0;
 }

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { describe, expect, test } from "bun:test";
 import { ScheduleNotFoundError, ScheduleOverlapPolicy } from "@temporalio/client";
 import { HTTPException } from "hono/http-exception";
@@ -13,7 +14,9 @@ import {
 } from "../src/app";
 import { shouldCreateScheduleAfterUpdateError, temporalOverlapPolicy, temporalScheduleSpec } from "../src/index";
 import { stripeCheckoutSessionCreateParams, stripeCustomerProvider } from "../src/routes/billing";
-import { discoverMcpRegistryCapabilities, validateMcpCapabilityConnection } from "../src/domain/capabilities";
+import { discoverMcpRegistryCapabilities, settingsWithMcpCapabilityServers, validateMcpCapabilityConnection } from "../src/domain/capabilities";
+import { encryptEnvironmentValue } from "@opengeni/db";
+import { testSettings } from "@opengeni/testing";
 import type { CapabilityCatalogItem, SessionEvent } from "@opengeni/contracts";
 
 describe("API helpers", () => {
@@ -279,14 +282,16 @@ describe("API helpers", () => {
       name: "Secure MCP",
       authModel: "credential_ref",
       runtime: {
-        available: false,
-        notes: "This MCP declares required remote headers. Capability credential injection is not implemented yet.",
+        available: true,
+        transport: "streamable-http",
+        notes: 'This MCP requires credential header(s) Authorization supplied in the enable request.',
       },
       metadata: {
         requiredHeaders: ["Authorization"],
       },
     });
-    expect(item?.tools).toEqual([]);
+    expect(item?.tags).toContain("requires-credentials");
+    expect(item?.tools).toHaveLength(1);
   });
 
   test("records MCP connectivity metadata after a successful enable probe", async () => {
@@ -310,6 +315,69 @@ describe("API helpers", () => {
       status: "ok",
       toolCount: 3,
     });
+  });
+
+  test("passes credential headers to the MCP enable probe", async () => {
+    const metadata = await validateMcpCapabilityConnection(capabilityItem({
+      id: "mcp:secure",
+      kind: "mcp",
+      name: "Secure MCP",
+      endpointUrl: "https://secure.example/mcp",
+      runtime: { available: true, mcpServerId: "cap-secure", transport: "streamable-http", notes: null },
+    }), async (input) => {
+      expect(input.headers).toEqual({ Authorization: "Bearer probe-token" });
+      return { toolCount: 1 };
+    }, { Authorization: "Bearer probe-token" });
+
+    expect(metadata.mcpConnectivity).toMatchObject({ status: "ok", toolCount: 1 });
+  });
+
+  test("merges enabled capability MCPs with decrypted credential headers into runtime settings", () => {
+    const key = randomBytes(32);
+    const settings = testSettings({ environmentsEncryptionKey: Buffer.from(key).toString("base64") });
+    const merged = settingsWithMcpCapabilityServers(settings, [{
+      capabilityId: "mcp:secure",
+      id: "cap-secure",
+      name: "Secure MCP",
+      url: "https://secure.example/mcp",
+      headersEncrypted: { Authorization: encryptEnvironmentValue(key, "Bearer runtime-token") },
+    }]);
+
+    const server = merged.mcpServers.find((candidate) => candidate.id === "cap-secure");
+    expect(server?.headers).toEqual({ Authorization: "Bearer runtime-token" });
+  });
+
+  test("omits credential-header capability MCPs when their headers cannot be decrypted", () => {
+    const key = randomBytes(32);
+    const otherKey = randomBytes(32);
+    const withoutKey = settingsWithMcpCapabilityServers(testSettings(), [{
+      capabilityId: "mcp:secure",
+      id: "cap-secure",
+      name: "Secure MCP",
+      url: "https://secure.example/mcp",
+      headersEncrypted: { Authorization: encryptEnvironmentValue(key, "Bearer runtime-token") },
+    }]);
+    expect(withoutKey.mcpServers.find((candidate) => candidate.id === "cap-secure")).toBeUndefined();
+
+    const wrongKey = settingsWithMcpCapabilityServers(
+      testSettings({ environmentsEncryptionKey: Buffer.from(otherKey).toString("base64") }),
+      [{
+        capabilityId: "mcp:secure",
+        id: "cap-secure",
+        name: "Secure MCP",
+        url: "https://secure.example/mcp",
+        headersEncrypted: { Authorization: encryptEnvironmentValue(key, "Bearer runtime-token") },
+      }],
+    );
+    expect(wrongKey.mcpServers.find((candidate) => candidate.id === "cap-secure")).toBeUndefined();
+
+    const headerless = settingsWithMcpCapabilityServers(testSettings(), [{
+      capabilityId: "mcp:open",
+      id: "cap-open",
+      name: "Open MCP",
+      url: "https://open.example/mcp",
+    }]);
+    expect(headerless.mcpServers.find((candidate) => candidate.id === "cap-open")).toMatchObject({ url: "https://open.example/mcp" });
   });
 
   test("rejects MCP enablement when the server cannot initialize", async () => {

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -1,5 +1,6 @@
-import type { Settings } from "@opengeni/config";
+import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
 import {
+  decryptedCapabilityHeaders,
   listEnabledMcpCapabilityServers,
   type Database,
   type EnabledMcpCapabilityServer,
@@ -14,16 +15,26 @@ function settingsWithMcpCapabilityServers(settings: Settings, enabled: EnabledMc
   if (enabled.length === 0) {
     return settings;
   }
+  const encryptionKey = environmentsEncryptionKeyBytes(settings);
   const existingIds = new Set(settings.mcpServers.map((server) => server.id));
   const dynamicServers = enabled
     .filter((server) => !existingIds.has(server.id))
-    .map((server) => ({
-      id: server.id,
-      name: server.name,
-      url: server.url,
-      ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
-      ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
-      cacheToolsList: server.cacheToolsList ?? false,
-    }));
+    .flatMap((server) => {
+      const headers = decryptedCapabilityHeaders(server, encryptionKey);
+      if (headers === "unavailable") {
+        // Without its credential headers this server can only fail auth at
+        // connect time and break agent turns; leave it out of the run.
+        return [];
+      }
+      return [{
+        id: server.id,
+        name: server.name,
+        url: server.url,
+        ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
+        ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
+        cacheToolsList: server.cacheToolsList ?? false,
+        ...(headers ? { headers } : {}),
+      }];
+    });
   return dynamicServers.length ? { ...settings, mcpServers: [...settings.mcpServers, ...dynamicServers] } : settings;
 }

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -11,9 +11,21 @@ The catalog merges:
 
 ## Runtime Behavior
 
-Remote MCP capabilities with a streamable HTTP endpoint are executable today when they do not require custom request headers or credentials. Enabling a remote MCP first performs an MCP initialize/list-tools probe. If the probe succeeds, OpenGeni stores a `capability_installations` row and the API/worker merge that row into the runtime MCP server list for new sessions, follow-ups, and scheduled tasks.
+Remote MCP capabilities with a streamable HTTP endpoint are executable. Enabling a remote MCP first performs an MCP initialize/list-tools probe. If the probe succeeds, OpenGeni stores a `capability_installations` row and the API/worker merge that row into the runtime MCP server list for new sessions, follow-ups, and scheduled tasks. If the probe fails, the API returns `422` and the capability stays disabled, so a stale, down, or auth-only endpoint never breaks agent turns at runtime.
 
-Registry entries that declare required headers remain visible in the catalog, but they are marked credential-gated and cannot be enabled until per-capability MCP credential injection is implemented. This prevents a public registry item with a stale, down, or auth-only endpoint from breaking agent turns at runtime.
+### Credential headers
+
+MCP servers that require request headers (for example an `Authorization` bearer token) are enabled by passing the headers in the enable request:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/v1/workspaces/$WORKSPACE_ID/capabilities/mcp%3Asecure-mcp/enable" \
+  -H 'content-type: application/json' \
+  -d '{"headers":{"Authorization":"Bearer <token>"}}'
+```
+
+The probe runs with those headers, and on success the values are stored encrypted (AES-256-GCM under `OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`, like workspace environment values) on the installation. At runtime the worker decrypts them and sends them only to that MCP server. The API never returns header values — installation responses expose the stored header names only. Re-enabling without a `headers` field reuses the stored credentials; passing `headers` replaces them.
+
+Registry entries that declare required headers are tagged `requires-credentials` and cannot be enabled until the declared headers are supplied.
 
 APIs, skills, and plugins are tracked in the same catalog and install table so operators can build a role-oriented workspace inventory. Built-in APIs and bundled skills are already available. Custom APIs, skills, and plugins need their own adapter or runtime implementation before tracking them changes agent execution.
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -196,6 +196,13 @@ const SettingsSchema = z.object({
     allowedTools: z.array(z.string().min(1)).optional(),
     timeoutMs: z.number().int().positive().optional(),
     cacheToolsList: z.boolean().default(false),
+    /**
+     * Extra request headers sent to this MCP server (credential injection
+     * for workspace-enabled capability MCPs). Populated at runtime from
+     * encrypted capability-installation credentials; do not put secrets in
+     * OPENGENI_MCP_SERVERS.
+     */
+    headers: z.record(z.string(), z.string()).optional(),
   })).default([]),
 });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1058,6 +1058,13 @@ export type CreateCapabilityCatalogItemRequest = z.infer<typeof CreateCapability
 export const EnableCapabilityRequest = z.object({
   config: z.record(z.string(), z.unknown()).default({}),
   metadata: z.record(z.string(), z.unknown()).default({}),
+  /**
+   * Credential headers for remote MCP capabilities (for example an
+   * Authorization bearer token). Values are encrypted at rest with the
+   * workspace-environments key, injected only into the runtime MCP client,
+   * and never returned by the API — responses expose header names only.
+   */
+  headers: z.record(z.string(), z.string()).default({}),
 });
 export type EnableCapabilityRequest = z.infer<typeof EnableCapabilityRequest>;
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -52,6 +52,7 @@ import type {
 import { and, asc, desc, eq, gt, gte, inArray, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { decryptEnvironmentValue } from "./environment-crypto";
 import * as schema from "./schema";
 
 export { sql as dbSql } from "drizzle-orm";
@@ -938,6 +939,13 @@ export type EnabledMcpCapabilityServer = {
   allowedTools?: string[];
   timeoutMs?: number;
   cacheToolsList?: boolean;
+  /**
+   * Credential request headers stored encrypted at enable time
+   * (AES-256-GCM under the workspace-environments key). Decrypted only at
+   * the runtime boundary that builds the MCP client; never exposed by the
+   * capability API surface.
+   */
+  headersEncrypted?: Record<string, string>;
 };
 
 export type EnqueueSessionTurnInput = {
@@ -1264,7 +1272,11 @@ export async function getCapabilityCatalogItem(db: Database, workspaceId: string
 export async function enableCapabilityInstallation(db: Database, input: EnableCapabilityInstallationInput): Promise<CapabilityInstallation> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
     const now = new Date();
-    const existing = await getCapabilityInstallation(scopedDb, input.workspaceId, input.capabilityId);
+    // Read the raw row (not the redacted mapping) so an omitted config
+    // preserves stored credential-header ciphertext instead of the redaction.
+    const [existing] = await scopedDb.select().from(schema.capabilityInstallations)
+      .where(and(eq(schema.capabilityInstallations.workspaceId, input.workspaceId), eq(schema.capabilityInstallations.capabilityId, input.capabilityId)))
+      .limit(1);
     if (existing) {
       const [row] = await scopedDb.update(schema.capabilityInstallations).set({
         kind: input.kind,
@@ -1343,7 +1355,13 @@ export async function listEnabledMcpCapabilityServers(db: Database, workspaceId:
     .orderBy(asc(schema.capabilityCatalogItems.name)));
 
   return rows.flatMap(({ item, installation }) => {
-    if (!item.endpointUrl || item.authModel || !mcpConnectivityOk(installation.metadata)) {
+    if (!item.endpointUrl || !mcpConnectivityOk(installation.metadata)) {
+      return [];
+    }
+    const headersEncrypted = encryptedHeadersConfig(installation.config.headersEncrypted);
+    if (item.authModel && !headersEncrypted) {
+      // Credential-gated MCPs are runnable only when credential headers were
+      // stored at enable time.
       return [];
     }
     const metadata = item.metadata;
@@ -1359,7 +1377,46 @@ export async function listEnabledMcpCapabilityServers(db: Database, workspaceId:
       ...(allowedTools ? { allowedTools } : {}),
       ...(timeoutMs ? { timeoutMs } : {}),
       ...(cacheToolsList !== undefined ? { cacheToolsList } : {}),
+      ...(headersEncrypted ? { headersEncrypted } : {}),
     }];
+  });
+}
+
+/**
+ * Decrypts an enabled capability MCP's stored credential headers. Returns
+ * null when the server has none, and "unavailable" when headers exist but
+ * cannot be recovered (missing key or failed decryption) — in which case the
+ * server must be skipped rather than connected without credentials.
+ */
+export function decryptedCapabilityHeaders(
+  server: EnabledMcpCapabilityServer,
+  encryptionKey: Uint8Array | null,
+): Record<string, string> | null | "unavailable" {
+  if (!server.headersEncrypted || Object.keys(server.headersEncrypted).length === 0) {
+    return null;
+  }
+  if (!encryptionKey) {
+    return "unavailable";
+  }
+  try {
+    return Object.fromEntries(Object.entries(server.headersEncrypted).map(([name, value]) => [name, decryptEnvironmentValue(encryptionKey, value)]));
+  } catch {
+    return "unavailable";
+  }
+}
+
+/**
+ * Returns the encrypted credential-header map stored on a capability
+ * installation, or null when none is stored. This is the only read path for
+ * the ciphertext besides listEnabledMcpCapabilityServers; the generic
+ * installation mapping redacts it to header names.
+ */
+export async function getStoredCapabilityHeaderCiphertext(db: Database, workspaceId: string, capabilityId: string): Promise<Record<string, string> | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select({ config: schema.capabilityInstallations.config }).from(schema.capabilityInstallations)
+      .where(and(eq(schema.capabilityInstallations.workspaceId, workspaceId), eq(schema.capabilityInstallations.capabilityId, capabilityId)))
+      .limit(1);
+    return row ? encryptedHeadersConfig(row.config.headersEncrypted) ?? null : null;
   });
 }
 
@@ -3015,19 +3072,19 @@ function mapWorkspacePack(row: typeof schema.workspacePacks.$inferSelect): Works
 }
 
 function mapCapabilityCatalogItem(row: typeof schema.capabilityCatalogItems.$inferSelect): CapabilityCatalogItem {
-  const runtime = row.kind === "mcp" && row.endpointUrl && !row.authModel
+  const runtime = row.kind === "mcp" && row.endpointUrl
     ? {
       available: true,
       mcpServerId: mcpServerIdForCapability(row.id, row.metadata),
       transport: "streamable-http",
-      notes: null,
+      notes: row.authModel
+        ? "Requires credential headers supplied in the enable request."
+        : null,
     }
     : {
       available: false,
       notes: row.kind === "mcp"
-        ? row.authModel
-          ? "Credential injection for remote MCP capabilities is not implemented yet."
-          : "Remote streamable HTTP endpoint is required for runtime use."
+        ? "Remote streamable HTTP endpoint is required for runtime use."
         : null,
     };
   return {
@@ -3075,11 +3132,26 @@ function mapCapabilityInstallation(row: typeof schema.capabilityInstallations.$i
     capabilityId: row.capabilityId,
     kind: row.kind as CapabilityKind,
     status: row.status as CapabilityInstallationStatus,
-    config: row.config,
+    config: redactInstallationConfig(row.config),
     metadata: row.metadata,
     enabledAt: row.enabledAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
+}
+
+/**
+ * Stored credential-header ciphertext never leaves the database through the
+ * generic installation mapping — callers see only the sorted header names.
+ * The runtime reads ciphertext through listEnabledMcpCapabilityServers and
+ * the enable flow through getStoredCapabilityHeaderCiphertext.
+ */
+function redactInstallationConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const headersEncrypted = encryptedHeadersConfig(config.headersEncrypted);
+  if (!headersEncrypted) {
+    return config;
+  }
+  const { headersEncrypted: _omitted, ...rest } = config;
+  return { ...rest, headerNames: Object.keys(headersEncrypted).sort() };
 }
 
 function mapSocialConnection(row: typeof schema.socialConnections.$inferSelect): SocialConnection {
@@ -3187,6 +3259,15 @@ function positiveIntegerConfig(value: unknown): number | undefined {
 
 function booleanConfig(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function encryptedHeadersConfig(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].length > 0);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function mcpConnectivityOk(metadata: Record<string, unknown>): boolean {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -316,7 +316,7 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       url,
       name: config.name ?? config.id,
       cacheToolsList: config.cacheToolsList,
-      ...await firstPartyMcpRequestInit(settings, config, options),
+      ...await mcpServerRequestInit(settings, config, options),
       ...(config.timeoutMs ? {
         timeout: config.timeoutMs,
         clientSessionTimeoutSeconds: Math.ceil(config.timeoutMs / 1000),
@@ -333,6 +333,19 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       await connected.close();
     },
   };
+}
+
+async function mcpServerRequestInit(settings: Settings, config: Settings["mcpServers"][number], options: PrepareToolsOptions): Promise<{ requestInit: { headers: Record<string, string> } } | {}> {
+  if (isFirstPartyMcpServer(settings, config)) {
+    return await firstPartyMcpRequestInit(settings, config, options);
+  }
+  // Third-party MCP servers get their configured credential headers (for
+  // example workspace-enabled capability MCP credentials) and nothing else —
+  // never OpenGeni's own access key or delegated tokens.
+  if (config.headers && Object.keys(config.headers).length > 0) {
+    return { requestInit: { headers: { ...config.headers } } };
+  }
+  return {};
 }
 
 async function firstPartyMcpRequestInit(settings: Settings, config: Settings["mcpServers"][number], options: PrepareToolsOptions): Promise<{ requestInit: { headers: Record<string, string> } } | {}> {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -827,6 +827,44 @@ describe("runtime event normalization", () => {
     }
   });
 
+  test("sends configured credential headers to third-party MCP servers", async () => {
+    const mcp = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    const prepared = await prepareAgentTools(testSettings({
+      mcpServers: [{
+        id: "cap-secure",
+        name: "Secure capability MCP",
+        url: mcp.url,
+        headers: { "x-api-key": "capability-credential" },
+        cacheToolsList: false,
+      }],
+    }), [{ kind: "mcp", id: "cap-secure" }]);
+    try {
+      const tools = await prepared.mcpServers[0]!.listTools();
+      expect(tools.map((tool) => tool.name)).toContain("cap-secure__search_documents");
+      const result = await prepared.mcpServers[0]!.callTool("cap-secure__search_documents", { query: "headers" });
+      expect(JSON.stringify(result)).toContain("found document for headers");
+    } finally {
+      await prepared.close();
+      mcp.close();
+    }
+  });
+
+  test("connecting without the required credential headers fails", async () => {
+    const mcp = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    try {
+      await expect(prepareAgentTools(testSettings({
+        mcpServers: [{
+          id: "cap-secure",
+          name: "Secure capability MCP",
+          url: mcp.url,
+          cacheToolsList: false,
+        }],
+      }), [{ kind: "mcp", id: "cap-secure" }])).rejects.toThrow();
+    } finally {
+      mcp.close();
+    }
+  });
+
   test("rejects unknown MCP tool ids during runtime preparation", async () => {
     await expect(prepareAgentTools(testSettings(), [{ kind: "mcp", id: "missing" }])).rejects.toThrow("Unknown MCP server id");
   });

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -4,7 +4,8 @@ import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
 import { buildOpenGeniMcpServer } from "../../apps/api/src/mcp/server";
-import { MemoryEventBus, parseSseBlock, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
+import { settingsWithEnabledCapabilityMcpServers } from "../../apps/worker/src/activities/capabilities";
+import { MemoryEventBus, parseSseBlock, startTestMcpServer, startTestServices, testSettings, type TestServices } from "@opengeni/testing";
 import { prepareAgentTools } from "@opengeni/runtime";
 import { createSignedState, readSignedState } from "@opengeni/github";
 
@@ -1248,6 +1249,118 @@ describe("API component integration", () => {
       set status = 'disabled', updated_at = now()
       where workspace_id = ${workspaceId} and capability_id = ${capabilityId}
     `);
+  });
+
+  test("enables a credential-header MCP capability end to end with encrypted storage", async () => {
+    const encryptionKey = crypto.getRandomValues(new Uint8Array(32));
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      environmentsEncryptionKey: Buffer.from(encryptionKey).toString("base64"),
+    });
+    const app = createApp({
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const context = await defaultAccessContext(app);
+    const bearer = `Bearer secure-${crypto.randomUUID()}`;
+    const mcp = startTestMcpServer({ requiredAuthorization: bearer });
+    const capabilityId = `mcp:secure-test-${crypto.randomUUID()}`;
+    const mcpServerId = `cap-secure-${crypto.randomUUID().slice(0, 8)}`;
+    try {
+      await upsertCapabilityCatalogItem(dbClient.db, {
+        accountId: context.defaultAccountId!,
+        workspaceId,
+        id: capabilityId,
+        kind: "mcp",
+        source: "manual",
+        name: "Secure Test MCP",
+        endpointUrl: mcp.url,
+        authModel: "credential_ref",
+        metadata: { mcpServerId, requiredHeaders: ["Authorization"] },
+      });
+
+      // Without the declared credential header the enable is rejected up front.
+      const withoutHeaders = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "content-type": "application/json" },
+      });
+      expect(withoutHeaders.status).toBe(422);
+      expect(await withoutHeaders.text()).toContain("requires credential header(s) Authorization");
+
+      // A wrong credential fails the live probe (the test MCP returns 401).
+      const wrongHeaders = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
+        method: "POST",
+        body: JSON.stringify({ headers: { Authorization: "Bearer wrong" } }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(wrongHeaders.status).toBe(422);
+      expect(await wrongHeaders.text()).toContain("could not be enabled");
+
+      const enabled = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
+        method: "POST",
+        body: JSON.stringify({ headers: { Authorization: bearer } }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(enabled.status).toBe(201);
+      const enabledBody = await enabled.text();
+      // The API response exposes header names only — never the credential.
+      expect(enabledBody).not.toContain(bearer);
+      const installation = JSON.parse(enabledBody) as { config: Record<string, unknown>; metadata: Record<string, unknown> };
+      expect(installation.config.headerNames).toEqual(["Authorization"]);
+      expect(installation.config.headersEncrypted).toBeUndefined();
+      expect(installation.metadata.mcpConnectivity).toMatchObject({ status: "ok" });
+
+      // The stored value is AES-GCM ciphertext that decrypts back to the credential.
+      const [row] = await dbClient.db.execute(dbSql`
+        select config from capability_installations
+        where workspace_id = ${workspaceId} and capability_id = ${capabilityId}
+      `) as Array<{ config: { headersEncrypted: Record<string, string> } }>;
+      const storedCiphertext = row!.config.headersEncrypted.Authorization!;
+      expect(storedCiphertext.startsWith("v1:")).toBe(true);
+      expect(decryptEnvironmentValue(encryptionKey, storedCiphertext)).toBe(bearer);
+
+      // The catalog reports the capability enabled and runtime-ready.
+      const catalogResponse = await app.request(workspacePath(workspaceId, "/capabilities"));
+      const catalog = await catalogResponse.json() as { items: Array<{ id: string; enabled: boolean; runtime: { available: boolean; mcpServerId?: string } }> };
+      expect(catalog.items.find((item) => item.id === capabilityId)).toMatchObject({
+        enabled: true,
+        runtime: { available: true, mcpServerId },
+      });
+
+      // The worker-side merge decrypts the headers for the runtime MCP client,
+      // and the runtime can list tools against the credentialed server.
+      const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(dbClient.db, workspaceId, settings);
+      const merged = runtimeSettings.mcpServers.find((server) => server.id === mcpServerId);
+      expect(merged?.headers).toEqual({ Authorization: bearer });
+      const prepared = await prepareAgentTools(runtimeSettings, [{ kind: "mcp", id: mcpServerId }]);
+      try {
+        const tools = await prepared.mcpServers[0]!.listTools();
+        expect(tools.map((tool) => tool.name)).toContain(`${mcpServerId}__search_documents`);
+      } finally {
+        await prepared.close();
+      }
+
+      // Re-enabling without headers reuses the stored credentials (probe still passes).
+      const reEnabled = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "content-type": "application/json" },
+      });
+      expect(reEnabled.status).toBe(201);
+      const reEnabledInstallation = await reEnabled.json() as { config: Record<string, unknown> };
+      expect(reEnabledInstallation.config.headerNames).toEqual(["Authorization"]);
+    } finally {
+      mcp.close();
+      await dbClient.db.execute(dbSql`
+        update capability_installations
+        set status = 'disabled', updated_at = now()
+        where workspace_id = ${workspaceId} and capability_id = ${capabilityId}
+      `);
+    }
   });
 
   test("returns 409 when disabling a never-enabled capability", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1300,18 +1300,36 @@ describe("API component integration", () => {
       expect(wrongHeaders.status).toBe(422);
       expect(await wrongHeaders.text()).toContain("could not be enabled");
 
+      // Header values must be valid HTTP field values (RFC 9110): control
+      // characters beyond CR/LF are rejected too.
+      const controlChars = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
+        method: "POST",
+        body: JSON.stringify({ headers: { Authorization: "Bearer bad\u0007value" } }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(controlChars.status).toBe(422);
+      expect(await controlChars.text()).toContain("forbidden control characters");
+
       const enabled = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(capabilityId)}/enable`), {
         method: "POST",
-        body: JSON.stringify({ headers: { Authorization: bearer } }),
+        body: JSON.stringify({
+          headers: { Authorization: bearer },
+          // Reserved keys in caller config must be stripped, never stored —
+          // a plaintext config.headers map must not bypass encryption.
+          config: { headers: { Authorization: "plaintext-bypass" }, headersEncrypted: "spoofed", note: "kept" },
+        }),
         headers: { "content-type": "application/json" },
       });
       expect(enabled.status).toBe(201);
       const enabledBody = await enabled.text();
       // The API response exposes header names only — never the credential.
       expect(enabledBody).not.toContain(bearer);
+      expect(enabledBody).not.toContain("plaintext-bypass");
       const installation = JSON.parse(enabledBody) as { config: Record<string, unknown>; metadata: Record<string, unknown> };
       expect(installation.config.headerNames).toEqual(["Authorization"]);
       expect(installation.config.headersEncrypted).toBeUndefined();
+      expect(installation.config.headers).toBeUndefined();
+      expect(installation.config.note).toBe("kept");
       expect(installation.metadata.mcpConnectivity).toMatchObject({ status: "ok" });
 
       // The stored value is AES-GCM ciphertext that decrypts back to the credential.


### PR DESCRIPTION
## What

Workspace-enabled remote MCP capabilities that declare required request headers (e.g. an `Authorization` bearer token) were credential-gated: visible in the catalog but impossible to enable, pending per-capability credential injection. This implements that injection as a small generic feature.

- `EnableCapabilityRequest` gains a `headers` field. The enable probe runs with those headers; on success the values are stored **encrypted** (AES-256-GCM under `OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`, the same scheme as workspace environment values) in the capability installation config.
- **The API never returns header values.** Installation responses redact the ciphertext to sorted header names (`config.headerNames`); the only ciphertext read paths are the runtime merge and the re-enable flow.
- The API/worker settings merge decrypts headers into the runtime MCP server config, and `prepareAgentTools` sends them only to that server. First-party servers keep their existing auth path and never receive capability headers; third-party servers never receive OpenGeni's access key or delegated tokens.
- Servers whose stored headers cannot be recovered (missing key, failed decryption) are skipped from the run instead of failing auth at connect time and breaking agent turns.
- Registry/manual items with `authModel`/`requiredHeaders` are now enableable; enabling validates the declared headers are supplied. Re-enabling without `headers` reuses the stored credentials (mirrors the pack environment-attachment preservation); passing `headers` replaces them.
- Header hygiene: RFC 9110 token names, no control characters in values, bounded count/length.

## Tests

- Unit: probe receives headers; runtime settings merge decrypts/skips correctly; runtime sends configured headers to third-party MCP servers (and connecting without them fails); registry mapping now reports credential MCPs as runtime-available with a descriptive note.
- Integration (`api.integration.ts`): full end-to-end flow against a live header-requiring test MCP — 422 without headers, 422 on wrong credential (probe 401), 201 with correct headers, response redaction (no credential anywhere in the response body), `v1:` AES-GCM ciphertext at rest that decrypts back, catalog enabled+runtime-ready, worker-side merge + `prepareAgentTools` lists tools through the credentialed server, re-enable without headers reuses stored credentials.

Gate: `bun run check` green; `api`, `db`, `workspace-isolation`, `worker-activity`, `nats` integration suites green. `docs/capabilities.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces credential storage, encryption, and HTTP header injection for remote MCPs—security-sensitive paths where misconfiguration or leakage would expose workspace tokens.
> 
> **Overview**
> Adds **per-workspace credential headers** for remote MCP capabilities so registry and manual MCPs that declare required headers (e.g. `Authorization`) can be enabled instead of staying catalog-only.
> 
> **Enable flow:** `EnableCapabilityRequest` gains a `headers` map. MCP enable validates header names/values, runs the existing connectivity probe with those headers, encrypts values with AES-256-GCM under `OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`, and stores them on the installation. Caller `config` cannot smuggle plaintext via reserved keys (`headers`, `headersEncrypted`, `headerNames`). Re-enable without `headers` decrypts and reuses stored credentials.
> 
> **API surface:** Installation responses redact ciphertext to sorted `config.headerNames` only; dedicated DB reads supply ciphertext for re-enable and runtime merge.
> 
> **Runtime:** API/worker merge decrypts headers into dynamic `mcpServers` entries; servers that need credentials but cannot decrypt are **omitted** so agent turns do not fail at connect. `prepareAgentTools` sends `headers` only to third-party MCPs (not first-party OpenGeni auth).
> 
> **Catalog:** Registry MCPs with required remote headers are **runtime-available** with `requires-credentials` tagging; runtime-ready checks require stored header names to satisfy `requiredHeaders` / `authModel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e5582f1ed3395e14905094460032130b066792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->