### PR TITLE
Pack-scoped runtime: pack-declared sandbox image + pack skills via the Skills capability

### DIFF
--- a/.agents/skills/opengeni/references/sandbox-configuration.md
+++ b/.agents/skills/opengeni/references/sandbox-configuration.md
@@ -98,6 +98,7 @@ Common resource behavior:
 - File resources become object-storage-backed mounts, commonly under `files/<file-id>`.
 - Uploaded files are read-only. Agents should copy them before modifying.
 - Bundled infrastructure skills may be made available under `.agents/` through the Agents SDK skills capability.
+- Enabled capability packs may add skills to the same `.agents/` skill index and may declare a `sandboxImage` that overrides `OPENGENI_DOCKER_IMAGE`/`OPENGENI_MODAL_IMAGE_REF` for the workspace's sessions (one image-declaring pack per workspace; see `docs/packs.md`).
 
 Always trace resource flow end to end:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ If a change alters architecture, terminology, the run lifecycle, the memory mode
 
 The Docker sandbox image includes Terraform, Checkov, Azure CLI, GitHub CLI, git, jq, curl, and base shell utilities. Bundled Terraform/checkov skills live under `packages/runtime/src/bundled_hashicorp_terraform_skills` and are mounted into the sandbox under `.agents/`.
 
+Enabled capability packs can scope the runtime per workspace: a registered pack manifest may declare `skills` (delivered into the same `.agents/` skill index as the bundled skills) and a `sandboxImage` that replaces the global `OPENGENI_DOCKER_IMAGE`/`OPENGENI_MODAL_IMAGE_REF` for that workspace's sessions. At most one enabled pack per workspace may declare an image — no image composition. See `docs/packs.md`.
+
 When the `azure` sandbox preparation profile is enabled and ARM/AZURE service-principal variables are allowed into the sandbox, the worker pre-authenticates normal Azure CLI inside the sandbox with `az login --service-principal` before the agent starts. There is no custom `opengeni-azure-login` helper.
 
 Sandbox preparation is controlled by:

--- a/apps/api/src/domain/capabilities.ts
+++ b/apps/api/src/domain/capabilities.ts
@@ -34,7 +34,7 @@ import {
   type EnabledMcpCapabilityServer,
 } from "@opengeni/db";
 import { HTTPException } from "hono/http-exception";
-import { listCapabilityPacks, listWorkspaceCapabilityPacks, resolveCapabilityPack } from "./packs";
+import { assertPackSandboxImageCompatible, listCapabilityPacks, listWorkspaceCapabilityPacks, resolveCapabilityPack } from "./packs";
 
 const officialMcpRegistryUrl = "https://registry.modelcontextprotocol.io";
 const firstPartyMcpServerIds = new Set(["opengeni", "files", "docs"]);
@@ -158,6 +158,7 @@ export async function enableCapability(input: {
     if (!pack) {
       throw new HTTPException(404, { message: "pack not found" });
     }
+    await assertPackSandboxImageCompatible(input.db, input.workspaceId, pack);
     // This generic enable path carries no environment attachment, so packs
     // that demand one must be enabled through the packs endpoint unless a
     // previous enable already stored an attachment; a stored attachment is
@@ -550,6 +551,9 @@ function packCatalogItem(pack: ReturnType<typeof listCapabilityPacks>[number], s
       connectors: pack.connectors,
       knowledge: pack.knowledge,
       scheduledTaskTemplates: pack.scheduledTaskTemplates,
+      // Runtime composition surface only: skill names, never file content.
+      ...(pack.sandboxImage ? { sandboxImage: pack.sandboxImage } : {}),
+      ...(pack.skills.length > 0 ? { skills: pack.skills.map((skill) => skill.name) } : {}),
       ...pack.metadata,
     },
   });

--- a/apps/api/src/domain/packs.ts
+++ b/apps/api/src/domain/packs.ts
@@ -3,7 +3,8 @@ import {
   type ScheduledTaskAgentConfig,
   type SocialConnection,
 } from "@opengeni/contracts";
-import { getWorkspacePack, listWorkspacePacks, type Database } from "@opengeni/db";
+import { getWorkspacePack, listPackInstallations, listWorkspacePacks, type Database } from "@opengeni/db";
+import { HTTPException } from "hono/http-exception";
 
 export const MARKETING_SOCIAL_PACK_ID = "marketing-social-daily-analysis";
 
@@ -14,6 +15,10 @@ const marketingSocialPack: CapabilityPack = {
   role: "marketing",
   category: "social-media",
   version: "0.1.0",
+  // Built-in packs deliberately declare no sandboxImage and no skills: the
+  // worker's pack-runtime resolution only reads manifest-registered packs
+  // (see apps/worker/src/activities/packs.ts), and a test enforces this.
+  skills: [],
   tools: [
     { kind: "mcp", id: "opengeni" },
     { kind: "mcp", id: "docs" },
@@ -157,6 +162,31 @@ export async function resolveCapabilityPack(db: Database, workspaceId: string, p
   }
   const parsed = CapabilityPack.safeParse(registration.pack);
   return parsed.success ? parsed.data : null;
+}
+
+/**
+ * v1 pack-scoped runtime rule: at most one enabled pack per workspace may
+ * declare a `sandboxImage` — there is deliberately no image composition or
+ * layering. Enforced when a pack is enabled (both the packs endpoint and the
+ * generic capability enable path) and re-checked at session start by the
+ * worker, which also covers manifests re-registered after enablement.
+ */
+export async function assertPackSandboxImageCompatible(db: Database, workspaceId: string, pack: CapabilityPack): Promise<void> {
+  if (!pack.sandboxImage) {
+    return;
+  }
+  const installations = await listPackInstallations(db, workspaceId);
+  for (const installation of installations) {
+    if (installation.status !== "active" || installation.packId === pack.id) {
+      continue;
+    }
+    const other = await resolveCapabilityPack(db, workspaceId, installation.packId);
+    if (other?.sandboxImage) {
+      throw new HTTPException(409, {
+        message: `pack ${pack.id} declares a sandbox image, but enabled pack ${other.id} already declares one; only one enabled pack per workspace may declare sandboxImage — disable ${other.id} first`,
+      });
+    }
+  }
 }
 
 export function buildMarketingDailyAnalysisAgentConfig(input: {

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -25,6 +25,7 @@ import { requireLimit } from "../billing/limits";
 import type { ApiRouteDeps } from "../dependencies";
 import { validateEnvironmentAttachment } from "../domain/environments";
 import {
+  assertPackSandboxImageCompatible,
   buildMarketingDailyAnalysisAgentConfig,
   isBuiltInCapabilityPack,
   listWorkspaceCapabilityPacks,
@@ -111,6 +112,7 @@ export function registerPackRoutes(app: Hono, deps: ApiRouteDeps): void {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
     const pack = await requirePack(db, workspaceId, c.req.param("packId"));
+    await assertPackSandboxImageCompatible(db, workspaceId, pack);
     const existing = await getPackInstallation(db, workspaceId, pack.id);
     const payload = EnablePackRequest.parse(await c.req.json());
     // Re-enabling without environmentId keeps the stored attachment instead of

--- a/apps/api/test/packs-domain.test.ts
+++ b/apps/api/test/packs-domain.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { listCapabilityPacks } from "../src/domain/packs";
+
+describe("built-in capability packs", () => {
+  // The worker's pack-scoped runtime resolution
+  // (apps/worker/src/activities/packs.ts) only reads manifest-registered
+  // packs from the database. That stays correct only while built-in packs
+  // never declare a sandbox image or skills; a built-in pack that needs
+  // either must move pack resolution into a shared module first.
+  test("never declare a pack-scoped runtime", () => {
+    for (const pack of listCapabilityPacks()) {
+      expect(pack.sandboxImage).toBeUndefined();
+      expect(pack.skills).toEqual([]);
+    }
+  });
+});

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -37,6 +37,7 @@ import {
   mergeToolRefs,
 } from "./common";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
+import { resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
 import { createSecretRedactor, identityRedactor } from "./redaction";
 import { turnInput } from "./run-input";
 import {
@@ -219,8 +220,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       ], true);
       turnStartedPublished = true;
 
+      // Pack-scoped runtime: enabled packs may declare the sandbox image this
+      // workspace's sessions run in and skills for the sandbox skill index.
+      // Resolved after turn.started so a composition conflict (two enabled
+      // packs declaring images) fails the turn with its plain error instead
+      // of failing the activity opaquely.
+      const packRuntime = await resolveWorkspacePackRuntime(db, input.workspaceId);
       const runSettings = {
-        ...capabilitySettings,
+        ...settingsWithPackSandboxImage(capabilitySettings, packRuntime.sandboxImage),
         openaiModel: turn.model,
         openaiReasoningEffort: turn.reasoningEffort,
         sandboxBackend: turn.sandboxBackend,
@@ -250,6 +257,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         sandboxEnvironment,
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
+        ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(workspaceEnvironment
           ? {
             workspaceEnvironment: {

--- a/apps/worker/src/activities/packs.ts
+++ b/apps/worker/src/activities/packs.ts
@@ -1,0 +1,97 @@
+import type { Settings } from "@opengeni/config";
+import { CapabilityPack } from "@opengeni/contracts";
+import { getWorkspacePack, listPackInstallations, type Database } from "@opengeni/db";
+import type { PackSkill } from "@opengeni/runtime";
+
+/**
+ * The pack-scoped runtime for a workspace: the sandbox image its sessions run
+ * in (when an enabled pack declares one) and the pack skills that join the
+ * sandbox skill index.
+ */
+export type WorkspacePackRuntime = {
+  sandboxImage: string | null;
+  skills: PackSkill[];
+};
+
+const emptyPackRuntime: WorkspacePackRuntime = { sandboxImage: null, skills: [] };
+
+/**
+ * Resolves the pack-scoped runtime from the workspace's active pack
+ * installations. Only registered (manifest-backed) packs can contribute a
+ * sandbox image or skills; built-in packs never declare either (enforced by a
+ * test on the built-in catalog), so their installations are skipped here
+ * without consulting the API's built-in pack list.
+ */
+export async function resolveWorkspacePackRuntime(db: Database, workspaceId: string): Promise<WorkspacePackRuntime> {
+  const installations = await listPackInstallations(db, workspaceId);
+  const active = installations.filter((installation) => installation.status === "active");
+  if (active.length === 0) {
+    return emptyPackRuntime;
+  }
+  const packs: CapabilityPack[] = [];
+  for (const installation of active) {
+    const registration = await getWorkspacePack(db, workspaceId, installation.packId);
+    if (!registration) {
+      continue;
+    }
+    const parsed = CapabilityPack.safeParse(registration.pack);
+    if (parsed.success) {
+      packs.push(parsed.data);
+    }
+  }
+  return workspacePackRuntimeFromPacks(packs);
+}
+
+/**
+ * Pure composition rule for enabled pack manifests. v1 keeps this small by
+ * design: at most one enabled pack may declare a sandbox image (no image
+ * layering or composition), and skill names must be unique across enabled
+ * packs. Violations fail the turn with a plain error instead of guessing.
+ */
+export function workspacePackRuntimeFromPacks(packs: CapabilityPack[]): WorkspacePackRuntime {
+  const imagePacks = packs.filter((pack) => typeof pack.sandboxImage === "string" && pack.sandboxImage.trim().length > 0);
+  if (imagePacks.length > 1) {
+    const ids = imagePacks.map((pack) => pack.id).sort().join(", ");
+    throw new Error(
+      `Multiple enabled packs declare a sandbox image (${ids}). Only one enabled pack per workspace may declare sandboxImage; disable the others and retry.`,
+    );
+  }
+  const skills: PackSkill[] = [];
+  const skillOwners = new Map<string, string>();
+  for (const pack of [...packs].sort((a, b) => a.id.localeCompare(b.id))) {
+    for (const skill of pack.skills) {
+      const existingOwner = skillOwners.get(skill.name);
+      if (existingOwner !== undefined && existingOwner !== pack.id) {
+        throw new Error(
+          `Enabled packs ${existingOwner} and ${pack.id} both declare a skill named "${skill.name}". Pack skill names must be unique across enabled packs; disable one of the packs and retry.`,
+        );
+      }
+      skillOwners.set(skill.name, pack.id);
+      skills.push({
+        name: skill.name,
+        description: skill.description ?? null,
+        files: skill.files.map((file) => ({ path: file.path, content: file.content })),
+      });
+    }
+  }
+  return {
+    sandboxImage: imagePacks[0]?.sandboxImage?.trim() ?? null,
+    skills,
+  };
+}
+
+/**
+ * Applies a pack-declared sandbox image to run settings. With no pack image
+ * the settings pass through untouched, so deployments without packs keep the
+ * global OPENGENI_DOCKER_IMAGE / OPENGENI_MODAL_IMAGE_REF behavior exactly.
+ */
+export function settingsWithPackSandboxImage(settings: Settings, sandboxImage: string | null): Settings {
+  if (!sandboxImage) {
+    return settings;
+  }
+  return {
+    ...settings,
+    dockerImage: sandboxImage,
+    modalImageRef: sandboxImage,
+  };
+}

--- a/apps/worker/src/activities/packs.ts
+++ b/apps/worker/src/activities/packs.ts
@@ -57,16 +57,19 @@ export function workspacePackRuntimeFromPacks(packs: CapabilityPack[]): Workspac
     );
   }
   const skills: PackSkill[] = [];
+  // Keyed case-insensitively to match the per-pack uniqueness rule in the
+  // CapabilityPack contract (and case-insensitive filesystems).
   const skillOwners = new Map<string, string>();
   for (const pack of [...packs].sort((a, b) => a.id.localeCompare(b.id))) {
     for (const skill of pack.skills) {
-      const existingOwner = skillOwners.get(skill.name);
+      const key = skill.name.toLowerCase();
+      const existingOwner = skillOwners.get(key);
       if (existingOwner !== undefined && existingOwner !== pack.id) {
         throw new Error(
           `Enabled packs ${existingOwner} and ${pack.id} both declare a skill named "${skill.name}". Pack skill names must be unique across enabled packs; disable one of the packs and retry.`,
         );
       }
-      skillOwners.set(skill.name, pack.id);
+      skillOwners.set(key, pack.id);
       skills.push({
         name: skill.name,
         description: skill.description ?? null,

--- a/apps/worker/test/packs.test.ts
+++ b/apps/worker/test/packs.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type { Settings } from "@opengeni/config";
+import { CapabilityPack } from "@opengeni/contracts";
+import { settingsWithPackSandboxImage, workspacePackRuntimeFromPacks } from "../src/activities/packs";
+
+function pack(overrides: Record<string, unknown>): CapabilityPack {
+  return CapabilityPack.parse({
+    id: "test-pack",
+    name: "Test pack",
+    description: "A pack used in worker runtime tests.",
+    role: "infrastructure",
+    category: "infrastructure",
+    version: "0.1.0",
+    ...overrides,
+  });
+}
+
+const infraSkill = {
+  name: "infra-ops",
+  files: [
+    { path: "SKILL.md", content: "---\nname: infra-ops\ndescription: Operate infrastructure safely.\n---\n# Infra ops\n" },
+    { path: "references/runbook.md", content: "Runbook." },
+  ],
+};
+
+describe("workspace pack runtime resolution", () => {
+  test("resolves to the global-image fallback when no pack declares a runtime", () => {
+    expect(workspacePackRuntimeFromPacks([])).toEqual({ sandboxImage: null, skills: [] });
+    expect(workspacePackRuntimeFromPacks([pack({ id: "plain" })])).toEqual({ sandboxImage: null, skills: [] });
+  });
+
+  test("selects the single declared sandbox image and collects pack skills", () => {
+    const runtime = workspacePackRuntimeFromPacks([
+      pack({ id: "plain" }),
+      pack({
+        id: "infra-runtime",
+        sandboxImage: "ghcr.io/example/infra-sandbox@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        skills: [infraSkill],
+      }),
+    ]);
+    expect(runtime.sandboxImage).toBe("ghcr.io/example/infra-sandbox@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    expect(runtime.skills).toEqual([
+      {
+        name: "infra-ops",
+        description: null,
+        files: infraSkill.files,
+      },
+    ]);
+  });
+
+  test("fails plainly when more than one enabled pack declares a sandbox image", () => {
+    const packs = [
+      pack({ id: "pack-b", sandboxImage: "example.com/b:1" }),
+      pack({ id: "pack-a", sandboxImage: "example.com/a:1" }),
+    ];
+    expect(() => workspacePackRuntimeFromPacks(packs)).toThrow(
+      "Multiple enabled packs declare a sandbox image (pack-a, pack-b). Only one enabled pack per workspace may declare sandboxImage; disable the others and retry.",
+    );
+  });
+
+  test("fails plainly when two enabled packs declare the same skill name", () => {
+    const packs = [
+      pack({ id: "pack-a", skills: [infraSkill] }),
+      pack({ id: "pack-b", skills: [infraSkill] }),
+    ];
+    expect(() => workspacePackRuntimeFromPacks(packs)).toThrow(
+      'Enabled packs pack-a and pack-b both declare a skill named "infra-ops".',
+    );
+  });
+
+  test("keeps explicit skill descriptions", () => {
+    const runtime = workspacePackRuntimeFromPacks([
+      pack({ id: "infra-runtime", skills: [{ ...infraSkill, description: "Operate workspace infrastructure." }] }),
+    ]);
+    expect(runtime.skills[0]?.description).toBe("Operate workspace infrastructure.");
+  });
+});
+
+describe("pack sandbox image settings", () => {
+  const settings = {
+    dockerImage: "opengeni-sandbox:local",
+    modalImageRef: undefined,
+  } as unknown as Settings;
+
+  test("leaves settings untouched without a pack image (global fallback)", () => {
+    expect(settingsWithPackSandboxImage(settings, null)).toBe(settings);
+  });
+
+  test("overrides docker and modal image refs with the pack image", () => {
+    const derived = settingsWithPackSandboxImage(settings, "ghcr.io/example/infra-sandbox@sha256:abc");
+    expect(derived.dockerImage).toBe("ghcr.io/example/infra-sandbox@sha256:abc");
+    expect(derived.modalImageRef).toBe("ghcr.io/example/infra-sandbox@sha256:abc");
+    // The original settings object is never mutated.
+    expect(settings.dockerImage).toBe("opengeni-sandbox:local");
+    expect(settings.modalImageRef).toBeUndefined();
+  });
+});

--- a/apps/worker/test/packs.test.ts
+++ b/apps/worker/test/packs.test.ts
@@ -66,6 +66,12 @@ describe("workspace pack runtime resolution", () => {
     expect(() => workspacePackRuntimeFromPacks(packs)).toThrow(
       'Enabled packs pack-a and pack-b both declare a skill named "infra-ops".',
     );
+    // Cross-pack uniqueness is case-insensitive, matching the per-pack
+    // contract rule.
+    expect(() => workspacePackRuntimeFromPacks([
+      pack({ id: "pack-a", skills: [infraSkill] }),
+      pack({ id: "pack-b", skills: [{ ...infraSkill, name: "Infra-Ops" }] }),
+    ])).toThrow("both declare a skill named");
   });
 
   test("keeps explicit skill descriptions", () => {

--- a/docs/packs.md
+++ b/docs/packs.md
@@ -26,6 +26,15 @@ CloudGeni used a similar split: a general integration record, provider-specific 
 
 Packs may also declare an `environment` block (`description`, `requiredVariables`, `required`). Enabling such a pack accepts an `environmentId` pointing at a workspace environment (see `docs/environments.md`); the required variable **names** are validated at enable time and scheduled tasks created from the pack's templates inherit the attachment. Environments store encrypted `NAME=value` material in Postgres under an operator key — a deliberate, documented contrast with the `credentialRef` rule above.
 
+## Pack-Scoped Runtime
+
+A registered pack manifest may declare the runtime its sessions compose into:
+
+- `sandboxImage` (optional string): a container image ref — digest-pinned recommended — that the workspace's sessions run in. With one enabled image-declaring pack, the worker derives run settings with `dockerImage`/`modalImageRef` replaced by the pack image. With none, sessions keep the deployment-wide `OPENGENI_DOCKER_IMAGE` / `OPENGENI_MODAL_IMAGE_REF` behavior exactly. If **more than one** enabled pack declares an image, enabling the second pack fails with `409`, and a session start that still finds two (for example after a manifest re-registration) fails the turn with a plain error. There is deliberately no image composition or layering in v1.
+- `skills` (optional array): skills delivered into the sandbox skill index. Each skill is `{ name, description?, files: [{ path, content }] }` where `files` must include a top-level `SKILL.md` and paths are safe relative POSIX paths (`references/...`, `scripts/...`). Skill content travels inline in the manifest and is stored with it (the `workspace_packs` JSONB row); no image baking or extra storage is involved. At run time the worker feeds enabled packs' skills into the OpenAI Agents SDK Skills capability alongside the bundled skills, so they appear in the same `.agents/` skill index, are lazily materialized via `load_skill`, and `skills/<name>` references resolve. A pack skill with the same directory name as a bundled skill shadows it; two enabled packs declaring the same skill name fail the turn plainly.
+
+Built-in packs never declare `sandboxImage` or `skills`; only registered (manifest-backed) packs participate in pack-scoped runtime composition.
+
 ## Marketing Social Pack
 
 The pack exposes:

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -894,7 +894,7 @@ export const CapabilityPack = z.object({
   // Container image ref (digest-pinned recommended) the pack's sessions run
   // in. At most one enabled pack per workspace may declare one; with none,
   // sessions use the deployment-wide image settings.
-  sandboxImage: z.string().min(1).max(512).optional(),
+  sandboxImage: z.string().trim().min(1).max(512).optional(),
   // Skills delivered into the sandbox skill index when the pack is enabled.
   skills: z.array(CapabilityPackSkill).max(32).superRefine((skills, ctx) => {
     const seen = new Set<string>();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -841,6 +841,49 @@ export const CapabilityPackScheduledTaskTemplate = z.object({
 });
 export type CapabilityPackScheduledTaskTemplate = z.infer<typeof CapabilityPackScheduledTaskTemplate>;
 
+// One file inside a pack skill directory. Paths are workspace-relative POSIX
+// paths inside the skill directory (for example "SKILL.md" or
+// "references/runbook.md"); content is UTF-8 text carried inline in the pack
+// manifest, which is also how registered packs persist it (the manifest JSONB
+// row in workspace_packs is the storage of record for pack skills).
+export const CapabilityPackSkillFile = z.object({
+  path: z.string().min(1).max(512).refine(isSafePackSkillRelativePath, {
+    message: "skill file path must be a safe relative POSIX path without '..' segments",
+  }),
+  content: z.string().max(256 * 1024),
+});
+export type CapabilityPackSkillFile = z.infer<typeof CapabilityPackSkillFile>;
+
+// A skill delivered by a capability pack. The name doubles as the skill
+// directory under the sandbox skill index (skills/<name>), so it must be a
+// single safe path segment. Every skill must ship a top-level SKILL.md.
+export const CapabilityPackSkill = z.object({
+  name: z.string().min(1).max(64).regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, {
+    message: "skill name must be a single path segment of letters, digits, '.', '_' or '-'",
+  }),
+  description: z.string().min(1).max(2048).optional(),
+  files: z.array(CapabilityPackSkillFile).min(1).max(64),
+}).superRefine((skill, ctx) => {
+  const seen = new Set<string>();
+  skill.files.forEach((file, index) => {
+    if (seen.has(file.path)) {
+      ctx.addIssue({ code: "custom", message: `duplicate skill file path: ${file.path}`, path: ["files", index, "path"] });
+    }
+    seen.add(file.path);
+  });
+  if (!skill.files.some((file) => file.path === "SKILL.md")) {
+    ctx.addIssue({ code: "custom", message: "skill must include a top-level SKILL.md file", path: ["files"] });
+  }
+});
+export type CapabilityPackSkill = z.infer<typeof CapabilityPackSkill>;
+
+function isSafePackSkillRelativePath(path: string): boolean {
+  if (path.startsWith("/") || path.includes("\\")) {
+    return false;
+  }
+  return path.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
 export const CapabilityPack = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
@@ -848,6 +891,21 @@ export const CapabilityPack = z.object({
   role: z.string().min(1),
   category: z.string().min(1),
   version: z.string().min(1),
+  // Container image ref (digest-pinned recommended) the pack's sessions run
+  // in. At most one enabled pack per workspace may declare one; with none,
+  // sessions use the deployment-wide image settings.
+  sandboxImage: z.string().min(1).max(512).optional(),
+  // Skills delivered into the sandbox skill index when the pack is enabled.
+  skills: z.array(CapabilityPackSkill).max(32).superRefine((skills, ctx) => {
+    const seen = new Set<string>();
+    skills.forEach((skill, index) => {
+      const key = skill.name.toLowerCase();
+      if (seen.has(key)) {
+        ctx.addIssue({ code: "custom", message: `duplicate pack skill name: ${skill.name}`, path: [index, "name"] });
+      }
+      seen.add(key);
+    });
+  }).default([]),
   tools: z.array(ToolRef).default([]),
   connectors: z.array(CapabilityPackConnector).default([]),
   knowledge: z.array(CapabilityPackKnowledge).default([]),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AddDocumentRequest,
   CapabilityCatalogResponse,
+  CapabilityPack,
   ClientConfig,
   ClientSessionEvent,
   CreateCapabilityCatalogItemRequest,
@@ -246,5 +247,76 @@ describe("contracts", () => {
     expect(() => CreateDocumentBaseRequest.parse({ name: "" })).toThrow();
     expect(() => AddDocumentRequest.parse({ fileId: "not-a-uuid" })).toThrow();
     expect(() => DocumentSearchRequest.parse({ query: "" })).toThrow();
+  });
+});
+
+describe("capability pack runtime manifest fields", () => {
+  const baseManifest = {
+    id: "infra-runtime",
+    name: "Infra runtime",
+    description: "Infrastructure operations pack.",
+    role: "infrastructure",
+    category: "infrastructure",
+    version: "0.1.0",
+  };
+  const skill = {
+    name: "infra-ops",
+    files: [
+      { path: "SKILL.md", content: "---\nname: infra-ops\ndescription: Operate infra.\n---\n# Infra ops\n" },
+      { path: "references/runbook.md", content: "Runbook." },
+    ],
+  };
+
+  test("packs without runtime fields keep their existing shape", () => {
+    const pack = CapabilityPack.parse(baseManifest);
+    expect(pack.sandboxImage).toBeUndefined();
+    expect(pack.skills).toEqual([]);
+  });
+
+  test("accepts a sandbox image ref and inline skills", () => {
+    const pack = CapabilityPack.parse({
+      ...baseManifest,
+      sandboxImage: "ghcr.io/example/infra-sandbox@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      skills: [skill],
+    });
+    expect(pack.sandboxImage).toContain("@sha256:");
+    expect(pack.skills).toHaveLength(1);
+    expect(pack.skills[0]?.files.map((file) => file.path)).toEqual(["SKILL.md", "references/runbook.md"]);
+  });
+
+  test("requires every skill to include a top-level SKILL.md", () => {
+    expect(() => CapabilityPack.parse({
+      ...baseManifest,
+      skills: [{ name: "infra-ops", files: [{ path: "references/runbook.md", content: "Runbook." }] }],
+    })).toThrow();
+  });
+
+  test("rejects unsafe skill file paths", () => {
+    for (const path of ["../escape.md", "/absolute.md", "a//b.md", "./SKILL.md", "refs/../SKILL.md", "refs\\windows.md"]) {
+      expect(() => CapabilityPack.parse({
+        ...baseManifest,
+        skills: [{ name: "infra-ops", files: [{ path: "SKILL.md", content: "x" }, { path, content: "x" }] }],
+      })).toThrow();
+    }
+  });
+
+  test("rejects skill names that are not a single safe path segment", () => {
+    for (const name of ["infra/ops", "..", ".hidden", "-leading", ""]) {
+      expect(() => CapabilityPack.parse({
+        ...baseManifest,
+        skills: [{ name, files: [{ path: "SKILL.md", content: "x" }] }],
+      })).toThrow();
+    }
+  });
+
+  test("rejects duplicate skill names and duplicate file paths", () => {
+    expect(() => CapabilityPack.parse({
+      ...baseManifest,
+      skills: [skill, { ...skill, description: "duplicate" }],
+    })).toThrow();
+    expect(() => CapabilityPack.parse({
+      ...baseManifest,
+      skills: [{ name: "infra-ops", files: [{ path: "SKILL.md", content: "a" }, { path: "SKILL.md", content: "b" }] }],
+    })).toThrow();
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,14 +35,18 @@ import {
   localDir,
   s3Mount,
   skills,
+  type Dir,
+  type Entry,
+  type LocalDirLazySkillSource,
   type SandboxClient,
   type SandboxSessionLike,
   type SandboxSessionState,
   type SandboxRunConfig,
+  type SkillIndexEntry,
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy, ModalImageSelector, ModalSandboxClient } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
-import { cpSync, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { userInfo } from "node:os";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -194,6 +198,23 @@ export type BuildAgentOptions = {
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
   workspaceEnvironment?: WorkspaceEnvironmentContext;
+  // Skills delivered by enabled capability packs. They join the bundled
+  // skills in the sandbox skill index (mounted under .agents/) so
+  // skills/<name> references resolve like any other indexed skill.
+  packSkills?: PackSkill[];
+};
+
+export type PackSkillFile = {
+  // Relative POSIX path inside the skill directory, e.g. "SKILL.md" or
+  // "references/runbook.md".
+  path: string;
+  content: string;
+};
+
+export type PackSkill = {
+  name: string;
+  description?: string | null;
+  files: PackSkillFile[];
 };
 
 /**
@@ -264,7 +285,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     ...(runAs ? { runAs } : {}),
     capabilities: [
       ...Capabilities.default(),
-      skills({ lazyFrom: localDirLazySkillSource({ src: bundledSkillsDir() }) }),
+      skills({ lazyFrom: lazySkillSourceWithPackSkills(options.packSkills ?? []) }),
     ],
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
@@ -1782,6 +1803,159 @@ function stageBundledSkills(packaged: string, target: string): string {
 function isPathWithin(root: string, candidate: string): boolean {
   const relativePath = relative(root, candidate);
   return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+/**
+ * The skill source fed to the SDK Skills capability. Without pack skills this
+ * is the plain bundled local-dir source, byte-for-byte the pre-pack behavior.
+ * With pack skills it becomes a single in-memory dir source combining bundled
+ * skill directories (as local_dir entries the SDK materializes lazily) with
+ * pack skill directories built from manifest-carried file content — one skill
+ * index, one `## Skills` instruction section, lazy `load_skill` for all of
+ * them. A pack skill shadows a bundled skill with the same directory name.
+ */
+export function lazySkillSourceWithPackSkills(packSkills: PackSkill[]): LocalDirLazySkillSource {
+  const bundledDir = bundledSkillsDir();
+  const bundled = localDirLazySkillSource({ src: bundledDir });
+  if (packSkills.length === 0) {
+    return bundled;
+  }
+  const children: Record<string, Entry> = {};
+  for (const name of bundledSkillDirNames(bundledDir)) {
+    children[name] = localDir({ src: join(bundledDir, name) });
+  }
+  const packIndex: SkillIndexEntry[] = [];
+  const packNames = new Set<string>();
+  for (const skill of packSkills) {
+    assertSafePackSkillName(skill.name);
+    if (packNames.has(skill.name)) {
+      throw new Error(`Duplicate pack skill name: ${skill.name}`);
+    }
+    packNames.add(skill.name);
+    children[skill.name] = packSkillDirEntry(skill);
+    packIndex.push({ name: skill.name, description: packSkillDescription(skill), path: skill.name });
+  }
+  return {
+    source: dir({ children }),
+    getIndex: (manifest, skillsPath) => [
+      ...(bundled.getIndex?.(manifest, skillsPath) ?? []).filter((entry) => !packNames.has(entry.path ?? entry.name)),
+      ...packIndex,
+    ],
+  };
+}
+
+function bundledSkillDirNames(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(root, entry.name, "SKILL.md")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+type PackSkillDirNode = {
+  dirs: Map<string, PackSkillDirNode>;
+  files: Map<string, string>;
+};
+
+function packSkillDirEntry(skill: PackSkill): Dir {
+  const root: PackSkillDirNode = { dirs: new Map(), files: new Map() };
+  for (const skillFile of skill.files) {
+    const segments = packSkillPathSegments(skill.name, skillFile.path);
+    let node = root;
+    for (const segment of segments.slice(0, -1)) {
+      if (node.files.has(segment)) {
+        throw new Error(`Pack skill ${skill.name} uses ${segment} as both a file and a directory`);
+      }
+      let next = node.dirs.get(segment);
+      if (!next) {
+        next = { dirs: new Map(), files: new Map() };
+        node.dirs.set(segment, next);
+      }
+      node = next;
+    }
+    const filename = segments[segments.length - 1]!;
+    if (node.dirs.has(filename) || node.files.has(filename)) {
+      throw new Error(`Duplicate pack skill file path in ${skill.name}: ${skillFile.path}`);
+    }
+    node.files.set(filename, skillFile.content);
+  }
+  if (!root.files.has("SKILL.md")) {
+    throw new Error(`Pack skill ${skill.name} is missing a top-level SKILL.md file`);
+  }
+  return packSkillDirFromNode(root);
+}
+
+function packSkillDirFromNode(node: PackSkillDirNode): Dir {
+  const children: Record<string, Entry> = {};
+  for (const [name, child] of node.dirs) {
+    children[name] = packSkillDirFromNode(child);
+  }
+  for (const [name, content] of node.files) {
+    children[name] = file({ content });
+  }
+  return dir({ children });
+}
+
+function assertSafePackSkillName(name: string): void {
+  if (packSkillPathSegments(name, name).length !== 1) {
+    throw new Error(`Invalid pack skill name: ${name}`);
+  }
+}
+
+function packSkillPathSegments(skillName: string, path: string): string[] {
+  const segments = path.split("/");
+  if (path.startsWith("/") || path.includes("\\") || segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    throw new Error(`Invalid pack skill file path for ${skillName}: ${path}`);
+  }
+  return segments;
+}
+
+function packSkillDescription(skill: PackSkill): string {
+  const explicit = skill.description?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const markdown = skill.files.find((skillFile) => skillFile.path === "SKILL.md")?.content ?? "";
+  return skillFrontmatterDescription(markdown) ?? "No description provided.";
+}
+
+function skillFrontmatterDescription(markdown: string): string | null {
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") {
+    return null;
+  }
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (end === -1) {
+    return null;
+  }
+  const collected: string[] = [];
+  let inDescription = false;
+  for (const line of lines.slice(1, end)) {
+    const match = line.match(/^description:\s*(.*)$/);
+    if (match) {
+      const inline = match[1]!.trim();
+      if (inline && inline !== ">-" && inline !== ">" && inline !== "|" && inline !== "|-") {
+        return unquoteFrontmatterValue(inline);
+      }
+      inDescription = true;
+      continue;
+    }
+    if (inDescription) {
+      if (/^\s+\S/.test(line)) {
+        collected.push(line.trim());
+        continue;
+      }
+      break;
+    }
+  }
+  const blockValue = collected.join(" ").trim();
+  return blockValue ? blockValue : null;
+}
+
+function unquoteFrontmatterValue(value: string): string {
+  if (value.length >= 2 && value[0] === value[value.length - 1] && (value[0] === '"' || value[0] === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1826,11 +1826,13 @@ export function lazySkillSourceWithPackSkills(packSkills: PackSkill[]): LocalDir
   }
   const packIndex: SkillIndexEntry[] = [];
   const packNames = new Set<string>();
+  const packNameKeys = new Set<string>();
   for (const skill of packSkills) {
     assertSafePackSkillName(skill.name);
-    if (packNames.has(skill.name)) {
+    if (packNameKeys.has(skill.name.toLowerCase())) {
       throw new Error(`Duplicate pack skill name: ${skill.name}`);
     }
+    packNameKeys.add(skill.name.toLowerCase());
     packNames.add(skill.name);
     children[skill.name] = packSkillDirEntry(skill);
     packIndex.push({ name: skill.name, description: packSkillDescription(skill), path: skill.name });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent } from "@openai/agents";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -885,3 +885,93 @@ function fakeMcpServer(name: string): MCPServer {
     async invalidateToolsCache() {},
   };
 }
+
+describe("pack skills in the sandbox skill index", () => {
+  const infraSkill = {
+    name: "infra-ops",
+    files: [
+      { path: "SKILL.md", content: "---\nname: infra-ops\ndescription: Operate workspace infrastructure.\n---\n# Infra ops\n" },
+      { path: "references/runbook.md", content: "Runbook." },
+    ],
+  };
+  const emptyManifest = new Manifest({ root: "/workspace", entries: {}, environment: {} });
+
+  test("without pack skills the source is the unchanged bundled local-dir source", () => {
+    const source = lazySkillSourceWithPackSkills([]);
+    expect((source.source as { type: string }).type).toBe("local_dir");
+    const index = source.getIndex?.(emptyManifest, ".agents") ?? [];
+    expect(index.map((entry) => entry.name)).toContain("checkov");
+    expect(index.map((entry) => entry.name)).not.toContain("infra-ops");
+  });
+
+  test("pack skills join the bundled skills in one lazy skill index", () => {
+    const source = lazySkillSourceWithPackSkills([infraSkill]);
+    const sourceDir = source.source as { type: string; children: Record<string, any> };
+    expect(sourceDir.type).toBe("dir");
+    // Bundled skills stay lazily materializable from their local directories.
+    expect(sourceDir.children.checkov.type).toBe("local_dir");
+    // Pack skill content is carried in-memory from the manifest.
+    expect(sourceDir.children["infra-ops"].type).toBe("dir");
+    expect(sourceDir.children["infra-ops"].children["SKILL.md"].content).toContain("# Infra ops");
+    expect(sourceDir.children["infra-ops"].children.references.children["runbook.md"].content).toBe("Runbook.");
+    const index = source.getIndex?.(emptyManifest, ".agents") ?? [];
+    const names = index.map((entry) => entry.name);
+    expect(names).toContain("checkov");
+    expect(names).toContain("infra-ops");
+    const infra = index.find((entry) => entry.name === "infra-ops");
+    expect(infra?.description).toBe("Operate workspace infrastructure.");
+    expect(infra?.path).toBe("infra-ops");
+  });
+
+  test("an explicit pack skill description wins over SKILL.md frontmatter", () => {
+    const source = lazySkillSourceWithPackSkills([{ ...infraSkill, description: "Explicit description." }]);
+    const index = source.getIndex?.(emptyManifest, ".agents") ?? [];
+    expect(index.find((entry) => entry.name === "infra-ops")?.description).toBe("Explicit description.");
+  });
+
+  test("a pack skill shadows a bundled skill with the same name", () => {
+    const source = lazySkillSourceWithPackSkills([{
+      name: "checkov",
+      files: [{ path: "SKILL.md", content: "---\ndescription: Pack-provided checkov.\n---\n" }],
+    }]);
+    const sourceDir = source.source as { type: string; children: Record<string, any> };
+    expect(sourceDir.children.checkov.type).toBe("dir");
+    const index = source.getIndex?.(emptyManifest, ".agents") ?? [];
+    const checkovEntries = index.filter((entry) => entry.name === "checkov");
+    expect(checkovEntries).toHaveLength(1);
+    expect(checkovEntries[0]?.description).toBe("Pack-provided checkov.");
+  });
+
+  test("rejects unsafe pack skill content instead of mounting it", () => {
+    expect(() => lazySkillSourceWithPackSkills([{
+      name: "bad",
+      files: [{ path: "SKILL.md", content: "x" }, { path: "../escape.md", content: "x" }],
+    }])).toThrow("Invalid pack skill file path");
+    expect(() => lazySkillSourceWithPackSkills([{
+      name: "no-entry",
+      files: [{ path: "references/only.md", content: "x" }],
+    }])).toThrow("missing a top-level SKILL.md");
+    expect(() => lazySkillSourceWithPackSkills([
+      { name: "dup", files: [{ path: "SKILL.md", content: "a" }] },
+      { name: "dup", files: [{ path: "SKILL.md", content: "b" }] },
+    ])).toThrow("Duplicate pack skill name");
+    expect(() => lazySkillSourceWithPackSkills([{
+      name: "bad/name",
+      files: [{ path: "SKILL.md", content: "x" }],
+    }])).toThrow("Invalid pack skill name");
+  });
+
+  test("buildOpenGeniAgent feeds pack skills through the SDK skills capability", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), [], { packSkills: [infraSkill] });
+    const capabilities = (agent as any).capabilities as Array<{ type: string; lazyFrom?: { source: { type: string }; getIndex?: (manifest: unknown, skillsPath: string) => Array<{ name: string }> } }>;
+    const skillsCapability = capabilities.find((capability) => capability.type === "skills");
+    expect(skillsCapability?.lazyFrom?.source.type).toBe("dir");
+    const index = skillsCapability?.lazyFrom?.getIndex?.(emptyManifest, ".agents") ?? [];
+    expect(index.map((entry) => entry.name)).toContain("infra-ops");
+    // Backward compatibility: without pack skills the capability keeps the
+    // plain bundled local-dir source.
+    const plainAgent = buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), []);
+    const plainCapability = ((plainAgent as any).capabilities as Array<{ type: string; lazyFrom?: { source: { type: string } } }>).find((capability) => capability.type === "skills");
+    expect(plainCapability?.lazyFrom?.source.type).toBe("local_dir");
+  });
+});

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1790,6 +1790,97 @@ describe("API component integration", () => {
     expect(capabilityInstallationAfterDelete?.status).toBe("disabled");
   });
 
+  test("allows only one enabled pack per workspace to declare a sandbox image", async () => {
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl, environmentsEncryptionKey: environmentsTestKey }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const imagePackManifest = (id: string, image: string) => ({
+      id,
+      name: `Pack ${id}`,
+      description: "Pack with a pack-scoped sandbox image.",
+      role: "infrastructure",
+      category: "infrastructure",
+      version: "0.1.0",
+      sandboxImage: image,
+      skills: [{
+        name: "infra-ops",
+        description: "Operate infrastructure with the pack runbook.",
+        files: [
+          { path: "SKILL.md", content: "---\nname: infra-ops\ndescription: Operate infrastructure.\n---\n# Infra ops\n" },
+          { path: "references/runbook.md", content: "Runbook." },
+        ],
+      }],
+    });
+    const packA = `img-a-${suffix}`;
+    const packB = `img-b-${suffix}`;
+    for (const [packId, image] of [[packA, "example.com/sandbox-a@sha256:aaaa"], [packB, "example.com/sandbox-b@sha256:bbbb"]] as const) {
+      const registered = await app.request(workspacePath(workspaceId, "/packs"), {
+        method: "POST",
+        body: JSON.stringify(imagePackManifest(packId, image)),
+        headers: { "content-type": "application/json" },
+      });
+      expect(registered.status).toBe(201);
+    }
+
+    const enabledA = await app.request(workspacePath(workspaceId, `/packs/${packA}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabledA.status).toBe(201);
+
+    // The catalog surfaces the pack's runtime composition (image ref and
+    // skill names) without leaking skill file content.
+    const catalogResponse = await app.request(workspacePath(workspaceId, "/capabilities"));
+    const catalog = await catalogResponse.json() as { items: Array<{ id: string; metadata: Record<string, unknown> }> };
+    const packAItem = catalog.items.find((item) => item.id === `pack:${packA}`);
+    expect(packAItem?.metadata.sandboxImage).toBe("example.com/sandbox-a@sha256:aaaa");
+    expect(packAItem?.metadata.skills).toEqual(["infra-ops"]);
+    expect(JSON.stringify(packAItem?.metadata)).not.toContain("Runbook.");
+
+    // A second image-declaring pack cannot be enabled, on either enable path.
+    const enabledB = await app.request(workspacePath(workspaceId, `/packs/${packB}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabledB.status).toBe(409);
+    expect(await enabledB.text()).toContain("only one enabled pack per workspace may declare sandboxImage");
+    const capabilityEnabledB = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(`pack:${packB}`)}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(capabilityEnabledB.status).toBe(409);
+
+    // Re-enabling the already-enabled image pack stays allowed.
+    const reenabledA = await app.request(workspacePath(workspaceId, `/packs/${packA}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(reenabledA.status).toBe(200);
+
+    // Disabling the first pack frees the slot for the second.
+    const disabledA = await app.request(workspacePath(workspaceId, `/capabilities/${encodeURIComponent(`pack:${packA}`)}/disable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(disabledA.status).toBeLessThan(300);
+    const enabledBAfterDisable = await app.request(workspacePath(workspaceId, `/packs/${packB}/enable`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enabledBAfterDisable.status).toBe(201);
+  });
+
   test("keeps scheduled task persistence consistent when schedule sync fails", async () => {
     workflow = new FakeWorkflowClient();
     const app = createApp({

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -22,7 +22,9 @@ import {
   createSessionGoal,
   createWorkspaceEnvironment,
   encryptEnvironmentValue,
+  enablePackInstallation,
   enqueueSessionTurn,
+  registerWorkspacePack,
   setWorkspaceEnvironmentVariable,
   finishTurn,
   getSession,
@@ -330,6 +332,70 @@ describe("worker activities integration", () => {
     expect(request).not.toContain("input_image");
     expect(request).not.toContain("direct model vision context");
     expect(request).toContain(`/workspace/files/${fileId}/large.png`);
+  });
+
+  test("fails the turn plainly when two enabled packs declare sandbox images", async () => {
+    const grant = await testGrant(dbClient.db);
+    const imagePack = (id: string, image: string) => ({
+      id,
+      name: `Pack ${id}`,
+      description: "Image-declaring pack for runtime composition tests.",
+      role: "infrastructure",
+      category: "infrastructure",
+      version: "0.1.0",
+      sandboxImage: image,
+      skills: [],
+      tools: [],
+      connectors: [],
+      knowledge: [],
+      scheduledTaskTemplates: [],
+      metadata: {},
+    });
+    for (const [packId, image] of [["img-a", "example.com/a@sha256:aaaa"], ["img-b", "example.com/b@sha256:bbbb"]] as const) {
+      await registerWorkspacePack(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        pack: imagePack(packId, image),
+      });
+      await enablePackInstallation(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        packId,
+        metadata: {},
+      });
+    }
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "run",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "run" } },
+    ]);
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({
+        model: new ScriptedModel([{ outputText: "should not run", chunks: ["never"] }]),
+      }),
+    });
+
+    const result = await activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      workflowId: "workflow-pack-image-conflict",
+    });
+    expect(result.status).toBe("failed");
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const failure = events.find((event) => event.type === "turn.failed");
+    expect(failure).toBeDefined();
+    expect(JSON.stringify(failure!.payload)).toContain("Multiple enabled packs declare a sandbox image (img-a, img-b)");
+    expect(latestStatus(events)).toBe("failed");
   });
 
   test("marks session failed when scripted model throws", async () => {


### PR DESCRIPTION
## Why

Pack enablement was structurally disconnected from runtime composition. A pack that needs its own tooling had to bake skills into a custom sandbox image (`/opt/geni-style` hacks) selected by the deployment-wide image env var, and the SDK Skills capability — the real skill index mounted under `/workspace/.agents/` — knew nothing about pack skills, so `skills/<name>` references from pack-driven tasks failed with "not available in this workspace's skill index".

## What

**Manifest fields** (`CapabilityPack` in `@opengeni/contracts`):
- `sandboxImage` (optional string): container image ref (digest-pinned recommended) the workspace's sessions run in.
- `skills` (optional array): `{ name, description?, files: [{ path, content }] }` with a required top-level `SKILL.md`, safe relative POSIX paths, and size caps. Skill content travels inline in the manifest and is stored with it (the `workspace_packs` JSONB row) — no image baking, no extra storage system.

**Image selection** (worker, per turn): exactly one enabled image-declaring pack ⇒ derived run settings replace `dockerImage`/`modalImageRef` with the pack image. None ⇒ global `OPENGENI_DOCKER_IMAGE` / `OPENGENI_MODAL_IMAGE_REF` behavior is untouched (settings object passes through identically). More than one ⇒ plain error; both enable paths (`/packs/:id/enable` and `/capabilities/pack::id/enable`) already reject the second image-declaring pack with 409, and the worker re-checks at session start as a backstop (covers manifest re-registration after enablement), failing the turn with `Multiple enabled packs declare a sandbox image (a, b)...`. v1 deliberately has no image composition/layering.

**Skills delivery** (runtime): pack skills are fed into the OpenAI Agents SDK Skills capability as an in-memory `dir` lazy source combined with the bundled local-dir skills — one skill index, one `## Skills` instruction section, lazy `load_skill` materialization for both kinds. Without pack skills the source is byte-for-byte the previous bundled `localDirLazySkillSource`. A pack skill shadows a bundled skill of the same name; duplicate skill names across enabled packs fail plainly.

Built-in packs never declare a pack-scoped runtime (test-enforced), which keeps the worker's resolution manifest-only.

## Tests

- contracts: manifest field validation (paths, SKILL.md, duplicates, name safety) + backward-compatible defaults
- runtime: combined lazy source composition, shadowing, index derivation, rejection of unsafe content, `buildOpenGeniAgent` wiring, unchanged no-pack source
- worker unit: image selection, multi-image error, cross-pack duplicate skill error, settings passthrough/no-mutation
- API integration: 409 on second image pack via both enable paths, catalog exposure (image + skill names, no content), re-enable allowed, disable frees the slot
- worker integration: end-to-end turn fails with the plain composition error
- full local gate green: typecheck, `bun test` (305), `bun run test:integration` (all 7 suites), workspace/billing static guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent turn sandbox image selection and skill mounting for workspaces with enabled packs; conflicts are guarded at enable time and turn start, but wrong pack images affect all sessions in that workspace.
> 
> **Overview**
> Adds **pack-scoped runtime composition** so enabled capability packs can shape agent sandboxes without baking skills into custom images.
> 
> **Contracts & API:** `CapabilityPack` gains optional `sandboxImage` and inline `skills` (with `SKILL.md`, path safety, and uniqueness validation). Pack enable on both `/packs/.../enable` and generic capability enable calls `assertPackSandboxImageCompatible` — at most one active pack per workspace may declare an image (`409` on conflict). The capability catalog exposes `sandboxImage` and skill **names** only, not file content.
> 
> **Worker:** New `resolveWorkspacePackRuntime` reads manifest-registered packs from active installations, applies the single-image rule and cross-pack skill-name checks (re-fail at turn start), overrides `dockerImage`/`modalImageRef` via `settingsWithPackSandboxImage`, and passes `packSkills` into agent build after `turn.started`.
> 
> **Runtime:** Pack skills merge with bundled HashiCorp skills in one SDK Skills lazy index (`lazySkillSourceWithPackSkills`); pack skills can shadow bundled names; no pack skills preserves prior behavior.
> 
> **Docs/guardrails:** `docs/packs.md`, `AGENTS.md`, and sandbox docs describe the model; built-in packs are test-enforced to declare neither image nor skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d13b50b67d3a5a1012207118f2b5f07f8943c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->