### PR TITLE
Stop depending on the provider's response store for model-call input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,13 @@ OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS=low,medium,high,xhigh
 OPENGENI_OPENAI_API_KEY=your-key
 # OPENGENI_OPENAI_BASE_URL=https://api.openai.com/v1
 # OPENGENI_OPENAI_RESPONSES_TRANSPORT=websocket
+# Provider item ids in model-call input: "strip" (default) keeps requests
+# self-contained instead of resolving rs_/msg_/fc_ ids against the provider's
+# response store (which can lose items mid-run); "preserve" passes them through.
+# OPENGENI_OPENAI_PROVIDER_ITEM_IDS=strip
+# Round-trip reasoning.encrypted_content with each call so reasoning survives
+# without provider-side response storage (default true).
+# OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT=true
 # OPENGENI_DISABLE_OPENAI_TRACING=true
 
 # Azure OpenAI provider.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -87,3 +87,14 @@ the session's sandbox on its next turn — decoupled from the RunState blob.
 
 See issue #35 for the rationale and the dual-write → flagged-read → default-flip
 migration history.
+
+One consequence of client-side conversation truth: model calls must not depend
+on the provider's server-side response store. Provider-assigned item ids
+(`rs_`/`msg_`/`fc_`…) are resolved against that store, and a response that
+streamed successfully can be missing from it on the very next call, failing a
+long run mid-turn with 400 "Item with id … not found". The runtime therefore
+strips provider item ids from every model-call input by default
+(`OPENGENI_OPENAI_PROVIDER_ITEM_IDS=strip`) and round-trips
+`reasoning.encrypted_content` instead
+(`OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT=true`), so requests are
+self-contained and reasoning continuity does not hinge on provider storage.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -119,6 +119,19 @@ const SettingsSchema = z.object({
   openaiReasoningEffort: ReasoningEffort.default("low"),
   openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
+  // Provider-assigned item ids (rs_/msg_/fc_…) in Responses API input are
+  // resolved against the provider's server-side response store. That store is
+  // not durable enough to anchor long runs on: a response that streamed fine
+  // can be missing from the store on the very next model call, which then
+  // fails with 400 "Item with id ... not found". "strip" removes the ids from
+  // every model-call input so requests are self-contained — conversation
+  // truth already lives client-side in session_history_items. "preserve"
+  // keeps the SDK's pass-through behavior.
+  openaiProviderItemIds: z.enum(["strip", "preserve"]).default("strip"),
+  // With ids stripped the provider cannot resolve prior reasoning server-side,
+  // so request reasoning.encrypted_content and send it back with each call:
+  // reasoning continuity without depending on provider-side storage.
+  openaiReasoningEncryptedContent: EnvBoolean.default(true),
   // Model-call retry budget for transient provider failures (429s and friends).
   // The openai client default of 2 retries is too small for sustained TPM
   // backpressure during long autonomous runs.
@@ -347,6 +360,8 @@ export function getSettings(): Settings {
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),
     openaiAllowedReasoningEfforts: optional("OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"),
     openaiResponsesTransport: optional("OPENGENI_OPENAI_RESPONSES_TRANSPORT"),
+    openaiProviderItemIds: optional("OPENGENI_OPENAI_PROVIDER_ITEM_IDS"),
+    openaiReasoningEncryptedContent: optional("OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT"),
     openaiMaxRetries: optional("OPENGENI_OPENAI_MAX_RETRIES"),
     azureOpenaiBaseUrl: optional("OPENGENI_AZURE_OPENAI_BASE_URL"),
     azureOpenaiEndpoint: optional("OPENGENI_AZURE_OPENAI_ENDPOINT"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -519,6 +519,27 @@ describe("workspace environments encryption key", () => {
   });
 });
 
+describe("provider item id policy", () => {
+  test("defaults to stripping provider item ids with encrypted reasoning round-trip", () => {
+    const settings = withEnv({}, () => getSettings());
+    expect(settings.openaiProviderItemIds).toBe("strip");
+    expect(settings.openaiReasoningEncryptedContent).toBe(true);
+  });
+
+  test("can preserve provider item ids and disable encrypted reasoning", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_PROVIDER_ITEM_IDS: "preserve",
+      OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT: "false",
+    }, () => getSettings());
+    expect(settings.openaiProviderItemIds).toBe("preserve");
+    expect(settings.openaiReasoningEncryptedContent).toBe(false);
+  });
+
+  test("rejects unknown provider item id policies", () => {
+    expect(() => withEnv({ OPENGENI_OPENAI_PROVIDER_ITEM_IDS: "sometimes" }, () => getSettings())).toThrow();
+  });
+});
+
 function withEnv<T>(env: NodeJS.ProcessEnv, fn: () => T): T {
   const original = process.env;
   process.env = { ...env };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   setDefaultOpenAIKey,
   setOpenAIResponsesTransport,
   type AgentInputItem,
+  type CallModelInputFilter,
   type MCPServer,
   type Model,
   type RunStreamEvent,
@@ -270,6 +271,15 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     ].join(" "),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },
+      // Round-trip the encrypted reasoning payload with every call so chains
+      // of thought survive without provider-side response storage (which is
+      // what stripped provider item ids opt us out of — see
+      // stripProviderItemIds). providerData.include replaces any
+      // tool-derived include entries; OpenGeni's tools are MCP/sandbox
+      // function tools, which contribute none.
+      ...(settings.openaiReasoningEncryptedContent
+        ? { providerData: { include: ["reasoning.encrypted_content"] } }
+        : {}),
     },
     ...(options.mcpServers?.length ? { mcpServers: options.mcpServers } : {}),
   } as const;
@@ -689,6 +699,35 @@ export type RunAgentStreamOptions = {
   onRuntimeEvent?: (event: NormalizedRuntimeEvent) => Promise<void> | void;
 };
 
+/**
+ * callModelInputFilter that removes provider-assigned item ids (rs_/msg_/fc_…)
+ * from every input item immediately before each model call. Responses-API
+ * requests that carry item ids are resolved against the provider's stored
+ * responses, and that store is not durable enough to anchor long runs on: a
+ * response that streamed successfully can be missing from the store on the
+ * very next call, which then fails with 400 "Item with id ... not found"
+ * (observed live on Azure OpenAI mid-turn). All item content — including the
+ * encrypted reasoning payload carried in providerData when
+ * `openaiReasoningEncryptedContent` is on — is sent inline, so the ids add
+ * fragility without adding information. Pairing fields (`call_id`/`callId`)
+ * are separate properties and stay untouched; items are cloned, never mutated.
+ */
+export const stripProviderItemIdsFilter: CallModelInputFilter = ({ modelData }) => ({
+  ...modelData,
+  input: modelData.input.map((item) => {
+    if (item && typeof item === "object" && "id" in item) {
+      const { id: _id, ...rest } = item as Record<string, unknown>;
+      return rest as AgentInputItem;
+    }
+    return item;
+  }),
+});
+
+/** The model-input filter the configured provider item id policy selects. */
+export function callModelInputFilterForSettings(settings: Settings): CallModelInputFilter | undefined {
+  return settings.openaiProviderItemIds === "strip" ? stripProviderItemIdsFilter : undefined;
+}
+
 export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgentInput | string | RunState<any, any>, settings: Settings, overrides: RunAgentStreamOptions = {}) {
   const prepared: PreparedAgentInput = typeof input === "string" || input instanceof RunState ? { input } : input;
   const environment = overrides.sandboxEnvironment ?? collectSandboxEnvironment(settings);
@@ -718,9 +757,16 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     ?? (prepared.serializedRunStateForSandbox && client
       ? await restoredSandboxSessionState(await RunState.fromString(agent, prepared.serializedRunStateForSandbox), client)
       : undefined);
+  const callModelInputFilter = callModelInputFilterForSettings(settings);
   const runOptions: Parameters<typeof run>[2] = {
     stream: true,
     maxTurns: settings.agentMaxModelCallsPerTurn,
+    // Strip provider-assigned item ids from every model call (turn-start
+    // history replay AND mid-turn follow-ups) so requests never depend on the
+    // provider's server-side response store. A stored response can vanish
+    // between two calls of the same turn, failing the run with 400 "Item with
+    // id 'rs_…' not found"; with the ids gone the request is self-contained.
+    ...(callModelInputFilter ? { callModelInputFilter } : {}),
   };
   void settings.disableOpenaiTracing;
   if (client) {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent } from "@openai/agents";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -973,5 +973,52 @@ describe("pack skills in the sandbox skill index", () => {
     const plainAgent = buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), []);
     const plainCapability = ((plainAgent as any).capabilities as Array<{ type: string; lazyFrom?: { source: { type: string } } }>).find((capability) => capability.type === "skills");
     expect(plainCapability?.lazyFrom?.source.type).toBe("local_dir");
+  });
+});
+
+describe("provider item id stripping", () => {
+  test("stripProviderItemIdsFilter removes provider ids from every item without touching pairing fields", () => {
+    const reasoning = {
+      type: "reasoning",
+      id: "rs_dangling",
+      content: [{ type: "input_text", text: "thinking" }],
+      providerData: { encrypted_content: "gAAAA-opaque" },
+    } as any;
+    const message = { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [{ type: "output_text", text: "hi" }] } as any;
+    const functionCall = { type: "function_call", id: "fc_1", callId: "call_abc", name: "exec_command", arguments: "{}", status: "completed" } as any;
+    const functionOutput = { type: "function_call_result", id: "fco_1", callId: "call_abc", status: "completed", output: { type: "text", text: "ok" } } as any;
+    const userMessage = { type: "message", role: "user", content: "do the thing" } as any;
+    const input = [reasoning, message, functionCall, functionOutput, userMessage];
+    const result = stripProviderItemIdsFilter({
+      modelData: { input, instructions: "be useful" },
+      agent: undefined as any,
+      context: undefined,
+    }) as { input: any[]; instructions?: string };
+    expect(result.instructions).toBe("be useful");
+    expect(result.input).toHaveLength(5);
+    for (const item of result.input) {
+      expect("id" in item).toBe(false);
+    }
+    // Pairing and content stay intact.
+    expect(result.input[0].providerData.encrypted_content).toBe("gAAAA-opaque");
+    expect(result.input[2].callId).toBe("call_abc");
+    expect(result.input[3].callId).toBe("call_abc");
+    expect(result.input[4]).toBe(userMessage);
+    // Originals are not mutated.
+    expect(reasoning.id).toBe("rs_dangling");
+    expect(message.id).toBe("msg_1");
+  });
+
+  test("callModelInputFilterForSettings follows the configured policy", () => {
+    expect(callModelInputFilterForSettings(testSettings())).toBe(stripProviderItemIdsFilter);
+    expect(callModelInputFilterForSettings(testSettings({ openaiProviderItemIds: "strip" }))).toBe(stripProviderItemIdsFilter);
+    expect(callModelInputFilterForSettings(testSettings({ openaiProviderItemIds: "preserve" }))).toBeUndefined();
+  });
+
+  test("buildOpenGeniAgent requests encrypted reasoning content unless disabled", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    expect((agent as any).modelSettings.providerData).toEqual({ include: ["reasoning.encrypted_content"] });
+    const disabled = buildOpenGeniAgent(testSettings({ sandboxBackend: "none", openaiReasoningEncryptedContent: false }), []);
+    expect((disabled as any).modelSettings.providerData).toBeUndefined();
   });
 });

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -72,6 +72,8 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     openaiReasoningEffort: "high",
     openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
     openaiResponsesTransport: "http",
+    openaiProviderItemIds: "strip",
+    openaiReasoningEncryptedContent: true,
     openaiMaxRetries: 5,
     azureOpenaiBaseUrl: undefined,
     azureOpenaiEndpoint: undefined,


### PR DESCRIPTION
## Why

A live goal-bearing worker session failed mid-turn with `400 Item with id 'rs_…' not found` right after a provider-rate-limit recovery, going terminal even though its conversation truth was fully intact in `session_history_items`. Responses-API input that carries provider-assigned item ids (`rs_`/`msg_`/`fc_`…) is resolved against the provider's server-side response store — and a response that streamed successfully can be missing from that store on the very next model call. A multi-day-run platform cannot anchor on that store.

Probed live against the staging model deployment to pin the failure shape:
- input with all provider ids stripped → 200 (with and without encrypted reasoning payload)
- input with only the reasoning id stripped (assistant message id kept) → 400 (the server demands the paired reasoning item), so the SDK's `reasoningItemIdPolicy: 'omit'` alone is not enough
- dangling id → 400 "Item with id … not found" (the incident)

## What

- **`openaiProviderItemIds`** (`OPENGENI_OPENAI_PROVIDER_ITEM_IDS`, default `strip`): a `callModelInputFilter` removes provider item ids from **every** model call — turn-start history replay and mid-turn follow-ups alike — so requests are self-contained. Pairing fields (`call_id`) untouched; items cloned, never mutated. `preserve` opts back into SDK pass-through.
- **`openaiReasoningEncryptedContent`** (`OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT`, default `true`): requests `include: ["reasoning.encrypted_content"]`; the encrypted payload rides in the item's `providerData` and the SDK re-sends it with each call, so reasoning continuity no longer hinges on provider storage (and now survives across turns too).
- `.env.example` + `docs/run-lifecycle.md` document the knobs; `testSettings` carries the new fields.

## Verification

- `bun run check` green (typecheck all packages, 345 unit tests incl. new filter/config/agent tests, sdk+react+web builds)
- `bun run test:integration` green (134 tests across 7 suites, against local Postgres/NATS/Temporal)
- `bun scripts/check-workspace-billing-static.ts` green
- Live probes above against the real Azure OpenAI deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every production model-call payload and reasoning continuity path; misconfiguration (`preserve` without durable store) could regress long-run stability, but defaults align with client-side `session_history_items` truth.
> 
> **Overview**
> Fixes long agent runs failing mid-turn with **400 "Item with id … not found"** when Responses API input still carries provider item ids (`rs_`/`msg_`/`fc_`) that resolve against the provider's ephemeral response store.
> 
> **Config (defaults on):** `OPENGENI_OPENAI_PROVIDER_ITEM_IDS=strip` and `OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT=true`, wired through `packages/config` with tests.
> 
> **Runtime:** A `callModelInputFilter` clones each input item and drops top-level `id` before every model call (history replay and mid-turn follow-ups); `call_id`/`callId` are unchanged. `runAgentStream` applies the filter when policy is `strip`; `preserve` skips it. `buildOpenGeniAgent` adds `providerData.include: ["reasoning.encrypted_content"]` when encrypted reasoning is enabled so chains of thought round-trip without server-side storage.
> 
> Docs (`.env.example`, `docs/run-lifecycle.md`) explain the knobs; `testSettings` and new runtime/config tests cover the filter and agent settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663960f2d99798293524117a2a4f30082e175902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->