### PR TITLE
Goal-bearing sessions always hold goals:manage in first-party MCP permissions

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -296,7 +296,7 @@ export async function createSessionForRequest(
   // (how an operator hands a manager-style session the orchestration tools),
   // but never one out-ranking its creator: every requested permission must be
   // held by the creating grant.
-  const firstPartyMcpPermissions = payload.firstPartyMcpPermissions ?? null;
+  let firstPartyMcpPermissions = payload.firstPartyMcpPermissions ?? null;
   if (firstPartyMcpPermissions && firstPartyMcpPermissions.length === 0) {
     // An empty set would sign an unusable zero-permission token; the default
     // worker set is expressed by omitting the field.
@@ -306,6 +306,18 @@ export async function createSessionForRequest(
     if (!hasPermission(grant.permissions, permission)) {
       throw new HTTPException(403, { message: `cannot grant first-party MCP permission beyond the creating grant: ${permission}` });
     }
+  }
+  // Invariant: a goal-bearing session always carries goals:manage in its
+  // effective first-party permissions. Without it the worker's delegated
+  // token never sees the goal tools (goal_complete/goal_pause/...), so the
+  // agent cannot stop its own goal and the continuation loop runs until an
+  // operator intervenes. The auto-added permission is deliberately exempt
+  // from the creating-grant check above: goal tools are scoped to the
+  // spawned session itself via the worker-signed sessionId claim, so a
+  // worker managing its OWN goal is not an escalation of the spawner's
+  // authority.
+  if (payload.goal && firstPartyMcpPermissions && !firstPartyMcpPermissions.includes("goals:manage")) {
+    firstPartyMcpPermissions = [...firstPartyMcpPermissions, "goals:manage"];
   }
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
   const session = await createAndStartSession({

--- a/packages/db/drizzle/0009_goal_sessions_first_party_goals_manage.sql
+++ b/packages/db/drizzle/0009_goal_sessions_first_party_goals_manage.sql
@@ -1,0 +1,34 @@
+-- Goal-bearing sessions must always hold goals:manage in their first-party
+-- MCP permission set. A session created with a goal plus an explicit
+-- first_party_mcp_permissions list lacking goals:manage never sees the goal
+-- tools (goal_complete/goal_pause/goal_set/goal_update) on its delegated
+-- token, so the agent cannot stop its own goal and the continuation loop
+-- runs until an operator intervenes. Session creation now unions
+-- goals:manage into explicit lists for goal-bearing sessions; this backfills
+-- the rows created before that fix.
+--
+-- The backfill is scoped to sessions with a non-completed goal and an
+-- explicit permission list missing goals:manage, and is idempotent. NULL
+-- permission lists (the default worker set) already include goals:manage at
+-- token-signing time and are left untouched.
+--
+-- Migrations run as the table owner, which FORCE ROW LEVEL SECURITY would
+-- otherwise subject to the workspace-scoped policies (matching zero rows
+-- here, where no workspace GUCs are set). NO FORCE only affects the owner -
+-- the app role stays policy-bound throughout - and FORCE is restored within
+-- the same implicit transaction that runs this file.
+ALTER TABLE "sessions" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE "session_goals" NO FORCE ROW LEVEL SECURITY;
+UPDATE "sessions" s
+SET "first_party_mcp_permissions" = s."first_party_mcp_permissions" || '["goals:manage"]'::jsonb
+WHERE s."first_party_mcp_permissions" IS NOT NULL
+  AND jsonb_typeof(s."first_party_mcp_permissions") = 'array'
+  AND NOT s."first_party_mcp_permissions" @> '"goals:manage"'::jsonb
+  AND EXISTS (
+    SELECT 1 FROM "session_goals" g
+    WHERE g."workspace_id" = s."workspace_id"
+      AND g."session_id" = s."id"
+      AND g."status" <> 'completed'
+  );
+ALTER TABLE "sessions" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "session_goals" FORCE ROW LEVEL SECURITY;

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3316,6 +3316,97 @@ describe("API component integration", () => {
     }
   });
 
+  test("goal-bearing sessions always hold goals:manage in their first-party MCP permissions", async () => {
+    const wf = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const delegationSecret = "test-delegation-secret";
+    const appSettings = testSettings({
+      databaseUrl: services.databaseUrl,
+      productAccessMode: "configured",
+      delegationSecret,
+    });
+    const app = createApp({
+      settings: appSettings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+    });
+    // The creating grant deliberately lacks goals:manage: the auto-added
+    // permission is exempt from the creator-holds-it check because goal
+    // tools are scoped to the spawned session itself via the worker-signed
+    // sessionId claim - a worker managing its OWN goal is not an escalation
+    // of the spawner's authority.
+    const creatorToken = await signDelegatedAccessToken(delegationSecret, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      subjectId: "test:goal-first-party-permissions",
+      permissions: ["workspace:read", "sessions:create", "sessions:read"],
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+
+    // REST create with a goal: goals:manage is unioned into the explicit
+    // set, otherwise the agent could never call goal_complete/goal_pause and
+    // the goal continuation loop would run until an operator intervenes.
+    const withGoal = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "take repo zero-to-one",
+        model: "scripted-model",
+        goal: { text: "repo deployed to staging" },
+        firstPartyMcpPermissions: ["workspace:read"],
+      }),
+      headers: { "content-type": "application/json", authorization: `Bearer ${creatorToken}` },
+    });
+    expect(withGoal.status).toBe(202);
+    const goalSession = await withGoal.json() as { id: string; firstPartyMcpPermissions: string[] | null };
+    expect(goalSession.firstPartyMcpPermissions).toEqual(["workspace:read", "goals:manage"]);
+    expect((await getSession(dbClient.db, grant.workspaceId, goalSession.id))?.firstPartyMcpPermissions)
+      .toEqual(["workspace:read", "goals:manage"] as Permission[]);
+
+    // Without a goal the explicit permission set is stored untouched.
+    const withoutGoal = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "no goal here",
+        model: "scripted-model",
+        firstPartyMcpPermissions: ["workspace:read"],
+      }),
+      headers: { "content-type": "application/json", authorization: `Bearer ${creatorToken}` },
+    });
+    expect(withoutGoal.status).toBe(202);
+    const plainSession = await withoutGoal.json() as { id: string; firstPartyMcpPermissions: string[] | null };
+    expect(plainSession.firstPartyMcpPermissions).toEqual(["workspace:read"]);
+    expect((await getSession(dbClient.db, grant.workspaceId, plainSession.id))?.firstPartyMcpPermissions)
+      .toEqual(["workspace:read"] as Permission[]);
+
+    // Same invariant through the MCP session_create tool, from a manager
+    // grant that also lacks goals:manage.
+    const mcpDeps = {
+      settings: appSettings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: wf,
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const managerGrant = { ...grant, permissions: ["workspace:read", "sessions:create", "sessions:read"] as Permission[] };
+    const managerMcp = buildOpenGeniMcpServer(mcpDeps, managerGrant);
+    const spawned = await callMcpTool<{ id: string; firstPartyMcpPermissions: string[] | null }>(managerMcp, "session_create", {
+      initialMessage: "spawn a goal-bearing worker",
+      model: "scripted-model",
+      sandboxBackend: "none",
+      goal: { text: "fleet healthy" },
+      firstPartyMcpPermissions: ["workspace:read"],
+    });
+    expect(spawned.firstPartyMcpPermissions).toEqual(["workspace:read", "goals:manage"]);
+    expect((await getSession(dbClient.db, grant.workspaceId, spawned.id))?.firstPartyMcpPermissions)
+      .toEqual(["workspace:read", "goals:manage"] as Permission[]);
+  });
+
   test("manager MCP session tools enforce environment attachment permission and billing limits", async () => {
     const wf = new FakeWorkflowClient();
     const grant = await bootstrapMcpGrant(dbClient.db);

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -36,7 +36,7 @@ import {
   withRlsContext,
   upsertCapabilityCatalogItem,
 } from "@opengeni/db";
-import type { AccessGrant } from "@opengeni/contracts";
+import type { AccessGrant, Permission } from "@opengeni/contracts";
 import { expectContiguousSequences, startTestServices, type TestServices } from "@opengeni/testing";
 
 describe("DB integration", () => {
@@ -554,6 +554,67 @@ describe("DB integration", () => {
     await finishTurn(dbClient.db, grant.workspaceId, boundedTurn.id, "completed");
     const atCap = await evaluateGoalContinuation(dbClient.db, { workspaceId: grant.workspaceId, sessionId: session.id, ...guards });
     expect(atCap).toMatchObject({ decision: "paused", reason: "max_auto_continuations" });
+  });
+
+  test("migration backfills goals:manage into goal-bearing sessions with explicit first-party permissions", async () => {
+    const migrationName = "0009_goal_sessions_first_party_goals_manage.sql";
+    const grant = await testGrant(dbClient.db);
+    const makeSession = async (firstPartyMcpPermissions: Permission[] | null) => await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "backfill fixture",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      firstPartyMcpPermissions,
+    });
+    const addGoal = async (sessionId: string) => await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId,
+      text: "stay green",
+      createdBy: "api",
+    });
+
+    // Healed: explicit permissions missing goals:manage + a non-completed goal.
+    const activeGoalSession = await makeSession(["workspace:read", "github:use"]);
+    await addGoal(activeGoalSession.id);
+    const pausedGoalSession = await makeSession(["workspace:read"]);
+    await addGoal(pausedGoalSession.id);
+    await setSessionGoalStatus(dbClient.db, grant.workspaceId, pausedGoalSession.id, { status: "paused", pausedReason: "operator hold" });
+    // Untouched: completed goal, no goal, already-holding, and default (null) sets.
+    const completedGoalSession = await makeSession(["workspace:read"]);
+    await addGoal(completedGoalSession.id);
+    await setSessionGoalStatus(dbClient.db, grant.workspaceId, completedGoalSession.id, { status: "completed", evidence: "done" });
+    const noGoalSession = await makeSession(["workspace:read"]);
+    const alreadyHoldingSession = await makeSession(["goals:manage", "workspace:read"]);
+    await addGoal(alreadyHoldingSession.id);
+    const defaultSetSession = await makeSession(null);
+    await addGoal(defaultSetSession.id);
+
+    // The fixture rows were created after beforeAll already applied the
+    // migration, so un-record it and run the migration path again - the same
+    // way an upgraded deployment replays pending files over existing data.
+    const rerunMigration = async () => {
+      await dbClient.db.execute(dbSql`DELETE FROM "schema_migrations" WHERE "name" = ${migrationName}`);
+      await services.migrate();
+    };
+    await rerunMigration();
+
+    const permissionsOf = async (sessionId: string) =>
+      (await getSession(dbClient.db, grant.workspaceId, sessionId))?.firstPartyMcpPermissions ?? null;
+    expect(await permissionsOf(activeGoalSession.id)).toEqual(["workspace:read", "github:use", "goals:manage"] as Permission[]);
+    expect(await permissionsOf(pausedGoalSession.id)).toEqual(["workspace:read", "goals:manage"] as Permission[]);
+    expect(await permissionsOf(completedGoalSession.id)).toEqual(["workspace:read"] as Permission[]);
+    expect(await permissionsOf(noGoalSession.id)).toEqual(["workspace:read"] as Permission[]);
+    expect(await permissionsOf(alreadyHoldingSession.id)).toEqual(["goals:manage", "workspace:read"] as Permission[]);
+    expect(await permissionsOf(defaultSetSession.id)).toBeNull();
+
+    // Idempotent: a second run adds nothing.
+    await rerunMigration();
+    expect(await permissionsOf(activeGoalSession.id)).toEqual(["workspace:read", "github:use", "goals:manage"] as Permission[]);
+    expect(await permissionsOf(alreadyHoldingSession.id)).toEqual(["goals:manage", "workspace:read"] as Permission[]);
   });
 
   test("RLS policies isolate session goal rows for a non-owner app role", async () => {


### PR DESCRIPTION
## Bug

A goal-bearing session could be created whose first-party MCP permission set lacks `goals:manage`, making the goal unstoppable by the agent:

- `createSessionForRequest` forces the goal tool refs (`withFirstPartyGoalTools`) when a goal is present, but stored an explicit `firstPartyMcpPermissions` list verbatim.
- The worker passes an explicit list through wholesale (`apps/worker/src/activities/agent-turn.ts`), replacing the runtime default set — which is the only place `goals:manage` normally comes from.
- The goal tools are only registered when the delegated grant carries the worker-signed `sessionId` claim AND `goals:manage` (`apps/api/src/mcp/server.ts`).

Result: the session loops goal continuations forever while the agent's `goal_complete` calls fail with `MCP error -32602: Tool goal_complete not found`, until an operator pauses the goal over REST. Reproduced live via the manager's `session_create` MCP tool with a goal plus `firstPartyMcpPermissions: ["workspace:read", ...]`.

## Fix

One invariant: a goal-bearing session always holds `goals:manage` in its effective first-party permissions. `createSessionForRequest` unions `goals:manage` into an explicit permission list whenever the payload carries a goal (both REST `POST /sessions` and the MCP `session_create` tool flow through it).

The auto-added permission is deliberately exempt from the creator-holds-it validation: goal tools are scoped to the spawned session itself via the worker-signed `sessionId` claim, so a worker managing its OWN goal is not an escalation of the spawner's authority. User-provided entries are validated exactly as before, and explicit lists on goalless sessions are stored untouched.

## Backfill

`packages/db/drizzle/0009_goal_sessions_first_party_goals_manage.sql` adds `goals:manage` to sessions that have a non-completed goal in `session_goals` and an explicit permission list missing it. Narrow and idempotent; toggles `NO FORCE ROW LEVEL SECURITY` around the owner-run UPDATE (owner-only effect, restored in the same implicit transaction) so the backfill sees all workspaces.

## Tests

- `test/integration/api.integration.ts`: REST and MCP `session_create` with a goal + explicit permissions lacking `goals:manage` produce a session whose stored permissions include it (from a creating grant that itself lacks `goals:manage`, proving the exemption); without a goal the explicit list is stored untouched.
- `test/integration/db.integration.ts`: the migration heals active- and paused-goal sessions, leaves completed-goal / goalless / already-holding / default(null) rows untouched, and is idempotent on re-run.

Local gate: typecheck, unit, and the full integration suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session permission semantics and runs a data migration with RLS toggling; scope is narrow (goal + explicit permission lists) and auto-added permission is session-scoped, but existing deployed sessions are mutated on upgrade.
> 
> **Overview**
> Fixes goal-bearing sessions that could be created with an explicit `firstPartyMcpPermissions` list missing **`goals:manage`**, so the worker never saw goal MCP tools and goal continuations could run until an operator intervened.
> 
> **Session creation** (`createSessionForRequest`): when the payload includes a **goal** and a non-null explicit permission list, **`goals:manage` is unioned in** if absent. That addition is **not** subject to the “creator must hold every permission” check (goal tools are scoped to the spawned session via the worker `sessionId` claim). Goalless sessions and omitted (default) permission lists are unchanged.
> 
> **Migration `0009_goal_sessions_first_party_goals_manage.sql`**: idempotent backfill appends `goals:manage` to `sessions.first_party_mcp_permissions` for rows with a **non-completed** goal and an explicit array missing the permission; temporarily **`NO FORCE` RLS** on `sessions` / `session_goals` so the owner-run `UPDATE` sees all workspaces.
> 
> **Tests**: REST + MCP `session_create` with goal + explicit permissions (creator without `goals:manage`); migration heals active/paused goals, skips completed/no-goal/already-holding/null lists, idempotent re-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341ca4c790e9e9010d5abb3e8aab77edac7642b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->