### PR TITLE
Idle, don't fail, goal-less sessions on retryable provider failures

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -579,45 +579,45 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         activityStatus = "idle";
         return { status: "idle" };
       }
-      // A retryable provider failure (rate limit) on a goal-bearing session is
-      // transient backpressure, not a session failure: the in-client retry
-      // budget is already exhausted by the time the error reaches here, so
-      // fail the turn truthfully but idle the session and let the goal
-      // continuation loop resume after a pacing delay. Sessions without an
-      // active goal keep the terminal behavior -- there is no continuation
-      // machinery to resume them, and a failed session is the honest signal
-      // for the user to retry.
+      // A retryable provider failure (rate limit) is transient backpressure,
+      // not a session failure: the in-client retry budget is already
+      // exhausted by the time the error reaches here, so fail the turn
+      // truthfully but idle the session. With an active goal the continuation
+      // loop resumes after a pacing delay; without one the session simply
+      // waits for the next user message. Long-lived sessions (a per-customer
+      // ops channel between goals) must never go terminal because the
+      // provider had a bad minute -- a failed session would reject the very
+      // retry message the failure asks for.
       const failure = agentRunFailurePayload(error);
       if (failure.retryable && publish && turnId && turnStartedPublished) {
         const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
-        if (goal && goal.status === "active") {
-          await batcher?.flush().catch(() => undefined);
-          // Provider errors rarely carry SDK run state; a null falls back to
-          // the previous snapshot, same degraded-context contract as the
-          // max-turns path above.
-          await reconcileConversationTruth();
-          const serializedRunState = agentsErrorRunState(error);
-          const runStateSaved = Boolean(serializedRunState) && settings.sessionHistorySource !== "items";
-          if (serializedRunState && settings.sessionHistorySource !== "items") {
-            await saveRunState(db, {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              turnId,
-              serializedRunState,
-              pendingApprovals: [],
-            });
-          }
-          await publish([
-            { type: "turn.failed", payload: { ...failure, recovery: "goal_continuation", runStateSaved } },
-            { type: "session.status.changed", payload: { status: "idle" } },
-          ], true);
-          await finishTurn(db, input.workspaceId, turnId, "failed");
-          await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
-          activityStatus = "idle";
-          activityError = error;
-          return { status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS };
+        const goalActive = Boolean(goal && goal.status === "active");
+        await batcher?.flush().catch(() => undefined);
+        // Provider errors rarely carry SDK run state; a null falls back to
+        // the previous snapshot, same degraded-context contract as the
+        // max-turns path above.
+        await reconcileConversationTruth();
+        const serializedRunState = agentsErrorRunState(error);
+        const runStateSaved = Boolean(serializedRunState) && settings.sessionHistorySource !== "items";
+        if (serializedRunState && settings.sessionHistorySource !== "items") {
+          await saveRunState(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId,
+            serializedRunState,
+            pendingApprovals: [],
+          });
         }
+        await publish([
+          { type: "turn.failed", payload: { ...failure, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved } },
+          { type: "session.status.changed", payload: { status: "idle" } },
+        ], true);
+        await finishTurn(db, input.workspaceId, turnId, "failed");
+        await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+        activityStatus = "idle";
+        activityError = error;
+        return goalActive ? { status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS } : { status: "idle" };
       }
       activityStatus = "failed";
       activityError = error;

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -27,10 +27,13 @@ run length; if a run is misbehaving, detect the pathology, do not cap the clock.
 
 Two recoverable conditions end a turn gracefully (idle the session, keep the
 context) instead of failing it, so a long run survives them: hitting the
-model-call cap (if one is configured) and provider rate-limit backpressure on a
-goal-bearing session. A budget/credit exhaustion between model calls likewise
-idles the turn rather than failing the session, so a top-up lets the same
-session continue.
+model-call cap (if one is configured) and provider rate-limit backpressure —
+with an active goal the continuation loop resumes after a pacing delay, and
+without one the session idles until the next user message (a long-lived
+session between goals must not go terminal because the provider had a bad
+minute). A budget/credit exhaustion between model calls likewise idles the
+turn rather than failing the session, so a top-up lets the same session
+continue.
 
 **Worker restarts are survivable.** A graceful worker shutdown (a deploy or
 rollout restart delivers SIGTERM; Temporal cancels in-flight activities with

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -468,7 +468,7 @@ describe("worker activities integration", () => {
     expect(turns.every((turn) => turn.status !== "failed")).toBe(true);
   });
 
-  test("classifies provider rate limits as retryable turn failures", async () => {
+  test("idles the session on a retryable provider failure without a goal", async () => {
     const grant = await testGrant(dbClient.db);
     const session = await createOwnedSession(dbClient.db, grant, {
       initialMessage: "rate limit",
@@ -497,15 +497,22 @@ describe("worker activities integration", () => {
       sessionId: session.id,
       triggerEventId: trigger!.id,
       workflowId: "workflow-rate-limit",
-    })).resolves.toEqual({ status: "failed" });
+    })).resolves.toEqual({ status: "idle" });
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     const failed = events.find((event) => event.type === "turn.failed");
     expect(failed?.payload).toEqual({
       error: "Model provider rate limit hit. Try again in a minute or lower the reasoning effort.",
       code: "provider_rate_limited",
       retryable: true,
+      recovery: "user_message",
+      runStateSaved: false,
     });
-    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("failed");
+    // The turn is truthfully failed, but a transient provider failure must
+    // not kill a long-lived session: it idles and the next user message
+    // resumes it (no continuation pacing -- there is no goal to continue).
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id, 10);
+    expect(turns.some((turn) => turn.status === "failed")).toBe(true);
   });
 
   test("idles the session on a retryable provider failure when a goal is active", async () => {


### PR DESCRIPTION
## Why

A transient provider 429 killed a long-lived session live: the retryable-failure carve-out (#28) only idled **goal-bearing** sessions, so a rate limit that landed right after `goal_complete` marked the session `failed` — and a failed session rejects the very retry message the failure text asks the user to send. For a per-customer ops channel that lives for months and naturally sits between goals, that is fatal: the provider having a bad minute must never be terminal.

## What

`apps/worker/src/activities/agent-turn.ts`: retryable provider failures now idle the session whether or not a goal is active.
- Active goal: unchanged — `turn.failed` with `recovery: "goal_continuation"`, idle, continuation resumes after the pacing delay.
- No active goal: `turn.failed` with `recovery: "user_message"`, idle, no pacing delay (nothing to continue) — the next user message resumes the session.
- The turn itself is still truthfully failed; non-retryable errors keep the terminal path.
- `docs/run-lifecycle.md` updated to match.

## Verification

- `bun run typecheck` + full `bun test` green
- `bun run test:integration` green (134 tests, local Postgres/NATS/Temporal) — including the rewritten goal-less rate-limit case asserting idle + `recovery: user_message` + the failed turn row, and the unchanged goal-bearing case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session terminal semantics on transient provider errors for long-lived goal-less channels; turn rows still fail and non-retryable errors remain terminal.
> 
> **Overview**
> **Retryable provider failures (e.g. rate limits) no longer mark the session `failed` when there is no active goal** — the same carve-out that already applied to goal-bearing sessions and to budget exhaustion.
> 
> In `runAgentTurn`, retryable provider errors still emit `turn.failed` and finish the turn as failed, but the session is set to **`idle`** instead of **`failed`**. Reconcile/run-state handling is shared for both cases; `turn.failed` now includes **`recovery: "goal_continuation"`** when a goal is active (workflow still returns **`continueDelayMs`** for pacing) or **`recovery: "user_message"`** when not (idle with no auto-continuation). Non-retryable errors keep the terminal failed session path.
> 
> `docs/run-lifecycle.md` documents goal vs goal-less behavior for provider backpressure. Integration coverage renames and updates the goal-less rate-limit test to expect idle session status and the new payload fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d1613ee6f4cbba52af837e35268cecba1a35f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->