### PR TITLE
Scheduled tasks default to enabled capability MCP tools like sessions

### DIFF
--- a/apps/api/src/domain/scheduled-tasks.ts
+++ b/apps/api/src/domain/scheduled-tasks.ts
@@ -25,7 +25,28 @@ import {
   validateFileResources,
   validateGitHubRepositorySelection,
   validateToolRefs,
+  withDefaultEnabledCapabilityMcpTools,
 } from "./resources";
+
+/**
+ * Whether a raw scheduled-task payload explicitly set agentConfig.tools.
+ * Zod's `.default([])` erases the distinction between "absent" and
+ * "explicitly empty", so callers detect it on the raw payload — the same
+ * contract sessions use: absent tools mean "give me the workspace defaults
+ * (enabled capability MCP servers)", an explicit list (even empty) is taken
+ * verbatim.
+ */
+export function scheduledTaskToolsProvided(rawPayload: unknown): boolean {
+  if (!rawPayload || typeof rawPayload !== "object") {
+    return false;
+  }
+  const agentConfig = (rawPayload as { agentConfig?: unknown }).agentConfig;
+  return Boolean(
+    agentConfig
+    && typeof agentConfig === "object"
+    && Object.prototype.hasOwnProperty.call(agentConfig, "tools"),
+  );
+}
 
 export async function createValidatedScheduledTask(input: {
   settings: Settings;
@@ -33,6 +54,10 @@ export async function createValidatedScheduledTask(input: {
   objectStorage: ObjectStorageDependency;
   grant: AccessGrant;
   payload: CreateScheduledTaskPayload;
+  // Whether the caller explicitly set agentConfig.tools (see
+  // scheduledTaskToolsProvided). Absent tools get the workspace's enabled
+  // capability MCP servers, mirroring session creation.
+  toolsProvided?: boolean;
   // Set for pack-installation-inherited attachments that were already
   // authorized with environments:use when the pack was enabled.
   environmentPreauthorized?: boolean;
@@ -72,6 +97,8 @@ export async function validatedScheduledTaskUpdate(input: {
   grant: AccessGrant;
   existing: ScheduledTask;
   payload: UpdateScheduledTaskPayload;
+  /** See createValidatedScheduledTask; only consulted when agentConfig is updated. */
+  toolsProvided?: boolean;
 }): Promise<UpdateScheduledTaskInput> {
   const update: UpdateScheduledTaskInput = {};
   if (input.payload.name !== undefined) {
@@ -133,6 +160,7 @@ export async function validatedScheduledTaskUpdate(input: {
       objectStorage: input.objectStorage,
       workspaceId: input.existing.workspaceId,
       payload: { agentConfig: input.payload.agentConfig },
+      ...(input.toolsProvided !== undefined ? { toolsProvided: input.toolsProvided } : {}),
     });
   }
   return update;
@@ -197,10 +225,19 @@ async function validateScheduledTaskAgentConfig(input: {
   objectStorage: ObjectStorageDependency;
   payload: { agentConfig: ScheduledTaskAgentConfig };
   workspaceId: string;
+  toolsProvided?: boolean;
 }): Promise<ScheduledTaskAgentConfig> {
   const resources = normalizeResources(input.payload.agentConfig.resources ?? []);
   const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(input.db, input.workspaceId, input.settings);
-  const tools = validateToolRefs(input.payload.agentConfig.tools ?? [], runtimeSettings);
+  const requestedTools = validateToolRefs(input.payload.agentConfig.tools ?? [], runtimeSettings);
+  // A task whose creator did not choose tools gets the workspace's enabled
+  // capability MCP servers, exactly like a session created without a tools
+  // key. Scheduled runs are sessions too; "no MCP servers at all" was a trap
+  // every pack/template instantiation path kept falling into (a maintenance
+  // task that cannot reach its workspace's notebook MCP cannot do its job).
+  const tools = (input.toolsProvided ?? true)
+    ? requestedTools
+    : withDefaultEnabledCapabilityMcpTools(requestedTools, input.settings, runtimeSettings);
   const prompt = input.payload.agentConfig.prompt.trim();
   if (!prompt) {
     throw new HTTPException(422, { message: "scheduled task prompt is required" });

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -55,6 +55,7 @@ import {
 } from "../domain/environments";
 import {
   createValidatedScheduledTask,
+  scheduledTaskToolsProvided,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
@@ -245,7 +246,7 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
     const payload = CreateScheduledTaskRequest.parse(args);
     requireEnvironmentsUseForMcpAttachment(grant, payload.environmentId);
     await requireLimit(deps, { accountId: grant.accountId, workspaceId: grant.workspaceId, action: "schedule:create", quantity: 1 });
-    const task = await createValidatedScheduledTask({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, grant, payload });
+    const task = await createValidatedScheduledTask({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, grant, payload, toolsProvided: scheduledTaskToolsProvided(args) });
     await syncCreatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, task });
     return json(task);
   });
@@ -267,7 +268,7 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
     const existing = await requireScheduledTask(deps.db, grant.workspaceId, id);
     const payload = UpdateScheduledTaskRequest.parse(raw);
     requireEnvironmentsUseForMcpAttachment(grant, payload.environmentId);
-    const update = await validatedScheduledTaskUpdate({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, grant, existing, payload });
+    const update = await validatedScheduledTaskUpdate({ settings: deps.settings, db: deps.db, objectStorage: deps.objectStorage, grant, existing, payload, toolsProvided: scheduledTaskToolsProvided(raw) });
     const task = await updateScheduledTask(deps.db, grant.workspaceId, id, update);
     await syncUpdatedScheduledTask({ db: deps.db, workflowClient: deps.workflowClient, previous: existing, task });
     return json(task);

--- a/apps/api/src/routes/scheduled-tasks.ts
+++ b/apps/api/src/routes/scheduled-tasks.ts
@@ -11,6 +11,7 @@ import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
 import type { ApiRouteDeps } from "../dependencies";
 import {
   createValidatedScheduledTask,
+  scheduledTaskToolsProvided,
   requireScheduledTaskForApi,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
@@ -24,9 +25,10 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
   app.post("/v1/workspaces/:workspaceId/scheduled-tasks", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "scheduled_tasks:manage");
-    const payload = CreateScheduledTaskRequest.parse(await c.req.json());
+    const rawPayload = await c.req.json();
+    const payload = CreateScheduledTaskRequest.parse(rawPayload);
     await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "schedule:create", quantity: 1 });
-    const task = await createValidatedScheduledTask({ settings, db, objectStorage, grant, payload });
+    const task = await createValidatedScheduledTask({ settings, db, objectStorage, grant, payload, toolsProvided: scheduledTaskToolsProvided(rawPayload) });
     await syncCreatedScheduledTask({ db, workflowClient, task });
     return c.json(task, 201);
   });
@@ -48,8 +50,9 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
     const grant = await requireAccessGrant(c, deps, workspaceId, "scheduled_tasks:manage");
     const taskId = c.req.param("taskId");
     const existing = await requireScheduledTaskForApi(db, workspaceId, taskId);
-    const payload = UpdateScheduledTaskRequest.parse(await c.req.json());
-    const update = await validatedScheduledTaskUpdate({ settings, db, objectStorage, grant, existing, payload });
+    const rawPayload = await c.req.json();
+    const payload = UpdateScheduledTaskRequest.parse(rawPayload);
+    const update = await validatedScheduledTaskUpdate({ settings, db, objectStorage, grant, existing, payload, toolsProvided: scheduledTaskToolsProvided(rawPayload) });
     const task = await updateScheduledTask(db, workspaceId, taskId, update);
     await syncUpdatedScheduledTask({ db, workflowClient, previous: existing, task });
     return c.json(task);

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -11,7 +11,7 @@ The catalog merges:
 
 ## Runtime Behavior
 
-Remote MCP capabilities with a streamable HTTP endpoint are executable. Enabling a remote MCP first performs an MCP initialize/list-tools probe. If the probe succeeds, OpenGeni stores a `capability_installations` row and the API/worker merge that row into the runtime MCP server list for new sessions, follow-ups, and scheduled tasks. If the probe fails, the API returns `422` and the capability stays disabled, so a stale, down, or auth-only endpoint never breaks agent turns at runtime.
+Remote MCP capabilities with a streamable HTTP endpoint are executable. Enabling a remote MCP first performs an MCP initialize/list-tools probe. If the probe succeeds, OpenGeni stores a `capability_installations` row and the API/worker merge that row into the runtime MCP server list for new sessions, follow-ups, and scheduled tasks. Sessions and scheduled tasks created without an explicit `tools` key are attached to every enabled capability MCP server by default; an explicit tools list (even an empty one) is taken verbatim. If the probe fails, the API returns `422` and the capability stays disabled, so a stale, down, or auth-only endpoint never breaks agent turns at runtime.
 
 ### Credential headers
 

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1244,6 +1244,54 @@ describe("API component integration", () => {
     expect(explicitEmptyTools.status).toBe(202);
     const explicitEmptySession = await explicitEmptyTools.json() as { id: string };
     expect((await requireSession(dbClient.db, workspaceId, explicitEmptySession.id)).tools).toEqual([]);
+
+    // Scheduled tasks mirror sessions: an absent agentConfig.tools key means
+    // "give me the workspace's enabled capability MCP servers", an explicit
+    // list (even empty) is taken verbatim. Without this, a task created
+    // toolless runs with no MCP servers at all (live customer-one lesson:
+    // maintenance tasks that cannot reach the workspace notebook MCP).
+    const omittedTaskResponse = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "default tools task",
+        schedule: { type: "interval", everySeconds: 3600 },
+        agentConfig: { prompt: "sweep" },
+      }),
+    });
+    expect(omittedTaskResponse.status).toBe(201);
+    const omittedTask = await omittedTaskResponse.json() as { id: string; agentConfig: { tools: unknown[] } };
+    expect(omittedTask.agentConfig.tools).toContainEqual({ kind: "mcp", id: "cap-route-mcp" });
+
+    const explicitEmptyTaskResponse = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "explicit empty tools task",
+        schedule: { type: "interval", everySeconds: 3600 },
+        agentConfig: { prompt: "sweep", tools: [] },
+      }),
+    });
+    expect(explicitEmptyTaskResponse.status).toBe(201);
+    const explicitEmptyTask = await explicitEmptyTaskResponse.json() as { id: string; agentConfig: { tools: unknown[] } };
+    expect(explicitEmptyTask.agentConfig.tools).toEqual([]);
+
+    // Updates follow the same contract when agentConfig is replaced.
+    const patchedDefault = await app.request(workspacePath(workspaceId, `/scheduled-tasks/${explicitEmptyTask.id}`), {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentConfig: { prompt: "sweep again" } }),
+    });
+    expect(patchedDefault.status).toBe(200);
+    expect(((await patchedDefault.json()) as { agentConfig: { tools: unknown[] } }).agentConfig.tools)
+      .toContainEqual({ kind: "mcp", id: "cap-route-mcp" });
+    const patchedExplicit = await app.request(workspacePath(workspaceId, `/scheduled-tasks/${omittedTask.id}`), {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentConfig: { prompt: "sweep verbatim", tools: [] } }),
+    });
+    expect(patchedExplicit.status).toBe(200);
+    expect(((await patchedExplicit.json()) as { agentConfig: { tools: unknown[] } }).agentConfig.tools).toEqual([]);
     await dbClient.db.execute(dbSql`
       update capability_installations
       set status = 'disabled', updated_at = now()


### PR DESCRIPTION
## Why

A scheduled task created without choosing tools runs with **no MCP servers at all**, while a session created the same way gets the workspace's enabled capability MCP servers. Live customer lesson, now twice (customer-zero 2026-06-12, customer-one today): maintenance tasks instantiated from pack templates landed with `tools: []`, could not reach the workspace's notebook MCP, and failed their playbook setup check. The pack manifest grew prose + metadata mirrors to compensate — but the trap is platform-shaped, so the fix belongs here.

## What

Scheduled task create/update — REST routes and the first-party MCP `scheduled_tasks_create`/`scheduled_tasks_update` — now mirror the session contract:
- absent `agentConfig.tools` key → attach the workspace's enabled capability MCP servers (`withDefaultEnabledCapabilityMcpTools`)
- explicit list (even empty) → verbatim

Zod's `.default([])` erases absence, so the callers detect it on the raw payload via a shared `scheduledTaskToolsProvided` helper — the same approach session creation uses. The marketing-pack template endpoint builds its agentConfig explicitly and is unchanged. `docs/capabilities.md` states the contract.

## Verification

- `bun run typecheck` + full `bun test` green
- `bun run test:integration` green — extended the capability-defaults case: task created without tools contains the enabled capability ref; explicit `[]` stays empty; PATCH with replaced agentConfig follows the same contract both ways
- `bun scripts/check-workspace-billing-static.ts` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent tool attachment for scheduled tasks (including pack/template creates without tools), which can widen MCP access for those tasks but fixes broken maintenance runs; explicit `tools: []` behavior is unchanged.
> 
> **Overview**
> Scheduled task **create/update** now match **sessions** for MCP tools: if `agentConfig.tools` is **omitted**, the API merges in the workspace’s **enabled capability MCP servers** via `withDefaultEnabledCapabilityMcpTools`; an **explicit** `tools` array (including `[]`) is stored unchanged.
> 
> Because Zod `.default([])` hides “missing” vs “empty”, REST and MCP handlers parse the **raw** body and pass `toolsProvided: scheduledTaskToolsProvided(...)`. `docs/capabilities.md` documents the contract; integration tests cover create and PATCH for both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c760d982ebae17d3756580f3c5157a0105d6c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->