### PR TITLE
API key dialog: offer every delegable permission

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@opengeni/contracts": "workspace:*",
     "@opengeni/react": "workspace:*",
     "@opengeni/sdk": "workspace:*",
     "@tailwindcss/vite": "^4.2.4",

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { Permission } from "@opengeni/contracts";
 import {
   agentConfigFromFormState,
+  buildApiKeyPermissionGroups,
   buildTools,
+  delegableApiKeyPermissions,
   capabilityErrorToast,
   enabledWorkspaceCapabilityMcpServers,
   filterCapabilityCatalogItems,
@@ -26,6 +29,50 @@ describe("workspace route helpers", () => {
 
   test("does not build legacy unscoped session URLs", () => {
     expect(workspaceSessionPath("workspace-1", "session-1")).not.toBe("/sessions/session-1");
+  });
+});
+
+describe("api key permission options", () => {
+  test("groups offer every contracts Permission exactly once", () => {
+    const offered = buildApiKeyPermissionGroups().flatMap((group) => group.permissions);
+    expect(offered.length).toBe(new Set(offered).size);
+    expect([...offered].sort()).toEqual([...Permission.options].sort());
+  });
+
+  test("groups have no catch-all bucket and keep workspace first, admin last", () => {
+    const labels = buildApiKeyPermissionGroups().map((group) => group.label);
+    expect(labels).toEqual([
+      "Workspace",
+      "Sessions",
+      "Files & documents",
+      "Scheduled tasks",
+      "Environments",
+      "GitHub",
+      "Goals",
+      "Admin & account",
+    ]);
+  });
+
+  test("offers the scopes the old hardcoded list omitted", () => {
+    const offered = buildApiKeyPermissionGroups().flatMap((group) => group.permissions);
+    const previouslyMissing: Permission[] = ["environments:manage", "environments:use", "goals:manage", "workspace:admin", "github:manage", "workspace:create", "billing:read", "billing:manage", "members:manage", "account:read", "account:admin"];
+    for (const permission of previouslyMissing) {
+      expect(offered).toContain(permission);
+    }
+  });
+
+  test("workspace:admin grants can delegate every permission", () => {
+    expect(delegableApiKeyPermissions(["workspace:admin"])).toEqual(new Set(Permission.options));
+  });
+
+  test("non-admin grants can only delegate their own permissions", () => {
+    const delegable = delegableApiKeyPermissions(["sessions:read", "files:read", "api_keys:manage"]);
+    expect([...delegable].sort()).toEqual(["api_keys:manage", "files:read", "sessions:read"]);
+    expect(delegable.has("environments:manage")).toBe(false);
+  });
+
+  test("empty grants can delegate nothing", () => {
+    expect(delegableApiKeyPermissions([]).size).toBe(0);
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -47,6 +47,7 @@ import {
   type TimelineItem,
   type UserMessageItem,
 } from "@opengeni/react";
+import { Permission } from "@opengeni/contracts";
 import {
   Link,
   Navigate,
@@ -1437,20 +1438,73 @@ function ManagedAuthPanel(props: {
   );
 }
 
-const apiKeyPermissionOptions = [
-  "workspace:read",
-  "sessions:create",
-  "sessions:read",
-  "sessions:control",
-  "files:upload",
-  "files:read",
-  "documents:manage",
-  "documents:search",
-  "scheduled_tasks:manage",
-  "scheduled_tasks:run",
-  "github:use",
-  "api_keys:manage",
-] as const;
+const apiKeyPermissionGroupAssignments: Record<Permission, string> = {
+  "workspace:read": "Workspace",
+  "workspace:create": "Workspace",
+  "sessions:create": "Sessions",
+  "sessions:read": "Sessions",
+  "sessions:control": "Sessions",
+  "files:upload": "Files & documents",
+  "files:read": "Files & documents",
+  "documents:manage": "Files & documents",
+  "documents:search": "Files & documents",
+  "scheduled_tasks:manage": "Scheduled tasks",
+  "scheduled_tasks:run": "Scheduled tasks",
+  "environments:manage": "Environments",
+  "environments:use": "Environments",
+  "github:manage": "GitHub",
+  "github:use": "GitHub",
+  "goals:manage": "Goals",
+  "workspace:admin": "Admin & account",
+  "api_keys:manage": "Admin & account",
+  "members:manage": "Admin & account",
+  "account:read": "Admin & account",
+  "account:admin": "Admin & account",
+  "billing:read": "Admin & account",
+  "billing:manage": "Admin & account",
+};
+
+const apiKeyPermissionGroupOrder = [
+  "Workspace",
+  "Sessions",
+  "Files & documents",
+  "Scheduled tasks",
+  "Environments",
+  "GitHub",
+  "Goals",
+  "Admin & account",
+];
+
+// Derived from the contracts Permission enum so the dialog can never drift
+// from the API again: every enum value lands in exactly one group.
+export function buildApiKeyPermissionGroups(): { label: string; permissions: Permission[] }[] {
+  const groups: { label: string; permissions: Permission[] }[] = [];
+  for (const permission of Permission.options) {
+    const label = apiKeyPermissionGroupAssignments[permission] ?? "Other";
+    const group = groups.find((candidate) => candidate.label === label);
+    if (group) {
+      group.permissions.push(permission);
+    } else {
+      groups.push({ label, permissions: [permission] });
+    }
+  }
+  const rank = (label: string): number => {
+    const index = apiKeyPermissionGroupOrder.indexOf(label);
+    return index === -1 ? apiKeyPermissionGroupOrder.length : index;
+  };
+  return groups.sort((a, b) => rank(a.label) - rank(b.label));
+}
+
+const apiKeyPermissionGroups = buildApiKeyPermissionGroups();
+
+// Mirrors the API's ensureDelegablePermissions: a workspace:admin grant can
+// delegate everything, any other grant only its own permissions.
+export function delegableApiKeyPermissions(grantPermissions: readonly string[]): Set<string> {
+  if (grantPermissions.includes("workspace:admin")) {
+    return new Set<string>(Permission.options);
+  }
+  return new Set<string>(Permission.options.filter((permission) => grantPermissions.includes(permission)));
+}
 
 const defaultApiKeyPermissions = new Set<string>([
   "workspace:read",
@@ -1481,6 +1535,9 @@ function AccountConsole(props: {
   const [busy, setBusy] = useState(false);
   const canManageApiKeys = hasWorkspacePermission(props.accessContext, props.workspaceId, "api_keys:manage");
   const canManageBilling = hasAccountPermission(props.accessContext, props.accountId, "billing:manage");
+  const workspaceGrant = props.accessContext?.workspaceGrants.find((grant) => grant.workspaceId === props.workspaceId) ?? null;
+  const delegablePermissions = delegableApiKeyPermissions(workspaceGrant?.permissions ?? []);
+  const requestedPermissions = [...selectedPermissions].filter((permission) => delegablePermissions.has(permission));
 
   useEffect(() => {
     if (!props.workspaceId) {
@@ -1499,7 +1556,7 @@ function AccountConsole(props: {
   }
 
   async function createKey() {
-    if (!apiKeyName.trim() || selectedPermissions.size === 0) {
+    if (!apiKeyName.trim() || requestedPermissions.length === 0) {
       toast.error("API key name and permissions are required");
       return;
     }
@@ -1507,7 +1564,7 @@ function AccountConsole(props: {
     try {
       const result = await createApiKey(props.workspaceId, {
         name: apiKeyName.trim(),
-        permissions: [...selectedPermissions],
+        permissions: requestedPermissions,
       });
       setCreatedToken(result.token);
       setApiKeys((current) => [result.apiKey, ...current]);
@@ -1643,14 +1700,32 @@ function AccountConsole(props: {
                 Create
               </Button>
             </div>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              {apiKeyPermissionOptions.map((permission) => (
-                <label key={permission} className="flex items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-2 py-1.5 text-xs">
-                  <input type="checkbox" checked={selectedPermissions.has(permission)} onChange={() => togglePermission(permission)} />
-                  <span>{permission}</span>
-                </label>
-              ))}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs text-[color:var(--color-fg-subtle)]">A key can only carry permissions your own grant can delegate.</p>
+              <Button type="button" variant="ghost" size="sm" disabled={delegablePermissions.size === 0} onClick={() => setSelectedPermissions(new Set(delegablePermissions))}>
+                Select all delegable
+              </Button>
             </div>
+            {apiKeyPermissionGroups.map((group) => (
+              <div key={group.label} className="grid gap-1.5">
+                <div className="text-xs font-medium text-[color:var(--color-fg-muted)]">{group.label}</div>
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                  {group.permissions.map((permission) => {
+                    const delegable = delegablePermissions.has(permission);
+                    return (
+                      <label
+                        key={permission}
+                        title={delegable ? undefined : "Your grant cannot delegate this permission"}
+                        className={`flex items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-2 py-1.5 text-xs ${delegable ? "" : "cursor-not-allowed opacity-50"}`}
+                      >
+                        <input type="checkbox" disabled={!delegable} checked={delegable && selectedPermissions.has(permission)} onChange={() => togglePermission(permission)} />
+                        <span>{permission}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
           </>
         ) : (
           <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot manage API keys for the selected workspace.</p>

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,9 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@opengeni/contracts": "workspace:*",
+        "@opengeni/react": "workspace:*",
+        "@opengeni/sdk": "workspace:*",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-router": "^1.170.15",
         "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Problem

The console's create-API-key UI hardcoded a 12-permission subset of the contracts `Permission` enum. Several scopes — `environments:manage`, `environments:use`, `goals:manage`, `workspace:admin`, `github:manage`, `workspace:create`, and the account/billing/members scopes — were not selectable at all, so a key carrying them could not be created through the UI even though the API accepts them. The list had silently drifted from `packages/contracts`.

## Fix

- **Derive the options from the contracts `Permission` enum.** Every enum value lands in exactly one labelled group (workspace, sessions, files & documents, scheduled tasks, environments, github, goals, admin & account). The group assignment map is typed `Record<Permission, string>`, so adding a new permission to the contract without grouping it is a compile error; an `Other` fallback group guards runtime completeness regardless.
- **Mirror the API's `ensureDelegablePermissions` client-side.** Permissions the creator's own grant cannot delegate render disabled with a hint instead of surprising the user with a 403 after submit. A `workspace:admin` grant can delegate everything, matching `apps/api/src/routes/api-keys.ts`. The submitted permission set is filtered to the delegable set.
- **Keep the existing default-checked set** and add a one-click "Select all delegable" button.
- **Unit tests** cover the derivation (enum → groups, exactly-once coverage, the previously missing scopes, delegability rules) so the dialog can no longer drift from the contract.

## Verification

- `bun run check` green (typecheck, unit tests, SDK + web builds)
- `bun scripts/check-workspace-billing-static.ts` green
- `packages/react` build + demo build green
- gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Console-only UX and client-side filtering for API key scopes; behavior matches existing API enforcement with no auth or data-model changes.
> 
> **Overview**
> Replaces the create-API-key UI’s **hardcoded 12-scope list** with permission options **derived from `@opengeni/contracts` `Permission`**, grouped under fixed labels (Workspace through Admin & account) so new contract scopes show up in the dialog instead of silently missing.
> 
> Adds **`delegableApiKeyPermissions`** aligned with the API’s `ensureDelegablePermissions`: non-delegable scopes render **disabled** with a hint, create submits only **delegable** permissions, plus **“Select all delegable”** and a short explanation. **`@opengeni/contracts`** is added as a web dependency; **unit tests** lock enum coverage, grouping order, previously omitted scopes, and delegation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cc74f8e7db9205ff586cdc785be515499d1cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->