### PR TITLE
Surface review round 3 fixes

### DIFF
--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -114,7 +114,6 @@ export function ConsoleComposer(props: {
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
-  hint?: string;
   fileUploadsEnabled: boolean;
   /** Console controls (model picker, tool toggles, ...) in the footer row. */
   controls?: ReactNode;
@@ -159,7 +158,6 @@ export function ConsoleComposer(props: {
         placeholder={props.placeholder}
         autoFocus={props.autoFocus}
         disabled={props.disabled}
-        hint={props.hint}
         onPaste={handlePaste}
         header={attachments.attachments.length > 0 ? (
           <AttachmentChips attachments={attachments.attachments} onRemove={attachments.removeAttachment} />

--- a/apps/web/src/lib/queue.test.ts
+++ b/apps/web/src/lib/queue.test.ts
@@ -11,6 +11,7 @@ import {
   deliveryModeExplanation,
   editedTurnFate,
   finishedTurns,
+  isMidTurn,
   moveTurnInQueue,
   reorderQueueByDrag,
   turnElapsedSeconds,
@@ -149,6 +150,24 @@ describe("deliveryModeExplanation", () => {
   test("unknown/null status reads as a plain send", () => {
     expect(deliveryModeExplanation("steer", null)).toContain("Nothing is running");
     expect(deliveryModeExplanation("queue", undefined)).toContain("starts immediately");
+  });
+});
+
+describe("isMidTurn", () => {
+  // Drives the steer-mode reset: an armed steer toggle falls back to queue
+  // once there is nothing left to steer, never across a live turn or queue.
+  test("running, queued, and requires_action keep steer armed", () => {
+    expect(isMidTurn("running")).toBe(true);
+    expect(isMidTurn("queued")).toBe(true);
+    expect(isMidTurn("requires_action")).toBe(true);
+  });
+
+  test("idle, terminal, and unknown statuses reset steer to the queue default", () => {
+    expect(isMidTurn("idle")).toBe(false);
+    expect(isMidTurn("failed")).toBe(false);
+    expect(isMidTurn("cancelled")).toBe(false);
+    expect(isMidTurn(null)).toBe(false);
+    expect(isMidTurn(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -91,12 +91,23 @@ export function turnSourceLabel(source: SessionTurn["source"]): string {
 }
 
 /**
+ * Session statuses during which steering has something to act on (interrupt
+ * a turn, or jump a queue). Outside these the composer falls back to the
+ * queue default so a stale steer toggle cannot surprise a later send.
+ */
+export function isMidTurn(status: SessionStatus | null | undefined): boolean {
+  return status === "running" || status === "queued" || status === "requires_action";
+}
+
+/**
  * Honest one-liner for the compose-time delivery choice, aligned with what
  * `OpenGeniClient.steerMessage` actually does per status: it interrupts only
  * `running` and `requires_action` sessions (steering a session paused on an
  * approval abandons that approval); on a `queued` session it promotes the
  * message to the queue front without interrupting anything; with nothing
- * active it degrades to a plain send.
+ * active it degrades to a plain send. A steer interrupt is tagged
+ * `reason: "steer"` and the worker keeps an active goal running through it
+ * (redirection, not a stop), so the hints stay silent about goals.
  */
 export function deliveryModeExplanation(mode: ComposerMode, status: SessionStatus | null | undefined): string {
   if (mode === "steer") {

--- a/apps/web/src/routes/account.tsx
+++ b/apps/web/src/routes/account.tsx
@@ -254,6 +254,7 @@ export function AccountRoute({ workspaceId }: { workspaceId: string }) {
         <UsageSection
           enabled={canReadBilling && Boolean(accountId)}
           loading={usage.loading}
+          error={usage.error}
           usage={usage.usage}
           onRefresh={() => void usage.refresh()}
         />
@@ -387,6 +388,7 @@ function EntitlementsSection(props: {
 function UsageSection(props: {
   enabled: boolean;
   loading: boolean;
+  error: Error | null;
   usage: UsageEvent[];
   onRefresh: () => void;
 }) {
@@ -409,6 +411,10 @@ function UsageSection(props: {
 
       {!props.enabled ? (
         <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing usage for the account.</p>
+      ) : props.error && props.usage.length === 0 ? (
+        // Honest failed-load state: a failed usage read must never render as
+        // "No usage recorded yet." (usage already on screen keeps rendering).
+        <LoadErrorState title="Couldn't load usage" error={props.error} onRetry={props.onRefresh} />
       ) : props.loading && props.usage.length === 0 ? (
         <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
           <Loader2Icon className="size-3.5 animate-spin" />

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -17,7 +17,7 @@ import {
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
-import { PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAppContext } from "@/context";
@@ -34,6 +34,7 @@ import {
   type CapabilityFormState,
   type PackContentsSummary,
 } from "@/lib/capabilities";
+import { listViewState } from "@/lib/load-state";
 import { cn } from "@/lib/utils";
 import type { CapabilityCatalogItem } from "@/types";
 
@@ -43,6 +44,7 @@ export function CapabilitiesRoute({ workspaceId }: { workspaceId: string }) {
   const onRuntimeChanged = () => void context.refreshWorkspaceMcpServers(workspaceId);
   const [items, setItems] = useState<CapabilityCatalogItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [filter, setFilter] = useState<CapabilityFilter>("all");
   const [query, setQuery] = useState("");
@@ -52,6 +54,10 @@ export function CapabilitiesRoute({ workspaceId }: { workspaceId: string }) {
   const [addForm, setAddForm] = useState<CapabilityFormState>(() => emptyCapabilityForm());
   const visibleItems = useMemo(() => filterCapabilityCatalogItems(items, filter, query), [items, filter, query]);
   const counts = useMemo(() => capabilityCounts(items), [items]);
+  // Honest list state: a failed catalog load renders as an error with retry,
+  // never as "No capabilities match this filter."; a catalog already on
+  // screen keeps rendering through a background refresh.
+  const catalogView = listViewState({ loading, error: loadError, count: items.length });
 
   useEffect(() => {
     void refresh();
@@ -65,7 +71,9 @@ export function CapabilitiesRoute({ workspaceId }: { workspaceId: string }) {
     try {
       const catalog = await client.listCapabilities(workspaceId);
       setItems(catalog.items);
+      setLoadError(null);
     } catch (error) {
+      setLoadError(error instanceof Error ? error : new Error(String(error)));
       toast.error("Failed to load capabilities", { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setLoading(false);
@@ -194,14 +202,16 @@ export function CapabilitiesRoute({ workspaceId }: { workspaceId: string }) {
 
         <div className="mt-5 grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_390px]">
           <div className="min-w-0">
-            {loading ? (
+            {catalogView === "loading" ? (
               <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-4 text-sm text-[color:var(--color-fg-muted)]">
                 <Loader2Icon className="size-4 animate-spin" />
                 Loading capabilities
               </div>
+            ) : catalogView === "error" ? (
+              <LoadErrorState title="Couldn't load capabilities" error={loadError} onRetry={() => void refresh()} />
             ) : visibleItems.length === 0 ? (
               <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-6 text-center text-sm text-[color:var(--color-fg-muted)]">
-                No capabilities match this filter.
+                {catalogView === "empty" ? "No capabilities in this workspace yet." : "No capabilities match this filter."}
               </div>
             ) : (
               <div className="grid gap-2">

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -4,10 +4,11 @@ import { CheckIcon, FileSearchIcon, FilesIcon, Loader2Icon, PlusIcon, RefreshCwI
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAppContext } from "@/context";
+import { listViewState } from "@/lib/load-state";
 import { cn } from "@/lib/utils";
 import type { DocumentBase, DocumentSearchResult, IndexedDocument } from "@/types";
 
@@ -16,8 +17,12 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const client = context.client;
   const fileUploadsEnabled = context.clientConfig.fileUploads.enabled === true;
   const [bases, setBases] = useState<DocumentBase[]>([]);
+  const [basesLoading, setBasesLoading] = useState(true);
+  const [basesError, setBasesError] = useState<Error | null>(null);
   const [selectedBaseId, setSelectedBaseId] = useState<string | null>(null);
   const [documents, setDocuments] = useState<IndexedDocument[]>([]);
+  const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [documentsError, setDocumentsError] = useState<Error | null>(null);
   const [results, setResults] = useState<DocumentSearchResult[]>([]);
   const [name, setName] = useState("");
   const [query, setQuery] = useState("");
@@ -29,6 +34,11 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const selectedBase = bases.find((base) => base.id === selectedBaseId) ?? null;
   const failedDocuments = documents.filter((document) => document.status === "failed");
+  // Honest list states: an initial fetch renders as loading and a failed load
+  // as an error with retry — never as "Create a document base to start." or
+  // "Upload files to index this base."
+  const basesView = listViewState({ loading: basesLoading, error: basesError, count: bases.length });
+  const documentsView = listViewState({ loading: documentsLoading, error: documentsError, count: documents.length });
 
   useEffect(() => {
     void refreshBases();
@@ -37,12 +47,11 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   useEffect(() => {
     if (!selectedBaseId) {
       setDocuments([]);
+      setDocumentsError(null);
       setResults([]);
       return;
     }
-    void client.listDocuments(workspaceId, selectedBaseId).then(setDocuments).catch((error) => {
-      toast.error("Failed to load documents", { description: String(error) });
-    });
+    void refreshDocuments(selectedBaseId);
   }, [workspaceId, selectedBaseId]);
 
   useEffect(() => {
@@ -56,12 +65,30 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   }, [workspaceId, selectedBaseId, documents]);
 
   async function refreshBases() {
+    setBasesLoading(true);
     try {
       const next = await client.listDocumentBases(workspaceId);
       setBases(next);
+      setBasesError(null);
       setSelectedBaseId((current) => current ?? next[0]?.id ?? null);
     } catch (error) {
+      setBasesError(error instanceof Error ? error : new Error(String(error)));
       toast.error("Failed to load document bases", { description: String(error) });
+    } finally {
+      setBasesLoading(false);
+    }
+  }
+
+  async function refreshDocuments(baseId: string) {
+    setDocumentsLoading(true);
+    try {
+      setDocuments(await client.listDocuments(workspaceId, baseId));
+      setDocumentsError(null);
+    } catch (error) {
+      setDocumentsError(error instanceof Error ? error : new Error(String(error)));
+      toast.error("Failed to load documents", { description: String(error) });
+    } finally {
+      setDocumentsLoading(false);
     }
   }
 
@@ -188,7 +215,14 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
               <div className="text-[11px] text-[color:var(--color-fg-subtle)]">{bases.length}</div>
             </div>
             <div className="space-y-1">
-              {bases.length === 0 ? (
+              {basesView === "loading" ? (
+                <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] p-3 text-xs text-[color:var(--color-fg-muted)]">
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                  Loading bases
+                </div>
+              ) : basesView === "error" ? (
+                <LoadErrorState title="Couldn't load document bases" error={basesError} onRetry={() => void refreshBases()} />
+              ) : basesView === "empty" ? (
                 <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-3 text-xs text-[color:var(--color-fg-muted)]">
                   Create a document base to start.
                 </div>
@@ -254,7 +288,14 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                 </div>
 
                 <div className="mt-4 space-y-2">
-                  {documents.length === 0 ? (
+                  {documentsView === "loading" ? (
+                    <div className="flex items-center justify-center gap-2 rounded-lg border border-[color:var(--color-border)] p-6 text-xs text-[color:var(--color-fg-muted)]">
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                      Loading documents
+                    </div>
+                  ) : documentsView === "error" ? (
+                    <LoadErrorState title="Couldn't load documents" error={documentsError} onRetry={() => selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined} />
+                  ) : documentsView === "empty" ? (
                     <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-6 text-center text-xs text-[color:var(--color-fg-muted)]">
                       Upload files to index this base.
                     </div>

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -17,13 +17,14 @@ import {
 import { useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
-import { EmptyState, PageHeader } from "@/components/common";
+import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
 import { ScheduledTaskRepositoryPicker } from "@/components/repository-picker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppContext } from "@/context";
 import { formatTimestamp } from "@/lib/format";
+import { listViewState } from "@/lib/load-state";
 import {
   agentConfigFromFormState,
   formStateFromScheduledTask,
@@ -41,28 +42,40 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
   const navigate = useNavigate();
   const client = context.client;
   const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | null>(null);
   const [runs, setRuns] = useState<Record<string, ScheduledTaskRun[]>>({});
   const [open, setOpen] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [historyTaskId, setHistoryTaskId] = useState<string | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
   const canAttachOpenGeniTool = context.clientConfig.mcpServers.some((server) => server.id === "opengeni");
+  // Honest list state: the initial fetch renders as loading and a failed load
+  // as an error with retry — never as the "No scheduled tasks." empty state.
+  const tasksView = listViewState({ loading, error: loadError, count: tasks.length });
 
   useEffect(() => {
     void refresh();
   }, [workspaceId]);
 
-  // Handles its own failures (toast) so a post-mutation reload error can
-  // never masquerade as a failed mutation in the callers' catch blocks.
+  // Handles its own failures (error state + toast) so a post-mutation reload
+  // error can never masquerade as a failed mutation in the callers' catch
+  // blocks. The toast still fires because a failed refresh with tasks already
+  // on screen keeps rendering the stale list.
   async function refresh() {
+    setLoading(true);
     try {
       const next = await client.listScheduledTasks(workspaceId);
       setTasks(next);
+      setLoadError(null);
       const entries = await Promise.all(next.slice(0, 12).map(async (task) =>
         [task.id, await client.listScheduledTaskRuns(workspaceId, task.id).catch(() => [] as ScheduledTaskRun[])] as const));
       setRuns(Object.fromEntries(entries));
     } catch (error) {
+      setLoadError(error instanceof Error ? error : new Error(String(error)));
       toast.error("Failed to load scheduled tasks", { description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -182,7 +195,14 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
       ) : null}
 
       <div className="mt-4 grid gap-2">
-        {tasks.length === 0 ? (
+        {tasksView === "loading" ? (
+          <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-4 text-sm text-[color:var(--color-fg-muted)]">
+            <Loader2Icon className="size-4 animate-spin" />
+            Loading scheduled tasks
+          </div>
+        ) : tasksView === "error" ? (
+          <LoadErrorState title="Couldn't load scheduled tasks" error={loadError} onRetry={() => void refresh()} />
+        ) : tasksView === "empty" ? (
           <EmptyState>No scheduled tasks.</EmptyState>
         ) : tasks.map((task) => {
           const taskRuns = runs[task.id] ?? [];

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -44,6 +44,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAppContext } from "@/context";
 import { isTerminalSessionStatus, projectSessionTimeline, summarizeSessionFailure } from "@/lib/events";
+import { isMidTurn } from "@/lib/queue";
 import { buildTools } from "@/lib/session-tools";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
@@ -191,6 +192,14 @@ function SessionChatPane(props: {
     onSent: () => attachments.clear(),
   });
 
+  // Steering needs something to interrupt: when the turn ends, fall back to
+  // the queue default so a stale steer toggle cannot surprise a later send.
+  useEffect(() => {
+    if (!isMidTurn(props.session.status) && composer.mode !== "queue") {
+      composer.setMode("queue");
+    }
+  }, [props.session.status, composer.mode, composer.setMode]);
+
   const renderMessageText = useCallback((text: string, item: AgentMessageItem | UserMessageItem) => {
     if (item.kind === "user-message") {
       return <UserMessageBody workspaceId={props.session.workspaceId} item={item} />;
@@ -272,7 +281,6 @@ function SessionChatPane(props: {
             disabled={terminal}
             showDeliveryMode
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
-            hint={terminal ? `Session is ${props.session.status}.` : undefined}
             placeholder={terminal
               ? `Session is ${props.session.status}.`
               : props.session.status === "failed"

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -9,6 +9,7 @@ import {
   enqueueSessionTurn,
   evaluateGoalContinuation,
   getBillingBalance,
+  getSessionEvent,
   getSessionGoal,
   recordUsageEvent,
   requireSession,
@@ -126,6 +127,12 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
 
   async function pauseGoalForInterrupt(input: PauseGoalForInterruptInput): Promise<void> {
     const { db, bus } = await services();
+    if (input.triggerEventId) {
+      const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
+      if (isSteerInterrupt(trigger)) {
+        return;
+      }
+    }
     await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
   }
 
@@ -136,10 +143,27 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
 }
 
 /**
+ * True when an interrupt's trigger event is a STEER: `user.interrupt` tagged
+ * `reason: "steer"`, sent by `OpenGeniClient.steerMessage`. Steering cancels
+ * the running turn only to deliver the steered message next — it redirects
+ * the work rather than stopping it, so an active goal keeps going. Every
+ * other user interrupt (the stop button, a plain `interrupt()` call) is the
+ * explicit act of stopping and pauses the goal.
+ */
+export function isSteerInterrupt(trigger: { type: string; payload: unknown } | null | undefined): boolean {
+  if (!trigger || trigger.type !== "user.interrupt") {
+    return false;
+  }
+  const payload = trigger.payload;
+  return typeof payload === "object" && payload !== null && (payload as { reason?: unknown }).reason === "steer";
+}
+
+/**
  * A user interrupt is the explicit act of stopping, so it pauses an active
  * goal. Shared by the idle-interrupt activity and `interruptActiveTurn` so the
- * loop never auto-continues a goal the user just stopped. No-op when the
- * session has no goal or it is not active.
+ * loop never auto-continues a goal the user just stopped. Callers gate this
+ * on `isSteerInterrupt` first: steer interrupts must NOT pause the goal.
+ * No-op when the session has no goal or it is not active.
  */
 export async function pauseActiveGoalOnInterrupt(db: Database, bus: EventBus, workspaceId: string, sessionId: string): Promise<void> {
   const goal = await getSessionGoal(db, workspaceId, sessionId);

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -11,7 +11,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { WORKER_DEATH_RESUME_TEXT } from "./agent-turn";
-import { pauseActiveGoalOnInterrupt } from "./goals";
+import { isSteerInterrupt, pauseActiveGoalOnInterrupt } from "./goals";
 import type {
   ActivityServices,
   ClaimNextQueuedTurnInput,
@@ -58,14 +58,19 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
   async function interruptActiveTurn(input: RunAgentTurnInput): Promise<void> {
     const { db, bus } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
+    const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
     // Pause an active goal before the early return below: an interrupt can
     // land after the turn already cleared activeTurnId, and skipping the pause
     // there would let the loop auto-continue the goal the user just stopped.
-    await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
+    // Steer interrupts are the exception: steering cancels the running turn
+    // only to deliver the steered message next — redirection, not a stop —
+    // so the goal loop stays active.
+    if (!isSteerInterrupt(trigger)) {
+      await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
+    }
     if (!session.activeTurnId) {
       return;
     }
-    const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
     await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [
       {
         turnId: session.activeTurnId,

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -78,6 +78,10 @@ export type MaybeContinueGoalResult = {
 export type PauseGoalForInterruptInput = {
   workspaceId: string;
   sessionId: string;
+  // The `user.interrupt` event that triggered the pause, when there is one.
+  // A steer-tagged interrupt (reason "steer") must NOT pause the goal:
+  // steering redirects the work, it does not stop it.
+  triggerEventId?: string;
 };
 
 export type DispatchScheduledTaskRunInput = {

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -89,10 +89,13 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       const seenWakeups = wakeups;
       const woke = await condition(() => interruptedEventId !== null || wakeups !== seenWakeups, "5s");
       if (interruptedEventId) {
+        const idleInterruptEventId = interruptedEventId;
         interruptedEventId = null;
         // An idle interrupt is an explicit stop: pause an active goal before
-        // shutting down so a later wake does not auto-continue it.
-        await activity.pauseGoalForInterrupt({ workspaceId: input.workspaceId, sessionId: input.sessionId });
+        // shutting down so a later wake does not auto-continue it. The
+        // activity inspects the trigger and skips the pause for steer-tagged
+        // interrupts (steering redirects work, it does not stop it).
+        await activity.pauseGoalForInterrupt({ workspaceId: input.workspaceId, sessionId: input.sessionId, triggerEventId: idleInterruptEventId });
         await activity.markSessionIdle({ workspaceId: input.workspaceId, sessionId: input.sessionId });
         return;
       }

--- a/apps/worker/test/goals.test.ts
+++ b/apps/worker/test/goals.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { isSteerInterrupt } from "../src/activities/goals";
+
+// The steer-vs-stop ruling: a `user.interrupt` tagged `reason: "steer"`
+// (sent by OpenGeniClient.steerMessage) redirects the work instead of
+// stopping it, so it must NOT pause an active goal. Everything else — the
+// stop button, a plain interrupt, any other event type — is a stop.
+describe("isSteerInterrupt", () => {
+  test("recognizes a steer-tagged user.interrupt", () => {
+    expect(isSteerInterrupt({ type: "user.interrupt", payload: { reason: "steer" } })).toBe(true);
+  });
+
+  test("a plain stop interrupt is not a steer", () => {
+    expect(isSteerInterrupt({ type: "user.interrupt", payload: {} })).toBe(false);
+    expect(isSteerInterrupt({ type: "user.interrupt", payload: { reason: "stop" } })).toBe(false);
+    expect(isSteerInterrupt({ type: "user.interrupt", payload: null })).toBe(false);
+  });
+
+  test("non-interrupt triggers and missing triggers are never steers", () => {
+    expect(isSteerInterrupt({ type: "user.message", payload: { reason: "steer" } })).toBe(false);
+    expect(isSteerInterrupt(null)).toBe(false);
+    expect(isSteerInterrupt(undefined)).toBe(false);
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -86,7 +86,11 @@ export type SendMessageInput = {
 export type SteerMessageResult = {
   /** The accepted `user.message` event. */
   accepted: SessionEvent;
-  /** The queued turn created for the message, when it could be located. */
+  /**
+   * The turn created for the message, when it could be located — usually
+   * still queued, but already claimed (running/requires_action or even
+   * finished) when the worker picked it up mid-call.
+   */
   turn: SessionTurn | null;
   /** True when the running turn was interrupted to make way for the message. */
   interrupted: boolean;
@@ -283,14 +287,15 @@ export class OpenGeniClient {
    * running turn so the session picks the steer turn up next. On a session
    * that is not running this degrades gracefully to a plain queued message.
    *
-   * The queued turn is located by `triggerEventId` (retried briefly in case
-   * the server is still materializing it). If it cannot be found while other
-   * turns are queued, the interrupt is skipped — stopping the running turn
-   * would otherwise promote someone else's queued work over this message —
-   * and the call degrades to a plain queued send (`interrupted: false`).
-   * The interrupt is also skipped when the session has already claimed the
-   * steer turn itself (the running turn finished mid-call): the message is
-   * being delivered, so interrupting would cancel the steer turn.
+   * The steer turn is located by `triggerEventId` across ALL turns (retried
+   * briefly in case the server is still materializing it) — not just the
+   * queued ones, because the worker can claim the steer turn before it is
+   * ever observed queued, and a claimed steer turn means the message is
+   * already being delivered: interrupting then would cancel the very message
+   * being steered. If the turn cannot be found while other turns are queued,
+   * the interrupt is also skipped — stopping the running turn would otherwise
+   * promote someone else's queued work over this message — and the call
+   * degrades to a plain queued send (`interrupted: false`).
    */
   async steerMessage(
     workspaceId: string,
@@ -308,21 +313,27 @@ export class OpenGeniClient {
       queued = turns
         .filter((turn) => turn.status === "queued")
         .sort((a, b) => a.position - b.position || a.createdAt.localeCompare(b.createdAt));
-      steerTurn = queued.find((turn) => turn.triggerEventId === accepted.id) ?? null;
+      // Match against every turn, whatever its status: a steer turn that is
+      // already running/requires_action (or even finished) was claimed before
+      // this listing — that is delivery, not grounds for an interrupt.
+      steerTurn = turns.find((turn) => turn.triggerEventId === accepted.id) ?? null;
       if (steerTurn) {
         break;
       }
     }
-    if (steerTurn && queued.length > 1) {
+    const steerTurnQueued = steerTurn?.status === "queued";
+    if (steerTurn && steerTurnQueued && queued.length > 1) {
       const front = steerTurn;
       await this.reorderQueuedTurns(workspaceId, sessionId, [
         front.id,
         ...queued.filter((turn) => turn.id !== front.id).map((turn) => turn.id),
       ]);
     }
-    // Without the steer turn at the queue front, an interrupt would hand the
-    // session to whatever else is queued — only safe when nothing else is.
-    const canDeliverNext = steerTurn !== null || queued.length === 0;
+    // Interrupting is only safe when the next claim is provably this message:
+    // either the steer turn sits queued (now at the front), or no turn
+    // materialized yet AND nothing else is queued. A steer turn observed in
+    // any non-queued state was already claimed — skip the interrupt.
+    const canDeliverNext = steerTurnQueued || (steerTurn === null && queued.length === 0);
     const session = await this.getSession(workspaceId, sessionId);
     // If the previously running turn already finished and the session claimed
     // the steer turn itself, interrupting now would cancel the very message

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -215,6 +215,51 @@ describe("OpenGeniClient turn queue", () => {
     expect(requests.filter((request) => request.body?.includes("user.interrupt"))).toHaveLength(1);
   });
 
+  test("steerMessage skips the interrupt when the steer turn was claimed before it was ever seen queued", async () => {
+    const accepted = makeEvent(9, "user.message", { text: "now" });
+    // The worker claimed the steer turn between sendMessage and the first
+    // turns listing: it never appears queued, only running. The queue is
+    // empty and the session reads "running" — interrupting here would cancel
+    // the steered message itself.
+    const claimedSteerTurn = fakeTurn({ id: TURN_B, status: "running", triggerEventId: accepted.id, startedAt: "2026-06-12T00:00:01.000Z" });
+    const { client, requests } = makeClient((request) => {
+      if (request.url.endsWith("/events")) {
+        return jsonResponse(accepted, 202);
+      }
+      if (request.url.endsWith("/turns")) {
+        return jsonResponse([fakeTurn({ id: "done", status: "completed" }), claimedSteerTurn]);
+      }
+      return jsonResponse({ id: SESSION_ID, status: "running", activeTurnId: TURN_B });
+    });
+    const result = await client.steerMessage(WORKSPACE_ID, SESSION_ID, "now");
+    expect(result.turn?.id).toBe(TURN_B);
+    expect(result.turn?.status).toBe("running");
+    expect(result.interrupted).toBe(false);
+    expect(requests.filter((request) => request.body?.includes("user.interrupt"))).toHaveLength(0);
+    expect(requests.filter((request) => request.url.endsWith("/reorder"))).toHaveLength(0);
+  });
+
+  test("steerMessage skips the interrupt when the steer turn already finished mid-call", async () => {
+    const accepted = makeEvent(9, "user.message", { text: "now" });
+    // Fast turn: claimed AND completed before the first listing. The session
+    // is already running someone else's next turn — interrupting would cancel
+    // unrelated work over a message that was fully delivered.
+    const finishedSteerTurn = fakeTurn({ id: TURN_B, status: "completed", triggerEventId: accepted.id, finishedAt: "2026-06-12T00:00:02.000Z" });
+    const { client, requests } = makeClient((request) => {
+      if (request.url.endsWith("/events")) {
+        return jsonResponse(accepted, 202);
+      }
+      if (request.url.endsWith("/turns")) {
+        return jsonResponse([finishedSteerTurn, fakeTurn({ id: TURN_A, status: "running" })]);
+      }
+      return jsonResponse({ id: SESSION_ID, status: "running", activeTurnId: TURN_A });
+    });
+    const result = await client.steerMessage(WORKSPACE_ID, SESSION_ID, "now");
+    expect(result.turn?.id).toBe(TURN_B);
+    expect(result.interrupted).toBe(false);
+    expect(requests.filter((request) => request.body?.includes("user.interrupt"))).toHaveLength(0);
+  });
+
   test("steerMessage does not interrupt an idle session", async () => {
     const accepted = makeEvent(3, "user.message", { text: "later" });
     const steerTurn = fakeTurn({ triggerEventId: accepted.id });

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -542,7 +542,9 @@ describe("Temporal workflow integration", () => {
       await handle.signal("interrupt", "interrupt-event");
       await handle.result();
       expect(order).toEqual(["pause", "idle"]);
-      expect(pauses).toEqual([{ workspaceId: scope.workspaceId, sessionId }]);
+      // The trigger event rides along so the activity can recognize (and
+      // skip pausing for) steer-tagged interrupts.
+      expect(pauses).toEqual([{ workspaceId: scope.workspaceId, sessionId, triggerEventId: "interrupt-event" }]);
     } finally {
       worker.shutdown();
       await run;

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2082,6 +2082,85 @@ describe("worker activities integration", () => {
     })).action).toBe("none");
   });
 
+  test("steer interrupts cancel the active turn without pausing the goal", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "steer me",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await createSessionGoal(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      text: "long objective",
+      createdBy: "api",
+    });
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+    const workflowId = `session-${session.id}`;
+    const [messageTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "steer me" } },
+    ]);
+    await enqueueSessionTurn(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: messageTrigger!.id,
+      temporalWorkflowId: workflowId,
+      source: "user",
+      prompt: "steer me",
+      resources: [],
+      tools: [],
+      model: "scripted-model",
+      reasoningEffort: "low",
+      sandboxBackend: "none",
+      metadata: {},
+    });
+    const claimed = await activities.claimNextQueuedTurn({ workspaceId: grant.workspaceId, sessionId: session.id, workflowId });
+    expect(claimed).not.toBeNull();
+
+    // A steer interrupt (`reason: "steer"`, sent by steerMessage) cancels the
+    // running turn to deliver the steered message next — redirection, not a
+    // stop — so the goal loop must stay active.
+    const [steerEvent] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.interrupt", payload: { reason: "steer" } },
+    ]);
+    await activities.interruptActiveTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: steerEvent!.id,
+      workflowId,
+    });
+    const turns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id);
+    expect(turns.find((turn) => turn.id === claimed!.id)?.status).toBe("cancelled");
+    const goal = await getSessionGoal(dbClient.db, grant.workspaceId, session.id);
+    expect(goal?.status).toBe("active");
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    expect(events.filter((event) => event.type === "goal.paused")).toHaveLength(0);
+    expect(events.filter((event) => event.type === "turn.cancelled")).toHaveLength(1);
+
+    // The idle-path pause activity also recognizes the steer tag.
+    await activities.pauseGoalForInterrupt({ workspaceId: grant.workspaceId, sessionId: session.id, triggerEventId: steerEvent!.id });
+    expect((await getSessionGoal(dbClient.db, grant.workspaceId, session.id))?.status).toBe("active");
+
+    // A plain stop (no steer tag) still pauses the goal.
+    const [stopEvent] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.interrupt", payload: {} },
+    ]);
+    await activities.pauseGoalForInterrupt({ workspaceId: grant.workspaceId, sessionId: session.id, triggerEventId: stopEvent!.id });
+    const paused = await getSessionGoal(dbClient.db, grant.workspaceId, session.id);
+    expect(paused?.status).toBe("paused");
+    expect(paused?.pausedReason).toBe("user_interrupt");
+  });
+
   test("scheduled tasks with goals arm and re-arm session goals on dispatch", async () => {
     const grant = await testGrant(dbClient.db);
     const task = await createOwnedScheduledTask(dbClient.db, grant, {


### PR DESCRIPTION
Round-3 adversarial review findings, fixed at source.

## Finding 1 (major): steerMessage could cancel its own message
When the worker claimed the steer turn before it was ever observed queued (the whole 4-attempt lookup window is ~900ms), the SDK matched the accepted event only against QUEUED turns, saw an empty queue on a running session, and interrupted — cancelling the very message being steered.

`steerMessage` now matches the accepted event's `triggerEventId` against ALL turns. A steer turn observed in any non-queued state (running, requires_action, or already finished) means the message was claimed — delivery, not grounds for an interrupt. The interrupt now only fires when the steer turn provably sits queued at the front, or no turn materialized and nothing else is queued. `SteerMessageResult.turn` returns the claimed turn too, instead of discarding it. New coverage: claimed-before-observed-queued and finished-mid-call cases (`packages/sdk/test/client-coverage.test.ts`).

## Finding 2 (major): steering silently paused an active goal
Every `user.interrupt` unconditionally paused an active goal — including the steer-tagged interrupts `steerMessage` sends. Ruling, pinned by tests: **steering redirects work, it does not stop it.** A steer interrupt (`reason: "steer"`) cancels the running turn only to deliver the steered message next, so the goal loop stays active; the stop button and plain `interrupt()` calls still pause the goal.

- `interruptActiveTurn` inspects the trigger event and skips `pauseActiveGoalOnInterrupt` for steer interrupts (`isSteerInterrupt`, unit-tested).
- The idle-path `pauseGoalForInterrupt` activity now receives the interrupt's `triggerEventId` (optional field, replay-safe) and applies the same rule.
- Both consoles' delivery-mode hints stay honest as written — steering genuinely no longer touches the goal.

Integration test: steer interrupt cancels the active turn, goal stays `active`, no `goal.paused` event; plain stop still pauses with `pausedReason: "user_interrupt"`.

## Finding 3 (major): dishonest empty/loading states on the routes round 2 skipped
All four now use the shared honest state machine (`listViewState` + `LoadErrorState`, error > loading > empty, data on screen survives a failed refresh):
- `schedules.tsx`: loading state during the initial fetch; a failed `listScheduledTasks` renders "Couldn't load scheduled tasks" + retry instead of permanently showing "No scheduled tasks.".
- `capabilities.tsx`: a failed `listCapabilities` renders an error + retry instead of "No capabilities match this filter."; a loaded catalog no longer flickers to the loading box on background refreshes.
- `documents.tsx`: bases and documents each get loading/error/empty states instead of "Create a document base to start." / "Upload files to index this base." on failure.
- `account.tsx` UsageSection: a failed usage read renders "Couldn't load usage" + retry instead of "No usage recorded yet." (`useBillingUsage.error` was previously dropped).

## Minor findings folded in
- Dropped `ConsoleComposer`'s dead `hint` prop: `ChatComposer` renders the hint only without `controlsStart`, which the console always passes, so it could never appear (the placeholder carries the same text).
- The console composer now resets steer → queue when the session leaves running/queued/requires_action (`isMidTurn`, unit-tested), matching the downstream channel idiom so a stale steer toggle cannot surprise a later send.

## Gate
`bun run typecheck`, `bun test` (467 tests), full `bun run test:integration` (all 7 suites, includes the new steer-goal coverage), browser e2e, `bun scripts/check-workspace-billing-static.ts`, `packages/react` build + demo build, `apps/web` build. gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes session interrupt/goal continuation behavior and SDK steer delivery logic—incorrect gating could cancel turns or leave goals running when users expect a stop.
> 
> **Overview**
> Addresses round-3 review findings across **steering**, **goals**, and **console UX**.
> 
> **`steerMessage`** now resolves the steer turn by `triggerEventId` across **all** turn statuses (not only queued). If the turn is already running, waiting on approval, or finished, the client **skips** the interrupt so it cannot cancel the message being steered; reorder and interrupt only run when the steer turn is still queued at the front. Docs and tests cover claimed-before-queued and finished-mid-call races.
> 
> **Steer vs stop for goals:** `user.interrupt` with `reason: "steer"` is treated as redirection, not a stop. **`isSteerInterrupt`** gates **`pauseActiveGoalOnInterrupt`** in **`interruptActiveTurn`** and in idle **`pauseGoalForInterrupt`** (workflow passes **`triggerEventId`**). Plain interrupts still pause active goals.
> 
> **Web console:** Schedules, capabilities, documents, and account usage use **`listViewState`** + **`LoadErrorState`** so failed loads show retry instead of empty copy; existing data stays visible on refresh failure. Session composer resets **steer → queue** when status leaves **`isMidTurn`**; unused **`ConsoleComposer` `hint`** prop removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b9315ae7def7950a9ef5865d600b95011d7f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->