### PR TITLE
First-party MCP tools-list must not cache across permission sets

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -723,7 +723,18 @@ function ensureBuiltInMcpServers(settings: Settings): Settings["mcpServers"] {
       id: "opengeni",
       name: "OpenGeni",
       url: firstPartyMcpUrl,
-      cacheToolsList: true,
+      // The opengeni server's tools/list response is permission-scoped: it
+      // varies by the calling session's delegated grant (e.g. a manager
+      // session sees sessions_*/environment_* tools that a worker session
+      // does not). The OpenAI Agents SDK caches tools/list in a process-global
+      // map keyed only by the MCP server name, which is identical for every
+      // session in the worker process. Caching here would let the first
+      // session to warm the cache dictate what every later session sees,
+      // regardless of permissions. tools/list is a cheap per-turn call, so we
+      // never cache it. (The files server pins allowedTools to a single
+      // permission-invariant tool and docs is already uncached, so both stay
+      // safe to cache / leave as-is.)
+      cacheToolsList: false,
     },
     ...(hasFiles ? [] : [{
       id: "files",

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -253,10 +253,18 @@ describe("sandbox preparation profiles", () => {
     expect(settings.mcpServers.find((server) => server.id === "opengeni")).toMatchObject({
       name: "OpenGeni",
       url: `http://127.0.0.1:${settings.apiPort}/v1/workspaces/{workspaceId}/mcp`,
+      // The opengeni server's tools/list is permission-scoped (varies by the
+      // caller's delegated grant). The Agents SDK caches tools/list in a
+      // process-global map keyed by server name, so caching here would let one
+      // session's grant dictate every later session's tool visibility. Must
+      // stay uncached.
+      cacheToolsList: false,
     });
     expect(settings.mcpServers.find((server) => server.id === "files")).toMatchObject({
       name: "Files",
       url: `http://127.0.0.1:${settings.apiPort}/v1/workspaces/{workspaceId}/mcp`,
+      // Safe to cache: allowedTools pins it to a single tool that every grant
+      // can see, so its effective tool list is permission-invariant.
       allowedTools: ["files_get_download_url"],
     });
     expect(settings.mcpServers.find((server) => server.id === "docs")).toMatchObject({

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent } from "@openai/agents";
+import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
+import { getSettings } from "@opengeni/config";
 import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
@@ -861,6 +862,67 @@ describe("runtime event normalization", () => {
         }],
       }), [{ kind: "mcp", id: "cap-secure" }])).rejects.toThrow();
     } finally {
+      mcp.close();
+    }
+  });
+
+  test("does not bleed the permission-scoped first-party tools-list across sessions", async () => {
+    // The Agents SDK caches tools/list in a process-global map keyed by MCP
+    // server name. The built-in `opengeni` server has the same name for every
+    // session in a worker process, and its tools/list is permission-scoped
+    // (a manager session is granted tools a worker session is not). If that
+    // server were cached, the first session to warm the cache would dictate
+    // every later session's tool visibility regardless of permissions. This
+    // test connects a worker-permission session FIRST (the ordering that
+    // previously poisoned the cache) and then a manager-permission session,
+    // and asserts the manager still sees its grant-only tool.
+    const managerAuthorization = "Bearer manager-grant";
+    const mcp = startTestMcpServer({
+      // Mirror the production first-party server: the manager grant unlocks an
+      // extra tool a worker grant never sees.
+      toolsForAuthorization: (authorization) =>
+        authorization === managerAuthorization ? ["session_create"] : [],
+    });
+
+    // Use the real config default for the opengeni server so a regression that
+    // flips cacheToolsList back to true is caught here too.
+    const opengeniDefault = getSettings().mcpServers.find((server) => server.id === "opengeni");
+    expect(opengeniDefault).toBeDefined();
+
+    const settingsForAuthorization = (authorization: string) => testSettings({
+      mcpServers: [{
+        id: "opengeni",
+        name: opengeniDefault!.name,
+        url: mcp.url,
+        headers: { authorization },
+        cacheToolsList: opengeniDefault!.cacheToolsList,
+      }],
+    });
+
+    const toolNamesFor = async (authorization: string): Promise<string[]> => {
+      const prepared = await prepareAgentTools(settingsForAuthorization(authorization), [{ kind: "mcp", id: "opengeni" }]);
+      try {
+        // Drive the exact code path the agent runner uses (getAllMcpTools),
+        // which is what populates the process-global cache.
+        const tools = await getAllMcpTools({ mcpServers: prepared.mcpServers });
+        return tools.map((tool) => tool.name).sort();
+      } finally {
+        await prepared.close();
+      }
+    };
+
+    // Start from a clean process-global cache: other tests in this process may
+    // have warmed the `opengeni` cache key.
+    await invalidateServerToolsCache("opengeni");
+
+    try {
+      const workerTools = await toolNamesFor("Bearer worker-grant");
+      expect(workerTools).not.toContain("opengeni__session_create");
+
+      const managerTools = await toolNamesFor(managerAuthorization);
+      expect(managerTools).toContain("opengeni__session_create");
+    } finally {
+      await invalidateServerToolsCache("opengeni");
       mcp.close();
     }
   });

--- a/packages/testing/src/mcp.ts
+++ b/packages/testing/src/mcp.ts
@@ -16,6 +16,11 @@ export type TestMcpServer = {
 export function startTestMcpServer(options: {
   requiredAuthorization?: string;
   requiredHeaders?: Record<string, string>;
+  // Permission-scoped tool registration: returns the extra tool names that the
+  // calling request's bearer token is authorized to see, in addition to the
+  // always-present base tools. Mirrors the production first-party MCP server,
+  // whose tools/list response varies by the delegated token's grant.
+  toolsForAuthorization?: (authorization: string | null) => string[];
 } = {}): TestMcpServer {
   const calls: TestMcpToolCall[] = [];
   const server = Bun.serve({
@@ -43,7 +48,10 @@ export function startTestMcpServer(options: {
       const transport = new WebStandardStreamableHTTPServerTransport({
         enableJsonResponse: true,
       });
-      const mcp = buildServer(calls);
+      const scopedTools = options.toolsForAuthorization
+        ? options.toolsForAuthorization(request.headers.get("authorization"))
+        : undefined;
+      const mcp = buildServer(calls, scopedTools);
       await mcp.connect(transport);
       return await transport.handleRequest(request);
     },
@@ -55,7 +63,7 @@ export function startTestMcpServer(options: {
   };
 }
 
-function buildServer(calls: TestMcpToolCall[]): McpServer {
+function buildServer(calls: TestMcpToolCall[], scopedTools?: string[]): McpServer {
   const server = new McpServer({
     name: "test-document-search",
     version: "1.0.0",
@@ -82,5 +90,19 @@ function buildServer(calls: TestMcpToolCall[]): McpServer {
       content: [{ type: "text", text: `document ${id}` }],
     };
   });
+  // Permission-scoped tools, registered only when the caller's grant includes
+  // them. The base tools above are always present, mirroring tools that every
+  // grant can see.
+  for (const toolName of scopedTools ?? []) {
+    server.registerTool(toolName, {
+      description: `Scoped tool ${toolName}.`,
+      inputSchema: {},
+    }, async () => {
+      calls.push({ tool: toolName, args: {} });
+      return {
+        content: [{ type: "text", text: `ran ${toolName}` }],
+      };
+    });
+  }
   return server;
 }


### PR DESCRIPTION
## Root cause

The built-in `opengeni` first-party MCP server is **permission-scoped**: its `tools/list` response varies by the calling session's delegated grant. A manager-style session is authorized for `sessions_*` / `environment_*` orchestration tools that a worker session is not.

The OpenAI Agents SDK (`@openai/agents` 0.11.x) caches `tools/list` in a **process-global** map (`_cachedTools` in `agents-core/dist/mcp.js`) keyed only by the MCP server name (`getMcpToolsFromServer` → `defaultMCPToolCacheKey` → `server.name`). In this codebase the `opengeni` server's name is the constant `"opengeni"` for **every session in a worker process** (`PrefixedMcpServer.name = registryId`). Because a fresh `MCPServerStreamableHttp` is constructed per turn, the per-instance cache provides no cross-turn benefit here, but the **module-level** cache still persists across all sessions in the process.

With `cacheToolsList: true`, the first session to warm the cache for a worker process dictates the tool list every later session sees, regardless of its own permissions and connection order:

1. A worker-default session (no `sessions:*` / `environments:*`) warms `_cachedTools["opengeni"]` with its truncated tool list.
2. A manager session in the same process then reuses that list — its correct delegated token is never even sent for `tools/list` — and silently loses exactly the `session_*` / `environment_*` groups, which is the manager's entire purpose.

This matches the live symptom (manager sees worker-default groups but not manager-only groups) and the intermittency (depends on which session warms the cache first in each worker process). It is also workspace-agnostic — the key is not workspace-scoped — so it can bleed across workspaces too.

Reproduced empirically through the exact `getAllMcpTools` runner path: with `cacheToolsList: true`, a worker-then-manager ordering leaves the manager without its grant-only tool; with `false`, the manager sees it.

## Fix

Set `cacheToolsList: false` for the `opengeni` built-in server. `tools/list` is a cheap per-turn call. The `files` built-in pins `allowedTools` to a single permission-invariant tool (`files_get_download_url`, registered unconditionally on the API side), so its effective list never varies and stays safe to cache; `docs` was already uncached.

## Tests

- **Runtime regression test** drives the real `getAllMcpTools` path: connects a worker-permission session first (the poisoning order), then a manager-permission session, and asserts the manager still sees its grant-only tool. Derives the server's `cacheToolsList` from the actual config default so flipping it back to `true` fails the test. Verified red before the fix, green after.
- **Config assertion** locks the `opengeni` built-in to `cacheToolsList: false` (and documents why `files` is safe to cache).
- Test MCP helper extended to serve a permission-scoped tool list per bearer token, mirroring the production server.

Full local gate green: typecheck (config, runtime, testing) + 465 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent tool visibility for all opengeni MCP sessions (extra per-turn `tools/list` calls) but fixes incorrect authorization behavior; tests lock the behavior.
> 
> **Overview**
> Fixes **cross-session MCP tool bleed** where manager sessions could lose orchestration tools (`session_*`, `environment_*`) after a worker session warmed the Agents SDK’s process-global `tools/list` cache.
> 
> The built-in **`opengeni`** server now sets **`cacheToolsList: false`**, because its `tools/list` varies by delegated grant while the SDK caches by server name only. **`files`** stays cacheable (single pinned tool); **`docs`** was already uncached.
> 
> Adds a **runtime regression test** (worker session first, then manager) via `getAllMcpTools`, config assertions, and **`toolsForAuthorization`** on the test MCP helper to mirror permission-scoped listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab47088bafb44dc35c0e85d85d865baf1d5cb30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->