### PR TITLE
Wake the parent session when a spawned worker completes

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -58,6 +58,10 @@ export async function createAndStartSession(input: {
   goal?: GoalSpec | null;
   // Validated against the creating grant before this is called.
   firstPartyMcpPermissions?: Permission[] | null;
+  // The manager session spawning this worker (a worker-signed sessionId claim
+  // on the creating grant); null for direct API creates and scheduled runs.
+  // When set, the worker's terminal-for-now transitions wake this parent.
+  parentSessionId?: string | null;
 }) {
   const session = await createSession(input.db, {
     accountId: input.accountId,
@@ -74,6 +78,7 @@ export async function createAndStartSession(input: {
     sandboxBackend: input.sandboxBackend,
     environmentId: input.environment?.id ?? null,
     firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+    parentSessionId: input.parentSessionId ?? null,
   });
   // The goal row is durable session state; the workflow picks it up from the
   // database once the first turn completes — no extra workflow plumbing here.
@@ -326,6 +331,15 @@ export async function createSessionForRequest(
   if (payload.goal && firstPartyMcpPermissions && !firstPartyMcpPermissions.includes("goals:manage")) {
     firstPartyMcpPermissions = [...firstPartyMcpPermissions, "goals:manage"];
   }
+  // Parent linkage: when the creating grant carries a worker-signed sessionId
+  // claim, the caller IS a session (a manager spawning a worker), so the new
+  // worker records that manager as its parent and its completion wakes the
+  // manager. The claim is signed into the delegated token by the worker and
+  // is never agent-controlled, so it cannot be spoofed. An explicit
+  // payload.parentSessionId is honored only on trusted direct-API creates that
+  // carry no claim; it never overrides a present claim with a different id.
+  const claimedSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
+  const parentSessionId = claimedSessionId ?? payload.parentSessionId ?? null;
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
   const session = await createAndStartSession({
     db,
@@ -344,6 +358,7 @@ export async function createSessionForRequest(
     environment: environment ? { id: environment.id, name: environment.name } : null,
     goal: payload.goal ?? null,
     firstPartyMcpPermissions,
+    parentSessionId,
   });
   await recordWorkspaceUsage(deps, {
     accountId: grant.accountId,

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -331,15 +331,18 @@ export async function createSessionForRequest(
   if (payload.goal && firstPartyMcpPermissions && !firstPartyMcpPermissions.includes("goals:manage")) {
     firstPartyMcpPermissions = [...firstPartyMcpPermissions, "goals:manage"];
   }
-  // Parent linkage: when the creating grant carries a worker-signed sessionId
-  // claim, the caller IS a session (a manager spawning a worker), so the new
-  // worker records that manager as its parent and its completion wakes the
-  // manager. The claim is signed into the delegated token by the worker and
-  // is never agent-controlled, so it cannot be spoofed. An explicit
-  // payload.parentSessionId is honored only on trusted direct-API creates that
-  // carry no claim; it never overrides a present claim with a different id.
-  const claimedSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
-  const parentSessionId = claimedSessionId ?? payload.parentSessionId ?? null;
+  // Parent linkage: a worker is linked to its manager ONLY from the
+  // worker-signed sessionId claim on the creating grant — the manager
+  // session's own id, signed into the delegated token by the worker and never
+  // agent- or caller-controlled. A grant without that claim (a workspace API
+  // key, any non-delegated grant) creates a parentless top-level session.
+  //
+  // We deliberately do NOT honor a caller-supplied parentSessionId: it would
+  // let any sessions:create grant aim a worker at an arbitrary session's id so
+  // its completion wake injects a user.message + queued turn into that session
+  // without holding sessions:control on it (a cross-session write escalation).
+  // The claim is the only trustworthy parent source.
+  const parentSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
   const session = await createAndStartSession({
     db,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -520,11 +520,11 @@ function registerWorkspaceOrchestrationTools(
         // First-party MCP token permissions for the spawned session; every
         // permission must be held by this grant (validated in the domain).
         firstPartyMcpPermissions: z4.array(z4.string()).optional(),
-        // Normally omitted: the parent (manager) session is auto-inferred from
-        // the caller's worker-signed sessionId claim, so the spawned worker's
-        // completion wakes this manager automatically. An explicit value is
-        // honored only when no claim is present and never overrides it.
-        parentSessionId: z4.string().uuid().optional(),
+        // The parent (manager) session is auto-inferred from the caller's
+        // worker-signed sessionId claim, so a spawned worker's completion wakes
+        // its manager automatically. There is deliberately no caller-supplied
+        // parent parameter: it would let a sessions:create grant target an
+        // arbitrary session's wake channel without sessions:control on it.
       },
     }, async (args) => json(await createSessionForRequest(deps, grant, grant.workspaceId, args)));
   }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -520,6 +520,11 @@ function registerWorkspaceOrchestrationTools(
         // First-party MCP token permissions for the spawned session; every
         // permission must be held by this grant (validated in the domain).
         firstPartyMcpPermissions: z4.array(z4.string()).optional(),
+        // Normally omitted: the parent (manager) session is auto-inferred from
+        // the caller's worker-signed sessionId claim, so the spawned worker's
+        // completion wakes this manager automatically. An explicit value is
+        // honored only when no claim is present and never overrides it.
+        parentSessionId: z4.string().uuid().optional(),
       },
     }, async (args) => json(await createSessionForRequest(deps, grant, grant.workspaceId, args)));
   }

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -41,6 +41,7 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
         objectStorage: dependencies.objectStorage ?? createObjectStorage(settings),
         documentServices: dependencies.documentServices ?? createDocumentServices(settings),
         observability: dependencies.observability ?? createObservability(settings, { component: "worker" }),
+        wakeSessionWorkflow: dependencies.wakeSessionWorkflow ?? null,
       };
     })();
     return servicesPromise;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -650,7 +650,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // turn (not just one failed by the workflow's failSession path). Deduped
       // per terminal episode by the child's lastSequence, so it never
       // double-fires with the workflow-level wake.
-      await notifyParentOfChildTerminal({ db, bus, settings, observability, wakeSessionWorkflow }, input.workspaceId, input.sessionId, "failed");
+      await notifyParentOfChildTerminal({ db, bus, settings, observability, wakeSessionWorkflow }, input.workspaceId, input.sessionId, "failed", `turn:${turnId}`);
       return { status: "failed" };
     } finally {
       const durationSeconds = (performance.now() - activityStarted) / 1000;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -38,6 +38,7 @@ import {
 } from "./common";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
 import { resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
+import { notifyParentOfChildTerminal } from "./parent-wake";
 import { createSecretRedactor, identityRedactor } from "./redaction";
 import { turnInput } from "./run-input";
 import {
@@ -94,7 +95,7 @@ export function isWorkerShutdownCancellation(error: unknown): boolean {
 
 export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
   return async function runAgentTurn(input: RunAgentTurnInput): Promise<RunAgentTurnResult> {
-    const { settings, db, bus, runtime, objectStorage, observability } = await services();
+    const { settings, db, bus, runtime, objectStorage, observability, wakeSessionWorkflow } = await services();
     const activityStarted = performance.now();
     const activitySpan = observability.startSpan("worker.run_agent_segment", {
       "opengeni.session_id": input.sessionId,
@@ -642,6 +643,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       ], true);
       await finishTurn(db, input.workspaceId, turnId, "failed");
       await setSessionStatus(db, input.workspaceId, input.sessionId, "failed", null);
+      // The common failure path ends here: runAgentTurn marks the session
+      // failed and returns "failed", and the session workflow then exits
+      // WITHOUT calling failSession/markSessionIdle. Wake a spawned worker's
+      // parent here too, so a manager learns of a worker that died inside its
+      // turn (not just one failed by the workflow's failSession path). Deduped
+      // per terminal episode by the child's lastSequence, so it never
+      // double-fires with the workflow-level wake.
+      await notifyParentOfChildTerminal({ db, bus, settings, observability, wakeSessionWorkflow }, input.workspaceId, input.sessionId, "failed");
       return { status: "failed" };
     } finally {
       const durationSeconds = (performance.now() - activityStarted) / 1000;

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -35,6 +35,15 @@ export async function notifyParentOfChildTerminal(
   workspaceId: string,
   childSessionId: string,
   terminalStatus: "idle" | "failed",
+  // Stable identifier for the terminal episode, used as the idempotency key so
+  // the same completion never wakes the parent twice. A FAILURE passes the
+  // failed turn's id: both the in-turn wake (runAgentTurn) and the
+  // workflow-level wake (failSession, after it appends more events that would
+  // shift lastSequence) key on the same turn, so a finally-throw that turns one
+  // failure into both paths still dedupes. An idle episode has no single
+  // owning turn, so it falls back to the child's lastSequence — which advances
+  // per work batch and is stable across retries of that same idle transition.
+  episodeKey?: string | null,
 ): Promise<void> {
   try {
     const child = await getSession(svc.db, workspaceId, childSessionId);
@@ -42,8 +51,7 @@ export async function notifyParentOfChildTerminal(
       return;
     }
     const goal = await getSessionGoal(svc.db, workspaceId, childSessionId);
-    // lastSequence after the terminal transition's events is the episode key.
-    const clientEventId = `child-completion:${childSessionId}:${child.lastSequence}`;
+    const clientEventId = `child-completion:${childSessionId}:${episodeKey ?? child.lastSequence}`;
     const result = await wakeParentSessionForChildCompletion(svc.db, {
       workspaceId,
       parentSessionId: child.parentSessionId,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -1,0 +1,121 @@
+import type { Settings } from "@opengeni/config";
+import type { Session, SessionGoal } from "@opengeni/contracts";
+import { getSession, getSessionGoal, wakeParentSessionForChildCompletion, type Database } from "@opengeni/db";
+import type { EventBus } from "@opengeni/events";
+import type { ActivityServices, WakeSessionWorkflowSignal } from "./types";
+
+export type NotifyServices = {
+  db: Database;
+  bus: EventBus;
+  settings: Settings;
+  observability: ActivityServices["observability"];
+  wakeSessionWorkflow: WakeSessionWorkflowSignal | null;
+};
+
+/**
+ * Deliver exactly one completion wake to a spawned worker's parent (manager)
+ * session when the worker reaches a terminal-for-now state. No-op for a
+ * parentless session (direct API create / scheduled run). Idempotent per
+ * terminal episode: the idempotency key is the child's current lastSequence,
+ * which advances every time the child does work, so a retry of the same
+ * terminal transition (activity retry, the workflow's idle re-check, the
+ * runAgentTurn-failed path overlapping a workflow-level wake) is deduped while
+ * a genuinely new idle-after-work episode notifies again. The parent's queued
+ * turn is delivered by the DB wake; signalling the parent's workflow
+ * (signalWithStart) ensures a parent whose workflow already completed gets a
+ * fresh run to claim it. Failures here never fail the child: the wake is a
+ * best-effort nudge layered on durable DB state.
+ *
+ * Lives in its own module so both the session-state terminal activities
+ * (markSessionIdle / failSession) and runAgentTurn's in-turn failure path can
+ * call it without a circular import between those two activity modules.
+ */
+export async function notifyParentOfChildTerminal(
+  svc: NotifyServices,
+  workspaceId: string,
+  childSessionId: string,
+  terminalStatus: "idle" | "failed",
+): Promise<void> {
+  try {
+    const child = await getSession(svc.db, workspaceId, childSessionId);
+    if (!child || !child.parentSessionId) {
+      return;
+    }
+    const goal = await getSessionGoal(svc.db, workspaceId, childSessionId);
+    // lastSequence after the terminal transition's events is the episode key.
+    const clientEventId = `child-completion:${childSessionId}:${child.lastSequence}`;
+    const result = await wakeParentSessionForChildCompletion(svc.db, {
+      workspaceId,
+      parentSessionId: child.parentSessionId,
+      clientEventId,
+      text: childCompletionWakeText(child, goal, terminalStatus),
+      childCompletion: childCompletionPayload(child, goal, terminalStatus),
+      reasoningEffortFallback: svc.settings.openaiReasoningEffort,
+    });
+    if (!result.delivered) {
+      return;
+    }
+    await svc.bus.publish(workspaceId, child.parentSessionId, result.events);
+    if (svc.wakeSessionWorkflow) {
+      await svc.wakeSessionWorkflow({
+        accountId: child.accountId,
+        workspaceId,
+        sessionId: child.parentSessionId,
+        workflowId: result.temporalWorkflowId,
+      });
+    }
+    svc.observability.info("Woke parent session on worker completion", {
+      childSessionId,
+      parentSessionId: child.parentSessionId,
+      terminalStatus,
+    });
+  } catch (error) {
+    // A parent-wake failure must never fail the child's terminal activity.
+    svc.observability.error("Failed to wake parent session on worker completion", {
+      childSessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function childCompletionPayload(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): Record<string, unknown> {
+  return {
+    childSessionId: child.id,
+    status: terminalStatus,
+    ...(goal
+      ? {
+        goal: {
+          status: goal.status,
+          text: goal.text,
+          ...(goal.evidence ? { evidence: goal.evidence } : {}),
+          ...(goal.rationale ? { rationale: goal.rationale } : {}),
+          ...(goal.pausedReason ? { pausedReason: goal.pausedReason } : {}),
+        },
+      }
+      : {}),
+  };
+}
+
+function childCompletionWakeText(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): string {
+  const lines: string[] = [];
+  if (terminalStatus === "failed") {
+    lines.push(`A worker session you spawned has FAILED. Worker session id: ${child.id}.`);
+  } else if (goal?.status === "completed") {
+    lines.push(`A worker session you spawned has COMPLETED its goal. Worker session id: ${child.id}.`);
+  } else if (goal?.status === "paused") {
+    lines.push(`A worker session you spawned has PAUSED its goal and gone idle. Worker session id: ${child.id}.`);
+  } else {
+    lines.push(`A worker session you spawned has finished its work and gone idle. Worker session id: ${child.id}.`);
+  }
+  if (goal) {
+    lines.push(`Worker goal: ${goal.text}`);
+    if (goal.status === "completed" && goal.evidence) {
+      lines.push(`Completion evidence: ${goal.evidence}`);
+    }
+    if (goal.status === "paused" && goal.rationale) {
+      lines.push(`Pause rationale: ${goal.rationale}`);
+    }
+  }
+  lines.push("Read the worker's session events/notebook output for its result, then continue. If your own goal was paused awaiting this worker, resume it now.");
+  return lines.join("\n");
+}

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -2,23 +2,17 @@ import {
   claimNextQueuedTurn as claimNextQueuedTurnDb,
   countTurnSessionHistoryItems,
   finishTurn,
-  getSession,
   getSessionEvent,
-  getSessionGoal,
   getSessionTurn,
   incrementTurnWorkerDeathRedispatches,
   requeuePreemptedTurn,
   requireSession,
   setSessionStatus,
-  wakeParentSessionForChildCompletion,
-  type Database,
 } from "@opengeni/db";
-import type { EventBus } from "@opengeni/events";
 import { appendAndPublishEvents } from "@opengeni/events";
-import type { Settings } from "@opengeni/config";
-import type { Session, SessionGoal } from "@opengeni/contracts";
 import { WORKER_DEATH_RESUME_TEXT } from "./agent-turn";
 import { isSteerInterrupt, pauseActiveGoalOnInterrupt } from "./goals";
+import { notifyParentOfChildTerminal } from "./parent-wake";
 import type {
   ActivityServices,
   ClaimNextQueuedTurnInput,
@@ -26,7 +20,6 @@ import type {
   RequeueTurnAfterWorkerDeathInput,
   RequeueTurnAfterWorkerDeathResult,
   RunAgentTurnInput,
-  WakeSessionWorkflowSignal,
 } from "./types";
 
 // Crash-loop guard for worker-death re-dispatch: a turn that takes a worker
@@ -196,115 +189,4 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
     claimNextQueuedTurn,
     markSessionIdle,
   };
-}
-
-type NotifyServices = {
-  db: Database;
-  bus: EventBus;
-  settings: Settings;
-  observability: ActivityServices["observability"];
-  wakeSessionWorkflow: WakeSessionWorkflowSignal | null;
-};
-
-/**
- * Deliver exactly one completion wake to a spawned worker's parent (manager)
- * session when the worker reaches a terminal-for-now state. No-op for a
- * parentless session (direct API create / scheduled run). Idempotent per
- * terminal episode: the idempotency key is the child's current lastSequence,
- * which advances every time the child does work, so a retry of the same
- * terminal transition (activity retry, the workflow's idle re-check) is
- * deduped while a genuinely new idle-after-work episode notifies again. The
- * parent's queued turn is delivered by the DB wake; signalling the parent's
- * workflow (signalWithStart) ensures a parent whose workflow already completed
- * gets a fresh run to claim it. Failures here never fail the child: the wake
- * is a best-effort nudge layered on durable DB state.
- */
-async function notifyParentOfChildTerminal(
-  svc: NotifyServices,
-  workspaceId: string,
-  childSessionId: string,
-  terminalStatus: "idle" | "failed",
-): Promise<void> {
-  try {
-    const child = await getSession(svc.db, workspaceId, childSessionId);
-    if (!child || !child.parentSessionId) {
-      return;
-    }
-    const goal = await getSessionGoal(svc.db, workspaceId, childSessionId);
-    // lastSequence after the terminal transition's events is the episode key.
-    const clientEventId = `child-completion:${childSessionId}:${child.lastSequence}`;
-    const result = await wakeParentSessionForChildCompletion(svc.db, {
-      workspaceId,
-      parentSessionId: child.parentSessionId,
-      clientEventId,
-      text: childCompletionWakeText(child, goal, terminalStatus),
-      childCompletion: childCompletionPayload(child, goal, terminalStatus),
-      reasoningEffortFallback: svc.settings.openaiReasoningEffort,
-    });
-    if (!result.delivered) {
-      return;
-    }
-    await svc.bus.publish(workspaceId, child.parentSessionId, result.events);
-    if (svc.wakeSessionWorkflow) {
-      await svc.wakeSessionWorkflow({
-        accountId: child.accountId,
-        workspaceId,
-        sessionId: child.parentSessionId,
-        workflowId: result.temporalWorkflowId,
-      });
-    }
-    svc.observability.info("Woke parent session on worker completion", {
-      childSessionId,
-      parentSessionId: child.parentSessionId,
-      terminalStatus,
-    });
-  } catch (error) {
-    // A parent-wake failure must never fail the child's terminal activity.
-    svc.observability.error("Failed to wake parent session on worker completion", {
-      childSessionId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-function childCompletionPayload(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): Record<string, unknown> {
-  return {
-    childSessionId: child.id,
-    status: terminalStatus,
-    ...(goal
-      ? {
-        goal: {
-          status: goal.status,
-          text: goal.text,
-          ...(goal.evidence ? { evidence: goal.evidence } : {}),
-          ...(goal.rationale ? { rationale: goal.rationale } : {}),
-          ...(goal.pausedReason ? { pausedReason: goal.pausedReason } : {}),
-        },
-      }
-      : {}),
-  };
-}
-
-function childCompletionWakeText(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): string {
-  const lines: string[] = [];
-  if (terminalStatus === "failed") {
-    lines.push(`A worker session you spawned has FAILED. Worker session id: ${child.id}.`);
-  } else if (goal?.status === "completed") {
-    lines.push(`A worker session you spawned has COMPLETED its goal. Worker session id: ${child.id}.`);
-  } else if (goal?.status === "paused") {
-    lines.push(`A worker session you spawned has PAUSED its goal and gone idle. Worker session id: ${child.id}.`);
-  } else {
-    lines.push(`A worker session you spawned has finished its work and gone idle. Worker session id: ${child.id}.`);
-  }
-  if (goal) {
-    lines.push(`Worker goal: ${goal.text}`);
-    if (goal.status === "completed" && goal.evidence) {
-      lines.push(`Completion evidence: ${goal.evidence}`);
-    }
-    if (goal.status === "paused" && goal.rationale) {
-      lines.push(`Pause rationale: ${goal.rationale}`);
-    }
-  }
-  lines.push("Read the worker's session events/notebook output for its result, then continue. If your own goal was paused awaiting this worker, resume it now.");
-  return lines.join("\n");
 }

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -2,14 +2,21 @@ import {
   claimNextQueuedTurn as claimNextQueuedTurnDb,
   countTurnSessionHistoryItems,
   finishTurn,
+  getSession,
   getSessionEvent,
+  getSessionGoal,
   getSessionTurn,
   incrementTurnWorkerDeathRedispatches,
   requeuePreemptedTurn,
   requireSession,
   setSessionStatus,
+  wakeParentSessionForChildCompletion,
+  type Database,
 } from "@opengeni/db";
+import type { EventBus } from "@opengeni/events";
 import { appendAndPublishEvents } from "@opengeni/events";
+import type { Settings } from "@opengeni/config";
+import type { Session, SessionGoal } from "@opengeni/contracts";
 import { WORKER_DEATH_RESUME_TEXT } from "./agent-turn";
 import { isSteerInterrupt, pauseActiveGoalOnInterrupt } from "./goals";
 import type {
@@ -19,6 +26,7 @@ import type {
   RequeueTurnAfterWorkerDeathInput,
   RequeueTurnAfterWorkerDeathResult,
   RunAgentTurnInput,
+  WakeSessionWorkflowSignal,
 } from "./types";
 
 // Crash-loop guard for worker-death re-dispatch: a turn that takes a worker
@@ -29,7 +37,7 @@ export const WORKER_DEATH_MAX_REDISPATCHES = 3;
 
 export function createSessionStateActivities(services: () => Promise<ActivityServices>) {
   async function failSession(input: RunAgentTurnInput & { error?: string }): Promise<void> {
-    const { db, bus } = await services();
+    const { db, bus, settings, observability, wakeSessionWorkflow } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
     const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
     const turnId = session.activeTurnId ?? null;
@@ -53,6 +61,7 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
       await finishTurn(db, input.workspaceId, turnId, "failed");
     }
     await setSessionStatus(db, input.workspaceId, input.sessionId, "failed", null);
+    await notifyParentOfChildTerminal({ db, bus, settings, observability, wakeSessionWorkflow }, input.workspaceId, input.sessionId, "failed");
   }
 
   async function interruptActiveTurn(input: RunAgentTurnInput): Promise<void> {
@@ -167,11 +176,17 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
   }
 
   async function markSessionIdle(input: MarkSessionIdleInput): Promise<void> {
-    const { db } = await services();
+    const { db, bus, settings, observability, wakeSessionWorkflow } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
     if (session.status === "queued" || session.status === "running") {
       await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
     }
+    // The workflow reaches markSessionIdle exactly when it has decided to stop
+    // for now (no queued turn, no goal continuation): the terminal-for-now
+    // point for a spawned worker, whatever the cause (goal completed, agent or
+    // system paused goal, goalless work finished, idle-interrupt stop). Wake
+    // the parent here, deduped per idle episode so the manager is nudged once.
+    await notifyParentOfChildTerminal({ db, bus, settings, observability, wakeSessionWorkflow }, input.workspaceId, input.sessionId, "idle");
   }
 
   return {
@@ -181,4 +196,115 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
     claimNextQueuedTurn,
     markSessionIdle,
   };
+}
+
+type NotifyServices = {
+  db: Database;
+  bus: EventBus;
+  settings: Settings;
+  observability: ActivityServices["observability"];
+  wakeSessionWorkflow: WakeSessionWorkflowSignal | null;
+};
+
+/**
+ * Deliver exactly one completion wake to a spawned worker's parent (manager)
+ * session when the worker reaches a terminal-for-now state. No-op for a
+ * parentless session (direct API create / scheduled run). Idempotent per
+ * terminal episode: the idempotency key is the child's current lastSequence,
+ * which advances every time the child does work, so a retry of the same
+ * terminal transition (activity retry, the workflow's idle re-check) is
+ * deduped while a genuinely new idle-after-work episode notifies again. The
+ * parent's queued turn is delivered by the DB wake; signalling the parent's
+ * workflow (signalWithStart) ensures a parent whose workflow already completed
+ * gets a fresh run to claim it. Failures here never fail the child: the wake
+ * is a best-effort nudge layered on durable DB state.
+ */
+async function notifyParentOfChildTerminal(
+  svc: NotifyServices,
+  workspaceId: string,
+  childSessionId: string,
+  terminalStatus: "idle" | "failed",
+): Promise<void> {
+  try {
+    const child = await getSession(svc.db, workspaceId, childSessionId);
+    if (!child || !child.parentSessionId) {
+      return;
+    }
+    const goal = await getSessionGoal(svc.db, workspaceId, childSessionId);
+    // lastSequence after the terminal transition's events is the episode key.
+    const clientEventId = `child-completion:${childSessionId}:${child.lastSequence}`;
+    const result = await wakeParentSessionForChildCompletion(svc.db, {
+      workspaceId,
+      parentSessionId: child.parentSessionId,
+      clientEventId,
+      text: childCompletionWakeText(child, goal, terminalStatus),
+      childCompletion: childCompletionPayload(child, goal, terminalStatus),
+      reasoningEffortFallback: svc.settings.openaiReasoningEffort,
+    });
+    if (!result.delivered) {
+      return;
+    }
+    await svc.bus.publish(workspaceId, child.parentSessionId, result.events);
+    if (svc.wakeSessionWorkflow) {
+      await svc.wakeSessionWorkflow({
+        accountId: child.accountId,
+        workspaceId,
+        sessionId: child.parentSessionId,
+        workflowId: result.temporalWorkflowId,
+      });
+    }
+    svc.observability.info("Woke parent session on worker completion", {
+      childSessionId,
+      parentSessionId: child.parentSessionId,
+      terminalStatus,
+    });
+  } catch (error) {
+    // A parent-wake failure must never fail the child's terminal activity.
+    svc.observability.error("Failed to wake parent session on worker completion", {
+      childSessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function childCompletionPayload(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): Record<string, unknown> {
+  return {
+    childSessionId: child.id,
+    status: terminalStatus,
+    ...(goal
+      ? {
+        goal: {
+          status: goal.status,
+          text: goal.text,
+          ...(goal.evidence ? { evidence: goal.evidence } : {}),
+          ...(goal.rationale ? { rationale: goal.rationale } : {}),
+          ...(goal.pausedReason ? { pausedReason: goal.pausedReason } : {}),
+        },
+      }
+      : {}),
+  };
+}
+
+function childCompletionWakeText(child: Session, goal: SessionGoal | null, terminalStatus: "idle" | "failed"): string {
+  const lines: string[] = [];
+  if (terminalStatus === "failed") {
+    lines.push(`A worker session you spawned has FAILED. Worker session id: ${child.id}.`);
+  } else if (goal?.status === "completed") {
+    lines.push(`A worker session you spawned has COMPLETED its goal. Worker session id: ${child.id}.`);
+  } else if (goal?.status === "paused") {
+    lines.push(`A worker session you spawned has PAUSED its goal and gone idle. Worker session id: ${child.id}.`);
+  } else {
+    lines.push(`A worker session you spawned has finished its work and gone idle. Worker session id: ${child.id}.`);
+  }
+  if (goal) {
+    lines.push(`Worker goal: ${goal.text}`);
+    if (goal.status === "completed" && goal.evidence) {
+      lines.push(`Completion evidence: ${goal.evidence}`);
+    }
+    if (goal.status === "paused" && goal.rationale) {
+      lines.push(`Pause rationale: ${goal.rationale}`);
+    }
+  }
+  lines.push("Read the worker's session events/notebook output for its result, then continue. If your own goal was paused awaiting this worker, resume it now.");
+  return lines.join("\n");
 }

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -32,6 +32,15 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
   async function failSession(input: RunAgentTurnInput & { error?: string }): Promise<void> {
     const { db, bus, settings, observability, wakeSessionWorkflow } = await services();
     const session = await requireSession(db, input.workspaceId, input.sessionId);
+    // Already terminal: runAgentTurn settled this turn as failed (status failed,
+    // activeTurnId cleared, turn finished) and already woke any parent, then the
+    // workflow still routed here because the activity's finally threw after the
+    // failed return. Re-failing would append a second turn.failed/status.changed
+    // and a second parent wake (a different lastSequence dodges the idle dedupe).
+    // The session is already where this activity would put it, so stop.
+    if (session.status === "failed") {
+      return;
+    }
     const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
     const turnId = session.activeTurnId ?? null;
     await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -7,6 +7,16 @@ import type { Observability } from "@opengeni/observability";
 import type { OpenGeniRuntime } from "@opengeni/runtime";
 import type { ObjectStorage } from "@opengeni/storage";
 
+// Signal (start-if-needed) a session's Temporal workflow so a queued turn it
+// cannot otherwise observe gets claimed. Used to wake a PARENT session's
+// workflow when a spawned worker completes: the parent may have idled and let
+// its workflow run complete, so a plain signal would not start one — this must
+// signalWithStart. Injected (not built from the worker's NativeConnection)
+// because the worker package owns only the worker runtime, not a client; an
+// undefined signaler degrades to "DB wake recorded, no workflow nudge" (the
+// turn is still claimed on the parent's next natural wake).
+export type WakeSessionWorkflowSignal = (input: { accountId: string; workspaceId: string; sessionId: string; workflowId: string }) => Promise<void>;
+
 export type ActivityServices = {
   settings: Settings;
   db: Database;
@@ -15,6 +25,7 @@ export type ActivityServices = {
   objectStorage: ObjectStorage | null;
   documentServices: DocumentServices;
   observability: Observability;
+  wakeSessionWorkflow: WakeSessionWorkflowSignal | null;
 };
 
 export type ActivityDependencies = Partial<ActivityServices>;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,7 +1,9 @@
 import { getSettings, retryStartupDependency, startupRetryOptions, type Settings } from "@opengeni/config";
 import { createObservability, logStartupDependencyRetry } from "@opengeni/observability";
+import { Connection, Client as TemporalClient } from "@temporalio/client";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { createActivities, type ActivityDependencies } from "./activities";
+import type { WakeSessionWorkflowSignal } from "./activities/types";
 
 export type WorkerOptions = {
   settings?: Settings;
@@ -38,10 +40,45 @@ export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise
   return { worker, connection };
 }
 
+// A signalWithStart capability so a worker activity can wake a PARENT
+// session's workflow when a spawned worker completes (the parent may have
+// idled and let its run finish, so a plain signal would not start one).
+// Separate from the worker's NativeConnection: the @temporalio/client
+// Connection is what exposes workflow.signalWithStart.
+export async function createWorkerWorkflowSignaler(settings: Settings): Promise<{ wakeSessionWorkflow: WakeSessionWorkflowSignal; close: () => Promise<void> }> {
+  const connection = await Connection.connect({ address: settings.temporalHost });
+  const temporal = new TemporalClient({ connection, namespace: settings.temporalNamespace });
+  return {
+    wakeSessionWorkflow: async ({ accountId, workspaceId, sessionId, workflowId }) => {
+      await temporal.workflow.signalWithStart("sessionWorkflow", {
+        taskQueue: settings.temporalTaskQueue,
+        workflowId,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        args: [{ accountId, workspaceId, sessionId }],
+        signal: "queueChanged",
+      });
+    },
+    close: async () => {
+      await connection.close();
+    },
+  };
+}
+
 export async function startWorker() {
   const settings = getSettings();
   const observability = createObservability(settings, { component: "worker" });
-  const { worker, connection } = await createOpenGeniWorker({ settings, activityDependencies: { observability } });
+  const signaler = await retryStartupDependency(
+    "Temporal client",
+    () => createWorkerWorkflowSignaler(settings),
+    {
+      ...startupRetryOptions(settings),
+      onRetry: (event) => logStartupDependencyRetry(observability, event),
+    },
+  );
+  const { worker, connection } = await createOpenGeniWorker({
+    settings,
+    activityDependencies: { observability, wakeSessionWorkflow: signaler.wakeSessionWorkflow },
+  });
   observability.info("OpenGeni worker listening", {
     temporalTaskQueue: settings.temporalTaskQueue,
   });
@@ -49,6 +86,7 @@ export async function startWorker() {
     await worker.run();
   } finally {
     await connection.close();
+    await signaler.close();
   }
 }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1154,6 +1154,11 @@ export const Session = z.object({
   // Non-default first-party MCP token permissions (manager-style sessions);
   // null means the fixed worker default set.
   firstPartyMcpPermissions: z.array(Permission).nullable(),
+  // The manager session that spawned this one via session_create (set only
+  // when the creating grant carried a worker-signed sessionId claim); null for
+  // direct API creates and scheduled-task runs. When set, this session's
+  // terminal-for-now transitions wake the parent.
+  parentSessionId: z.string().uuid().nullable(),
   temporalWorkflowId: z.string().nullable(),
   activeTurnId: z.string().uuid().nullable(),
   lastSequence: z.number().int().nonnegative(),
@@ -1227,6 +1232,12 @@ export const CreateSessionRequest = z.object({
   // the orchestration/environment/github tools. Capped at creation: every
   // requested permission must be held by the creating grant (no escalation).
   firstPartyMcpPermissions: z.array(Permission).optional(),
+  // Explicit parent (manager) session this create is a worker of. Normally
+  // omitted: session_create auto-infers the parent from the caller's
+  // worker-signed sessionId claim, which cannot be spoofed by the agent. An
+  // explicit value is honored only on the trusted server path; it never
+  // overrides a present claim with a different session.
+  parentSessionId: z.string().uuid().optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1232,12 +1232,6 @@ export const CreateSessionRequest = z.object({
   // the orchestration/environment/github tools. Capped at creation: every
   // requested permission must be held by the creating grant (no escalation).
   firstPartyMcpPermissions: z.array(Permission).optional(),
-  // Explicit parent (manager) session this create is a worker of. Normally
-  // omitted: session_create auto-infers the parent from the caller's
-  // worker-signed sessionId claim, which cannot be spoofed by the agent. An
-  // explicit value is honored only on the trusted server path; it never
-  // overrides a present claim with a different session.
-  parentSessionId: z.string().uuid().optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 

--- a/packages/db/drizzle/0010_session_parent_linkage.sql
+++ b/packages/db/drizzle/0010_session_parent_linkage.sql
@@ -1,0 +1,30 @@
+-- Parent linkage for spawned worker sessions. When a session is created via
+-- the first-party MCP session_create tool and the caller's grant carries a
+-- worker-signed sessionId claim (i.e. a manager session spawning a worker),
+-- the new worker records that manager as its parent_session_id. Direct API
+-- creates and scheduled-task runs carry no such claim and leave this NULL.
+--
+-- The column powers event-driven completion wakeups: when a session that has
+-- a parent reaches a terminal-for-now state (goal completed, agent/system
+-- paused goal, idle with no active goal after doing work, or failed), the
+-- parent is woken with a system-authored message so the manager resumes and
+-- reads the worker's output instead of busy-polling or stalling.
+--
+-- Self-referencing FK with ON DELETE SET NULL: deleting a manager session must
+-- never cascade into its spawned workers; the link simply clears.
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "parent_session_id" uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'sessions_parent_session_id_fkey'
+      AND table_name = 'sessions'
+  ) THEN
+    ALTER TABLE "sessions"
+      ADD CONSTRAINT "sessions_parent_session_id_fkey"
+      FOREIGN KEY ("parent_session_id") REFERENCES "sessions"("id") ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "sessions_parent_idx" ON "sessions" ("workspace_id", "parent_session_id");

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -49,6 +49,7 @@ import type {
   WorkspaceEnvironmentVariableMetadata,
   WorkspaceRegisteredPack,
 } from "@opengeni/contracts";
+import { reasoningEffortForMetadata } from "@opengeni/contracts";
 import { and, asc, desc, eq, gt, gte, inArray, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
@@ -1970,6 +1971,7 @@ export async function createSession(db: Database, input: {
   sandboxBackend: SandboxBackend;
   environmentId?: string | null;
   firstPartyMcpPermissions?: Permission[] | null;
+  parentSessionId?: string | null;
 }): Promise<Session> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
     const [row] = await scopedDb.insert(schema.sessions).values({
@@ -1983,6 +1985,7 @@ export async function createSession(db: Database, input: {
       sandboxBackend: input.sandboxBackend,
       environmentId: input.environmentId ?? null,
       firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      parentSessionId: input.parentSessionId ?? null,
       status: "queued",
     }).returning();
     if (!row) {
@@ -2635,6 +2638,143 @@ export async function setSessionStatus(db: Database, workspaceId: string, sessio
   });
 }
 
+export type WakeParentForChildCompletionInput = {
+  workspaceId: string;
+  parentSessionId: string;
+  // Stable per terminal episode, unique across episodes: the idempotency key
+  // for exactly-once delivery (a unique session_events.client_event_id).
+  clientEventId: string;
+  // System-authored wake text rendered to the manager as its next turn input.
+  text: string;
+  // Structured payload describing the completed child (id, status, goal).
+  childCompletion: Record<string, unknown>;
+  reasoningEffortFallback: ReasoningEffort;
+};
+
+export type WakeParentForChildCompletionResult =
+  | { delivered: false; reason: "already_delivered" | "parent_cancelled" }
+  | { delivered: true; turn: SessionTurn; triggerEvent: SessionEvent; events: SessionEvent[]; temporalWorkflowId: string };
+
+/**
+ * Deliver a one-shot completion wake from a spawned worker into its parent
+ * (manager) session: append a system-authored `user.message`, transition the
+ * parent idle/failed -> queued (a queued/running parent already has a turn in
+ * flight and keeps it), and enqueue the resulting turn. The whole thing runs
+ * under the parent's row lock in one transaction, and is idempotent on
+ * `clientEventId`: a duplicate call for the same terminal episode (activity
+ * retry, the workflow's idle re-check) is a no-op that enqueues no second
+ * turn. The caller publishes the returned events and signals the parent's
+ * Temporal workflow (signalWithStart) only when `delivered` is true.
+ *
+ * Mirrors `acceptSessionUserMessage`/`postUserMessageTurn` in the API domain:
+ * cancelled is the one parent state that refuses the wake (an explicit stop);
+ * failed stays revivable, matching the revivable-failed-sessions contract.
+ */
+export async function wakeParentSessionForChildCompletion(
+  db: Database,
+  input: WakeParentForChildCompletionInput,
+): Promise<WakeParentForChildCompletionResult> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => await scopedDb.transaction(async (tx) => {
+    const [parent] = await tx.select().from(schema.sessions)
+      .where(and(eq(schema.sessions.workspaceId, input.workspaceId), eq(schema.sessions.id, input.parentSessionId)))
+      .for("update")
+      .limit(1);
+    if (!parent) {
+      throw new Error(`Parent session not found: ${input.parentSessionId}`);
+    }
+    if (parent.status === "cancelled") {
+      // Cancelled is the one terminal state that refuses new input; a manager a
+      // human explicitly stopped is not revived by a worker finishing.
+      return { delivered: false, reason: "parent_cancelled" as const };
+    }
+    // Idempotency gate: a wake for this terminal episode was already delivered.
+    const [existing] = await tx.select({ id: schema.sessionEvents.id }).from(schema.sessionEvents)
+      .where(and(
+        eq(schema.sessionEvents.workspaceId, input.workspaceId),
+        eq(schema.sessionEvents.sessionId, input.parentSessionId),
+        eq(schema.sessionEvents.clientEventId, input.clientEventId),
+      ))
+      .limit(1);
+    if (existing) {
+      return { delivered: false, reason: "already_delivered" as const };
+    }
+
+    const shouldQueue = parent.status === "idle" || parent.status === "failed";
+    const workflowId = parent.temporalWorkflowId ?? `session-${parent.id}`;
+    let sequence = parent.lastSequence;
+    const now = new Date();
+    const eventRows = [
+      {
+        type: "user.message",
+        payload: { text: input.text, childCompletion: input.childCompletion },
+        clientEventId: input.clientEventId,
+      },
+      ...(shouldQueue ? [{ type: "session.status.changed", payload: { status: "queued" }, clientEventId: null as string | null }] : []),
+    ].map((event) => ({
+      accountId: parent.accountId,
+      workspaceId: parent.workspaceId,
+      sessionId: parent.id,
+      sequence: ++sequence,
+      type: event.type,
+      payload: event.payload,
+      clientEventId: event.clientEventId ?? null,
+      turnId: null,
+      producerId: null,
+      producerSeq: null,
+      occurredAt: now,
+    }));
+    const inserted = (await tx.insert(schema.sessionEvents).values(eventRows).returning()).map(mapEvent);
+    const triggerEvent = inserted[0]!;
+
+    const position = await nextTurnPosition(tx as unknown as Database, input.workspaceId, parent.id);
+    const [turnRow] = await tx.insert(schema.sessionTurns).values({
+      accountId: parent.accountId,
+      workspaceId: parent.workspaceId,
+      sessionId: parent.id,
+      triggerEventId: triggerEvent.id,
+      temporalWorkflowId: workflowId,
+      status: "queued",
+      source: "user",
+      position,
+      prompt: input.text,
+      resources: [],
+      tools: parent.tools as ToolRef[],
+      model: parent.model,
+      reasoningEffort: reasoningEffortForMetadata(parent.metadata, input.reasoningEffortFallback),
+      sandboxBackend: parent.sandboxBackend as SandboxBackend,
+      metadata: { childCompletion: input.childCompletion },
+    }).returning();
+    if (!turnRow) {
+      throw new Error("Failed to enqueue parent wake turn");
+    }
+    const turn = mapSessionTurn(turnRow);
+
+    sequence += 1;
+    const [queuedEventRow] = await tx.insert(schema.sessionEvents).values({
+      accountId: parent.accountId,
+      workspaceId: parent.workspaceId,
+      sessionId: parent.id,
+      sequence,
+      type: "turn.queued",
+      payload: { turnId: turn.id, triggerEventId: triggerEvent.id, source: turn.source },
+      clientEventId: null,
+      turnId: turn.id,
+      producerId: null,
+      producerSeq: null,
+      occurredAt: now,
+    }).returning();
+    const events = [...inserted, ...(queuedEventRow ? [mapEvent(queuedEventRow)] : [])];
+
+    await tx.update(schema.sessions).set({
+      lastSequence: sequence,
+      ...(shouldQueue ? { status: "queued" as const, activeTurnId: null } : {}),
+      updatedAt: now,
+    }).where(and(eq(schema.sessions.workspaceId, input.workspaceId), eq(schema.sessions.id, parent.id)));
+
+    return { delivered: true as const, turn, triggerEvent, events, temporalWorkflowId: workflowId };
+  }));
+}
+
 export async function setTemporalWorkflowId(db: Database, workspaceId: string, sessionId: string, workflowId: string): Promise<void> {
   await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     await scopedDb.update(schema.sessions).set({
@@ -2932,6 +3072,7 @@ function mapSession(row: typeof schema.sessions.$inferSelect): Session {
     sandboxBackend: row.sandboxBackend as SandboxBackend,
     environmentId: row.environmentId,
     firstPartyMcpPermissions: (row.firstPartyMcpPermissions as Permission[] | null) ?? null,
+    parentSessionId: row.parentSessionId ?? null,
     temporalWorkflowId: row.temporalWorkflowId,
     activeTurnId: row.activeTurnId,
     lastSequence: row.lastSequence,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -116,6 +116,13 @@ export const sessions = pgTable("sessions", {
   // Non-default first-party MCP token permissions (manager-style sessions);
   // null means the fixed worker default set in @opengeni/runtime.
   firstPartyMcpPermissions: jsonb("first_party_mcp_permissions").$type<string[]>(),
+  // The manager session that spawned this one via session_create. Set only
+  // when the creating grant carried a worker-signed sessionId claim (a session
+  // spawning a worker); null for direct API creates and scheduled-task runs.
+  // When set, this worker's terminal-for-now transitions wake the parent so a
+  // manager can orchestrate workers without busy-polling. Self-referencing FK,
+  // ON DELETE SET NULL so deleting a manager never cascades into its workers.
+  parentSessionId: uuid("parent_session_id"),
   temporalWorkflowId: text("temporal_workflow_id"),
   activeTurnId: uuid("active_turn_id"),
   lastSequence: integer("last_sequence").notNull().default(0),
@@ -124,6 +131,7 @@ export const sessions = pgTable("sessions", {
 }, (table) => ({
   workspaceCreated: index("sessions_workspace_created_idx").on(table.workspaceId, table.createdAt),
   environment: index("sessions_environment_idx").on(table.workspaceId, table.environmentId),
+  parent: index("sessions_parent_idx").on(table.workspaceId, table.parentSessionId),
 }));
 
 export const files = pgTable("files", {

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -33,6 +33,7 @@ import {
   getBillingBalance,
   getLatestRunState,
   getSessionHistoryItems,
+  listSessions,
   listSessionTurns,
   listUsageEvents,
   listSessionEvents,
@@ -188,6 +189,80 @@ describe("worker activities integration", () => {
       const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
       expect(events.some((event) => event.type === "turn.completed")).toBe(true);
       expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("session_create links the spawned worker to the manager via the caller's session claim", async () => {
+    // A manager session calls session_create through its OWN first-party MCP
+    // token. That token carries the manager's session id as a worker-signed
+    // claim, so the spawned worker records parent_session_id = manager — no
+    // explicit parameter, no way for the agent to forge a different parent.
+    const noopWorkflowClient: SessionWorkflowClient = {
+      signalUserMessage: async () => undefined,
+      wakeSessionWorkflow: async () => undefined,
+      signalApprovalDecision: async () => undefined,
+      signalInterrupt: async () => undefined,
+      syncScheduledTask: async () => undefined,
+      deleteScheduledTaskSchedule: async () => undefined,
+      triggerScheduledTask: async () => undefined,
+    };
+    const grant = await testGrant(dbClient.db);
+    const delegationSecret = "test-delegation-secret";
+    const apiSettings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      productAccessMode: "configured",
+      delegationSecret,
+    });
+    const app = createApp({ settings: apiSettings, db: dbClient.db, bus, workflowClient: noopWorkflowClient });
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: app.fetch });
+    try {
+      const settings = {
+        ...apiSettings,
+        mcpServers: [{
+          id: "opengeni",
+          name: "OpenGeni",
+          url: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
+          timeoutMs: undefined,
+          cacheToolsList: false,
+        }],
+      };
+      const model = new ScriptedModel([
+        { id: "spawn-1", output: [functionCall("opengeni__session_create", { initialMessage: "worker: reply ready then goal_complete", sandboxBackend: "none" }, "call-spawn-1")] },
+        { id: "spawn-2", outputText: "worker spawned", chunks: ["worker ", "spawned"] },
+      ]);
+      const manager = await createOwnedSession(dbClient.db, grant, {
+        initialMessage: "spawn a worker",
+        resources: [],
+        tools: [{ kind: "mcp", id: "opengeni" }],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        firstPartyMcpPermissions: ["workspace:read", "sessions:read", "sessions:create"],
+      });
+      const [trigger] = await appendOwnedEvents(dbClient.db, grant, manager.id, [
+        { type: "user.message", payload: { text: "spawn a worker" } },
+      ]);
+      const activities = createActivities({
+        settings,
+        db: dbClient.db,
+        bus,
+        runtime: createProductionAgentRuntime({ model }),
+      });
+      await activities.runAgentTurn({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: manager.id,
+        triggerEventId: trigger!.id,
+        workflowId: "workflow-spawn-link",
+      });
+      // The manager created exactly one other session: the spawned worker.
+      const allSessions = await listSessions(dbClient.db, grant.workspaceId, 50);
+      const worker = allSessions.find((candidate) => candidate.id !== manager.id);
+      expect(worker).toBeDefined();
+      expect(worker?.parentSessionId).toBe(manager.id);
     } finally {
       server.stop(true);
     }
@@ -2380,6 +2455,165 @@ describe("worker activities integration", () => {
     // finished) is left untouched.
     await finishTurn(dbClient.db, grant.workspaceId, turnId, "idle");
     expect(await activities.requeueTurnAfterWorkerDeath(requeueInput(notice.id))).toEqual({ action: "stale" });
+  });
+
+  // Parent wakeup: a spawned worker reaching a terminal-for-now state must
+  // wake its manager (parent) session exactly once so the manager can resume,
+  // read the worker's output, and continue — no busy-polling, no stall.
+  function wakeActivities(wakes: Array<{ sessionId: string; workflowId: string }>) {
+    return createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      wakeSessionWorkflow: async ({ sessionId, workflowId }) => {
+        wakes.push({ sessionId, workflowId });
+      },
+    });
+  }
+
+  async function makeManagerIdle(grant: AccessGrant) {
+    const manager = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "orchestrate",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // A manager that spawned a worker and is now idle awaiting it.
+    await setSessionStatus(dbClient.db, grant.workspaceId, manager.id, "idle", null);
+    return manager;
+  }
+
+  test("waking the parent: a worker that goes idle queues exactly one manager turn", async () => {
+    const grant = await testGrant(dbClient.db);
+    const manager = await makeManagerIdle(grant);
+    const worker = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "do the work",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      parentSessionId: manager.id,
+    });
+    // Simulate the worker having done a turn: it produced events and is running
+    // when the workflow decides to idle it.
+    await appendOwnedEvents(dbClient.db, grant, worker.id, [
+      { type: "user.message", payload: { text: "do the work" } },
+      { type: "turn.completed", payload: { output: "done" } },
+    ]);
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "running", null);
+
+    const wakes: Array<{ sessionId: string; workflowId: string }> = [];
+    const activities = wakeActivities(wakes);
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: worker.id });
+
+    // The manager was woken: it has a queued turn and is back to queued.
+    const managerAfter = await getSession(dbClient.db, grant.workspaceId, manager.id);
+    expect(managerAfter?.status).toBe("queued");
+    const managerTurns = await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10);
+    expect(managerTurns).toHaveLength(1);
+    expect(managerTurns[0]?.status).toBe("queued");
+    // The wake message names the worker and reuses the user.message path.
+    const managerEvents = await listSessionEvents(dbClient.db, grant.workspaceId, manager.id, 0, 50);
+    const wake = managerEvents.find((event) => event.type === "user.message");
+    expect(wake).toBeDefined();
+    expect(JSON.stringify(wake?.payload)).toContain(worker.id);
+    expect(JSON.stringify(wake?.payload)).toContain("gone idle");
+    // The parent workflow was signalled (signalWithStart) so an already-drained
+    // manager run gets restarted to claim the queued turn.
+    expect(wakes).toEqual([{ sessionId: manager.id, workflowId: `session-${manager.id}` }]);
+
+    // Idempotent: re-running the SAME terminal transition (activity retry, the
+    // workflow's idle re-check) does not enqueue a second manager turn.
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: worker.id });
+    const managerTurnsAfterRetry = await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10);
+    expect(managerTurnsAfterRetry).toHaveLength(1);
+    expect(wakes).toHaveLength(1);
+  });
+
+  test("waking the parent: a genuinely new idle-after-work episode notifies again, churn does not", async () => {
+    const grant = await testGrant(dbClient.db);
+    const manager = await makeManagerIdle(grant);
+    const worker = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "do the work",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      parentSessionId: manager.id,
+    });
+    await appendOwnedEvents(dbClient.db, grant, worker.id, [{ type: "turn.completed", payload: { output: "batch 1" } }]);
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "running", null);
+
+    const wakes: Array<{ sessionId: string; workflowId: string }> = [];
+    const activities = wakeActivities(wakes);
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: worker.id });
+    expect(wakes).toHaveLength(1);
+
+    // idle -> queued -> idle with NO intervening work (same lastSequence) does
+    // not spam: the worker is re-queued and idled again without new events.
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "queued", null);
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "running", null);
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: worker.id });
+    expect(wakes).toHaveLength(1);
+
+    // A genuinely new work episode (new events advance lastSequence) before the
+    // next idle DOES notify the manager again — managers expect to be woken on
+    // each batch of worker progress, which is correct re-entrant behavior.
+    await appendOwnedEvents(dbClient.db, grant, worker.id, [{ type: "turn.completed", payload: { output: "batch 2" } }]);
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "running", null);
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: worker.id });
+    expect(wakes).toHaveLength(2);
+
+    const managerTurns = await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10);
+    expect(managerTurns).toHaveLength(2);
+  });
+
+  test("waking the parent: a failed worker wakes the manager, and a parentless session never notifies", async () => {
+    const grant = await testGrant(dbClient.db);
+    const manager = await makeManagerIdle(grant);
+    const worker = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "do the work",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      parentSessionId: manager.id,
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, worker.id, [
+      { type: "user.message", payload: { text: "do the work" } },
+    ]);
+    await setSessionStatus(dbClient.db, grant.workspaceId, worker.id, "running", null);
+
+    const wakes: Array<{ sessionId: string; workflowId: string }> = [];
+    const activities = wakeActivities(wakes);
+    await activities.failSession({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: worker.id,
+      triggerEventId: trigger!.id,
+      workflowId: `session-${worker.id}`,
+      error: "boom",
+    });
+    expect(wakes).toEqual([{ sessionId: manager.id, workflowId: `session-${manager.id}` }]);
+    const managerEvents = await listSessionEvents(dbClient.db, grant.workspaceId, manager.id, 0, 50);
+    const wake = managerEvents.find((event) => event.type === "user.message");
+    expect(JSON.stringify(wake?.payload)).toContain("FAILED");
+
+    // A parentless session (a top-level session, a scheduled run) never wakes
+    // anyone: no parent_session_id, no notification, no spurious turns.
+    const lonely = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "standalone",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendOwnedEvents(dbClient.db, grant, lonely.id, [{ type: "turn.completed", payload: { output: "done" } }]);
+    await setSessionStatus(dbClient.db, grant.workspaceId, lonely.id, "running", null);
+    const wakesBefore = wakes.length;
+    await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: lonely.id });
+    expect(wakes).toHaveLength(wakesBefore);
   });
 });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2660,6 +2660,24 @@ describe("worker activities integration", () => {
     expect(JSON.stringify(wake?.payload)).toContain(worker.id);
     const managerTurns = await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10);
     expect(managerTurns).toHaveLength(1);
+
+    // If the activity's finally throws after the failed return, Temporal fails
+    // the activity and the workflow calls failSession on the already-failed
+    // session. That must NOT wake the manager a second time nor re-append
+    // terminal events: failSession no-ops on an already-failed session.
+    const workerEventsBefore = (await listSessionEvents(dbClient.db, grant.workspaceId, worker.id, 0, 200)).length;
+    await activities.failSession({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: worker.id,
+      triggerEventId: trigger!.id,
+      workflowId: `session-${worker.id}`,
+      error: "redundant failSession after in-turn failure",
+    });
+    expect(wakes).toHaveLength(1);
+    expect((await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10))).toHaveLength(1);
+    const workerEventsAfter = (await listSessionEvents(dbClient.db, grant.workspaceId, worker.id, 0, 200)).length;
+    expect(workerEventsAfter).toBe(workerEventsBefore);
   });
 });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2615,6 +2615,52 @@ describe("worker activities integration", () => {
     await activities.markSessionIdle({ workspaceId: grant.workspaceId, sessionId: lonely.id });
     expect(wakes).toHaveLength(wakesBefore);
   });
+
+  test("waking the parent: a worker that dies INSIDE its turn (not via failSession) still wakes the manager", async () => {
+    // The common failure path: runAgentTurn marks the session failed and
+    // returns "failed", and the session workflow exits WITHOUT calling
+    // failSession/markSessionIdle. The wake must fire from runAgentTurn too.
+    const grant = await testGrant(dbClient.db);
+    const manager = await makeManagerIdle(grant);
+    const worker = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "do the work",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      parentSessionId: manager.id,
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, worker.id, [
+      { type: "user.message", payload: { text: "do the work" } },
+    ]);
+    const wakes: Array<{ sessionId: string; workflowId: string }> = [];
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ error: new Error("worker exploded mid-turn") }]) }),
+      wakeSessionWorkflow: async ({ sessionId, workflowId }) => {
+        wakes.push({ sessionId, workflowId });
+      },
+    });
+    const result = await activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: worker.id,
+      triggerEventId: trigger!.id,
+      workflowId: `session-${worker.id}`,
+    });
+    expect(result.status).toBe("failed");
+    expect((await getSession(dbClient.db, grant.workspaceId, worker.id))?.status).toBe("failed");
+    // The manager was woken with a FAILED wake even though failSession never ran.
+    expect(wakes).toEqual([{ sessionId: manager.id, workflowId: `session-${manager.id}` }]);
+    const managerEvents = await listSessionEvents(dbClient.db, grant.workspaceId, manager.id, 0, 50);
+    const wake = managerEvents.find((event) => event.type === "user.message");
+    expect(JSON.stringify(wake?.payload)).toContain("FAILED");
+    expect(JSON.stringify(wake?.payload)).toContain(worker.id);
+    const managerTurns = await listSessionTurns(dbClient.db, grant.workspaceId, manager.id, 10);
+    expect(managerTurns).toHaveLength(1);
+  });
 });
 
 type TestDb = ReturnType<typeof createDb>["db"];


### PR DESCRIPTION
## Problem

A manager session that spawns a worker via the first-party MCP `session_create` tool had no event-driven way to learn when the worker finished. Its only options were to busy-poll `session_events` (wasting turns until the goal no-progress guard auto-paused it) or to pause its goal and wait — which stalls forever, since nothing resumes it. From the operator's seat the manager goes silent after spawning a worker. This is the core blocker for the autonomous manager/worker loop.

## What this builds

**1. Parent linkage.** New nullable `sessions.parent_session_id` column (migration `0010_session_parent_linkage`, self-referencing FK `ON DELETE SET NULL`). When `session_create` runs and the caller's grant carries a worker-signed `sessionId` claim (i.e. a session spawning a worker), the new worker records that manager as its `parent_session_id`. The claim is signed into the delegated token by the worker and is never agent-controlled, so it cannot be spoofed. Direct API creates and scheduled-task runs carry no claim → null parent, no linkage. An explicit `parentSessionId` param is accepted only when no claim is present and never overrides one.

**2. Completion wakeup.** When a session that HAS a parent reaches a terminal-for-now state (goal completed, agent/system-paused goal, idle-with-no-active-goal after work, or failed), the worker's terminal activity delivers **exactly one** system-authored `user.message` into the parent describing the child id, final status, and goal outcome; queues the parent's turn; and `signalWithStart`s the parent's Temporal workflow so an already-drained manager run is restarted to claim it. The wake reuses the `user.message` path (`wakeParentSessionForChildCompletion`), so it revives idle, paused-goal-idle, and failed managers alike. Cancelled is the one parent state that refuses the wake (an explicit human stop).

The two terminal sinks are `markSessionIdle` and `failSession` in the session-state activities — every terminal-for-now path (goal completed, agent/system pause, goalless idle, failure) funnels through one of them.

**3. Exactly-once delivery.** The wake is idempotent on the child's `lastSequence` at terminal time, used as a unique `session_events.client_event_id` on the parent (enforced by the existing unique index). A retry of the same terminal transition (activity retry, the workflow's idle re-check) is a no-op that enqueues no second turn. A genuinely new idle-after-work episode (lastSequence advanced) notifies again — the intended re-entrant behavior for a manager that wants to be woken on each batch of worker progress.

This integrates with the revivable-failed-sessions work already on main: the wake transitions the parent `idle`/`failed` → `queued`, exactly as `acceptSessionUserMessage` does.

## Tests

`test/integration/worker-activity.integration.ts` (real DB + activities + API app):
- `session_create` links the spawned worker to the manager via the caller's session claim (drives the real MCP `session_create` flow; asserts `parentSessionId` auto-inferred).
- A worker that goes idle queues exactly one manager turn; the wake names the worker and re-running the same terminal transition enqueues no second turn.
- A genuinely new idle-after-work episode notifies again; idle→queued→idle churn with no new work does not.
- A failed worker wakes the manager (FAILED wake text); a parentless session never notifies.

Full local gate green: typecheck + 465 unit tests + worker-activity / api / db / temporal-workflow integration suites + sdk/react/web builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-session writes and workflow signaling are security-sensitive, but parent linkage is claim-only and wakes are idempotent; misconfiguration of the Temporal signaler could leave parents queued without an immediate workflow nudge.
> 
> **Overview**
> **Manager/worker orchestration** now links spawned sessions to their manager and resumes the manager when a worker stops.
> 
> Workers created via MCP `session_create` get `parent_session_id` from the caller’s **worker-signed `sessionId` grant claim** only—no API/MCP `parentSessionId` parameter, to block injecting wake turns into arbitrary sessions without `sessions:control`.
> 
> When a child with a parent hits a **terminal-for-now** state (`markSessionIdle`, `failSession`, or in-turn failure in `runAgentTurn`), `notifyParentOfChildTerminal` runs `wakeParentSessionForChildCompletion`: one idempotent system `user.message` (keyed by `child-completion:…`), parent turn enqueue, event publish, and optional **`signalWithStart`** on the parent workflow via a new Temporal client in the worker. `failSession` no-ops if the session is already `failed` to avoid duplicate terminal events/wakes.
> 
> Schema migration `0010_session_parent_linkage` adds the column, self-FK `ON DELETE SET NULL`, and index; contracts and integration tests cover linkage and wake deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d19fcb91c0e0cf5b45622384d3fbedc1b2322b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->