### PR TITLE
Sanitize replayed history and stop persisting orphaned tool outputs

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -26,6 +26,7 @@ import {
   maxTurnsExceededRunState,
   modelResponseUsageFromSdkEvent,
   normalizeSdkEvent,
+  sanitizeHistoryItemsForModel,
   type SandboxFileDownload,
   type OpenGeniRuntime,
 } from "@opengeni/runtime";
@@ -93,6 +94,45 @@ export function isWorkerShutdownCancellation(error: unknown): boolean {
   return error instanceof CancelledFailure && error.message === "WORKER_SHUTDOWN";
 }
 
+/**
+ * Compute the conversation-truth rows a reconcile pass should append, given the
+ * SDK's current `state.history` and the count already persisted.
+ *
+ * `state.history` is a computed getter that runs the SDK's orphan-tool-call
+ * pruning on every access, so it is non-monotonic: a `function_call` with no
+ * settling result yet is transiently absent and a later access yields a
+ * different, possibly shorter/reordered list. The old code sliced this list by
+ * a blind length watermark and appended at fixed positions with
+ * onConflictDoNothing, which could freeze a position with one shape and later
+ * persist a `function_call_result` whose `function_call` had been pruned away in
+ * an earlier slice — the orphaned tool output that 400s the Responses API and
+ * bricks the session on every replay.
+ *
+ * Defending: sanitize the full current history into an API-valid sequence (the
+ * same pure rules the read path uses), then append only the new tail beyond the
+ * watermark. A trailing dangling call is dropped here and re-evaluated next
+ * pass once its result lands, so a call and its result are written together at
+ * consecutive positions and a result is never persisted without its call. The
+ * watermark advances to the sanitized length — never past anything unwritten —
+ * so a non-monotonic history can never desync it. When previously-persisted
+ * rows already exceed the sanitized length (e.g. legacy orphans written before
+ * this fix), nothing new is appended and the watermark holds steady.
+ */
+export function historyRowsToAppend(
+  rawHistory: Array<Record<string, unknown>>,
+  persistedHistoryCount: number,
+): { rows: Array<{ position: number; item: Record<string, unknown> }>; nextWatermark: number } {
+  const sanitized = sanitizeHistoryItemsForModel(rawHistory);
+  if (sanitized.length <= persistedHistoryCount) {
+    return { rows: [], nextWatermark: persistedHistoryCount };
+  }
+  const rows = sanitized.slice(persistedHistoryCount).map((item, offset) => ({
+    position: persistedHistoryCount + offset,
+    item: item as Record<string, unknown>,
+  }));
+  return { rows, nextWatermark: sanitized.length };
+}
+
 export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
   return async function runAgentTurn(input: RunAgentTurnInput): Promise<RunAgentTurnResult> {
     const { settings, db, bus, runtime, objectStorage, observability, wakeSessionWorkflow } = await services();
@@ -113,9 +153,26 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>> | undefined;
     // Dual-write of conversation truth (issue #35): completed items are
     // reconciled into session_history_items after every model response and at
-    // every turn-end path (idempotent on position, watermark-sliced), and the
-    // sandbox recovery envelope is upserted alongside. Best-effort by design:
-    // persistence problems must never fail the run.
+    // every turn-end path (idempotent on position), and the sandbox recovery
+    // envelope is upserted alongside. Best-effort by design: persistence
+    // problems must never fail the run.
+    //
+    // Orphaned-tool-output guard: `stream.state.history` is NOT a plain
+    // append-only array — it is a computed getter
+    // (`getTurnInput(originalInput, generatedItems)`) that runs the SDK's
+    // `dropOrphanToolCalls` on every access, so a `function_call` with no
+    // settling result yet is transiently ABSENT from history and a later
+    // reconcile sees a DIFFERENT, shorter/reordered list. A blind length
+    // watermark with onConflictDoNothing-on-position then freezes the first
+    // shape of a position and can persist a `function_call_result` at a tail
+    // position while its `function_call` was pruned away in an earlier slice
+    // and never written — the orphan that bricks the session. We defend against
+    // it by sanitizing the current history into an API-valid sequence (the same
+    // pure function the read path uses) before persisting: a dangling call is
+    // never persisted (it is deferred until its result exists, when the pair is
+    // written together at consecutive positions), and a result is never
+    // persisted without its preceding call. The watermark counts only items we
+    // actually persisted, so a non-monotonic history can never desync it.
     let persistedHistoryCount = 0;
     let historyCountAtTurnStart = 0;
     const reconcileConversationTruth = async () => {
@@ -123,20 +180,22 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         return;
       }
       try {
-        const history = (stream.state as { history?: unknown[] }).history;
-        if (Array.isArray(history) && history.length > persistedHistoryCount) {
-          const rows = history.slice(persistedHistoryCount).map((item, offset) => ({
-            position: persistedHistoryCount + offset,
-            item: item as Record<string, unknown>,
-          }));
-          await appendSessionHistoryItems(db, {
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            sessionId: input.sessionId,
-            turnId,
-            items: rows,
-          });
-          persistedHistoryCount = history.length;
+        const rawHistory = (stream.state as { history?: unknown[] }).history;
+        if (Array.isArray(rawHistory)) {
+          const { rows, nextWatermark } = historyRowsToAppend(
+            rawHistory as Array<Record<string, unknown>>,
+            persistedHistoryCount,
+          );
+          if (rows.length > 0) {
+            await appendSessionHistoryItems(db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId,
+              items: rows,
+            });
+          }
+          persistedHistoryCount = nextWatermark;
         }
         const envelope = sandboxStateEntryFromRunState(stream.state);
         if (envelope) {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,6 +1,107 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
-import { isWorkerShutdownCancellation, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { historyRowsToAppend, isWorkerShutdownCancellation, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+
+// Item shapes mirror the SDK history representation persisted into
+// session_history_items (type discriminator, camelCase callId).
+function userMessage(text: string) {
+  return { type: "message", role: "user", content: text };
+}
+function functionCall(callId: string) {
+  return { type: "function_call", callId, name: "tool", arguments: "{}", status: "completed" };
+}
+function functionResult(callId: string) {
+  return { type: "function_call_result", callId, status: "completed", output: { type: "text", text: "ok" } };
+}
+
+/**
+ * Drive a sequence of reconcile passes the way the live worker does: each
+ * element is the SDK's computed `state.history` at one reconcile point, and the
+ * watermark carries forward. Returns every row that would have been persisted,
+ * in position order, after onConflictDoNothing-on-position is applied (a
+ * position is frozen by the first row written to it).
+ */
+function persistAcrossReconciles(snapshots: Array<Array<Record<string, unknown>>>) {
+  const persistedByPosition = new Map<number, Record<string, unknown>>();
+  let watermark = 0;
+  for (const snapshot of snapshots) {
+    const { rows, nextWatermark } = historyRowsToAppend(snapshot, watermark);
+    for (const row of rows) {
+      if (!persistedByPosition.has(row.position)) {
+        persistedByPosition.set(row.position, row.item);
+      }
+    }
+    watermark = nextWatermark;
+  }
+  return [...persistedByPosition.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, item]) => item);
+}
+
+describe("conversation-truth reconcile (orphaned tool output guard)", () => {
+  test("never persists a function_call_result whose function_call was pruned mid-batch", () => {
+    // Reproduces the live orphan: a parallel tool-call batch where the SDK's
+    // computed history is non-monotonic across reconciles, then an abnormal
+    // turn end (goal-pause / interrupt) settles only part of the batch. The old
+    // blind length watermark could freeze a position and later persist a result
+    // whose call had been pruned away in an earlier slice.
+    //
+    // Snapshot 1: model emitted two parallel calls; neither has a result yet,
+    // so the SDK's dropOrphanToolCalls prunes BOTH from state.history.
+    const snap1 = [userMessage("do A and B")];
+    // Snapshot 2: tool A settled; A's call+result are now present, B still
+    // pending and pruned. History grew but at DIFFERENT positions than a naive
+    // append-only view assumed.
+    const snap2 = [userMessage("do A and B"), functionCall("call_a"), functionResult("call_a")];
+    // Snapshot 3 (abnormal end): the goal paused; B was cancelled mid-batch and
+    // never produced a result, so B stays pruned. Final history is A's settled
+    // pair only.
+    const snap3 = [userMessage("do A and B"), functionCall("call_a"), functionResult("call_a")];
+
+    const persisted = persistAcrossReconciles([snap1, snap2, snap3]);
+
+    // Every persisted result has its call earlier in the persisted rows.
+    const callIds = new Set(
+      persisted.filter((item) => item.type === "function_call").map((item) => item.callId),
+    );
+    for (const item of persisted) {
+      if (item.type === "function_call_result") {
+        expect(callIds.has(item.callId)).toBe(true);
+      }
+    }
+    // No trace of the cancelled call B leaked through (neither orphaned result
+    // nor dangling call).
+    expect(persisted.some((item) => item.callId === "call_b")).toBe(false);
+    // The settled A pair is intact and ordered.
+    expect(persisted).toEqual([userMessage("do A and B"), functionCall("call_a"), functionResult("call_a")]);
+  });
+
+  test("defers a dangling call until its result lands, then persists the pair together", () => {
+    // A trailing call with no result yet must NOT be persisted alone (it would
+    // dangle and 400). It is deferred and the next reconcile writes call+result.
+    const snapWithDanglingCall = [userMessage("go"), functionCall("call_x")];
+    // The SDK prunes the dangling call, so the reconcile persists only the user
+    // message and the watermark stays at 1.
+    const first = historyRowsToAppend(snapWithDanglingCall, 0);
+    expect(first.rows.map((row) => row.item)).toEqual([userMessage("go")]);
+    expect(first.nextWatermark).toBe(1);
+    // Next reconcile: the result arrived; call and result persist together.
+    const snapSettled = [userMessage("go"), functionCall("call_x"), functionResult("call_x")];
+    const second = historyRowsToAppend(snapSettled, first.nextWatermark);
+    expect(second.rows.map((row) => row.item)).toEqual([functionCall("call_x"), functionResult("call_x")]);
+    expect(second.nextWatermark).toBe(3);
+  });
+
+  test("holds steady when prior rows already exceed the sanitized length (legacy orphans)", () => {
+    // A session already carrying orphan rows from before the fix: the watermark
+    // (DB row count) can exceed the sanitized history length. Nothing new is
+    // appended and the watermark does not move backward or rewrite rows.
+    const sanitizedShorter = [userMessage("hi")];
+    const result = historyRowsToAppend(sanitizedShorter, 5);
+    expect(result.rows).toEqual([]);
+    expect(result.nextWatermark).toBe(5);
+  });
+});
 
 describe("worker shutdown preemption", () => {
   test("classifies only WORKER_SHUTDOWN cancellations as graceful preemption", () => {

--- a/packages/runtime/src/history-sanitizer.ts
+++ b/packages/runtime/src/history-sanitizer.ts
@@ -1,0 +1,203 @@
+/**
+ * Read-path sanitizer for replayed conversation history (issue: orphaned
+ * tool outputs brick a session).
+ *
+ * Conversation truth is persisted as a flat list of SDK history items in
+ * `session_history_items` and replayed verbatim into the model on every turn.
+ * The OpenAI Responses API rejects the whole request (HTTP 400) when that list
+ * violates its tool-call pairing rules — most destructively:
+ *
+ *   `400 No tool call found for function call output with call_id <X>`
+ *
+ * when a `function_call_result` (a.k.a. function_call_output) has no matching
+ * `function_call` earlier in the list. Because the corrupt item is replayed on
+ * every subsequent turn, one orphaned output permanently bricks the session
+ * across revival — it stays dead until the row is hand-deleted.
+ *
+ * This module is the reliability net: before history items are sent to the
+ * model they pass through `sanitizeHistoryItemsForModel`, which removes any
+ * item that would make the request invalid. It mirrors the SDK's own
+ * `dropOrphanToolCalls` continuation logic (which only runs over the SDK's
+ * in-memory `state.history`, not over rows we reload from the database) so a
+ * reloaded history is shaped exactly like a freshly-generated one.
+ *
+ * It is a pure function over plain JSON item shapes (no SDK import, no I/O) so
+ * it is cheap to unit-test exhaustively. It NEVER mutates its input items and
+ * NEVER touches the stored rows — only the in-memory copy sent to the model is
+ * filtered, keeping the persisted audit trail intact.
+ */
+
+/** A history item is any JSON object; we only inspect a few discriminator fields. */
+export type HistoryItem = Record<string, unknown>;
+
+/**
+ * Tool-call item types and the result-item type that settles them. Kept in
+ * sync with the SDK's `TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE`; `function_call` is
+ * the one observed live, the rest are included so the same pairing logic holds
+ * for every tool-call kind the SDK can emit.
+ */
+const RESULT_TYPE_BY_CALL_TYPE: Record<string, string> = {
+  function_call: "function_call_result",
+  computer_call: "computer_call_result",
+  shell_call: "shell_call_output",
+  apply_patch_call: "apply_patch_call_output",
+};
+
+const RESULT_TYPES = new Set(Object.values(RESULT_TYPE_BY_CALL_TYPE));
+
+function itemType(item: unknown): string | undefined {
+  if (!item || typeof item !== "object") {
+    return undefined;
+  }
+  const type = (item as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+/**
+ * Correlation id for a tool call / result. The SDK's canonical history shape
+ * uses camelCase `callId`; the raw Responses wire shape uses snake_case
+ * `call_id`. Persisted rows are the SDK shape, but we accept either so a row
+ * written by any code path (or hand-repaired) still correlates.
+ */
+function callIdOf(item: unknown): string | undefined {
+  if (!item || typeof item !== "object") {
+    return undefined;
+  }
+  const record = item as { callId?: unknown; call_id?: unknown };
+  if (typeof record.callId === "string") {
+    return record.callId;
+  }
+  if (typeof record.call_id === "string") {
+    return record.call_id;
+  }
+  return undefined;
+}
+
+/**
+ * Sanitize a replayed history item list into a sequence the Responses API
+ * accepts. Pure: returns a new array of the same item references in order,
+ * with invalid items omitted. Valid histories come back byte-identical
+ * (same references, same order).
+ *
+ * Rules, each motivated by a concrete 400 the API raises:
+ *
+ *  1. Drop every tool-call RESULT whose matching tool CALL does not appear
+ *     earlier in the list. This is the session-bricking orphan: a
+ *     `function_call_result` with no preceding `function_call` of the same
+ *     `call_id`. ("No tool call found for function call output…")
+ *
+ *  2. Drop every tool CALL that has no matching RESULT anywhere after it.
+ *     The Responses API requires each tool call to be settled by its output
+ *     before the conversation can continue; a dangling call left in replayed
+ *     history 400s with "No tool output found for function call…". Dropping
+ *     the dangling call (rather than synthesizing a fake output) is what the
+ *     SDK itself does for in-memory continuation, so a reloaded history is
+ *     shaped identically. The matching result, if it later exists, is kept;
+ *     only genuinely unpaired calls are removed.
+ *
+ *  3. Drop any `reasoning` item that immediately precedes (across a run of
+ *     reasoning items) a dropped tool call. The Responses API ties an
+ *     encrypted reasoning item to the tool call it produced; a reasoning item
+ *     orphaned by rule 2 trips "Item 'rs_…' of type 'reasoning' was provided
+ *     without its required following item". Mirrors the SDK's
+ *     `dropReasoningItemsPrecedingDroppedCalls`.
+ *
+ * A `call_id` is paired only when BOTH a call and a result of the matching
+ * types exist with that id, the call appearing before the result. Calls and
+ * results that satisfy that survive untouched.
+ */
+export function sanitizeHistoryItemsForModel<T extends HistoryItem>(items: readonly T[]): T[] {
+  if (items.length === 0) {
+    return [];
+  }
+
+  // Pre-scan: for every (call-type, call_id) record the index of a RESULT that
+  // appears strictly after the call. A call is valid only when such a result
+  // exists; a result is valid only when its call appears strictly before it.
+  // We resolve pairs in order so ordering is enforced both ways (a result that
+  // precedes its call is an orphan, and a call whose only result precedes it is
+  // dangling).
+  const dropped = new Set<number>();
+
+  // For each result-type, the call_ids of CALLs we have seen so far that are
+  // still waiting to be settled by a following result.
+  const openCallIdsByResultType = new Map<string, Set<string>>();
+
+  items.forEach((item, index) => {
+    const type = itemType(item);
+    const callId = callIdOf(item);
+    if (!type || !callId) {
+      return;
+    }
+    const callResultType = RESULT_TYPE_BY_CALL_TYPE[type];
+    if (callResultType) {
+      const open = openCallIdsByResultType.get(callResultType) ?? new Set<string>();
+      open.add(callId);
+      openCallIdsByResultType.set(callResultType, open);
+      return;
+    }
+    if (RESULT_TYPES.has(type)) {
+      const open = openCallIdsByResultType.get(type);
+      if (open && open.has(callId)) {
+        // Settles a call we have already seen — keep both, close the call.
+        open.delete(callId);
+      } else {
+        // Rule 1: result whose call is absent or appears later — the orphan.
+        dropped.add(index);
+      }
+    }
+  });
+
+  // Rule 2: any call still open after the full scan has no result after it —
+  // a dangling call the API rejects. Drop those calls. We re-walk to find the
+  // indices of the still-open call_ids (the last unmatched call per id).
+  const stillOpen = new Map<string, Set<string>>();
+  for (const [resultType, open] of openCallIdsByResultType) {
+    if (open.size > 0) {
+      stillOpen.set(resultType, new Set(open));
+    }
+  }
+  if (stillOpen.size > 0) {
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index];
+      const type = itemType(item);
+      const callId = callIdOf(item);
+      if (!type || !callId) {
+        continue;
+      }
+      const resultType = RESULT_TYPE_BY_CALL_TYPE[type];
+      if (!resultType) {
+        continue;
+      }
+      const open = stillOpen.get(resultType);
+      if (open && open.has(callId)) {
+        dropped.add(index);
+        open.delete(callId);
+      }
+    }
+  }
+
+  if (dropped.size > 0) {
+    // Rule 3: drop reasoning items stranded by a dropped tool call. A reasoning
+    // item is stranded when the next non-reasoning item after it is dropped.
+    for (let index = 0; index < items.length; index += 1) {
+      if (dropped.has(index) || itemType(items[index]) !== "reasoning") {
+        continue;
+      }
+      for (let next = index + 1; next < items.length; next += 1) {
+        if (itemType(items[next]) === "reasoning") {
+          continue;
+        }
+        if (dropped.has(next)) {
+          dropped.add(index);
+        }
+        break;
+      }
+    }
+  }
+
+  if (dropped.size === 0) {
+    return items.slice();
+  }
+  return items.filter((_item, index) => !dropped.has(index));
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -52,6 +52,11 @@ import { userInfo } from "node:os";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { sanitizeHistoryItemsForModel } from "./history-sanitizer";
+
+export { sanitizeHistoryItemsForModel } from "./history-sanitizer";
+export type { HistoryItem } from "./history-sanitizer";
+
 ensureReadableStreamFrom();
 
 const SANDBOX_LIFECYCLE_COMMAND_TIMEOUT_MS = 120_000;
@@ -649,9 +654,19 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
       const sandboxSessionState = input.sandboxEnvelope
         ? await restoredSandboxSessionStateFromEntry(input.sandboxEnvelope, options.sandboxClient)
         : undefined;
+      // Replayed conversation truth is reloaded verbatim from the database, so
+      // it can contain a tool-call pairing the Responses API rejects (most
+      // destructively an orphaned function_call_result with no matching
+      // function_call — which 400s every turn and bricks the session until the
+      // row is hand-deleted). Sanitize the in-memory copy before it reaches the
+      // model so existing corruption self-heals and a future write-path race is
+      // non-fatal; the stored rows are never touched.
+      const sanitizedHistory = sanitizeHistoryItemsForModel(
+        input.historyItems as unknown as Array<Record<string, unknown>>,
+      ) as unknown as AgentInputItem[];
       return {
         input: [
-          ...input.historyItems,
+          ...sanitizedHistory,
           {
             type: "message",
             role: "user",
@@ -666,9 +681,15 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
     }
     const state = await RunState.fromString(agent, input.serializedRunState);
     const sandboxSessionState = await restoredSandboxSessionState(state, options.sandboxClient);
+    // state.history already runs the SDK's own orphan-tool-call pruning, but
+    // applying the same sanitizer keeps the legacy run-state resume path under
+    // one invariant with the items path and is defensive against a corrupt blob.
+    const sanitizedHistory = sanitizeHistoryItemsForModel(
+      state.history as unknown as Array<Record<string, unknown>>,
+    ) as unknown as AgentInputItem[];
     return {
       input: [
-        ...state.history,
+        ...sanitizedHistory,
         {
           type: "message",
           role: "user",

--- a/packages/runtime/test/history-sanitizer.test.ts
+++ b/packages/runtime/test/history-sanitizer.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeHistoryItemsForModel } from "../src/history-sanitizer";
+
+// Item shapes mirror the SDK's canonical history representation
+// (`type` discriminator, camelCase `callId`) that is persisted verbatim into
+// session_history_items and replayed into the Responses API.
+function reasoning(id: string) {
+  return { type: "reasoning", id, content: [{ type: "input_text", text: "thinking" }] };
+}
+function userMessage(text: string) {
+  return { type: "message", role: "user", content: text };
+}
+function assistantMessage(text: string) {
+  return { type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text }] };
+}
+function functionCall(callId: string, name = "tool") {
+  return { type: "function_call", callId, name, arguments: "{}", status: "completed" };
+}
+function functionResult(callId: string) {
+  return { type: "function_call_result", callId, status: "completed", output: { type: "text", text: "ok" } };
+}
+
+describe("sanitizeHistoryItemsForModel", () => {
+  test("drops an orphaned function_call_result whose function_call is absent", () => {
+    // This is the session-bricking corruption: a tool output replayed without
+    // its tool call (observed live for journal / goal-pause tools near turn
+    // boundaries). The API 400s on the whole request until it is removed.
+    const items = [
+      userMessage("do the thing"),
+      functionResult("call_orphan"),
+      assistantMessage("done"),
+    ];
+    const result = sanitizeHistoryItemsForModel(items);
+    expect(result).toEqual([items[0], items[2]]);
+    expect(result.some((item) => (item as any).type === "function_call_result")).toBe(false);
+  });
+
+  test("drops a result whose call appears only AFTER it (still an orphan to the API)", () => {
+    const call = functionCall("call_late");
+    const result = functionResult("call_late");
+    // Result before its call: the API still rejects it.
+    const items = [userMessage("hi"), result, call];
+    const sanitized = sanitizeHistoryItemsForModel(items);
+    // The result is dropped; the now-dangling call is dropped too (no result
+    // after it), leaving just the user message.
+    expect(sanitized).toEqual([items[0]]);
+  });
+
+  test("drops a dangling function_call that has no result", () => {
+    const items = [
+      userMessage("hi"),
+      reasoning("rs_1"),
+      functionCall("call_dangling"),
+    ];
+    const result = sanitizeHistoryItemsForModel(items);
+    // The dangling call is dropped, and the reasoning item that produced it is
+    // dropped with it (Responses API ties reasoning to its following call).
+    expect(result).toEqual([items[0]]);
+  });
+
+  test("keeps reasoning when its following call is well-formed", () => {
+    const items = [
+      userMessage("hi"),
+      reasoning("rs_keep"),
+      functionCall("call_ok"),
+      functionResult("call_ok"),
+      assistantMessage("done"),
+    ];
+    const result = sanitizeHistoryItemsForModel(items);
+    expect(result).toEqual(items);
+  });
+
+  test("leaves a well-formed history byte-identical (same references and order)", () => {
+    const items = [
+      userMessage("first"),
+      functionCall("call_a"),
+      functionResult("call_a"),
+      assistantMessage("a done"),
+      userMessage("second"),
+      reasoning("rs_b"),
+      functionCall("call_b"),
+      functionResult("call_b"),
+      assistantMessage("b done"),
+    ];
+    const result = sanitizeHistoryItemsForModel(items);
+    expect(result).toHaveLength(items.length);
+    result.forEach((item, index) => {
+      // Same reference, not a clone — the valid items pass through untouched.
+      expect(item).toBe(items[index]);
+    });
+  });
+
+  test("keeps valid pairs while dropping an orphan in a parallel tool-call batch", () => {
+    // Parallel batch where one call/result pair is intact and a second result
+    // was orphaned (its call lost to a write-path desync). Only the orphan goes.
+    const items = [
+      userMessage("go"),
+      functionCall("call_a"),
+      functionCall("call_b"),
+      functionResult("call_a"),
+      functionResult("call_b"),
+      functionResult("call_ghost"),
+      assistantMessage("done"),
+    ];
+    const result = sanitizeHistoryItemsForModel(items);
+    expect(result).toEqual([
+      items[0], items[1], items[2], items[3], items[4], items[6],
+    ]);
+  });
+
+  test("accepts snake_case call_id correlation as well as camelCase callId", () => {
+    const call = { type: "function_call", call_id: "call_snake", name: "t", arguments: "{}" };
+    const orphan = { type: "function_call_result", call_id: "call_missing", output: { type: "text", text: "x" } };
+    const result = { type: "function_call_result", call_id: "call_snake", output: { type: "text", text: "ok" } };
+    const items = [userMessage("hi"), call, result, orphan];
+    const sanitized = sanitizeHistoryItemsForModel(items);
+    expect(sanitized).toEqual([items[0], call, result]);
+  });
+
+  test("empty input returns empty", () => {
+    expect(sanitizeHistoryItemsForModel([])).toEqual([]);
+  });
+
+  test("does not mutate the input array or its items", () => {
+    const orphan = functionResult("call_x");
+    const items = [userMessage("hi"), orphan];
+    const snapshot = JSON.stringify(items);
+    sanitizeHistoryItemsForModel(items);
+    expect(items).toHaveLength(2);
+    expect(JSON.stringify(items)).toBe(snapshot);
+  });
+});

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -269,6 +269,32 @@ describe("runtime event normalization", () => {
     expect(prepared.input).toBe("hello");
   });
 
+  test("sanitizes an orphaned tool output out of replayed items-mode history", async () => {
+    // A session whose stored history carries an orphaned function_call_result
+    // (its function_call lost to a write-path desync) must still produce a
+    // valid model input instead of one the Responses API 400s on. The read
+    // path sanitizes the in-memory copy; the orphan never reaches the model.
+    const orphan = { type: "function_call_result", callId: "call_orphan", output: { type: "text", text: "stale" } };
+    const validCall = { type: "function_call", callId: "call_ok", name: "tool", arguments: "{}" };
+    const validResult = { type: "function_call_result", callId: "call_ok", output: { type: "text", text: "ok" } };
+    const prepared = await prepareRunInput(buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []), {
+      kind: "message",
+      text: "continue",
+      historyItems: [
+        { type: "message", role: "user", content: "earlier" } as any,
+        orphan as any,
+        validCall as any,
+        validResult as any,
+      ],
+    });
+    const input = prepared.input as Array<Record<string, unknown>>;
+    expect(Array.isArray(input)).toBe(true);
+    // The orphan is gone; the valid pair and the new user turn remain in order.
+    expect(input.filter((item) => item.type === "function_call_result")).toEqual([validResult]);
+    expect(input.some((item) => item.type === "function_call_result" && item.callId === "call_orphan")).toBe(false);
+    expect(input[input.length - 1]).toEqual({ type: "message", role: "user", content: "continue" });
+  });
+
   test("builds agents without MCP servers by default", () => {
     const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
     expect(agent.mcpServers).toEqual([]);

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1213,6 +1213,76 @@ describe("worker activities integration", () => {
     expect(blobAfterTurn2?.id).toBe(blobAfterTurn1?.id);
   });
 
+  test("runs a turn whose stored history carries an orphaned tool output instead of 400ing", async () => {
+    // A session whose session_history_items contains an orphaned
+    // function_call_result (a tool output whose function_call is absent — the
+    // corruption that 400s the Responses API and bricks the session on every
+    // replay) must still run a turn: the read path sanitizes the in-memory copy
+    // before it reaches the model, and the stored audit trail is left intact.
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "earlier work",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const turn = await createTurn(dbClient.db, {
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      temporalWorkflowId: "workflow-orphan-seed",
+      triggerEventId: crypto.randomUUID(),
+    });
+    // Seed a stored history that is corrupt exactly the way the live incidents
+    // were: a valid user turn, then a function_call_result with NO matching
+    // function_call anywhere in the items.
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      turnId: turn,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "earlier work" } },
+        { position: 1, item: { type: "function_call_result", callId: "call_orphaned", status: "completed", output: { type: "text", text: "stale result" } } },
+        { position: 2, item: { type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text: "ack" }] } },
+      ],
+    });
+
+    const model = new ScriptedModel([
+      { id: "orphan-recover", outputText: "recovered", chunks: ["recovered"] },
+    ]);
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl, sessionHistorySource: "items" }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model }),
+    });
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "continue please" } },
+    ]);
+
+    // The turn SUCCEEDS instead of failing the session with a 400.
+    await expect(activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      workflowId: "workflow-orphan-recover",
+    })).resolves.toEqual({ status: "idle" });
+
+    // The orphan never reached the model: the sanitized request omits it while
+    // keeping the surrounding valid items and the new user turn.
+    const lastRequestInput = JSON.stringify((model.requests.at(-1) as { input?: unknown })?.input ?? "");
+    expect(lastRequestInput).not.toContain("call_orphaned");
+    expect(lastRequestInput).not.toContain("stale result");
+    expect(lastRequestInput).toContain("earlier work");
+    expect(lastRequestInput).toContain("continue please");
+
+    // The stored audit trail is untouched — the orphan row still exists.
+    const storedItems = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(storedItems.some((row) => JSON.stringify(row.item).includes("call_orphaned"))).toBe(true);
+  });
+
   test("blocks async document embeddings when managed credits are empty", async () => {
     const grant = await testGrant(dbClient.db);
     const upload = await createOwnedFileUpload(dbClient.db, grant, {


### PR DESCRIPTION
## Problem

A long-lived agent session could permanently fail every turn with the OpenAI Responses API error `400 No tool call found for function call output with call_id <X>`. The session stayed dead across revival.

Root cause confirmed: `session_history_items` accumulated an **orphaned tool output** — a `function_call_result` (function_call_output) whose matching `function_call` was absent from the history. That corrupt item was replayed verbatim into the model on every turn, so the API rejected the whole request and the session could not recover until the row was hand-deleted. Observed for tool results near turn boundaries / preempts / goal-pause.

## Mechanism (write path)

`stream.state.history` is **not** a plain append-only array — it is a computed getter (`getTurnInput(originalInput, generatedItems)`) that runs the SDK's `dropOrphanToolCalls` on every access. A `function_call` with no settling result yet is transiently **absent** from `history`, so the list is non-monotonic (shorter/reordered) across reconciles. The old reconcile sliced this list by a blind length watermark and appended at fixed positions with `onConflictDoNothing`. With a parallel tool-call batch plus an abnormal turn end (goal-pause / interrupt cancelling part of the batch), a position could be frozen with one shape and a later reconcile could persist a `function_call_result` at a tail position while its `function_call` had been pruned away in an earlier slice and never written — the orphan.

## Fix — two parts

1. **Read-path sanitizer** (`sanitizeHistoryItemsForModel`, new pure function): before history reaches the model, drop any tool-call result whose call does not precede it, drop dangling calls with no result, and drop reasoning items stranded by a dropped call — mirroring the SDK's own `dropOrphanToolCalls`. Applied in `prepareRunInput` for both items-mode and legacy run-state paths. Only the in-memory copy is filtered; **stored rows are never touched** (audit trail intact). Existing corruption self-heals; future races are non-fatal.

2. **Write-path correctness** (`reconcileConversationTruth` / extracted `historyRowsToAppend`): sanitize the full current history, then append only the valid new tail. A dangling call is deferred until its result lands (the pair persists together at consecutive positions); a result is never persisted without its call. The watermark advances only to the sanitized length, so a non-monotonic history can never desync it. Best-effort and idempotent-on-position behavior preserved; legacy orphan rows that exceed the sanitized length hold the watermark steady without rewriting.

## Tests (fail before, pass after)

- Pure-function unit tests for the sanitizer (orphan output dropped; dangling call dropped; reasoning-stranding; well-formed history byte-identical; snake/camel `call_id`; no mutation).
- Runtime test: an orphaned items-mode history yields a valid model input via `prepareRunInput`.
- Write-path test: parallel-batch + abnormal-turn-end scenario asserts no orphaned output is persisted; dangling-call deferral; legacy-orphan steadiness.
- Integration test: a session whose stored history contains an orphaned tool output now runs a turn (`status: idle`) instead of 400ing; the orphan is absent from the model request; the stored row is preserved.

Full local gate green: typecheck (all packages), unit suite (478 pass), worker-activity integration suite (48 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent turn input and conversation-truth dual-write; behavior change is intentional and well-tested but affects every items-mode session replay and reconcile.
> 
> **Overview**
> Fixes sessions that **permanently 400** on every turn when `session_history_items` contains an orphaned `function_call_result` (no matching `function_call`), which the Responses API rejects on replay.
> 
> **Read path:** Adds `sanitizeHistoryItemsForModel` to drop invalid tool pairings and stranded reasoning before history reaches the model. Wired in `prepareRunInput` for items-mode and legacy run-state resume; **DB rows are not modified**, so existing corruption self-heals on the next turn.
> 
> **Write path:** Replaces blind length-based slicing of SDK `state.history` (non-monotonic due to orphan pruning) with `historyRowsToAppend`, which sanitizes the full history, appends only the new tail, defers dangling calls until results exist, and advances the watermark to sanitized length only.
> 
> Unit, runtime, worker reconcile, and integration tests cover the orphan scenario and related edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ea0c7e9b04126c0d0b5a698385e518f44de5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->