### PR TITLE
Fix compaction overwriting a real history row (audit-trail loss)

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -11,7 +11,8 @@ import {
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
-  countSessionHistoryItems,
+  countActiveSessionHistoryItems,
+  nextSessionHistoryPosition,
   requeuePreemptedTurn,
   saveRunState,
   upsertSandboxSessionEnvelope,
@@ -122,17 +123,28 @@ export function isWorkerShutdownCancellation(error: unknown): boolean {
  */
 export function historyRowsToAppend(
   rawHistory: Array<Record<string, unknown>>,
+  // How many items of the CURRENT in-memory history are already persisted (the
+  // slice index into `sanitized`). This is the in-memory history length, NOT the
+  // total persisted-row count: after a compaction the in-memory history is the
+  // short [summary, ...tail, ...new] list, far shorter than the total rows in
+  // the table (which still hold the superseded prefix).
   persistedHistoryCount: number,
-): { rows: Array<{ position: number; item: Record<string, unknown> }>; nextWatermark: number } {
+  // Next free WHOLE-NUMBER absolute position to write at. Decoupled from the
+  // slice index because compaction inserts a fractional summary position, so the
+  // total-row count no longer equals max(position)+1. Defaults to
+  // persistedHistoryCount to preserve the pre-compaction behaviour (contiguous
+  // positions from 0) when callers do not pass an explicit next position.
+  nextPosition: number = persistedHistoryCount,
+): { rows: Array<{ position: number; item: Record<string, unknown> }>; nextWatermark: number; nextPosition: number } {
   const sanitized = sanitizeHistoryItemsForModel(rawHistory);
   if (sanitized.length <= persistedHistoryCount) {
-    return { rows: [], nextWatermark: persistedHistoryCount };
+    return { rows: [], nextWatermark: persistedHistoryCount, nextPosition };
   }
   const rows = sanitized.slice(persistedHistoryCount).map((item, offset) => ({
-    position: persistedHistoryCount + offset,
+    position: nextPosition + offset,
     item: item as Record<string, unknown>,
   }));
-  return { rows, nextWatermark: sanitized.length };
+  return { rows, nextWatermark: sanitized.length, nextPosition: nextPosition + rows.length };
 }
 
 export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
@@ -177,6 +189,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // actually persisted, so a non-monotonic history can never desync it.
     let persistedHistoryCount = 0;
     let historyCountAtTurnStart = 0;
+    // Next free WHOLE-NUMBER absolute position to append at. Tracked separately
+    // from persistedHistoryCount (the in-memory slice index) because a compaction
+    // inserts a fractional summary position, so total rows no longer equal
+    // max(position)+1 and the slice index can no longer double as the position.
+    let nextHistoryPosition = 0;
     const reconcileConversationTruth = async () => {
       if (!stream || !turnId) {
         return;
@@ -184,9 +201,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       try {
         const rawHistory = (stream.state as { history?: unknown[] }).history;
         if (Array.isArray(rawHistory)) {
-          const { rows, nextWatermark } = historyRowsToAppend(
+          const { rows, nextWatermark, nextPosition } = historyRowsToAppend(
             rawHistory as Array<Record<string, unknown>>,
             persistedHistoryCount,
+            nextHistoryPosition,
           );
           if (rows.length > 0) {
             await appendSessionHistoryItems(db, {
@@ -198,6 +216,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             });
           }
           persistedHistoryCount = nextWatermark;
+          nextHistoryPosition = nextPosition;
         }
         const envelope = sandboxStateEntryFromRunState(stream.state);
         if (envelope) {
@@ -366,8 +385,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         }
       }
       const runInput = await turnInput(db, runtime, agent, trigger, runSettings);
-      persistedHistoryCount = await countSessionHistoryItems(db, input.workspaceId, input.sessionId);
+      // Slice index = the length of the model-facing (active) history this turn
+      // is seeded from; new items beyond it (the trigger message + this turn's
+      // generated items) are the ones to persist. After a compaction this is the
+      // short [summary, ...tail] active set, NOT the total row count. The
+      // absolute write position is tracked separately (next whole number past
+      // the max existing position) because the fractional summary row means
+      // total rows no longer equal max(position)+1. Pre-compaction both reduce to
+      // the old total-count value, so the common path is unchanged.
+      persistedHistoryCount = await countActiveSessionHistoryItems(db, input.workspaceId, input.sessionId);
       historyCountAtTurnStart = persistedHistoryCount;
+      nextHistoryPosition = await nextSessionHistoryPosition(db, input.workspaceId, input.sessionId);
       let responseUsageCount = 0;
       // Actual input tokens of the most recent model response this turn; the
       // pre-read trigger for the NEXT turn. Persisted at every turn-end path.

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -34,9 +34,11 @@ export type MaybeCompactResult =
  * the un-compacted history. The read path's existing sanitizer keeps that safe.
  *
  * The boundary the planner picks is the start of a kept user-message turn, so
- * no tool-call pair straddles the cut. The summary row is inserted at the
- * position immediately before the kept tail (a freed prefix position), so the
- * active read path returns [summary, ...recent tail] in order.
+ * no tool-call pair straddles the cut. The summary row is inserted at a
+ * fractional position a half-step before the kept tail (boundaryPosition - 0.5),
+ * which sorts ahead of the tail without overwriting any real prefix row, so the
+ * active read path returns [summary, ...recent tail] in order and the full
+ * superseded prefix survives untouched as an audit trail.
  */
 export type CompactionSummarizer = (
   settings: Settings,
@@ -80,18 +82,21 @@ export async function maybeCompactContext(
   }
 
   // Boundary is an index into the active rows; map to absolute positions. The
-  // kept tail starts at the boundary row's position; the summary takes the
-  // position immediately before it (a position inside the just-superseded
-  // prefix, guaranteed free and sorting before the tail).
+  // kept tail starts at the boundary row's position; the summary takes a
+  // FRACTIONAL position a half-step before it. Positions are whole numbers, so
+  // boundaryPosition - 0.5 sorts immediately ahead of the kept tail and behind
+  // the last superseded prefix row while colliding with NO real row — the
+  // earlier `boundaryPosition - 1` always landed on (and overwrote) the real
+  // prefix row there.
   const boundaryRow = active[plan.boundaryIndex];
   if (!boundaryRow) {
     return { compacted: false, reason: "boundary_out_of_range" };
   }
   const boundaryPosition = boundaryRow.position;
-  const summaryPosition = boundaryPosition - 1;
-  if (summaryPosition < 0) {
+  if (boundaryPosition <= 0) {
     return { compacted: false, reason: "boundary_at_origin" };
   }
+  const summaryPosition = boundaryPosition - 0.5;
 
   await applyContextCompaction(db, {
     accountId: scope.accountId,

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -101,6 +101,42 @@ describe("conversation-truth reconcile (orphaned tool output guard)", () => {
     expect(result.rows).toEqual([]);
     expect(result.nextWatermark).toBe(5);
   });
+
+  test("appends at fresh absolute positions after a compaction (slice index decoupled from position)", () => {
+    // Post-compaction, the in-memory history is the SHORT active set
+    // [summary, ...tail] whose slice index (2) is far below the next free
+    // absolute position. The summary sits at a fractional position (e.g. 5.5)
+    // and the last superseded prefix tops out at 9, so the next whole-number
+    // position is 10 — NOT the slice index. New items must land at 10, 11, ...
+    // (never colliding with superseded prefix rows nor the fractional summary).
+    const sanitized = [
+      userMessage("[summary] folded prefix"), // slice idx 0 — already persisted at 5.5
+      userMessage("recent turn"),             // slice idx 1 — already persisted at 6
+      userMessage("brand new turn"),          // slice idx 2 — NEW
+      functionCall("call_z"),                 // slice idx 3 — NEW
+      functionResult("call_z"),               // slice idx 4 — NEW
+    ];
+    const result = historyRowsToAppend(sanitized, /* persistedHistoryCount */ 2, /* nextPosition */ 10);
+    expect(result.rows.map((row) => row.position)).toEqual([10, 11, 12]);
+    expect(result.rows.map((row) => row.item)).toEqual([
+      userMessage("brand new turn"),
+      functionCall("call_z"),
+      functionResult("call_z"),
+    ]);
+    // Slice watermark advances to the in-memory length; the next absolute
+    // position advances past the rows just written.
+    expect(result.nextWatermark).toBe(5);
+    expect(result.nextPosition).toBe(13);
+  });
+
+  test("default nextPosition preserves contiguous-from-zero appends (uncompacted path)", () => {
+    // When callers omit nextPosition (the common, never-compacted path) the
+    // absolute position equals the slice index, exactly as before this change.
+    const sanitized = [userMessage("a"), userMessage("b"), userMessage("c")];
+    const result = historyRowsToAppend(sanitized, 1);
+    expect(result.rows.map((row) => row.position)).toEqual([1, 2]);
+    expect(result.nextPosition).toBe(3);
+  });
 });
 
 describe("worker shutdown preemption", () => {

--- a/packages/db/drizzle/0012_compaction_summary_fractional_position.sql
+++ b/packages/db/drizzle/0012_compaction_summary_fractional_position.sql
@@ -1,0 +1,19 @@
+-- Audit-safe compaction summary placement.
+--
+-- The first cut of client-side compaction (0011) inserted the synthetic summary
+-- at integer position `boundaryPosition - 1`. Because history positions are
+-- always contiguous from 0, that position is ALWAYS occupied by a real prefix
+-- row, and the upsert overwrote that row's item JSON — destroying one real
+-- history row per compaction and violating the "supersede, never delete" audit
+-- guarantee (it also stranded the summary under the prefix row's old turn_id).
+--
+-- Fix: store the summary at a FRACTIONAL position (boundaryPosition - 0.5) that
+-- sorts immediately ahead of the kept tail and collides with nothing. That
+-- requires `position` to be numeric rather than integer. Normal appends keep
+-- whole-number positions; only the summary uses the half-step.
+--
+-- Safe in place: every existing position is a whole number, so the integer ->
+-- numeric widening is loss-free and the unique index is rebuilt automatically by
+-- the type change. No data is rewritten beyond the column representation.
+ALTER TABLE "session_history_items"
+  ALTER COLUMN "position" TYPE numeric USING "position"::numeric;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2122,19 +2122,44 @@ export async function getActiveSessionHistoryItems(db: Database, workspaceId: st
 }
 
 /**
+ * Count of ACTIVE (live, model-facing) history rows for a session. This is the
+ * length of the history the next turn is seeded from — the dual-write slice
+ * index — which after a compaction is far smaller than the total persisted-row
+ * count (countSessionHistoryItems still includes the superseded prefix).
+ */
+export async function countActiveSessionHistoryItems(db: Database, workspaceId: string, sessionId: string): Promise<number> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select({
+      count: sql<number>`count(*)`,
+    }).from(schema.sessionHistoryItems)
+      .where(and(
+        eq(schema.sessionHistoryItems.workspaceId, workspaceId),
+        eq(schema.sessionHistoryItems.sessionId, sessionId),
+        eq(schema.sessionHistoryItems.active, true),
+      ));
+    return Number(row?.count ?? 0);
+  });
+}
+
+/**
  * Apply a client-side context compaction as an atomic, audit-preserving write:
  *
  *  - supersede (set active=false) every active row whose position lies in
  *    [0, boundaryPosition) — i.e. the summarized prefix — EXCLUDING the tail.
  *    Rows are never deleted.
- *  - insert ONE active synthetic summary row at `summaryPosition` (a freed
- *    prefix position that sorts immediately before the kept tail). Idempotent
- *    on position: a retry that finds the row already there does not duplicate.
+ *  - insert ONE active synthetic summary row at `summaryPosition` (a FRACTIONAL
+ *    position — boundaryPosition - 0.5 — that sorts immediately before the kept
+ *    tail and collides with NO existing row, so no real prefix row is ever
+ *    overwritten). Idempotent on position: a retry that finds the summary row
+ *    already there does not duplicate it (it only re-activates the existing
+ *    summary row at that fractional position) and — crucially — never mutates
+ *    the real row at boundaryPosition - 1.
  *
  * The caller computes the boundary from the orphan-safe planner so no tool-call
- * pair straddles the cut. `summaryPosition` must be < boundaryPosition (a
- * position inside the just-superseded prefix), guaranteeing it is free and
- * sorts before the tail.
+ * pair straddles the cut. `summaryPosition` must be < boundaryPosition (between
+ * the last superseded prefix row and the kept tail), guaranteeing it sorts
+ * before the tail. Because positions are whole numbers and summaries are
+ * half-steps, the summary's fractional position can never equal a real row.
  */
 export async function applyContextCompaction(db: Database, input: {
   accountId: string;
@@ -2143,7 +2168,7 @@ export async function applyContextCompaction(db: Database, input: {
   turnId?: string | null;
   /** Active prefix rows with position < boundaryPosition get superseded. */
   boundaryPosition: number;
-  /** Position for the new summary row (must be < boundaryPosition). */
+  /** Fractional position for the new summary row (must be < boundaryPosition). */
   summaryPosition: number;
   summaryItem: Record<string, unknown>;
 }): Promise<void> {
@@ -2157,6 +2182,17 @@ export async function applyContextCompaction(db: Database, input: {
           eq(schema.sessionHistoryItems.active, true),
           lt(schema.sessionHistoryItems.position, input.boundaryPosition),
         ));
+      // Insert the summary at its FRACTIONAL position. The supersede step above
+      // also sets active=false for any rows with position < boundaryPosition —
+      // which on a RETRY includes the summary itself (it sits below the
+      // boundary). The conflict target here is that fractional position, which
+      // can ONLY ever collide with a prior summary row (real rows are whole
+      // numbers), so onConflictDoUpdate set:{active:true} is safe: it merely
+      // re-activates the existing summary, keeping the retry idempotent WITHOUT
+      // mutating its item/turnId and — crucially — WITHOUT ever touching the
+      // real row at boundaryPosition - 1 (the old integer placement overwrote
+      // it). The summary carries the current turnId so per-turn counts stay
+      // correct.
       await tx.insert(schema.sessionHistoryItems).values({
         accountId: input.accountId,
         workspaceId: input.workspaceId,
@@ -2167,9 +2203,28 @@ export async function applyContextCompaction(db: Database, input: {
         active: true,
       }).onConflictDoUpdate({
         target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
-        set: { item: input.summaryItem, active: true },
+        set: { active: true },
       });
     });
+  });
+}
+
+/**
+ * The next free WHOLE-NUMBER history position for a session: one past the
+ * largest existing position (active or superseded), floored so the synthetic
+ * summary's fractional half-step never shifts the count. The dual-write
+ * watermark uses this to append new rows at fresh absolute positions, decoupled
+ * from the in-memory history length (which, after a compaction, is far shorter
+ * than the total persisted-row count and so cannot serve as the next position).
+ */
+export async function nextSessionHistoryPosition(db: Database, workspaceId: string, sessionId: string): Promise<number> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select({
+      maxPosition: sql<number | null>`max(${schema.sessionHistoryItems.position})`,
+    }).from(schema.sessionHistoryItems)
+      .where(and(eq(schema.sessionHistoryItems.workspaceId, workspaceId), eq(schema.sessionHistoryItems.sessionId, sessionId)));
+    const max = row?.maxPosition;
+    return max === null || max === undefined ? 0 : Math.floor(Number(max)) + 1;
   });
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { bigint, boolean, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid, customType } from "drizzle-orm/pg-core";
+import { bigint, boolean, index, integer, jsonb, numeric, pgTable, text, timestamp, uniqueIndex, uuid, customType } from "drizzle-orm/pg-core";
 
 const vector = customType<{ data: number[]; driverData: string }>({
   dataType() {
@@ -316,7 +316,13 @@ export const sessionHistoryItems = pgTable("session_history_items", {
   workspaceId: uuid("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
   sessionId: uuid("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
   turnId: uuid("turn_id").references(() => sessionTurns.id, { onDelete: "set null" }),
-  position: integer("position").notNull(),
+  // Numeric (not integer) so the synthetic compaction-summary row can be
+  // inserted at a FRACTIONAL position (boundaryPosition - 0.5) that sorts ahead
+  // of the kept tail without colliding with — and thus overwriting — the real
+  // prefix row at boundaryPosition - 1. Normally-appended rows keep whole-number
+  // positions; only the summary uses the half-step. `mode: "number"` maps the
+  // postgres.js string back to a JS number so every reader stays numeric.
+  position: numeric("position", { mode: "number" }).notNull(),
   item: jsonb("item").$type<Record<string, unknown>>().notNull(),
   // Live-row flag for client-side context compaction. The read path selects
   // only active rows; a compaction supersedes the summarized prefix (sets this

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -899,21 +899,32 @@ describe("DB integration", () => {
       workspaceId: grant.workspaceId,
       sessionId: session.id,
       boundaryPosition: 4,
-      summaryPosition: 3,
+      // Fractional: a half-step before the kept tail. Collides with NO real row,
+      // so the real prefix row at position 3 is never overwritten.
+      summaryPosition: 3.5,
       summaryItem: { type: "message", role: "user", content: "[CONTEXT CHECKPOINT] SUMMARY:folded", opengeni_context_summary: true },
     });
 
-    // Active read = [summary @3, recent user @4, assistant @5].
+    // Active read = [summary @3.5, recent user @4, assistant @5].
     const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect(active.map((row) => row.position)).toEqual([3, 4, 5]);
+    expect(active.map((row) => row.position)).toEqual([3.5, 4, 5]);
     expect((active[0]!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
     expect(active[1]!.item).toMatchObject({ role: "user", content: "recent turn" });
 
-    // Audit trail preserved: superseded prefix rows still exist (positions 0..2)
-    // and total row count grew by exactly one (the summary).
+    // Audit trail preserved: every original prefix row STILL EXISTS — including
+    // position 3, the row the old (boundaryPosition - 1) placement overwrote.
+    // The summary is an ADDITIONAL row, so total count grew by exactly one.
     const all = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect(all.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(await countSessionHistoryItems(dbClient.db, grant.workspaceId, session.id)).toBe(6);
+    expect(all.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 3.5, 4, 5]);
+    expect(await countSessionHistoryItems(dbClient.db, grant.workspaceId, session.id)).toBe(7);
+
+    // The exact audit-loss regression: the original assistant 'a2' at position 3
+    // must still be retrievable verbatim after compaction (the bug overwrote it
+    // with the summary). Assert the real item survives untouched.
+    const positionThree = all.find((row) => row.position === 3);
+    expect(positionThree).toBeDefined();
+    expect(positionThree!.item).toMatchObject({ role: "assistant", content: [{ type: "output_text", text: "a2" }] });
+    expect((positionThree!.item as Record<string, unknown>).opengeni_context_summary).toBeUndefined();
   });
 
   test("applyContextCompaction is idempotent on a retry (same summary position)", async () => {
@@ -942,13 +953,21 @@ describe("DB integration", () => {
       workspaceId: grant.workspaceId,
       sessionId: session.id,
       boundaryPosition: 2,
-      summaryPosition: 1,
+      summaryPosition: 1.5,
       summaryItem: { type: "message", role: "user", content: "SUMMARY:s", opengeni_context_summary: true },
     });
     await apply();
-    await apply(); // retry must not duplicate or throw
+    await apply(); // retry must not duplicate, throw, or overwrite the real row
     const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect(active.map((row) => row.position)).toEqual([1, 2]);
+    expect(active.map((row) => row.position)).toEqual([1.5, 2]);
+    // The retry-idempotent insert (onConflictDoNothing) must not have touched the
+    // real superseded row at position 1: it survives verbatim, exactly once.
+    const all = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    const positionOne = all.filter((row) => row.position === 1);
+    expect(positionOne).toHaveLength(1);
+    expect(positionOne[0]!.item).toMatchObject({ role: "assistant", content: [{ type: "output_text", text: "a1" }] });
+    // Exactly one summary row total (no duplicate from the retry).
+    expect(all.filter((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toHaveLength(1);
   });
 
   test("setSessionLastInputTokens persists the pre-turn compaction signal", async () => {

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -15,6 +15,7 @@ import {
   bootstrapWorkspace,
   completeFileUpload,
   applyCreditLedgerEntry,
+  countTurnSessionHistoryItems,
   createTurn,
   createDb,
   createFileUpload,
@@ -2826,9 +2827,88 @@ describe("worker activities integration", () => {
     expect(active.at(-1)!.item).toMatchObject({ role: "assistant" });
     expect(types).not.toContain("function_call_result");
 
-    // Audit trail intact: superseded rows still present.
+    // Audit trail intact: ALL ten seeded rows still present (none overwritten),
+    // plus the one summary row => eleven total. The earlier integer placement
+    // overwrote one real row, leaving ten.
     const all = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect(all.length).toBeGreaterThanOrEqual(10);
+    expect(all.length).toBe(11);
+    expect(all.filter((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toHaveLength(1);
+    // Every original seeded position (0..9) survives verbatim — in particular the
+    // assistant 'a2' at position 7 that the half-step before the boundary used to
+    // overwrite is untouched.
+    for (let position = 0; position <= 9; position += 1) {
+      expect(all.some((row) => row.position === position)).toBe(true);
+    }
+    const seededAssistant = all.find((row) => row.position === 7);
+    expect(seededAssistant!.item).toMatchObject({ role: "assistant", content: [{ type: "output_text", text: "a2" }] });
+  });
+
+  test("maybeCompactContext records the summary under the current turn (per-turn count stays correct)", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "turn-count session",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // Prefix rows belong to an OLD turn; the summary must NOT inherit that turn's
+    // id. The overwrite bug (onConflictDoUpdate set only {item, active}) left the
+    // summary stranded under the prefix row's turn_id, so the compaction turn's
+    // per-turn count (the worker-death resume-with-notice signal) miscounted.
+    const oldTurnId = await createTurn(dbClient.db, {
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      temporalWorkflowId: `wf-old-${crypto.randomUUID()}`,
+      triggerEventId: crypto.randomUUID(),
+    });
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      turnId: oldTurnId,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "old turn 1" } },
+        { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "a1" }] } },
+        { position: 2, item: { type: "message", role: "user", content: "old turn 2" } },
+        { position: 3, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "a2" }] } },
+        { position: 4, item: { type: "message", role: "user", content: "recent turn" } },
+        { position: 5, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "a3" }] } },
+      ],
+    });
+    const compactionTurnId = await createTurn(dbClient.db, {
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      temporalWorkflowId: `wf-new-${crypto.randomUUID()}`,
+      triggerEventId: crypto.randomUUID(),
+    });
+
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      sessionHistorySource: "items",
+      openaiProvider: "azure",
+      contextCompactionMode: "auto",
+      contextWindowTokens: 1000,
+      contextReservedOutputTokens: 0,
+      contextCompactSoftFraction: 0.5,
+      contextKeepRecentTokens: 40,
+    });
+
+    const result = await maybeCompactContext(
+      dbClient.db,
+      settings,
+      { accountId: grant.accountId, workspaceId: grant.workspaceId, sessionId: session.id, turnId: compactionTurnId },
+      900,
+      async () => "objective: ship; durable facts in the notebook (pointers only).",
+    );
+    expect(result.compacted).toBe(true);
+
+    // The summary is attributed to the compaction turn, not the prefix's old
+    // turn — so the per-turn count used by the worker-death resume decision sees
+    // exactly the one row this turn wrote.
+    expect(await countTurnSessionHistoryItems(dbClient.db, grant.workspaceId, compactionTurnId)).toBe(1);
+    expect(await countTurnSessionHistoryItems(dbClient.db, grant.workspaceId, oldTurnId)).toBe(6);
   });
 
   test("maybeCompactContext is a no-op on the OpenAI platform (server path owns compaction there)", async () => {


### PR DESCRIPTION
## What

Adversarial-review finding (major): client-side compaction overwrote one real history row per run, violating the non-negotiable "supersede, never delete" audit-trail guarantee.

**Verified valid.** Root cause at `apps/worker/src/activities/context-compaction.ts` (`summaryPosition = boundaryPosition - 1`) + `packages/db/src/index.ts` `applyContextCompaction` (`onConflictDoUpdate set:{item,active}`). History positions are always contiguous from 0 (`agent-turn.ts` writes `position = persistedHistoryCount + offset`), so `boundaryPosition - 1` is ALWAYS an occupied real prefix row; the upsert overwrote its `item` JSON. It also left only `{item,active}` set, so the summary kept the prefix row's old `turn_id`, miscounting the compaction turn in the worker-death resume decision (`countTurnSessionHistoryItems`). The prior db integration test proved the loss (asserted `count===6`) but never checked the original item survived.

## Fix

- Store the summary at a **fractional position** `boundaryPosition - 0.5` that sorts ahead of the kept tail and collides with no real row. Widen `session_history_items.position` from `integer` to `numeric` (migration `0012`, loss-free in place, verified on a pre-0012 DB; `numeric` `mode:"number"` keeps every reader numeric).
- Insert carries the current `turnId`; `onConflictDoUpdate set:{active:true}` only — a retry re-activates the existing summary without mutating its `item`/`turnId` and never touches the real row at `boundaryPosition - 1`.
- Compaction now makes total-row-count diverge from `max(position)+1`, so the dual-write watermark is split into the in-memory **slice index** (active-row count) and the next whole-number **absolute write position** (`nextSessionHistoryPosition`). Pre-compaction both reduce to the old total-count value (common path unchanged); post-compaction new rows append at fresh positions instead of being silently suppressed.

## Tests

- db integration: now asserts the original item at the collision position survives verbatim and total rows grew by exactly one (was count-only).
- worker-activity: new test asserts the summary is attributed to the compaction turn (per-turn count correct); existing audit test now asserts all original rows survive; retry test asserts no duplicate/overwrite.
- agent-turn unit: new tests for the decoupled slice-index/absolute-position append.

Full local gate green: typecheck (all packages), 511 unit, and integration (db 19, worker-activity 52, worker-restart 3, api 62, nats 2, isolation 1, temporal 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conversation-truth persistence and schema migration for `session_history_items.position`; behavior is well-covered by integration/unit tests but post-compaction append paths are subtle.
> 
> **Overview**
> **Fixes a major audit-trail bug** where client-side context compaction placed the synthetic summary at integer `boundaryPosition - 1`, which always collided with an existing prefix row and **upsert-overwrote** its `item` JSON (and could leave the summary on the wrong `turn_id`).
> 
> Compaction summaries now go at **`boundaryPosition - 0.5`**, with `session_history_items.position` widened from **integer → numeric** (migration `0012`). `applyContextCompaction` inserts with the current `turnId` and on retry only **`set: { active: true }`**, so real rows at whole-number positions are never mutated.
> 
> Because fractional summaries break `total rows === max(position)+1`, the worker **splits the dual-write watermark**: **active-row count** (`countActiveSessionHistoryItems`) is the in-memory slice index, and **`nextSessionHistoryPosition`** supplies the next whole-number append position. `historyRowsToAppend` accepts optional `nextPosition`; omitting it keeps the pre-compaction contiguous-from-zero behavior.
> 
> Tests assert prefix rows survive verbatim, retry idempotency, post-compaction appends at fresh positions, and correct per-turn history attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bcdf64f29f6d011f68c684a3d53a982af5c99d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->