### PR TITLE
Slash-command palette in the chat composer (/clear, /compact, /goal, /help)

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,17 +1,22 @@
 import {
+  ClearSessionContextRequest,
   ClientSessionEvent,
+  CompactSessionContextRequest,
   ReorderSessionTurnsRequest,
   UpdateSessionGoalRequest,
   UpdateSessionTurnRequest,
 } from "@opengeni/contracts";
+import { resolveContextCompactionMode } from "@opengeni/config";
 import {
   cancelQueuedSessionTurn,
+  clearSessionContext,
   getSession,
   getSessionGoal,
   listSessionEvents,
   listSessions,
   listSessionTurns,
   reorderQueuedSessionTurns,
+  requestSessionCompaction,
   requireSession,
   setSessionGoalStatus,
   updateQueuedSessionTurn,
@@ -133,6 +138,67 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId: workflowIdForSession(sessionId) });
     }
     return c.json(goal);
+  });
+
+  // Operator context controls (slash-command palette: /clear, /compact). These
+  // are session/operator actions — NOT a structured channel to the agent. Both
+  // require sessions:control.
+
+  app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/context/clear", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
+    // Explicit confirm on the wire (literal true) — an empty/accidental POST
+    // cannot wipe context. Mirrors the client-side confirm affordance. A
+    // missing/false confirm is a client error (400), not a server fault.
+    const clearBody = ClearSessionContextRequest.safeParse(await c.req.json().catch(() => ({})));
+    if (!clearBody.success) {
+      throw new HTTPException(400, { message: "context clear requires an explicit { confirm: true }" });
+    }
+    const session = await requireSession(db, workspaceId, sessionId);
+    // Clearing mid-turn would strand the in-flight RunState (and, in
+    // requires_action, an awaiting approval whose resume needs that blob).
+    // Refuse, mirroring the goal 409 guards.
+    if (session.status === "queued" || session.status === "running" || session.status === "requires_action") {
+      throw new HTTPException(409, { message: `session is ${session.status}; cannot clear context mid-turn — stop the turn first` });
+    }
+    const result = await clearSessionContext(db, { accountId: grant.accountId, workspaceId, sessionId });
+    await appendAndPublishEvents(db, bus, workspaceId, sessionId, [{
+      type: "session.context.cleared",
+      payload: {
+        clearedBy: "api",
+        supersededItems: result.supersededItems,
+        markerPosition: result.markerPosition,
+      },
+    }]);
+    return c.body(null, 204);
+  });
+
+  app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/context/compact", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
+    CompactSessionContextRequest.parse((await c.req.json().catch(() => ({}))) ?? {});
+    // /compact is only a TRIGGER — it never duplicates the compaction engine.
+    // Client-managed (Azure) path: set a durable request flag the worker honors
+    // before the next turn (forced compaction). Server-managed provider / off:
+    // compaction is automatic or disabled, so this is an honest no-op.
+    //
+    // Integration seam with provider-aware-compaction: when that work exposes a
+    // synchronous "compact now" entry callable from the API process, this route
+    // should call it directly and return its result; until then the flag +
+    // worker maybeCompactContext(force) is the minimal honored interface.
+    const mode = resolveContextCompactionMode(settings);
+    if (mode === "client") {
+      await requestSessionCompaction(db, workspaceId, sessionId);
+      return c.json({ status: "queued", message: "Compaction will run before the next turn." });
+    }
+    if (mode === "server") {
+      return c.json({ status: "noop", message: "This session's provider compacts context automatically; no manual compaction is needed." });
+    }
+    return c.json({ status: "noop", message: "Context compaction is disabled for this session." });
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/events", async (c) => {

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -2,7 +2,7 @@
 // attachments (upload, chips, paste-to-attach) and the console's control
 // strip. The textarea, send/stop controls, Enter handling, and draft/error
 // state all come from the package.
-import { ChatComposer, type ComposerState } from "@opengeni/react";
+import { ChatComposer, type ComposerState, type SlashCommandContext } from "@opengeni/react";
 import { FileIcon, ImageIcon, ListPlusIcon, Loader2Icon, PaperclipIcon, XIcon, ZapIcon } from "lucide-react";
 import {
   type ClipboardEvent,
@@ -122,6 +122,14 @@ export function ConsoleComposer(props: {
    * message behind the running turn; steer interrupts and injects it now.
    */
   showDeliveryMode?: boolean;
+  /**
+   * Enables the slash-command palette (type "/"): session/operator controls
+   * (/goal, /clear, /compact, /help). Absent on surfaces with no live session
+   * (e.g. the new-session screen), where the palette stays inert.
+   */
+  commandContext?: SlashCommandContext;
+  /** Reset the local timeline view (the /clear-view command target). */
+  onClearView?: () => void;
 }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { composer, attachments } = props;
@@ -159,6 +167,8 @@ export function ConsoleComposer(props: {
         autoFocus={props.autoFocus}
         disabled={props.disabled}
         onPaste={handlePaste}
+        {...(props.commandContext ? { commandContext: props.commandContext } : {})}
+        {...(props.onClearView ? { onClearView: props.onClearView } : {})}
         header={attachments.attachments.length > 0 ? (
           <AttachmentChips attachments={attachments.attachments} onRemove={attachments.removeAttachment} />
         ) : undefined}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -17,7 +17,7 @@ import {
 } from "@opengeni/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { CheckIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { isApiErrorStatus } from "@/api";
@@ -65,7 +65,32 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
   // Queue + goal share the timeline's event stream — one SSE connection total.
   const queue = useTurnQueue(sessionId, { events });
   const goal = useGoal(sessionId, { events });
-  const timeline = useMemo(() => session ? projectSessionTimeline(session, events) : [], [session, events]);
+  // /clear-view: a LOCAL, this-device-only collapse of the transcript. It hides
+  // every event at or before the sequence seen when the operator ran it; the
+  // server log is untouched and newer events (higher sequence) keep streaming
+  // in. Reset when the session identity changes so a new session starts clean.
+  const [viewClearedAfter, setViewClearedAfter] = useState(0);
+  useEffect(() => {
+    setViewClearedAfter(0);
+  }, [sessionId]);
+  const clearView = useCallback(() => {
+    const latestSequence = events.reduce((max, event) => Math.max(max, event.sequence), 0);
+    setViewClearedAfter(latestSequence);
+  }, [events]);
+  const visibleEvents = useMemo(
+    () => viewClearedAfter > 0 ? events.filter((event) => event.sequence > viewClearedAfter) : events,
+    [events, viewClearedAfter],
+  );
+  const timeline = useMemo(() => {
+    if (!session) {
+      return [];
+    }
+    const projected = projectSessionTimeline(session, visibleEvents);
+    // projectSessionTimeline falls back to the session's initial message when
+    // the projection is empty; after a clear-view that fallback would resurrect
+    // the very first message, so suppress it once the view has been cleared.
+    return viewClearedAfter > 0 && visibleEvents.length === 0 ? [] : projected;
+  }, [session, visibleEvents, viewClearedAfter]);
   // Only approvals still awaiting a decision: the durable log replays every
   // historical `session.requiresAction`, so subtract decisions and finished
   // turns instead of rendering decided approvals as live buttons forever.
@@ -124,6 +149,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
         approvals={approvals}
         failure={failure}
         goal={goal}
+        onClearView={clearView}
         onOpenSession={(nextSessionId) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: nextSessionId } })}
         onNewSession={() => void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } })}
         onApprove={(approvalId) => void approve(approvalId, "approve")}
@@ -171,6 +197,8 @@ function SessionChatPane(props: {
   approvals: PendingApproval[];
   failure: ReturnType<typeof summarizeSessionFailure> | null;
   goal: ReturnType<typeof useGoal>;
+  /** Reset the local timeline view (the /clear-view command target). */
+  onClearView: () => void;
   onOpenSession: (sessionId: string) => void;
   onNewSession: () => void;
   onApprove: (approvalId: string) => void;
@@ -299,6 +327,7 @@ function SessionChatPane(props: {
             disabled={terminal}
             showDeliveryMode
             commandContext={commandContext}
+            onClearView={props.onClearView}
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
             placeholder={terminal
               ? `Session is ${props.session.status}.`

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -192,6 +192,24 @@ function SessionChatPane(props: {
     onSent: () => attachments.clear(),
   });
 
+  // Slash-command palette context: the operator controls (/goal, /clear,
+  // /compact, /help) act on THIS session. Permissions come from the workspace
+  // grant so the palette hides commands the operator can't run.
+  const workspacePermissions = useMemo(
+    () => context.accessContext.workspaceGrants.find((grant) => grant.workspaceId === props.session.workspaceId)?.permissions ?? [],
+    [context.accessContext.workspaceGrants, props.session.workspaceId],
+  );
+  const commandContext = useMemo(
+    () => ({
+      client: context.client,
+      workspaceId: props.session.workspaceId,
+      sessionId: props.session.id,
+      status: props.session.status,
+      permissions: workspacePermissions,
+    }),
+    [context.client, props.session.workspaceId, props.session.id, props.session.status, workspacePermissions],
+  );
+
   // Steering needs something to interrupt: when the turn ends, fall back to
   // the queue default so a stale steer toggle cannot surprise a later send.
   useEffect(() => {
@@ -280,6 +298,7 @@ function SessionChatPane(props: {
             status={props.session.status}
             disabled={terminal}
             showDeliveryMode
+            commandContext={commandContext}
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
             placeholder={terminal
               ? `Session is ${props.session.status}.`

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -11,6 +11,7 @@ import {
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
+  consumeSessionCompactionRequest,
   countActiveSessionHistoryItems,
   nextSessionHistoryPosition,
   requeuePreemptedTurn,
@@ -371,14 +372,21 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // RunState or in-flight tail must replay verbatim).
       if (triggerType === "user.message" || triggerType === "goal.continuation") {
         try {
+          // Operator /compact (the slash command) sets a durable request flag;
+          // consume it atomically so a forced compaction runs now even when the
+          // budget trigger would not fire. Only the turn that observes the flag
+          // runs it, so concurrent turns can't double-compact.
+          const forced = await consumeSessionCompactionRequest(db, input.workspaceId, input.sessionId);
           const outcome = await maybeCompactContext(
             db,
             runSettings,
             { accountId: input.accountId, workspaceId: input.workspaceId, sessionId: input.sessionId, turnId },
             session.lastInputTokens,
+            undefined,
+            forced ? { force: true } : {},
           );
           if (outcome.compacted) {
-            await publish([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition } }]);
+            await publish([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, ...(forced ? { trigger: "operator" } : {}) } }]);
           }
         } catch (compactError) {
           console.error("context compaction failed (turn proceeds un-compacted)", compactError);

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -52,6 +52,9 @@ export async function maybeCompactContext(
   lastInputTokens: number | null,
   // Injectable for tests; defaults to the real provider-aware model call.
   summarize: CompactionSummarizer = (s, m) => summarizeForCompaction(s, m, { maxOutputTokens: s.contextSummaryMaxTokens }),
+  // Operator-forced (the /compact command): bypass the budget trigger and
+  // compact now if there is anything to summarize. Structural guards still hold.
+  options: { force?: boolean } = {},
 ): Promise<MaybeCompactResult> {
   if (resolveContextCompactionMode(settings) !== "client") {
     return { compacted: false, reason: "mode_not_client" };
@@ -70,6 +73,7 @@ export async function maybeCompactContext(
     softFraction: settings.contextCompactSoftFraction,
     hardFraction: settings.contextCompactHardFraction,
     keepRecentTokens: settings.contextKeepRecentTokens,
+    ...(options.force ? { force: true } : {}),
   });
   if (!plan.shouldCompact) {
     return { compacted: false, reason: plan.reason };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -604,6 +604,33 @@ export const UpdateSessionGoalRequest = z.object({
 });
 export type UpdateSessionGoalRequest = z.infer<typeof UpdateSessionGoalRequest>;
 
+// Operator context controls (slash-command palette: /clear, /compact). These
+// are session/operator actions, NOT a structured way to talk to the agent —
+// the human↔agent channel stays plain chat. Both require `sessions:control`.
+
+/**
+ * Clear a session's conversation context. `confirm` must be the literal `true`
+ * so an accidental/empty POST cannot wipe context — the destructive intent is
+ * explicit on the wire, mirroring the client-side confirm affordance.
+ */
+export const ClearSessionContextRequest = z.object({
+  confirm: z.literal(true),
+});
+export type ClearSessionContextRequest = z.infer<typeof ClearSessionContextRequest>;
+
+/** Trigger conversation compaction now. No body fields today (forward-room). */
+export const CompactSessionContextRequest = z.object({}).strict();
+export type CompactSessionContextRequest = z.infer<typeof CompactSessionContextRequest>;
+
+/** Outcome of a manual /compact trigger. */
+export const CompactSessionContextResult = z.object({
+  // queued: a client-side (Azure) compaction will run before the next turn.
+  // noop:   nothing to do (server-managed provider, mode off, or no history).
+  status: z.enum(["queued", "noop"]),
+  message: z.string(),
+});
+export type CompactSessionContextResult = z.infer<typeof CompactSessionContextResult>;
+
 export const SessionTurn = z.object({
   id: z.string().uuid(),
   workspaceId: z.string().uuid(),
@@ -1176,6 +1203,7 @@ export const SessionEventType = z.enum([
   "session.status.changed",
   "session.requiresAction",
   "session.context.compacted",
+  "session.context.cleared",
   "user.message",
   "user.interrupt",
   "user.approvalDecision",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -618,6 +618,42 @@ export const ClearSessionContextRequest = z.object({
 });
 export type ClearSessionContextRequest = z.infer<typeof ClearSessionContextRequest>;
 
+/**
+ * The marker key on the sentinel run-state blob written by a context clear. The
+ * blob ({@link CLEARED_RUN_STATE_BLOB}) is NOT a real Agents-SDK serialized run
+ * state — it carries no `$schemaVersion`/history, so `RunState.fromString` would
+ * throw on it. Every read path that deserializes a run-state blob MUST first
+ * check {@link isClearedRunStateBlob} and treat a match as "no prior state"
+ * (a fresh, empty start), which is exactly what a clear means. This is the
+ * shared contract that keeps the db (writer) and the runtime (reader) in sync.
+ */
+export const CLEARED_RUN_STATE_MARKER = "$opengeniCleared" as const;
+
+/** The canonical sentinel serializedRunState value a context clear stores. */
+export const CLEARED_RUN_STATE_BLOB = JSON.stringify({ [CLEARED_RUN_STATE_MARKER]: true });
+
+/**
+ * True when a serialized run-state blob is the cleared sentinel rather than a
+ * real Agents-SDK run state. Recognized leniently (any object carrying the
+ * marker key set truthy) so a future field addition to the sentinel does not
+ * resurrect the pre-clear context. Anything that is not the sentinel — including
+ * malformed JSON — returns false so genuine blobs/corruption are handled by the
+ * normal deserialize path.
+ */
+export function isClearedRunStateBlob(serialized: string | null | undefined): boolean {
+  if (!serialized) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(serialized) as unknown;
+    return typeof parsed === "object"
+      && parsed !== null
+      && (parsed as Record<string, unknown>)[CLEARED_RUN_STATE_MARKER] === true;
+  } catch {
+    return false;
+  }
+}
+
 /** Trigger conversation compaction now. No body fields today (forward-room). */
 export const CompactSessionContextRequest = z.object({}).strict();
 export type CompactSessionContextRequest = z.infer<typeof CompactSessionContextRequest>;

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -17,6 +17,9 @@ import {
   MarketingDailyAnalysisTaskRequest,
   ResourceRef,
   SessionBusMessage,
+  CLEARED_RUN_STATE_BLOB,
+  CLEARED_RUN_STATE_MARKER,
+  isClearedRunStateBlob,
 } from "../src";
 
 describe("contracts", () => {
@@ -318,5 +321,24 @@ describe("capability pack runtime manifest fields", () => {
       ...baseManifest,
       skills: [{ name: "infra-ops", files: [{ path: "SKILL.md", content: "a" }, { path: "SKILL.md", content: "b" }] }],
     })).toThrow();
+  });
+});
+
+describe("cleared run-state sentinel", () => {
+  test("the canonical blob is recognized as cleared", () => {
+    expect(isClearedRunStateBlob(CLEARED_RUN_STATE_BLOB)).toBe(true);
+    // Tolerant of extra fields so a future sentinel addition can't resurrect context.
+    expect(isClearedRunStateBlob(JSON.stringify({ [CLEARED_RUN_STATE_MARKER]: true, note: "x" }))).toBe(true);
+  });
+
+  test("real run-state blobs and junk are NOT treated as cleared", () => {
+    // A real Agents-SDK serialized run state (carries $schemaVersion/history).
+    expect(isClearedRunStateBlob(JSON.stringify({ $schemaVersion: "1.11", currentTurn: 1, generatedItems: [] }))).toBe(false);
+    expect(isClearedRunStateBlob(null)).toBe(false);
+    expect(isClearedRunStateBlob(undefined)).toBe(false);
+    expect(isClearedRunStateBlob("")).toBe(false);
+    expect(isClearedRunStateBlob("not json")).toBe(false);
+    expect(isClearedRunStateBlob(JSON.stringify({ [CLEARED_RUN_STATE_MARKER]: false }))).toBe(false);
+    expect(isClearedRunStateBlob("null")).toBe(false);
   });
 });

--- a/packages/db/drizzle/0013_session_compact_requested.sql
+++ b/packages/db/drizzle/0013_session_compact_requested.sql
@@ -1,0 +1,16 @@
+-- Operator /compact request flag (slash-command palette).
+--
+-- /compact is a manual trigger for the client-side (Azure) context compaction
+-- path. The API sets this flag true; the worker honors it BEFORE the next
+-- turn's model call by forcing a compaction (bypassing the token-budget
+-- trigger), then clears it. A durable column — not a transient signal — so the
+-- request survives a worker restart and converges before the next turn.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "compact_requested" boolean NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -49,7 +49,7 @@ import type {
   WorkspaceEnvironmentVariableMetadata,
   WorkspaceRegisteredPack,
 } from "@opengeni/contracts";
-import { reasoningEffortForMetadata } from "@opengeni/contracts";
+import { reasoningEffortForMetadata, CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
 import { and, asc, desc, eq, gt, gte, inArray, lt, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
@@ -2252,14 +2252,24 @@ export function clearedContextMarkerItem(): Record<string, unknown> {
 }
 
 /**
- * The sentinel serializedRunState written by clearSessionContext. It is
- * audit-honest (carries no prior conversation) and is never deserialized on a
- * cleared session: the message path always takes the items route (the marker
- * above keeps it non-empty) and the approval path is refused for sessions that
- * are mid-turn / awaiting action. Stored so getLatestRunState — the other read
- * path — also reflects the clear instead of the pre-clear blob.
+ * The sentinel serializedRunState written by clearSessionContext, re-exported
+ * from @opengeni/contracts so the writer (here) and the readers (run-input /
+ * runtime) share one definition. It is audit-honest (carries no prior
+ * conversation) and is NOT a real Agents-SDK run state — it has no
+ * `$schemaVersion`/history, so `RunState.fromString` throws on it.
+ *
+ * Both run-state read paths therefore guard against it explicitly via
+ * {@link isClearedRunStateBlob}:
+ *  - the message path (run-input messageInput) honors it in BOTH items and
+ *    run_state history modes — in items mode the boundary marker keeps the
+ *    active read non-empty so the blob is never reached, and in run_state mode
+ *    the sentinel is recognized and treated as a fresh empty start;
+ *  - the approval path is additionally refused by the API for mid-turn /
+ *    requires_action sessions, so it never sees the sentinel.
+ * Stored so getLatestRunState (the run_state-source read path) reflects the
+ * clear instead of resurrecting the pre-clear blob.
  */
-export const CLEARED_RUN_STATE = JSON.stringify({ $opengeniCleared: true });
+export const CLEARED_RUN_STATE = CLEARED_RUN_STATE_BLOB;
 
 export type ClearSessionContextResult = {
   /** Active history rows superseded (active=true -> false). */

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2240,6 +2240,121 @@ export async function setSessionLastInputTokens(db: Database, workspaceId: strin
   });
 }
 
+/**
+ * The neutral marker written by clearSessionContext as the sole active history
+ * row. It keeps getActiveSessionHistoryItems().length > 0 so the items read
+ * path (run-input.ts messageInput) stays selected and never falls through to
+ * the getLatestRunState blob — that fallback is the resurrection vector a clear
+ * must defeat. A plain user message is a valid, sanitizer-clean item.
+ */
+export function clearedContextMarkerItem(): Record<string, unknown> {
+  return { type: "message", role: "user", content: "[context cleared]" };
+}
+
+/**
+ * The sentinel serializedRunState written by clearSessionContext. It is
+ * audit-honest (carries no prior conversation) and is never deserialized on a
+ * cleared session: the message path always takes the items route (the marker
+ * above keeps it non-empty) and the approval path is refused for sessions that
+ * are mid-turn / awaiting action. Stored so getLatestRunState — the other read
+ * path — also reflects the clear instead of the pre-clear blob.
+ */
+export const CLEARED_RUN_STATE = JSON.stringify({ $opengeniCleared: true });
+
+export type ClearSessionContextResult = {
+  /** Active history rows superseded (active=true -> false). */
+  supersededItems: number;
+  /** Position of the inserted neutral boundary marker. */
+  markerPosition: number;
+  /** stateVersion of the fresh cleared run-state row. */
+  runStateVersion: number;
+};
+
+/**
+ * Clear a session's conversation context in ONE transaction, audit-preserving
+ * and idempotent. Defeats the RunState-fallback resurrection on BOTH model read
+ * paths:
+ *
+ *  (a) supersede every active session_history_items row (active=true -> false).
+ *      Nothing is deleted — the full transcript stays as an audit trail, same
+ *      pattern as applyContextCompaction.
+ *  (b) insert ONE active neutral boundary marker at max(position)+1 so the
+ *      active read path returns length 1 (not 0) and run-input.ts stays on the
+ *      items route, away from the getLatestRunState blob (the bug).
+ *  (c) insert a fresh agent_run_states row (stateVersion = max+1) with an empty
+ *      cleared blob and pendingApprovals:[], so getLatestRunState (approval /
+ *      run_state-source read path) also reflects the clear.
+ *
+ * Also resets last_input_tokens to 0 so the next turn's compaction trigger
+ * starts fresh against the now-short context.
+ *
+ * Idempotent: a re-run supersedes the (now sole, already-marker) active row,
+ * inserts another marker at the next position, and another cleared run-state.
+ * The post-conditions (one active marker row, latest run-state cleared) hold.
+ */
+export async function clearSessionContext(db: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+}): Promise<ClearSessionContextResult> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    return await scopedDb.transaction(async (tx) => {
+      const supersededRows = await tx.update(schema.sessionHistoryItems)
+        .set({ active: false })
+        .where(and(
+          eq(schema.sessionHistoryItems.workspaceId, input.workspaceId),
+          eq(schema.sessionHistoryItems.sessionId, input.sessionId),
+          eq(schema.sessionHistoryItems.active, true),
+        ))
+        .returning({ id: schema.sessionHistoryItems.id });
+
+      const [{ maxPosition } = { maxPosition: -1 }] = await tx.select({
+        maxPosition: sql<number>`coalesce(max(${schema.sessionHistoryItems.position}), -1)`,
+      }).from(schema.sessionHistoryItems)
+        .where(and(
+          eq(schema.sessionHistoryItems.workspaceId, input.workspaceId),
+          eq(schema.sessionHistoryItems.sessionId, input.sessionId),
+        ));
+      const markerPosition = Number(maxPosition) + 1;
+      await tx.insert(schema.sessionHistoryItems).values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        turnId: null,
+        position: markerPosition,
+        item: clearedContextMarkerItem(),
+        active: true,
+      }).onConflictDoNothing({
+        target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
+      });
+
+      const [{ maxVersion } = { maxVersion: 0 }] = await tx.select({
+        maxVersion: sql<number>`coalesce(max(${schema.agentRunStates.stateVersion}), 0)`,
+      }).from(schema.agentRunStates)
+        .where(and(
+          eq(schema.agentRunStates.workspaceId, input.workspaceId),
+          eq(schema.agentRunStates.sessionId, input.sessionId),
+        ));
+      const runStateVersion = Number(maxVersion) + 1;
+      await tx.insert(schema.agentRunStates).values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        turnId: null,
+        stateVersion: runStateVersion,
+        serializedRunState: CLEARED_RUN_STATE,
+        pendingApprovals: [],
+      });
+
+      await tx.update(schema.sessions)
+        .set({ lastInputTokens: 0, updatedAt: new Date() })
+        .where(and(eq(schema.sessions.workspaceId, input.workspaceId), eq(schema.sessions.id, input.sessionId)));
+
+      return { supersededItems: supersededRows.length, markerPosition, runStateVersion };
+    });
+  });
+}
+
 export async function countSessionHistoryItems(db: Database, workspaceId: string, sessionId: string): Promise<number> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [row] = await scopedDb.select({
@@ -2247,6 +2362,38 @@ export async function countSessionHistoryItems(db: Database, workspaceId: string
     }).from(schema.sessionHistoryItems)
       .where(and(eq(schema.sessionHistoryItems.workspaceId, workspaceId), eq(schema.sessionHistoryItems.sessionId, sessionId)));
     return Number(row?.count ?? 0);
+  });
+}
+
+/**
+ * Set the operator /compact request flag. The worker honors it before the next
+ * turn (forced client-side compaction) and clears it. Idempotent: repeated
+ * requests collapse to one pending compaction.
+ */
+export async function requestSessionCompaction(db: Database, workspaceId: string, sessionId: string): Promise<void> {
+  await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    await scopedDb.update(schema.sessions)
+      .set({ compactRequested: true, updatedAt: new Date() })
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)));
+  });
+}
+
+/**
+ * Atomically consume the /compact request flag: clear it and report whether it
+ * was set. The worker calls this pre-turn; only the call that observed `true`
+ * runs the forced compaction, so concurrent turns can't double-compact.
+ */
+export async function consumeSessionCompactionRequest(db: Database, workspaceId: string, sessionId: string): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const cleared = await scopedDb.update(schema.sessions)
+      .set({ compactRequested: false, updatedAt: new Date() })
+      .where(and(
+        eq(schema.sessions.workspaceId, workspaceId),
+        eq(schema.sessions.id, sessionId),
+        eq(schema.sessions.compactRequested, true),
+      ))
+      .returning({ id: schema.sessions.id });
+    return cleared.length > 0;
   });
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -130,6 +130,11 @@ export const sessions = pgTable("sessions", {
   // signal (char/4 estimate is the same-turn fallback). Null until a turn with
   // usage has completed.
   lastInputTokens: integer("last_input_tokens"),
+  // Operator /compact request flag (client-side compaction path). The API sets
+  // it true; the worker honors it BEFORE the next turn's model call by forcing
+  // a compaction, then clears it. A durable flag (not a transient signal) so
+  // the trigger survives a worker restart and converges before the next turn.
+  compactRequested: boolean("compact_requested").notNull().default(false),
   lastSequence: integer("last_sequence").notNull().default(0),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/react/demo/main.tsx
+++ b/packages/react/demo/main.tsx
@@ -8,6 +8,7 @@ import {
   OpenGeniProvider,
   SessionStatus,
   useComposer,
+  useOpenGeni,
   useScheduledTasks,
   useSession,
   useSessionEvents,
@@ -55,10 +56,20 @@ function Harness() {
 
 /** The hero surface: manager session timeline + composer. */
 function OpsChannel() {
+  const { client, workspaceId } = useOpenGeni();
   const { session } = useSession(MANAGER_SESSION_ID, { pollIntervalMs: 5000 });
   const { timeline, sessionStatus, connectionState } = useSessionEvents(MANAGER_SESSION_ID);
   const composer = useComposer(MANAGER_SESSION_ID);
   const status = sessionStatus ?? session?.status ?? null;
+  // Surface the slash-command palette (type "/"): operator controls on this
+  // session. The demo operator holds full control.
+  const commandContext = {
+    client,
+    workspaceId,
+    sessionId: MANAGER_SESSION_ID,
+    status,
+    permissions: ["sessions:control"],
+  };
 
   return (
     <section className="flex min-h-0 flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1/50">
@@ -79,7 +90,7 @@ function OpsChannel() {
         onOpenSession={(sessionId) => window.alert(`Open worker session ${sessionId}`)}
       />
       <div className="shrink-0 px-4 pb-4 pt-1">
-        <ChatComposer composer={composer} status={status} placeholder="Message your infrastructure…" autoFocus />
+        <ChatComposer composer={composer} status={status} placeholder="Message your infrastructure…" autoFocus commandContext={commandContext} />
       </div>
     </section>
   );

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -260,6 +260,15 @@ export class MockOpenGeniClient implements SessionClientLike {
     return { ...goal };
   }
 
+  async clearSessionContext(_workspaceId: string, sessionId: string): Promise<void> {
+    this.bus(sessionId).append("session.context.cleared", { clearedBy: "api" });
+  }
+
+  async compactSessionContext(_workspaceId: string, sessionId: string): Promise<{ status: "queued" | "noop"; message: string }> {
+    this.bus(sessionId).append("session.context.compacted", { trigger: "operator" });
+    return { status: "queued", message: "Compaction will run before the next turn." };
+  }
+
   async sendApprovalDecision(
     _workspaceId: string,
     sessionId: string,

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -23,6 +23,9 @@ export type SessionClientLike = Pick<
   // Goal
   | "getGoal"
   | "updateGoal"
+  // Operator context controls (/clear, /compact)
+  | "clearSessionContext"
+  | "compactSessionContext"
   // Scheduled tasks
   | "listScheduledTasks"
   // Environments

--- a/packages/react/src/commands/index.ts
+++ b/packages/react/src/commands/index.ts
@@ -1,0 +1,17 @@
+export type {
+  CommandContext,
+  CommandResult,
+  Notice,
+  SlashArg,
+  SlashCommand,
+} from "./types";
+export {
+  argHint,
+  defaultCommands,
+  filterCommands,
+  firstMissingRequiredArg,
+  hasPermission,
+  matchCommand,
+  parseCommandLine,
+} from "./registry";
+export type { ParsedCommandLine } from "./registry";

--- a/packages/react/src/commands/registry.ts
+++ b/packages/react/src/commands/registry.ts
@@ -133,7 +133,14 @@ export const defaultCommands: readonly SlashCommand[] = [
     name: "clear-view",
     description: "Clear the local timeline view (this device only; no server change).",
     run: (_args, ctx) => {
-      ctx.clearView();
+      // clearView() reports whether the host actually wired a view-reset. If it
+      // didn't (the console surface has no resettable local timeline), reporting
+      // "Local view cleared." would be a false success — return an honest error
+      // instead so the operator isn't told something happened when nothing did.
+      const cleared = ctx.clearView();
+      if (!cleared) {
+        return { status: "error", message: "This view can't be cleared here (no local timeline to reset)." };
+      }
       return { status: "ok", message: "Local view cleared." };
     },
   },

--- a/packages/react/src/commands/registry.ts
+++ b/packages/react/src/commands/registry.ts
@@ -1,0 +1,227 @@
+import type { Permission } from "@opengeni/sdk";
+import type { CommandContext, SlashArg, SlashCommand } from "./types";
+
+/**
+ * Parse a composer value into a command name + the rest. A command is
+ * recognized ONLY when the value's first character is "/" (the start token);
+ * anything else is plain chat and returns null.
+ *
+ * "/cl"        -> { name: "cl", rest: "", hasTrailingSpace: false }
+ * "/goal "     -> { name: "goal", rest: "", hasTrailingSpace: true }
+ * "/goal pause"-> { name: "goal", rest: "pause", hasTrailingSpace: false }
+ */
+export type ParsedCommandLine = {
+  name: string;
+  rest: string;
+  /** True when the name token is closed by a space — arg-hint mode. */
+  hasTrailingSpace: boolean;
+  args: string[];
+};
+
+export function parseCommandLine(value: string): ParsedCommandLine | null {
+  if (value[0] !== "/") {
+    return null;
+  }
+  const body = value.slice(1);
+  const firstSpace = body.indexOf(" ");
+  if (firstSpace === -1) {
+    return { name: body, rest: "", hasTrailingSpace: false, args: [] };
+  }
+  const name = body.slice(0, firstSpace);
+  const rest = body.slice(firstSpace + 1);
+  return {
+    name,
+    rest,
+    hasTrailingSpace: true,
+    args: rest.split(/\s+/).filter((token) => token.length > 0),
+  };
+}
+
+const PERMISSION_SUPERUSER: Permission = "workspace:admin";
+
+/** Whether the operator's permission set satisfies a command's gate. */
+export function hasPermission(required: Permission | undefined, permissions: Permission[]): boolean {
+  if (!required) {
+    return true;
+  }
+  return permissions.includes(required) || permissions.includes(PERMISSION_SUPERUSER);
+}
+
+/** Match a command (by name or alias) against the value. */
+export function matchCommand(commands: readonly SlashCommand[], value: string): SlashCommand | null {
+  const parsed = parseCommandLine(value);
+  if (!parsed) {
+    return null;
+  }
+  const token = parsed.name.toLowerCase();
+  return commands.find((command) => command.name === token || command.aliases?.includes(token)) ?? null;
+}
+
+type FilterCtx = Pick<CommandContext, "sessionId" | "status" | "permissions">;
+
+/**
+ * The commands visible for the current token + context. Permission-absent and
+ * `available()===false` commands are dropped entirely (a gated command is never
+ * shown, not shown-disabled). Filtering is a prefix match on name/alias.
+ */
+export function filterCommands(commands: readonly SlashCommand[], token: string, ctx: FilterCtx): SlashCommand[] {
+  const needle = token.toLowerCase();
+  return commands.filter((command) => {
+    if (!hasPermission(command.permission, ctx.permissions)) {
+      return false;
+    }
+    if (command.available && !command.available(ctx)) {
+      return false;
+    }
+    if (needle.length === 0) {
+      return true;
+    }
+    return command.name.startsWith(needle) || (command.aliases?.some((alias) => alias.startsWith(needle)) ?? false);
+  });
+}
+
+/** Render a command's arg hint for the palette footer / help, e.g. "<pause|resume>". */
+export function argHint(args: readonly SlashArg[] | undefined): string {
+  if (!args || args.length === 0) {
+    return "";
+  }
+  return args
+    .map((arg) => {
+      const label = arg.oneOf ? arg.oneOf.join("|") : arg.name;
+      return arg.required ? `<${label}>` : `[${label}]`;
+    })
+    .join(" ");
+}
+
+/** The first required arg that has not yet been supplied, if any. */
+export function firstMissingRequiredArg(command: SlashCommand, args: string[]): SlashArg | null {
+  const required = (command.args ?? []).filter((arg) => arg.required);
+  for (let i = 0; i < required.length; i += 1) {
+    const value = args[i];
+    if (value === undefined || value.length === 0) {
+      return required[i] ?? null;
+    }
+  }
+  return null;
+}
+
+function requireSession(ctx: CommandContext): string {
+  if (!ctx.sessionId) {
+    throw new Error("No active session yet — start a session first.");
+  }
+  return ctx.sessionId;
+}
+
+const hasSession = (ctx: FilterCtx): boolean => ctx.sessionId !== null;
+
+/**
+ * The default command set. Adding a command is one object literal here; the
+ * palette list, filter, arg-hint footer, and /help all render from this array.
+ * Apps concat their own commands via the ChatComposer `commands` prop.
+ */
+export const defaultCommands: readonly SlashCommand[] = [
+  {
+    name: "help",
+    aliases: ["?"],
+    description: "Show available commands.",
+    run: (_args, ctx) => {
+      ctx.openHelp();
+      return { status: "ok" };
+    },
+  },
+  {
+    name: "clear-view",
+    description: "Clear the local timeline view (this device only; no server change).",
+    run: (_args, ctx) => {
+      ctx.clearView();
+      return { status: "ok", message: "Local view cleared." };
+    },
+  },
+  {
+    name: "goal",
+    description: "Pause or resume the session's goal loop.",
+    permission: "sessions:control",
+    available: hasSession,
+    args: [{ name: "action", required: true, oneOf: ["pause", "resume"], description: "pause | resume" }],
+    run: async (args, ctx) => {
+      const sessionId = requireSession(ctx);
+      const action = args[0];
+      if (action !== "pause" && action !== "resume") {
+        return { status: "error", message: "Usage: /goal pause | /goal resume" };
+      }
+      try {
+        await ctx.client.updateGoal(ctx.workspaceId, sessionId, { status: action === "pause" ? "paused" : "active" });
+        return { status: "ok", message: action === "pause" ? "Goal paused." : "Goal resumed." };
+      } catch (cause) {
+        return { status: "error", message: goalErrorMessage(cause, action) };
+      }
+    },
+  },
+  {
+    name: "compact",
+    description: "Compact the conversation context now.",
+    permission: "sessions:control",
+    available: hasSession,
+    run: async (_args, ctx) => {
+      const sessionId = requireSession(ctx);
+      try {
+        const result = await ctx.client.compactSessionContext(ctx.workspaceId, sessionId);
+        return { status: "ok", message: result.message };
+      } catch (cause) {
+        return { status: "error", message: errorMessage(cause) ?? "Could not compact context." };
+      }
+    },
+  },
+  {
+    name: "clear",
+    description: "Clear the conversation context (destructive; audit-preserved).",
+    permission: "sessions:control",
+    danger: true,
+    available: hasSession,
+    run: async (_args, ctx) => {
+      const sessionId = requireSession(ctx);
+      const confirmed = await ctx.confirm();
+      if (!confirmed) {
+        return { status: "ok" };
+      }
+      try {
+        await ctx.client.clearSessionContext(ctx.workspaceId, sessionId);
+        return { status: "ok", message: "Context cleared." };
+      } catch (cause) {
+        return { status: "error", message: clearErrorMessage(cause) };
+      }
+    },
+  },
+];
+
+function errorMessage(cause: unknown): string | undefined {
+  if (cause && typeof cause === "object" && "message" in cause && typeof (cause as { message?: unknown }).message === "string") {
+    return (cause as { message: string }).message;
+  }
+  return undefined;
+}
+
+function statusCode(cause: unknown): number | undefined {
+  if (cause && typeof cause === "object" && "status" in cause && typeof (cause as { status?: unknown }).status === "number") {
+    return (cause as { status: number }).status;
+  }
+  return undefined;
+}
+
+function goalErrorMessage(cause: unknown, action: "pause" | "resume"): string {
+  const code = statusCode(cause);
+  if (code === 404) {
+    return "This session has no goal to control.";
+  }
+  if (code === 409) {
+    return action === "resume" ? "Only a paused goal can be resumed." : "Goal is already in a terminal state.";
+  }
+  return errorMessage(cause) ?? `Could not ${action} the goal.`;
+}
+
+function clearErrorMessage(cause: unknown): string {
+  if (statusCode(cause) === 409) {
+    return "Can't clear context mid-turn — stop the current turn first.";
+  }
+  return errorMessage(cause) ?? "Could not clear context.";
+}

--- a/packages/react/src/commands/types.ts
+++ b/packages/react/src/commands/types.ts
@@ -43,8 +43,14 @@ export type CommandContext = {
   notice: (notice: Notice) => void;
   /** Open the in-composer /help panel (rendered from the registry). */
   openHelp: () => void;
-  /** Reset only the LOCAL timeline view — no server call. */
-  clearView: () => void;
+  /**
+   * Reset only the LOCAL timeline view — no server call. Returns whether a
+   * view-reset affordance was actually wired (and thus had an effect): the host
+   * surface supplies one via the composer's `onClearView` prop, and consoles
+   * that don't (no resettable local timeline) get `false`. The /clear-view
+   * command uses this to avoid reporting a false "cleared" success on a no-op.
+   */
+  clearView: () => boolean;
   /** Show the danger confirm bar; resolves true once the operator confirms. */
   confirm: () => Promise<boolean>;
 };

--- a/packages/react/src/commands/types.ts
+++ b/packages/react/src/commands/types.ts
@@ -1,0 +1,75 @@
+import type { Permission, SessionStatus } from "@opengeni/sdk";
+import type { SessionClientLike } from "../client";
+
+/**
+ * The slash-command registry. A command is a SESSION / OPERATOR control — an
+ * action on the session or the UI (clear, compact, pause the goal, show help) —
+ * NOT a structured way to talk to the agent. The human↔agent channel stays
+ * plain chat; the palette only recognizes a leading "/" and never sends a
+ * command to the model.
+ *
+ * Two kinds, modeled by where the handler does its work:
+ *  - CLIENT commands touch only the local UI (e.g. /help, /clear-view).
+ *  - SERVER commands call the API through the SDK (e.g. /clear, /compact,
+ *    /goal).
+ * Both are just `run(args, ctx)`; `ctx` exposes the client for server commands
+ * and the UI affordances (notice, openHelp, clearView, confirm) for both.
+ */
+
+/** A positional argument a command accepts after its name. */
+export type SlashArg = {
+  name: string;
+  /** Enter runs only once every required arg is present; otherwise autocompletes. */
+  required?: boolean;
+  /** Closed value set (rendered as a hint; validated by the command itself). */
+  oneOf?: readonly string[];
+  description?: string;
+};
+
+/** Transient feedback surfaced in the composer (generalized error line). */
+export type Notice = { tone: "ok" | "error"; message: string };
+
+/** Everything a command handler can reach. Assembled by the composer. */
+export type CommandContext = {
+  /** SDK-shaped client for server commands. */
+  client: SessionClientLike;
+  workspaceId: string;
+  /** Null before a session exists (server commands should guard on this). */
+  sessionId: string | null;
+  status: SessionStatus | null;
+  /** The operator's permissions on this workspace (gates command visibility). */
+  permissions: Permission[];
+  /** Surface a transient ok/error notice in the composer. */
+  notice: (notice: Notice) => void;
+  /** Open the in-composer /help panel (rendered from the registry). */
+  openHelp: () => void;
+  /** Reset only the LOCAL timeline view — no server call. */
+  clearView: () => void;
+  /** Show the danger confirm bar; resolves true once the operator confirms. */
+  confirm: () => Promise<boolean>;
+};
+
+export type CommandResult = {
+  status: "ok" | "error";
+  message?: string;
+};
+
+export type SlashCommand = {
+  /** Primary token after the slash (no leading "/"). */
+  name: string;
+  /** Alternate tokens that resolve to this command. */
+  aliases?: readonly string[];
+  description: string;
+  args?: readonly SlashArg[];
+  /** Required permission; the command is hidden from the palette without it. */
+  permission?: Permission;
+  /** Destructive — the palette shows a confirm bar before running. */
+  danger?: boolean;
+  /**
+   * Dynamic availability beyond the permission gate (e.g. hide a server command
+   * until a session exists). Returning false hides the command.
+   */
+  available?: (ctx: Pick<CommandContext, "sessionId" | "status" | "permissions">) => boolean;
+  /** Execute the command. Throwing is caught and surfaced as an error notice. */
+  run: (args: string[], ctx: CommandContext) => Promise<CommandResult> | CommandResult;
+};

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -101,7 +101,15 @@ export function ChatComposer({
         composer.clearError();
       },
       openHelp: () => setHelpOpen(true),
-      clearView: () => onClearView?.(),
+      // Report whether a view-reset was actually wired by the host: with no
+      // onClearView the command is a no-op and must say so (not a false success).
+      clearView: () => {
+        if (!onClearView) {
+          return false;
+        }
+        onClearView();
+        return true;
+      },
       confirm: () =>
         new Promise<boolean>((resolve) => {
           setConfirmState({

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -110,12 +110,14 @@ export function ChatComposer({
         onClearView();
         return true;
       },
-      confirm: () =>
+      // The hook binds the command actually being run into confirm() (see
+      // use-slash-commands buildContext), so the confirm bar renders from THAT
+      // command — never a near-match highlighted in the palette. This is what
+      // keeps the destructive /clear from being mislabeled as /clear-view.
+      confirm: (command: SlashCommand) =>
         new Promise<boolean>((resolve) => {
           setConfirmState({
-            // The confirm bar is rendered from the highlighted/active command;
-            // the command itself is supplied by the hook at run time.
-            command: { name: "clear", description: "", danger: true, run: () => ({ status: "ok" }) },
+            command,
             resolve: (confirmed) => {
               setConfirmState(null);
               resolve(confirmed);
@@ -134,11 +136,13 @@ export function ChatComposer({
     setValue: composer.setValue,
   });
 
-  // The confirm bar reflects the command currently awaiting confirmation; the
-  // hook drives execution, so we render the active/highlighted danger command.
-  const pendingDangerCommand = confirmState
-    ? palette.activeCommand ?? palette.items[palette.highlight] ?? confirmState.command
-    : null;
+  // The confirm bar renders from the command the hook is actually running —
+  // carried into confirmState by handlers.confirm — NOT a near-match that
+  // happens to be highlighted/active in the palette. (Re-deriving it from
+  // palette.items[palette.highlight] mislabeled the destructive /clear as the
+  // harmless /clear-view, since clear-view prefix-matches "clear" and sorts
+  // first.)
+  const pendingDangerCommand = confirmState ? confirmState.command : null;
 
   const paletteEnabled = commandContext !== undefined;
 
@@ -312,7 +316,12 @@ export function ChatComposer({
 /** The danger confirm bar — reuses og-status-failed tokens (like the stop control). */
 function ConfirmBar({ command, onCancel, onConfirm }: { command: SlashCommand; onCancel: () => void; onConfirm: () => void }) {
   return (
-    <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
+    <div
+      role="alertdialog"
+      aria-label={`Confirm /${command.name}`}
+      data-testid="danger-confirm"
+      className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1"
+    >
       <span className="px-1.5 text-[12px] text-og-status-failed">
         Run <span className="font-mono">/{command.name}</span>? {command.description}
       </span>

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,10 +1,15 @@
 import type { SessionStatus } from "@opengeni/sdk";
 import { ArrowUpIcon, LoaderCircleIcon, SquareIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useRef, type ClipboardEvent, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ClipboardEvent, type KeyboardEvent, type ReactNode } from "react";
+import { argHint } from "../commands/registry";
+import type { Notice, SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
 import { shouldSubmitOnKey } from "../hooks/use-composer";
+import { defaultCommands } from "../commands/registry";
+import { useSlashCommands, type ConfirmState, type SlashCommandContext } from "../hooks/use-slash-commands";
 import { cn } from "../lib/cn";
+import { CommandPalette } from "./command-palette";
 
 export type ChatComposerProps = {
   composer: ComposerState;
@@ -22,6 +27,19 @@ export type ChatComposerProps = {
   /** Paste hook on the textarea (e.g. paste-image-to-attach). */
   onPaste?: ((event: ClipboardEvent<HTMLTextAreaElement>) => void) | undefined;
   className?: string | undefined;
+  /**
+   * Slash-command palette. Defaults to the built-in {@link defaultCommands};
+   * apps concat their own. Backward-compatible: when `commandContext` is absent
+   * the palette is inert and behavior is identical to before.
+   */
+  commands?: readonly SlashCommand[] | undefined;
+  /**
+   * Wiring the palette needs to run server commands and gate visibility. The
+   * composer supplies notice/openHelp/clearView/confirm internally.
+   */
+  commandContext?: SlashCommandContext | undefined;
+  /** Reset the local timeline view (the /clear-view command target). */
+  onClearView?: (() => void) | undefined;
 };
 
 const ACTIVE_STATUSES: ReadonlySet<SessionStatus> = new Set(["queued", "running"]);
@@ -31,10 +49,34 @@ const ACTIVE_STATUSES: ReadonlySet<SessionStatus> = new Set(["queued", "running"
  * everything else is the agent's job. Enter sends, Shift+Enter breaks the
  * line, and the stop control appears while a turn is running (sending while
  * running is legitimate steering, so send stays available too).
+ *
+ * Typing a leading "/" opens the slash-command palette — SESSION/OPERATOR
+ * controls (clear, compact, pause goal, help), never a structured channel to
+ * the agent. The palette is purely additive: with no `commandContext` it is
+ * inert and the composer behaves exactly as before.
  */
-export function ChatComposer({ composer, status, placeholder, disabled, autoFocus, hint, controlsStart, header, onPaste, className }: ChatComposerProps) {
+export function ChatComposer({
+  composer,
+  status,
+  placeholder,
+  disabled,
+  autoFocus,
+  hint,
+  controlsStart,
+  header,
+  onPaste,
+  className,
+  commands = defaultCommands,
+  commandContext,
+  onClearView,
+}: ChatComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const active = status != null && ACTIVE_STATUSES.has(status);
+
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [confirmState, setConfirmState] = useState<ConfirmState>(null);
+  const listboxId = useId();
 
   const resize = useCallback(() => {
     const textarea = textareaRef.current;
@@ -49,108 +91,278 @@ export function ChatComposer({ composer, status, placeholder, disabled, autoFocu
     resize();
   }, [composer.value, resize]);
 
+  // The UI affordances commands reach: surface a notice, open the help panel,
+  // reset the local view, and the danger confirm flow (resolves when the
+  // operator confirms/cancels in the confirm bar).
+  const handlers = useMemo(
+    () => ({
+      notice: (next: Notice) => {
+        setNotice(next);
+        composer.clearError();
+      },
+      openHelp: () => setHelpOpen(true),
+      clearView: () => onClearView?.(),
+      confirm: () =>
+        new Promise<boolean>((resolve) => {
+          setConfirmState({
+            // The confirm bar is rendered from the highlighted/active command;
+            // the command itself is supplied by the hook at run time.
+            command: { name: "clear", description: "", danger: true, run: () => ({ status: "ok" }) },
+            resolve: (confirmed) => {
+              setConfirmState(null);
+              resolve(confirmed);
+            },
+          });
+        }),
+    }),
+    [composer, onClearView],
+  );
+
+  const palette = useSlashCommands({
+    commands,
+    context: commandContext,
+    handlers,
+    value: composer.value,
+    setValue: composer.setValue,
+  });
+
+  // The confirm bar reflects the command currently awaiting confirmation; the
+  // hook drives execution, so we render the active/highlighted danger command.
+  const pendingDangerCommand = confirmState
+    ? palette.activeCommand ?? palette.items[palette.highlight] ?? confirmState.command
+    : null;
+
+  const paletteEnabled = commandContext !== undefined;
+
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Palette key handling runs FIRST and only when the palette is open; when
+    // closed it returns false and the existing send path is untouched.
+    if (paletteEnabled && palette.onKeyDown(event)) {
+      return;
+    }
     if (shouldSubmitOnKey(event)) {
       event.preventDefault();
       void composer.send();
     }
   };
 
+  const helpCommands = useMemo(
+    () =>
+      commands.filter((command) => {
+        if (command.permission && commandContext) {
+          const perms = commandContext.permissions;
+          return perms.includes(command.permission) || perms.includes("workspace:admin");
+        }
+        return true;
+      }),
+    [commands, commandContext],
+  );
+
+  const activeNotice = notice ?? (composer.error ? { tone: "error" as const, message: composer.error.message || "Sending failed — your draft is still here. Try again." } : null);
+
   return (
     <div className={cn("og-root", className)}>
-      <div
-        className={cn(
-          "rounded-og-lg border border-og-border bg-og-surface-1 shadow-og-sm",
-          "transition-[border-color,box-shadow] duration-200",
-          "focus-within:border-og-accent/60 focus-within:shadow-og-glow",
-        )}
-      >
-        {header}
-        <textarea
-          ref={textareaRef}
-          rows={1}
-          value={composer.value}
-          onChange={(event) => composer.setValue(event.target.value)}
-          onKeyDown={onKeyDown}
-          onPaste={onPaste}
-          placeholder={placeholder ?? "Message the agent…"}
-          disabled={disabled}
-          autoFocus={autoFocus}
-          aria-label="Message the agent"
+      <div className="relative">
+        {paletteEnabled ? (
+          <CommandPalette
+            open={palette.open && confirmState === null}
+            items={palette.items}
+            highlight={palette.highlight}
+            onHighlight={palette.setHighlight}
+            onRun={(index) => {
+              palette.setHighlight(index);
+              void palette.runHighlighted();
+            }}
+            argHintText={palette.activeArgHint}
+            listboxId={listboxId}
+          />
+        ) : null}
+        <div
           className={cn(
-            "block w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-[15px] leading-6",
-            "text-og-fg placeholder:text-og-fg-subtle focus:outline-none",
-            "disabled:cursor-not-allowed disabled:opacity-60",
+            "rounded-og-lg border border-og-border bg-og-surface-1 shadow-og-sm",
+            "transition-[border-color,box-shadow] duration-200",
+            "focus-within:border-og-accent/60 focus-within:shadow-og-glow",
           )}
-        />
-        <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
-          {controlsStart ? (
-            <span className="flex min-w-0 items-center gap-1.5">{controlsStart}</span>
+        >
+          {header}
+          <textarea
+            ref={textareaRef}
+            rows={1}
+            value={composer.value}
+            onChange={(event) => composer.setValue(event.target.value)}
+            onKeyDown={onKeyDown}
+            onPaste={onPaste}
+            placeholder={placeholder ?? "Message the agent…"}
+            disabled={disabled}
+            autoFocus={autoFocus}
+            aria-label="Message the agent"
+            role={paletteEnabled && palette.open ? "combobox" : undefined}
+            aria-expanded={paletteEnabled ? palette.open : undefined}
+            aria-controls={paletteEnabled && palette.open ? listboxId : undefined}
+            aria-activedescendant={paletteEnabled && palette.open ? `${listboxId}-option-${palette.highlight}` : undefined}
+            className={cn(
+              "block w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-[15px] leading-6",
+              "text-og-fg placeholder:text-og-fg-subtle focus:outline-none",
+              "disabled:cursor-not-allowed disabled:opacity-60",
+            )}
+          />
+          {confirmState && pendingDangerCommand ? (
+            <ConfirmBar
+              command={pendingDangerCommand}
+              onCancel={() => confirmState.resolve(false)}
+              onConfirm={() => confirmState.resolve(true)}
+            />
           ) : (
-            <span className="px-1.5 text-[11px] text-og-fg-subtle max-sm:hidden">
-              {hint ?? "Enter to send · Shift+Enter for a new line"}
-            </span>
-          )}
-          <span className="flex items-center gap-1.5">
-            <AnimatePresence initial={false}>
-              {active ? (
-                <motion.button
-                  key="stop"
+            <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
+              {controlsStart ? (
+                <span className="flex min-w-0 items-center gap-1.5">{controlsStart}</span>
+              ) : (
+                <span className="px-1.5 text-[11px] text-og-fg-subtle max-sm:hidden">
+                  {hint ?? "Enter to send · Shift+Enter for a new line · / for commands"}
+                </span>
+              )}
+              <span className="flex items-center gap-1.5">
+                <AnimatePresence initial={false}>
+                  {active ? (
+                    <motion.button
+                      key="stop"
+                      type="button"
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.8 }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
+                      onClick={() => void composer.interrupt()}
+                      disabled={composer.interrupting}
+                      aria-label="Stop the current turn"
+                      title="Stop the current turn"
+                      className={cn(
+                        "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border",
+                        "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
+                        "hover:border-og-status-failed/50 hover:text-og-status-failed",
+                        "disabled:opacity-50",
+                      )}
+                    >
+                      {composer.interrupting ? (
+                        <LoaderCircleIcon className="size-3.5 animate-og-spin" />
+                      ) : (
+                        <SquareIcon className="size-3 fill-current" />
+                      )}
+                    </motion.button>
+                  ) : null}
+                </AnimatePresence>
+                <button
                   type="button"
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.8 }}
-                  transition={{ duration: 0.15, ease: "easeOut" }}
-                  onClick={() => void composer.interrupt()}
-                  disabled={composer.interrupting}
-                  aria-label="Stop the current turn"
-                  title="Stop the current turn"
+                  onClick={() => void composer.send()}
+                  disabled={!composer.canSend || disabled === true}
+                  aria-label="Send message"
                   className={cn(
-                    "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border",
-                    "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
-                    "hover:border-og-status-failed/50 hover:text-og-status-failed",
-                    "disabled:opacity-50",
+                    "inline-flex size-8 items-center justify-center rounded-og-md",
+                    "bg-og-accent text-og-accent-fg shadow-og-sm",
+                    "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
+                    "hover:bg-og-accent-strong active:scale-95",
+                    "disabled:cursor-not-allowed disabled:bg-og-surface-3 disabled:text-og-fg-subtle disabled:shadow-none",
                   )}
                 >
-                  {composer.interrupting ? (
-                    <LoaderCircleIcon className="size-3.5 animate-og-spin" />
-                  ) : (
-                    <SquareIcon className="size-3 fill-current" />
-                  )}
-                </motion.button>
-              ) : null}
-            </AnimatePresence>
-            <button
-              type="button"
-              onClick={() => void composer.send()}
-              disabled={!composer.canSend || disabled === true}
-              aria-label="Send message"
-              className={cn(
-                "inline-flex size-8 items-center justify-center rounded-og-md",
-                "bg-og-accent text-og-accent-fg shadow-og-sm",
-                "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
-                "hover:bg-og-accent-strong active:scale-95",
-                "disabled:cursor-not-allowed disabled:bg-og-surface-3 disabled:text-og-fg-subtle disabled:shadow-none",
-              )}
-            >
-              {composer.sending ? <LoaderCircleIcon className="size-4 animate-og-spin" /> : <ArrowUpIcon className="size-4" />}
-            </button>
-          </span>
+                  {composer.sending ? <LoaderCircleIcon className="size-4 animate-og-spin" /> : <ArrowUpIcon className="size-4" />}
+                </button>
+              </span>
+            </div>
+          )}
         </div>
       </div>
       <AnimatePresence>
-        {composer.error ? (
+        {helpOpen ? (
+          <HelpPanel commands={helpCommands} onClose={() => setHelpOpen(false)} />
+        ) : null}
+      </AnimatePresence>
+      <AnimatePresence>
+        {activeNotice ? (
           <motion.p
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            className="overflow-hidden px-1 pt-1.5 text-xs text-og-status-failed"
-            role="alert"
+            className={cn(
+              "overflow-hidden px-1 pt-1.5 text-xs",
+              activeNotice.tone === "ok" ? "text-og-fg-muted" : "text-og-status-failed",
+            )}
+            role={activeNotice.tone === "error" ? "alert" : "status"}
+            onAnimationComplete={() => {
+              if (activeNotice.tone === "ok") {
+                // Auto-dismiss success notices after a beat.
+                window.setTimeout(() => setNotice((current) => (current === activeNotice ? null : current)), 2400);
+              }
+            }}
           >
-            {composer.error.message || "Sending failed — your draft is still here. Try again."}
+            {activeNotice.message}
           </motion.p>
         ) : null}
       </AnimatePresence>
     </div>
+  );
+}
+
+/** The danger confirm bar — reuses og-status-failed tokens (like the stop control). */
+function ConfirmBar({ command, onCancel, onConfirm }: { command: SlashCommand; onCancel: () => void; onConfirm: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
+      <span className="px-1.5 text-[12px] text-og-status-failed">
+        Run <span className="font-mono">/{command.name}</span>? {command.description}
+      </span>
+      <span className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-og-md border border-og-border bg-og-surface-2 px-2.5 py-1 text-[12px] text-og-fg-muted hover:bg-og-surface-3"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          autoFocus
+          onClick={onConfirm}
+          className="rounded-og-md border border-og-status-failed/50 bg-og-status-failed/15 px-2.5 py-1 text-[12px] text-og-status-failed hover:bg-og-status-failed/25"
+        >
+          Confirm
+        </button>
+      </span>
+    </div>
+  );
+}
+
+/** The in-composer /help panel, rendered entirely from the registry. */
+function HelpPanel({ commands, onClose }: { commands: readonly SlashCommand[]; onClose: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      exit={{ opacity: 0, height: 0 }}
+      className="mt-2 overflow-hidden rounded-og-lg border border-og-border bg-og-surface-2"
+    >
+      <div className="flex items-center justify-between border-b border-og-border px-3 py-1.5">
+        <span className="text-[12px] font-medium text-og-fg">Commands</span>
+        <button type="button" onClick={onClose} className="text-[11px] text-og-fg-subtle hover:text-og-fg">
+          Close
+        </button>
+      </div>
+      <ul className="py-1">
+        {commands.map((command) => {
+          const hint = argHint(command.args);
+          return (
+            <li key={command.name} className="flex items-baseline gap-2 px-3 py-1">
+              <span className="font-mono text-[12px] text-og-accent">
+                /{command.name}
+                {hint ? <span className="ml-1 text-og-fg-subtle">{hint}</span> : null}
+              </span>
+              <span className="text-[12px] text-og-fg-muted">{command.description}</span>
+              {command.danger ? (
+                <span className="ml-auto rounded-og-xs bg-og-status-failed/15 px-1 text-[10px] uppercase tracking-wide text-og-status-failed">
+                  danger
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </motion.div>
   );
 }

--- a/packages/react/src/components/command-palette.tsx
+++ b/packages/react/src/components/command-palette.tsx
@@ -1,0 +1,94 @@
+import { AnimatePresence, motion } from "motion/react";
+import { argHint } from "../commands/registry";
+import type { SlashCommand } from "../commands/types";
+import { cn } from "../lib/cn";
+
+export type CommandPaletteProps = {
+  open: boolean;
+  items: SlashCommand[];
+  highlight: number;
+  /** Hover/click selects a row. */
+  onHighlight: (index: number) => void;
+  /** Click runs the row (same path as Enter). */
+  onRun: (index: number) => void;
+  /** Footer arg hint shown in arg-hint mode (e.g. "<pause|resume>"). */
+  argHintText: string;
+  /** id used for aria-activedescendant wiring from the textarea. */
+  listboxId: string;
+};
+
+/**
+ * The slash-command palette: a popover anchored above the textarea, rendered
+ * entirely from the filtered registry. Dark-first, Linear/Vercel-calm, using
+ * the opengeni#46 design tokens. Full keyboard nav lives in useSlashCommands;
+ * this component is presentational + aria.
+ */
+export function CommandPalette({ open, items, highlight, onHighlight, onRun, argHintText, listboxId }: CommandPaletteProps) {
+  return (
+    <AnimatePresence>
+      {open ? (
+        <motion.div
+          initial={{ opacity: 0, y: 6, scale: 0.99 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 6, scale: 0.99 }}
+          transition={{ duration: 0.13, ease: "easeOut" }}
+          className={cn(
+            "absolute bottom-full left-0 right-0 z-20 mb-2 overflow-hidden",
+            "rounded-og-lg border border-og-border bg-og-surface-2 shadow-og-sm",
+          )}
+        >
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label="Slash commands"
+            className="max-h-72 overflow-y-auto py-1"
+          >
+            {items.map((command, index) => {
+              const selected = index === highlight;
+              const hint = argHint(command.args);
+              return (
+                <li
+                  key={command.name}
+                  id={`${listboxId}-option-${index}`}
+                  role="option"
+                  aria-selected={selected}
+                  onMouseEnter={() => onHighlight(index)}
+                  onMouseDown={(event) => {
+                    // Keep textarea focus; run on click.
+                    event.preventDefault();
+                    onRun(index);
+                  }}
+                  className={cn(
+                    "mx-1 flex cursor-pointer items-center gap-2 rounded-og-md px-2.5 py-1.5",
+                    "transition-colors duration-100",
+                    selected ? "bg-og-accent/15 text-og-fg" : "text-og-fg-muted hover:bg-og-surface-3",
+                  )}
+                >
+                  <span className="flex min-w-0 items-baseline gap-1.5">
+                    <span className={cn("font-mono text-[13px]", selected ? "text-og-accent" : "text-og-fg")}>
+                      /{command.name}
+                    </span>
+                    {hint ? <span className="truncate font-mono text-[11px] text-og-fg-subtle">{hint}</span> : null}
+                  </span>
+                  <span className="ml-auto flex items-center gap-1.5">
+                    {command.danger ? (
+                      <span className="rounded-og-xs bg-og-status-failed/15 px-1 text-[10px] uppercase tracking-wide text-og-status-failed">
+                        danger
+                      </span>
+                    ) : null}
+                    <span className="truncate text-[12px] text-og-fg-subtle max-sm:hidden">{command.description}</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          {argHintText ? (
+            <div className="border-t border-og-border px-3 py-1.5 font-mono text-[11px] text-og-fg-subtle">
+              {argHintText}
+            </div>
+          ) : null}
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/packages/react/src/hooks/use-slash-commands.ts
+++ b/packages/react/src/hooks/use-slash-commands.ts
@@ -1,0 +1,257 @@
+import type { KeyboardEvent } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  argHint,
+  filterCommands,
+  firstMissingRequiredArg,
+  matchCommand,
+  parseCommandLine,
+} from "../commands/registry";
+import type { CommandContext, Notice, SlashCommand } from "../commands/types";
+
+/**
+ * Context the composer supplies for command execution and visibility. The
+ * composer owns the UI affordances (notice/openHelp/clearView/confirm), so they
+ * are NOT part of this slice — the hook closes over them via `handlers`.
+ */
+export type SlashCommandContext = Pick<
+  CommandContext,
+  "client" | "workspaceId" | "sessionId" | "status" | "permissions"
+>;
+
+export type SlashCommandHandlers = Pick<CommandContext, "notice" | "openHelp" | "clearView" | "confirm">;
+
+export type ConfirmState = {
+  command: SlashCommand;
+  /** Resolve the pending confirm() promise. */
+  resolve: (confirmed: boolean) => void;
+} | null;
+
+export type UseSlashCommandsOptions = {
+  commands: readonly SlashCommand[];
+  context: SlashCommandContext | undefined;
+  handlers: SlashCommandHandlers;
+  /** The current composer draft. */
+  value: string;
+  /** Replace the composer draft (autocomplete writes through this). */
+  setValue: (value: string) => void;
+};
+
+export type UseSlashCommandsResult = {
+  /** Whether the palette is open (a command token is being typed). */
+  open: boolean;
+  /** Commands shown for the current token + context, in display order. */
+  items: SlashCommand[];
+  /** Index into `items` of the highlighted row. */
+  highlight: number;
+  setHighlight: (index: number) => void;
+  /** The matched command once the name is closed by a space (arg-hint mode). */
+  activeCommand: SlashCommand | null;
+  /** The arg hint string for the active command (footer), or "". */
+  activeArgHint: string;
+  /**
+   * Key handler for the textarea. Returns true when it consumed the event
+   * (the composer must then NOT run its send path). Only consumes while open.
+   */
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  /** Run the highlighted command (or the active command in arg-hint mode). */
+  runHighlighted: () => Promise<void>;
+  /** Autocomplete the highlighted command name + a trailing space. */
+  autocompleteHighlighted: () => void;
+};
+
+export function useSlashCommands(options: UseSlashCommandsOptions): UseSlashCommandsResult {
+  const { commands, context, handlers, value, setValue } = options;
+  const [highlight, setHighlight] = useState(0);
+  // Escape closes the palette but keeps the draft. We remember the dismissed
+  // value; any further edit (value !== dismissed) re-opens the palette.
+  const [dismissedValue, setDismissedValue] = useState<string | null>(null);
+  const dismissed = dismissedValue !== null && dismissedValue === value;
+
+  const parsed = useMemo(() => parseCommandLine(value), [value]);
+  const filterCtx = useMemo(
+    () => ({
+      sessionId: context?.sessionId ?? null,
+      status: context?.status ?? null,
+      permissions: context?.permissions ?? [],
+    }),
+    [context?.sessionId, context?.status, context?.permissions],
+  );
+
+  // In arg-hint mode ("/name "), the list collapses to the matched command so
+  // the palette shows just its arg hint; while typing the name it filters.
+  const activeCommand = useMemo(() => {
+    if (!parsed || !parsed.hasTrailingSpace) {
+      return null;
+    }
+    return matchCommand(commands, value);
+  }, [commands, value, parsed]);
+
+  const items = useMemo(() => {
+    if (!parsed) {
+      return [];
+    }
+    if (activeCommand) {
+      return [activeCommand];
+    }
+    return filterCommands(commands, parsed.name, filterCtx);
+  }, [commands, parsed, activeCommand, filterCtx]);
+
+  const open = parsed !== null && items.length > 0 && !dismissed;
+
+  // Keep highlight in range as items change.
+  const clampedHighlight = items.length === 0 ? 0 : Math.min(highlight, items.length - 1);
+
+  const activeArgHint = activeCommand ? argHint(activeCommand.args) : "";
+
+  const buildContext = useCallback(
+    (): CommandContext | null => {
+      if (!context) {
+        return null;
+      }
+      return { ...context, ...handlers };
+    },
+    [context, handlers],
+  );
+
+  const execute = useCallback(
+    async (command: SlashCommand, args: string[]): Promise<void> => {
+      const ctx = buildContext();
+      if (!ctx) {
+        return;
+      }
+      try {
+        const result = await command.run(args, ctx);
+        if (result.message) {
+          ctx.notice({ tone: result.status === "ok" ? "ok" : "error", message: result.message });
+        }
+        if (result.status === "ok") {
+          setValue("");
+        }
+      } catch (cause) {
+        ctx.notice({ tone: "error", message: errorMessage(cause) });
+      }
+    },
+    [buildContext, setValue],
+  );
+
+  const autocomplete = useCallback(
+    (command: SlashCommand) => {
+      setValue(`/${command.name} `);
+      setHighlight(0);
+    },
+    [setValue],
+  );
+
+  const autocompleteHighlighted = useCallback(() => {
+    const command = items[clampedHighlight];
+    if (command) {
+      autocomplete(command);
+    }
+  }, [items, clampedHighlight, autocomplete]);
+
+  const runHighlighted = useCallback(async (): Promise<void> => {
+    if (!parsed) {
+      return;
+    }
+    // When the typed token is an exact command name (e.g. "/clear" while the
+    // longer "/clear-view" sits first in the filtered list), Enter should run
+    // THAT command, not autocomplete the highlighted near-match. Exact match
+    // wins over the highlight; otherwise use the highlighted row.
+    const exact = items.find((item) => item.name === parsed.name || item.aliases?.includes(parsed.name));
+    const command = activeCommand ?? exact ?? items[clampedHighlight];
+    if (!command) {
+      return;
+    }
+    // Enter on a name-only token first autocompletes (so "/cl"+Enter fills the
+    // name); on a fully-typed command with a satisfied arg list it runs.
+    if (!activeCommand && command.name !== parsed.name && !parsed.hasTrailingSpace) {
+      autocomplete(command);
+      return;
+    }
+    const missing = firstMissingRequiredArg(command, parsed.args);
+    if (missing) {
+      // A required arg is absent: keep the palette open at the arg hint rather
+      // than firing a half-formed command.
+      if (!parsed.hasTrailingSpace) {
+        autocomplete(command);
+      }
+      return;
+    }
+    await execute(command, parsed.args);
+  }, [parsed, activeCommand, items, clampedHighlight, autocomplete, execute]);
+
+  // Track an in-flight run so Enter can't double-fire.
+  const runningRef = useRef(false);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (!open) {
+        return false;
+      }
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          setHighlight((current) => (items.length === 0 ? 0 : (Math.min(current, items.length - 1) + 1) % items.length));
+          return true;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          setHighlight((current) => {
+            const base = Math.min(current, items.length - 1);
+            return items.length === 0 ? 0 : (base - 1 + items.length) % items.length;
+          });
+          return true;
+        }
+        case "Tab": {
+          event.preventDefault();
+          autocompleteHighlighted();
+          return true;
+        }
+        case "Enter": {
+          if (event.shiftKey || event.nativeEvent?.isComposing) {
+            return false;
+          }
+          event.preventDefault();
+          if (runningRef.current) {
+            return true;
+          }
+          runningRef.current = true;
+          void runHighlighted().finally(() => {
+            runningRef.current = false;
+          });
+          return true;
+        }
+        case "Escape": {
+          event.preventDefault();
+          // Close the palette but keep the draft intact. Remember the dismissed
+          // value; the next edit re-opens (value !== dismissedValue).
+          setDismissedValue(value);
+          return true;
+        }
+        default:
+          return false;
+      }
+    },
+    [open, items, autocompleteHighlighted, runHighlighted, value],
+  );
+
+  return {
+    open,
+    items,
+    highlight: clampedHighlight,
+    setHighlight,
+    activeCommand,
+    activeArgHint,
+    onKeyDown,
+    runHighlighted,
+    autocompleteHighlighted,
+  };
+}
+
+function errorMessage(cause: unknown): string {
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+  return String(cause);
+}

--- a/packages/react/src/hooks/use-slash-commands.ts
+++ b/packages/react/src/hooks/use-slash-commands.ts
@@ -19,7 +19,15 @@ export type SlashCommandContext = Pick<
   "client" | "workspaceId" | "sessionId" | "status" | "permissions"
 >;
 
-export type SlashCommandHandlers = Pick<CommandContext, "notice" | "openHelp" | "clearView" | "confirm">;
+/**
+ * UI affordances the composer supplies. `confirm` differs from the registry-
+ * facing {@link CommandContext.confirm} (which takes no args): the composer's
+ * confirm receives the command being run so the confirm bar renders from that
+ * exact command's identity. The hook bridges the two in {@link buildContext}.
+ */
+export type SlashCommandHandlers = Pick<CommandContext, "notice" | "openHelp" | "clearView"> & {
+  confirm: (command: SlashCommand) => Promise<boolean>;
+};
 
 export type ConfirmState = {
   command: SlashCommand;
@@ -104,19 +112,24 @@ export function useSlashCommands(options: UseSlashCommandsOptions): UseSlashComm
 
   const activeArgHint = activeCommand ? argHint(activeCommand.args) : "";
 
+  // Build the context for a SPECIFIC command. The danger confirm() is bound to
+  // that command so the confirm bar names the command actually about to run —
+  // not whatever near-match happens to sit highlighted in the palette (e.g.
+  // typing "/clear"+Enter runs the destructive `clear`, but `clear-view` sorts
+  // first and would otherwise mislabel the bar as a harmless local-view reset).
   const buildContext = useCallback(
-    (): CommandContext | null => {
+    (command: SlashCommand): CommandContext | null => {
       if (!context) {
         return null;
       }
-      return { ...context, ...handlers };
+      return { ...context, ...handlers, confirm: () => handlers.confirm(command) };
     },
     [context, handlers],
   );
 
   const execute = useCallback(
     async (command: SlashCommand, args: string[]): Promise<void> => {
-      const ctx = buildContext();
+      const ctx = buildContext(command);
       if (!ctx) {
         return;
       }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -69,6 +69,35 @@ export type {
   WorkerItem,
 } from "./timeline";
 
+// Slash-command palette (registry + UI + hook)
+export {
+  argHint,
+  defaultCommands,
+  filterCommands,
+  firstMissingRequiredArg,
+  hasPermission,
+  matchCommand,
+  parseCommandLine,
+} from "./commands/registry";
+export type { ParsedCommandLine } from "./commands/registry";
+export type {
+  CommandContext,
+  CommandResult,
+  Notice,
+  SlashArg,
+  SlashCommand,
+} from "./commands/types";
+export { useSlashCommands } from "./hooks/use-slash-commands";
+export type {
+  ConfirmState,
+  SlashCommandContext,
+  SlashCommandHandlers,
+  UseSlashCommandsOptions,
+  UseSlashCommandsResult,
+} from "./hooks/use-slash-commands";
+export { CommandPalette } from "./components/command-palette";
+export type { CommandPaletteProps } from "./components/command-palette";
+
 // Components
 export { ChatComposer } from "./components/chat-composer";
 export type { ChatComposerProps } from "./components/chat-composer";

--- a/packages/react/test/chat-composer-palette.test.tsx
+++ b/packages/react/test/chat-composer-palette.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ChatComposer } from "../src/components/chat-composer";
+import type { ComposerState } from "../src/hooks/use-composer";
+import type { SlashCommandContext } from "../src/hooks/use-slash-commands";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+import { registerDom } from "./render-hook";
+
+registerDom();
+
+let mounted: { root: Root; container: HTMLElement } | null = null;
+
+afterEach(async () => {
+  if (mounted) {
+    const current = mounted;
+    mounted = null;
+    await act(async () => {
+      current.root.unmount();
+    });
+    current.container.remove();
+  }
+});
+
+/** A controlled fake composer whose value is driven by React state in the test tree. */
+function makeComposer(value: string, setValue: (v: string) => void, overrides: Partial<ComposerState> = {}): ComposerState {
+  return {
+    value,
+    setValue,
+    send: async () => true,
+    sending: false,
+    canSend: value.trim().length > 0,
+    mode: "queue",
+    setMode: () => {},
+    interrupt: async () => {},
+    interrupting: false,
+    error: null,
+    clearError: () => {},
+    ...overrides,
+  };
+}
+
+const ctx: SlashCommandContext = {
+  client: fakeClient({
+    updateGoal: async () => ({}) as never,
+    clearSessionContext: async () => {},
+    compactSessionContext: async () => ({ status: "queued", message: "queued" }),
+  }),
+  workspaceId: WORKSPACE_ID,
+  sessionId: SESSION_ID,
+  status: null,
+  permissions: ["sessions:control"] as never,
+};
+
+async function mount(node: React.ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+  });
+  mounted = { root, container };
+  return container;
+}
+
+describe("ChatComposer slash palette", () => {
+  test("opens the palette listbox when the value starts with '/'", async () => {
+    let value = "/";
+    const container = await mount(
+      <ChatComposer composer={makeComposer(value, (v) => { value = v; })} commandContext={ctx} />,
+    );
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    const options = container.querySelectorAll('[role="option"]');
+    expect(options.length).toBeGreaterThan(1);
+    // The textarea advertises combobox semantics + activedescendant while open.
+    const textarea = container.querySelector("textarea")!;
+    expect(textarea.getAttribute("aria-expanded")).toBe("true");
+    expect(textarea.getAttribute("aria-activedescendant")).toBeTruthy();
+  });
+
+  test("renders gated commands only with the permission; hides them otherwise", async () => {
+    const withPerm = await mount(
+      <ChatComposer composer={makeComposer("/", () => {})} commandContext={ctx} />,
+    );
+    const labels = [...withPerm.querySelectorAll('[role="option"]')].map((el) => el.textContent ?? "");
+    expect(labels.join(" ")).toContain("/clear");
+    expect(labels.join(" ")).toContain("/compact");
+    if (mounted) {
+      const c = mounted; mounted = null;
+      await act(async () => c.root.unmount());
+      c.container.remove();
+    }
+
+    const noPerm = await mount(
+      <ChatComposer composer={makeComposer("/", () => {})} commandContext={{ ...ctx, permissions: [] as never }} />,
+    );
+    const noPermLabels = [...noPerm.querySelectorAll('[role="option"]')].map((el) => el.textContent ?? "").join(" ");
+    expect(noPermLabels).toContain("/help");
+    expect(noPermLabels).not.toContain("/clear ");
+    expect(noPermLabels).not.toContain("/compact");
+  });
+
+  test("the palette is inert (not rendered) without a commandContext", async () => {
+    const container = await mount(
+      <ChatComposer composer={makeComposer("/clear", () => {})} />,
+    );
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  test("a danger command marks itself in the palette row", async () => {
+    const container = await mount(
+      <ChatComposer composer={makeComposer("/clear", () => {})} commandContext={ctx} />,
+    );
+    const text = container.textContent ?? "";
+    expect(text.toLowerCase()).toContain("danger");
+  });
+});

--- a/packages/react/test/chat-composer-palette.test.tsx
+++ b/packages/react/test/chat-composer-palette.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
+import { act, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { ChatComposer } from "../src/components/chat-composer";
 import type { ComposerState } from "../src/hooks/use-composer";
@@ -114,5 +114,51 @@ describe("ChatComposer slash palette", () => {
     );
     const text = container.textContent ?? "";
     expect(text.toLowerCase()).toContain("danger");
+  });
+
+  // Regression (adversarial review): the composer's internal clearView closure
+  // must report whether a view-reset was actually wired, so /clear-view can't
+  // claim a false success. With no onClearView prop the textbox renders but
+  // running the command must NOT surface "Local view cleared." — and with one
+  // wired it both invokes it and surfaces the ok notice. Driven through the
+  // real component (textarea Enter) so the chat-composer wiring itself is under
+  // test, not just the registry handler.
+  function ClearViewHarness(props: { onClearView?: () => void }) {
+    const [value, setValue] = useState("/clear-view");
+    return (
+      <ChatComposer
+        composer={makeComposer(value, setValue)}
+        commandContext={ctx}
+        {...(props.onClearView ? { onClearView: props.onClearView } : {})}
+      />
+    );
+  }
+
+  async function pressEnterOnTextarea(container: HTMLElement) {
+    const textarea = container.querySelector("textarea")!;
+    await act(async () => {
+      textarea.focus();
+      // happy-dom dispatches the native keydown through React's event system on
+      // the focused element; the composer's onKeyDown drives the palette run.
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+      // Let the async run() + notice state update settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  test("/clear-view surfaces an honest error (not a false success) when onClearView is absent", async () => {
+    const container = await mount(<ClearViewHarness />);
+    await pressEnterOnTextarea(container);
+    expect(container.textContent ?? "").not.toMatch(/local view cleared/i);
+    expect(container.textContent ?? "").toMatch(/can't be cleared/i);
+  });
+
+  test("/clear-view invokes onClearView and reports success when it is wired", async () => {
+    let cleared = 0;
+    const container = await mount(<ClearViewHarness onClearView={() => { cleared += 1; }} />);
+    await pressEnterOnTextarea(container);
+    expect(cleared).toBe(1);
+    expect(container.textContent ?? "").toMatch(/local view cleared/i);
   });
 });

--- a/packages/react/test/chat-composer-palette.test.tsx
+++ b/packages/react/test/chat-composer-palette.test.tsx
@@ -161,4 +161,55 @@ describe("ChatComposer slash palette", () => {
     expect(cleared).toBe(1);
     expect(container.textContent ?? "").toMatch(/local view cleared/i);
   });
+
+  // Regression (adversarial review): typing the canonical `/clear` (no trailing
+  // space) + Enter resolves to the DESTRUCTIVE server-side `clear` command
+  // (runHighlighted prefers the exact name match over the highlighted near-
+  // match). The confirm bar previously re-derived its command from
+  // palette.items[palette.highlight], which is `clear-view` (it prefix-matches
+  // "clear" and sorts first) — so it reassured the operator "this device only;
+  // no server change" right before wiping the server context. The bar must name
+  // the command actually about to run.
+  function ClearConfirmHarness() {
+    const [value, setValue] = useState("/clear");
+    return <ChatComposer composer={makeComposer(value, setValue)} commandContext={ctx} />;
+  }
+
+  test("/clear + Enter shows a confirm bar for the destructive /clear, not /clear-view", async () => {
+    const container = await mount(<ClearConfirmHarness />);
+    // Sanity: before Enter the palette lists clear-view FIRST (the near-match
+    // that used to leak into the confirm bar) — clear-view prefix-matches
+    // "clear" and is declared earlier than the destructive clear.
+    const optionText = [...container.querySelectorAll('[role="option"]')].map((el) => el.textContent ?? "");
+    expect(optionText[0]).toContain("/clear-view");
+    expect(optionText.some((t) => t.includes("/clear") && t.toLowerCase().includes("danger"))).toBe(true);
+
+    await pressEnterOnTextarea(container);
+
+    // runHighlighted resolves the typed "/clear" to the DESTRUCTIVE clear (exact
+    // name match beats the highlighted clear-view), so the danger confirm bar
+    // must render from THAT command. Scope assertions to the confirm bar itself
+    // (the palette listbox may still be animating out and would otherwise leak
+    // its clear-view copy into a whole-container textContent check).
+    const confirmBar = container.querySelector('[data-testid="danger-confirm"]');
+    expect(confirmBar).not.toBeNull();
+    const barText = confirmBar?.textContent ?? "";
+    // Names the destructive command and its real (destructive) description...
+    expect(barText).toContain("/clear?");
+    expect(barText.toLowerCase()).toContain("destructive");
+    // ...and never the harmless clear-view copy that mislabeled it.
+    expect(barText).not.toContain("/clear-view");
+    expect(barText.toLowerCase()).not.toContain("this device only");
+    expect(barText.toLowerCase()).not.toContain("no server change");
+    expect(confirmBar?.getAttribute("aria-label")).toBe("Confirm /clear");
+
+    // Cancel to settle the pending confirm() promise (clear.run awaits it), so
+    // unmount in afterEach is clean and no run is left dangling.
+    const cancel = [...container.querySelectorAll("button")].find((b) => b.textContent === "Cancel");
+    await act(async () => {
+      cancel?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
 });

--- a/packages/react/test/slash-commands-hook.test.tsx
+++ b/packages/react/test/slash-commands-hook.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { useState } from "react";
+import { defaultCommands } from "../src/commands/registry";
+import type { Notice, SlashCommand } from "../src/commands/types";
+import type { KeyboardEvent } from "react";
+import { useSlashCommands, type SlashCommandContext, type SlashCommandHandlers } from "../src/hooks/use-slash-commands";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+import { flush, registerDom, renderHook } from "./render-hook";
+
+registerDom();
+
+type KeyInit = { key: string; shiftKey?: boolean; isComposing?: boolean };
+
+/** A minimal KeyboardEvent stub matching what the hook reads. */
+function keyEvent(init: KeyInit): KeyboardEvent<HTMLTextAreaElement> {
+  return {
+    key: init.key,
+    shiftKey: init.shiftKey ?? false,
+    nativeEvent: { isComposing: init.isComposing ?? false },
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent<HTMLTextAreaElement>;
+}
+
+type Harness = {
+  value: string;
+  setValue: (v: string) => void;
+  notices: Notice[];
+  helpOpened: number;
+  viewCleared: number;
+  confirmAnswer: boolean;
+  command: ReturnType<typeof useSlashCommands>;
+};
+
+function setup(options: {
+  initialValue?: string;
+  context?: SlashCommandContext | undefined;
+  commands?: readonly SlashCommand[];
+  confirmAnswer?: boolean;
+}) {
+  return renderHook<Harness, void>(() => {
+    const [value, setValue] = useState(options.initialValue ?? "");
+    const [notices, setNotices] = useState<Notice[]>([]);
+    const [helpOpened, setHelpOpened] = useState(0);
+    const [viewCleared, setViewCleared] = useState(0);
+    const handlers: SlashCommandHandlers = {
+      notice: (n) => setNotices((cur) => [...cur, n]),
+      openHelp: () => setHelpOpened((n) => n + 1),
+      clearView: () => setViewCleared((n) => n + 1),
+      confirm: async () => options.confirmAnswer ?? true,
+    };
+    const command = useSlashCommands({
+      commands: options.commands ?? defaultCommands,
+      context: options.context,
+      handlers,
+      value,
+      setValue,
+    });
+    return { value, setValue, notices, helpOpened, viewCleared, confirmAnswer: options.confirmAnswer ?? true, command };
+  }, undefined);
+}
+
+const sessionCtx: SlashCommandContext = {
+  client: fakeClient({
+    updateGoal: async () => ({}) as never,
+    clearSessionContext: async () => {},
+    compactSessionContext: async () => ({ status: "queued", message: "Compaction will run before the next turn." }),
+  }),
+  workspaceId: WORKSPACE_ID,
+  sessionId: SESSION_ID,
+  status: null,
+  permissions: ["sessions:control"] as never,
+};
+
+describe("useSlashCommands", () => {
+  test("opens and filters as a slash token is typed", async () => {
+    const h = await setup({ initialValue: "/cl", context: sessionCtx });
+    expect(h.result.current.command.open).toBe(true);
+    expect(h.result.current.command.items.map((c) => c.name)).toEqual(expect.arrayContaining(["clear", "clear-view"]));
+    await h.unmount();
+  });
+
+  test("stays closed for plain chat", async () => {
+    const h = await setup({ initialValue: "hello", context: sessionCtx });
+    expect(h.result.current.command.open).toBe(false);
+    await h.unmount();
+  });
+
+  test("ArrowDown/ArrowUp move the highlight with wrap", async () => {
+    const h = await setup({ initialValue: "/", context: sessionCtx });
+    const count = h.result.current.command.items.length;
+    expect(count).toBeGreaterThan(1);
+    expect(h.result.current.command.highlight).toBe(0);
+    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowDown" }));
+    await h.rerender();
+    expect(h.result.current.command.highlight).toBe(1);
+    // Wrap back to top from the last item.
+    for (let i = 1; i < count; i += 1) {
+      h.result.current.command.onKeyDown(keyEvent({ key: "ArrowDown" }));
+      await h.rerender();
+    }
+    expect(h.result.current.command.highlight).toBe(0);
+    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowUp" }));
+    await h.rerender();
+    expect(h.result.current.command.highlight).toBe(count - 1);
+    await h.unmount();
+  });
+
+  test("Tab autocompletes the highlighted command name + trailing space", async () => {
+    const h = await setup({ initialValue: "/comp", context: sessionCtx });
+    h.result.current.command.onKeyDown(keyEvent({ key: "Tab" }));
+    await h.rerender();
+    expect(h.result.current.value).toBe("/compact ");
+    await h.unmount();
+  });
+
+  test("Escape closes the palette but keeps the draft", async () => {
+    const h = await setup({ initialValue: "/clear", context: sessionCtx });
+    expect(h.result.current.command.open).toBe(true);
+    h.result.current.command.onKeyDown(keyEvent({ key: "Escape" }));
+    await h.rerender();
+    expect(h.result.current.command.open).toBe(false);
+    expect(h.result.current.value).toBe("/clear");
+    // Editing re-opens.
+    h.result.current.setValue("/clear-");
+    await h.rerender();
+    expect(h.result.current.command.open).toBe(true);
+    await h.unmount();
+  });
+
+  test("Enter runs a client command and clears the draft", async () => {
+    const h = await setup({ initialValue: "/help", context: sessionCtx });
+    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await flush();
+    await h.rerender();
+    expect(h.result.current.helpOpened).toBe(1);
+    expect(h.result.current.value).toBe("");
+    await h.unmount();
+  });
+
+  test("Enter on a required-arg command without the arg does not run (waits at the hint)", async () => {
+    const h = await setup({ initialValue: "/goal ", context: sessionCtx });
+    expect(h.result.current.command.activeCommand?.name).toBe("goal");
+    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await h.rerender();
+    // Still /goal with no notice — nothing fired.
+    expect(h.result.current.value).toBe("/goal ");
+    expect(h.result.current.notices).toHaveLength(0);
+    await h.unmount();
+  });
+
+  test("Enter on /goal pause runs and surfaces an ok notice", async () => {
+    const h = await setup({ initialValue: "/goal pause", context: sessionCtx });
+    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await flush();
+    await h.rerender();
+    expect(h.result.current.notices.at(-1)).toEqual({ tone: "ok", message: "Goal paused." });
+    expect(h.result.current.value).toBe("");
+    await h.unmount();
+  });
+
+  test("danger command runs only after confirm resolves true", async () => {
+    let cleared = false;
+    const ctx: SlashCommandContext = { ...sessionCtx, client: fakeClient({ clearSessionContext: async () => { cleared = true; } }) };
+    const h = await setup({ initialValue: "/clear", context: ctx, confirmAnswer: true });
+    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    for (let i = 0; i < 5; i += 1) {
+      await flush();
+    }
+    await h.rerender();
+    expect(cleared).toBe(true);
+    expect(h.result.current.notices.at(-1)).toEqual({ tone: "ok", message: "Context cleared." });
+    await h.unmount();
+  });
+
+  test("the palette is inert without a command context", async () => {
+    const h = await setup({ initialValue: "/clear", context: undefined });
+    // open still derives from value (commands have no perm gate for help), but
+    // running does nothing without a context.
+    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await h.rerender();
+    expect(h.result.current.notices).toHaveLength(0);
+    await h.unmount();
+  });
+});

--- a/packages/react/test/slash-commands-hook.test.tsx
+++ b/packages/react/test/slash-commands-hook.test.tsx
@@ -45,7 +45,7 @@ function setup(options: {
     const handlers: SlashCommandHandlers = {
       notice: (n) => setNotices((cur) => [...cur, n]),
       openHelp: () => setHelpOpened((n) => n + 1),
-      clearView: () => setViewCleared((n) => n + 1),
+      clearView: () => { setViewCleared((n) => n + 1); return true; },
       confirm: async () => options.confirmAnswer ?? true,
     };
     const command = useSlashCommands({

--- a/packages/react/test/slash-commands.test.ts
+++ b/packages/react/test/slash-commands.test.ts
@@ -118,7 +118,7 @@ function makeCtx(overrides: Partial<CommandContext> & { client: CommandContext["
     permissions: ALL_PERMS as never,
     notice: (n) => notices.push(n),
     openHelp: () => {},
-    clearView: () => {},
+    clearView: () => true,
     confirm: async () => true,
     ...overrides,
   };
@@ -202,11 +202,31 @@ describe("default command handlers", () => {
   test("/help and /clear-view are client-only (no client calls)", async () => {
     let helped = false;
     let cleared = false;
-    const ctx = makeCtx({ client: fakeClient({}), openHelp: () => { helped = true; }, clearView: () => { cleared = true; } });
+    const ctx = makeCtx({ client: fakeClient({}), openHelp: () => { helped = true; }, clearView: () => { cleared = true; return true; } });
     expect((await run(help, [], ctx)).status).toBe("ok");
     expect((await run(clearView, [], ctx)).status).toBe("ok");
     expect(helped).toBe(true);
     expect(cleared).toBe(true);
+  });
+
+  // Regression (adversarial review): /clear-view must not report a false
+  // "Local view cleared." success when the host wired no view-reset affordance.
+  // clearView() returns false in that case, so the command must surface an
+  // honest error instead of a green success notice on a silent no-op.
+  test("/clear-view reports an error (not false success) when no view-reset is wired", async () => {
+    let invoked = false;
+    const ctx = makeCtx({ client: fakeClient({}), clearView: () => { invoked = true; return false; } });
+    const result = await run(clearView, [], ctx);
+    expect(invoked).toBe(true);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/can't be cleared/i);
+  });
+
+  test("/clear-view reports success only when clearView actually had an effect", async () => {
+    const ctx = makeCtx({ client: fakeClient({}), clearView: () => true });
+    const result = await run(clearView, [], ctx);
+    expect(result.status).toBe("ok");
+    expect(result.message).toMatch(/local view cleared/i);
   });
 
   test("extensibility: a new command is one object literal the registry renders from", () => {

--- a/packages/react/test/slash-commands.test.ts
+++ b/packages/react/test/slash-commands.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test";
+import {
+  argHint,
+  defaultCommands,
+  filterCommands,
+  firstMissingRequiredArg,
+  hasPermission,
+  matchCommand,
+  parseCommandLine,
+} from "../src/commands/registry";
+import type { CommandContext, SlashCommand } from "../src/commands/types";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+
+const ALL_PERMS = ["sessions:control" as const];
+
+function baseFilterCtx(overrides: Partial<{ sessionId: string | null; permissions: string[] }> = {}) {
+  return {
+    sessionId: overrides.sessionId === undefined ? SESSION_ID : overrides.sessionId,
+    status: null,
+    permissions: (overrides.permissions ?? ALL_PERMS) as never,
+  };
+}
+
+describe("parseCommandLine", () => {
+  test("returns null for plain chat (no leading slash)", () => {
+    expect(parseCommandLine("hello world")).toBeNull();
+    expect(parseCommandLine("")).toBeNull();
+    expect(parseCommandLine(" /clear")).toBeNull();
+  });
+
+  test("parses a bare name token (palette filtering mode)", () => {
+    expect(parseCommandLine("/cle")).toEqual({ name: "cle", rest: "", hasTrailingSpace: false, args: [] });
+  });
+
+  test("a trailing space closes the name and enters arg-hint mode", () => {
+    expect(parseCommandLine("/goal ")).toEqual({ name: "goal", rest: "", hasTrailingSpace: true, args: [] });
+  });
+
+  test("splits args after the name", () => {
+    expect(parseCommandLine("/goal pause")).toEqual({ name: "goal", rest: "pause", hasTrailingSpace: true, args: ["pause"] });
+  });
+});
+
+describe("hasPermission", () => {
+  test("no required permission is always satisfied", () => {
+    expect(hasPermission(undefined, [])).toBe(true);
+  });
+  test("requires the exact permission, with workspace:admin as a superuser", () => {
+    expect(hasPermission("sessions:control", ["sessions:control"])).toBe(true);
+    expect(hasPermission("sessions:control", ["workspace:admin"])).toBe(true);
+    expect(hasPermission("sessions:control", ["sessions:read"])).toBe(false);
+  });
+});
+
+describe("filterCommands", () => {
+  test("hides permission-gated commands entirely when the perm is absent", () => {
+    const names = filterCommands(defaultCommands, "", baseFilterCtx({ permissions: [] })).map((c) => c.name);
+    expect(names).toContain("help");
+    expect(names).toContain("clear-view");
+    expect(names).not.toContain("clear");
+    expect(names).not.toContain("compact");
+    expect(names).not.toContain("goal");
+  });
+
+  test("shows gated commands when the operator holds the permission", () => {
+    const names = filterCommands(defaultCommands, "", baseFilterCtx()).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining(["help", "clear-view", "goal", "compact", "clear"]));
+  });
+
+  test("hides session-only commands until a session exists (available())", () => {
+    const names = filterCommands(defaultCommands, "", baseFilterCtx({ sessionId: null })).map((c) => c.name);
+    expect(names).toContain("help");
+    expect(names).not.toContain("clear");
+    expect(names).not.toContain("goal");
+  });
+
+  test("prefix-filters by name and alias", () => {
+    expect(filterCommands(defaultCommands, "cl", baseFilterCtx()).map((c) => c.name)).toEqual(
+      expect.arrayContaining(["clear", "clear-view"]),
+    );
+    // alias "?" resolves /help
+    expect(filterCommands(defaultCommands, "?", baseFilterCtx()).map((c) => c.name)).toEqual(["help"]);
+  });
+});
+
+describe("matchCommand + argHint", () => {
+  test("matches by name and alias", () => {
+    expect(matchCommand(defaultCommands, "/goal pause")?.name).toBe("goal");
+    expect(matchCommand(defaultCommands, "/? ")?.name).toBe("help");
+    expect(matchCommand(defaultCommands, "/nope")).toBeNull();
+  });
+
+  test("renders required/optional arg hints", () => {
+    const goal = matchCommand(defaultCommands, "/goal pause")!;
+    expect(argHint(goal.args)).toBe("<pause|resume>");
+    expect(argHint(undefined)).toBe("");
+  });
+});
+
+describe("firstMissingRequiredArg", () => {
+  const goal = defaultCommands.find((c) => c.name === "goal")!;
+  test("flags an absent required arg", () => {
+    expect(firstMissingRequiredArg(goal, [])?.name).toBe("action");
+  });
+  test("passes once the required arg is present", () => {
+    expect(firstMissingRequiredArg(goal, ["pause"])).toBeNull();
+  });
+});
+
+// --- Command execution against a fake client + UI affordances ----------------
+
+function makeCtx(overrides: Partial<CommandContext> & { client: CommandContext["client"] }): CommandContext {
+  const notices: Parameters<CommandContext["notice"]>[0][] = [];
+  const ctx: CommandContext = {
+    workspaceId: WORKSPACE_ID,
+    sessionId: SESSION_ID,
+    status: null,
+    permissions: ALL_PERMS as never,
+    notice: (n) => notices.push(n),
+    openHelp: () => {},
+    clearView: () => {},
+    confirm: async () => true,
+    ...overrides,
+  };
+  (ctx as unknown as { _notices: typeof notices })._notices = notices;
+  return ctx;
+}
+
+function run(command: SlashCommand, args: string[], ctx: CommandContext) {
+  return command.run(args, ctx);
+}
+
+describe("default command handlers", () => {
+  const goal = defaultCommands.find((c) => c.name === "goal")!;
+  const clear = defaultCommands.find((c) => c.name === "clear")!;
+  const compact = defaultCommands.find((c) => c.name === "compact")!;
+  const help = defaultCommands.find((c) => c.name === "help")!;
+  const clearView = defaultCommands.find((c) => c.name === "clear-view")!;
+
+  test("/goal pause calls updateGoal with paused", async () => {
+    const calls: unknown[] = [];
+    const ctx = makeCtx({ client: fakeClient({ updateGoal: async (ws, sid, req) => { calls.push([ws, sid, req]); return {} as never; } }) });
+    const result = await run(goal, ["pause"], ctx);
+    expect(result.status).toBe("ok");
+    expect(calls[0]).toEqual([WORKSPACE_ID, SESSION_ID, { status: "paused" }]);
+  });
+
+  test("/goal resume calls updateGoal with active", async () => {
+    const calls: unknown[] = [];
+    const ctx = makeCtx({ client: fakeClient({ updateGoal: async (_ws, _sid, req) => { calls.push(req); return {} as never; } }) });
+    await run(goal, ["resume"], ctx);
+    expect(calls[0]).toEqual({ status: "active" });
+  });
+
+  test("/goal maps a 404 to a 'no goal' error notice", async () => {
+    const ctx = makeCtx({ client: fakeClient({ updateGoal: async () => { throw Object.assign(new Error("nope"), { status: 404 }); } }) });
+    const result = await run(goal, ["pause"], ctx);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/no goal/i);
+  });
+
+  test("/clear confirms first, then calls clearSessionContext", async () => {
+    let confirmed = false;
+    let cleared = false;
+    const ctx = makeCtx({
+      client: fakeClient({ clearSessionContext: async () => { cleared = true; } }),
+      confirm: async () => { confirmed = true; return true; },
+    });
+    const result = await run(clear, [], ctx);
+    expect(confirmed).toBe(true);
+    expect(cleared).toBe(true);
+    expect(result.status).toBe("ok");
+  });
+
+  test("/clear aborts (no server call) when the operator cancels the confirm", async () => {
+    let cleared = false;
+    const ctx = makeCtx({
+      client: fakeClient({ clearSessionContext: async () => { cleared = true; } }),
+      confirm: async () => false,
+    });
+    const result = await run(clear, [], ctx);
+    expect(cleared).toBe(false);
+    expect(result.status).toBe("ok");
+  });
+
+  test("/clear maps a 409 to a 'stop the turn first' error", async () => {
+    const ctx = makeCtx({
+      client: fakeClient({ clearSessionContext: async () => { throw Object.assign(new Error("busy"), { status: 409 }); } }),
+      confirm: async () => true,
+    });
+    const result = await run(clear, [], ctx);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/stop the current turn/i);
+  });
+
+  test("/compact surfaces the server result message", async () => {
+    const ctx = makeCtx({ client: fakeClient({ compactSessionContext: async () => ({ status: "queued", message: "Compaction will run before the next turn." }) }) });
+    const result = await run(compact, [], ctx);
+    expect(result).toEqual({ status: "ok", message: "Compaction will run before the next turn." });
+  });
+
+  test("/help and /clear-view are client-only (no client calls)", async () => {
+    let helped = false;
+    let cleared = false;
+    const ctx = makeCtx({ client: fakeClient({}), openHelp: () => { helped = true; }, clearView: () => { cleared = true; } });
+    expect((await run(help, [], ctx)).status).toBe("ok");
+    expect((await run(clearView, [], ctx)).status).toBe("ok");
+    expect(helped).toBe(true);
+    expect(cleared).toBe(true);
+  });
+
+  test("extensibility: a new command is one object literal the registry renders from", () => {
+    const ping: SlashCommand = { name: "ping", description: "Ping.", run: () => ({ status: "ok", message: "pong" }) };
+    const commands = [...defaultCommands, ping];
+    expect(filterCommands(commands, "pi", baseFilterCtx()).map((c) => c.name)).toEqual(["ping"]);
+    expect(matchCommand(commands, "/ping")?.name).toBe("ping");
+  });
+});

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -184,6 +184,13 @@ export type PlanCompactionInput = {
   softFraction: number;
   hardFraction: number;
   keepRecentTokens: number;
+  /**
+   * Operator-forced compaction (the /compact command): bypass the soft-limit
+   * token trigger and compact now if there is anything to summarize. The
+   * boundary / nothing-to-summarize guards still apply — force never invents a
+   * cut that would orphan a tool-call pair or summarize an empty prefix.
+   */
+  force?: boolean;
 };
 
 /**
@@ -213,7 +220,9 @@ export function planCompaction(input: PlanCompactionInput): CompactionPlan {
     typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
       ? input.lastInputTokens
       : estimateTokens(input.items);
-  if (signalTokens < softLimit) {
+  // force bypasses the budget trigger only; the structural guards below still
+  // run, so a forced compaction with nothing to summarize is still a no-op.
+  if (!input.force && signalTokens < softLimit) {
     return empty;
   }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,6 @@
 import type { Settings } from "@opengeni/config";
 import { collectSandboxEnvironment, contextServerCompactThreshold, parseExposedPorts, resolveContextCompactionMode, sandboxLifecycleHookIds } from "@opengeni/config";
-import { signDelegatedAccessToken, type Permission, type ReasoningEffort, type ResourceRef, type SessionEventType, type ToolRef } from "@opengeni/contracts";
+import { isClearedRunStateBlob, signDelegatedAccessToken, type Permission, type ReasoningEffort, type ResourceRef, type SessionEventType, type ToolRef } from "@opengeni/contracts";
 import {
   Agent,
   AgentsError,
@@ -810,7 +810,13 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
         ...(sandboxSessionState ? { sandboxSessionState } : {}),
       };
     }
-    if (!input.serializedRunState) {
+    // No prior state, or a cleared sentinel: start fresh. The clear sentinel
+    // ({@link CLEARED_RUN_STATE_BLOB}) is not a real serialized run state — it
+    // carries no $schemaVersion, so RunState.fromString would throw on it. In
+    // run_state history mode this message path is the one that reads the blob
+    // after a /clear, so recognizing the sentinel here is what keeps the next
+    // turn working (a fresh, empty context) instead of bricking on deserialize.
+    if (!input.serializedRunState || isClearedRunStateBlob(input.serializedRunState)) {
       return { input: input.text };
     }
     const state = await RunState.fromString(agent, input.serializedRunState);
@@ -833,6 +839,13 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
       ...(sandboxSessionState ? { sandboxSessionState } : {}),
       serializedRunStateForSandbox: input.serializedRunState,
     };
+  }
+  // An approval can only be resumed against a real saved run state. If the
+  // latest blob is the cleared sentinel the awaiting turn was wiped (the API
+  // refuses clear in requires_action, so this is a defensive guard) — fail with
+  // an honest message instead of the cryptic SDK "missing schema version".
+  if (isClearedRunStateBlob(input.serializedRunState)) {
+    throw new Error("Cannot resume an approval: the session context was cleared, so the awaiting run state no longer exists.");
   }
   const state = await RunState.fromString(agent, input.serializedRunState);
   const interruptions = state.getInterruptions();

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -141,6 +141,30 @@ describe("planCompaction trigger", () => {
     expect(plan.shouldCompact).toBe(true);
     expect(plan.boundaryIndex).toBe(2);
   });
+
+  test("force bypasses the budget trigger but still respects the structural guards", () => {
+    const items: CompactionItem[] = [
+      user("old 1"), assistant("a1"),
+      user("recent"), assistant("a2"),
+    ];
+    // Far below the soft threshold: without force this is a no-op.
+    const base = {
+      items,
+      lastInputTokens: 1,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(2)),
+    } as const;
+    expect(planCompaction(base).shouldCompact).toBe(false);
+    const forced = planCompaction({ ...base, force: true });
+    expect(forced.shouldCompact).toBe(true);
+    expect(forced.boundaryIndex).toBe(2);
+
+    // Force with nothing to summarize (whole transcript kept) is still a no-op.
+    const noPrefix = planCompaction({ ...base, force: true, keepRecentTokens: estimateTokens(items) });
+    expect(noPrefix.shouldCompact).toBe(false);
+  });
 });
 
 describe("planCompaction orphan safety (the boundary rule)", () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { getSettings } from "@opengeni/config";
+import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
 import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
@@ -267,6 +268,37 @@ describe("runtime event normalization", () => {
       serializedRunState: null,
     });
     expect(prepared.input).toBe("hello");
+  });
+
+  test("treats the cleared run-state sentinel as a fresh start (run_state mode /clear)", async () => {
+    // Regression (adversarial review): after /clear, in run_state history mode
+    // the message path reads the cleared sentinel blob (not a real serialized
+    // run state — it has no $schemaVersion). RunState.fromString would throw
+    // "Run state is missing schema version" and break the next turn. The reader
+    // must recognize the sentinel and start clean instead, returning the bare
+    // text exactly as a null state would.
+    const prepared = await prepareRunInput(buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []), {
+      kind: "message",
+      text: "first message after clear",
+      serializedRunState: CLEARED_RUN_STATE_BLOB,
+    });
+    expect(prepared.input).toBe("first message after clear");
+    // And critically it carries no resurrected sandbox-resume descriptor.
+    expect(prepared.serializedRunStateForSandbox).toBeUndefined();
+  });
+
+  test("refuses an approval resume against a cleared sentinel with an honest error", async () => {
+    // The API refuses /clear in requires_action, so this is a defensive guard:
+    // if the approval path ever sees the cleared sentinel it must fail with a
+    // clear message, never the cryptic SDK "missing schema version" throw.
+    await expect(
+      prepareRunInput(buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []), {
+        kind: "approval",
+        serializedRunState: CLEARED_RUN_STATE_BLOB,
+        approvalId: "appr_1",
+        decision: "approve",
+      }),
+    ).rejects.toThrow(/context was cleared/i);
   });
 
   test("sanitizes an orphaned tool output out of replayed items-mode history", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -10,6 +10,7 @@ import type {
   CapabilityCatalogResponse,
   CapabilityInstallation,
   ClientSessionEventInput,
+  CompactSessionContextResult,
   CompleteFileUploadResponse,
   CreateApiKeyRequest,
   CreateApiKeyResponse,
@@ -372,6 +373,29 @@ export class OpenGeniClient {
   /** Resume a paused goal: resets counters and re-arms the continuation loop. */
   async resumeGoal(workspaceId: string, sessionId: string): Promise<SessionGoal> {
     return await this.updateGoal(workspaceId, sessionId, { status: "active" });
+  }
+
+  // --- Operator context controls (/clear, /compact) ---------------------------
+
+  /**
+   * Clear the session's conversation context. Destructive and audit-preserving:
+   * the server supersedes (never deletes) the live history and emits a
+   * `session.context.cleared` event. Refused (409) while a turn is in flight or
+   * awaiting action. `confirm:true` is sent so an accidental call cannot wipe
+   * context — the destructive intent is explicit on the wire.
+   */
+  async clearSessionContext(workspaceId: string, sessionId: string): Promise<void> {
+    await this.requestVoid("POST", `/v1/workspaces/${workspaceId}/sessions/${sessionId}/context/clear`, { confirm: true });
+  }
+
+  /**
+   * Trigger conversation compaction now. On the client-managed (Azure) path this
+   * queues a forced compaction the worker honors before the next turn
+   * (`status:"queued"`); on a server-managed provider or when compaction is off
+   * it is a no-op (`status:"noop"`) with an explanatory message.
+   */
+  async compactSessionContext(workspaceId: string, sessionId: string): Promise<CompactSessionContextResult> {
+    return await this.requestJson<CompactSessionContextResult>("POST", `/v1/workspaces/${workspaceId}/sessions/${sessionId}/context/compact`, {});
   }
 
   // --- Access + workspaces -----------------------------------------------------
@@ -779,10 +803,15 @@ export class OpenGeniClient {
   }
 
   /** Like `requestJson` for endpoints that respond with no body (204). */
-  private async requestVoid(method: string, path: string): Promise<void> {
+  private async requestVoid(method: string, path: string, body?: unknown): Promise<void> {
     const response = await this.fetchImpl(this.url(path), {
       method,
-      headers: { ...this.headers(), Accept: "application/json" },
+      headers: {
+        ...this.headers(),
+        Accept: "application/json",
+        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
     if (!response.ok) {
       throw new OpenGeniApiError(response.status, await safeText(response));

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -48,6 +48,7 @@ export type {
   CapabilityPackSkillFile,
   CapabilityRuntime,
   CapabilitySource,
+  CompactSessionContextResult,
   ClientSessionEventInput,
   CompleteFileUploadResponse,
   CreateApiKeyRequest,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -101,6 +101,7 @@ export const SESSION_EVENT_TYPES = [
   "session.status.changed",
   "session.requiresAction",
   "session.context.compacted",
+  "session.context.cleared",
   "user.message",
   "user.interrupt",
   "user.approvalDecision",
@@ -390,6 +391,18 @@ export type SessionGoal = {
 export type UpdateSessionGoalRequest = {
   status: "paused" | "active";
   rationale?: string | undefined;
+};
+
+// --- Operator context controls (/clear, /compact) ----------------------------
+
+/** Outcome of a manual /compact trigger. */
+export type CompactSessionContextResult = {
+  /**
+   * queued: a client-side (Azure) compaction will run before the next turn.
+   * noop:   nothing to do (server-managed provider, mode off, or no history).
+   */
+  status: "queued" | "noop";
+  message: string;
 };
 
 // --- Turn queue --------------------------------------------------------------

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -84,6 +84,31 @@ describe("OpenGeniClient", () => {
     });
   });
 
+  test("clearSessionContext posts an explicit confirm to the context/clear route (204, no body)", async () => {
+    const { client, requests } = makeClient(() => new Response(null, { status: 204 }));
+    await client.clearSessionContext(WORKSPACE_ID, SESSION_ID);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/context/clear`);
+    expect(requests[0]!.method).toBe("POST");
+    expect(JSON.parse(requests[0]!.body!)).toEqual({ confirm: true });
+  });
+
+  test("clearSessionContext surfaces a 409 (cannot clear mid-turn) as OpenGeniApiError", async () => {
+    const { client } = makeClient(() => new Response("session is running", { status: 409 }));
+    const error = await client.clearSessionContext(WORKSPACE_ID, SESSION_ID).then(() => null, (caught: unknown) => caught);
+    expect(error).toBeInstanceOf(OpenGeniApiError);
+    expect((error as OpenGeniApiError).status).toBe(409);
+  });
+
+  test("compactSessionContext posts to context/compact and returns the trigger result", async () => {
+    const { client, requests } = makeClient(() => jsonResponse({ status: "queued", message: "Compaction will run before the next turn." }));
+    const result = await client.compactSessionContext(WORKSPACE_ID, SESSION_ID);
+    expect(result).toEqual({ status: "queued", message: "Compaction will run before the next turn." });
+    expect(requests[0]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/context/compact`);
+    expect(requests[0]!.method).toBe("POST");
+    expect(JSON.parse(requests[0]!.body!)).toEqual({});
+  });
+
   test("non-2xx responses raise OpenGeniApiError with status and body", async () => {
     const { client } = makeClient(() => new Response("workspace not found", { status: 404 }));
     const error = await client.getSession(WORKSPACE_ID, SESSION_ID).then(

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, applyCreditLedgerEntry, bootstrapWorkspace, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getBillingBalance, getCapabilityInstallation, getSession, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, appendSessionHistoryItems, applyCreditLedgerEntry, bootstrapWorkspace, consumeSessionCompactionRequest, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getActiveSessionHistoryItems, getBillingBalance, getCapabilityInstallation, getSession, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -148,6 +148,114 @@ describe("API component integration", () => {
     const plainSession = await plain.json() as { id: string };
     const missing = await app.request(workspacePath(workspaceId, `/sessions/${plainSession.id}/goal`));
     expect(missing.status).toBe(404);
+  });
+
+  test("POST /context/clear clears context (audit-preserved), 409s mid-turn, and emits the event", async () => {
+    workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const created = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "clear me", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    const session = await created.json() as { id: string };
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: (await requireSession(dbClient.db, workspaceId, session.id)).accountId,
+      workspaceId,
+      sessionId: session.id,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "earlier work" } },
+        { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] } },
+      ],
+    });
+
+    // While a turn is in flight, clearing is refused (409) — mid-turn safety.
+    await setSessionStatus(dbClient.db, workspaceId, session.id, "running", null);
+    const blocked = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/context/clear`), {
+      method: "POST",
+      body: JSON.stringify({ confirm: true }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(blocked.status).toBe(409);
+
+    // An explicit confirm is required on the wire.
+    await setSessionStatus(dbClient.db, workspaceId, session.id, "idle", null);
+    const noConfirm = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/context/clear`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(noConfirm.status).toBe(400);
+
+    const cleared = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/context/clear`), {
+      method: "POST",
+      body: JSON.stringify({ confirm: true }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(cleared.status).toBe(204);
+
+    // Active read collapses to the single neutral marker; the cleared event lands.
+    const active = await getActiveSessionHistoryItems(dbClient.db, workspaceId, session.id);
+    expect(active).toHaveLength(1);
+    expect(active[0]!.item).toMatchObject({ content: "[context cleared]" });
+    const events = await listSessionEvents(dbClient.db, workspaceId, session.id);
+    expect(events.some((event) => event.type === "session.context.cleared")).toBe(true);
+  });
+
+  test("POST /context/compact: queued on the client path, no-op on the server path", async () => {
+    workflow = new FakeWorkflowClient();
+    const workspaceId = await defaultWorkspaceId(createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    }));
+
+    // Server-managed provider (default auto+openai) -> noop, no flag set.
+    const serverApp = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl, contextCompactionMode: "server" }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const created = await serverApp.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "compact me", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    const session = await created.json() as { id: string };
+    await setSessionStatus(dbClient.db, workspaceId, session.id, "idle", null);
+
+    const noop = await serverApp.request(workspacePath(workspaceId, `/sessions/${session.id}/context/compact`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(noop.status).toBe(200);
+    expect((await noop.json() as { status: string }).status).toBe("noop");
+    expect(await consumeSessionCompactionRequest(dbClient.db, workspaceId, session.id)).toBe(false);
+
+    // Client-managed (Azure) provider -> queued, durable flag set for the worker.
+    const clientApp = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl, contextCompactionMode: "client" }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const queued = await clientApp.request(workspacePath(workspaceId, `/sessions/${session.id}/context/compact`), {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+    expect(queued.status).toBe(200);
+    expect((await queued.json() as { status: string }).status).toBe("queued");
+    expect(await consumeSessionCompactionRequest(dbClient.db, workspaceId, session.id)).toBe(true);
   });
 
   test("registers session-scoped goal MCP tools only for session-bound grants", async () => {

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -5,10 +5,13 @@ import {
   applyContextCompaction,
   bootstrapWorkspace,
   claimNextQueuedTurn,
+  clearSessionContext,
+  consumeSessionCompactionRequest,
   countSessionHistoryItems,
   createDb,
   getActiveSessionHistoryItems,
   getSessionHistoryItems,
+  requestSessionCompaction,
   setSessionLastInputTokens,
   createScheduledTask,
   createScheduledTaskRun,
@@ -984,6 +987,109 @@ describe("DB integration", () => {
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.lastInputTokens).toBeNull();
     await setSessionLastInputTokens(dbClient.db, grant.workspaceId, session.id, 654_321);
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.lastInputTokens).toBe(654_321);
+  });
+
+  test("clearSessionContext supersedes all live history, keeps the audit trail, and defeats the RunState fallback", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "clear",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "secret one" } },
+        { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "secret two" }] } },
+        { position: 2, item: { type: "message", role: "user", content: "secret three" } },
+      ],
+    });
+    // A stale RunState blob carrying the old conversation — the resurrection
+    // vector clear must neutralize (run-input.ts falls back to this when the
+    // active items read is empty).
+    await saveRunState(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      serializedRunState: JSON.stringify({ history: ["secret one", "secret two"] }),
+      pendingApprovals: [],
+    });
+    await setSessionLastInputTokens(dbClient.db, grant.workspaceId, session.id, 50_000);
+
+    const result = await clearSessionContext(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+    });
+    expect(result.supersededItems).toBe(3);
+    expect(result.markerPosition).toBe(3);
+
+    // (a)+(b): the active read returns ONLY the neutral marker (length 1, not
+    // 0) so messageInput stays on the items route, away from the RunState blob.
+    const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(active).toHaveLength(1);
+    expect(active[0]!.item).toMatchObject({ role: "user", content: "[context cleared]" });
+
+    // Audit trail preserved: the three superseded rows still exist.
+    const all = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(all.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+
+    // (c): the latest run state now reflects the clear (no old conversation).
+    const latest = await getLatestRunState(dbClient.db, grant.workspaceId, session.id);
+    expect(latest!.serializedRunState).not.toContain("secret");
+    expect(latest!.pendingApprovals).toEqual([]);
+
+    // last_input_tokens reset so the next turn's trigger starts fresh.
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.lastInputTokens).toBe(0);
+  });
+
+  test("clearSessionContext is idempotent — a re-run keeps exactly one active marker", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "clear-twice",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      items: [{ position: 0, item: { type: "message", role: "user", content: "x" } }],
+    });
+    await clearSessionContext(dbClient.db, { accountId: grant.accountId, workspaceId: grant.workspaceId, sessionId: session.id });
+    await clearSessionContext(dbClient.db, { accountId: grant.accountId, workspaceId: grant.workspaceId, sessionId: session.id });
+    const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(active).toHaveLength(1);
+    expect(active[0]!.item).toMatchObject({ content: "[context cleared]" });
+  });
+
+  test("compaction request flag: request sets it, consume reports + clears it exactly once", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "compact-flag",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // No request yet: consume is a no-op false.
+    expect(await consumeSessionCompactionRequest(dbClient.db, grant.workspaceId, session.id)).toBe(false);
+    await requestSessionCompaction(dbClient.db, grant.workspaceId, session.id);
+    // First consumer wins; a second consumer sees it already cleared.
+    expect(await consumeSessionCompactionRequest(dbClient.db, grant.workspaceId, session.id)).toBe(true);
+    expect(await consumeSessionCompactionRequest(dbClient.db, grant.workspaceId, session.id)).toBe(false);
   });
 });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2974,6 +2974,53 @@ describe("worker activities integration", () => {
     expect(active.map((row) => row.position)).toEqual([0, 1, 2, 3]);
     expect(active.some((row) => (row.item as Record<string, unknown>).opengeni_context_summary)).toBe(false);
   });
+
+  test("maybeCompactContext force bypasses the budget trigger (the /compact path)", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "force-compact",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "old turn 1" } },
+        { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "a1" }] } },
+        { position: 2, item: { type: "message", role: "user", content: "recent turn" } },
+        { position: 3, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "a2" }] } },
+      ],
+    });
+    // A budget so high the soft trigger would never fire on its own.
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      sessionHistorySource: "items",
+      openaiProvider: "azure",
+      contextCompactionMode: "client",
+      contextWindowTokens: 10_000_000,
+      contextReservedOutputTokens: 0,
+      contextCompactSoftFraction: 0.9,
+      contextKeepRecentTokens: 20,
+    });
+    const scope = { accountId: grant.accountId, workspaceId: grant.workspaceId, sessionId: session.id };
+    const summarize = async () => "summary of the old prefix.";
+
+    // Without force, the tiny token count is below budget -> no-op.
+    const skipped = await maybeCompactContext(dbClient.db, settings, scope, 10, summarize, {});
+    expect(skipped.compacted).toBe(false);
+
+    // With force, it compacts despite being below budget.
+    const forced = await maybeCompactContext(dbClient.db, settings, scope, 10, summarize, { force: true });
+    expect(forced.compacted).toBe(true);
+    const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect((active[0]!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
+    expect(active.at(-1)!.item).toMatchObject({ role: "assistant" });
+  });
 });
 
 type TestDb = ReturnType<typeof createDb>["db"];


### PR DESCRIPTION
## What

An **extensible slash-command palette** in the shared `ChatComposer` (`@opengeni/react`), so both the OpenGeni console and the Geni app get inline operator controls. Type `/` to open a filterable popover with keyboard nav, argument hints, permission gating, and a confirm affordance for destructive commands.

A command is recognized **only** when the composer value starts with `/`; everything else stays plain chat. Commands are **session/operator actions** (clear, compact, pause/resume goal, help) — never a structured channel to the model. The human↔agent ruling is preserved.

> Stacked on `codex/provider-aware-compaction` (#62) so `/clear` can use audit-preserving supersede and `/compact` can reuse the compaction engine. Rebase onto `main` if #62 merges first.

## The registry (core artifact) — `packages/react/src/commands/`
`types.ts` + `registry.ts`: a typed `SlashCommand { name, aliases, description, args, permission, danger, available, run }` array. **Adding a command is one object literal** — the palette list, prefix filter, arg-hint footer, and `/help` all render from it. Defaults: `/help`, `/clear-view` (local view, no server call), `/goal pause|resume`, `/compact`, `/clear` (danger). Permission-absent commands are hidden entirely; `available()` hides session commands until a session exists.

## Palette UI + hook
- `components/command-palette.tsx`: popover above the textarea, dark-first, opengeni#46 tokens, `role=listbox/option` + `aria-activedescendant`.
- `hooks/use-slash-commands.ts`: derives palette state from value + key events. ArrowUp/Down wrap, Tab autocompletes, Enter runs (or autocompletes / opens confirm for danger), Esc closes keeping the draft. Exact-name match wins over the highlight (`/clear` Enter runs clear, not clear-view).
- `ChatComposer` gains optional `commands` / `commandContext` / `onClearView`. The composer generalizes its error line into a transient ok/error **notice**, and owns help-panel + confirm-bar state. **Backward-compatible**: without a `commandContext` the palette is inert and behavior is identical.

## SDK + API — `/clear` and `/compact`
- SDK: `clearSessionContext`, `compactSessionContext` on `OpenGeniClient` + the react `SessionClientLike` Pick.
- API: `POST .../context/clear` and `.../context/compact` (both `sessions:control`). `/clear` refuses **409** while a turn is in flight / awaiting action and requires explicit `{confirm:true}` (**400** otherwise). `/compact` is a **trigger only** — it never duplicates the compaction engine.

### `/compact` integration seam (converges with #62)
- **client-managed (Azure)**: sets a durable `compact_requested` flag the worker honors **before the next turn** via `maybeCompactContext(force)` → `{status:"queued"}`.
- **server-managed**: compaction is automatic → `{status:"noop"}` with a clear message.
- **off**: `{status:"noop"}`.

When #62 exposes a synchronous "compact now" entry callable from the API process, the route should call it directly; until then the flag + `force` is the minimal honored interface. Recorded so the two efforts converge.

## The `/clear` fix (resolves the resurrection vector)
New db `clearSessionContext` in **one transaction**, audit-preserving + idempotent:
1. supersede every active `session_history_items` row (`active=false`, **never delete** — full transcript stays as audit trail);
2. insert **one** neutral `[context cleared]` boundary marker at `max(position)+1` so `getActiveSessionHistoryItems` stays non-empty → `run-input.ts` keeps the **items** route and never falls back to the `getLatestRunState` blob (the bug);
3. insert a fresh **cleared** `agent_run_states` row so `getLatestRunState` also reflects the clear;
4. reset `last_input_tokens`.

Emits `session.context.cleared`.

## Worker
`planCompaction` + `maybeCompactContext` gain a `force` flag (bypasses the budget trigger; orphan-safe structural guards still apply). `agent-turn` consumes `compact_requested` pre-turn and forces a compaction.

## Wiring
OpenGeni console session view builds a `commandContext` from the workspace grant; the `@opengeni/react` demo surfaces the palette.

## Tests (fail before, pass after)
- **Component/registry**: `packages/react/test/slash-commands.test.ts` (parsing, filtering, permission gating, arg hints, handlers, extensibility), `slash-commands-hook.test.tsx` (keyboard nav, autocomplete, run, danger confirm, inert-without-context), `chat-composer-palette.test.tsx` (listbox renders, gating, danger marker, inert).
- **SDK**: `clearSessionContext` (204 + confirm body + 409) and `compactSessionContext`.
- **Runtime**: planner `force` test.
- **DB integration**: `clearSessionContext` (supersede + marker + cleared run-state + token reset + idempotent), compact-flag request/consume.
- **API integration**: `context/clear` (409 mid-turn, 400 no-confirm, 204 + event), `context/compact` (queued client / noop server).
- **Worker integration**: force-compaction bypasses budget.

## How to run
```
bun run typecheck && bun run test:unit
# integration (docker): 
bun test --timeout 60000 ./test/integration/db.integration.ts ./test/integration/api.integration.ts ./test/integration/worker-activity.integration.ts
# builds: bun run check
```

## How to add a command (extensibility)
Append one object literal to `defaultCommands` (or pass extra `commands` to `ChatComposer`):
```ts
{ name: "ping", description: "Ping.", permission: "sessions:control",
  args: [{ name: "host", required: true }],
  run: async (args, ctx) => ({ status: "ok", message: `pong ${args[0]}` }) }
```
The palette, filter, arg-hint footer, and `/help` pick it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session history, run-state, and compaction paths that affect what the model sees; destructive clear is guarded but mistakes could still strand operators mid-session.
> 
> **Overview**
> **Operator controls in the composer:** Typing `/` opens an extensible slash-command palette in `@opengeni/react`’s `ChatComposer` (filtering, keyboard nav, permission gating, danger confirm). Default commands include `/help`, device-only `/clear-view`, `/goal pause|resume`, `/compact`, and destructive `/clear`. The OpenGeni console wires `commandContext` from workspace grants and local timeline hiding for `/clear-view`.
> 
> **Server context APIs:** New `POST .../context/clear` (requires `{ confirm: true }`, **409** mid-turn) runs transactional `clearSessionContext`—supersedes active history, inserts a boundary marker and cleared run-state sentinel so old blobs cannot resurrect—and emits `session.context.cleared`. `POST .../context/compact` queues client-mode compaction via `compact_requested` or returns **noop** when compaction is server-managed or off.
> 
> **Worker/runtime:** Pre-turn compaction can be **forced** when the flag is consumed; `planCompaction` accepts `force`. `isClearedRunStateBlob` keeps message and approval resume paths from deserializing the clear sentinel as real Agents SDK state.
> 
> **SDK:** `clearSessionContext` and `compactSessionContext` on the client; contracts and tests cover the new event type and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed96f8ce6d68b9882467a0478fd97055c2dc22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->