### PR TITLE
Byte-cap first-party session-read MCP tools (session_events/session_get)

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -61,6 +61,7 @@ import {
   validatedScheduledTaskUpdate,
 } from "../domain/scheduled-tasks";
 import { acceptSessionUserMessage, createSessionForRequest } from "../domain/sessions";
+import { capEventPage, capSessionDetail } from "./session-view";
 
 export type McpServerOptions = {
   // Origin of the HTTP request that reached the MCP route; last-resort base
@@ -479,18 +480,18 @@ function registerWorkspaceOrchestrationTools(
     }, async ({ limit }) => json({ sessions: await listSessions(deps.db, grant.workspaceId, boundedMcpLimit(limit)) }));
 
     server.registerTool("session_get", {
-      description: "Get one session: status, goal-bearing metadata, resources, tools, and environment attachment (names/ids only, never variable values).",
+      description: "Get one session: status, goal-bearing metadata, resources, tools, and environment attachment (names/ids only, never variable values). Unbounded agent-set fields (metadata, initial message) are clamped so monitoring another session cannot flood this context.",
       inputSchema: { sessionId: z4.string().uuid() },
     }, async ({ sessionId }) => {
       const session = await getSession(deps.db, grant.workspaceId, sessionId);
       if (!session) {
         throw new Error("session not found");
       }
-      return json(session);
+      return json(capSessionDetail(session));
     });
 
     server.registerTool("session_events", {
-      description: "Read a session's event timeline (oldest first). Pass `after` = the highest event `sequence` already seen to page forward; the response's `nextAfter` is that cursor. Use it to monitor another session's progress.",
+      description: "Read a session's event timeline (oldest first), to monitor another session's progress. Pass `after` = the highest event `sequence` already seen to page forward; the response's `nextAfter` is that cursor. The response is BYTE-CAPPED for a monitoring glance: fat per-event payloads (a worker's verbatim tool outputs, message/reasoning bodies) are clamped, and an over-budget page is reduced to its head + tail with a marker — page the gap with `after`/`limit`, or read the worker's session notebook, if you need omitted content verbatim. `nextAfter` always advances past every event the page covered, so paging never skips real events.",
       inputSchema: {
         sessionId: z4.string().uuid(),
         after: z4.number().int().nonnegative().optional(),
@@ -499,8 +500,12 @@ function registerWorkspaceOrchestrationTools(
     }, async ({ sessionId, after, limit }) => {
       await requireSession(deps.db, grant.workspaceId, sessionId);
       const events = await listSessionEvents(deps.db, grant.workspaceId, sessionId, after ?? 0, boundedMcpLimit(limit));
-      const last = events[events.length - 1];
-      return json({ events, nextAfter: last ? last.sequence : after ?? 0 });
+      const capped = capEventPage(events);
+      return json({
+        events: capped.events,
+        nextAfter: capped.nextAfter ?? after ?? 0,
+        ...(capped.truncated ? { truncated: true } : {}),
+      });
     });
   }
 

--- a/apps/api/src/mcp/session-view.ts
+++ b/apps/api/src/mcp/session-view.ts
@@ -1,0 +1,281 @@
+/**
+ * Byte/token caps for the cross-session read tools (`session_events`,
+ * `session_get`) exposed to manager-style agents over MCP.
+ *
+ * A long-lived manager session monitors its spawned workers by reading their
+ * event timeline. A worker's events carry verbatim model output and, worse,
+ * verbatim TOOL OUTPUTS (`agent.toolCall.output.payload.output`) and raw tool
+ * call items (`agent.toolCall.created.payload.raw` / `.arguments`). Those are
+ * sized for the worker's own context, not the manager's: a single
+ * `session_events` page (the DB limit caps event COUNT, not BYTES) can return
+ * tens of thousands of characters, and a manager that pages a busy worker piles
+ * hundreds of thousands of characters into its own context in one monitoring
+ * turn — the exact "parent ingests child" blow-up that bricks the manager.
+ *
+ * The manager rarely needs a worker's full message deltas / tool outputs
+ * verbatim; it needs status + recent progress. So these tools cap what they
+ * hand back in two stages, both pure and exhaustively testable here:
+ *
+ *  1. PER-EVENT FIELD TRIM (`capEventPayload` / `capPayloadValue`): walk each
+ *     event's payload and clamp any over-long string (and any over-large nested
+ *     object, by serializing then clamping) to a per-field budget, leaving an
+ *     explicit `…N chars truncated…` marker. Type-agnostic: it targets whatever
+ *     field is fat (`text`, `output`, `arguments`, `raw`, `delta`, …) without
+ *     enumerating event types, so a new fat event type is capped automatically.
+ *
+ *  2. HEAD+TAIL PAGE BUDGET (`capEventPage`): after per-event trim, if the page
+ *     still exceeds the total token budget, keep a HEAD (oldest, for entry
+ *     context) and a TAIL (newest, for recent progress) of events and drop the
+ *     middle, inserting one synthetic marker event that says how many were
+ *     dropped and how to get them (page with `after`/`limit`, or read the
+ *     notebook). Pagination semantics are preserved: `nextAfter` is still the
+ *     real highest `sequence` returned, so the next page starts exactly where
+ *     this one ended.
+ *
+ * Worker-side and UI consumers never go through here — they call the DB
+ * functions or the REST routes directly. This module only shapes the MCP tool
+ * result a manager model reads, and it is intentionally dependency-free (no DB)
+ * so the cap logic can be unit-tested in isolation.
+ */
+
+import type { SessionEvent } from "@opengeni/contracts";
+
+// ~4 chars per token is the same coarse estimate the runtime compaction path
+// uses; we only need an order-of-magnitude budget, not exact tokenization.
+const CHARS_PER_TOKEN = 4;
+
+export function estimateTokensFromChars(chars: number): number {
+  return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+function estimateValueTokens(value: unknown): number {
+  return estimateTokensFromChars(safeStringify(value).length);
+}
+
+export type EventCapConfig = {
+  // Per-event cap: max characters any single string field (or serialized
+  // nested object) inside an event payload may contribute before it is clamped
+  // with a truncation marker.
+  perFieldChars: number;
+  // Total page cap: max estimated tokens the whole returned event array may
+  // occupy. When the per-event-trimmed page still exceeds this, head+tail
+  // selection drops the middle.
+  pageTokenBudget: number;
+  // When head+tail selection kicks in, how many events to keep at each end.
+  headEvents: number;
+  tailEvents: number;
+};
+
+// ~2k chars (~500 tokens) per fat field keeps a status glance readable without
+// shipping a worker's whole tool output. ~10k-token page budget sits in the
+// 8–12k target band; head/tail of 8 keeps entry context plus recent progress.
+export const DEFAULT_EVENT_CAP: EventCapConfig = {
+  perFieldChars: 2_000,
+  pageTokenBudget: 10_000,
+  headEvents: 8,
+  tailEvents: 8,
+};
+
+// ~6k chars (~1.5k tokens) for a single session detail blob: resources/tools/
+// metadata are normally tiny, but agent-set metadata is unbounded, so clamp it.
+export const DEFAULT_SESSION_DETAIL_CHARS = 6_000;
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncationMarker(droppedChars: number): string {
+  return `…[${droppedChars} chars truncated — page with after/limit on session_events, or read the session notebook for the full content]`;
+}
+
+function clampString(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  // Keep a head and a small tail of the field so both the start and the end
+  // (often the most diagnostic part of a tool output / error) survive.
+  const dropped = value.length - maxChars;
+  const headChars = Math.max(0, Math.floor(maxChars * 0.7));
+  const tailChars = Math.max(0, maxChars - headChars);
+  const head = value.slice(0, headChars);
+  const tail = tailChars > 0 ? value.slice(value.length - tailChars) : "";
+  return `${head}${truncationMarker(dropped)}${tail}`;
+}
+
+/**
+ * Recursively clamp any over-budget string or nested value inside a payload.
+ * Strings longer than `perFieldChars` are head+tail clamped. Nested objects /
+ * arrays whose serialized form exceeds `perFieldChars` are recursed into so the
+ * clamp lands on the actual fat leaf; if recursion cannot shrink them enough
+ * (e.g. thousands of tiny fields), the whole branch is replaced by its clamped
+ * serialization. Plain scalars pass through untouched. A depth guard makes the
+ * walk safe against pathological / cyclic structures.
+ */
+export function capPayloadValue(value: unknown, perFieldChars: number, depth = 0): unknown {
+  if (typeof value === "string") {
+    return clampString(value, perFieldChars);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  // Guard against pathological / cyclic structures: past a reasonable depth,
+  // collapse to a clamped serialization.
+  if (depth >= 8) {
+    return clampString(safeStringify(value), perFieldChars);
+  }
+  const serializedLength = safeStringify(value).length;
+  if (serializedLength <= perFieldChars) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const mapped = value.map((entry) => capPayloadValue(entry, perFieldChars, depth + 1));
+    if (safeStringify(mapped).length <= perFieldChars * 2) {
+      return mapped;
+    }
+    return clampString(safeStringify(value), perFieldChars);
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = capPayloadValue(entry, perFieldChars, depth + 1);
+  }
+  // If recursion still left the object fat (many small fields), fall back to a
+  // clamped serialization so the page budget is respected.
+  if (safeStringify(out).length <= perFieldChars * 4) {
+    return out;
+  }
+  return clampString(safeStringify(value), perFieldChars);
+}
+
+export function capEventPayload(event: SessionEvent, perFieldChars: number): SessionEvent {
+  const cappedPayload = capPayloadValue(event.payload, perFieldChars);
+  if (cappedPayload === event.payload) {
+    return event;
+  }
+  return { ...event, payload: cappedPayload };
+}
+
+export type CappedEventPage = {
+  events: SessionEvent[];
+  // The real highest `sequence` among the events the DB returned, so the caller
+  // can advance the cursor correctly even when the middle was dropped. Null
+  // when the page was empty.
+  nextAfter: number | null;
+  truncated: boolean;
+};
+
+/**
+ * Build a synthetic marker event that stands in for the dropped middle. It is
+ * NOT a real persisted event; its `id` is the zero UUID and its sequence sits
+ * between the kept head and tail so ordering by sequence stays monotonic. It
+ * never participates in pagination (the caller derives `nextAfter` from the
+ * real events, not this marker). Typed `session.status.changed` so the
+ * synthetic event still validates against the `SessionEvent` contract.
+ */
+function buildTruncationEvent(
+  template: SessionEvent,
+  droppedCount: number,
+  firstDroppedSequence: number,
+  lastDroppedSequence: number,
+  markerSequence: number,
+): SessionEvent {
+  return {
+    id: "00000000-0000-0000-0000-000000000000",
+    workspaceId: template.workspaceId,
+    sessionId: template.sessionId,
+    sequence: markerSequence,
+    type: "session.status.changed",
+    payload: {
+      _truncated: true,
+      note: `${droppedCount} event(s) (sequence ${firstDroppedSequence}–${lastDroppedSequence}) omitted from this monitoring view to keep the response bounded. Page the gap with session_events after=${firstDroppedSequence - 1} limit=… if you need them verbatim, or read the worker's session notebook.`,
+      droppedCount,
+      omittedSequenceRange: [firstDroppedSequence, lastDroppedSequence],
+    },
+    occurredAt: template.occurredAt,
+    clientEventId: null,
+    turnId: null,
+  };
+}
+
+/**
+ * Apply per-event field trim then, if the page is still over budget, keep a
+ * head and a tail of events and drop the middle behind a marker. `events` is
+ * assumed oldest-first (as `listSessionEvents` returns).
+ */
+export function capEventPage(events: SessionEvent[], config: EventCapConfig = DEFAULT_EVENT_CAP): CappedEventPage {
+  const realLast = events[events.length - 1];
+  const nextAfter = realLast ? realLast.sequence : null;
+
+  const trimmed = events.map((event) => capEventPayload(event, config.perFieldChars));
+
+  let runningTokens = 0;
+  let overBudget = false;
+  for (const event of trimmed) {
+    runningTokens += estimateValueTokens(event);
+    if (runningTokens > config.pageTokenBudget) {
+      overBudget = true;
+      break;
+    }
+  }
+
+  const keepCount = config.headEvents + config.tailEvents;
+  if (!overBudget || trimmed.length <= keepCount + 1) {
+    return { events: trimmed, nextAfter, truncated: overBudget && trimmed.length > keepCount + 1 };
+  }
+
+  const head = trimmed.slice(0, config.headEvents);
+  const tail = trimmed.slice(trimmed.length - config.tailEvents);
+  const droppedStart = config.headEvents;
+  const droppedEnd = trimmed.length - config.tailEvents - 1;
+  const droppedCount = droppedEnd - droppedStart + 1;
+  const firstDroppedSequence = trimmed[droppedStart]!.sequence;
+  const lastDroppedSequence = trimmed[droppedEnd]!.sequence;
+  // Marker sequence sits between the kept head and tail; reusing the last head
+  // sequence keeps the returned page monotonic non-decreasing by sequence.
+  const markerSequence = head[head.length - 1]!.sequence;
+  const marker = buildTruncationEvent(
+    realLast!,
+    droppedCount,
+    firstDroppedSequence,
+    lastDroppedSequence,
+    markerSequence,
+  );
+
+  return {
+    events: [...head, marker, ...tail],
+    nextAfter,
+    truncated: true,
+  };
+}
+
+/**
+ * Clamp a single session-detail object for `session_get`. Only the unbounded
+ * agent-controlled fields (`metadata`, and defensively `initialMessage`) can
+ * grow large; everything else is small and structural. Returns a shallow copy
+ * with those fields capped when over budget, otherwise the original reference.
+ */
+export function capSessionDetail<T extends { metadata?: unknown; initialMessage?: unknown }>(
+  session: T,
+  perFieldChars: number = DEFAULT_SESSION_DETAIL_CHARS,
+): T {
+  let changed = false;
+  const out: T = { ...session };
+  if (session.metadata !== undefined) {
+    const capped = capPayloadValue(session.metadata, perFieldChars);
+    if (capped !== session.metadata) {
+      (out as { metadata?: unknown }).metadata = capped;
+      changed = true;
+    }
+  }
+  if (typeof session.initialMessage === "string" && session.initialMessage.length > perFieldChars) {
+    (out as { initialMessage?: unknown }).initialMessage = clampString(session.initialMessage, perFieldChars);
+    changed = true;
+  }
+  return changed ? out : session;
+}

--- a/apps/api/test/session-view.test.ts
+++ b/apps/api/test/session-view.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import { SessionEvent, type SessionEvent as SessionEventType } from "@opengeni/contracts";
+import {
+  capEventPage,
+  capEventPayload,
+  capPayloadValue,
+  capSessionDetail,
+  DEFAULT_EVENT_CAP,
+  DEFAULT_SESSION_DETAIL_CHARS,
+  estimateTokensFromChars,
+} from "../src/mcp/session-view";
+
+const WORKSPACE = "00000000-0000-4000-8000-000000000001";
+const SESSION = "00000000-0000-4000-8000-000000000002";
+
+function makeEvent(sequence: number, type: SessionEventType["type"], payload: unknown): SessionEventType {
+  return {
+    id: `00000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
+    workspaceId: WORKSPACE,
+    sessionId: SESSION,
+    sequence,
+    type,
+    payload,
+    occurredAt: "2026-06-14T00:00:00.000Z",
+    clientEventId: null,
+    turnId: null,
+  };
+}
+
+function jsonChars(value: unknown): number {
+  return JSON.stringify(value).length;
+}
+
+describe("capPayloadValue", () => {
+  test("passes through small scalars and small objects untouched", () => {
+    expect(capPayloadValue("ok", 2_000)).toBe("ok");
+    expect(capPayloadValue(42, 2_000)).toBe(42);
+    expect(capPayloadValue(null, 2_000)).toBe(null);
+    const small = { text: "hello", n: 1 };
+    expect(capPayloadValue(small, 2_000)).toBe(small);
+  });
+
+  test("clamps an over-long string with a head+tail truncation marker", () => {
+    const long = "A".repeat(5_000) + "TAILMARK";
+    const capped = capPayloadValue(long, 2_000) as string;
+    expect(capped.length).toBeLessThan(long.length);
+    expect(capped).toContain("chars truncated");
+    expect(capped).toContain("page with after/limit");
+    expect(capped).toContain("read the session notebook");
+    // head retained
+    expect(capped.startsWith("A")).toBe(true);
+    // tail retained (the most diagnostic part of an output/error survives)
+    expect(capped).toContain("TAILMARK");
+  });
+
+  test("recurses to clamp the fat leaf inside a nested payload", () => {
+    const payload = {
+      id: "call_1",
+      output: "B".repeat(10_000),
+      meta: { ok: true },
+    };
+    const capped = capPayloadValue(payload, 2_000) as typeof payload;
+    expect(capped.id).toBe("call_1");
+    expect(capped.meta).toEqual({ ok: true });
+    expect(typeof capped.output).toBe("string");
+    expect(capped.output).toContain("chars truncated");
+    expect(jsonChars(capped)).toBeLessThan(jsonChars(payload));
+  });
+
+  test("collapses an object made of thousands of tiny fields to a clamped serialization", () => {
+    const fat: Record<string, string> = {};
+    for (let i = 0; i < 5_000; i++) {
+      fat[`k${i}`] = "v";
+    }
+    const capped = capPayloadValue(fat, 2_000);
+    // Collapsed to a single clamped string near the per-field budget; the raw
+    // string length is the budget unit (JSON quote-escaping inflates the
+    // serialized form, but that is bounded too).
+    expect(typeof capped).toBe("string");
+    expect((capped as string).length).toBeLessThanOrEqual(2_000 + 200);
+    expect(capped).toContain("chars truncated");
+  });
+
+  test("is resilient to cyclic structures via the depth guard", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    expect(() => capPayloadValue(a, 2_000)).not.toThrow();
+  });
+});
+
+describe("capEventPayload", () => {
+  test("returns the same reference when nothing needs trimming", () => {
+    const event = makeEvent(1, "turn.started", { turnId: "t1" });
+    expect(capEventPayload(event, 2_000)).toBe(event);
+  });
+
+  test("clamps a worker's verbatim tool output", () => {
+    const event = makeEvent(7, "agent.toolCall.output", {
+      id: "call_42",
+      output: "X".repeat(60_000),
+    });
+    const capped = capEventPayload(event, DEFAULT_EVENT_CAP.perFieldChars);
+    expect(capped).not.toBe(event);
+    expect(jsonChars(capped.payload)).toBeLessThan(jsonChars(event.payload));
+    expect((capped.payload as { id: string }).id).toBe("call_42");
+  });
+});
+
+describe("capEventPage", () => {
+  test("empty page yields null nextAfter and no truncation", () => {
+    const result = capEventPage([]);
+    expect(result.events).toEqual([]);
+    expect(result.nextAfter).toBeNull();
+    expect(result.truncated).toBe(false);
+  });
+
+  test("small page passes through with the real nextAfter", () => {
+    const events = [
+      makeEvent(10, "user.message", { text: "go" }),
+      makeEvent(11, "turn.started", {}),
+      makeEvent(12, "agent.message.completed", { text: "done" }),
+    ];
+    const result = capEventPage(events);
+    expect(result.truncated).toBe(false);
+    expect(result.events).toHaveLength(3);
+    expect(result.nextAfter).toBe(12);
+  });
+
+  test("per-event trim keeps every event but shrinks the bytes (no head/tail drop when count is small)", () => {
+    // 5 events each with a fat tool output: heavy bytes, but only 5 events so
+    // head+tail drop should NOT engage (keepCount default 16).
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent(100 + i, "agent.toolCall.output", { id: `c${i}`, output: "Y".repeat(40_000) }),
+    );
+    const rawChars = jsonChars(events);
+    const result = capEventPage(events);
+    expect(result.events).toHaveLength(5);
+    expect(result.truncated).toBe(false);
+    expect(jsonChars(result.events)).toBeLessThan(rawChars);
+    // Each event was clamped near the per-field budget.
+    for (const event of result.events) {
+      expect(jsonChars(event.payload)).toBeLessThan(DEFAULT_EVENT_CAP.perFieldChars * 2);
+    }
+  });
+
+  test("over-budget page is reduced to head + marker + tail and stays under budget", () => {
+    // 100 fat events. Even after per-event trim (~2k chars each) the page is
+    // ~200k chars / ~50k tokens, well over the 10k-token budget -> head/tail.
+    const events = Array.from({ length: 100 }, (_, i) =>
+      makeEvent(1_000 + i, "agent.toolCall.output", { id: `call_${i}`, output: "Z".repeat(40_000) }),
+    );
+    const result = capEventPage(events);
+    expect(result.truncated).toBe(true);
+    // head (8) + 1 marker + tail (8)
+    expect(result.events).toHaveLength(DEFAULT_EVENT_CAP.headEvents + 1 + DEFAULT_EVENT_CAP.tailEvents);
+
+    const marker = result.events[DEFAULT_EVENT_CAP.headEvents]!;
+    expect((marker.payload as { _truncated?: boolean })._truncated).toBe(true);
+    expect((marker.payload as { droppedCount: number }).droppedCount).toBe(
+      100 - DEFAULT_EVENT_CAP.headEvents - DEFAULT_EVENT_CAP.tailEvents,
+    );
+
+    // nextAfter still points at the real last event so paging does not skip.
+    expect(result.nextAfter).toBe(1_099);
+
+    // The whole capped page is comfortably within the token budget (allow the
+    // marker's small fixed overhead).
+    expect(estimateTokensFromChars(jsonChars(result.events))).toBeLessThanOrEqual(
+      DEFAULT_EVENT_CAP.pageTokenBudget + 200,
+    );
+  });
+
+  test("the capped page (including the synthetic marker) validates against the SessionEvent contract", () => {
+    const events = Array.from({ length: 80 }, (_, i) =>
+      makeEvent(5_000 + i, "agent.toolCall.output", { id: `c${i}`, output: "M".repeat(40_000) }),
+    );
+    const result = capEventPage(events);
+    expect(result.truncated).toBe(true);
+    for (const event of result.events) {
+      // Every returned event — real or synthetic marker — must still parse as a
+      // SessionEvent so downstream consumers and the wire contract hold.
+      expect(() => SessionEvent.parse(event)).not.toThrow();
+    }
+  });
+
+  test("kept head is oldest and kept tail is newest (entry context + recent progress)", () => {
+    const events = Array.from({ length: 100 }, (_, i) =>
+      makeEvent(2_000 + i, "agent.message.completed", { text: "W".repeat(40_000) }),
+    );
+    const result = capEventPage(events);
+    expect(result.events[0]!.sequence).toBe(2_000);
+    expect(result.events[result.events.length - 1]!.sequence).toBe(2_099);
+  });
+
+  test("sequences in the returned page are monotonic non-decreasing including the marker", () => {
+    const events = Array.from({ length: 60 }, (_, i) =>
+      makeEvent(3_000 + i, "agent.reasoning.delta", { text: "R".repeat(40_000) }),
+    );
+    const result = capEventPage(events);
+    const seqs = result.events.map((event) => event.sequence);
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]!).toBeGreaterThanOrEqual(seqs[i - 1]!);
+    }
+  });
+
+  test("marker carries a pageable omitted-sequence range", () => {
+    const events = Array.from({ length: 50 }, (_, i) =>
+      makeEvent(4_000 + i, "agent.toolCall.output", { id: `c${i}`, output: "Q".repeat(40_000) }),
+    );
+    const result = capEventPage(events);
+    const marker = result.events[DEFAULT_EVENT_CAP.headEvents]!;
+    const range = (marker.payload as { omittedSequenceRange: [number, number] }).omittedSequenceRange;
+    // first dropped is head index (8) -> sequence 4008; last dropped is
+    // length-tail-1 = 50-8-1 = 41 -> sequence 4041.
+    expect(range[0]).toBe(4_008);
+    expect(range[1]).toBe(4_041);
+  });
+
+  test("does not mutate the input events array or its event objects", () => {
+    const events = Array.from({ length: 30 }, (_, i) =>
+      makeEvent(6_000 + i, "agent.toolCall.output", { id: `c${i}`, output: "K".repeat(40_000) }),
+    );
+    const originalLength = events.length;
+    const firstPayloadRef = events[0]!.payload;
+    capEventPage(events);
+    expect(events).toHaveLength(originalLength);
+    // The original (uncapped) event object is untouched — caps return copies.
+    expect(events[0]!.payload).toBe(firstPayloadRef);
+    expect((events[0]!.payload as { output: string }).output).toHaveLength(40_000);
+  });
+});
+
+describe("capSessionDetail", () => {
+  test("returns the same reference when metadata and message are small", () => {
+    const session = { metadata: { k: "v" }, initialMessage: "hi", status: "running" };
+    expect(capSessionDetail(session)).toBe(session);
+  });
+
+  test("clamps unbounded agent-set metadata", () => {
+    const session = {
+      metadata: { note: "M".repeat(50_000) },
+      initialMessage: "small",
+    };
+    const capped = capSessionDetail(session);
+    expect(capped).not.toBe(session);
+    expect(jsonChars(capped.metadata)).toBeLessThan(jsonChars(session.metadata));
+    expect((capped.metadata as { note: string }).note).toContain("chars truncated");
+    // unrelated fields preserved
+    expect(capped.initialMessage).toBe("small");
+  });
+
+  test("clamps an over-long initial message", () => {
+    const session = { metadata: {}, initialMessage: "I".repeat(DEFAULT_SESSION_DETAIL_CHARS + 5_000) };
+    const capped = capSessionDetail(session);
+    expect((capped.initialMessage as string).length).toBeLessThan(session.initialMessage.length);
+    expect(capped.initialMessage).toContain("chars truncated");
+  });
+});


### PR DESCRIPTION
## Problem

A long-lived **manager** session monitors its spawned workers by reading their event timeline over the first-party MCP (`session_events`, `session_get`). A worker's events carry verbatim model output and, worse, verbatim **tool outputs** (`agent.toolCall.output.payload.output`) and raw tool-call items (`agent.toolCall.created.payload.raw` / `.arguments`) — sized for the *worker's* own context, not the manager's.

The `session_events` DB limit (`boundedMcpLimit`, default 100 / max 500) caps event **COUNT**, not **BYTES**. Measured on a real session, one `session_events` page returned ~50,000 chars and a single monitoring turn piled ~200,000 chars into the manager — the "parent ingests child" blow-up that can brick a long-lived manager. `session_get`'s only unbounded field is agent-set `metadata` (plus, defensively, `initialMessage`).

## Fix

New pure, dependency-free module `apps/api/src/mcp/session-view.ts` (no DB), wired into the two cross-session read tools:

**`session_events` — two-stage cap:**
1. **Per-event field trim** (`capPayloadValue`/`capEventPayload`): recursively clamp any over-long string (and any over-large nested blob, by serialize-then-clamp) to a per-field budget (default ~2k chars) with a head(70%)+tail(30%) `…N chars truncated…` marker. Type-agnostic — no event-type enumeration, so a new fat event type is capped automatically. Depth guard (>=8) is cyclic-safe.
2. **Head+tail page budget** (`capEventPage`): after trim, if the page still exceeds the token budget (~10k tokens), keep the oldest **head** (8) + newest **tail** (8) and drop the middle behind **one synthetic marker event** (typed `session.status.changed` so it still validates against the `SessionEvent` contract; payload carries `_truncated`, `droppedCount`, `omittedSequenceRange`, and how to page the gap or read the notebook).

**Pagination preserved:** `nextAfter` is the **real** highest `sequence` the DB returned, so the next page starts exactly where this one ended — paging never skips real events.

**`session_get`:** clamp only the unbounded agent-controlled fields (`metadata`, and defensively `initialMessage`).

## Scope / safety

REST routes (`apps/api/src/routes/sessions.ts`) and worker/UI consumers are **untouched** — they call the DB functions directly. Only the MCP tool result a manager model reads is shaped. The cap returns copies and never mutates the input events.

## Tests

`apps/api/test/session-view.test.ts` (19 tests): small-scalar passthrough, string/nested-leaf/tiny-field/cyclic trimming, empty/small/over-budget pages, head=oldest & tail=newest, monotonic sequences incl. the marker, marker's pageable omitted range, **the capped page (incl. synthetic marker) validates against the `SessionEvent` contract**, no-input-mutation, and `session_get` metadata/initialMessage clamping.

Gates: API typecheck clean; full unit suite green (594 pass / 0 fail). gitleaks clean on the staged diff.

## Companion doctrine

The manager doctrine half (don't busy-poll a worker; rely on the opengeni#60 parent-wakeup and use a single bounded `session_events` glance) already shipped in the **Geni** pack as Pack 0.4.3 (private repo, geni#20 "manager doctrine — await worker completion via wakeup, not polling"), so no separate doctrine PR is opened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manager-facing MCP read semantics (truncation vs full events) but leaves REST/workers untouched; pagination and contract-valid synthetic markers are tested to limit regression risk.
> 
> **Overview**
> Adds **`session-view`** shaping so manager agents monitoring workers over MCP no longer ingest unbounded worker event payloads into their own context.
> 
> **`session_events`** now runs a two-stage cap on the MCP response only: per-event payload trim (~2k chars per fat field, type-agnostic recursion with truncation markers), then a ~10k-token page budget that keeps oldest **head** + newest **tail** events and inserts a synthetic **`session.status.changed`** marker for the dropped middle. **`nextAfter`** still reflects the real highest sequence from the DB page (plus optional **`truncated: true`**), so paging does not skip events.
> 
> **`session_get`** clamps unbounded **`metadata`** and **`initialMessage`** (~6k chars) via the same payload capping helpers.
> 
> REST and worker/UI paths are unchanged; tool descriptions document the bounded monitoring behavior. **`session-view.test.ts`** covers trimming, head/tail pages, pagination semantics, contract validation for synthetic markers, immutability, and session detail clamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f93d60db2c07c182571d44cb7a9d28dfeec99ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->