### PR TITLE
Compaction self-heal: trigger on max(actual, estimate) + hard-force backstop

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -386,7 +386,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             forced ? { force: true } : {},
           );
           if (outcome.compacted) {
-            await publish([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, ...(forced ? { trigger: "operator" } : {}) } }]);
+            // trigger precedence: an explicit operator /compact wins for the
+            // event label; otherwise a hard-forced (at/over hardFraction*B)
+            // compaction is surfaced as "hard" so the backstop firing is
+            // observable downstream, and the default soft trigger is implicit.
+            const trigger = forced ? "operator" : outcome.hardForced ? "hard" : undefined;
+            await publish([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, ...(trigger ? { trigger } : {}) } }]);
           }
         } catch (compactError) {
           console.error("context compaction failed (turn proceeds un-compacted)", compactError);

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -18,7 +18,7 @@ import {
 
 export type MaybeCompactResult =
   | { compacted: false; reason: string }
-  | { compacted: true; supersededFrom: number; summaryPosition: number };
+  | { compacted: true; supersededFrom: number; summaryPosition: number; hardForced: boolean };
 
 /**
  * Pre-turn client-side context compaction (the Azure path).
@@ -78,6 +78,15 @@ export async function maybeCompactContext(
   if (!plan.shouldCompact) {
     return { compacted: false, reason: plan.reason };
   }
+  if (plan.hardForced) {
+    // At/over the hard ceiling (hardFraction*B): the session is past the soft
+    // trigger by a wide margin (often because last_input_tokens was stale-low
+    // and the actual history overflowed). Logged distinctly so the hard-force
+    // backstop firing is observable in production.
+    console.warn(
+      `context compaction HARD-FORCED for session ${scope.sessionId}: signal ${plan.signalTokens} tokens at/over hard ceiling`,
+    );
+  }
 
   const messages = buildCompactionMessages(plan);
   const summaryBody = await summarize(settings, messages);
@@ -112,5 +121,5 @@ export async function maybeCompactContext(
     summaryItem: buildSummaryItem(summaryBody),
   });
 
-  return { compacted: true, supersededFrom: boundaryPosition, summaryPosition };
+  return { compacted: true, supersededFrom: boundaryPosition, summaryPosition, hardForced: plan.hardForced };
 }

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -1,4 +1,5 @@
 import type { Settings } from "@opengeni/config";
+import { contextInputBudgetTokens, resolveContextCompactionMode } from "@opengeni/config";
 import type { FileAsset, ResourceRef } from "@opengeni/contracts";
 import {
   getActiveSessionHistoryItems,
@@ -91,6 +92,11 @@ async function messageInput(
   text: string,
   settings?: Settings,
 ) {
+  // Read-path budget guard (the last-resort backstop behind best-effort pre-turn
+  // compaction): supply B only when the client-side compaction path is active
+  // (Azure). On the OpenAI server path the SDK manages the window, so we leave
+  // the guard off and never crudely trim. Undefined = guard disabled.
+  const inputBudgetTokens = readPathBudgetTokens(settings);
   if (settings?.sessionHistorySource === "items") {
     // Active rows only: after a client-side context compaction this is
     // [active summary, ...active recent tail]; superseded (summarized-away)
@@ -98,20 +104,42 @@ async function messageInput(
     const stored = await getActiveSessionHistoryItems(db, trigger.workspaceId, trigger.sessionId);
     if (stored.length > 0) {
       const envelope = await getSandboxSessionEnvelope(db, trigger.workspaceId, trigger.sessionId);
-      return await runtime.prepareInput(agent, {
-        kind: "message",
-        text,
-        historyItems: stored.map((row) => row.item) as any,
-        sandboxEnvelope: envelope,
-      });
+      return await runtime.prepareInput(
+        agent,
+        {
+          kind: "message",
+          text,
+          historyItems: stored.map((row) => row.item) as any,
+          sandboxEnvelope: envelope,
+        },
+        inputBudgetTokens ? { inputBudgetTokens } : {},
+      );
     }
   }
   const latestState = await getLatestRunState(db, trigger.workspaceId, trigger.sessionId);
-  return await runtime.prepareInput(agent, {
-    kind: "message",
-    text,
-    serializedRunState: latestState?.serializedRunState ?? null,
-  });
+  return await runtime.prepareInput(
+    agent,
+    {
+      kind: "message",
+      text,
+      serializedRunState: latestState?.serializedRunState ?? null,
+    },
+    inputBudgetTokens ? { inputBudgetTokens } : {},
+  );
+}
+
+/**
+ * The usable input-token budget B to hand the read-path guard, or undefined
+ * when the guard should stay off. Active only when the resolved compaction mode
+ * is "client" (the Azure path that runs our own compaction); on the server path
+ * the SDK enforces the window, and with no settings we can't compute B.
+ */
+function readPathBudgetTokens(settings?: Settings): number | undefined {
+  if (!settings || resolveContextCompactionMode(settings) !== "client") {
+    return undefined;
+  }
+  const budget = contextInputBudgetTokens(settings);
+  return budget > 0 ? budget : undefined;
 }
 
 export async function userMessageTextWithAttachments(

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -153,11 +153,78 @@ export function findKeepBoundary(items: readonly CompactionItem[], keepRecentTok
   return boundaries[boundaries.length - 1]!;
 }
 
+/**
+ * READ-PATH BUDGET GUARD (last-resort backstop).
+ *
+ * Pre-turn compaction is best-effort: it can no-op (summarizer model call
+ * fails, "client" mode off, a fresh user message arrives after a turn already
+ * ballooned the history) and STILL leave an assembled input that exceeds the
+ * model context window. The #61 orphan sanitizer is purely structural — it has
+ * NO size awareness — so without this guard an over-budget input is sent and
+ * 400s every turn, re-bricking the session.
+ *
+ * `enforceInputBudget` drops the OLDEST history at a clean turn boundary until
+ * the estimated input fits `maxTokens`, ALWAYS keeping the most recent turn(s).
+ * It is orphan-safe by construction: it only ever cuts at the start of a user
+ * message (via `findKeepBoundary`), so no tool-call pair is split. It is a
+ * crude data-loss fallback (no summary is generated) that exists solely so a
+ * single over-budget assembled input is never put on the wire — real context
+ * preservation is the summarizing pre-turn path; this is the airbag.
+ *
+ * Pure: returns a new array (same item references, in order) with an oldest
+ * prefix omitted, or the input unchanged when it already fits. The provided
+ * `trailingTokens` accounts for the un-stored part of the assembled input (the
+ * new user/continuation message + fixed system/tool overhead) so the cap is
+ * measured against the WHOLE request, not just the stored history.
+ */
+export function enforceInputBudget<T extends CompactionItem>(
+  items: readonly T[],
+  maxTokens: number,
+  trailingTokens = 0,
+): { items: T[]; trimmed: boolean; droppedCount: number; estimatedTokens: number } {
+  const total = estimateTokens(items) + Math.max(0, trailingTokens);
+  if (items.length === 0 || total <= maxTokens) {
+    return { items: items.slice(), trimmed: false, droppedCount: 0, estimatedTokens: total };
+  }
+  // Budget left for the stored history once the fixed trailing cost is paid.
+  const historyBudget = Math.max(0, maxTokens - Math.max(0, trailingTokens));
+  // Find the EARLIEST user-message boundary whose tail fits historyBudget; that
+  // boundary's prefix is the oldest history we drop. findKeepBoundary already
+  // returns a clean turn boundary (start of a user message), so the cut is
+  // orphan-safe. A boundary of 0 means nothing could be dropped safely (no
+  // earlier boundary) — we leave the input as-is rather than orphan a pair.
+  const boundary = findKeepBoundary(items, historyBudget);
+  if (boundary <= 0) {
+    return { items: items.slice(), trimmed: false, droppedCount: 0, estimatedTokens: total };
+  }
+  const kept = items.slice(boundary);
+  return {
+    items: kept,
+    trimmed: true,
+    droppedCount: boundary,
+    estimatedTokens: estimateTokens(kept) + Math.max(0, trailingTokens),
+  };
+}
+
 export type CompactionPlan = {
   /** Whether a compaction should run this turn. */
   shouldCompact: boolean;
   /** Why not, when shouldCompact is false (for logs/tests). */
   reason: "below_threshold" | "no_boundary" | "nothing_to_summarize" | "compact";
+  /**
+   * The signal-token count the trigger decision was made on:
+   * max(actual last-turn input tokens, char/4 estimate of the active items).
+   * Recorded for logging / metrics and so a caller can reason about pressure.
+   */
+  signalTokens: number;
+  /**
+   * True when the signal reached hardFraction*B — the session is at/over the
+   * hard ceiling and compaction was forced even if the recorded last-turn count
+   * was stale-low. The boundary walk is run with a SHRUNK keep-recent budget in
+   * this case so an over-budget history always yields a non-empty prefix to
+   * summarize (the everything-is-"recent" deadlock can't strand it un-compacted).
+   */
+  hardForced: boolean;
   /** Index (into the active items) where the kept tail begins. */
   boundaryIndex: number;
   /**
@@ -196,37 +263,74 @@ export type PlanCompactionInput = {
 /**
  * Decide whether and where to compact. Pure.
  *
- * Trigger: signal tokens >= softFraction*B (or hardFraction*B as the hard
- * force; both are above-threshold here, the caller may distinguish for logging
- * but the action is the same). Signal = actual last-turn input tokens when
- * available, else char/4 estimate of the active items.
+ * Trigger: signal tokens >= softFraction*B (soft) or hardFraction*B (hard).
+ * Signal = MAX(actual last-turn input tokens, char/4 estimate of the active
+ * items). The max — not "trust the recorded count, estimate only when it's
+ * null" — is the self-heal fix: `sessions.last_input_tokens` is written ONLY
+ * when a model response reports usage, so a turn that OVERFLOWS on its first
+ * model call records NOTHING and the column keeps a STALE-POSITIVE value from
+ * the last good turn (e.g. ~600k). Trusting that stale-low number let an
+ * actually-over-budget history (>1.05M) slip under the soft limit and overflow
+ * again, re-bricking with no self-heal. Taking the max means a bloated history
+ * triggers compaction regardless of a stale recorded count.
  *
- * Boundary: the latest user-message boundary whose kept tail fits
- * keepRecentTokens. The prefix before it (minus any prior summary, which is
- * folded forward) is what gets summarized.
+ * Hard force (hardFraction*B): at/over the hard ceiling we compact even if the
+ * recorded count was stale-low, AND we run the boundary walk with a shrunk
+ * keep-recent budget so an over-budget history always yields a non-empty prefix
+ * — otherwise a history where the whole thing reads as "recent" (tail within
+ * keepRecentTokens) would find no prefix and strand the session over budget.
+ *
+ * Boundary: the earliest user-message boundary whose kept tail fits the
+ * (possibly shrunk) keep-recent budget. The prefix before it (minus any prior
+ * summary, which is folded forward) is what gets summarized.
  */
 export function planCompaction(input: PlanCompactionInput): CompactionPlan {
+  const softLimit = Math.floor(input.inputBudgetTokens * input.softFraction);
+  const hardLimit = Math.floor(input.inputBudgetTokens * input.hardFraction);
+  // Signal = MAX(recorded last-turn input tokens, estimate of the actual
+  // history). See the doc comment: the max is what defeats the stale-positive
+  // re-brick — a bloated history wins over a stale-low recorded count.
+  const recorded =
+    typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
+      ? input.lastInputTokens
+      : 0;
+  const signalTokens = Math.max(recorded, estimateTokens(input.items));
+  const hardForced = signalTokens >= hardLimit;
+
   const empty: CompactionPlan = {
     shouldCompact: false,
     reason: "below_threshold",
+    signalTokens,
+    hardForced,
     boundaryIndex: input.items.length,
     prefixItems: [],
     priorSummaryItem: null,
     tailItems: [...input.items],
   };
 
-  const softLimit = Math.floor(input.inputBudgetTokens * input.softFraction);
-  const signalTokens =
-    typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
-      ? input.lastInputTokens
-      : estimateTokens(input.items);
-  // force bypasses the budget trigger only; the structural guards below still
-  // run, so a forced compaction with nothing to summarize is still a no-op.
+  // force (operator /compact) bypasses the budget trigger; the structural
+  // guards below still run, so a forced compaction with nothing to summarize is
+  // still a no-op. A hard-forced compaction is, like soft, gated by those
+  // guards but additionally shrinks the keep-recent budget (below) so it can
+  // actually find a prefix when the whole history is over budget.
   if (!input.force && signalTokens < softLimit) {
     return empty;
   }
 
-  const boundaryIndex = findKeepBoundary(input.items, input.keepRecentTokens);
+  // Under hard pressure, cap the verbatim tail well below B so the boundary walk
+  // is forced to leave a summarizable prefix even when last_input_tokens was
+  // stale-low and the history exceeds the window. We keep at most HALF the
+  // configured keep-recent budget (and never more than a quarter of B) — enough
+  // recent context to stay coherent, little enough that a real prefix always
+  // remains to compact. Soft compactions keep the full configured budget.
+  const effectiveKeepRecent = hardForced
+    ? Math.min(
+        Math.floor(input.keepRecentTokens / 2),
+        Math.floor(input.inputBudgetTokens / 4),
+      )
+    : input.keepRecentTokens;
+
+  const boundaryIndex = findKeepBoundary(input.items, effectiveKeepRecent);
   if (boundaryIndex <= 0) {
     // No prefix to summarize (cut at the very start) — nothing to do.
     return { ...empty, reason: "no_boundary", boundaryIndex };
@@ -261,6 +365,8 @@ export function planCompaction(input: PlanCompactionInput): CompactionPlan {
   return {
     shouldCompact: true,
     reason: "compact",
+    signalTokens,
+    hardForced,
     boundaryIndex,
     prefixItems,
     priorSummaryItem,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -57,12 +57,14 @@ import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:pa
 import { fileURLToPath } from "node:url";
 
 import { sanitizeHistoryItemsForModel } from "./history-sanitizer";
+import { enforceInputBudget, estimateItemTokens } from "./context-compaction";
 
 export { sanitizeHistoryItemsForModel } from "./history-sanitizer";
 export type { HistoryItem } from "./history-sanitizer";
 
 export {
   planCompaction,
+  enforceInputBudget,
   buildSummaryItem,
   buildCompactionMessages,
   isCompactionSummary,
@@ -777,7 +779,43 @@ async function connectDockerNetwork(network: string, containerId: string): Promi
 
 export type PrepareInputOptions = {
   sandboxClient?: unknown;
+  /**
+   * Usable input-token budget B (window - reserved output). When set, the
+   * assembled history is passed through `enforceInputBudget` so a single
+   * over-budget input can never be sent — the last-resort backstop behind the
+   * best-effort pre-turn compaction. Omitted (undefined) disables the guard
+   * (no behaviour change for callers that don't opt in).
+   */
+  inputBudgetTokens?: number;
 };
+
+/**
+ * Apply the read-path budget guard to an assembled model input: drop the oldest
+ * history at a clean turn boundary until the request fits B. Orphan-safe (only
+ * cuts at user-message boundaries) and only active when a budget is supplied.
+ * The trailing user message is counted against the budget but never dropped.
+ */
+function guardAssembledInput(
+  history: AgentInputItem[],
+  trailing: AgentInputItem,
+  inputBudgetTokens: number | undefined,
+): AgentInputItem[] {
+  if (typeof inputBudgetTokens !== "number" || inputBudgetTokens <= 0) {
+    return [...history, trailing];
+  }
+  const trailingTokens = estimateItemTokens(trailing as unknown as Record<string, unknown>);
+  const guarded = enforceInputBudget(
+    history as unknown as Array<Record<string, unknown>>,
+    inputBudgetTokens,
+    trailingTokens,
+  );
+  if (guarded.trimmed) {
+    console.warn(
+      `read-path budget guard trimmed ${guarded.droppedCount} oldest history item(s) to fit input budget (${inputBudgetTokens} tokens); the over-budget input was NOT sent`,
+    );
+  }
+  return [...(guarded.items as unknown as AgentInputItem[]), trailing];
+}
 
 export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmentInput, options: PrepareInputOptions = {}): Promise<PreparedAgentInput> {
   if (input.kind === "message") {
@@ -799,14 +837,19 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
         input.historyItems as unknown as Array<Record<string, unknown>>,
       ) as unknown as AgentInputItem[];
       return {
-        input: [
-          ...sanitizedHistory,
+        // Read-path budget guard: even after the orphan sanitizer, an assembled
+        // input can exceed the model window (pre-turn compaction is best-effort
+        // and can no-op). Trim the oldest history at a clean turn boundary so an
+        // over-budget request is never sent. No-op when no budget is supplied.
+        input: guardAssembledInput(
+          sanitizedHistory,
           {
             type: "message",
             role: "user",
             content: input.text,
           } as AgentInputItem,
-        ],
+          options.inputBudgetTokens,
+        ),
         ...(sandboxSessionState ? { sandboxSessionState } : {}),
       };
     }
@@ -828,14 +871,18 @@ export async function prepareRunInput(agent: Agent<any, any>, input: AgentSegmen
       state.history as unknown as Array<Record<string, unknown>>,
     ) as unknown as AgentInputItem[];
     return {
-      input: [
-        ...sanitizedHistory,
+      // Read-path budget guard (see the items path above): keep an over-budget
+      // resumed history off the wire by trimming the oldest turns when a budget
+      // is supplied.
+      input: guardAssembledInput(
+        sanitizedHistory,
         {
           type: "message",
           role: "user",
           content: input.text,
         } as AgentInputItem,
-      ],
+        options.inputBudgetTokens,
+      ),
       ...(sandboxSessionState ? { sandboxSessionState } : {}),
       serializedRunStateForSandbox: input.serializedRunState,
     };

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -5,6 +5,7 @@ import {
   buildCompactionMessages,
   buildSummaryItem,
   compactionSummaryText,
+  enforceInputBudget,
   estimateTokens,
   findKeepBoundary,
   isCompactionSummary,
@@ -167,6 +168,171 @@ describe("planCompaction trigger", () => {
   });
 });
 
+describe("planCompaction self-heal: trigger on max(actual, estimate)", () => {
+  // The stale-positive re-brick: `sessions.last_input_tokens` is written ONLY
+  // when usage is observed, so a turn that overflows on its first model call
+  // records nothing and the column keeps a stale-low value from the last good
+  // turn. The old trigger TRUSTED that positive number and only estimated when
+  // it was null — so an actually-over-budget history slipped under the soft
+  // limit and overflowed again, permanently. These tests pin the fix: the
+  // trigger is max(recorded, estimate), so a bloated history compacts regardless
+  // of a stale-low recorded count.
+  test("stale-positive last_input_tokens + over-budget history MUST compact (re-brick prevented)", () => {
+    // Recorded count is a stale ~600k from the last good turn — comfortably
+    // UNDER the soft limit (645,400). But the ACTUAL history estimates ABOVE the
+    // budget (the turn ballooned the history past the window). The old code
+    // trusted 600k and did NOT compact; the new code takes the max and must.
+    const STALE = 600_000;
+    expect(STALE).toBeLessThan(Math.floor(BUDGET * SOFT)); // would slip past the old trigger
+    const items: CompactionItem[] = [
+      bigItem("user", BUDGET), assistant("a-old"), // a single over-budget prefix turn
+      user("recent"), assistant("a-recent"),
+    ];
+    expect(estimateTokens(items)).toBeGreaterThan(BUDGET); // history truly exceeds B
+    const plan = planCompaction({
+      items,
+      lastInputTokens: STALE, // STALE-POSITIVE, under the soft limit
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(2)),
+    });
+    expect(plan.shouldCompact).toBe(true);
+    expect(plan.reason).toBe("compact");
+    // The estimate (not the stale count) drove the decision.
+    expect(plan.signalTokens).toBe(estimateTokens(items));
+    expect(plan.signalTokens).toBeGreaterThan(STALE);
+  });
+
+  test("post-overflow session self-heals on the next turn (estimate triggers despite stale count)", () => {
+    // Model the turn AFTER an overflow: last_input_tokens is whatever the last
+    // SUCCESSFUL turn recorded (stale, under soft), and the active history is the
+    // bloated set that just 400'd. The next pre-turn check must compact so the
+    // turn after that fits — i.e. the session heals itself with no operator.
+    const STALE_FROM_LAST_GOOD_TURN = 500_000;
+    const items: CompactionItem[] = [
+      bigItem("assistant", Math.ceil(BUDGET * 0.9)), // bloated prefix from the overflow turn
+      user("turn that will retry"), assistant("a"),
+    ];
+    const plan = planCompaction({
+      items,
+      lastInputTokens: STALE_FROM_LAST_GOOD_TURN,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(1)),
+    });
+    expect(plan.shouldCompact).toBe(true);
+    // After applying the plan the active history shrinks below the soft limit,
+    // so the FOLLOWING turn would not re-trigger — the heal converges.
+    const healed: CompactionItem[] = [buildSummaryItem("s"), ...plan.tailItems];
+    expect(estimateTokens(healed)).toBeLessThan(Math.floor(BUDGET * SOFT));
+  });
+
+  test("signalTokens never trusts a stale-low count when the real history is larger", () => {
+    const items: CompactionItem[] = [bigItem("user", 700_000), user("recent"), assistant("a")];
+    const plan = planCompaction({
+      items,
+      lastInputTokens: 10, // absurdly stale-low
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(1)),
+    });
+    expect(plan.signalTokens).toBe(estimateTokens(items));
+    expect(plan.shouldCompact).toBe(true);
+  });
+
+  test("an accurate recorded count above the estimate still wins (system+tool overhead the items don't show)", () => {
+    // The recorded last-turn input includes system prompt + tool schemas the
+    // stored items don't contain, so it can legitimately exceed the item
+    // estimate. max() keeps trusting it — we never UNDER-count by switching to
+    // the estimate.
+    const items: CompactionItem[] = [user("old"), assistant("a"), user("recent"), assistant("b")];
+    const accurate = Math.floor(BUDGET * SOFT) + 5_000;
+    expect(accurate).toBeGreaterThan(estimateTokens(items));
+    const plan = planCompaction({
+      items,
+      lastInputTokens: accurate,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(2)),
+    });
+    expect(plan.signalTokens).toBe(accurate);
+    expect(plan.shouldCompact).toBe(true);
+  });
+});
+
+describe("planCompaction hard-force backstop (hardFraction*B)", () => {
+  test("at/over the hard ceiling, hardForced is set and the plan still compacts", () => {
+    const items: CompactionItem[] = [
+      bigItem("user", Math.ceil(BUDGET * HARD)), assistant("a-old"),
+      user("recent"), assistant("a-recent"),
+    ];
+    expect(estimateTokens(items)).toBeGreaterThanOrEqual(Math.floor(BUDGET * HARD));
+    const plan = planCompaction({
+      items,
+      lastInputTokens: null,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(2)),
+    });
+    expect(plan.hardForced).toBe(true);
+    expect(plan.shouldCompact).toBe(true);
+    expect(plan.reason).toBe("compact");
+  });
+
+  test("below the hard ceiling but above soft: compacts WITHOUT hardForced", () => {
+    const items: CompactionItem[] = [
+      bigItem("user", Math.ceil(BUDGET * SOFT) + 1_000), assistant("a"),
+      user("recent"), assistant("b"),
+    ];
+    const est = estimateTokens(items);
+    expect(est).toBeGreaterThanOrEqual(Math.floor(BUDGET * SOFT));
+    expect(est).toBeLessThan(Math.floor(BUDGET * HARD));
+    const plan = planCompaction({
+      items,
+      lastInputTokens: null,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      keepRecentTokens: estimateTokens(items.slice(2)),
+    });
+    expect(plan.shouldCompact).toBe(true);
+    expect(plan.hardForced).toBe(false);
+  });
+
+  test("hard-force shrinks the keep-recent budget so an over-budget 'all recent' history still finds a prefix", () => {
+    // The deadlock the shrink defeats: the configured keepRecentTokens is huge
+    // (the whole history fits inside it), so a SOFT walk would keep everything
+    // verbatim and find NO prefix to summarize — stranding an over-budget
+    // session. Under hard pressure the effective keep-recent is capped, forcing
+    // a cut that leaves a non-empty prefix.
+    const items: CompactionItem[] = [
+      user("turn 0"), bigItem("assistant", 300_000),
+      user("turn 1"), bigItem("assistant", 300_000),
+      user("turn 2"), bigItem("assistant", 300_000),
+    ];
+    expect(estimateTokens(items)).toBeGreaterThanOrEqual(Math.floor(BUDGET * HARD)); // over the hard ceiling
+    const plan = planCompaction({
+      items,
+      lastInputTokens: null,
+      inputBudgetTokens: BUDGET,
+      softFraction: SOFT,
+      hardFraction: HARD,
+      // keepRecentTokens is the WHOLE history — a soft walk keeps everything and
+      // would find no prefix (boundary 0). Hard-force must override that.
+      keepRecentTokens: estimateTokens(items) + 1,
+    });
+    expect(plan.hardForced).toBe(true);
+    expect(plan.shouldCompact).toBe(true);
+    expect(plan.boundaryIndex).toBeGreaterThan(0); // a real prefix WAS found
+    expect(plan.prefixItems.length).toBeGreaterThan(0);
+  });
+});
+
 describe("planCompaction orphan safety (the boundary rule)", () => {
   test("never splits a tool-call pair: the dropped prefix keeps call+result together", () => {
     // turn 0: user + call/result pair. turn 1 (recent): user + call/result pair.
@@ -265,6 +431,76 @@ describe("planCompaction fold-forward (single live summary)", () => {
     expect(plan.boundaryIndex).toBe(1);
     expect(plan.shouldCompact).toBe(false);
     expect(plan.reason).toBe("nothing_to_summarize");
+  });
+});
+
+describe("enforceInputBudget (read-path guard backstop)", () => {
+  test("leaves an in-budget input untouched (no trim, byte-identical)", () => {
+    const items: CompactionItem[] = [user("a"), assistant("b"), user("c"), assistant("d")];
+    const out = enforceInputBudget(items, BUDGET);
+    expect(out.trimmed).toBe(false);
+    expect(out.droppedCount).toBe(0);
+    expect(out.items).toEqual(items);
+  });
+
+  test("trims the OLDEST history at a clean boundary until it fits, keeping the recent tail", () => {
+    const items: CompactionItem[] = [
+      user("old turn"), bigItem("assistant", 1_000_000),
+      user("recent turn"), assistant("kept"),
+    ];
+    expect(estimateTokens(items)).toBeGreaterThan(BUDGET);
+    const out = enforceInputBudget(items, BUDGET);
+    expect(out.trimmed).toBe(true);
+    expect(out.droppedCount).toBeGreaterThan(0);
+    // The most recent turn survives; the assembled input now fits.
+    expect(out.items).toContainEqual(user("recent turn"));
+    expect(out.estimatedTokens).toBeLessThanOrEqual(BUDGET);
+  });
+
+  test("an over-budget assembled input can NOT be sent: trailingTokens counts against the cap", () => {
+    // The stored history alone fits, but the new user message (trailing) pushes
+    // the WHOLE request over budget. The guard must still trim so the request on
+    // the wire fits — the guard measures history + trailing, not history alone.
+    const items: CompactionItem[] = [
+      user("old"), bigItem("assistant", 600_000),
+      user("recent"), assistant("a"),
+    ];
+    const historyOnly = estimateTokens(items);
+    expect(historyOnly).toBeLessThan(BUDGET); // history alone fits
+    const trailing = BUDGET - historyOnly + 50_000; // trailing blows the budget
+    const out = enforceInputBudget(items, BUDGET, trailing);
+    expect(out.trimmed).toBe(true);
+    expect(out.estimatedTokens).toBeLessThanOrEqual(BUDGET);
+  });
+
+  test("the trimmed result is orphan-clean (cut only at user boundaries, no split tool pairs)", () => {
+    const items: CompactionItem[] = [
+      user("old"), call("c0"), result("c0"), bigItem("assistant", 1_000_000),
+      user("recent"), call("c1"), result("c1"), assistant("done"),
+    ];
+    const out = enforceInputBudget(items, BUDGET);
+    expect(out.trimmed).toBe(true);
+    // The cut landed at a user-message boundary, so no call/result straddles it:
+    // the sanitizer leaves the kept tail byte-identical.
+    expect(sanitizeHistoryItemsForModel(out.items)).toEqual(out.items);
+    // The old turn's pair was dropped whole; the recent turn's pair is intact.
+    expect(out.items.some((i) => i.callId === "c0")).toBe(false);
+    expect(out.items.filter((i) => i.callId === "c1").length).toBe(2);
+  });
+
+  test("never orphans a pair: when no earlier safe boundary exists it leaves the input as-is", () => {
+    // A single over-budget turn with no earlier user boundary to cut at — the
+    // guard cannot trim without splitting the turn, so it declines (no-op).
+    const items: CompactionItem[] = [user("only turn"), bigItem("assistant", BUDGET * 2)];
+    const out = enforceInputBudget(items, BUDGET);
+    expect(out.trimmed).toBe(false);
+    expect(out.items).toEqual(items);
+  });
+
+  test("empty history is a no-op", () => {
+    const out = enforceInputBudget([], BUDGET, 1000);
+    expect(out.trimmed).toBe(false);
+    expect(out.items).toEqual([]);
   });
 });
 

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -327,6 +327,53 @@ describe("runtime event normalization", () => {
     expect(input[input.length - 1]).toEqual({ type: "message", role: "user", content: "continue" });
   });
 
+  test("read-path budget guard trims an over-budget items-mode input before it is sent", async () => {
+    // Even after the orphan sanitizer, an assembled input can exceed the model
+    // window (pre-turn compaction is best-effort and can no-op). With a budget
+    // supplied, the guard drops the oldest turn at a clean boundary so the
+    // request that reaches the model fits — the over-budget input is never sent.
+    const huge = "x".repeat(4_000_000); // ~1M token estimate, over a small test budget
+    const prepared = await prepareRunInput(
+      buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []),
+      {
+        kind: "message",
+        text: "continue",
+        historyItems: [
+          { type: "message", role: "user", content: "old turn" } as any,
+          { type: "message", role: "assistant", content: huge } as any,
+          { type: "message", role: "user", content: "recent turn" } as any,
+          { type: "message", role: "assistant", content: "kept" } as any,
+        ],
+      },
+      { inputBudgetTokens: 200_000 },
+    );
+    const input = prepared.input as Array<Record<string, unknown>>;
+    expect(Array.isArray(input)).toBe(true);
+    // The bloated old turn was dropped; the recent turn and the new user message
+    // survive, in order.
+    expect(input.some((item) => item.content === huge)).toBe(false);
+    expect(input.some((item) => item.content === "recent turn")).toBe(true);
+    expect(input[input.length - 1]).toEqual({ type: "message", role: "user", content: "continue" });
+  });
+
+  test("read-path budget guard is OFF when no budget is supplied (no behaviour change for non-opted callers)", async () => {
+    const huge = "x".repeat(4_000_000);
+    const prepared = await prepareRunInput(
+      buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []),
+      {
+        kind: "message",
+        text: "continue",
+        historyItems: [
+          { type: "message", role: "user", content: "old turn" } as any,
+          { type: "message", role: "assistant", content: huge } as any,
+        ],
+      },
+      // no inputBudgetTokens -> guard disabled, history passes through untrimmed.
+    );
+    const input = prepared.input as Array<Record<string, unknown>>;
+    expect(input.some((item) => item.content === huge)).toBe(true);
+  });
+
   test("builds agents without MCP servers by default", () => {
     const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
     expect(agent.mcpServers).toEqual([]);


### PR DESCRIPTION
## Problem

The client-side (Azure) conversation-compaction trigger could permanently brick a long-lived session.

`planCompaction` decided whether to compact from:

```
signalTokens = (typeof lastInputTokens === 'number' && lastInputTokens > 0)
  ? lastInputTokens
  : estimateTokens(items)
```

i.e. it **trusted the last turn's recorded input tokens** whenever positive and only fell back to estimating the actual history when that was null. But `sessions.last_input_tokens` is written **only when a model response reports usage** (`apps/worker/src/activities/agent-turn.ts`, guarded by `lastInputTokensObserved !== null`). A turn that **overflows on its first model call** observes no usage, so the column keeps a **stale-positive** value from the last good turn (e.g. ~600k). The next pre-turn check then saw `600k < softLimit (645,400)`, did **not** compact, the real history was `>1.05M`, and the turn overflowed again — a permanent re-brick with no self-heal.

Two related gaps:
- **`hardFraction` was inert** — declared on `PlanCompactionInput`, wired from config, mentioned in a doc comment, but never read in `planCompaction`'s body. It had zero distinct behaviour.
- **No size-aware read-path guard** — the only read-path net was the #61 orphan sanitizer, which is purely *structural* (no token awareness), so an over-budget assembled input could still be put on the wire and 400 every turn.

## Fix

1. **Trigger on `max(actual, estimate)`** — `signalTokens = Math.max(recorded last_input_tokens or 0, estimateTokens(items))`. A bloated history triggers compaction regardless of a stale-low recorded count, so an overflowed session heals on the very next turn. An accurate recorded count above the estimate (it includes system + tool-schema overhead the stored items don't) still wins, so we never under-count.

2. **True hard-force at `hardFraction*B`** — when the signal reaches the hard ceiling, `plan.hardForced` is set and the boundary walk runs with a **shrunk keep-recent budget** so an over-budget history where the whole thing reads as "recent" still yields a non-empty prefix to summarize (no everything-is-recent deadlock). Surfaced in worker logs and on the `session.context.compacted` event as `trigger: "hard"`.

3. **Read-path budget guard (`enforceInputBudget`)** — a pure, orphan-safe last-resort trimmer applied to the assembled input in `prepareRunInput` when a budget is supplied. It drops the oldest history at a clean user-message boundary until the request fits B, always keeping the most recent turn(s), and declines (no-op) rather than orphan a tool-call pair when no earlier safe boundary exists. The worker enables it **only on the client (Azure) compaction path**; on the OpenAI server path the SDK owns the window. A single over-budget input can no longer reach the model.

## Files

- `packages/runtime/src/context-compaction.ts` — `planCompaction` trigger = `max(actual, estimate)`; `hardForced` + shrunk-keep-recent hard path; new pure `enforceInputBudget`; `signalTokens`/`hardForced` added to `CompactionPlan`.
- `packages/runtime/src/index.ts` — export `enforceInputBudget`; `inputBudgetTokens` on `PrepareInputOptions`; `guardAssembledInput` applied to both assembled-input paths in `prepareRunInput`.
- `apps/worker/src/activities/context-compaction.ts` — propagate `hardForced` on `MaybeCompactResult`; distinct hard-force log line.
- `apps/worker/src/activities/run-input.ts` — thread B into `prepareInput` via `readPathBudgetTokens` (client mode only).
- `apps/worker/src/activities/agent-turn.ts` — emit `trigger: "hard"` on the compaction event.

## Tests

`packages/runtime/test/context-compaction.test.ts`:
- stale-positive `last_input_tokens` + over-budget history **must compact** (re-brick prevented)
- **post-overflow session self-heals** on the next turn (estimate triggers despite stale count; heal converges below soft)
- `signalTokens` never trusts a stale-low count when the real history is larger
- an accurate recorded count above the estimate still wins
- hard-force: `hardForced` set at/over the ceiling; below ceiling compacts **without** `hardForced`; **shrinks keep-recent so an over-budget 'all recent' history still finds a prefix**
- `enforceInputBudget`: in-budget input untouched; trims oldest-first keeping the tail; `trailingTokens` counts against the cap; result is orphan-clean; declines when no safe boundary; empty no-op

`packages/runtime/test/runtime.test.ts`:
- read-path guard trims an over-budget items-mode input before it is sent
- guard is OFF when no budget is supplied (no behaviour change for non-opted callers)

## Gate

- `bun run typecheck` — green across all 16 packages/apps
- `bun test` (unit) — **590 pass, 0 fail**
- gitleaks (staged + dir scan) — no leaks found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core context-window handling for long-lived Azure sessions; behavior changes when history estimate exceeds stale `last_input_tokens`, and the read-path guard can drop oldest turns without summarization (data loss) as a last resort.
> 
> **Overview**
> Fixes **permanent session bricking** on the Azure client-side compaction path when `last_input_tokens` stays stale after an overflow turn while the real history is over budget.
> 
> **Pre-turn compaction (`planCompaction`)** now uses **`signalTokens = max(recorded last_input_tokens, estimated history tokens)`** so a bloated transcript triggers compaction even when the DB still holds an old low count. At **`hardFraction * B`**, **`hardForced`** shrinks the keep-recent budget so compaction can always find a summarizable prefix; the worker logs that case and emits **`session.context.compacted`** with **`trigger: "hard"`** (operator `/compact` still wins as **`operator`**).
> 
> **Read-path backstop:** new **`enforceInputBudget`** trims oldest history at orphan-safe user-message boundaries when the assembled request (history + trailing user message) would exceed **`inputBudgetTokens`**. **`prepareRunInput`** applies this via **`guardAssembledInput`**; the worker passes the budget only when compaction mode is **`client`** (Azure). Callers without a budget are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f661828a800cd682e4fa61db74de6c13cf74f66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->