### PR TITLE
Fix user.interrupt 500: start-or-signal the session workflow

### DIFF
--- a/apps/api/src/dependencies.ts
+++ b/apps/api/src/dependencies.ts
@@ -11,7 +11,15 @@ export type SessionWorkflowClient = {
   signalUserMessage: (input: { sessionId: string; eventId: string; workflowId: string }) => Promise<void>;
   wakeSessionWorkflow: (input: { accountId: string; workspaceId: string; sessionId: string; workflowId: string }) => Promise<void>;
   signalApprovalDecision: (input: { sessionId: string; eventId: string; workflowId: string }) => Promise<void>;
-  signalInterrupt: (input: { sessionId: string; eventId: string; workflowId: string }) => Promise<void>;
+  // Interrupt must reach the workflow whether or not an execution is currently
+  // running: a long-lived session that has gone idle (its workflow returned
+  // after markSessionIdle) has NO running execution, so a plain
+  // getHandle().signal() throws WorkflowNotFoundError -> a 500 that leaves an
+  // operator unable to stop a session. signalWithStart start-or-signals, so it
+  // needs the session-workflow args (accountId/workspaceId) to start a fresh
+  // run when none is live; the buffered `interrupt` signal is then honored by
+  // the workflow's idle-interrupt path (pause goal + mark idle).
+  signalInterrupt: (input: { accountId: string; workspaceId: string; sessionId: string; eventId: string; workflowId: string }) => Promise<void>;
   syncScheduledTask: (input: { task: ScheduledTask }) => Promise<void>;
   deleteScheduledTaskSchedule: (input: { temporalScheduleId: string }) => Promise<void>;
   triggerScheduledTask: (input: { task: ScheduledTask; agentRunUsageIdempotencyKey?: string }) => Promise<void>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -48,8 +48,22 @@ export async function createTemporalWorkflowClient(settings: ReturnType<typeof g
     signalApprovalDecision: async ({ eventId, workflowId }) => {
       await temporal.workflow.getHandle(workflowId).signal("approvalDecision", eventId);
     },
-    signalInterrupt: async ({ eventId, workflowId }) => {
-      await temporal.workflow.getHandle(workflowId).signal("interrupt", eventId);
+    signalInterrupt: async ({ accountId, workspaceId, sessionId, eventId, workflowId }) => {
+      // Start-or-signal: an interrupt POSTed while the session is idle has no
+      // running workflow execution to signal, and getHandle().signal() would
+      // throw WorkflowNotFoundError -> a 500 (the operator-can't-stop bug). Like
+      // wakeSessionWorkflow, signalWithStart delivers the signal to a live run
+      // when one exists and otherwise starts a fresh sessionWorkflow that picks
+      // the buffered `interrupt` up immediately. ALLOW_DUPLICATE matches the
+      // wake path so a running execution is reused rather than rejected.
+      await temporal.workflow.signalWithStart("sessionWorkflow", {
+        taskQueue: settings.temporalTaskQueue,
+        workflowId,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        args: [{ accountId, workspaceId, sessionId }],
+        signal: "interrupt",
+        signalArgs: [eventId],
+      });
     },
     syncScheduledTask: async ({ task }) => {
       const schedule = temporal.schedule.getHandle(task.temporalScheduleId);

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -330,7 +330,13 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (event.type === "user.approvalDecision") {
       await workflowClient.signalApprovalDecision({ sessionId, eventId: accepted.id, workflowId });
     } else {
-      await workflowClient.signalInterrupt({ sessionId, eventId: accepted.id, workflowId });
+      await workflowClient.signalInterrupt({
+        accountId: grant.accountId,
+        workspaceId,
+        sessionId,
+        eventId: accepted.id,
+        workflowId,
+      });
     }
     return c.json(accepted, 202);
   });

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -2514,6 +2514,29 @@ describe("API component integration", () => {
     });
     expect(interruptAccepted.status).toBe(202);
     expect(workflow.interrupts).toHaveLength(1);
+    // The route must hand signalInterrupt the start-or-signal args (accountId +
+    // workspaceId), not just {sessionId,eventId,workflowId}: a session that has
+    // gone idle has no running workflow execution, so the client must
+    // signalWithStart, which needs the sessionWorkflow args. Without these the
+    // interrupt 500s for any idle session (the operator-can't-stop bug).
+    expect(workflow.interrupts[0]).toMatchObject({
+      workspaceId,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+    });
+    expect((workflow.interrupts[0] as { accountId?: unknown }).accountId).toBeTruthy();
+
+    // An interrupt on an IDLE session (no running workflow) must still be
+    // accepted (202), not 500 — the exact production failure. The route appends
+    // the event and start-or-signals regardless of session status.
+    await setSessionStatus(dbClient.db, workspaceId, session.id, "idle", null);
+    const idleInterrupt = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/events`), {
+      method: "POST",
+      body: JSON.stringify({ type: "user.interrupt", payload: { reason: "stop" } }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(idleInterrupt.status).toBe(202);
+    expect(workflow.interrupts).toHaveLength(2);
 
     const malformed = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/events`), {
       method: "POST",

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -325,6 +325,62 @@ describe("Temporal workflow integration", () => {
     }
   }, temporalWorkflowTestTimeoutMs);
 
+  test("interrupt start-or-signals an idle session with no running workflow (the production 500 fix)", async () => {
+    // Reproduces the operator-can't-stop bug: a long-lived session that has gone
+    // idle has NO running workflow execution. The OLD API client did
+    // getHandle(workflowId).signal("interrupt", …), which throws
+    // WorkflowNotFoundError -> a 500. The FIXED client uses signalWithStart
+    // exactly as wired below; it must start a fresh sessionWorkflow that
+    // immediately honors the buffered interrupt via the idle-interrupt path
+    // (pause goal for the trigger event + mark idle), with no active turn to
+    // cancel.
+    const taskQueue = `workflow-test-${crypto.randomUUID()}`;
+    const scope = workflowScope();
+    const sessionId = crypto.randomUUID();
+    const workflowId = `wf-${crypto.randomUUID()}`;
+    const idleMarks: unknown[] = [];
+    const pauses: unknown[] = [];
+    const interrupts: unknown[] = [];
+    const worker = await testWorker(nativeConnection, taskQueue, {
+      claimNextQueuedTurn: async () => null,
+      markSessionIdle: async (input: unknown) => {
+        idleMarks.push(input);
+      },
+      pauseGoalForInterrupt: async (input: unknown) => {
+        pauses.push(input);
+      },
+      runAgentTurn: async () => ({ status: "idle" }),
+      failSession: async () => undefined,
+      interruptActiveTurn: async (input: unknown) => {
+        interrupts.push(input);
+      },
+    });
+    const run = worker.run();
+    try {
+      const client = new Client({ connection });
+      // EXACT production API-client wiring: no prior workflow.start — the only
+      // call is signalWithStart, the start-or-signal path the fixed
+      // signalInterrupt uses. Against a not-running workflow this must START it.
+      const handle = await client.workflow.signalWithStart("sessionWorkflow", {
+        taskQueue,
+        workflowId,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        args: [{ ...scope, sessionId }],
+        signal: "interrupt",
+        signalArgs: ["interrupt-event"],
+      });
+      await handle.result();
+      // The idle-interrupt path ran: the goal was paused for the trigger event
+      // and the session was marked idle. No active turn existed to cancel.
+      expect(pauses).toEqual([{ workspaceId: scope.workspaceId, sessionId, triggerEventId: "interrupt-event" }]);
+      expect(idleMarks).toEqual([{ workspaceId: scope.workspaceId, sessionId }]);
+      expect(interrupts).toHaveLength(0);
+    } finally {
+      worker.shutdown();
+      await run;
+    }
+  }, temporalWorkflowTestTimeoutMs);
+
   test("interrupt during an active run cancels the active turn and continues queued work", async () => {
     const taskQueue = `workflow-test-${crypto.randomUUID()}`;
     const scope = workflowScope();


### PR DESCRIPTION
## Problem

POSTing \`{type:"user.interrupt"}\` to \`POST /v1/workspaces/:ws/sessions/:sid/events\` returns **500 Internal Server Error** whenever the target session's workflow is not currently running — i.e. a long-lived session that has gone idle (its \`sessionWorkflow\` returned after \`markSessionIdle\`, so there is no live execution). The old API client did:

\`\`\`ts
signalInterrupt: ({ eventId, workflowId }) =>
  temporal.workflow.getHandle(workflowId).signal("interrupt", eventId)
\`\`\`

\`getHandle(workflowId).signal()\` throws \`WorkflowNotFoundError\` when there is no running execution, which the events route does not catch → 500. An operator could not stop a runaway/looping-then-idle session.

The \`user.message\` path never had this bug because it goes through \`wakeSessionWorkflow\` → \`signalWithStart\` (start-or-signal).

## Fix

Make \`signalInterrupt\` use \`signalWithStart("sessionWorkflow", …)\` exactly like \`wakeSessionWorkflow\`:

- a **running** execution receives the \`interrupt\` signal (cancels the active turn — unchanged behavior);
- an **idle/closed** session is started fresh and immediately honors the buffered \`interrupt\` via the workflow's idle-interrupt path (pause the active goal for the trigger event, then mark idle).

This needs the \`sessionWorkflow\` args (\`accountId\`/\`workspaceId\`), threaded into \`signalInterrupt\` from the access grant the route already holds. The route stays permission-gated on \`sessions:control\`.

## Tests

- **temporal-workflow.integration** — \`interrupt start-or-signals an idle session with no running workflow\`: uses the exact production wiring (only \`signalWithStart\`, no prior \`workflow.start\`) against a not-running workflow; asserts it starts the workflow and runs the idle-interrupt path (pause + mark idle) with no active turn cancelled.
- **api.integration** — the events route hands \`signalInterrupt\` the start-or-signal args (\`accountId\` + \`workspaceId\` + \`workflowId\`), and an interrupt POSTed to an **idle** session returns **202** (not 500). Running-turn cancellation remains covered by the existing active-run interrupt test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session control / Temporal signaling on a critical operator path; behavior for running sessions should stay the same, but start-or-signal can start workflows that were fully idle.
> 
> **Overview**
> Fixes **500s when operators POST `user.interrupt`** on sessions whose Temporal `sessionWorkflow` is not running (e.g. after the workflow returned idle). The API client no longer uses `getHandle(workflowId).signal("interrupt", …)`, which throws `WorkflowNotFoundError` with no execution.
> 
> **`signalInterrupt` now mirrors `wakeSessionWorkflow`:** it calls `signalWithStart("sessionWorkflow", …)` with `ALLOW_DUPLICATE`, delivering `interrupt` to a live run or starting a new run that consumes the buffered signal via the idle-interrupt path. The client contract gains **`accountId` and `workspaceId`** so a fresh workflow can be started; the sessions events route passes those from the existing access grant.
> 
> Integration coverage asserts the route forwards start-or-signal args, **idle-session interrupts return 202**, and a Temporal test exercises **signalWithStart-only** against a not-running workflow (pause goal + mark idle, no active turn cancel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992fea7e10a7e0c7e31652021523e7af546b8fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->