### PR TITLE
Reconciler: seed watermark from sanitized history; repair legacy orphans

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -12,7 +12,7 @@ import {
   recordUsageEvent,
   appendSessionHistoryItems,
   consumeSessionCompactionRequest,
-  countActiveSessionHistoryItems,
+  getActiveSessionHistoryItems,
   nextSessionHistoryPosition,
   requeuePreemptedTurn,
   saveRunState,
@@ -406,7 +406,23 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // the max existing position) because the fractional summary row means
       // total rows no longer equal max(position)+1. Pre-compaction both reduce to
       // the old total-count value, so the common path is unchanged.
-      persistedHistoryCount = await countActiveSessionHistoryItems(db, input.workspaceId, input.sessionId);
+      //
+      // CRITICAL: seed from the SANITIZED active-row length, not the raw active
+      // count. `prepareRunInput` builds `state.history` from
+      // `sanitizeHistoryItemsForModel(activeRows)`, so when sanitization drops K
+      // rows (a legacy orphan/dangling pair), the in-memory history this turn
+      // starts from is K shorter than the raw row count. The reconcile slices the
+      // re-sanitized `state.history` off `persistedHistoryCount`; seeding it from
+      // the raw count (K too high) skips K genuinely-new items, and a
+      // `function_call` left in that skipped region can later have its
+      // `function_call_result` persisted alone — the orphan that 400s on replay
+      // and bricks the session (issue-61). The sanitized seed is already
+      // orphan-free, so it is a stable prefix of the re-sanitized history and the
+      // slice begins exactly at the first genuinely-new item.
+      const activeSeedRows = await getActiveSessionHistoryItems(db, input.workspaceId, input.sessionId);
+      persistedHistoryCount = sanitizeHistoryItemsForModel(
+        activeSeedRows.map((row) => row.item),
+      ).length;
       historyCountAtTurnStart = persistedHistoryCount;
       nextHistoryPosition = await nextSessionHistoryPosition(db, input.workspaceId, input.sessionId);
       let responseUsageCount = 0;

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
+import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
 import { historyRowsToAppend, isWorkerShutdownCancellation, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 
 // Item shapes mirror the SDK history representation persisted into
@@ -136,6 +137,106 @@ describe("conversation-truth reconcile (orphaned tool output guard)", () => {
     const result = historyRowsToAppend(sanitized, 1);
     expect(result.rows.map((row) => row.position)).toEqual([1, 2]);
     expect(result.nextPosition).toBe(3);
+  });
+});
+
+describe("reconcile seed watermark (issue-61 skew: raw vs sanitized active count)", () => {
+  // The seed the live worker computes at turn start. The fix is to seed from the
+  // SANITIZED active length (what prepareRunInput actually puts into
+  // state.history), NOT the raw active-row count.
+  const sanitizedSeed = (activeRows: Array<Record<string, unknown>>) =>
+    sanitizeHistoryItemsForModel(activeRows).length;
+
+  test("a K-orphan legacy active history seeds K-too-high under the raw count and strands a new item", () => {
+    // A legacy-corrupted session: its stored ACTIVE rows carry K=1 orphaned
+    // function_call_result (call_legacy has no preceding function_call). The raw
+    // active-row count is 3; sanitization drops the orphan, so state.history this
+    // turn is seeded from only 2 items.
+    const activeRows = [
+      userMessage("earlier turn"),
+      functionResult("call_legacy"), // K=1 orphan: no matching call. Dropped by sanitizer.
+      userMessage("another earlier turn"),
+    ];
+    const rawActiveCount = activeRows.length; // 3 — the OLD seed
+    const seed = sanitizedSeed(activeRows); // 2 — the FIXED seed
+    expect(rawActiveCount).toBe(3);
+    expect(seed).toBe(2);
+
+    // This turn the model produced a fresh tool-call pair after the trigger. The
+    // SDK's state.history is the sanitized prior history + the new trigger +
+    // generated items (the orphan is already gone from the in-memory copy).
+    const stateHistory = [
+      userMessage("earlier turn"),
+      userMessage("another earlier turn"),
+      userMessage("new trigger"),
+      functionCall("call_new"),
+      functionResult("call_new"),
+    ];
+
+    // OLD behavior (raw seed = 3): the slice starts 1 item too late and skips the
+    // genuinely-new "new trigger" item; worse, on a multi-step turn it can skip a
+    // function_call while later persisting its function_call_result alone.
+    const old = historyRowsToAppend(stateHistory, rawActiveCount);
+    expect(old.rows.map((row) => row.item)).not.toContainEqual(userMessage("new trigger"));
+
+    // FIXED behavior (sanitized seed = 2): the slice starts exactly at the first
+    // genuinely-new item; every new item is persisted and no result is stranded.
+    const fixed = historyRowsToAppend(stateHistory, seed);
+    expect(fixed.rows.map((row) => row.item)).toEqual([
+      userMessage("new trigger"),
+      functionCall("call_new"),
+      functionResult("call_new"),
+    ]);
+  });
+
+  test("raw seed can persist a function_call_result whose function_call was in the skipped region", () => {
+    // The session-bricking variant. K=2 orphans inflate the raw count so the
+    // slice skips the new function_call but NOT its trailing result.
+    const activeRows = [
+      functionResult("orphan_1"), // K orphan
+      functionResult("orphan_2"), // K orphan
+      userMessage("prior turn"),
+    ];
+    const rawActiveCount = activeRows.length; // 4? no — 3
+    const seed = sanitizedSeed(activeRows); // 1 (only the user message survives)
+    expect(seed).toBe(1);
+
+    // state.history seeded from the 1 surviving item, then this turn appended a
+    // new call+result pair.
+    const stateHistory = [
+      userMessage("prior turn"),
+      functionCall("call_new"),
+      functionResult("call_new"),
+    ];
+
+    // OLD (raw seed = 3): slice(3) keeps only the trailing result — the orphan
+    // the API 400s on. historyRowsToAppend re-sanitizes, so a single call here is
+    // dropped as dangling; but had the call sat below the slice boundary in a
+    // longer history its result would persist alone. Assert the FIXED seed never
+    // produces that skip.
+    const oldRows = historyRowsToAppend(stateHistory, rawActiveCount);
+    expect(oldRows.rows).toEqual([]); // raw seed >= sanitized length: nothing new captured, the real new pair is lost
+
+    const fixedRows = historyRowsToAppend(stateHistory, seed);
+    const persisted = fixedRows.rows.map((row) => row.item);
+    const callIds = new Set(
+      persisted.filter((item) => item.type === "function_call").map((item) => item.callId),
+    );
+    for (const item of persisted) {
+      if (item.type === "function_call_result") {
+        expect(callIds.has(item.callId)).toBe(true);
+      }
+    }
+    expect(persisted).toEqual([functionCall("call_new"), functionResult("call_new")]);
+  });
+
+  test("orphan-free active history: sanitized seed equals raw count (common path unchanged)", () => {
+    const activeRows = [
+      userMessage("hi"),
+      functionCall("c1"),
+      functionResult("c1"),
+    ];
+    expect(sanitizedSeed(activeRows)).toBe(activeRows.length);
   });
 });
 

--- a/packages/db/drizzle/0014_repair_orphaned_function_call_results.sql
+++ b/packages/db/drizzle/0014_repair_orphaned_function_call_results.sql
@@ -1,0 +1,125 @@
+-- One-time REPAIR of legacy orphaned tool-call RESULT rows (issue-61 self-heal).
+--
+-- Conversation truth is replayed verbatim into the model on every turn. The
+-- Responses API rejects the whole request (HTTP 400 "No tool call found for
+-- function call output with call_id <X>") when a tool-call RESULT row
+-- (function_call_result / computer_call_result / shell_call_output /
+-- apply_patch_call_output) has no matching CALL earlier in the active sequence.
+-- Because the corrupt row is replayed every turn, one such orphan permanently
+-- bricks the session across revival until the row is removed.
+--
+-- The read-path sanitizer (sanitizeHistoryItemsForModel) already filters these
+-- in-memory so new turns survive, and the write-path watermark fix (seed from
+-- the SANITIZED active length) stops new orphans from ever being persisted. But
+-- sessions corrupted BEFORE those fixes still carry the orphaned row on disk;
+-- the audit trail (session_get / session_events / exports) keeps surfacing a
+-- result with no call, and the row needlessly re-triggers the sanitizer every
+-- turn. This migration strips those already-persisted orphans once so corrupted
+-- sessions self-heal on disk, paired and audited.
+--
+-- DEFINITION OF AN ORPHAN (mirrors the sanitizer's rule 1 exactly):
+--   * The row is an ACTIVE result-type row (the live, model-facing sequence is
+--     the only thing the read path replays; superseded prefix rows are audit
+--     trail and never reach the model). active=false rows are left untouched.
+--   * No ACTIVE row of the matching CALL type, with the same correlation id,
+--     exists at a STRICTLY EARLIER position in the same (workspace, session).
+--   * Correlation id is read from BOTH the SDK camelCase `callId` and the wire
+--     snake_case `call_id`, matching the sanitizer's callIdOf().
+--
+-- We deliberately do NOT touch DANGLING CALLS (a call with no result yet): a
+-- call awaiting a not-yet-settled result is valid mid-turn, not corruption; the
+-- read-path sanitizer drops it transiently and it settles on the next pass.
+--
+-- Every deleted row is first copied verbatim into the permanent audit table
+-- session_history_items_repair_audit, so the repair is reversible and auditable.
+
+-- Permanent audit of every row this repair removed.
+CREATE TABLE IF NOT EXISTS "session_history_items_repair_audit" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  -- The original session_history_items row, captured verbatim. No FK back to the
+  -- source row: it is being deleted, and the audit must outlive it.
+  "source_id" uuid NOT NULL,
+  "account_id" uuid NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "session_id" uuid NOT NULL,
+  "turn_id" uuid,
+  "position" numeric NOT NULL,
+  "item" jsonb NOT NULL,
+  "source_created_at" timestamptz NOT NULL,
+  "repair_reason" text NOT NULL,
+  "repaired_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Result-item types and the CALL type that settles each, kept in sync with the
+-- runtime sanitizer's RESULT_TYPE_BY_CALL_TYPE. Built once as a CTE so the
+-- DELETE and the audit INSERT share one definition of an orphan.
+WITH "result_call_pairs" ("result_type", "call_type") AS (
+  VALUES
+    ('function_call_result', 'function_call'),
+    ('computer_call_result', 'computer_call'),
+    ('shell_call_output', 'shell_call'),
+    ('apply_patch_call_output', 'apply_patch_call')
+),
+-- Every ACTIVE result-type row, with its correlation id and the call type that
+-- would settle it.
+"active_results" AS (
+  SELECT
+    h."id",
+    h."account_id",
+    h."workspace_id",
+    h."session_id",
+    h."turn_id",
+    h."position",
+    h."item",
+    h."created_at",
+    p."call_type",
+    COALESCE(h."item" ->> 'callId', h."item" ->> 'call_id') AS "call_id"
+  FROM "session_history_items" h
+  JOIN "result_call_pairs" p
+    ON p."result_type" = (h."item" ->> 'type')
+  WHERE h."active" = true
+    AND COALESCE(h."item" ->> 'callId', h."item" ->> 'call_id') IS NOT NULL
+),
+-- The orphans: an active result row with NO active matching call at a strictly
+-- earlier position in the same session.
+"orphans" AS (
+  SELECT r.*
+  FROM "active_results" r
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM "session_history_items" c
+    WHERE c."workspace_id" = r."workspace_id"
+      AND c."session_id" = r."session_id"
+      AND c."active" = true
+      AND (c."item" ->> 'type') = r."call_type"
+      AND COALESCE(c."item" ->> 'callId', c."item" ->> 'call_id') = r."call_id"
+      AND c."position" < r."position"
+  )
+),
+-- Audit every orphan before deleting it.
+"audited" AS (
+  INSERT INTO "session_history_items_repair_audit" (
+    "source_id", "account_id", "workspace_id", "session_id", "turn_id",
+    "position", "item", "source_created_at", "repair_reason"
+  )
+  SELECT
+    o."id", o."account_id", o."workspace_id", o."session_id", o."turn_id",
+    o."position", o."item", o."created_at",
+    'orphaned_tool_call_result_no_matching_call'
+  FROM "orphans" o
+  RETURNING "source_id"
+)
+DELETE FROM "session_history_items" h
+USING "audited" a
+WHERE h."id" = a."source_id";
+
+-- The audit table holds no workspace-scoped RLS (it is an operator/audit
+-- artifact written only by this migration), but grant the app role the same
+-- table access the rest of the schema gets so a later GRANT-ALL sweep is
+-- idempotent and the role inventory stays uniform.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2142,6 +2142,107 @@ export async function countActiveSessionHistoryItems(db: Database, workspaceId: 
 }
 
 /**
+ * Result-item types and the CALL type that settles each. Kept byte-for-byte in
+ * sync with the runtime sanitizer's RESULT_TYPE_BY_CALL_TYPE and the repair
+ * migration (0014). The repair, the read-path sanitizer, and this spec all share
+ * one definition of a tool-call pair.
+ */
+const REPAIR_CALL_TYPE_BY_RESULT_TYPE: Record<string, string> = {
+  function_call_result: "function_call",
+  computer_call_result: "computer_call",
+  shell_call_output: "shell_call",
+  apply_patch_call_output: "apply_patch_call",
+};
+
+function repairCallIdOf(item: unknown): string | undefined {
+  if (!item || typeof item !== "object") {
+    return undefined;
+  }
+  const record = item as { callId?: unknown; call_id?: unknown };
+  if (typeof record.callId === "string") {
+    return record.callId;
+  }
+  if (typeof record.call_id === "string") {
+    return record.call_id;
+  }
+  return undefined;
+}
+
+function repairItemType(item: unknown): string | undefined {
+  if (!item || typeof item !== "object") {
+    return undefined;
+  }
+  const type = (item as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+/**
+ * Pure TypeScript SPEC for the one-time orphan repair (migration 0014),
+ * mirroring its SQL WHERE clause so the deletion rule is unit-testable without a
+ * database. Given the ACTIVE history rows of a single session in position order,
+ * returns the indices of the orphaned tool-call RESULT rows the repair deletes.
+ *
+ * An orphan is a result-type row (function_call_result / computer_call_result /
+ * shell_call_output / apply_patch_call_output) with no matching CALL of the
+ * paired type, same correlation id (camelCase `callId` OR snake_case `call_id`),
+ * at a STRICTLY EARLIER position in the same session. This is exactly the
+ * session-bricking row the Responses API 400s on ("No tool call found for
+ * function call output").
+ *
+ * DANGLING CALLS (a call with no result yet) are intentionally NOT returned: a
+ * call awaiting a not-yet-settled result is valid, not corruption. Only unpaired
+ * results are removed.
+ *
+ * EXISTENCE, not consumption: like the migration's `NOT EXISTS (... earlier
+ * call ...)`, a result is kept whenever ANY earlier matching call exists. A
+ * second result that re-uses a call_id already settled earlier is therefore NOT
+ * flagged here (a matching call still exists before it) — this conservative
+ * choice matches the SQL exactly and never deletes a row whose call is present;
+ * the read-path sanitizer (which consumes calls one-for-one) still drops such a
+ * rare duplicate in-memory, so the model request stays valid regardless.
+ *
+ * Callers pass rows already ordered by position. The earlier-position test is
+ * by array order (the SQL orders by the numeric position column, which the read
+ * path also orders by), so identical inputs yield identical decisions.
+ */
+export function orphanedResultRowIndicesForRepair(
+  activeRowsInPositionOrder: ReadonlyArray<{ item: Record<string, unknown> }>,
+): number[] {
+  // call_ids of CALLs seen so far, per matching result type. A result is an
+  // orphan unless a call of its paired type with the same id appeared earlier.
+  const seenCallIdsByResultType = new Map<string, Set<string>>();
+  // Pre-index every call type to the result type(s) it can settle.
+  const resultTypeByCallType: Record<string, string> = {};
+  for (const [resultType, callType] of Object.entries(REPAIR_CALL_TYPE_BY_RESULT_TYPE)) {
+    resultTypeByCallType[callType] = resultType;
+  }
+  const orphanIndices: number[] = [];
+  activeRowsInPositionOrder.forEach((row, index) => {
+    const type = repairItemType(row.item);
+    const callId = repairCallIdOf(row.item);
+    if (!type || !callId) {
+      return;
+    }
+    const settlesResultType = resultTypeByCallType[type];
+    if (settlesResultType) {
+      // This row is a CALL: record its id so a later matching result is paired.
+      const seen = seenCallIdsByResultType.get(settlesResultType) ?? new Set<string>();
+      seen.add(callId);
+      seenCallIdsByResultType.set(settlesResultType, seen);
+      return;
+    }
+    if (REPAIR_CALL_TYPE_BY_RESULT_TYPE[type]) {
+      // This row is a RESULT: orphan unless an earlier matching call was seen.
+      const seen = seenCallIdsByResultType.get(type);
+      if (!seen || !seen.has(callId)) {
+        orphanIndices.push(index);
+      }
+    }
+  });
+  return orphanIndices;
+}
+
+/**
  * Apply a client-side context compaction as an atomic, audit-preserving write:
  *
  *  - supersede (set active=false) every active row whose position lies in

--- a/packages/db/test/orphan-repair.test.ts
+++ b/packages/db/test/orphan-repair.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { orphanedResultRowIndicesForRepair } from "../src/index";
+
+// Pure spec for migration 0014 (repair of legacy orphaned tool-call results).
+// orphanedResultRowIndicesForRepair() mirrors the migration's SQL WHERE clause:
+// over a session's ACTIVE rows in position order, it returns the indices of the
+// orphaned RESULT rows the repair deletes — exactly the session-bricking rows
+// the Responses API 400s on ("No tool call found for function call output").
+
+function row(item: Record<string, unknown>) {
+  return { item };
+}
+function userMessage(text: string) {
+  return { type: "message", role: "user", content: text };
+}
+function functionCall(callId: string) {
+  return { type: "function_call", callId, name: "tool", arguments: "{}" };
+}
+function functionResult(callId: string) {
+  return { type: "function_call_result", callId, output: { type: "text", text: "ok" } };
+}
+
+describe("orphanedResultRowIndicesForRepair (migration 0014 spec)", () => {
+  test("flags a function_call_result with no preceding function_call (the brick)", () => {
+    const rows = [
+      row(userMessage("hi")),
+      row(functionResult("orphan")), // index 1 — orphan, no call before it
+      row(userMessage("bye")),
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([1]);
+  });
+
+  test("keeps a properly paired call+result (call strictly earlier)", () => {
+    const rows = [
+      row(functionCall("c1")),
+      row(functionResult("c1")), // paired — kept
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([]);
+  });
+
+  test("a result BEFORE its call is still an orphan (ordering enforced)", () => {
+    const rows = [
+      row(functionResult("c1")), // index 0 — call appears later, so this is an orphan
+      row(functionCall("c1")),
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([0]);
+  });
+
+  test("does NOT flag a dangling call (call with no result yet — valid, not corruption)", () => {
+    const rows = [
+      row(userMessage("go")),
+      row(functionCall("pending")), // dangling but valid mid-turn — untouched
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([]);
+  });
+
+  test("matches snake_case call_id as well as camelCase callId", () => {
+    const rows = [
+      row({ type: "function_call", call_id: "snake" }),
+      row({ type: "function_call_result", call_id: "snake" }), // paired via snake_case — kept
+      row({ type: "function_call_result", call_id: "missing" }), // index 2 — orphan
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([2]);
+  });
+
+  test("covers every result/call type pair the SDK can emit", () => {
+    const rows = [
+      // orphans (no preceding call)
+      row({ type: "computer_call_result", callId: "cc" }),       // 0 orphan
+      row({ type: "shell_call_output", callId: "sh" }),          // 1 orphan
+      row({ type: "apply_patch_call_output", callId: "ap" }),    // 2 orphan
+      // paired
+      row({ type: "shell_call", callId: "ok" }),                 // 3 call
+      row({ type: "shell_call_output", callId: "ok" }),          // 4 result — kept
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([0, 1, 2]);
+  });
+
+  test("multiple orphans interleaved with valid pairs", () => {
+    const rows = [
+      row(functionResult("orphan_a")), // 0 orphan
+      row(functionCall("good")),
+      row(functionResult("good")),     // paired — kept
+      row(functionResult("orphan_b")), // 3 orphan
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([0, 3]);
+  });
+
+  test("existence semantics: a duplicate result is NOT deleted while its call still exists earlier", () => {
+    // The repair is conservative — it deletes a result only when NO earlier
+    // matching call exists (matching the migration's NOT EXISTS). A second result
+    // re-using an already-settled call_id is left on disk because the call is
+    // still present before it; the read-path sanitizer drops the rare duplicate
+    // in-memory, so the model request is valid regardless. The repair must never
+    // delete a row whose call exists.
+    const rows = [
+      row(functionCall("c1")),
+      row(functionResult("c1")),
+      row(functionResult("c1")), // duplicate, but a matching call exists earlier — kept
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([]);
+  });
+
+  test("ignores non-tool rows and items without a correlation id", () => {
+    const rows = [
+      row(userMessage("a")),
+      row({ type: "reasoning", id: "rs_1" }),
+      row({ type: "function_call_result" }), // no call_id — cannot correlate; left alone
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([]);
+  });
+
+  test("clean history yields no deletions", () => {
+    const rows = [
+      row(userMessage("hi")),
+      row(functionCall("c1")),
+      row(functionResult("c1")),
+      row(userMessage("bye")),
+    ];
+    expect(orphanedResultRowIndicesForRepair(rows)).toEqual([]);
+  });
+});

--- a/packages/testing/src/compose.ts
+++ b/packages/testing/src/compose.ts
@@ -126,6 +126,22 @@ export async function buildSandboxImage(tag = "opengeni-sandbox:local", cwd = pr
   }
 }
 
+/**
+ * Run a raw, possibly multi-statement SQL script (e.g. a migration file's full
+ * text, including DO $$ ... $$ blocks) against a database. Uses the simple
+ * protocol via `unsafe`, the same path the migration runner uses, so a hand-
+ * authored .sql file behaves identically in a test. Intended for exercising
+ * migration files directly; not for app queries.
+ */
+export async function applyRawSql(databaseUrl: string, sqlText: string): Promise<void> {
+  const sql = postgres(databaseUrl, { max: 1 });
+  try {
+    await sql.unsafe(sqlText);
+  } finally {
+    await sql.end().catch(() => undefined);
+  }
+}
+
 async function waitForPostgres(databaseUrl: string): Promise<void> {
   await waitFor(async () => {
     const sql = postgres(databaseUrl, { max: 1 });

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   appendSessionEvents,
@@ -46,7 +49,7 @@ import {
   upsertCapabilityCatalogItem,
 } from "@opengeni/db";
 import type { AccessGrant, Permission } from "@opengeni/contracts";
-import { expectContiguousSequences, startTestServices, type TestServices } from "@opengeni/testing";
+import { applyRawSql, expectContiguousSequences, startTestServices, type TestServices } from "@opengeni/testing";
 
 describe("DB integration", () => {
   let services: TestServices;
@@ -1090,6 +1093,98 @@ describe("DB integration", () => {
     // First consumer wins; a second consumer sees it already cleared.
     expect(await consumeSessionCompactionRequest(dbClient.db, grant.workspaceId, session.id)).toBe(true);
     expect(await consumeSessionCompactionRequest(dbClient.db, grant.workspaceId, session.id)).toBe(false);
+  });
+
+  test("migration 0014 repair strips a legacy orphaned function_call_result, audits it, and spares valid pairs + dangling calls", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "orphan-repair",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // A second session that must stay completely untouched — proves the repair
+    // is session-scoped and never deletes a result whose call lives elsewhere.
+    const otherSession = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "orphan-repair-other",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // Legacy corruption: an orphaned function_call_result (no preceding call), a
+    // valid call+result pair, and a trailing dangling call (valid mid-turn).
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "go" } },
+        { position: 1, item: { type: "function_call_result", callId: "orphan_x", output: { type: "text", text: "leaked" } } },
+        { position: 2, item: { type: "function_call", callId: "paired", name: "tool", arguments: "{}" } },
+        { position: 3, item: { type: "function_call_result", callId: "paired", output: { type: "text", text: "ok" } } },
+        // snake_case orphan: a result whose call_id has no earlier call.
+        { position: 4, item: { type: "shell_call_output", call_id: "orphan_snake", output: "leaked2" } },
+        { position: 5, item: { type: "function_call", callId: "dangling", name: "tool", arguments: "{}" } },
+      ],
+    });
+    // The other session holds a call with the SAME id as this session's orphan,
+    // to prove cross-session call presence does NOT spare an orphan (scoping).
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: otherSession.id,
+      items: [
+        { position: 0, item: { type: "function_call", callId: "orphan_x", name: "tool", arguments: "{}" } },
+        { position: 1, item: { type: "function_call_result", callId: "orphan_x", output: { type: "text", text: "ok" } } },
+      ],
+    });
+
+    // Run the ACTUAL shipped migration SQL against the live DB. CREATE TABLE IF
+    // NOT EXISTS and the GRANT block make re-running it (already applied in
+    // beforeAll) idempotent; the CTE DELETE re-evaluates the new orphans.
+    const migrationPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../packages/db/drizzle/0014_repair_orphaned_function_call_results.sql",
+    );
+    const migrationSql = await readFile(migrationPath, "utf8");
+    await applyRawSql(services.databaseUrl, migrationSql);
+
+    // The two orphans are gone; everything else survives in order.
+    const remaining = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(remaining.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 2, 3, 5]);
+    const remainingTypes = remaining
+      .sort((a, b) => a.position - b.position)
+      .map((row) => (row.item as Record<string, unknown>).type);
+    expect(remainingTypes).toEqual(["message", "function_call", "function_call_result", "function_call"]);
+    // The dangling call (valid mid-turn) was NOT deleted.
+    expect(remaining.some((row) => (row.item as Record<string, unknown>).callId === "dangling")).toBe(true);
+    // Neither orphan survives.
+    expect(remaining.some((row) => (row.item as Record<string, unknown>).callId === "orphan_x")).toBe(false);
+    expect(remaining.some((row) => (row.item as Record<string, unknown>).call_id === "orphan_snake")).toBe(false);
+
+    // The other session is completely untouched (scoping).
+    const otherRemaining = await getSessionHistoryItems(dbClient.db, grant.workspaceId, otherSession.id);
+    expect(otherRemaining.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1]);
+
+    // Both deleted orphans were audited verbatim into the permanent audit table.
+    const audit = await dbClient.db.execute(dbSql`
+      select source_id, position, item, repair_reason
+      from session_history_items_repair_audit
+      where session_id = ${session.id}
+      order by position
+    `);
+    const auditRows = audit as unknown as Array<{ position: number; item: Record<string, unknown>; repair_reason: string }>;
+    expect(auditRows).toHaveLength(2);
+    expect(auditRows.map((r) => Number(r.position)).sort((a, b) => a - b)).toEqual([1, 4]);
+    expect(auditRows.every((r) => r.repair_reason === "orphaned_tool_call_result_no_matching_call")).toBe(true);
+    const auditedCallIds = auditRows.map((r) => r.item.callId ?? r.item.call_id);
+    expect(auditedCallIds.sort()).toEqual(["orphan_snake", "orphan_x"]);
   });
 });
 


### PR DESCRIPTION
## Problem (CRITICAL — issue-61 incompletely fixed)

The conversation-truth dual-write seeded its persisted-history watermark from the **raw** active-row count (`countActiveSessionHistoryItems`), but the reconcile slices the **sanitized** `state.history`.

`prepareRunInput` builds `state.history` from `sanitizeHistoryItemsForModel(activeRows)`. When sanitization drops K rows (a legacy orphan / dangling-call pair), the in-memory history this turn starts from is K shorter than the raw row count. The raw seed (`apps/worker/src/activities/agent-turn.ts:409`, origin/main) is therefore K too high, so `historyRowsToAppend` skips K genuinely-new items — and a `function_call` left in that skipped region can later have its `function_call_result` persisted **alone**. That orphaned tool output 400s the Responses API on every replay (`No tool call found for function call output`) and **permanently bricks** the session. It self-perpetuates on legacy-orphan sessions.

## Fix

1. **Seed from the sanitized active length** (`agent-turn.ts`): `persistedHistoryCount = sanitizeHistoryItemsForModel(activeRows).length` — the exact prefix `prepareRunInput` puts into `state.history`. The sanitized seed is orphan-free, so re-sanitizing `state.history` keeps it as a stable prefix and the slice begins exactly at the first genuinely-new item; a result is never persisted without its preceding call. The single seed point feeds every reconcile (mid-stream, interruption, completion, preempt, error paths); the preempt `resumeWithNotice` comparison (`persistedHistoryCount > historyCountAtTurnStart`) stays correct because both watermarks now seed from the same sanitized basis. Absolute write positions stay decoupled (still `max(position)+1`), so no collision with existing rows.

2. **Repair migration 0014** strips already-persisted orphaned tool-call RESULT rows (`function_call_result` / `computer_call_result` / `shell_call_output` / `apply_patch_call_output`) whose matching CALL does **not** appear at a strictly-earlier position in the same session — matching both camelCase `callId` and snake_case `call_id`. Dangling calls (valid, not-yet-settled) are left untouched. Every deleted row is copied verbatim into a permanent audit table (`session_history_items_repair_audit`) first. `orphanedResultRowIndicesForRepair()` is a pure-TS spec mirroring the SQL `WHERE` clause, exported and unit-tested.

## Tests

- `apps/worker/test/agent-turn.test.ts`: reconcile seed-skew — under the raw seed a K-orphan history strands a new item / would lose the new pair; the sanitized seed persists exactly the new tail with no orphan. Plus the orphan-free common-path equality.
- `packages/db/test/orphan-repair.test.ts`: the pure repair spec (orphan vs paired vs dangling, snake/camel id, all four call/result types, scoping, existence semantics).
- `test/integration/db.integration.ts`: runs the **actual** migration 0014 SQL against a live DB — strips two orphans (one camelCase, one snake_case), audits them verbatim, and spares the valid pair, the trailing dangling call, and a same-id call in another session.

Full local gate green (typecheck across all packages, `bun test` 622 pass, db integration 23 pass). gitleaks clean.

Coordinates with the concurrent manager-robustness workflow (also edits `agent-turn.ts`, different lines/functions). Based on latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session history persistence and runs a destructive one-time data repair, but changes are narrowly scoped to orphan handling with audit trail and extensive tests; wrong orphan detection could delete valid rows.
> 
> **Overview**
> Completes **issue-61** by aligning the conversation-truth reconcile watermark with what the model actually sees.
> 
> **Worker (`agent-turn.ts`):** At turn start, `persistedHistoryCount` is now `sanitizeHistoryItemsForModel(activeRows).length` instead of the raw active-row count. When legacy rows include orphans the sanitizer drops, the old seed was too high and `historyRowsToAppend` could skip new items or persist a `function_call_result` without its call—Responses API 400s that brick the session. Orphan-free sessions behave the same as before.
> 
> **DB migration 0014:** One-time removal of active orphaned tool-call **result** rows (no matching earlier call in the same session), with rows copied to `session_history_items_repair_audit` first. Dangling calls are not deleted.
> 
> **Tests & tooling:** Unit tests for seed skew and `orphanedResultRowIndicesForRepair` (TS spec mirroring the SQL); integration test runs the real migration SQL; `applyRawSql` helper for migration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f7b6775dadbf446dcce3fe1157ef67fb0024cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->