### PR TITLE
Scheduled-task + billing integrity: no cancelled-resurrection, idempotent trigger, stable usage key

### DIFF
--- a/apps/api/src/dependencies.ts
+++ b/apps/api/src/dependencies.ts
@@ -22,7 +22,7 @@ export type SessionWorkflowClient = {
   signalInterrupt: (input: { accountId: string; workspaceId: string; sessionId: string; eventId: string; workflowId: string }) => Promise<void>;
   syncScheduledTask: (input: { task: ScheduledTask }) => Promise<void>;
   deleteScheduledTaskSchedule: (input: { temporalScheduleId: string }) => Promise<void>;
-  triggerScheduledTask: (input: { task: ScheduledTask; agentRunUsageIdempotencyKey?: string }) => Promise<void>;
+  triggerScheduledTask: (input: { task: ScheduledTask; agentRunUsageIdempotencyKey?: string; triggerWorkflowId?: string }) => Promise<void>;
 };
 
 export type DocumentIndexClient = {

--- a/apps/api/src/domain/scheduled-tasks.ts
+++ b/apps/api/src/domain/scheduled-tasks.ts
@@ -219,6 +219,47 @@ export function scheduledTaskTemporalScheduleId(taskId: string): string {
   return `scheduled-task-${taskId}`;
 }
 
+/**
+ * Stable token that identifies a single logical manual trigger. A client that
+ * retries a `/trigger` POST (network blip, lambda re-invocation) passes the
+ * SAME token so the retry is idempotent — one usage charge, one workflow run.
+ * When the client supplies nothing we mint one UUID PER REQUEST and reuse it
+ * for both the idempotency key and the workflowId, so a single request stays
+ * internally consistent while two genuinely-distinct manual triggers (no token,
+ * fired a second apart) still each get their own run. The token is sanitized to
+ * the Temporal workflow-id-safe charset so a client value cannot smuggle a
+ * collision into a different task's id space.
+ */
+export function scheduledTaskTriggerToken(clientTriggerId?: string | null): string {
+  const trimmed = (clientTriggerId ?? "").trim();
+  if (!trimmed) {
+    return crypto.randomUUID();
+  }
+  const safe = trimmed.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 128);
+  // A value that sanitizes to empty (only disallowed chars) is unusable as a
+  // stable id; fall back to a fresh token rather than collapse to a constant.
+  return safe.length > 0 ? safe : crypto.randomUUID();
+}
+
+/**
+ * Deterministic Temporal workflow id for a manual trigger. Derived purely from
+ * the task id and the stable trigger token, so a retry with the same token maps
+ * to the same id and `workflowIdReusePolicy: "REJECT_DUPLICATE"` collapses the
+ * second start into a no-op instead of spawning a second run.
+ */
+export function manualScheduledTaskTriggerWorkflowId(taskId: string, triggerToken: string): string {
+  return `scheduled-task-${taskId}-manual-${triggerToken}`;
+}
+
+/**
+ * Deterministic usage idempotency key for a manual trigger's agent_run.created
+ * charge. Shares the stable trigger token with the workflow id so the charge
+ * and the run dedupe together under retry.
+ */
+export function manualScheduledTaskTriggerUsageKey(workspaceId: string, taskId: string, triggerToken: string): string {
+  return `agent_run.created:scheduled-trigger:${workspaceId}:${taskId}:${triggerToken}`;
+}
+
 async function validateScheduledTaskAgentConfig(input: {
   settings: Settings;
   db: Database;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,9 +3,19 @@ import type { ScheduledTask, ScheduledTaskOverlapPolicy, ScheduledTaskScheduleSp
 import { createDb } from "@opengeni/db";
 import { createNatsEventBus } from "@opengeni/events";
 import { createObservability, logStartupDependencyRetry } from "@opengeni/observability";
-import { Connection, Client as TemporalClient, ScheduleNotFoundError, ScheduleOverlapPolicy } from "@temporalio/client";
+import { Connection, Client as TemporalClient, ScheduleNotFoundError, ScheduleOverlapPolicy, WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import type { ScheduleOptions, ScheduleSpec, ScheduleUpdateOptions } from "@temporalio/client";
 import { createApp, type DocumentIndexClient, type SessionWorkflowClient } from "./app";
+
+/**
+ * A REJECT_DUPLICATE start collides on the deterministic workflowId when the
+ * same manual trigger token fires twice. Temporal surfaces that as
+ * WorkflowExecutionAlreadyStartedError; the caller treats it as an idempotent
+ * no-op rather than a failure.
+ */
+function isWorkflowAlreadyStarted(error: unknown): boolean {
+  return error instanceof WorkflowExecutionAlreadyStartedError;
+}
 
 const TEMPORAL_MONTHS = [
   "JANUARY",
@@ -80,18 +90,33 @@ export async function createTemporalWorkflowClient(settings: ReturnType<typeof g
     deleteScheduledTaskSchedule: async ({ temporalScheduleId }) => {
       await temporal.schedule.getHandle(temporalScheduleId).delete().catch(() => undefined);
     },
-	    triggerScheduledTask: async ({ task, agentRunUsageIdempotencyKey }) => {
-	      await temporal.workflow.start("scheduledTaskFireWorkflow", {
-        taskQueue: settings.temporalTaskQueue,
-        workflowId: `scheduled-task-${task.id}-manual-${crypto.randomUUID()}`,
-        args: [{
-          accountId: task.accountId,
-	          workspaceId: task.workspaceId,
-	          taskId: task.id,
-	          triggerType: "manual",
-	          agentRunUsageIdempotencyKey,
-	        }],
-	      });
+	    triggerScheduledTask: async ({ task, agentRunUsageIdempotencyKey, triggerWorkflowId }) => {
+	      // Deterministic workflowId (derived from the trigger token by the
+	      // caller) + REJECT_DUPLICATE makes a retried manual trigger idempotent:
+	      // the second start collides on the id and is rejected instead of
+	      // spawning a second run. The shared idempotency key dedupes the charge.
+	      const workflowId = triggerWorkflowId ?? `scheduled-task-${task.id}-manual-${crypto.randomUUID()}`;
+	      try {
+	        await temporal.workflow.start("scheduledTaskFireWorkflow", {
+	          taskQueue: settings.temporalTaskQueue,
+	          workflowId,
+	          workflowIdReusePolicy: "REJECT_DUPLICATE",
+	          args: [{
+	            accountId: task.accountId,
+	            workspaceId: task.workspaceId,
+	            taskId: task.id,
+	            triggerType: "manual",
+	            agentRunUsageIdempotencyKey,
+	          }],
+	        });
+	      } catch (error) {
+	        // A duplicate trigger token started this run already; treat the retry
+	        // as a no-op so the (idempotent) usage charge stays the only effect.
+	        if (isWorkflowAlreadyStarted(error)) {
+	          return;
+	        }
+	        throw error;
+	      }
 	    },
   };
   const documentIndexer: DocumentIndexClient = {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -55,7 +55,10 @@ import {
 } from "../domain/environments";
 import {
   createValidatedScheduledTask,
+  manualScheduledTaskTriggerUsageKey,
+  manualScheduledTaskTriggerWorkflowId,
   scheduledTaskToolsProvided,
+  scheduledTaskTriggerToken,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
@@ -296,13 +299,15 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
   });
 
   server.registerTool("scheduled_tasks_trigger", {
-    description: "Trigger a scheduled task immediately.",
-    inputSchema: { id: z4.string().uuid() },
-  }, async ({ id }) => {
+    description: "Trigger a scheduled task immediately. Pass a stable triggerId to make a retried trigger idempotent (one charge, one run).",
+    inputSchema: { id: z4.string().uuid(), triggerId: z4.string().min(1).max(128).optional() },
+  }, async ({ id, triggerId }) => {
     const task = await requireScheduledTask(deps.db, grant.workspaceId, id);
     await requireLimit(deps, { accountId: grant.accountId, workspaceId: grant.workspaceId, action: "agent_run:create", quantity: 1 });
-    const agentRunUsageIdempotencyKey = `agent_run.created:scheduled-trigger:${grant.workspaceId}:${task.id}:${crypto.randomUUID()}`;
-    await deps.workflowClient.triggerScheduledTask({ task, agentRunUsageIdempotencyKey });
+    const triggerToken = scheduledTaskTriggerToken(triggerId);
+    const agentRunUsageIdempotencyKey = manualScheduledTaskTriggerUsageKey(grant.workspaceId, task.id, triggerToken);
+    const triggerWorkflowId = manualScheduledTaskTriggerWorkflowId(task.id, triggerToken);
+    await deps.workflowClient.triggerScheduledTask({ task, agentRunUsageIdempotencyKey, triggerWorkflowId });
     await recordWorkspaceUsage(deps, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,

--- a/apps/api/src/routes/scheduled-tasks.ts
+++ b/apps/api/src/routes/scheduled-tasks.ts
@@ -1,4 +1,4 @@
-import { CreateScheduledTaskRequest, UpdateScheduledTaskRequest } from "@opengeni/contracts";
+import { CreateScheduledTaskRequest, TriggerScheduledTaskRequest, UpdateScheduledTaskRequest } from "@opengeni/contracts";
 import {
   deleteScheduledTask,
   listScheduledTaskRuns,
@@ -11,7 +11,10 @@ import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
 import type { ApiRouteDeps } from "../dependencies";
 import {
   createValidatedScheduledTask,
+  manualScheduledTaskTriggerUsageKey,
+  manualScheduledTaskTriggerWorkflowId,
   scheduledTaskToolsProvided,
+  scheduledTaskTriggerToken,
   requireScheduledTaskForApi,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
@@ -81,8 +84,14 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
     const grant = await requireAccessGrant(c, deps, workspaceId, "scheduled_tasks:run");
     await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
     const task = await requireScheduledTaskForApi(db, workspaceId, c.req.param("taskId"));
-    const agentRunUsageIdempotencyKey = `agent_run.created:scheduled-trigger:${workspaceId}:${task.id}:${crypto.randomUUID()}`;
-    await workflowClient.triggerScheduledTask({ task, agentRunUsageIdempotencyKey });
+    // Body is optional (a bare POST is still a valid trigger); only a present,
+    // non-empty body must parse against the contract.
+    const body = await c.req.json().catch(() => ({}));
+    const { triggerId } = TriggerScheduledTaskRequest.parse(body ?? {});
+    const triggerToken = scheduledTaskTriggerToken(triggerId);
+    const agentRunUsageIdempotencyKey = manualScheduledTaskTriggerUsageKey(workspaceId, task.id, triggerToken);
+    const triggerWorkflowId = manualScheduledTaskTriggerWorkflowId(task.id, triggerToken);
+    await workflowClient.triggerScheduledTask({ task, agentRunUsageIdempotencyKey, triggerWorkflowId });
     await recordWorkspaceUsage(deps, {
       accountId: grant.accountId,
       workspaceId,

--- a/apps/api/test/scheduled-task-trigger.test.ts
+++ b/apps/api/test/scheduled-task-trigger.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  manualScheduledTaskTriggerUsageKey,
+  manualScheduledTaskTriggerWorkflowId,
+  scheduledTaskTriggerToken,
+} from "../src/domain/scheduled-tasks";
+
+const WORKSPACE = "ws-1";
+const TASK = "task-1";
+
+describe("manual scheduled-task trigger idempotency token", () => {
+  test("a client-supplied trigger id derives a stable token -> idempotent retry", () => {
+    // A retried trigger that reuses the same token must produce the SAME usage
+    // key AND the SAME workflowId, so the charge dedupes and the duplicate
+    // workflow start is rejected -> one charge, one run.
+    const token1 = scheduledTaskTriggerToken("my-stable-token");
+    const token2 = scheduledTaskTriggerToken("my-stable-token");
+    expect(token1).toBe(token2);
+    expect(manualScheduledTaskTriggerUsageKey(WORKSPACE, TASK, token1))
+      .toBe(manualScheduledTaskTriggerUsageKey(WORKSPACE, TASK, token2));
+    expect(manualScheduledTaskTriggerWorkflowId(TASK, token1))
+      .toBe(manualScheduledTaskTriggerWorkflowId(TASK, token2));
+  });
+
+  test("usage key and workflow id share the token so charge and run dedupe together", () => {
+    const token = scheduledTaskTriggerToken("shared");
+    expect(manualScheduledTaskTriggerUsageKey(WORKSPACE, TASK, token)).toContain(token);
+    expect(manualScheduledTaskTriggerWorkflowId(TASK, token)).toContain(token);
+  });
+
+  test("absent trigger id mints a fresh token -> distinct triggers stay distinct", () => {
+    // Two separate manual triggers with no client token are legitimately
+    // different runs and must NOT collapse into one.
+    const a = scheduledTaskTriggerToken();
+    const b = scheduledTaskTriggerToken();
+    expect(a).not.toBe(b);
+    expect(manualScheduledTaskTriggerWorkflowId(TASK, a)).not.toBe(manualScheduledTaskTriggerWorkflowId(TASK, b));
+    expect(manualScheduledTaskTriggerUsageKey(WORKSPACE, TASK, a)).not.toBe(manualScheduledTaskTriggerUsageKey(WORKSPACE, TASK, b));
+  });
+
+  test("blank / whitespace-only trigger id is treated as absent (fresh token)", () => {
+    expect(scheduledTaskTriggerToken("")).not.toBe(scheduledTaskTriggerToken(""));
+    expect(scheduledTaskTriggerToken("   ")).not.toBe(scheduledTaskTriggerToken("   "));
+    expect(scheduledTaskTriggerToken(null)).not.toBe(scheduledTaskTriggerToken(undefined));
+  });
+
+  test("sanitizes a client token to the workflow-id-safe charset (no id-space smuggling)", () => {
+    // A malicious or sloppy token cannot inject characters that would let it
+    // collide with a DIFFERENT task's deterministic id or break Temporal's id.
+    const token = scheduledTaskTriggerToken("../other-task/../evil id!");
+    expect(token).toMatch(/^[a-zA-Z0-9._-]+$/);
+    const workflowId = manualScheduledTaskTriggerWorkflowId(TASK, token);
+    expect(workflowId.startsWith(`scheduled-task-${TASK}-manual-`)).toBe(true);
+  });
+
+  test("a non-empty token stays deterministic after sanitization (stable idempotency)", () => {
+    // Disallowed chars are mapped to '_', not stripped, so a non-empty client
+    // token always yields a non-empty, stable token: the same input gives the
+    // same key on retry. (Only a blank/whitespace-only input mints fresh.)
+    const a = scheduledTaskTriggerToken("///");
+    const b = scheduledTaskTriggerToken("///");
+    expect(a).toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+    expect(a).toMatch(/^[a-zA-Z0-9._-]+$/);
+  });
+
+  test("clamps an overlong token so it cannot exceed Temporal id limits", () => {
+    const token = scheduledTaskTriggerToken("x".repeat(500));
+    expect(token.length).toBeLessThanOrEqual(128);
+  });
+});

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -122,6 +122,34 @@ export function isWorkerShutdownCancellation(error: unknown): boolean {
  * rows already exceed the sanitized length (e.g. legacy orphans written before
  * this fix), nothing new is appended and the watermark holds steady.
  */
+/**
+ * Stable+unique usage source key for one model call, used to build the per-call
+ * idempotency key (`usage:model.tokens:${turnId}:${sourceKey}`). The turnId is
+ * shared across a re-dispatch of the SAME turn (preemption resume, approval
+ * rerun, activity retry), so the sourceKey alone must distinguish calls.
+ *
+ * - A provider responseId is globally stable+unique, so reuse it verbatim: a
+ *   true activity retry that re-emits the same responseId correctly DEDUPES
+ *   (one charge), while two distinct calls get distinct ids.
+ * - Without a responseId the only fallback was POSITIONAL ("response-1",
+ *   "aggregate"), which collides across a re-dispatch — dispatch B's first
+ *   call reuses dispatch A's "response-1" key and its charge is silently
+ *   dropped (undercharge). Qualifying the positional fallback with the
+ *   per-execution dispatch id (the Temporal activityId, unique per scheduled
+ *   execution) makes re-dispatched calls distinct while still deduping a
+ *   same-execution retry.
+ */
+export function modelUsageSourceKey(input: {
+  responseId?: string | null | undefined;
+  dispatchId: string | null;
+  positionalKey: string;
+}): string {
+  if (input.responseId) {
+    return input.responseId;
+  }
+  return input.dispatchId ? `${input.dispatchId}:${input.positionalKey}` : input.positionalKey;
+}
+
 export function historyRowsToAppend(
   rawHistory: Array<Record<string, unknown>>,
   // How many items of the CURRENT in-memory history are already persisted (the
@@ -287,6 +315,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // trip the per-producer uniqueness constraint on the event log. The
       // Temporal activity id is unique per scheduled execution.
       const producerId = `${input.workflowId}:${turnId}${activityContext ? `:${activityContext.info.activityId}` : ""}`;
+      // Unique per scheduled activity execution (Temporal activityId). Folded
+      // into positional usage source keys so a re-dispatch of this turn does
+      // not collide its model-call charges with the prior dispatch's. A genuine
+      // activity retry reuses the same activityId, so its re-emitted calls keep
+      // deduping (no double charge).
+      const dispatchId = activityContext?.info.activityId ?? null;
       publish = async (events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>, immediate = false) => {
         const inputs = events.map((event) => ({
           ...event,
@@ -463,7 +497,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               turnId,
               model: turn.model,
               usage: responseUsage.usage,
-              sourceKey: responseUsage.responseId ?? `response-${responseUsageCount}`,
+              sourceKey: modelUsageSourceKey({
+                responseId: responseUsage.responseId,
+                dispatchId,
+                positionalKey: `response-${responseUsageCount}`,
+              }),
             });
             await reconcileConversationTruth();
             try {
@@ -508,7 +546,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           turnId,
           model: turn.model,
           usage: stream.state.usage,
-          sourceKey: "aggregate",
+          sourceKey: modelUsageSourceKey({ responseId: null, dispatchId, positionalKey: "aggregate" }),
         });
       }
       if (lastInputTokensObserved !== null) {

--- a/apps/worker/src/activities/common.ts
+++ b/apps/worker/src/activities/common.ts
@@ -1,10 +1,26 @@
-import type { ResourceRef, ToolRef } from "@opengeni/contracts";
+import type { ResourceRef, SessionStatus, ToolRef } from "@opengeni/contracts";
 
 export {
   mergeResourceRefs,
   mergeToolRefs,
   reasoningEffortForMetadata as reasoningEffortForSession,
 } from "@opengeni/contracts";
+
+/**
+ * Refuse to revive a terminal reusable session on a scheduled fire. Mirrors the
+ * API-level guard in apps/api/src/domain/sessions.ts (post a user message ->
+ * 409 when cancelled): "cancelled" is the one terminal state, an explicit user
+ * act, so a recurring task must NOT silently resurrect and re-bill it. Failed
+ * and idle sessions stay revivable (talking to a session is how it resumes), so
+ * only "cancelled" is rejected. Throwing inside the FOR UPDATE locked-update
+ * callback aborts the whole append+enqueue transaction atomically, and the
+ * dispatch catch marks the scheduled_task_run "failed" rather than dispatched.
+ */
+export function assertReusableSessionRevivable(status: SessionStatus): void {
+  if (status === "cancelled") {
+    throw new Error("reusable session is cancelled; refusing to revive on scheduled fire");
+  }
+}
 
 export function scheduledUserMessagePayload(prompt: string, resources: ResourceRef[], tools: ToolRef[], taskId: string, runId: string): Record<string, unknown> {
   return {

--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -18,6 +18,7 @@ import {
 import { appendAndPublishEvents } from "@opengeni/events";
 import { configuredStaticUsageLimits, type Settings } from "@opengeni/config";
 import {
+  assertReusableSessionRevivable,
   mergeResourceRefs,
   mergeToolRefs,
   scheduledUserMessagePayload,
@@ -173,6 +174,11 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
           };
         } else {
           const session = await requireSession(db, task.workspaceId, task.reusableSessionId);
+          // A user-cancelled (terminal) reusable session must not be revived and
+          // re-billed on the next fire. Early check avoids the pre-lock goal
+          // upsert side-effect; the locked-callback check below is the
+          // authoritative atomic guard. Mirrors apps/api/src/domain/sessions.ts.
+          assertReusableSessionRevivable(session.status);
           // Defensive backstop for the API-level 409: a reusable session keeps
           // its creation-time attachment, so a diverged task attachment must
           // fail the run instead of silently running with the wrong secrets.
@@ -192,29 +198,36 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
               createdBy: "scheduled_task",
             })
             : null;
-          const events = await appendSessionEventsWithLockedSessionUpdate(db, task.workspaceId, session.id, (locked) => ({
-            events: [
-              ...(reusableGoal ? [{
-                type: "goal.set" as const,
-                payload: {
-                  goalId: reusableGoal.goal.id,
-                  text: reusableGoal.goal.text,
-                  ...(reusableGoal.goal.successCriteria ? { successCriteria: reusableGoal.goal.successCriteria } : {}),
-                  version: reusableGoal.goal.version,
-                  actor: "scheduled_task",
-                  replaced: reusableGoal.replaced,
+          const events = await appendSessionEventsWithLockedSessionUpdate(db, task.workspaceId, session.id, (locked) => {
+            // Authoritative guard under the FOR UPDATE row lock: re-check the
+            // current status to close the TOCTOU between the early read and the
+            // lock (a cancel could land in between). Throwing aborts the whole
+            // append+update transaction, so no user.message is persisted.
+            assertReusableSessionRevivable(locked.status);
+            return {
+              events: [
+                ...(reusableGoal ? [{
+                  type: "goal.set" as const,
+                  payload: {
+                    goalId: reusableGoal.goal.id,
+                    text: reusableGoal.goal.text,
+                    ...(reusableGoal.goal.successCriteria ? { successCriteria: reusableGoal.goal.successCriteria } : {}),
+                    version: reusableGoal.goal.version,
+                    actor: "scheduled_task",
+                    replaced: reusableGoal.replaced,
+                  },
+                }] : []),
+                {
+                  type: "user.message",
+                  payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, taskTools, task.id, run.id),
                 },
-              }] : []),
-              {
-                type: "user.message",
-                payload: scheduledUserMessagePayload(task.agentConfig.prompt, task.agentConfig.resources, taskTools, task.id, run.id),
+              ],
+              update: {
+                resources: mergeResourceRefs(locked.resources, task.agentConfig.resources),
+                tools: mergeToolRefs(locked.tools, taskTools),
               },
-            ],
-            update: {
-              resources: mergeResourceRefs(locked.resources, task.agentConfig.resources),
-              tools: mergeToolRefs(locked.tools, taskTools),
-            },
-          }));
+            };
+          });
           await bus.publish(task.workspaceId, session.id, events);
           const trigger = events.find((event) => event.type === "user.message");
           if (!trigger) {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
-import { historyRowsToAppend, isWorkerShutdownCancellation, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 
 // Item shapes mirror the SDK history representation persisted into
 // session_history_items (type discriminator, camelCase callId).
@@ -237,6 +237,53 @@ describe("reconcile seed watermark (issue-61 skew: raw vs sanitized active count
       functionResult("c1"),
     ];
     expect(sanitizedSeed(activeRows)).toBe(activeRows.length);
+  });
+});
+
+describe("model usage source key (re-dispatch charge stability)", () => {
+  test("uses the provider responseId verbatim when present (stable + unique)", () => {
+    expect(modelUsageSourceKey({ responseId: "resp_abc", dispatchId: "act-1", positionalKey: "response-1" }))
+      .toBe("resp_abc");
+    // The responseId path ignores the dispatch id, so a true activity retry
+    // that re-emits the SAME responseId produces the SAME key and dedupes the
+    // charge (no double-bill).
+    expect(modelUsageSourceKey({ responseId: "resp_abc", dispatchId: "act-2", positionalKey: "response-1" }))
+      .toBe("resp_abc");
+  });
+
+  test("positional fallback is unique per dispatch so a re-dispatch does not collide", () => {
+    // The bug: without a responseId the old key was purely positional, so the
+    // first model call of dispatch A and of dispatch B both keyed "response-1"
+    // -> the second charge deduped away (undercharge). Folding the per-execution
+    // dispatch id in keeps them distinct.
+    const dispatchAFirst = modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "response-1" });
+    const dispatchBFirst = modelUsageSourceKey({ responseId: null, dispatchId: "act-B", positionalKey: "response-1" });
+    expect(dispatchAFirst).not.toBe(dispatchBFirst);
+    expect(dispatchAFirst).toBe("act-A:response-1");
+    expect(dispatchBFirst).toBe("act-B:response-1");
+
+    // The aggregate fallback (no per-response usage at all) has the same hazard
+    // and the same fix.
+    const aggA = modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "aggregate" });
+    const aggB = modelUsageSourceKey({ responseId: null, dispatchId: "act-B", positionalKey: "aggregate" });
+    expect(aggA).not.toBe(aggB);
+  });
+
+  test("within one dispatch the positional fallback stays stable per call (in-dispatch dedupe)", () => {
+    // Same dispatch id + same positional slot -> same key, so a retried record
+    // within the one execution still dedupes (idempotent), while distinct calls
+    // (response-1 vs response-2) stay distinct.
+    expect(modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "response-1" }))
+      .toBe(modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "response-1" }));
+    expect(modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "response-1" }))
+      .not.toBe(modelUsageSourceKey({ responseId: null, dispatchId: "act-A", positionalKey: "response-2" }));
+  });
+
+  test("degrades to the bare positional key when no dispatch id is available", () => {
+    // Outside a Temporal activity context (local/test) there is no activityId;
+    // the key falls back to the positional value rather than throwing.
+    expect(modelUsageSourceKey({ responseId: null, dispatchId: null, positionalKey: "aggregate" }))
+      .toBe("aggregate");
   });
 });
 

--- a/apps/worker/test/scheduled-tasks-common.test.ts
+++ b/apps/worker/test/scheduled-tasks-common.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionStatus } from "@opengeni/contracts";
+import { assertReusableSessionRevivable } from "../src/activities/common";
+
+describe("reusable session revival guard (cancelled-resurrection)", () => {
+  test("refuses to revive a cancelled (terminal) reusable session", () => {
+    // The one terminal state: an explicit user cancel. A scheduled fire must not
+    // silently resurrect and re-bill it.
+    expect(() => assertReusableSessionRevivable("cancelled")).toThrow(/cancelled/i);
+  });
+
+  test("allows revivable states so a recurring task keeps working", () => {
+    // Failed/idle stay revivable (talking to a session is how it resumes), and
+    // an actively-running/queued session is signalled, not blocked.
+    const revivable: SessionStatus[] = ["queued", "running", "idle", "requires_action", "failed"];
+    for (const status of revivable) {
+      expect(() => assertReusableSessionRevivable(status)).not.toThrow();
+    }
+  });
+
+  test("mirrors the API guard's terminal set exactly (only cancelled is rejected)", () => {
+    // Keep parity with apps/api/src/domain/sessions.ts: cancelled is the SOLE
+    // rejected state. If a future status is added, this test forces a conscious
+    // decision rather than silently widening or narrowing the guard.
+    const all: SessionStatus[] = ["queued", "running", "idle", "requires_action", "failed", "cancelled"];
+    const rejected = all.filter((status) => {
+      try {
+        assertReusableSessionRevivable(status);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+    expect(rejected).toEqual(["cancelled"]);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -862,6 +862,16 @@ export const UpdateScheduledTaskRequest = z.object({
 });
 export type UpdateScheduledTaskRequest = z.infer<typeof UpdateScheduledTaskRequest>;
 
+/**
+ * Manual-trigger body. `triggerId` is a client-supplied idempotency token: a
+ * retried trigger that reuses the same token charges once and starts one run.
+ * Omitting it makes each call a distinct trigger (the server mints a token).
+ */
+export const TriggerScheduledTaskRequest = z.object({
+  triggerId: z.string().min(1).max(128).optional(),
+});
+export type TriggerScheduledTaskRequest = z.infer<typeof TriggerScheduledTaskRequest>;
+
 export const CapabilityPackConnectorAuthModel = z.enum([
   "oauth2_authorization_code_pkce",
   "oauth2_authorization_code",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -439,9 +439,17 @@ export class OpenGeniClient {
     return await this.requestJson<ScheduledTask>("POST", `/v1/workspaces/${workspaceId}/scheduled-tasks/${taskId}/resume`);
   }
 
-  /** Fire the task immediately (manual trigger), independent of its schedule. */
-  async triggerScheduledTask(workspaceId: string, taskId: string): Promise<ScheduledTask> {
-    return await this.requestJson<ScheduledTask>("POST", `/v1/workspaces/${workspaceId}/scheduled-tasks/${taskId}/trigger`);
+  /**
+   * Fire the task immediately (manual trigger), independent of its schedule.
+   * Pass a stable `triggerId` to make a retried trigger idempotent — the same
+   * token charges once and starts one run. Omit it and each call is distinct.
+   */
+  async triggerScheduledTask(workspaceId: string, taskId: string, options: { triggerId?: string } = {}): Promise<ScheduledTask> {
+    return await this.requestJson<ScheduledTask>(
+      "POST",
+      `/v1/workspaces/${workspaceId}/scheduled-tasks/${taskId}/trigger`,
+      options.triggerId ? { triggerId: options.triggerId } : undefined,
+    );
   }
 
   async deleteScheduledTask(workspaceId: string, taskId: string): Promise<void> {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1728,6 +1728,100 @@ describe("API component integration", () => {
     expect((await listed.json() as Array<{ id: string }>).some((item) => item.id === task.id)).toBe(true);
   });
 
+  test("a retried manual trigger (same triggerId) charges once and starts one run", async () => {
+    const workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const created = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
+      method: "POST",
+      body: JSON.stringify({
+        name: "idempotent",
+        schedule: { type: "interval", everySeconds: 3600 },
+        runMode: "new_session_per_run",
+        overlapPolicy: "allow_concurrent",
+        agentConfig: { prompt: "inspect", resources: [], tools: [] },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(created.status).toBe(201);
+    const task = await created.json() as { id: string };
+
+    const triggerWith = async (triggerId: string) =>
+      await app.request(workspacePath(workspaceId, `/scheduled-tasks/${task.id}/trigger`), {
+        method: "POST",
+        body: JSON.stringify({ triggerId }),
+        headers: { "content-type": "application/json" },
+      });
+
+    // The client retries the SAME logical trigger (a network blip re-POSTs with
+    // the same idempotency token). Both reach the handler.
+    const first = await triggerWith("retry-token-1");
+    const second = await triggerWith("retry-token-1");
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+
+    // Both calls derive the SAME usage idempotency key AND the SAME workflowId
+    // from the shared token, so the charge dedupes and the duplicate workflow
+    // start collapses (deterministic id + REJECT_DUPLICATE at the worker).
+    const triggers = workflow.triggers as Array<{ agentRunUsageIdempotencyKey?: string; triggerWorkflowId?: string }>;
+    expect(triggers).toHaveLength(2);
+    expect(triggers[0]?.agentRunUsageIdempotencyKey).toBe(triggers[1]?.agentRunUsageIdempotencyKey);
+    expect(triggers[0]?.triggerWorkflowId).toBe(triggers[1]?.triggerWorkflowId);
+    expect(triggers[0]?.agentRunUsageIdempotencyKey).toContain("retry-token-1");
+    expect(triggers[0]?.triggerWorkflowId).toContain("retry-token-1");
+
+    // Exactly ONE agent_run.created usage row exists for this token despite two
+    // POSTs (idempotency-key dedup in recordWorkspaceUsage).
+    const usage = await listUsageEvents(dbClient.db, { accountId: (await getScheduledTask(dbClient.db, workspaceId, task.id))!.accountId, workspaceId });
+    const charged = usage.filter((event) => event.idempotencyKey === triggers[0]?.agentRunUsageIdempotencyKey);
+    expect(charged).toHaveLength(1);
+
+    // A DIFFERENT token is a genuinely distinct trigger: new key, new run, a
+    // second charge.
+    const third = await triggerWith("retry-token-2");
+    expect(third.status).toBe(202);
+    const allTriggers = workflow.triggers as Array<{ agentRunUsageIdempotencyKey?: string; triggerWorkflowId?: string }>;
+    expect(allTriggers[2]?.agentRunUsageIdempotencyKey).not.toBe(triggers[0]?.agentRunUsageIdempotencyKey);
+    expect(allTriggers[2]?.triggerWorkflowId).not.toBe(triggers[0]?.triggerWorkflowId);
+  });
+
+  test("a manual trigger without a triggerId stays a distinct run each time", async () => {
+    const workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const created = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
+      method: "POST",
+      body: JSON.stringify({
+        name: "anon-trigger",
+        schedule: { type: "interval", everySeconds: 3600 },
+        runMode: "new_session_per_run",
+        overlapPolicy: "allow_concurrent",
+        agentConfig: { prompt: "inspect", resources: [], tools: [] },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    const task = await created.json() as { id: string };
+
+    // A bare POST (no body) is still a valid, distinct trigger.
+    const a = await app.request(workspacePath(workspaceId, `/scheduled-tasks/${task.id}/trigger`), { method: "POST" });
+    const b = await app.request(workspacePath(workspaceId, `/scheduled-tasks/${task.id}/trigger`), { method: "POST" });
+    expect(a.status).toBe(202);
+    expect(b.status).toBe(202);
+    const triggers = workflow.triggers as Array<{ agentRunUsageIdempotencyKey?: string; triggerWorkflowId?: string }>;
+    expect(triggers[0]?.agentRunUsageIdempotencyKey).not.toBe(triggers[1]?.agentRunUsageIdempotencyKey);
+    expect(triggers[0]?.triggerWorkflowId).not.toBe(triggers[1]?.triggerWorkflowId);
+  });
+
   test("does not record manual scheduled trigger usage when workflow start fails", async () => {
     workflow = new FakeWorkflowClient();
     workflow.triggerError = new Error("temporal trigger unavailable");

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2046,6 +2046,58 @@ describe("worker activities integration", () => {
     expect(runs[0]?.status).toBe("failed");
   });
 
+  test("refuses to revive a cancelled reusable session on the next fire", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "reusable",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    // The user explicitly cancelled this reusable session (the one terminal
+    // state). The next scheduled fire must NOT resurrect and re-bill it.
+    await setSessionStatus(dbClient.db, grant.workspaceId, session.id, "cancelled", null);
+    const beforeEvents = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    const task = await createOwnedScheduledTask(dbClient.db, grant, {
+      name: "cancelled reusable",
+      status: "active",
+      schedule: { type: "interval", everySeconds: 3600 },
+      temporalScheduleId: `scheduled-task-${crypto.randomUUID()}`,
+      runMode: "reusable_session",
+      overlapPolicy: "allow_concurrent",
+      agentConfig: { prompt: "follow up", resources: [], tools: [], metadata: {} },
+      metadata: {},
+    });
+    await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, { reusableSessionId: session.id });
+    const activities = createActivities({
+      settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
+      db: dbClient.db,
+      bus,
+      runtime: createProductionAgentRuntime({ model: new ScriptedModel([{ outputText: "ok" }]) }),
+    });
+
+    await expect(activities.dispatchScheduledTaskRun({
+      workspaceId: grant.workspaceId,
+      taskId: task.id,
+      triggerType: "scheduled",
+    })).rejects.toThrow(/cancelled/i);
+
+    // Nothing was appended to the cancelled session: no new user.message, no
+    // turn queued, and the session stays cancelled (not revived to queued).
+    const afterEvents = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
+    expect(afterEvents.length).toBe(beforeEvents.length);
+    expect(afterEvents.filter((event) => event.type === "user.message")).toHaveLength(0);
+    expect(afterEvents.filter((event) => event.type === "turn.queued")).toHaveLength(0);
+    const revived = await getSession(dbClient.db, grant.workspaceId, session.id);
+    expect(revived?.status).toBe("cancelled");
+    const queuedTurns = await listSessionTurns(dbClient.db, grant.workspaceId, session.id, 50);
+    expect(queuedTurns.filter((turn) => turn.status === "queued")).toHaveLength(0);
+    // The run is recorded as failed, not dispatched.
+    const runs = await listScheduledTaskRuns(dbClient.db, grant.workspaceId, task.id);
+    expect(runs[0]?.status).toBe("failed");
+  });
+
   test("synthesizes billed goal continuation turns and auto-pauses on no progress", async () => {
     const grant = await testGrant(dbClient.db);
     const session = await createOwnedSession(dbClient.db, grant, {


### PR DESCRIPTION
Fixes three confirmed scheduled-task + per-call-usage bugs (verified against `file:line` before fixing). Each ships with tests; full local gate is green.

## (3) MAJOR — reusable_session scheduled task resurrected a CANCELLED session
`apps/worker/src/activities/scheduled-tasks.ts` only null-checked `requireSession`, and its locked update set `{resources, tools}` without inspecting `locked.status`. A user-cancelled (terminal) session got a fresh `user.message` + queued turn and was signalled/restarted → revived and re-billed on the next fire.

**Fix:** mirror the canonical API guard (`apps/api/src/domain/sessions.ts:209-211` — "cancelled is the one terminal state"). A pure `assertReusableSessionRevivable(status)` helper refuses only `cancelled` (failed/idle stay revivable). Called as an early check after `requireSession` (avoids the pre-lock goal-upsert side-effect) and authoritatively **inside the FOR UPDATE locked-update callback** (closes the read-vs-lock TOCTOU; throwing aborts the whole append+enqueue transaction). The existing dispatch catch records the `scheduled_task_run` as `failed`.

## (4) MAJOR — manual trigger idempotency key embedded a fresh UUID → double-charge + double-spawn
The trigger idempotency key and the Temporal workflowId each embedded `crypto.randomUUID()` per request (`routes/scheduled-tasks.ts`, `mcp/server.ts`, `index.ts`), so a retried trigger never collided.

**Fix:** derive both from a **stable trigger token**. The REST and MCP trigger endpoints accept an optional client-supplied `triggerId` (new `TriggerScheduledTaskRequest` contract; SDK `triggerScheduledTask` gains `options.triggerId`). `scheduledTaskTriggerToken` sanitizes it to the workflow-id-safe charset (or mints one UUID per request when absent, so distinct triggers stay distinct). `manualScheduledTaskTriggerUsageKey` and `manualScheduledTaskTriggerWorkflowId` derive the charge key and workflowId from the **same** token, and the worker-trigger start now uses `workflowIdReusePolicy: REJECT_DUPLICATE` with the duplicate-start error swallowed as an idempotent no-op. A retry with the same token → **one charge, one run**.

## (5) MINOR/billing — positional usage sourceKey collided on re-dispatch → undercharge
`apps/worker/src/activities/agent-turn.ts` fell back to a positional sourceKey (`response-N` / `aggregate`) when the provider omitted a `responseId`. Since the idempotency key is `usage:model.tokens:${turnId}:${sourceKey}` and `turnId` is stable across a re-dispatch of the same turn, dispatch B's first call reused dispatch A's `response-1` key and its charge was silently dropped.

**Fix:** a pure `modelUsageSourceKey` helper uses a real `responseId` verbatim (so a true activity retry still dedupes) and qualifies the positional fallback with the per-execution dispatch id (Temporal `activityId`, unique per scheduled execution) — re-dispatched calls become distinct while a same-execution retry still dedupes.

## Tests
- `apps/worker/test/scheduled-tasks-common.test.ts` — revival guard rejects only `cancelled`, mirrors the API terminal set exactly.
- `test/integration/worker-activity.integration.ts` — a cancelled reusable session is NOT revived on the next fire (no `user.message`, no queued turn, status stays `cancelled`, run recorded `failed`).
- `apps/api/test/scheduled-task-trigger.test.ts` — same `triggerId` → same usage key + workflowId; absent/blank → distinct; client token sanitized + clamped.
- `test/integration/api.integration.ts` — a retried trigger (same `triggerId`) charges once (one usage row) and yields one workflowId; a different/absent `triggerId` stays a distinct run.
- `apps/worker/test/agent-turn.test.ts` — `modelUsageSourceKey` keeps a `responseId` verbatim, makes the positional fallback unique per dispatch (`response-N` and `aggregate`), and still dedupes within one dispatch.

Local gate green: full typecheck (16 packages/apps), worker + api + sdk + contracts + db + runtime unit tests, the two touched integration suites (api 66/66, worker-activity 54/54), and sdk/react/demo/web builds. gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing idempotency, Temporal workflow starts, and scheduled reusable-session dispatch—high-impact paths—but behavior is narrowly scoped with extensive unit and integration tests.
> 
> **Overview**
> This PR tightens **scheduled-task and billing integrity** in three areas.
> 
> **Manual triggers** can pass an optional **`triggerId`** (REST, MCP, SDK, `TriggerScheduledTaskRequest`). The server derives a sanitized **trigger token** and uses it for both the **`agent_run.created` idempotency key** and the **Temporal workflow id**; starts use **`REJECT_DUPLICATE`**, with duplicate starts treated as a no-op. Retries with the same token → **one charge, one run**; omitting `triggerId` still mints a fresh token per request so distinct triggers stay separate.
> 
> **Reusable-session scheduled fires** no longer revive **`cancelled`** sessions: `assertReusableSessionRevivable` mirrors the API rule (only `cancelled` is terminal), checked before side effects and again **inside the `FOR UPDATE` session update** so a cancel in between cannot append a `user.message` or queue a turn; the run is recorded **failed**.
> 
> **Per-call model token usage** when the provider omits `responseId` now keys charges with **`modelUsageSourceKey`**, qualifying positional fallbacks (`response-N`, `aggregate`) with the Temporal **`activityId`** so a **re-dispatched** turn does not reuse the prior dispatch’s keys and **undercharge**; same-execution retries still dedupe when `responseId` or the same `activityId` is reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83007db87bf6320cb6726cc701a1363dd1243eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->