### PR TITLE
docs: long-lived manager-session robustness (self-heal, byte-cap, no-poll, interrupt)

### DIFF
--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -132,16 +132,91 @@ That is the entire platform path. No DB writes, no synthetic summary, no
 This is the substantive new machinery. It runs **pre-turn**, before the model
 call, when the resolved mode is `client`.
 
-### Trigger
+### Trigger (self-heal: `max(recorded, estimate)`)
 
-The signal is the **last turn's actual `inputTokens`** (recorded on
-`sessions.last_input_tokens` at the end of each turn from the response usage —
-see `agent-turn.ts` `setSessionLastInputTokens`). When that is unavailable (a
-brand-new session), the planner falls back to a char/4 estimate over the active
-items. Compaction fires when the signal reaches `softFraction × B`
-(≈ 645k with defaults); `hardFraction × B` (≈ 784k) is the hard-force point.
-Both are config-driven; in the current planner both simply mean "compact now"
-(the distinction exists for logging/tuning headroom).
+The trigger signal is
+**`signalTokens = max(recorded last-turn input tokens, char/4 estimate of the
+active items)`** — see `planCompaction` in `context-compaction.ts`. Compaction
+fires when `signalTokens ≥ softFraction × B` (≈ 645,400 with defaults);
+`hardFraction × B` (≈ 783,700 = `floor(922,000 × 0.85)`) is the hard-force point
+(see below — it now has distinct behavior).
+
+The **`max`** matters and is a deliberate self-heal fix. `sessions.last_input_tokens`
+is written **only** when a model response reports usage (`agent-turn.ts`,
+guarded by `lastInputTokensObserved !== null` at the end of a turn). A turn that
+**overflows on its first model call observes no usage at all**, so the column
+keeps a **stale-positive** value from the last good turn (e.g. ~600k). The old
+planner *trusted* that recorded count whenever it was positive and only
+estimated from the real history when it was null — so a stale-low 600k slipped
+under the 645k soft limit, no compaction ran, the actually-over-budget history
+(>1.05M) was sent, and the turn overflowed **again**: a permanent re-brick with
+no self-heal. Reachable in practice (e.g. a manager paging a worker's large
+event stream balloons the history in one turn). Taking the **max** of the
+recorded count and a fresh estimate of the *actual* active items means a bloated
+history triggers compaction **regardless** of a stale recorded count, so the
+session self-heals on the very next turn.
+
+A brand-new session (no recorded count, small history) simply has a small
+estimate and does not compact — same outcome as before.
+
+### Hard-force backstop (`hardFraction × B`)
+
+`hardFraction` is **no longer informational** — it drives a distinct, more
+aggressive path. When `signalTokens ≥ hardFraction × B` the plan is marked
+`hardForced` and the boundary walk runs with a **shrunk keep-recent budget**:
+
+```
+effectiveKeepRecent = hardForced
+  ? min( floor(keepRecentTokens / 2), floor(B / 4) )
+  : keepRecentTokens
+```
+
+Why: the soft path keeps the full `contextKeepRecentTokens` (32k) tail verbatim.
+But under hard pressure — especially when the recorded count was stale-low and
+the *history itself* is over the window — a history whose entire tail still
+reads as "recent" (fits within `keepRecentTokens`) would find **no prefix to
+summarize** and strand the session over budget (the everything-is-recent
+deadlock). Shrinking the tail under hard pressure forces the boundary walk to
+leave a non-empty, summarizable prefix, so an over-budget history **always**
+yields a real compaction. The structural guards still apply: a hard-force never
+invents a cut that orphans a tool-call pair or summarizes an empty prefix.
+
+`maybeCompactContext` logs a `context compaction HARD-FORCED …` line and the
+emitted `session.context.compacted` event carries `trigger: "hard"` (vs
+`"operator"` for a `/compact`, vs unset for a normal soft compaction), so the
+hard path is observable.
+
+### Read-path budget guard (the airbag — last-resort backstop)
+
+Pre-turn compaction is **best-effort**: it can no-op (the summarizer model call
+fails, `client` mode is off, or a fresh user message arrives *after* a turn
+already ballooned the history) and still leave an assembled input that exceeds
+the window. The #61 orphan sanitizer is purely **structural** — it has no size
+awareness — so without a size backstop an over-budget input would be put on the
+wire and 400 every turn, re-bricking the session.
+
+`enforceInputBudget` (in `context-compaction.ts`) is that backstop. It runs at
+**input-assembly time** in `prepareRunInput` (`packages/runtime/src/index.ts`,
+via `guardAssembledInput`) and drops the **oldest** history at a clean turn
+boundary until the estimated request fits `B`, **always** keeping the most
+recent turn(s). It is:
+
+- **Orphan-safe by construction** — it only ever cuts at the start of a user
+  message (via `findKeepBoundary`), so no tool-call pair is split; a boundary of
+  0 (no earlier safe cut) leaves the input unchanged rather than orphaning a pair.
+- **Whole-request aware** — the trailing user/continuation message and fixed
+  system/tool overhead are counted (`trailingTokens`) so the cap is measured
+  against the *whole* request, not just the stored history.
+- **A crude data-loss fallback** — it generates **no** summary; real context
+  preservation is the summarizing pre-turn path. This is the airbag, not the
+  seatbelt. When it trims it logs
+  `read-path budget guard trimmed N oldest history item(s) … the over-budget
+  input was NOT sent`.
+
+It is wired **only on the Azure client path** (`readPathBudgetTokens` returns a
+budget only when `resolveContextCompactionMode(settings) === "client"`); on the
+server path the SDK enforces the window. So in production (Azure) a single
+over-budget assembled input can never reach the model.
 
 ### Boundary rule (orphan safety — critical)
 
@@ -309,12 +384,26 @@ SELECT id, last_input_tokens FROM sessions WHERE last_input_tokens IS NOT NULL;
   summarized prefix is **superseded not deleted** (the audit rows remain), that
   exactly one summary row exists, that no real row is overwritten, and that the
   summary is recorded under the current turn so per-turn counts stay correct.
-- **Deploy state (re-read live):** staging `/healthz` reports
-  `deploymentRevision = 0b8f8c08…`, `ok: true`. Staging and production AKS
-  `opengeni-api`/`-web`/`-worker` deployments all run the
-  `…-0b8f8c08a61b9cb3bff950effdb0a1e7c360bdce-…` image. The schema migration is
-  applied on the staging DB (verified live: `session_history_items.position` is
-  `numeric`, `.active` is `boolean`, `sessions.last_input_tokens` exists).
+- **Self-heal + hard-force (PR #69):** the `max(recorded, estimate)` trigger and
+  the hard-force / read-path-guard backstops were added in PR #69
+  (`cc17837`). Their unit coverage lives in
+  `packages/runtime/test/context-compaction.test.ts` and proves the two
+  regressions this doc calls out: a **stale-positive `last_input_tokens` + an
+  over-budget history MUST compact** (the `max` defeats the stale-low count), and
+  a **post-overflow session self-heals on the next turn**; plus the hard-force
+  shrunk-tail prefix guarantee and `enforceInputBudget`'s orphan-safe oldest-drop.
+- **Deploy state (re-read live 2026-06-14):** staging **and** production
+  `/healthz` both report
+  `deploymentRevision = 21315832b6cd92ec78ea6da677eb3b766a943d66`, `ok: true` —
+  the HEAD of `origin/main`, which includes PR #69 (self-heal + hard-force), #68
+  (session-read byte cap), and #70 (interrupt fix). The full ops pipeline
+  (Build Staging Artifacts → Deploy Staging → Promote Production Artifacts →
+  Deploy Production) ran green at 12:39–12:57Z on 2026-06-14, all after the
+  merges. (The staging DB is a **private** Azure endpoint not reachable from the
+  authoring environment, and no AKS/Azure credentials were available to spin up
+  an in-cluster probe pod, so a direct readback of `session_history_items`
+  column types / live summary rows was **not** re-performed in this pass — see
+  residual gaps.)
 - **Earlier live proof (point-in-time, from the shipping run):** a real Azure
   staging session exercised the deployed client-side path and cut model input
   ~377k → ~29k tokens (~92%), creating a summary, superseding (not deleting) the
@@ -323,22 +412,25 @@ SELECT id, last_input_tokens FROM sessions WHERE last_input_tokens IS NOT NULL;
 
 ## Residual gaps and caveats (read this)
 
-- **No live compaction event is currently re-confirmable on staging.** At the
-  time of writing, a fresh staging DB read shows **0** superseded rows, **0**
-  summary items, **0** fractional positions, and **0** sessions with
-  `last_input_tokens` set — because the latest session activity on staging
-  (≈ 07:22Z) predates the #62 deploy (≈ 08:31Z): **no agent turn has run through
-  the new code path on staging since it went live**, and the earlier 377k→29k
-  test session's rows are no longer present (cleaned). The schema is live and the
-  logic is proven by the integration test against a real DB, but the specific
-  "it fired in production traffic" claim rests on the earlier point-in-time run,
-  not on a current readback. The first long staging/prod session to cross the
-  soft threshold will be the live confirmation; watch for `session.context.compacted`
-  events and superseded rows.
-- **`hardFraction` is currently informational.** Soft and hard thresholds both
-  resolve to "compact now" in the planner; there is no distinct hard-force
-  behavior (e.g. a more aggressive tail trim) yet. If a single turn's growth ever
-  outpaces the soft trigger, this is where to add it.
+- **No live compaction *firing* has been re-confirmed by a current DB readback.**
+  The deployed revision is confirmed live (staging+prod `/healthz` = `21315832`),
+  the trigger column `sessions.last_input_tokens` is written by the deployed
+  worker, and the `session.context.compacted` event type is in the contract and
+  emitted by `agent-turn.ts`. But the staging DB is a **private Azure endpoint**
+  and this authoring pass had **no AKS/Azure credentials** to open an in-cluster
+  `psql` probe, so the "a real session crossed the soft threshold and produced a
+  summary row" claim still rests on the **earlier point-in-time shipping run**
+  (377k→29k), not on a fresh readback. The compaction logic is proven by the
+  real-Postgres integration test and the unit suite. The first long staging/prod
+  session to cross ~645k tokens is the live confirmation; watch for
+  `session.context.compacted` events (now carrying `trigger`) and superseded
+  (`active = false`) rows.
+- **~~`hardFraction` is currently informational.~~ FIXED (PR #69).** Hard force
+  now shrinks the keep-recent tail so an over-budget history always yields a
+  summarizable prefix, and the read-path `enforceInputBudget` guard ensures a
+  single over-budget assembled input is never sent. The stale-positive
+  `last_input_tokens` re-brick is closed by the `max(recorded, estimate)`
+  trigger. See "Hard-force backstop" and "Read-path budget guard" above.
 - **Summarizer cost/latency.** Each client-side compaction is an extra model
   call (≤ `contextSummaryMaxTokens` output). On a busy long session this recurs;
   it is bounded by the single-live-summary fold-forward but is not free. Monitor
@@ -361,11 +453,22 @@ capability (so no more 400s), and a pre-turn client-side compaction summarizes
 the old prefix into a single plain user message at an orphan-safe turn boundary,
 supersedes (never deletes) the prefix, and assembles a bounded
 `[summary, …recent tail]` read path — so history can no longer grow without
-bound. Server-side compaction is **preserved and used** automatically on the
+bound. **The two self-heal holes are closed (PR #69):** the
+`max(recorded, estimate)` trigger defeats the stale-positive `last_input_tokens`
+re-brick, the hard-force path shrinks the keep-recent tail so an over-budget
+history always yields a summarizable prefix, and the `enforceInputBudget`
+read-path guard guarantees a single over-budget assembled input is never put on
+the wire. Server-side compaction is **preserved and used** automatically on the
 OpenAI platform (correct 645,400 threshold, `store: false`), with no
-client-side double-compaction. The code is merged (`0b8f8c0`, PR #62, with the
-audit-trail fix #63 folded in), deployed to staging and production, and
-schema-migrated live. The one honest caveat is that **the live firing has not
-been re-confirmed by a current readback** (no post-deploy traffic has crossed
-the threshold on staging yet); the mechanism itself is proven by the
-real-database integration test and the earlier point-in-time live run.
+client-side double-compaction. The code is merged (PR #62 + audit-trail fix #63
++ self-heal/hard-force #69), deployed to staging **and** production
+(`/healthz` = `21315832`, re-read live 2026-06-14), and schema-migrated. The one
+honest caveat is that **the live compaction *firing* has not been re-confirmed
+by a current DB readback** this pass (the staging DB is a private endpoint and no
+in-cluster probe was available); the mechanism is proven by the real-database
+integration test, the unit suite, and the earlier point-in-time live run.
+
+> The compaction self-heal is one of four manager-session robustness fixes.
+> For the whole picture — session-read byte caps, the don't-poll doctrine, and
+> the `user.interrupt` fix — and the cross-cutting executive verdict, see
+> [`manager-session-robustness.md`](./manager-session-robustness.md).

--- a/docs/manager-session-robustness.md
+++ b/docs/manager-session-robustness.md
@@ -1,0 +1,238 @@
+# Long-lived manager-session robustness
+
+OpenGeni's defining workload is the **long-lived "manager" session**: a
+per-customer ops channel that lives for **weeks**, spawning and monitoring
+short-lived **worker** sessions. A manager that bricks takes the whole customer
+relationship down with it, silently, days into a run. This document is the
+single place that explains the four failure modes that could brick or stall such
+a session and how each is now fixed — with how each fix is verified, honestly,
+including what was **not** re-confirmed.
+
+Code and the per-area docs win over this summary. Cross-references:
+
+- Compaction internals: [`context-compaction.md`](./context-compaction.md).
+- Parent wakeup on worker completion: `apps/worker/src/activities/parent-wake.ts`.
+- Session-read byte caps: `apps/api/src/mcp/session-view.ts`.
+- Interrupt control path: `apps/api/src/index.ts` (`signalInterrupt`),
+  `apps/api/src/routes/sessions.ts` (events route),
+  `apps/worker/src/workflows/session.ts` (the `interrupt` signal).
+
+## The four failure modes and their fixes
+
+| # | Failure mode | Symptom if unfixed | Fix | Shipped |
+| - | ------------ | ------------------ | --- | ------- |
+| 1 | **Unbounded overflow + re-brick** | History grows past the window; a turn that overflows records no usage, leaving a stale-low `last_input_tokens` → next pre-turn check doesn't compact → overflows again → permanent brick | `max(recorded, estimate)` trigger + hard-force shrunk tail + read-path budget guard | PR #69 (`cc17837`) |
+| 2 | **Worker-monitoring bloat** ("parent ingests child") | A manager paging a worker's event stream piles 100k+ chars into its own context in one turn | Byte/token cap on the cross-session MCP read tools + the don't-busy-poll doctrine | PR #68 (`730eda5`) + Geni Pack 0.4.3 |
+| 3 | **Un-cancellable runaway turn** | `POST {type:"user.interrupt"}` to an idle/closed-workflow session 500s → operator cannot stop a looping turn | `signalInterrupt` uses `signalWithStart` (start-or-signal) instead of `getHandle().signal()` | PR #70 (`2131583`) |
+| 4 | **Single over-budget input** (backstop for #1) | Pre-turn compaction no-ops and an over-budget assembled input is still sent → 400 every turn | Hard-force path + `enforceInputBudget` read-path airbag | PR #69 (`cc17837`) |
+
+All three PRs are merged to `origin/main` and **deployed to staging and
+production** — both `/healthz` endpoints report
+`deploymentRevision = 21315832b6cd92ec78ea6da677eb3b766a943d66` (the HEAD of
+`origin/main`), re-read live on 2026-06-14.
+
+---
+
+## 1 + 4. Compaction self-heal and the over-budget backstop
+
+Full detail is in [`context-compaction.md`](./context-compaction.md); the
+robustness-critical parts:
+
+- **`max(recorded, estimate)` trigger.** The pre-turn compaction decision uses
+  `signalTokens = max(recorded last-turn input tokens, char/4 estimate of the
+  active history)`. `sessions.last_input_tokens` is written **only** when a model
+  response reports usage; a turn that **overflows on its first model call**
+  records nothing, so the column keeps a **stale-positive** value (e.g. ~600k)
+  from the last good turn. The old code *trusted* that stale-low number, slipped
+  under the 645k soft limit, did **not** compact, and overflowed again — a
+  permanent re-brick. Taking the **max** against a fresh estimate of the real
+  history makes a bloated history compact regardless of the stale count, so the
+  session **self-heals on the next turn**.
+- **Hard-force path (`hardFraction × B`).** Previously `hardFraction` was
+  informational. Now, at/over the hard ceiling, the boundary walk runs with a
+  **shrunk keep-recent budget** (`min(keepRecent/2, B/4)`) so an over-budget
+  history whose whole tail reads as "recent" still leaves a non-empty,
+  summarizable prefix instead of stranding the session. The
+  `session.context.compacted` event carries `trigger: "hard"` for observability.
+- **Read-path budget guard (`enforceInputBudget`).** The airbag. At input
+  assembly time (`prepareRunInput`), if the assembled request still exceeds `B`
+  (compaction no-op'd, summarizer failed, or a fresh message arrived after a turn
+  ballooned the history), the **oldest** history is dropped at a clean
+  user-message turn boundary — orphan-safe by construction — until it fits,
+  **always** keeping the most recent turn(s). Wired only on the Azure client path
+  (production). It is a crude data-loss fallback (no summary), so a single
+  over-budget input can never reach the model.
+
+**Verified:**
+- Unit suite `packages/runtime/test/context-compaction.test.ts` is green and
+  covers the two regressions explicitly: stale-positive `last_input_tokens` +
+  over-budget history MUST compact, and a post-overflow session self-heals; plus
+  the hard-force shrunk-tail prefix guarantee and `enforceInputBudget`'s
+  orphan-safe oldest-drop. `bun run typecheck` green; the compaction +
+  session-view + api unit files re-run green this pass (`78 pass` /
+  `19 pass` / etc., 0 fail).
+- Deployed revision confirmed live on staging+prod (`/healthz` = `21315832`).
+- **Not re-confirmed this pass:** a live compaction *firing* against the staging
+  DB. The staging Postgres is a **private Azure endpoint** and this pass had no
+  AKS/Azure credentials to open an in-cluster `psql` probe pod, so the
+  "a real session crossed ~645k and produced a summary row" claim still rests on
+  the **earlier point-in-time shipping run** (377k→29k tokens), not a fresh
+  readback. The mechanism is proven by the real-Postgres integration test and
+  the unit suite.
+
+## 2a. Session-read byte cap (platform)
+
+A manager monitors a worker by reading the worker's event timeline over the
+first-party MCP. A worker's events carry **verbatim** model output and, worse,
+verbatim **tool outputs** and raw tool-call items — sized for the *worker's* own
+context, not the manager's. The DB `limit` caps event **count, not bytes**, so a
+single `session_events` page can be tens of thousands of characters, and a
+manager paging a busy worker piles **hundreds of thousands** of characters into
+its own context in one monitoring turn. That is the "parent ingests child"
+blow-up that bricks the manager.
+
+`apps/api/src/mcp/session-view.ts` adds a pure, dependency-free cap, wired into
+the two cross-session read MCP tools in `apps/api/src/mcp/server.ts`:
+
+- **`session_events`** — two stages. (1) **Per-event field trim**: recursively
+  clamp any over-long string / over-large nested blob to a per-field budget
+  (`2,000` chars) with a head+tail `…N chars truncated…` marker; type-agnostic,
+  so a new fat event type is capped automatically. (2) **Head+tail page budget**:
+  if the per-event-trimmed page still exceeds the token budget (`~10,000`), keep
+  the oldest `headEvents` + newest `tailEvents` (8 each) and drop the middle
+  behind **one synthetic marker event** (typed `session.status.changed` so it
+  still validates against the `SessionEvent` contract; payload carries
+  `droppedCount`, the omitted sequence range, and how to page the gap or read the
+  notebook). **Pagination is preserved**: `nextAfter` is the real highest
+  `sequence` the DB returned, so the next page starts exactly where this one
+  ended and never skips real events.
+- **`session_get`** — clamps the only unbounded agent-controlled fields
+  (`metadata`, and defensively `initialMessage`) to `~6,000` chars.
+
+**REST routes and worker/UI consumers are untouched** — they call the DB
+functions directly. Only the MCP tool result a *manager model* reads is shaped.
+
+**Verified:**
+- Unit suite `apps/api/test/session-view.test.ts` green (`19 pass / 0 fail`):
+  string/nested/tiny-field/cyclic trimming, empty/small/over-budget pages,
+  monotonic sequences, contract-validity of the capped page, no input mutation,
+  and session-detail clamping.
+- **Live on deployed staging (revision `21315832`):** through the first-party
+  MCP endpoint (`POST /v1/workspaces/:ws/mcp`, `tools/call session_get`) against
+  a throwaway session created with a **50,000-char** `metadata.huge` field, the
+  raw REST `session_get` returned the full 50,000 chars (uncapped, by design)
+  while the **MCP** `session_get` returned the same field clamped to **6,117
+  chars** with the `…chars truncated…` marker present — the cap demonstrably
+  fires live on the path a manager actually reads.
+- The `session_events` head+tail page-drop was exercised live against a real
+  ~100-event session, but that session's events were genuinely small (~8.3k
+  tokens, under the 10k budget) so the page correctly returned **un-trimmed** —
+  the cap only fires when over budget. The over-budget drop is covered by the
+  unit suite.
+
+## 2b. Don't-busy-poll doctrine (Geni pack — private repo)
+
+The platform cap bounds the blast radius, but the manager should not be paging a
+worker on a poll loop in the first place. opengeni **#60** auto-wakes the parent
+session when a spawned worker reaches a terminal-for-now state (`idle` or
+`failed`) — see `apps/worker/src/activities/parent-wake.ts`
+(`notifyParentOfChildTerminal`, idempotent per terminal episode via the child's
+`lastSequence`). So the manager should **spawn, then go idle and await the
+wakeup**, not busy-poll; when it does need a status glance it uses a **single
+bounded check**, not a poll loop.
+
+That behavioral doctrine lives in the **private** Geni pack
+(`skills/geni-manager` §2 Orchestration), not in this OSS repo. It is shipped on
+Geni `origin/main` as **Pack 0.4.3** (PR #20, commit `5ce7354`): the monitor
+guidance now reads "await completion by going idle — do not busy-poll", aligned
+with the shipped wakeup. No content from the private pack is reproduced here.
+
+## 3. `user.interrupt` cleanly cancels a running turn
+
+`POST {type:"user.interrupt"}` to
+`/v1/workspaces/:ws/sessions/:sid/events` is the operator's stop button for a
+runaway or looping turn. It was returning **500**.
+
+**Root cause:** `signalInterrupt` used
+`temporal.workflow.getHandle(workflowId).signal("interrupt", …)`. When the
+session workflow has gone **idle/closed** (it returned after `markSessionIdle`,
+so there is **no running execution**), `getHandle().signal()` throws
+`WorkflowNotFoundError`, which surfaced as a 500 — leaving an operator unable to
+stop a session that was running-then-idle, or looping in a way that closed and
+reopened the workflow.
+
+**Fix (PR #70):** make `signalInterrupt` use
+`temporal.workflow.signalWithStart("sessionWorkflow", …)` — exactly mirroring
+`wakeSessionWorkflow`. It delivers the `interrupt` signal to a live execution
+when one exists, and otherwise **starts** a fresh `sessionWorkflow` that
+immediately honors the buffered `interrupt` via the workflow's idle-interrupt
+path (`pauseGoalForInterrupt` + `markSessionIdle`). This required threading
+`accountId`/`workspaceId` (the `sessionWorkflow` args) into `signalInterrupt`;
+the events route already holds both on the access grant. The route stays
+**permission-gated on `sessions:control`**.
+
+When a turn **is** active, the workflow races the turn against
+`condition(() => interruptedEventId !== null)`; on interrupt it `scope.cancel()`s
+the turn and calls `interruptActiveTurn` — the runaway turn is cancelled.
+
+**Verified:**
+- Integration tests (`temporal-workflow.integration`, `api.integration`):
+  interrupt via `signalWithStart` against a **not-running** workflow starts it
+  and runs the idle-interrupt path; the events route hands `signalInterrupt` the
+  start-or-signal args and an interrupt on an idle session returns **202, not
+  500**; running-turn cancellation is covered by the existing active-run test.
+- **Live on deployed staging (revision `21315832`):** against a throwaway
+  session told to "count upward forever and never stop":
+  - `user.interrupt` **while the turn was actively counting** → **202**, and the
+    session settled to `status: idle` — the runaway turn was cancelled. (The
+    session's event sequence had advanced from ~7 to ~111, proving a real turn
+    ran and was then stopped.)
+  - `user.interrupt` **while the session was idle** (the exact 500-repro: no
+    running execution) → **202**, **not 500**. The start-or-signal path works on
+    the deployed image.
+
+---
+
+## Executive verdict
+
+**Long-lived manager sessions are now robust against all four named failure
+modes**, and the fixes are merged, deployed to staging **and** production
+(`/healthz` = `21315832`, re-read live), and — for the two externally
+observable ones — **live-verified on the deployed image**:
+
+| Failure mode | Verdict | Strength of evidence |
+| ------------ | ------- | -------------------- |
+| **Unbounded overflow / re-brick** | **Fixed** | Code + unit + real-Postgres integration; deployed. Live *firing* readback NOT re-done this pass (private DB, no probe access). |
+| **Worker-monitoring bloat** | **Fixed** | Platform cap: unit + **live MCP readback** (50k→6,117 char clamp on deployed staging). Doctrine: shipped on Geni Pack 0.4.3. |
+| **Un-cancellable runaway turn** | **Fixed** | Code + integration + **live readback** (202 not 500, idle and active; runaway turn cancelled) on deployed staging. |
+| **Single over-budget input** | **Fixed** | `enforceInputBudget` airbag, client-path-only, unit-covered; deployed. |
+
+### Residual gaps / unconverged findings (LOUD)
+
+- **Live compaction firing is NOT re-confirmed by a current DB readback.** The
+  staging Postgres is a private Azure endpoint and this pass had no AKS/Azure
+  credentials to open an in-cluster `psql` probe, so the "a real session crossed
+  ~645k tokens and produced a summary row" claim rests on the earlier
+  point-in-time shipping run, not a fresh readback. The deployed revision, the
+  `last_input_tokens` write, and the `session.context.compacted` emitter are all
+  confirmed present; the *firing* is the one unverified-this-pass link. **Watch
+  the first long staging/prod session that crosses the soft threshold** for a
+  `session.context.compacted` event (now carrying `trigger`) and superseded
+  (`active = false`) rows.
+- **`session_events` head+tail page-drop was not live-fired**, only the per-field
+  / page-drop unit tests plus a live call that was legitimately under budget (so
+  returned un-trimmed). To force a live page-drop, monitor a worker that emits
+  large tool outputs and confirm the synthetic `_truncated` marker event appears
+  with `nextAfter` still advancing.
+- **Review rounds did not converge with a live reviewer.** Per the shipping
+  record, both code-review rounds ended with "reviewer died"; the merges relied
+  on CI + Bugbot being green, not on a converged human/agent review. The four
+  fixes here were nonetheless independently re-verified against the merged code
+  and (for #2a and #3) against the deployed image in this pass.
+- **Server-side compaction path is unexercised in our production** (we run on
+  Azure). It is unit-tested and correct per the platform's GA contract; validate
+  live if/when OpenGeni moves to the OpenAI platform.
+- **Single-turn-overflow is out of scope.** A single tool result large enough to
+  overflow the window in one shot is bounded by `enforceInputBudget` (it drops
+  it if it sits in older history) and `contextReservedOutputTokens` headroom, but
+  a pathological single *current* item is not summarized away.


### PR DESCRIPTION
## What

Documents the four long-lived **manager-session** hardening fixes as one
coherent story and brings `docs/context-compaction.md` in line with the shipped
code (it still described the pre-#69 behavior).

- **New** `docs/manager-session-robustness.md` — umbrella doc: the four failure
  modes (unbounded overflow / re-brick, worker-monitoring bloat, un-cancellable
  runaway turn, single over-budget input), each fix, how each is verified, and a
  cross-cutting executive verdict with residual gaps called out loudly.
- **Updated** `docs/context-compaction.md`:
  - Trigger is now `max(recorded last_input_tokens, char/4 estimate)` — the
    self-heal that defeats the stale-positive `last_input_tokens` re-brick (a
    turn overflowing on its first model call records no usage).
  - New **Hard-force backstop** section (shrunk keep-recent tail so an
    over-budget history always yields a summarizable prefix; `trigger:"hard"`
    on the event).
  - New **Read-path budget guard** section (`enforceInputBudget` airbag, wired
    on the Azure client path in `prepareRunInput`).
  - Removed the now-false "hardFraction is informational" residual gap; refreshed
    the deploy-state and go/no-go to the live revision.

## Verification

Every claim re-verified against merged `origin/main`:

- **Deployed revision live:** staging **and** production `/healthz` both report
  `deploymentRevision = 21315832…` (HEAD of `origin/main`, includes #68/#69/#70),
  re-read 2026-06-14.
- **#2a (byte cap) live:** through the first-party MCP `session_get` on deployed
  staging, a 50,000-char `metadata` field came back clamped to **6,117 chars**
  with the truncation marker (raw REST returned the full 50k, uncapped by design).
- **#3 (interrupt) live:** `user.interrupt` returned **202 (not 500)** both while
  a turn was actively running (runaway turn cancelled, session → idle) and while
  the session was idle (the exact 500-repro), on the deployed image.
- **Unit gate:** `bun run typecheck` green; compaction + session-view + api unit
  files green this pass (0 fail).

## Honest gaps (also in the doc)

- A live compaction **firing** was **not** re-confirmed by a current staging-DB
  readback — the DB is a private Azure endpoint and no in-cluster probe access
  was available this pass; the claim rests on the integration test + the earlier
  point-in-time shipping run.
- Doc only; no code changes. gitleaks clean; no UUIDs / hostnames / secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> **Documentation only** — aligns operator docs with shipped manager-session hardening (PRs #68–#70) and adds an umbrella narrative.
> 
> Adds **`docs/manager-session-robustness.md`**, which ties together four long-lived manager failure modes (overflow/re-brick, worker-monitoring bloat, un-cancellable interrupt, over-budget input backstop), their fixes, verification evidence, residual gaps, and an executive verdict table.
> 
> **Updates `docs/context-compaction.md`** so it no longer describes pre-#69 behavior: the trigger is documented as **`max(recorded last_input_tokens, char/4 estimate)`** (stale-usage self-heal), plus new sections for **hard-force** (shrunk keep-recent tail, `trigger: "hard"`) and **`enforceInputBudget`** (Azure read-path airbag). Removes the obsolete “`hardFraction` is informational” caveat, refreshes deploy state to revision `21315832`, and links to the new robustness doc from the go/no-go section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80f0f43b50e2445b8832a07dfeeab119845881d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->