### PR TITLE
web: fold OpenGeni/Docs tool pills into the unified Tools dropdown

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -349,31 +349,31 @@ describe("summarizeSessionFailure", () => {
 });
 
 describe("buildTools", () => {
-  test("adds OpenGeni tool once when enabled", () => {
-    expect(buildTools(undefined, false, true)).toEqual([{ kind: "mcp", id: "opengeni" }]);
-    expect(buildTools([{ kind: "mcp", id: "opengeni" }], false, true)).toEqual([{ kind: "mcp", id: "opengeni" }]);
+  test("adds a selected MCP tool once", () => {
+    expect(buildTools(undefined, ["opengeni"])).toEqual([{ kind: "mcp", id: "opengeni" }]);
+    expect(buildTools([{ kind: "mcp", id: "opengeni" }], ["opengeni"])).toEqual([{ kind: "mcp", id: "opengeni" }]);
   });
 
-  test("adds document search and file download tools once when enabled", () => {
-    expect(buildTools(undefined, true, false)).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
-    expect(buildTools([{ kind: "mcp", id: "docs" }], true, false)).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
-    expect(buildTools([{ kind: "mcp", id: "files" }], true, false)).toEqual([{ kind: "mcp", id: "files" }, { kind: "mcp", id: "docs" }]);
+  test("pulls in the file download helper whenever document search is selected", () => {
+    expect(buildTools(undefined, ["docs"])).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
+    expect(buildTools([{ kind: "mcp", id: "docs" }], ["docs"])).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "files" }]);
+    expect(buildTools([{ kind: "mcp", id: "files" }], ["docs"])).toEqual([{ kind: "mcp", id: "files" }, { kind: "mcp", id: "docs" }]);
   });
 
-  test("preserves existing tools when document search is disabled", () => {
-    expect(buildTools([{ kind: "mcp", id: "custom" }], false, false)).toEqual([{ kind: "mcp", id: "custom" }]);
+  test("preserves existing tools when nothing is selected", () => {
+    expect(buildTools([{ kind: "mcp", id: "custom" }], [])).toEqual([{ kind: "mcp", id: "custom" }]);
   });
 
   test("combines OpenGeni with document tools", () => {
-    expect(buildTools(undefined, true, true)).toEqual([
+    expect(buildTools(undefined, ["opengeni", "docs"])).toEqual([
       { kind: "mcp", id: "opengeni" },
       { kind: "mcp", id: "docs" },
       { kind: "mcp", id: "files" },
     ]);
   });
 
-  test("adds enabled custom MCP tools once", () => {
-    expect(buildTools([{ kind: "mcp", id: "custom" }], false, false, ["custom", "search"])).toEqual([
+  test("adds selected MCP tools once", () => {
+    expect(buildTools([{ kind: "mcp", id: "custom" }], ["custom", "search"])).toEqual([
       { kind: "mcp", id: "custom" },
       { kind: "mcp", id: "search" },
     ]);

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ChevronDownIcon, FilesIcon, PlugIcon, WrenchIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, PlugIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -74,54 +74,6 @@ function pillClass(active: boolean): string {
     active
       ? "border-[color:var(--color-brand)]/35 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]"
       : "border-transparent text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
-  );
-}
-
-export function DocumentSearchToolToggle(props: {
-  enabled: boolean;
-  disabled?: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <Button
-      type="button"
-      variant={props.enabled ? "secondary" : "ghost"}
-      size="sm"
-      disabled={props.disabled}
-      onClick={props.onToggle}
-      aria-pressed={props.enabled}
-      aria-label="Attach document search tool"
-      title="Attach document search"
-      className={pillClass(props.enabled)}
-    >
-      <FilesIcon className="size-3.5" />
-      <span className="truncate">Docs</span>
-      {props.enabled ? <CheckIcon className="size-3 shrink-0" /> : null}
-    </Button>
-  );
-}
-
-export function OpenGeniToolToggle(props: {
-  enabled: boolean;
-  disabled?: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <Button
-      type="button"
-      variant={props.enabled ? "secondary" : "ghost"}
-      size="sm"
-      disabled={props.disabled}
-      onClick={props.onToggle}
-      aria-pressed={props.enabled}
-      aria-label="Attach OpenGeni tool"
-      title="Attach OpenGeni"
-      className={pillClass(props.enabled)}
-    >
-      <WrenchIcon className="size-3.5" />
-      <span className="truncate">OpenGeni</span>
-      {props.enabled ? <CheckIcon className="size-3 shrink-0" /> : null}
-    </Button>
   );
 }
 

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -38,12 +38,12 @@ import { Label } from "@/components/ui/label";
 import {
   buildResources,
   buildTools,
-  enabledCustomMcpServers,
   enabledWorkspaceCapabilityMcpServers,
   groupRepositories,
   isAbortError,
   isUiReasoningEffort,
   mergeMcpServerOptions,
+  selectableMcpServers,
   selectedAvailableCapabilityToolIds,
   type IntelligenceEffort,
   type McpServerOption,
@@ -95,10 +95,6 @@ export type AppContextValue = {
   setGithubAppOpen: Dispatch<SetStateAction<boolean>>;
   githubOrg: string;
   setGithubOrg: Dispatch<SetStateAction<string>>;
-  openGeniToolEnabled: boolean;
-  setOpenGeniToolEnabled: Dispatch<SetStateAction<boolean>>;
-  documentSearchEnabled: boolean;
-  setDocumentSearchEnabled: Dispatch<SetStateAction<boolean>>;
   selectedCapabilityToolIds: Set<string>;
   setSelectedCapabilityToolIds: Dispatch<SetStateAction<Set<string>>>;
   busy: boolean;
@@ -106,7 +102,7 @@ export type AppContextValue = {
   githubAppBusy: boolean;
   selectedInstallationId: number | null;
   repositoryGroups: RepositoryGroup[];
-  customMcpServers: McpServerOption[];
+  toolMcpServers: McpServerOption[];
   currentResources: ResourceRef[];
   addManualRepository: () => void;
   forgetAccessKey: () => void;
@@ -162,11 +158,12 @@ export function RootRouteComponent() {
   const [githubStatus, setGithubStatus] = useState<{ configured: boolean; missing: string[]; installUrl: string | null } | null>(null);
   const [githubAppOpen, setGithubAppOpen] = useState(false);
   const [githubOrg, setGithubOrg] = useState("");
-  const [openGeniToolEnabled, setOpenGeniToolEnabled] = useState(true);
-  const [documentSearchEnabled, setDocumentSearchEnabled] = useState(false);
   const [workspaceMcpServers, setWorkspaceMcpServers] = useState<McpServerOption[]>([]);
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(() => new Set());
-  const previousCapabilityToolIds = useRef<Set<string>>(new Set());
+  // Seed "docs" as already-seen so Document Search is not auto-selected on first
+  // load (it stays opt-in, as the old Docs toggle was). Every other tool server,
+  // including the first-party "opengeni", is auto-selected when it first appears.
+  const previousCapabilityToolIds = useRef<Set<string>>(new Set(["docs"]));
   const githubRefreshId = useRef(0);
   const mcpRefreshId = useRef(0);
   const [busy, setBusy] = useState(false);
@@ -281,8 +278,8 @@ export function RootRouteComponent() {
   const selectedInstalledRepositories = githubRepos.filter((repo) => selectedRepoIds.has(repo.id));
   const selectedInstallationId = selectedInstalledRepositories[0]?.installationId ?? null;
   const repositoryGroups = useMemo(() => groupRepositories(githubRepos), [githubRepos]);
-  const customMcpServers = useMemo(
-    () => mergeMcpServerOptions(enabledCustomMcpServers(clientConfig), workspaceMcpServers),
+  const toolMcpServers = useMemo(
+    () => mergeMcpServerOptions(selectableMcpServers(clientConfig), workspaceMcpServers),
     [clientConfig, workspaceMcpServers],
   );
   const currentResources = useMemo(
@@ -294,10 +291,10 @@ export function RootRouteComponent() {
     if (!clientConfig) {
       return;
     }
-    const availableIds = customMcpServers.map((server) => server.id);
+    const availableIds = toolMcpServers.map((server) => server.id);
     setSelectedCapabilityToolIds((current) => selectedAvailableCapabilityToolIds(current, availableIds, previousCapabilityToolIds.current));
     previousCapabilityToolIds.current = new Set(availableIds);
-  }, [clientConfig, customMcpServers]);
+  }, [clientConfig, toolMcpServers]);
 
   // Workspace create/rename keep the cached `workspaces` list and the access
   // context (the create grants the caller an owner grant) in sync.
@@ -379,7 +376,7 @@ export function RootRouteComponent() {
   async function startSession(workspaceId: string, submission: TurnSubmission): Promise<Session | null> {
     setBusy(true);
     try {
-      const selectedTools = buildTools(submission.tools, documentSearchEnabled, openGeniToolEnabled, [...selectedCapabilityToolIds]);
+      const selectedTools = buildTools(submission.tools, [...selectedCapabilityToolIds]);
       const created = await client.createSession(workspaceId, {
         initialMessage: submission.text,
         resources: [...currentResources, ...(submission.resources ?? [])],
@@ -534,10 +531,6 @@ export function RootRouteComponent() {
     setGithubAppOpen,
     githubOrg,
     setGithubOrg,
-    openGeniToolEnabled,
-    setOpenGeniToolEnabled,
-    documentSearchEnabled,
-    setDocumentSearchEnabled,
     selectedCapabilityToolIds,
     setSelectedCapabilityToolIds,
     busy,
@@ -545,7 +538,7 @@ export function RootRouteComponent() {
     githubAppBusy,
     selectedInstallationId,
     repositoryGroups,
-    customMcpServers,
+    toolMcpServers,
     currentResources,
     addManualRepository,
     forgetAccessKey,

--- a/apps/web/src/lib/session-tools.ts
+++ b/apps/web/src/lib/session-tools.ts
@@ -14,21 +14,17 @@ export function labelEffort(value: IntelligenceEffort): string {
   return value === "xhigh" ? "Extra high" : value.slice(0, 1).toUpperCase() + value.slice(1);
 }
 
-export function buildTools(existing: ToolRef[] | undefined, documentSearchEnabled: boolean, openGeniEnabled: boolean, extraMcpServerIds: string[] = []): ToolRef[] {
+export function buildTools(existing: ToolRef[] | undefined, mcpServerIds: string[] = []): ToolRef[] {
   const out = [...(existing ?? [])];
-  if (openGeniEnabled && !out.some((tool) => tool.kind === "mcp" && tool.id === "opengeni")) {
-    out.push({ kind: "mcp", id: "opengeni" });
+  const ids = [...mcpServerIds];
+  // Document Search is one user-facing tool but needs its file-download helper
+  // ("files") alongside it; pull it in whenever "docs" is selected.
+  if (ids.includes("docs") && !ids.includes("files")) {
+    ids.push("files");
   }
-  for (const id of extraMcpServerIds) {
+  for (const id of ids) {
     if (id && !out.some((tool) => tool.kind === "mcp" && tool.id === id)) {
       out.push({ kind: "mcp", id });
-    }
-  }
-  if (documentSearchEnabled) {
-    for (const id of ["docs", "files"]) {
-      if (!out.some((tool) => tool.kind === "mcp" && tool.id === id)) {
-        out.push({ kind: "mcp", id });
-      }
     }
   }
   return out;
@@ -135,12 +131,16 @@ export function groupRepositories(repositories: GitHubRepository[]): RepositoryG
   }, []);
 }
 
-export function enabledCustomMcpServers(config: ClientConfig | null): McpServerOption[] {
+export function selectableMcpServers(config: ClientConfig | null): McpServerOption[] {
   if (!config) {
     return [];
   }
-  const builtIns = new Set(["opengeni", "docs", "files"]);
-  return config.mcpServers.filter((server) => !builtIns.has(server.id));
+  // "files" is the document-search download helper, attached automatically with
+  // "docs" (see buildTools) — it is not a tool the user picks on its own, so
+  // hide it. Everything else, including the first-party "opengeni" and "docs",
+  // is selectable from the unified Tools dropdown.
+  const hidden = new Set(["files"]);
+  return config.mcpServers.filter((server) => !hidden.has(server.id));
 }
 
 export function enabledWorkspaceCapabilityMcpServers(items: CapabilityCatalogItem[]): McpServerOption[] {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -25,10 +25,8 @@ import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { MarkdownText } from "@/components/markdown";
 import {
-  DocumentSearchToolToggle,
   EnabledMcpToolPicker,
   ModelPicker,
-  OpenGeniToolToggle,
 } from "@/components/pickers";
 import {
   FailedSessionBanner,
@@ -210,13 +208,13 @@ function SessionChatPane(props: {
   const context = useAppContext();
   const terminal = isTerminalSessionStatus(props.session.status);
   const attachments = useDraftAttachments(props.session.workspaceId);
-  const { documentSearchEnabled, openGeniToolEnabled, selectedCapabilityToolIds, model, reasoningEffort } = context;
+  const { selectedCapabilityToolIds, model, reasoningEffort } = context;
   const composer = useComposer(props.session.id, {
-    // Evaluated at send time: attachments and tool toggles picked while the
-    // draft was being written ride along with the message.
+    // Evaluated at send time: attachments and tools picked while the draft was
+    // being written ride along with the message.
     sendExtras: () => ({
       resources: attachments.readyResources,
-      tools: buildTools(undefined, documentSearchEnabled, openGeniToolEnabled, [...selectedCapabilityToolIds]),
+      tools: buildTools(undefined, [...selectedCapabilityToolIds]),
       model,
       reasoningEffort,
     }),
@@ -347,18 +345,8 @@ function SessionChatPane(props: {
                   onModelChange={context.setModel}
                   onEffortChange={context.setReasoningEffort}
                 />
-                <DocumentSearchToolToggle
-                  enabled={context.documentSearchEnabled}
-                  disabled={composer.sending || terminal}
-                  onToggle={() => context.setDocumentSearchEnabled((enabled) => !enabled)}
-                />
-                <OpenGeniToolToggle
-                  enabled={context.openGeniToolEnabled}
-                  disabled={composer.sending || terminal}
-                  onToggle={() => context.setOpenGeniToolEnabled((enabled) => !enabled)}
-                />
                 <EnabledMcpToolPicker
-                  servers={context.customMcpServers}
+                  servers={context.toolMcpServers}
                   selectedIds={context.selectedCapabilityToolIds}
                   disabled={composer.sending || terminal}
                   onChange={context.setSelectedCapabilityToolIds}

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -9,10 +9,8 @@ import { useEffect, useState } from "react";
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { PermissionGroupPicker } from "@/components/permission-picker";
 import {
-  DocumentSearchToolToggle,
   EnabledMcpToolPicker,
   ModelPicker,
-  OpenGeniToolToggle,
 } from "@/components/pickers";
 import { RepositoryContextPicker } from "@/components/repository-picker";
 import { Button } from "@/components/ui/button";
@@ -185,18 +183,8 @@ function SessionControlStrip({ workspaceId }: { workspaceId: string }) {
         onOrgChange={context.setGithubOrg}
         onStartGitHubApp={() => void context.startGitHubAppManifestFlow(workspaceId)}
       />
-      <DocumentSearchToolToggle
-        enabled={context.documentSearchEnabled}
-        disabled={context.busy}
-        onToggle={() => context.setDocumentSearchEnabled((enabled) => !enabled)}
-      />
-      <OpenGeniToolToggle
-        enabled={context.openGeniToolEnabled}
-        disabled={context.busy}
-        onToggle={() => context.setOpenGeniToolEnabled((enabled) => !enabled)}
-      />
       <EnabledMcpToolPicker
-        servers={context.customMcpServers}
+        servers={context.toolMcpServers}
         selectedIds={context.selectedCapabilityToolIds}
         disabled={context.busy}
         onChange={context.setSelectedCapabilityToolIds}


### PR DESCRIPTION
The new-session and running-session composers carried two bespoke pills — **OpenGeni** and **Docs** — next to the general MCP **Tools** dropdown. The dropdown deliberately *excluded* the three first-party built-ins (`opengeni`/`docs`/`files`) so the pills could own them — a redundant, inconsistent split.

This folds the built-ins into the single Tools dropdown and removes the pills:

- `selectableMcpServers` (was `enabledCustomMcpServers`) now surfaces `opengeni` and `docs` (Document Search) in the dropdown, hiding only the `files` download helper.
- `buildTools(existing, mcpServerIds)` drops its two booleans and auto-pairs `files` whenever `docs` is selected (so Document Search still attaches both, exactly as the old pill did).
- Defaults preserved: **OpenGeni** auto-selected, **Document Search** opt-in (`previousCapabilityToolIds` seeded with `"docs"`).

Net UX: one Tools dropdown listing OpenGeni, Document Search, and any workspace/custom MCP servers — same attach behavior, same defaults, no bespoke pills.

**Verified:** monorepo typecheck ✓, `bun test apps/web` (63 pass) ✓, `bun run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web UI and session tool assembly only; behavior is covered by updated `buildTools` tests and matches prior attach defaults.
> 
> **Overview**
> **OpenGeni** and **Document Search** are no longer separate composer pills; first-party and workspace MCPs are chosen from one **Tools** dropdown (`EnabledMcpToolPicker`).
> 
> `selectableMcpServers` (renamed from `enabledCustomMcpServers`) lists `opengeni` and `docs` with workspace MCPs and still hides the `files` helper. `buildTools` now takes only a list of MCP server IDs and still attaches `files` when `docs` is selected. App context drops `openGeniToolEnabled` / `documentSearchEnabled` in favor of `selectedCapabilityToolIds` and `toolMcpServers`; seeding `previousCapabilityToolIds` with `"docs"` keeps Document Search opt-in while other new tools (including OpenGeni) auto-select on first appearance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b81d65ad7d3d5f4fbbd75c5c404ead5598480a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->