### PR TITLE
sandbox: install ripgrep in the agent sandbox image

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
         openssh-client \
         fuse3 \
         rclone \
+        ripgrep \
         unzip \
         wget \
     "; \


### PR DESCRIPTION
Agents frequently reach for `rg` to search repos/workspaces, but ripgrep was not in the sandbox image, so the binary was missing in every Geni/OpenGeni session. This adds `ripgrep` to the apt package set in `docker/sandbox.Dockerfile` so `rg` is available in all sandboxes built from this image.

**Verified:** `apt-get install ripgrep` on the `python:3.12-slim` base yields `ripgrep 14.1.1` at `/usr/bin/rg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-package addition to the sandbox Docker image with no application or security logic changes.
> 
> **Overview**
> Adds **`ripgrep`** to the apt package list in `docker/sandbox.Dockerfile` so the **`rg`** binary is present in sandboxes built from this image.
> 
> This closes a gap where agent workflows and skills already assume **`rg`** for fast repo search, but the sandbox image did not ship it—so Geni/OpenGeni sessions could fail when agents invoked **`rg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bad7803885428522900fb9e50c07436134d7b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->