### PR TITLE
fix(composer): remove doubled focus highlight, keep whole-composer glow

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -148,8 +148,12 @@ body {
   background: transparent;
 }
 
-/* Focus ring */
-:where(button, a, input, textarea, [role="button"], [tabindex]):focus-visible {
+/* Focus ring. The composer textarea is excluded: its wrapper already shows a
+   whole-composer focus affordance (focus-within border + soft glow), and a
+   per-textarea outline here painted a second highlight bounded to the textarea
+   box (the top half, stopping above the toolbar). Scoping it out of `.og-root`
+   leaves every other control's focus ring intact. */
+:where(button, a, input, textarea, [role="button"], [tabindex]):focus-visible:not(.og-root textarea) {
   outline: 2px solid var(--color-brand);
   outline-offset: 2px;
   border-radius: var(--radius-sm);

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -67,8 +67,11 @@
   --og-shadow-sm: 0 1px 2px oklch(0 0 0 / 0.28);
   --og-shadow-md: 0 2px 8px oklch(0 0 0 / 0.32), 0 1px 2px oklch(0 0 0 / 0.24);
   --og-shadow-lg: 0 8px 28px oklch(0 0 0 / 0.42), 0 2px 8px oklch(0 0 0 / 0.28);
-  --og-shadow-glow: 0 0 0 1px color-mix(in oklch, var(--og-color-accent) 45%, transparent),
-    0 0 24px color-mix(in oklch, var(--og-color-accent) 18%, transparent);
+  /* One soft halo only. The composer's focus affordance already draws a crisp
+     brand edge via `focus-within:border-og-accent/60`; the old `0 0 0 1px`
+     ring sat flush against that border and read as a doubled hairline, so the
+     glow is now purely the diffuse outer halo. */
+  --og-shadow-glow: 0 0 24px color-mix(in oklch, var(--og-color-accent) 18%, transparent);
 
   color-scheme: dark;
 }
@@ -102,8 +105,7 @@
   --og-shadow-sm: 0 1px 2px oklch(0.2 0.02 260 / 0.07);
   --og-shadow-md: 0 2px 8px oklch(0.2 0.02 260 / 0.09), 0 1px 2px oklch(0.2 0.02 260 / 0.06);
   --og-shadow-lg: 0 8px 28px oklch(0.2 0.02 260 / 0.13), 0 2px 8px oklch(0.2 0.02 260 / 0.07);
-  --og-shadow-glow: 0 0 0 1px color-mix(in oklch, var(--og-color-accent) 38%, transparent),
-    0 0 20px color-mix(in oklch, var(--og-color-accent) 14%, transparent);
+  --og-shadow-glow: 0 0 20px color-mix(in oklch, var(--og-color-accent) 14%, transparent);
 
   color-scheme: light;
 }


### PR DESCRIPTION
## Problem

The focused chat composer rendered **two** stacked brand-colored highlights instead of one. Reported as a double-highlight on the composer.

## Root cause

Two independent mechanisms, both surgical to fix:

1. **`--og-shadow-glow` inner ring (reaches Geni)** — the composer wrapper uses `focus-within:border-og-accent/60 focus-within:shadow-og-glow` (`chat-composer.tsx:212`). The `--og-shadow-glow` token (`packages/react/styles/tokens.css`) carried a hard `0 0 0 1px` ring as its first layer, which sits flush against the `focus-within` border — two adjacent 1px brand lines reading as a doubled hairline. `shadow-og-glow` has exactly one consumer (the composer), so narrowing the token is safe.

2. **App-level `:focus-visible` outline (OpenGeni web only)** — `apps/web/src/styles.css` painted a 2px brand outline on the focusable `<textarea>` but not the non-focusable toolbar `<div>`, so the outline wrapped only the textarea box (top half, stopping above the icon row).

## Fix

- Drop the `0 0 0 1px` inner ring from `--og-shadow-glow` (dark + light), leaving a single diffuse halo over the crisp `focus-within` border. The whole-composer affordance — border + soft halo covering the toolbar too — is unchanged.
- Scope the global focus outline out of the composer textarea via `:not(.og-root textarea)`. Every other control keeps its focus ring.

No component TSX changes; the wrapper's `focus-within` glow remains the single intended focus affordance.

## Verification

- `cd packages/react && bun run build` — clean
- `cd packages/react && bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only focus and shadow token tweaks scoped to the composer and glow utility; no logic or data-path changes.
> 
> **Overview**
> Fixes a **double brand-colored focus** on the chat composer by aligning two styling layers that were stacking on top of each other.
> 
> In **`packages/react/styles/tokens.css`**, **`--og-shadow-glow`** (dark and light) no longer includes the inner **`0 0 0 1px`** ring—only the soft outer halo remains—so it does not duplicate the composer wrapper’s **`focus-within`** accent border when **`shadow-og-glow`** is applied.
> 
> In **`apps/web/src/styles.css`**, the global **`:focus-visible`** outline is **excluded** for **`.og-root textarea`**, so the web app does not draw a second outline on just the textarea while the wrapper already shows the whole-composer focus treatment. Other controls keep their focus rings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ef23a6a333afaccb452d8d9bc52ac22f418568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->