### PR TITLE
fix(composer): kill self-scoped textarea focus outline, keep wrapper glow

### DIFF
--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -230,7 +230,15 @@ export function ChatComposer({
             aria-activedescendant={paletteEnabled && palette.open ? `${listboxId}-option-${palette.highlight}` : undefined}
             className={cn(
               "block w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-[15px] leading-6",
-              "text-og-fg placeholder:text-og-fg-subtle focus:outline-none",
+              // The wrapper owns the whole-composer focus affordance (focus-within
+              // border + soft glow). Suppress any self-scoped focus outline on the
+              // textarea itself: `focus:outline-none` alone only sets outline-style
+              // on `:focus`, which a host app's zero-specificity
+              // `:where(...):focus-visible { outline: ... }` base rule re-applies as
+              // the full shorthand. `focus-visible:outline-none` matches the same
+              // state at class specificity and wins, so no second highlight (the
+              // top-half rectangle bounded to the textarea box) ever paints.
+              "text-og-fg placeholder:text-og-fg-subtle focus:outline-none focus-visible:outline-none",
               "disabled:cursor-not-allowed disabled:opacity-60",
             )}
           />


### PR DESCRIPTION
## Problem

On focus the chat composer painted **two** brand affordances: the intended soft whole-composer glow on the wrapper, plus an **unintended bright 2px accent rectangle bounded to the `<textarea>` box** — the top half, stopping above the toolbar/send-button row.

## Root cause (specificity gap, not the app stylesheet)

The textarea carried only `focus:outline-none`, which emits `outline-style: none` under `:focus`. A host app's conventional base rule

```css
:where(button, a, input, textarea, [role="button"], [tabindex]):focus-visible {
  outline: 2px solid var(--color-brand); outline-offset: 2px;
}
```

sets the full `outline` *shorthand*. Because `:where()` contributes **zero specificity**, that rule is `(0,1,0)` and the textarea's `focus:outline-none` utility (also `(0,1,0)`) only ties — losing on source order — so the accent outline re-applies on every focus. Text inputs match `:focus-visible` on plain mouse-click too, so it showed on every click into the box.

## Fix

Add `focus-visible:outline-none` on the textarea. It targets the **same `:focus-visible` state at class specificity** — `.focus-visible\:outline-none:focus-visible` is `(0,2,0)` vs the base rule's `(0,1,0)` — so it wins **order-independently** and resets `outline-style` to `none`. The second highlight never paints, while the wrapper keeps its sole intended focus affordance (`focus-within:border-og-accent/60 focus-within:shadow-og-glow`), which covers the toolbar too.

Minimal, textarea-only, one utility added. This makes `@opengeni/react` robust regardless of the consumer app's `:focus-visible` base rule (it is vendored into geni, which has no app-level guard).

## Verification

- Headless **Chromium** against a faithful harness (verbatim composer DOM under `.og-root` + the deployed staging CSS inlined), real mouse click into the textarea:
  - **Before:** textarea `outline-style: none -> solid`, `outline: oklch(0.72 0.15 255) solid 2px` (the top-half rectangle).
  - **After:** textarea `outline-style: none -> none`, `outline: ... none 0px` — gone.
  - Wrapper glow in both: `... 0 0 0 1px accent, 0 0 24px accent` (`shadow-og-glow`) — **unchanged**.
- `cd packages/react && bun run build` — passes.

| Before (focused) | After (focused) |
|---|---|
| bright top-half textarea rectangle + glow | single whole-composer glow only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind utility on the composer textarea; visual-only, no behavior or security impact.
> 
> **Overview**
> Fixes a **double focus ring** on the chat composer when host apps ship a global `:where(...):focus-visible { outline: ... }` base style.
> 
> The composer textarea only had `focus:outline-none`, which ties on specificity with that rule and can lose on source order—so a **second accent outline** still painted on the textarea while the wrapper’s `focus-within` glow was also active. The change adds **`focus-visible:outline-none`** so the textarea wins on `:focus-visible` and only the **whole-composer** border/glow affordance shows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56b6c42978d45a4cf2b0341e698f1911de038fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->