### PR TITLE
runtime: enable native web search (webSearchTool) for all agents

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -169,6 +169,13 @@ const SettingsSchema = z.object({
   // The openai client default of 2 retries is too small for sustained TPM
   // backpressure during long autonomous runs.
   openaiMaxRetries: z.coerce.number().int().nonnegative().default(5),
+  // Native hosted web search. The live Azure Responses path executes the
+  // hosted web_search tool, so this is provider-unconditional: ON by default
+  // on every provider, exposed only so operators can disable it. When true,
+  // buildOpenGeniAgent attaches webSearchTool() to the agent's tools — it is
+  // merged with the MCP-server tools (getAllTools = [...mcpTools, ...tools])
+  // and the sandbox capability tools, never replacing them.
+  webSearchEnabled: EnvBoolean.default(true),
   azureOpenaiBaseUrl: z.string().optional(),
   azureOpenaiEndpoint: z.string().optional(),
   azureOpenaiDeployment: z.string().optional(),
@@ -404,6 +411,7 @@ export function getSettings(): Settings {
     openaiProviderItemIds: optional("OPENGENI_OPENAI_PROVIDER_ITEM_IDS"),
     openaiReasoningEncryptedContent: optional("OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT"),
     openaiMaxRetries: optional("OPENGENI_OPENAI_MAX_RETRIES"),
+    webSearchEnabled: optional("OPENGENI_WEB_SEARCH_ENABLED"),
     azureOpenaiBaseUrl: optional("OPENGENI_AZURE_OPENAI_BASE_URL"),
     azureOpenaiEndpoint: optional("OPENGENI_AZURE_OPENAI_ENDPOINT"),
     azureOpenaiDeployment: optional("OPENGENI_AZURE_OPENAI_DEPLOYMENT"),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -13,6 +13,11 @@ import {
   setDefaultOpenAIClient,
   setDefaultOpenAIKey,
   setOpenAIResponsesTransport,
+  // Hosted web_search tool factory. Re-exported from @openai/agents-openai via
+  // `export * from '@openai/agents-openai'` in @openai/agents' index (0.11.6);
+  // it returns a { type: 'hosted_tool', providerData: { type: 'web_search' } }
+  // descriptor the OpenAI Responses model serializes into request.tools[].
+  webSearchTool,
   type AgentInputItem,
   type CallModelInputFilter,
   type MCPServer,
@@ -361,6 +366,14 @@ const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
 
 export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[], options: BuildAgentOptions = {}): Agent<any, any> {
+  // Native hosted tools attached to every constructed agent. webSearchEnabled
+  // is ON by default and provider-unconditional (the live Azure Responses path
+  // executes the hosted web_search tool). The SDK merges this explicit `tools`
+  // array with the MCP-server tools (Agent.getAllTools = [...mcpTools, ...tools])
+  // and, on the SandboxAgent path, with the sandbox capability tools
+  // (prepareSandboxAgent: tools = [...agent.tools, ...capability.tools()]), so
+  // hosted web_search coexists with both rather than overriding them.
+  const hostedTools = settings.webSearchEnabled ? [webSearchTool()] : [];
   const baseConfig = {
     name: "OpenGeni Agent",
     model: options.model ?? settings.openaiModel,
@@ -398,6 +411,11 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
         ? { providerData: { include: ["reasoning.encrypted_content"] } }
         : {}),
     },
+    // Explicit hosted tools (web_search when enabled). Threaded into BOTH the
+    // `new Agent(baseConfig)` path (sandboxBackend === "none") and the
+    // `new SandboxAgent({ ...baseConfig, ... })` path via the shared baseConfig
+    // spread; the SDK concatenates these with MCP and sandbox capability tools.
+    ...(hostedTools.length ? { tools: hostedTools } : {}),
     ...(options.mcpServers?.length ? { mcpServers: options.mcpServers } : {}),
   } as const;
 

--- a/packages/runtime/test/capabilities.test.ts
+++ b/packages/runtime/test/capabilities.test.ts
@@ -55,6 +55,60 @@ describe("provider-aware capability selection", () => {
   });
 });
 
+function webSearchHostedTools(agent: ReturnType<typeof buildOpenGeniAgent>): Array<Record<string, unknown>> {
+  return ((agent as { tools?: Array<Record<string, unknown>> }).tools ?? []).filter((tool) =>
+    tool.type === "hosted_tool"
+    && (tool.providerData as { type?: unknown } | undefined)?.type === "web_search");
+}
+
+describe("native web search hosted tool", () => {
+  test("default settings attach a web_search hosted tool on the non-sandbox Agent path", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    const tools = webSearchHostedTools(agent);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.name).toBe("web_search");
+  });
+
+  test("default settings attach a web_search hosted tool on the SandboxAgent path", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), []);
+    const tools = webSearchHostedTools(agent);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.name).toBe("web_search");
+  });
+
+  test("web_search is on by default even on Azure (provider-unconditional)", () => {
+    const agent = buildOpenGeniAgent(
+      testSettings({ sandboxBackend: "none", openaiProvider: "azure", contextCompactionMode: "client" }),
+      [],
+    );
+    expect(webSearchHostedTools(agent)).toHaveLength(1);
+  });
+
+  test("the hosted tool serializes into the model request items the SDK sends", async () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    // getAllTools is the exact snapshot the runner serializes into request.tools[]
+    // (runner/modelPreparation: serializedTools = getAllTools().map(serializeTool)).
+    const allTools = await (agent as unknown as {
+      getAllTools: (ctx?: unknown) => Promise<Array<Record<string, unknown>>>;
+    }).getAllTools();
+    const webSearch = allTools.filter((tool) =>
+      tool.type === "hosted_tool"
+      && (tool.providerData as { type?: unknown } | undefined)?.type === "web_search");
+    expect(webSearch).toHaveLength(1);
+    expect((webSearch[0]!.providerData as { type: string }).type).toBe("web_search");
+  });
+
+  test("operators can disable it: webSearchEnabled=false attaches no web_search tool and no tools field", () => {
+    const noneAgent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none", webSearchEnabled: false }), []);
+    const sandboxAgent = buildOpenGeniAgent(testSettings({ sandboxBackend: "docker", webSearchEnabled: false }), []);
+    expect(webSearchHostedTools(noneAgent)).toHaveLength(0);
+    expect(webSearchHostedTools(sandboxAgent)).toHaveLength(0);
+    // With the flag off the explicit tools field is omitted entirely, preserving
+    // the SDK's "no explicit tools" tool-choice semantics.
+    expect((noneAgent as { tools?: unknown[] }).tools ?? []).toHaveLength(0);
+  });
+});
+
 describe("server-path store:false precondition", () => {
   test("server mode sets store=false (encrypted compaction item round-trips)", () => {
     const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none", openaiProvider: "openai", contextCompactionMode: "server" }), []);

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -83,6 +83,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     openaiProviderItemIds: "strip",
     openaiReasoningEncryptedContent: true,
     openaiMaxRetries: 5,
+    webSearchEnabled: true,
     azureOpenaiBaseUrl: undefined,
     azureOpenaiEndpoint: undefined,
     azureOpenaiDeployment: undefined,


### PR DESCRIPTION
## What

Attach the OpenAI hosted `web_search` tool to every agent `buildOpenGeniAgent` constructs, gated by a new `webSearchEnabled` setting.

- **Default ON**, env var `OPENGENI_WEB_SEARCH_ENABLED`, **provider-unconditional** (the live Azure Responses path executes the hosted `web_search` tool).
- The explicit `tools` array is spread through the shared `baseConfig` into BOTH the non-sandbox `new Agent(...)` path and the `new SandboxAgent({ ...baseConfig, ... })` path.
- The SDK merges it with MCP-server tools (`getAllTools = [...mcpTools, ...enabledTools]`; hosted tools bypass the function-only `isEnabled` filter) and, on the sandbox path, with sandbox capability tools — `web_search` **coexists** with both rather than overriding them.
- When the flag is off the `tools` key is omitted entirely, preserving the SDK's "no explicit tools" tool-choice semantics.

## Files changed

- `packages/config/src/index.ts` — `webSearchEnabled: EnvBoolean.default(true)` + `OPENGENI_WEB_SEARCH_ENABLED` wiring
- `packages/runtime/src/index.ts` — `webSearchTool` import + `hostedTools` spread into `baseConfig`
- `packages/testing/src/settings.ts` — `webSearchEnabled: true` in the test settings literal
- `packages/runtime/test/capabilities.test.ts` — 5 new tests

## Verification

Verified against the resolved `@openai/agents@0.11.6` tree:

1. `webSearchTool()` emits `{ type:'hosted_tool', name:'web_search', providerData:{ type:'web_search', ... } }` (agents-openai `tools.mjs`).
2. `getAllTools` returns `[...mcpTools, ...enabledTools]`; the `isEnabled` filter is function-only, so the hosted tool always passes (agents-core `agent.mjs:417-434`).
3. `serializeTool` passes the `hosted_tool` through with `providerData` intact; flows into `request.tools[]` (`run.mjs:451/739/769`).
4. `openaiResponsesModel.getTools` converts a `web_search` hosted tool into the Responses `{ type:'web_search', user_location, filters, search_context_size }` wire payload (`openaiResponsesModel.mjs:956-966`).

Empirically constructed the agent and inspected `getAllTools()` (the exact snapshot the runner serializes): **exactly one** `web_search` tool when enabled on the non-sandbox, sandbox, and Azure paths; **zero and no `tools` field** when disabled; and **`mcpServers` not clobbered** when an MCP server is also attached.

Typecheck PASS (config, runtime, testing, contracts, deployment, apps/worker, apps/api). Tests PASS: capabilities 13/0, runtime 118/0, config 44/0. gitleaks on the staged diff: no leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on provider-hosted web search for all agents by default, which changes model tool behavior, cost, and external data access; mitigated by an operator kill switch and tests that verify merge/disable semantics.
> 
> **Overview**
> Adds **native hosted `web_search`** to every agent built via `buildOpenGeniAgent`, controlled by a new **`webSearchEnabled`** setting (**on by default**, env **`OPENGENI_WEB_SEARCH_ENABLED`**).
> 
> When enabled, `webSearchTool()` is spread into shared `baseConfig` for both plain `Agent` and `SandboxAgent` paths; the SDK merges it with MCP and sandbox capability tools rather than replacing them. With the flag off, the explicit `tools` field is omitted so prior tool-choice behavior is unchanged.
> 
> Config wiring, test defaults, and five runtime tests cover default-on behavior (including Azure), `getAllTools` serialization, and opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70daa1a270a0fb52d4b5d48c103f924107a7ab94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->