### PR TITLE
runtime+api: per-workspace agent system-prompt override (white-label persona)

### DIFF
--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -51,6 +51,7 @@ export function registerWorkspaceRoutes(app: Hono, deps: ApiRouteDeps): void {
       slug: payload.slug?.trim() || null,
       externalSource: payload.externalSource ?? null,
       externalId: payload.externalId ?? null,
+      ...(payload.agentInstructions !== undefined ? { agentInstructions: normalizeAgentInstructions(payload.agentInstructions) } : {}),
     });
     await grantWorkspaceAccess(deps.db, {
       accountId,
@@ -76,9 +77,21 @@ export function registerWorkspaceRoutes(app: Hono, deps: ApiRouteDeps): void {
     const workspace = await updateWorkspace(deps.db, workspaceId, {
       ...(payload.name !== undefined ? { name: payload.name.trim() } : {}),
       ...(payload.slug !== undefined ? { slug: payload.slug?.trim() || null } : {}),
+      ...(payload.agentInstructions !== undefined ? { agentInstructions: normalizeAgentInstructions(payload.agentInstructions) } : {}),
     });
     return c.json(Workspace.parse(workspace));
   });
+}
+
+// A persona override that is null or trims to empty collapses to null (use the
+// deployment default). Otherwise the template is stored verbatim so the runtime
+// can substitute the non-bypassable CORE at its {{core}} marker.
+function normalizeAgentInstructions(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function requireAccountPermission(context: AccessContext, accountId: string, permission: Permission): void {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -888,6 +888,7 @@ describe("workspace switcher helpers", () => {
       slug: null,
       externalSource: null,
       externalId: null,
+      agentInstructions: null,
       createdAt: "2026-06-11T08:00:00.000Z",
       updatedAt: "2026-06-11T08:00:00.000Z",
       ...patch,

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -42,7 +42,7 @@ import {
 } from "./common";
 import { maybeCompactContext } from "./context-compaction";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
-import { resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
+import { resolveWorkspaceAgentInstructions, resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
 import { notifyParentOfChildTerminal } from "./parent-wake";
 import { createSecretRedactor, identityRedactor } from "./redaction";
 import { turnInput } from "./run-input";
@@ -354,6 +354,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // packs declaring images) fails the turn with its plain error instead
       // of failing the activity opaquely.
       const packRuntime = await resolveWorkspacePackRuntime(db, input.workspaceId);
+      // Workspace tier of the agent-persona resolution (session > workspace >
+      // deployment default). null means the workspace has no override, so the
+      // runtime falls back to runSettings.agentInstructionsTemplate (the
+      // deployment default, byte-identical to the historical preamble).
+      const workspaceAgentInstructions = await resolveWorkspaceAgentInstructions(db, input.workspaceId);
       const runSettings = {
         ...settingsWithPackSandboxImage(capabilitySettings, packRuntime.sandboxImage),
         openaiModel: turn.model,
@@ -386,6 +391,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
+        ...(workspaceAgentInstructions ? { instructionsTemplate: workspaceAgentInstructions } : {}),
         ...(workspaceEnvironment
           ? {
             workspaceEnvironment: {

--- a/apps/worker/src/activities/packs.ts
+++ b/apps/worker/src/activities/packs.ts
@@ -1,6 +1,6 @@
 import type { Settings } from "@opengeni/config";
 import { CapabilityPack } from "@opengeni/contracts";
-import { getWorkspacePack, listPackInstallations, type Database } from "@opengeni/db";
+import { getWorkspace, getWorkspacePack, listPackInstallations, type Database } from "@opengeni/db";
 import type { PackSkill } from "@opengeni/runtime";
 
 /**
@@ -81,6 +81,22 @@ export function workspacePackRuntimeFromPacks(packs: CapabilityPack[]): Workspac
     sandboxImage: imagePacks[0]?.sandboxImage?.trim() ?? null,
     skills,
   };
+}
+
+/**
+ * Resolves the per-workspace agent persona override (the white-label surface).
+ * Returns the workspace's stored template when set, else null to mean "use the
+ * deployment default" (settings.agentInstructionsTemplate). The runtime always
+ * injects the non-bypassable CORE regardless, so a null here keeps the
+ * byte-identical default and a non-null value only restyles the persona.
+ *
+ * This is the workspace tier of the session > workspace > deployment-default
+ * resolution; per-session overrides do not exist in this slice, so the worker
+ * resolves workspace > default and passes the result as instructionsTemplate.
+ */
+export async function resolveWorkspaceAgentInstructions(db: Database, workspaceId: string): Promise<string | null> {
+  const workspace = await getWorkspace(db, workspaceId);
+  return workspace?.agentInstructions ?? null;
 }
 
 /**

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -58,6 +58,47 @@ export const sandboxPreparationProfiles: Record<string, { env: string[]; hooks: 
   },
 };
 
+/**
+ * Placeholder token inside an agent-instructions persona template. The runtime
+ * substitutes the non-bypassable CORE (goal-loop ownership + the dynamic
+ * workspace-environment block) at this marker. A template that omits the
+ * marker still gets the CORE appended after it (a non-bypassable fail-safe),
+ * so a white-labelled persona can never drop the goal-loop contract or the
+ * environment metadata the agent depends on.
+ */
+export const AGENT_INSTRUCTIONS_CORE_PLACEHOLDER = "{{core}}";
+
+/**
+ * Default per-workspace agent persona template. This is the BRAND + tool-usage
+ * opinion (the white-labellable surface): the "You are an OpenGeni workspace
+ * agent." identity line, the framing/opinion lines, and the mount-path facts.
+ *
+ * The CORE that MUST survive any override — the goal-loop ownership line (which
+ * names the opengeni__goal_* tools) and the dynamic workspace-environment block
+ * — is injected at AGENT_INSTRUCTIONS_CORE_PLACEHOLDER by the runtime, never
+ * baked into this overridable string.
+ *
+ * INVARIANT: with no per-workspace override and an empty environment, the
+ * runtime's composed instructions are BYTE-IDENTICAL to the historical
+ * hardcoded preamble. The template below is exactly the historical lines 1–11
+ * joined by " ", followed by " " + the placeholder. Changing a single
+ * character here changes that default; a runtime test pins it.
+ */
+export const DEFAULT_AGENT_INSTRUCTIONS = [
+  "You are an OpenGeni workspace agent.",
+  "Follow the user's task and any enabled pack or skill instructions for the current role.",
+  "Work inside the sandbox workspace and use filesystem and shell tools when useful.",
+  "Repository resources are mounted under repos/<owner>/<repo>.",
+  "File resources are mounted under files/<file-id>/ unless the session specifies another mount path.",
+  "Attached files are mounted read-only; copy them before modifying.",
+  "Bundled skills are under .agents/ and can include infrastructure, marketing, or other role-specific guidance.",
+  "Use Checkov, Terraform, Azure CLI, GitHub CLI, and repository tools when relevant.",
+  "When the Azure sandbox preparation profile is enabled and service-principal variables are present, the sandbox is pre-authenticated with normal Azure CLI before work starts.",
+  "Treat code-changing work as GitOps work: create a focused branch/commit/PR when GitHub credentials are available; otherwise report exact commands and blockers.",
+  "Return concise, factual summaries with files changed, commands run, and remaining blockers.",
+  AGENT_INSTRUCTIONS_CORE_PLACEHOLDER,
+].join(" ");
+
 const SettingsSchema = z.object({
   serviceName: z.string().default("opengeni"),
   environment: z.string().default("local"),
@@ -176,6 +217,14 @@ const SettingsSchema = z.object({
   // merged with the MCP-server tools (getAllTools = [...mcpTools, ...tools])
   // and the sandbox capability tools, never replacing them.
   webSearchEnabled: EnvBoolean.default(true),
+  // Deployment-default agent persona template (the white-label surface). The
+  // runtime resolves the effective template per turn as
+  // per-session-override > per-workspace override > this default, substitutes
+  // the non-bypassable CORE at AGENT_INSTRUCTIONS_CORE_PLACEHOLDER (or appends
+  // it when the template omits the marker), and uses the result as the agent's
+  // instructions. Defaulting to DEFAULT_AGENT_INSTRUCTIONS keeps the composed
+  // default byte-identical to the historical hardcoded preamble.
+  agentInstructionsTemplate: z.string().default(DEFAULT_AGENT_INSTRUCTIONS),
   azureOpenaiBaseUrl: z.string().optional(),
   azureOpenaiEndpoint: z.string().optional(),
   azureOpenaiDeployment: z.string().optional(),
@@ -412,6 +461,7 @@ export function getSettings(): Settings {
     openaiReasoningEncryptedContent: optional("OPENGENI_OPENAI_REASONING_ENCRYPTED_CONTENT"),
     openaiMaxRetries: optional("OPENGENI_OPENAI_MAX_RETRIES"),
     webSearchEnabled: optional("OPENGENI_WEB_SEARCH_ENABLED"),
+    agentInstructionsTemplate: optional("OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE"),
     azureOpenaiBaseUrl: optional("OPENGENI_AZURE_OPENAI_BASE_URL"),
     azureOpenaiEndpoint: optional("OPENGENI_AZURE_OPENAI_ENDPOINT"),
     azureOpenaiDeployment: optional("OPENGENI_AZURE_OPENAI_DEPLOYMENT"),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -113,6 +113,12 @@ export const Workspace = z.object({
   slug: z.string().nullable(),
   externalSource: z.string().nullable(),
   externalId: z.string().nullable(),
+  // Per-workspace agent persona template (white-label override). null means
+  // the deployment default (OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE /
+  // DEFAULT_AGENT_INSTRUCTIONS) is used. The runtime always injects the
+  // non-bypassable CORE (goal-loop ownership + environment block), so an
+  // override restyles the persona without dropping that contract.
+  agentInstructions: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -196,12 +202,18 @@ export const CreateWorkspaceRequest = z.object({
   slug: z.string().min(1).optional(),
   externalSource: z.string().min(1).optional(),
   externalId: z.string().min(1).optional(),
+  // White-label persona override for this workspace's agent. null/omitted uses
+  // the deployment default template.
+  agentInstructions: z.string().min(1).nullable().optional(),
 });
 export type CreateWorkspaceRequest = z.infer<typeof CreateWorkspaceRequest>;
 
 export const UpdateWorkspaceRequest = z.object({
   name: z.string().min(1).optional(),
   slug: z.string().min(1).nullable().optional(),
+  // White-label persona override. Pass null to clear it back to the deployment
+  // default; omit to leave it unchanged.
+  agentInstructions: z.string().min(1).nullable().optional(),
 });
 export type UpdateWorkspaceRequest = z.infer<typeof UpdateWorkspaceRequest>;
 

--- a/packages/db/drizzle/0015_workspace_agent_instructions.sql
+++ b/packages/db/drizzle/0015_workspace_agent_instructions.sql
@@ -1,0 +1,17 @@
+-- Per-workspace white-label agent persona override.
+--
+-- NULL means "use the deployment default template"
+-- (OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE / DEFAULT_AGENT_INSTRUCTIONS), so every
+-- existing workspace keeps the historical, byte-identical preamble after this
+-- migration without a backfill. The runtime always injects the non-bypassable
+-- CORE (goal-loop ownership + workspace-environment block) regardless of this
+-- value, so an override can restyle the persona but never drop that contract.
+ALTER TABLE "workspaces"
+  ADD COLUMN IF NOT EXISTS "agent_instructions" text;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -376,6 +376,7 @@ export async function createWorkspace(db: Database, input: {
   slug?: string | null;
   externalSource?: string | null;
   externalId?: string | null;
+  agentInstructions?: string | null;
 }): Promise<Workspace> {
   const [row] = await db.insert(schema.workspaces).values({
     accountId: input.accountId,
@@ -383,6 +384,7 @@ export async function createWorkspace(db: Database, input: {
     slug: input.slug ?? null,
     externalSource: input.externalSource ?? null,
     externalId: input.externalId ?? null,
+    agentInstructions: input.agentInstructions ?? null,
   }).returning();
   if (!row) {
     throw new Error("Failed to create workspace");
@@ -419,10 +421,12 @@ export async function grantWorkspaceAccess(db: Database, input: {
 export async function updateWorkspace(db: Database, workspaceId: string, input: {
   name?: string;
   slug?: string | null;
+  agentInstructions?: string | null;
 }): Promise<Workspace> {
   const [row] = await db.update(schema.workspaces).set({
     ...(input.name !== undefined ? { name: input.name } : {}),
     ...(input.slug !== undefined ? { slug: input.slug } : {}),
+    ...(input.agentInstructions !== undefined ? { agentInstructions: input.agentInstructions } : {}),
     updatedAt: new Date(),
   }).where(eq(schema.workspaces.id, workspaceId)).returning();
   if (!row) {
@@ -3708,6 +3712,7 @@ function mapWorkspace(row: typeof schema.workspaces.$inferSelect): Workspace {
     slug: row.slug,
     externalSource: row.externalSource,
     externalId: row.externalId,
+    agentInstructions: row.agentInstructions ?? null,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -28,6 +28,9 @@ export const workspaces = pgTable("workspaces", {
   slug: text("slug"),
   externalSource: text("external_source"),
   externalId: text("external_id"),
+  // White-label agent persona template override. NULL means the deployment
+  // default (OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE / DEFAULT_AGENT_INSTRUCTIONS).
+  agentInstructions: text("agent_instructions"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -620,6 +620,7 @@ function fabricateWorkspace(name: string): Workspace {
     slug: name.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
     externalSource: null,
     externalId: null,
+    agentInstructions: null,
     createdAt: now,
     updatedAt: now,
   };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,5 @@
 import type { Settings } from "@opengeni/config";
-import { collectSandboxEnvironment, contextServerCompactThreshold, parseExposedPorts, resolveContextCompactionMode, sandboxLifecycleHookIds } from "@opengeni/config";
+import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, collectSandboxEnvironment, contextServerCompactThreshold, parseExposedPorts, resolveContextCompactionMode, sandboxLifecycleHookIds } from "@opengeni/config";
 import { isClearedRunStateBlob, signDelegatedAccessToken, type Permission, type ReasoningEffort, type ResourceRef, type SessionEventType, type ToolRef } from "@opengeni/contracts";
 import {
   Agent,
@@ -314,6 +314,14 @@ export type BuildAgentOptions = {
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
   workspaceEnvironment?: WorkspaceEnvironmentContext;
+  // Per-call agent persona override (the white-label surface). Resolved by the
+  // caller as session > workspace > deployment default; when omitted the
+  // runtime falls back to settings.agentInstructionsTemplate. The runtime
+  // substitutes the non-bypassable CORE at AGENT_INSTRUCTIONS_CORE_PLACEHOLDER
+  // (or appends it when the template omits the marker), so an override can
+  // restyle the persona but never drop the goal-loop contract or environment
+  // block.
+  instructionsTemplate?: string;
   // Skills delivered by enabled capability packs. They join the bundled
   // skills in the sandbox skill index (mounted under .agents/) so
   // skills/<name> references resolve like any other indexed skill.
@@ -362,6 +370,40 @@ export function workspaceEnvironmentInstructions(environment: WorkspaceEnvironme
   return lines;
 }
 
+/**
+ * The non-bypassable CORE of the agent instructions: the goal-loop ownership
+ * line (which names the opengeni__goal_* tools and is what keeps a long-running
+ * session driving itself) followed by the dynamic workspace-environment block.
+ * Returned as ordered lines so the caller joins them with the rest of the
+ * instructions by " ", exactly as the historical preamble did.
+ *
+ * This is the slice a white-labelled persona template must never be able to
+ * drop: composeAgentInstructions() substitutes it at the persona template's
+ * {{core}} marker, and appends it when the marker is absent.
+ */
+export function coreInstructions(workspaceEnvironment?: WorkspaceEnvironmentContext): string[] {
+  return [
+    "If the session has a goal, you own it: keep working until you call opengeni__goal_complete with concrete evidence or opengeni__goal_pause with a rationale; revise it with opengeni__goal_update; create one with opengeni__goal_set when given a long-running objective.",
+    ...(workspaceEnvironment ? workspaceEnvironmentInstructions(workspaceEnvironment) : []),
+  ];
+}
+
+/**
+ * Composes the final agent instructions from a (possibly white-labelled)
+ * persona template and the non-bypassable CORE. The CORE is substituted at the
+ * template's {{core}} marker; if the template omits the marker, the CORE is
+ * appended after it instead (the non-bypassable fail-safe). The substitution
+ * and the append both join by " ", so the DEFAULT_AGENT_INSTRUCTIONS template
+ * with an empty environment reproduces the historical preamble byte-for-byte.
+ */
+export function composeAgentInstructions(template: string, workspaceEnvironment?: WorkspaceEnvironmentContext): string {
+  const core = coreInstructions(workspaceEnvironment).join(" ");
+  if (template.includes(AGENT_INSTRUCTIONS_CORE_PLACEHOLDER)) {
+    return template.split(AGENT_INSTRUCTIONS_CORE_PLACEHOLDER).join(core);
+  }
+  return core ? `${template} ${core}` : template;
+}
+
 const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
 
@@ -377,21 +419,18 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   const baseConfig = {
     name: "OpenGeni Agent",
     model: options.model ?? settings.openaiModel,
-    instructions: [
-      "You are an OpenGeni workspace agent.",
-      "Follow the user's task and any enabled pack or skill instructions for the current role.",
-      "Work inside the sandbox workspace and use filesystem and shell tools when useful.",
-      "Repository resources are mounted under repos/<owner>/<repo>.",
-      "File resources are mounted under files/<file-id>/ unless the session specifies another mount path.",
-      "Attached files are mounted read-only; copy them before modifying.",
-      "Bundled skills are under .agents/ and can include infrastructure, marketing, or other role-specific guidance.",
-      "Use Checkov, Terraform, Azure CLI, GitHub CLI, and repository tools when relevant.",
-      "When the Azure sandbox preparation profile is enabled and service-principal variables are present, the sandbox is pre-authenticated with normal Azure CLI before work starts.",
-      "Treat code-changing work as GitOps work: create a focused branch/commit/PR when GitHub credentials are available; otherwise report exact commands and blockers.",
-      "Return concise, factual summaries with files changed, commands run, and remaining blockers.",
-      "If the session has a goal, you own it: keep working until you call opengeni__goal_complete with concrete evidence or opengeni__goal_pause with a rationale; revise it with opengeni__goal_update; create one with opengeni__goal_set when given a long-running objective.",
-      ...(options.workspaceEnvironment ? workspaceEnvironmentInstructions(options.workspaceEnvironment) : []),
-    ].join(" "),
+    // White-label persona composition. The effective template is the per-call
+    // override (options.instructionsTemplate, resolved by the caller as
+    // session > workspace) falling back to the deployment default
+    // (settings.agentInstructionsTemplate, default DEFAULT_AGENT_INSTRUCTIONS).
+    // composeAgentInstructions substitutes the non-bypassable CORE (goal-loop
+    // ownership + workspace-environment block) at the {{core}} marker, or
+    // appends it when the template omits the marker. With the default template
+    // and no environment this is byte-identical to the historical preamble.
+    instructions: composeAgentInstructions(
+      options.instructionsTemplate ?? settings.agentInstructionsTemplate,
+      options.workspaceEnvironment,
+    ),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },
       // Server-side compaction (OpenAI platform) requires store=false: the

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
-import { getSettings } from "@opengeni/config";
+import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -416,6 +416,77 @@ describe("runtime event normalization", () => {
     expect(minimal.instructions).toContain('A workspace environment named "bare" is attached to this session');
     expect(minimal.instructions).not.toContain("Exported environment variables:");
     expect(minimal.instructions).not.toContain("Environment notes from the operator:");
+  });
+
+  // THE GATE. The exact preamble buildOpenGeniAgent produced before the
+  // white-label split: the historical hardcoded `instructions` array from
+  // origin/main (packages/runtime/src/index.ts), with no workspace environment,
+  // joined by " ". Captured verbatim; the composed default MUST equal it
+  // byte-for-byte so the white-label slice changes nothing on the default path.
+  const HISTORICAL_DEFAULT_INSTRUCTIONS = [
+    "You are an OpenGeni workspace agent.",
+    "Follow the user's task and any enabled pack or skill instructions for the current role.",
+    "Work inside the sandbox workspace and use filesystem and shell tools when useful.",
+    "Repository resources are mounted under repos/<owner>/<repo>.",
+    "File resources are mounted under files/<file-id>/ unless the session specifies another mount path.",
+    "Attached files are mounted read-only; copy them before modifying.",
+    "Bundled skills are under .agents/ and can include infrastructure, marketing, or other role-specific guidance.",
+    "Use Checkov, Terraform, Azure CLI, GitHub CLI, and repository tools when relevant.",
+    "When the Azure sandbox preparation profile is enabled and service-principal variables are present, the sandbox is pre-authenticated with normal Azure CLI before work starts.",
+    "Treat code-changing work as GitOps work: create a focused branch/commit/PR when GitHub credentials are available; otherwise report exact commands and blockers.",
+    "Return concise, factual summaries with files changed, commands run, and remaining blockers.",
+    "If the session has a goal, you own it: keep working until you call opengeni__goal_complete with concrete evidence or opengeni__goal_pause with a rationale; revise it with opengeni__goal_update; create one with opengeni__goal_set when given a long-running objective.",
+  ].join(" ");
+
+  test("default template composes byte-identically to the historical preamble (no override, no environment)", () => {
+    // Direct composition: default template + empty CORE-with-no-env.
+    expect(composeAgentInstructions(DEFAULT_AGENT_INSTRUCTIONS)).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+    // End-to-end through the agent builder with the default settings template.
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    expect(agent.instructions).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+  });
+
+  test("default template with an attached environment appends the env block exactly as before", () => {
+    const env = {
+      name: "azure-prod",
+      description: "Clone the journal repo over SSH with JOURNAL_DEPLOY_KEY.",
+      variableNames: ["JOURNAL_DEPLOY_KEY", "ARM_CLIENT_ID"],
+    };
+    const expected = [
+      HISTORICAL_DEFAULT_INSTRUCTIONS,
+      'A workspace environment named "azure-prod" is attached to this session; its variables are exported in the sandbox shell environment.',
+      "Exported environment variables: ARM_CLIENT_ID, JOURNAL_DEPLOY_KEY.",
+      "Environment notes from the operator: Clone the journal repo over SSH with JOURNAL_DEPLOY_KEY.",
+    ].join(" ");
+    expect(composeAgentInstructions(DEFAULT_AGENT_INSTRUCTIONS, env)).toBe(expected);
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], { workspaceEnvironment: env });
+    expect(agent.instructions).toBe(expected);
+  });
+
+  test("a white-label persona override is substituted at {{core}} but keeps the non-bypassable CORE", () => {
+    const template = `You are ACME's deployment co-pilot. ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER} Stay on brand.`;
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], { instructionsTemplate: template });
+    expect(agent.instructions).toContain("You are ACME's deployment co-pilot.");
+    expect(agent.instructions).not.toContain("You are an OpenGeni workspace agent.");
+    // CORE (the goal-loop ownership line naming opengeni__goal_*) survives.
+    expect(agent.instructions).toContain("you call opengeni__goal_complete with concrete evidence");
+    expect(agent.instructions).toBe(`You are ACME's deployment co-pilot. ${coreInstructions().join(" ")} Stay on brand.`);
+  });
+
+  test("a persona template without the marker still gets the CORE appended (non-bypassable fail-safe)", () => {
+    const template = "You are ACME's deployment co-pilot.";
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], { instructionsTemplate: template });
+    expect(agent.instructions).toBe(`${template} ${coreInstructions().join(" ")}`);
+    expect(agent.instructions).toContain("opengeni__goal_complete");
+  });
+
+  test("the per-call override beats the deployment-default template", () => {
+    const settings = testSettings({ sandboxBackend: "none", agentInstructionsTemplate: `DEPLOY DEFAULT ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER}` });
+    const withoutOverride = buildOpenGeniAgent(settings, []);
+    expect(withoutOverride.instructions.startsWith("DEPLOY DEFAULT ")).toBe(true);
+    const withOverride = buildOpenGeniAgent(settings, [], { instructionsTemplate: `WORKSPACE OVERRIDE ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER}` });
+    expect(withOverride.instructions.startsWith("WORKSPACE OVERRIDE ")).toBe(true);
+    expect(withOverride.instructions).not.toContain("DEPLOY DEFAULT");
   });
 
   test("builds native S3 mount entries for file resources", () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -314,6 +314,7 @@ export type Workspace = {
   slug: string | null;
   externalSource: string | null;
   externalId: string | null;
+  agentInstructions: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -324,11 +325,13 @@ export type CreateWorkspaceRequest = {
   slug?: string | undefined;
   externalSource?: string | undefined;
   externalId?: string | undefined;
+  agentInstructions?: string | null | undefined;
 };
 
 export type UpdateWorkspaceRequest = {
   name?: string | undefined;
   slug?: string | null | undefined;
+  agentInstructions?: string | null | undefined;
 };
 
 export type ApiKey = {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -1,4 +1,4 @@
-import type { Settings } from "@opengeni/config";
+import { DEFAULT_AGENT_INSTRUCTIONS, type Settings } from "@opengeni/config";
 
 export function testSettings(overrides: Partial<Settings> = {}): Settings {
   return {
@@ -84,6 +84,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     openaiReasoningEncryptedContent: true,
     openaiMaxRetries: 5,
     webSearchEnabled: true,
+    agentInstructionsTemplate: DEFAULT_AGENT_INSTRUCTIONS,
     azureOpenaiBaseUrl: undefined,
     azureOpenaiEndpoint: undefined,
     azureOpenaiDeployment: undefined,


### PR DESCRIPTION
## What

Lets each workspace override the agent's persona system prompt (white-label) without ever being able to drop the non-bypassable contract.

The historical hardcoded preamble is split into:

- **PERSONA** (`DEFAULT_AGENT_INSTRUCTIONS` in `@opengeni/config`) — the brand identity line, framing/opinion lines, and the mount-path facts (historical lines 1-11), joined by `" "` and followed by a `{{core}}` placeholder. Fully overridable per workspace.
- **CORE** (`coreInstructions()` in `@opengeni/runtime`) — the goal-loop ownership line (which names `opengeni__goal_complete/_pause/_update/_set`) plus the dynamic workspace-environment block.

`composeAgentInstructions(template, env?)` substitutes CORE at the template's `{{core}}` marker, or **appends** it when the marker is absent (non-bypassable fail-safe — CORE is never empty because the goal line is always present).

## Boundary rationale

CORE is the contiguous **tail** (goal line + env block) — the most safety-critical slice (tool naming + dynamic env an override must never drop). The mount facts stay in the default persona template; they are brand-free (the only brand, "OpenGeni", is line 1, fully overridable), so the white-label objective is met while keeping the gate below exact.

## The gate: default is byte-identical

With no override and no environment, the composed prompt is **byte-identical** to today's preamble. Pinned by `packages/runtime/test/runtime.test.ts` against the verbatim `origin/main` array, and independently verified character-for-character (extracted programmatically from `git show origin/main` — length 1317, exact match).

## Plumbing

- **DB**: nullable `workspaces.agent_instructions` (migration `0015`). NULL = deployment default, so existing workspaces need no backfill. Verified end-to-end against a live pgvector/pg17 Postgres (full 0000→0015 chain, column created, recorded in `schema_migrations`, re-run idempotent, GRANT applied).
- **Contracts / API**: `agentInstructions` on `Workspace` + Create/Update requests; POST/PATCH normalize whitespace-only → null (deployment default). Update only writes when the field is present (null clears, omit leaves unchanged).
- **Config**: deployment default configurable via `OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE`.
- **Worker**: resolves workspace > deployment default and passes `instructionsTemplate` into `buildAgent`, mirroring `packSkills`/`workspaceEnvironment`.
- **SDK / testing / web / react** mirrors updated.

## Verification

- `bun run typecheck` green across all 16 packages/apps.
- Tests green for every touched package: runtime, config, contracts, db, worker, api, sdk, web, react.
- Builds green: sdk, react, web.
- gitleaks: no leaks.

## Out of scope (deferred)

The `opengeni__` tool-name prefix in CORE still leaks the brand — `firstPartyMcpLabel` de-branding is the follow-up. Per-session overrides are not added in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every agent turn builds system instructions; overrides are admin-controlled and CORE injection limits risk, but custom personas still alter agent behavior workspace-wide.
> 
> **Overview**
> Adds **per-workspace (and deployment-default) agent persona templates** while keeping goal-loop and environment instructions mandatory.
> 
> The runtime no longer hardcodes the full system prompt in `buildOpenGeniAgent`. It composes instructions from a **persona template** (`DEFAULT_AGENT_INSTRUCTIONS` / `OPENGENI_AGENT_INSTRUCTIONS_TEMPLATE`) plus a **non-bypassable CORE** (`coreInstructions`: goal `opengeni__goal_*` contract and dynamic workspace-environment text). `composeAgentInstructions` injects CORE at `{{core}}` or appends it if the marker is missing.
> 
> **Storage & API:** nullable `workspaces.agent_instructions` (migration `0015`); `agentInstructions` on workspace create/update with whitespace-only normalized to null (deployment default). Contracts, SDK, and test fixtures updated.
> 
> **Worker:** each turn loads the workspace override via `resolveWorkspaceAgentInstructions` and passes it as `instructionsTemplate` when set; otherwise the deployment default applies.
> 
> **Compatibility:** with no workspace override and no environment, composed instructions stay **byte-identical** to the old preamble (pinned in `runtime.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38087af7c4cb1233eef4dd873d3785515f9cc4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->