### PR TITLE
api: workspace-scoped session-create idempotency (fix stranded queued sessions)

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -16,7 +16,9 @@ import {
   appendSessionEventsWithLockedSessionUpdate,
   createSession,
   createSessionGoal,
+  createSessionWithIdempotencyKey,
   enqueueSessionTurn,
+  getSessionByCreateIdempotencyKey,
   getSessionTurn,
   requireSession,
   setTemporalWorkflowId,
@@ -62,24 +64,84 @@ export async function createAndStartSession(input: {
   // on the creating grant); null for direct API creates and scheduled runs.
   // When set, the worker's terminal-for-now transitions wake this parent.
   parentSessionId?: string | null;
+  // Workspace-scoped CREATE idempotency key. When present, a double-fire with
+  // the same key (sequential retry OR concurrent race) collapses to a single
+  // session: a prior winner is returned as-is and the start flow below is
+  // skipped, so the dup never re-emits events / re-enqueues a turn.
+  createIdempotencyKey?: string | null;
 }) {
+  const sessionMetadata = {
+    ...input.metadata,
+    model: input.model,
+    reasoningEffort: input.reasoningEffort,
+  };
+  // Fast path with a key: return a session already created under this key
+  // (the sequential retry / double-submit case) without inserting again.
+  if (input.createIdempotencyKey) {
+    const existing = await getSessionByCreateIdempotencyKey(input.db, input.workspaceId, input.createIdempotencyKey);
+    if (existing) {
+      return existing;
+    }
+    // No prior session: insert under the key, racing concurrent creates. The
+    // partial unique index lets exactly one insert win; a loser gets back the
+    // winner's row with created=false and must NOT run the start flow (the
+    // winner owns the events/turn/workflow), so we return it as-is.
+    const { session: keyed, created } = await createSessionWithIdempotencyKey(input.db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      initialMessage: input.initialMessage,
+      resources: input.resources,
+      tools: input.tools,
+      metadata: sessionMetadata,
+      model: input.model,
+      sandboxBackend: input.sandboxBackend,
+      environmentId: input.environment?.id ?? null,
+      firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      parentSessionId: input.parentSessionId ?? null,
+      createIdempotencyKey: input.createIdempotencyKey,
+    });
+    if (!created) {
+      return keyed;
+    }
+    return await finishStartSession(input, keyed);
+  }
   const session = await createSession(input.db, {
     accountId: input.accountId,
     workspaceId: input.workspaceId,
     initialMessage: input.initialMessage,
     resources: input.resources,
     tools: input.tools,
-    metadata: {
-      ...input.metadata,
-      model: input.model,
-      reasoningEffort: input.reasoningEffort,
-    },
+    metadata: sessionMetadata,
     model: input.model,
     sandboxBackend: input.sandboxBackend,
     environmentId: input.environment?.id ?? null,
     firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
     parentSessionId: input.parentSessionId ?? null,
   });
+  return await finishStartSession(input, session);
+}
+
+/**
+ * The post-insert half of {@link createAndStartSession}: durable goal row,
+ * the initial event batch (session.created / goal.set / user.message /
+ * status.changed), turn enqueue, and the workflow wake. Split out so the
+ * idempotency-key winner and the key-less create share one body, and the
+ * idempotency-key loser/dup can skip it entirely.
+ */
+async function finishStartSession(input: {
+  db: Database;
+  bus: EventBus;
+  workflowClient: SessionWorkflowClient;
+  initialMessage: string;
+  resources: ResourceRef[];
+  tools: ToolRef[];
+  clientEventId?: string;
+  model: string;
+  reasoningEffort: Settings["openaiReasoningEffort"];
+  sandboxBackend: Settings["sandboxBackend"];
+  environment?: { id: string; name: string } | null;
+  goal?: GoalSpec | null;
+}, session: Session): Promise<Session> {
   // The goal row is durable session state; the workflow picks it up from the
   // database once the first turn completes — no extra workflow plumbing here.
   const goal = input.goal
@@ -362,6 +424,7 @@ export async function createSessionForRequest(
     goal: payload.goal ?? null,
     firstPartyMcpPermissions,
     parentSessionId,
+    createIdempotencyKey: payload.idempotencyKey ?? null,
   });
   await recordWorkspaceUsage(deps, {
     accountId: grant.accountId,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -527,6 +527,9 @@ function registerWorkspaceOrchestrationTools(
         reasoningEffort: z4.string().optional(),
         sandboxBackend: z4.string().optional(),
         metadata: z4.record(z4.string(), z4.unknown()).optional(),
+        // Workspace-scoped CREATE idempotency key: a retried session_create with
+        // the same key returns the already-spawned worker instead of a duplicate.
+        idempotencyKey: z4.string().min(1).max(200).optional(),
         // First-party MCP token permissions for the spawned session; every
         // permission must be held by this grant (validated in the domain).
         firstPartyMcpPermissions: z4.array(z4.string()).optional(),

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -684,6 +684,7 @@ function session(patch: Partial<Session> = {}): Session {
     sandboxBackend: "none",
     environmentId: null,
     firstPartyMcpPermissions: null,
+    createIdempotencyKey: null,
     temporalWorkflowId: null,
     activeTurnId: "turn-1",
     lastSequence: 0,

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -166,6 +166,13 @@ export function RootRouteComponent() {
   const previousCapabilityToolIds = useRef<Set<string>>(new Set(["docs"]));
   const githubRefreshId = useRef(0);
   const mcpRefreshId = useRef(0);
+  // Stable CREATE idempotency key for the in-flight session create. Generated
+  // lazily and reused across retries (and across a double-click that re-enters
+  // startSession before busy flips), so duplicate creates collapse to one
+  // session server-side; cleared only once a create succeeds so the next real
+  // submit gets a fresh, independent key. Distinct from the per-call
+  // clientEventId (a fresh UUID every send).
+  const pendingCreateKey = useRef<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [repoBusy, setRepoBusy] = useState(false);
   const [githubAppBusy, setGithubAppBusy] = useState(false);
@@ -375,6 +382,10 @@ export function RootRouteComponent() {
 
   async function startSession(workspaceId: string, submission: TurnSubmission): Promise<Session | null> {
     setBusy(true);
+    // Reuse the in-flight key if one survives a prior failed/double-fired
+    // attempt; otherwise mint a fresh stable key for this logical create.
+    const idempotencyKey = pendingCreateKey.current ?? crypto.randomUUID();
+    pendingCreateKey.current = idempotencyKey;
     try {
       const selectedTools = buildTools(submission.tools, [...selectedCapabilityToolIds]);
       const created = await client.createSession(workspaceId, {
@@ -384,15 +395,20 @@ export function RootRouteComponent() {
         model: submission.model ?? model,
         reasoningEffort: submission.reasoningEffort ?? reasoningEffort,
         clientEventId: crypto.randomUUID(),
+        idempotencyKey,
         ...(submission.sandboxBackend ? { sandboxBackend: submission.sandboxBackend } : {}),
         ...(submission.environmentId ? { environmentId: submission.environmentId } : {}),
         ...(submission.goal ? { goal: submission.goal } : {}),
         ...(submission.firstPartyMcpPermissions ? { firstPartyMcpPermissions: submission.firstPartyMcpPermissions } : {}),
       });
+      // Success: release the key so the next distinct submit is independent.
+      pendingCreateKey.current = null;
       setSession(created);
       setConnectionState("idle");
       return created;
     } catch (error) {
+      // Keep the key on failure so a manual retry reuses it and dedups against
+      // a create that may have actually landed server-side.
       toast.error("Failed to start session", { description: error instanceof Error ? error.message : String(error) });
       return null;
     } finally {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1244,6 +1244,10 @@ export const Session = z.object({
   // direct API creates and scheduled-task runs. When set, this session's
   // terminal-for-now transitions wake the parent.
   parentSessionId: z.string().uuid().nullable(),
+  // Workspace-scoped CREATE idempotency key the session was created under (the
+  // dedup target collapsing double-submit/retry races to one session); null
+  // when the create carried no key.
+  createIdempotencyKey: z.string().nullable(),
   temporalWorkflowId: z.string().nullable(),
   activeTurnId: z.string().uuid().nullable(),
   // Actual input tokens of the last model call of the most recent turn; the
@@ -1318,6 +1322,13 @@ export const CreateSessionRequest = z.object({
   environmentId: z.string().uuid().optional(),
   goal: GoalSpec.optional(),
   clientEventId: z.string().min(1).optional(),
+  // Workspace-scoped CREATE idempotency key: collapses concurrent/retried
+  // create calls carrying the same key to a single session (partial unique
+  // index on (workspace_id, create_idempotency_key)). Distinct from
+  // clientEventId, whose uniqueness is per-session and so cannot dedup the
+  // creation of a brand-new session. Absent means no create-dedup (each call
+  // is an independent create).
+  idempotencyKey: z.string().min(1).max(200).optional(),
   // Permissions the session's first-party MCP token should carry instead of
   // the fixed worker default — how an operator hands a manager-style session
   // the orchestration/environment/github tools. Capped at creation: every

--- a/packages/db/drizzle/0016_session_create_idempotency.sql
+++ b/packages/db/drizzle/0016_session_create_idempotency.sql
@@ -1,0 +1,27 @@
+-- Workspace-scoped CREATE idempotency for sessions.
+--
+-- Closes the stuck-queued create-path bug: createSessionForRequest used to
+-- unconditionally insert a brand-new session on every call, so a double-fire
+-- (client double-submit / retry / double-dispatch) created duplicate sessions,
+-- some stranded status=queued forever. clientEventId cannot dedup this — its
+-- unique index is per-session, so two brand-new sessions never collide on it.
+--
+-- The new nullable key + PARTIAL unique index gives the create path a
+-- workspace-scoped dedup target: concurrent creates carrying the same key
+-- collapse to a single row (the loser sees a unique violation, which the
+-- domain layer catches and turns into "return the existing session"). NULL
+-- keys are exempt from the index, so back-compat (key-less) creates stay
+-- independent and existing rows need no backfill.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "create_idempotency_key" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "sessions_workspace_create_idempotency_idx"
+  ON "sessions" ("workspace_id", "create_idempotency_key")
+  WHERE "create_idempotency_key" IS NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1976,6 +1976,7 @@ export async function createSession(db: Database, input: {
   environmentId?: string | null;
   firstPartyMcpPermissions?: Permission[] | null;
   parentSessionId?: string | null;
+  createIdempotencyKey?: string | null;
 }): Promise<Session> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
     const [row] = await scopedDb.insert(schema.sessions).values({
@@ -1990,12 +1991,83 @@ export async function createSession(db: Database, input: {
       environmentId: input.environmentId ?? null,
       firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
       parentSessionId: input.parentSessionId ?? null,
+      createIdempotencyKey: input.createIdempotencyKey ?? null,
       status: "queued",
     }).returning();
     if (!row) {
       throw new Error("Failed to create session");
     }
     return mapSession(row);
+  });
+}
+
+/**
+ * Inserts a session under a workspace-scoped CREATE idempotency key, collapsing
+ * a concurrent race on the same key to a single row. On the unique-violation
+ * the conflicting insert does nothing (`onConflictDoNothing` on the partial
+ * unique index) and the now-existing winning row is fetched and returned, so
+ * two near-simultaneous creates with the same key yield ONE session and both
+ * callers see the same id. `created` distinguishes the winner (true: this call
+ * inserted and must run the rest of the start flow) from the loser/dup (false:
+ * the row already existed and must be returned as-is).
+ */
+export async function createSessionWithIdempotencyKey(db: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  initialMessage: string;
+  resources: ResourceRef[];
+  tools?: ToolRef[];
+  metadata: Record<string, unknown>;
+  model: string;
+  sandboxBackend: SandboxBackend;
+  environmentId?: string | null;
+  firstPartyMcpPermissions?: Permission[] | null;
+  parentSessionId?: string | null;
+  createIdempotencyKey: string;
+}): Promise<{ session: Session; created: boolean }> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const [inserted] = await scopedDb.insert(schema.sessions).values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      initialMessage: input.initialMessage,
+      resources: input.resources,
+      tools: input.tools ?? [],
+      metadata: input.metadata,
+      model: input.model,
+      sandboxBackend: input.sandboxBackend,
+      environmentId: input.environmentId ?? null,
+      firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      parentSessionId: input.parentSessionId ?? null,
+      createIdempotencyKey: input.createIdempotencyKey,
+      status: "queued",
+    }).onConflictDoNothing({
+      target: [schema.sessions.workspaceId, schema.sessions.createIdempotencyKey],
+      where: sql`${schema.sessions.createIdempotencyKey} is not null`,
+    }).returning();
+    if (inserted) {
+      return { session: mapSession(inserted), created: true };
+    }
+    const [existing] = await scopedDb.select().from(schema.sessions).where(and(
+      eq(schema.sessions.workspaceId, input.workspaceId),
+      eq(schema.sessions.createIdempotencyKey, input.createIdempotencyKey),
+    )).limit(1);
+    if (!existing) {
+      // No row inserted and none found: the conflict target did not actually
+      // collide (should never happen for a present key) — surface it rather
+      // than silently returning a phantom.
+      throw new Error("Failed to create session under idempotency key");
+    }
+    return { session: mapSession(existing), created: false };
+  });
+}
+
+export async function getSessionByCreateIdempotencyKey(db: Database, workspaceId: string, createIdempotencyKey: string): Promise<Session | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb.select().from(schema.sessions).where(and(
+      eq(schema.sessions.workspaceId, workspaceId),
+      eq(schema.sessions.createIdempotencyKey, createIdempotencyKey),
+    )).limit(1);
+    return row ? mapSession(row) : null;
   });
 }
 
@@ -3478,6 +3550,7 @@ function mapSession(row: typeof schema.sessions.$inferSelect): Session {
     environmentId: row.environmentId,
     firstPartyMcpPermissions: (row.firstPartyMcpPermissions as Permission[] | null) ?? null,
     parentSessionId: row.parentSessionId ?? null,
+    createIdempotencyKey: row.createIdempotencyKey ?? null,
     temporalWorkflowId: row.temporalWorkflowId,
     activeTurnId: row.activeTurnId,
     lastInputTokens: row.lastInputTokens ?? null,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -126,6 +126,12 @@ export const sessions = pgTable("sessions", {
   // manager can orchestrate workers without busy-polling. Self-referencing FK,
   // ON DELETE SET NULL so deleting a manager never cascades into its workers.
   parentSessionId: uuid("parent_session_id"),
+  // Workspace-scoped CREATE idempotency key. NULL means the create carried no
+  // key (each such create is independent). When set, the partial unique index
+  // below collapses concurrent/retried creates with the same key in the same
+  // workspace to a single session row — the dedup that closes the
+  // double-submit/double-dispatch stuck-queued bug.
+  createIdempotencyKey: text("create_idempotency_key"),
   temporalWorkflowId: text("temporal_workflow_id"),
   activeTurnId: uuid("active_turn_id"),
   // Actual input tokens reported for the last model call of the most recent
@@ -145,6 +151,11 @@ export const sessions = pgTable("sessions", {
   workspaceCreated: index("sessions_workspace_created_idx").on(table.workspaceId, table.createdAt),
   environment: index("sessions_environment_idx").on(table.workspaceId, table.environmentId),
   parent: index("sessions_parent_idx").on(table.workspaceId, table.parentSessionId),
+  // Partial unique index: one session per (workspace, create_idempotency_key)
+  // when a key is present. Concurrent creates racing on the same key see a
+  // unique violation on all but one; the domain layer catches it and returns
+  // the winning row instead of erroring.
+  createIdempotency: uniqueIndex("sessions_workspace_create_idempotency_idx").on(table.workspaceId, table.createIdempotencyKey).where(sql`${table.createIdempotencyKey} is not null`),
 }));
 
 export const files = pgTable("files", {

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -444,6 +444,7 @@ export class MockOpenGeniClient implements SessionClientLike {
       sandboxBackend: "modal",
       environmentId: null,
       firstPartyMcpPermissions: null,
+      createIdempotencyKey: null,
       temporalWorkflowId: null,
       activeTurnId: null,
       lastSequence: this.bus(sessionId).events.length,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -57,6 +57,7 @@ export type Session = {
   sandboxBackend: SandboxBackend;
   environmentId: string | null;
   firstPartyMcpPermissions: string[] | null;
+  createIdempotencyKey: string | null;
   temporalWorkflowId: string | null;
   activeTurnId: string | null;
   lastSequence: number;
@@ -236,6 +237,10 @@ export type CreateSessionRequest = {
   environmentId?: string | undefined;
   goal?: GoalSpec | undefined;
   clientEventId?: string | undefined;
+  // Workspace-scoped CREATE idempotency key: forward a STABLE value to make a
+  // double-submit/retry of the same logical create collapse to one session.
+  // Distinct from the per-call clientEventId.
+  idempotencyKey?: string | undefined;
   firstPartyMcpPermissions?: string[] | undefined;
 };
 

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -60,6 +60,70 @@ describe("API component integration", () => {
     expect(sessions.some((item) => item.id === session.id && item.workspaceId === workspaceId && item.initialMessage === "hello")).toBe(true);
   });
 
+  test("create idempotency key dedups double-submit and concurrent creates to one session over the API", async () => {
+    workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const create = (idempotencyKey: string) => app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "dedup me", idempotencyKey, model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    // Sequential double-submit: same key twice -> one session, no second start.
+    const seqKey = `route-seq-${crypto.randomUUID()}`;
+    const wakeupsBefore = workflow.wakeups.length;
+    const firstResp = await create(seqKey);
+    expect(firstResp.status).toBe(202);
+    const firstSession = await firstResp.json() as { id: string };
+    const secondResp = await create(seqKey);
+    expect(secondResp.status).toBe(202);
+    const secondSession = await secondResp.json() as { id: string };
+    expect(secondSession.id).toBe(firstSession.id);
+    // Only the winner ran the start flow: one wakeup, one event batch.
+    expect(workflow.wakeups.length).toBe(wakeupsBefore + 1);
+    const seqEvents = await listSessionEvents(dbClient.db, workspaceId, firstSession.id);
+    expect(seqEvents.map((event) => event.type)).toEqual(["session.created", "user.message", "session.status.changed", "turn.queued"]);
+
+    // Concurrent double-dispatch: N at once on the same key -> one session.
+    const raceKey = `route-race-${crypto.randomUUID()}`;
+    const wakeupsBeforeRace = workflow.wakeups.length;
+    const responses = await Promise.all(Array.from({ length: 6 }, () => create(raceKey)));
+    const raceSessions = await Promise.all(responses.map(async (resp) => {
+      expect(resp.status).toBe(202);
+      return (await resp.json() as { id: string }).id;
+    }));
+    const uniqueRaceIds = new Set(raceSessions);
+    expect(uniqueRaceIds.size).toBe(1);
+    // Exactly one create won the start flow despite the race.
+    expect(workflow.wakeups.length).toBe(wakeupsBeforeRace + 1);
+    const rows = await withWorkspaceCount(dbClient.db, workspaceId, raceKey);
+    expect(rows).toBe(1);
+
+    // Different key -> an independent session (back-compat).
+    const otherResp = await create(`route-other-${crypto.randomUUID()}`);
+    const otherSession = await otherResp.json() as { id: string };
+    expect(otherSession.id).not.toBe(firstSession.id);
+
+    // Absent key -> independent each time (the legacy path).
+    const plain1 = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "no key", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    const plain2 = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "no key", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect((await plain1.json() as { id: string }).id).not.toBe((await plain2.json() as { id: string }).id);
+  });
+
   test("creates sessions with goals and manages the goal lifecycle over the API", async () => {
     workflow = new FakeWorkflowClient();
     const app = createApp({
@@ -4130,6 +4194,11 @@ async function hmacSha256Hex(secret: string, message: string): Promise<string> {
 
 function workspacePath(workspaceId: string, path: string): string {
   return `/v1/workspaces/${workspaceId}${path}`;
+}
+
+async function withWorkspaceCount(db: ReturnType<typeof createDb>["db"], workspaceId: string, createIdempotencyKey: string): Promise<number> {
+  const rows = await db.execute(dbSql<{ n: number }>`select count(*)::int as n from sessions where workspace_id = ${workspaceId} and create_idempotency_key = ${createIdempotencyKey}`);
+  return Number(rows[0]?.n ?? 0);
 }
 
 async function bootstrapMcpGrant(db: ReturnType<typeof createDb>["db"]) {

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -21,6 +21,8 @@ import {
   createApiKey,
   createSession,
   createSessionGoal,
+  createSessionWithIdempotencyKey,
+  getSessionByCreateIdempotencyKey,
   createTurn,
   dbSql,
   enableCapabilityInstallation,
@@ -132,6 +134,94 @@ describe("DB integration", () => {
     await expect(appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [
       { type: "agent.message.delta", payload: { text: "b" }, producerId: "p", producerSeq: 1 },
     ])).rejects.toThrow();
+  });
+
+  test("workspace-scoped create idempotency key collapses sequential and concurrent races to one session", async () => {
+    const grant = await testGrant(dbClient.db);
+    const otherGrant = await testGrant(dbClient.db);
+    const countSessions = async (workspaceId: string, key: string): Promise<number> => {
+      const rows = await dbClient.db.execute(dbSql<{ n: number }>`select count(*)::int as n from sessions where workspace_id = ${workspaceId} and create_idempotency_key = ${key}`);
+      return Number(rows[0]?.n ?? 0);
+    };
+    const baseInput = (key: string) => ({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "idempotent create",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none" as const,
+      createIdempotencyKey: key,
+    });
+
+    // 1. Sequential: same key twice -> one row, second is a dup of the first.
+    const seqKey = `seq-${crypto.randomUUID()}`;
+    const first = await createSessionWithIdempotencyKey(dbClient.db, baseInput(seqKey));
+    const second = await createSessionWithIdempotencyKey(dbClient.db, baseInput(seqKey));
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.session.id).toBe(first.session.id);
+    expect(await countSessions(grant.workspaceId, seqKey)).toBe(1);
+    // The lookup helper resolves the same row by key.
+    expect((await getSessionByCreateIdempotencyKey(dbClient.db, grant.workspaceId, seqKey))?.id).toBe(first.session.id);
+
+    // 2. Concurrent: N near-simultaneous creates with the same key race the
+    //    partial unique index; exactly one wins (created=true), the rest catch
+    //    the unique violation and return the winner's row.
+    const raceKey = `race-${crypto.randomUUID()}`;
+    const results = await Promise.all(Array.from({ length: 8 }, () =>
+      createSessionWithIdempotencyKey(dbClient.db, baseInput(raceKey))));
+    const winners = results.filter((r) => r.created);
+    expect(winners).toHaveLength(1);
+    const ids = new Set(results.map((r) => r.session.id));
+    expect(ids.size).toBe(1);
+    expect([...ids][0]).toBe(winners[0]!.session.id);
+    expect(await countSessions(grant.workspaceId, raceKey)).toBe(1);
+
+    // 3a. Different key -> independent create (back-compat).
+    const otherKey = `other-${crypto.randomUUID()}`;
+    const otherKeyed = await createSessionWithIdempotencyKey(dbClient.db, baseInput(otherKey));
+    expect(otherKeyed.created).toBe(true);
+    expect(otherKeyed.session.id).not.toBe(first.session.id);
+
+    // 3b. Same key string but a DIFFERENT workspace -> independent create (the
+    //     key is workspace-scoped, not global).
+    const crossWorkspace = await createSessionWithIdempotencyKey(dbClient.db, {
+      accountId: otherGrant.accountId,
+      workspaceId: otherGrant.workspaceId,
+      initialMessage: "idempotent create",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+      createIdempotencyKey: seqKey,
+    });
+    expect(crossWorkspace.created).toBe(true);
+    expect(crossWorkspace.session.id).not.toBe(first.session.id);
+
+    // 3c. Absent key (the legacy createSession path) -> always independent, and
+    //     two key-less creates never collide on the partial index.
+    const plainA = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "no key a",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const plainB = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "no key b",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    expect(plainA.id).not.toBe(plainB.id);
+    expect(plainA.createIdempotencyKey).toBeNull();
+    expect(plainB.createIdempotencyKey).toBeNull();
   });
 
   test("persists run state versions and turn status transitions", async () => {


### PR DESCRIPTION
## Problem

`createSessionForRequest` unconditionally called `createAndStartSession`, whose first statement inserted a brand-new `sessions` row on every call with no dedup. Any double-fire (client double-submit / retry / double-dispatch) created a duplicate session, some stranded `status=queued` forever.

`clientEventId` cannot dedup new-session creation: its unique index `session_events_workspace_client_event_idx` includes `session_id`, so two brand-new sessions never collide on it.

## Fix

Workspace-scoped CREATE idempotency key:

- **contracts / schema / sdk / mcp**: optional `idempotencyKey` (`z.string().min(1).max(200).optional()`), persisted as `sessions.create_idempotency_key` (nullable text).
- **migration `0016_session_create_idempotency.sql`**: `PARTIAL UNIQUE INDEX sessions_workspace_create_idempotency_idx ON sessions(workspace_id, create_idempotency_key) WHERE create_idempotency_key IS NOT NULL`. NULL keys are exempt, so key-less creates stay independent (back-compat) and existing rows need no backfill. Includes the standard `opengeni_app` GRANT DO-block; applied via `migrate.ts` under the advisory lock.
- **domain `createAndStartSession`**: when a key is present, lookup-or-insert-on-conflict-return. A sequential retry resolves to the existing session and skips the start flow. Concurrent creates race the partial unique index: the winner runs the events/turn/workflow once (`created=true`); every loser's insert no-ops via `onConflictDoNothing`, the winning row is `SELECT`ed and returned with `created=false` (never a 500), so the dup never re-emits events or re-enqueues a turn.
- **web `context.tsx`**: mints a STABLE `pendingCreateKey` reused across double-click / retry (cleared only on success), distinct from the per-call `clientEventId`.

## Verification

- Full monorepo typecheck (16 packages): exit 0.
- Builds: SDK, react, react demo, web app: all exit 0.
- Unit tests: 646 pass / 0 fail.
- **DB integration: 24 pass / 0 fail** — new idempotency test covers sequential dedup, 8-way concurrent unique-violation collapse, different-key independence, cross-workspace independence, absent-key back-compat. Migration chain `0000 -> 0016` applies on real `pgvector/pgvector:pg17`; idempotent re-run confirmed.
- **API integration: 67 pass / 0 fail** — new route dedup test: sequential double-submit and 6-way concurrent double-dispatch each collapse to one session id, one workflow wakeup, one DB row, exact event sequence `[session.created, user.message, session.status.changed, turn.queued]`. Different-key and absent-key creates stay independent.
- gitleaks sweep on staged changes: no leaks.

## Note

Repairing the ~5 already-stranded queued + ~31 failed staging rows is a separate one-shot data repair, handled at closeout — not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core session start path and schema migration; behavior change is intentional but duplicate creates now share one workflow/events path, and callers must send stable keys for dedup to work.
> 
> **Overview**
> Adds **workspace-scoped CREATE idempotency** so double-submits, retries, and concurrent creates with the same key collapse to one session instead of spawning duplicates stuck in `queued`.
> 
> **Persistence:** nullable `sessions.create_idempotency_key` plus a partial unique index on `(workspace_id, create_idempotency_key)` when the key is set; key-less creates stay independent.
> 
> **API/domain:** optional `idempotencyKey` on create (REST, contracts, SDK, MCP `session_create`). `createAndStartSession` looks up an existing row by key, or inserts with `onConflictDoNothing` on concurrent races. Only the insert **winner** runs the post-create path (`finishStartSession`: goal, events, turn enqueue, workflow wake); losers return the existing session without re-emitting events or enqueueing another turn.
> 
> **Web:** `startSession` keeps a stable `pendingCreateKey` across retries and double-clicks (cleared on success), separate from per-call `clientEventId`.
> 
> Integration tests cover sequential and concurrent dedup over HTTP and DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60771e6f73409659b1f52d5b31334fb805686c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->