### PR TITLE
web: resolve /billing?checkout=success Stripe return

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -16,7 +16,7 @@ import {
   buildSessionMcpPermissionGroups,
   delegableApiKeyPermissions,
 } from "./lib/permissions";
-import { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "./lib/routes";
+import { parseCheckoutOutcome, workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "./lib/routes";
 import {
   emptyAdvancedSessionDraft,
   submissionExtrasFromAdvancedSessionDraft,
@@ -62,6 +62,23 @@ describe("workspace route helpers", () => {
 
   test("does not build legacy unscoped session URLs", () => {
     expect(workspaceSessionPath("workspace-1", "session-1")).not.toBe("/sessions/session-1");
+  });
+});
+
+describe("Stripe checkout return", () => {
+  // Regression: the API bakes `/billing?checkout=success` into every checkout
+  // session, but the console had no `/billing` route, so the post-payment
+  // redirect rendered "Page not found". The /billing route now validates this
+  // search param and forwards onto the account page.
+  test("recognizes the success and cancelled outcomes Stripe redirects with", () => {
+    expect(parseCheckoutOutcome({ checkout: "success" })).toBe("success");
+    expect(parseCheckoutOutcome({ checkout: "cancelled" })).toBe("cancelled");
+  });
+
+  test("drops unknown or absent outcomes so no stray confirmation renders", () => {
+    expect(parseCheckoutOutcome({ checkout: "bogus" })).toBeUndefined();
+    expect(parseCheckoutOutcome({})).toBeUndefined();
+    expect(parseCheckoutOutcome({ checkout: "" })).toBeUndefined();
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@
 //   /workspaces/:id/schedules                → scheduled tasks + run history
 //   /workspaces/:id/documents                → document bases + search
 //   /workspaces/:id/account                  → account, usage, API keys
+//   /billing?checkout=success|cancelled      → Stripe return → default account
 import {
   Navigate,
   RouterProvider,
@@ -21,6 +22,7 @@ import {
 
 import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
+import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
 import { AccountRoute } from "@/routes/account";
 import { CapabilitiesRoute } from "@/routes/capabilities";
 import { DocumentsRoute } from "@/routes/documents";
@@ -40,6 +42,19 @@ const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   component: RootIndexRoute,
+});
+// Stripe checkout return target. The API bakes `/billing?checkout=…` into every
+// checkout session's success_url/cancel_url; this top-level route forwards the
+// shopper onto their default workspace account (where the balance lives) so the
+// redirect resolves instead of hitting the not-found page.
+const billingReturnRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "billing",
+  validateSearch: (search: Record<string, unknown>): { checkout?: CheckoutOutcome } => {
+    const checkout = parseCheckoutOutcome(search);
+    return checkout ? { checkout } : {};
+  },
+  component: BillingReturnRoute,
 });
 const workspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -102,10 +117,17 @@ const workspaceDocumentsRoute = createRoute({
 const workspaceAccountRoute = createRoute({
   getParentRoute: () => workspaceRoute,
   path: "account",
+  // `?checkout=success|cancelled` arrives via the /billing Stripe-return
+  // redirect so the account page can confirm the top-up.
+  validateSearch: (search: Record<string, unknown>): { checkout?: CheckoutOutcome } => {
+    const checkout = parseCheckoutOutcome(search);
+    return checkout ? { checkout } : {};
+  },
   component: Account,
 });
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  billingReturnRoute,
   workspaceRoute.addChildren([
     workspaceIndexRoute,
     workspaceAgentRoute,
@@ -195,7 +217,25 @@ function Documents() {
 
 function Account() {
   const { workspaceId } = workspaceAccountRoute.useParams();
-  return <AccountRoute workspaceId={workspaceId} />;
+  const { checkout } = workspaceAccountRoute.useSearch();
+  return <AccountRoute workspaceId={workspaceId} checkout={checkout} />;
+}
+
+function BillingReturnRoute() {
+  const context = useAppContext();
+  const { checkout } = billingReturnRoute.useSearch();
+  const workspaceId = context.accessContext.defaultWorkspaceId ?? context.workspaces[0]?.id ?? context.accessContext.workspaceGrants[0]?.workspaceId;
+  if (!workspaceId) {
+    return <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />;
+  }
+  return (
+    <Navigate
+      to="/workspaces/$workspaceId/account"
+      params={{ workspaceId }}
+      search={checkout ? { checkout } : {}}
+      replace
+    />
+  );
 }
 
 function NotFoundRoute() {

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -17,3 +17,14 @@ export function workspaceAgentPath(workspaceId: string): string {
 export function workspaceSessionPath(workspaceId: string, sessionId: string): string {
   return `${workspaceSessionsPath(workspaceId)}/${encodeURIComponent(sessionId)}`;
 }
+
+// Stripe checkout redirects land on `/billing?checkout=success|cancelled` (the
+// success_url/cancel_url baked into every checkout session by the API). The
+// `/billing` route forwards the shopper onto their account page, carrying this
+// outcome so the balance view can confirm the top-up. Unknown values are
+// dropped so a stray `?checkout=foo` never renders a confirmation.
+export type CheckoutOutcome = "success" | "cancelled";
+
+export function parseCheckoutOutcome(search: Record<string, unknown>): CheckoutOutcome | undefined {
+  return search.checkout === "success" || search.checkout === "cancelled" ? search.checkout : undefined;
+}

--- a/apps/web/src/routes/account.tsx
+++ b/apps/web/src/routes/account.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/lib/permissions";
 import type { ApiKey, BillingEntitlementsResponse, BillingSummary, UsageEvent } from "@/types";
 
-export function AccountRoute({ workspaceId }: { workspaceId: string }) {
+export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; checkout?: "success" | "cancelled" }) {
   const context = useAppContext();
   const client = context.client;
   const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
@@ -65,6 +65,17 @@ export function AccountRoute({ workspaceId }: { workspaceId: string }) {
     }
     void refresh();
   }, [workspaceId, accountId]);
+
+  // Confirm the Stripe checkout outcome the /billing return redirect forwarded
+  // here. Credits post via the asynchronous webhook, so success is phrased as
+  // "shortly" rather than implying the balance already reflects the top-up.
+  useEffect(() => {
+    if (checkout === "success") {
+      toast.success("Payment received", { description: "Your credits will appear shortly." });
+    } else if (checkout === "cancelled") {
+      toast("Checkout cancelled", { description: "No charge was made." });
+    }
+  }, [checkout]);
 
   // Each loader records its own failure: a failed request must render as an
   // error with retry, never as "No API keys." or a quietly absent balance.


### PR DESCRIPTION
## Problem

`https://staging.app.opengeni.ai/billing?checkout=success` rendered **"Page not found."**

Stripe checkout sessions bake `/billing?checkout=success` and `/billing?checkout=cancelled` into their `success_url`/`cancel_url` (`apps/api/src/routes/billing.ts:139-140`), but the web console's TanStack router has **no `/billing` route** — billing UI lives under the workspace-scoped `/workspaces/:id/account`. The SPA shell returns HTTP 200, then the client-side router matches nothing and renders `NotFoundRoute` ("Page not found").

## Fix (web-only)

- Add a top-level `/billing` route that validates the `checkout` outcome and **redirects the shopper onto their default workspace's account page** (where the balance lives), carrying `?checkout=…`.
- The account page surfaces a confirmation **toast** — phrased "your credits will appear shortly" because the top-up posts via the asynchronous Stripe webhook, so the balance may not reflect it the instant the page loads.
- `parseCheckoutOutcome` drops unknown/empty values so a stray `?checkout=foo` never renders a confirmation.

No API change: the baked-in default `success_url` now resolves. Any SDK/CLI caller relying on the default also benefits.

## Verification

- `tsc --noEmit` ✓ (TanStack typed routes validate the new route tree)
- 65 web unit tests ✓, including 2 new for `parseCheckoutOutcome`
- **Headless chromium proof**: with the boot endpoints stubbed so the router renders, an unregistered control path (`/nonsense-xyz`) still shows "Page not found", while `/billing?checkout=success` redirects to `/workspaces/<id>/account?checkout=success` (not-found = false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web-only routing and UX toasts; no API or payment logic changes.
> 
> **Overview**
> Fixes post-Stripe redirects that hit **`/billing?checkout=success`** or **`cancelled`** and previously showed **Page not found** because the console had no top-level `/billing` route.
> 
> Adds a **`/billing`** route that parses the `checkout` query via **`parseCheckoutOutcome`** (only `success` and `cancelled` are accepted) and **replaces** navigation to the user’s default workspace **`/workspaces/:id/account`**, preserving `?checkout=…`. The workspace account route also validates that search param and passes it into **`AccountRoute`**, which shows a one-time toast—success wording notes credits may lag the async webhook.
> 
> Unit tests cover **`parseCheckoutOutcome`**; users with no workspace still get the existing no-access panel instead of a silent not-found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01fbd2af1730d0cce4bc55125d156e3b75f1de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->