### PR TITLE
web: clamp overflowing workspace session titles in the sessions list

### DIFF
--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -358,7 +358,7 @@ function WorkspaceSessions({ onSelect }: { onSelect: (id: string) => void }) {
         ) : sessions.length === 0 ? (
           <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">No sessions in this workspace yet.</div>
         ) : sessions.map((item) => (
-          <button key={item.id} type="button" onClick={() => onSelect(item.id)} className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-left text-sm hover:bg-[color:var(--color-surface-2)]">
+          <button key={item.id} type="button" onClick={() => onSelect(item.id)} className="min-w-0 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-left text-sm hover:bg-[color:var(--color-surface-2)]">
             <div className="flex min-w-0 items-center justify-between gap-3">
               <div className="min-w-0 truncate font-medium">{item.initialMessage}</div>
               <SessionStatusBadge status={item.status} />


### PR DESCRIPTION
## Problem

Long session titles in the workspace **sessions list** flowed off the right edge of the screen — no wrapping, no truncation.

## Root cause

The title element already had `min-w-0 truncate` and its flex parent had `min-w-0`, but truncation never engaged. The row `<button>` is an item in an implicit single-column `grid` (the `mt-3 grid gap-2` container), and a grid item defaults to `min-width: auto`. The non-truncating metadata row (date / model / sandbox) drove that `auto` track to its **max-content** width, blowing the column — and the page — wider than the viewport, so the inner `truncate` had no finite width to clamp against.

## Fix

Add `min-w-0` to the row `<button>` (`apps/web/src/routes/sessions-index.tsx`) so its minimum contribution is 0, the implicit grid track is bounded by the container, and the existing `truncate` clamps the title to one line with an ellipsis. One-line change; matches the `min-w-0` chain idiom already used in `components/common.tsx`.

## Verification

- `tsc`, 65 web unit tests, `bun run build` — all green.
- **Headless chromium, before/after** (per the render-in-browser practice), with a 300-char title:
  - **unfixed**: title box `scrollWidth=3039`, running ~2154px past the 1280 viewport (clipped by an ancestor `overflow-x-hidden`, no ellipsis, status badge pushed off-screen)
  - **fixed**: title clamps with ellipsis (`overflowX:hidden; textOverflow:ellipsis`), every ancestor bounded (`scrollWidth==clientWidth`), badge visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a list row button; layout-only with no auth, data, or API changes.
> 
> **Overview**
> Long session titles in the workspace sessions list could extend past the viewport because the row `<button>` is a grid item with default `min-width: auto`, so metadata max-content width prevented the inner `truncate` from getting a bounded width.
> 
> Adds **`min-w-0`** to that row button in `sessions-index.tsx`, completing the shrink chain so the grid track respects the container and titles ellipsis correctly while the status badge stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc4903bff65578d5509504d409206c1656c30f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->