### PR TITLE
deploy: persist CORS allow-origins (blob staging + API regex) for Geni uploads

### DIFF
--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -61,6 +61,11 @@ config:
   OPENGENI_AUTH_ALLOW_HEALTH: "true"
   OPENGENI_AUTH_ALLOW_METRICS: "false"
   OPENGENI_WEB_ALLOWED_HOSTS: opengeni.example.com
+  # Cross-origin allow-list for the API. The code wraps this as ^(?:<value>)$,
+  # so it is an unanchored exact-alternation regex (no leading ^ / trailing $).
+  # Covers localhost dev plus the managed staging and production app origins
+  # (a single universal value is fine across staging and prod).
+  OPENGENI_CORS_ALLOW_ORIGIN_REGEX: 'https?://(localhost|127\.0\.0\.1)(:\d+)?|https://staging\.app\.opengeni\.ai|https://geni-staging\.app\.opengeni\.ai|https://app\.opengeni\.ai'
   OPENGENI_PRODUCT_ACCESS_MODE: configured
   OPENGENI_BILLING_MODE: disabled
   OPENGENI_ENTITLEMENTS_MODE: none

--- a/deploy/terraform/azure/terraform.tfvars.example
+++ b/deploy/terraform/azure/terraform.tfvars.example
@@ -33,5 +33,8 @@ object_storage = {
   bucket = "opengeni-files"
   # Required for direct browser uploads to signed Blob URLs. Prefer exact
   # HTTPS app origins; "*" is acceptable only for short-lived private evaluation stacks.
+  # List every app origin that uploads directly to Blob, e.g. a primary app plus
+  # an additional product front-end sharing the same storage account:
+  #   cors_allowed_origins = ["https://staging.app.opengeni.ai", "https://geni-staging.app.opengeni.ai"]
   cors_allowed_origins = ["https://opengeni.example.com"]
 }


### PR DESCRIPTION
## What & why

Two CORS fixes were already applied **live** to unblock Geni direct-to-Blob uploads and cross-origin API calls. This PR makes them **durable** so a future Helm bootstrap re-render (and the documented Terraform template) does not silently revert them.

### Change 1 — API allow-origin regex (durable home: `values.azure-managed.example.yaml`)

The API gates CORS with `OPENGENI_CORS_ALLOW_ORIGIN_REGEX`. In deployed config this key was **unset**, so the service ran the localhost-only code default (`packages/config/src/index.ts:186`) and rejected cross-origin requests even from its own origins. It was patched live into the `opengeni-config` ConfigMap on **both** clusters.

I added the key to the `config:` block of `deploy/helm/opengeni/values.azure-managed.example.yaml`:

```
OPENGENI_CORS_ALLOW_ORIGIN_REGEX: 'https?://(localhost|127\.0\.0\.1)(:\d+)?|https://staging\.app\.opengeni\.ai|https://geni-staging\.app\.opengeni\.ai|https://app\.opengeni\.ai'
```

**Why this home (cited proof it's consumed by bootstrap):**

- The bootstrap deploy step renders the `azure-managed` profile from exactly this file: `helmValuesFileFor()` returns `deploy/helm/opengeni/values.azure-managed.example.yaml` at `packages/deployment/src/index.ts:961`, which becomes `helmValuesFile` and is passed to Helm as `--values <file>` at `packages/deployment/src/index.ts:1042` → emitted into the `helm upgrade --install` command at `packages/deployment/src/index.ts:1043`.
- CI independently renders the same file: `.github/workflows/ci.yml:97` (`-f deploy/helm/opengeni/values.azure-managed.example.yaml`).
- The chart writes every `config.*` key verbatim into the `opengeni-config` ConfigMap (`deploy/helm/opengeni/templates/configmap.yaml`, `range $key, $value := .Values.config`). So a fresh bootstrap now emits this key into `opengeni-config`.
- The managed values **builder** `addRuntimeConfigHelmValues()` (`packages/deployment/src/index.ts:1527-1562`) does **not** set this key, so the static file's value is not overridden by the generated values file (which Helm applies last). The static `config:` block is therefore the correct, lowest-risk home and a single universal value covers both staging and prod (matching the live patch).

**Value correctness:** the API wraps the value as `^(?:<value>)$` (`apps/api/src/app.ts:218-220`), so the stored string is intentionally **unanchored** (no leading `^` / trailing `$`). Verified the wrapped regex allows `https://geni-staging.app.opengeni.ai`, `https://staging.app.opengeni.ai`, `https://app.opengeni.ai`, and localhost/127.0.0.1, while blocking look-alikes (`xstaging.app.opengeni.ai`, `app.opengeni.ai.evil.com`).

### Change 2 — Blob staging CORS (`opengenistgneufiles`)

The Azure Blob staging account `opengenistgneufiles` was updated **live via `az`** to allow the Geni origin. The Terraform-declared list that a future `apply` reconciles against is `var.object_storage.cors_allowed_origins`, rendered into the storage `cors_rule` at `deploy/terraform/azure/main.tf:336-345`.

The **live** value lives in `deploy/terraform/azure/terraform.tfvars`, which is **gitignored** (`.gitignore:21`) and not part of this public repo — its durable home is the private ops tfvars, out of scope here. To make the requirement discoverable and durable for operators, I updated the committed template `deploy/terraform/azure/terraform.tfvars.example` to document the multi-origin shape, including both staging origins:

```
#   cors_allowed_origins = ["https://staging.app.opengeni.ai", "https://geni-staging.app.opengeni.ai"]
```

I deliberately did **not** replace the generic `https://opengeni.example.com` placeholder, since this file is the self-host template, not Cloudgeni's environment file.

> Note: the original task referenced editing `deploy/terraform/azure/terraform.tfvars` directly. That file is gitignored and absent from this OSS checkout, so it cannot be committed here; the example template is the only committable Terraform-vars artifact and the canonical reference operators copy.

## Verification

- gitleaks (`protect --staged`): **no leaks found** — the diff contains only public origins and a public regex, no secrets.
- `packages/deployment` tests: **29 pass / 0 fail**.
- `apps/api` tests (incl. `allowedCorsOrigin`): **23 pass / 0 fail**.
- `packages/deployment` typecheck (`tsc --noEmit`): **clean**.
- YAML scalar extracted and validated; wrapped-regex match/block cases all pass.
- `helm`/`terraform` binaries not available in this environment (non-blocking, per scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only deploy configuration and comments; no application logic changes, though incorrect CORS values in real tfvars/Helm would affect browser uploads and API access.
> 
> **Overview**
> Codifies **live** CORS fixes so Helm bootstrap and Terraform templates do not revert them after the next deploy.
> 
> The **azure-managed** Helm example now sets **`OPENGENI_CORS_ALLOW_ORIGIN_REGEX`** in the `config` block (with comments on how the API wraps the value), allowing localhost plus **`staging.app.opengeni.ai`**, **`geni-staging.app.opengeni.ai`**, and **`app.opengeni.ai`** for cross-origin API calls.
> 
> **`terraform.tfvars.example`** gains operator guidance to list every HTTPS app origin that performs direct browser uploads to Azure Blob, including a commented example with both staging Geni origins; the placeholder **`cors_allowed_origins`** entry is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 331c72fad13607f2c97c17acb1421b1c478f201f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->