### PR TITLE
react: own file uploads in @opengeni/react (useFileAttachments + ChatComposer prop)

### DIFF
--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -1,115 +1,34 @@
-// Console chrome around @opengeni/react's ChatComposer: draft file
-// attachments (upload, chips, paste-to-attach) and the console's control
-// strip. The textarea, send/stop controls, Enter handling, and draft/error
-// state all come from the package.
-import { ChatComposer, type ComposerState, type SlashCommandContext } from "@opengeni/react";
-import { FileIcon, ImageIcon, ListPlusIcon, Loader2Icon, PaperclipIcon, XIcon, ZapIcon } from "lucide-react";
+// Console chrome around @opengeni/react's ChatComposer: the console's control
+// strip (delivery-mode toggle, model picker, tool toggles) plus the package's
+// built-in file-attachment UI. File upload state, chips, paste-to-attach, and
+// the send-gate now live in the package (useFileAttachments + ChatComposer's
+// `attachments` prop); the console just wires them through.
 import {
-  type ClipboardEvent,
-  type ChangeEvent,
-  type ReactNode,
-  useCallback,
-  useRef,
-  useState,
-} from "react";
+  ChatComposer,
+  useFileAttachments,
+  type ComposerState,
+  type SlashCommandContext,
+  type UseFileAttachmentsResult,
+} from "@opengeni/react";
+import { ListPlusIcon, ZapIcon } from "lucide-react";
+import { type ReactNode } from "react";
 
-import { Button } from "@/components/ui/button";
-import { useAppContext } from "@/context";
-import { formatBytes } from "@/lib/format";
 import { deliveryModeExplanation } from "@/lib/queue";
 import { cn } from "@/lib/utils";
-import type { FileAsset, ResourceRef, SessionStatus } from "@/types";
+import type { SessionStatus } from "@/types";
 
-type DraftAttachment = {
-  id: string;
-  name: string;
-  contentType: string;
-  sizeBytes: number;
-  status: "uploading" | "ready" | "failed";
-  file?: FileAsset;
-  previewUrl?: string;
-  error?: string;
-};
-
-export type DraftAttachmentsState = {
-  attachments: DraftAttachment[];
-  /** File resources for every attachment that finished uploading. */
-  readyResources: ResourceRef[];
-  uploading: boolean;
-  enqueueFiles: (files: Iterable<File>) => void;
-  removeAttachment: (id: string) => void;
-  clear: () => void;
-};
-
-/** Upload-and-track state for files attached to the next message (via the SDK's uploadFile). */
-export function useDraftAttachments(workspaceId: string): DraftAttachmentsState {
-  const { client } = useAppContext();
-  const [attachments, setAttachments] = useState<DraftAttachment[]>([]);
-
-  const enqueueFiles = useCallback((files: Iterable<File>) => {
-    for (const file of files) {
-      const id = crypto.randomUUID();
-      const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
-      setAttachments((current) => [...current, {
-        id,
-        name: file.name || "image",
-        contentType: file.type || "application/octet-stream",
-        sizeBytes: file.size,
-        status: "uploading",
-        ...(previewUrl ? { previewUrl } : {}),
-      }]);
-      void client.uploadFile(workspaceId, {
-        filename: file.name || "file",
-        contentType: file.type || "application/octet-stream",
-        data: file,
-      }).then((asset) => {
-        setAttachments((current) => current.map((attachment) => attachment.id === id
-          ? { ...attachment, status: "ready", file: asset, name: asset.filename, contentType: asset.contentType, sizeBytes: asset.sizeBytes }
-          : attachment));
-      }).catch((error) => {
-        setAttachments((current) => current.map((attachment) => attachment.id === id
-          ? { ...attachment, status: "failed", error: error instanceof Error ? error.message : String(error) }
-          : attachment));
-      });
-    }
-  }, [client, workspaceId]);
-
-  const removeAttachment = useCallback((id: string) => {
-    setAttachments((current) => {
-      const removed = current.find((attachment) => attachment.id === id);
-      if (removed?.previewUrl) {
-        URL.revokeObjectURL(removed.previewUrl);
-      }
-      return current.filter((attachment) => attachment.id !== id);
-    });
-  }, []);
-
-  const clear = useCallback(() => {
-    setAttachments((current) => {
-      for (const attachment of current) {
-        if (attachment.previewUrl) {
-          URL.revokeObjectURL(attachment.previewUrl);
-        }
-      }
-      return [];
-    });
-  }, []);
-
-  return {
-    attachments,
-    readyResources: attachments.flatMap((attachment): ResourceRef[] => attachment.status === "ready" && attachment.file
-      ? [{ kind: "file", fileId: attachment.file.id }]
-      : []),
-    uploading: attachments.some((attachment) => attachment.status === "uploading"),
-    enqueueFiles,
-    removeAttachment,
-    clear,
-  };
+/**
+ * Back-compat shim over the package's workspace-scoped {@link useFileAttachments}.
+ * The new-session surface still calls this positionally; the session route uses
+ * the package hook directly (the provider supplies the workspace there).
+ */
+export function useDraftAttachments(workspaceId: string): UseFileAttachmentsResult {
+  return useFileAttachments({ workspaceId });
 }
 
 export function ConsoleComposer(props: {
   composer: ComposerState;
-  attachments: DraftAttachmentsState;
+  attachments: UseFileAttachmentsResult;
   status?: SessionStatus | null;
   placeholder?: string;
   autoFocus?: boolean;
@@ -131,65 +50,25 @@ export function ConsoleComposer(props: {
   /** Reset the local timeline view (the /clear-view command target). */
   onClearView?: () => void;
 }) {
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { composer, attachments } = props;
-  // Block sends while attachments are still uploading so a message never
-  // departs without the files the user attached to it. `send` is gated too:
-  // Enter-to-send calls it directly, without consulting `canSend`.
-  const gatedComposer: ComposerState = attachments.uploading
-    ? { ...composer, canSend: false, send: async () => false }
-    : composer;
-
-  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
-    if (event.target.files) {
-      attachments.enqueueFiles(event.target.files);
-    }
-    event.target.value = "";
-  }
-
-  function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    if (!props.fileUploadsEnabled) {
-      return;
-    }
-    const files = [...event.clipboardData.files].filter((file) => file.type.startsWith("image/"));
-    if (files.length > 0) {
-      attachments.enqueueFiles(files);
-    }
-  }
 
   return (
     <div className="w-full">
-      <input ref={fileInputRef} type="file" multiple className="hidden" onChange={handleFileChange} />
       <ChatComposer
-        composer={gatedComposer}
+        composer={composer}
         status={props.status}
         placeholder={props.placeholder}
         autoFocus={props.autoFocus}
         disabled={props.disabled}
-        onPaste={handlePaste}
+        {...(props.fileUploadsEnabled ? { attachments } : {})}
         {...(props.commandContext ? { commandContext: props.commandContext } : {})}
         {...(props.onClearView ? { onClearView: props.onClearView } : {})}
-        header={attachments.attachments.length > 0 ? (
-          <AttachmentChips attachments={attachments.attachments} onRemove={attachments.removeAttachment} />
-        ) : undefined}
         controlsStart={(
           <>
             {props.showDeliveryMode ? (
               <DeliveryModeToggle composer={composer} disabled={props.disabled} />
             ) : null}
             {props.controls}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-8 rounded-md"
-              disabled={props.disabled || !props.fileUploadsEnabled}
-              onClick={() => fileInputRef.current?.click()}
-              aria-label={props.fileUploadsEnabled ? "Attach files" : "File uploads unavailable"}
-              title={props.fileUploadsEnabled ? "Attach files" : "File uploads are not configured"}
-            >
-              <PaperclipIcon className="size-4" />
-            </Button>
           </>
         )}
       />
@@ -253,52 +132,6 @@ function DeliveryModeToggle({ composer, disabled }: { composer: ComposerState; d
         <ZapIcon className="size-3.5" />
         Steer
       </button>
-    </div>
-  );
-}
-
-function AttachmentChips({ attachments, onRemove }: {
-  attachments: DraftAttachment[];
-  onRemove: (id: string) => void;
-}) {
-  return (
-    <div className="flex flex-wrap gap-2 border-b border-[color:var(--color-border)] px-3 py-2">
-      {attachments.map((attachment) => (
-        <div
-          key={attachment.id}
-          className={cn(
-            "flex min-w-0 max-w-[240px] items-center gap-2 rounded-md border px-2 py-1.5",
-            "border-[color:var(--color-border)] bg-[color:var(--color-surface-2)] text-xs",
-          )}
-        >
-          {attachment.previewUrl ? (
-            <img src={attachment.previewUrl} alt="" className="size-8 shrink-0 rounded object-cover" />
-          ) : attachment.contentType.startsWith("image/") ? (
-            <ImageIcon className="size-4 shrink-0 text-[color:var(--color-fg-muted)]" />
-          ) : (
-            <FileIcon className="size-4 shrink-0 text-[color:var(--color-fg-muted)]" />
-          )}
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-medium text-[color:var(--color-fg)]">{attachment.name}</div>
-            <div className={cn(
-              "truncate text-[11px]",
-              attachment.status === "failed" ? "text-[color:var(--color-danger)]" : "text-[color:var(--color-fg-subtle)]",
-            )}
-            >
-              {attachment.status === "uploading" ? "Uploading" : attachment.status === "failed" ? "Upload failed" : formatBytes(attachment.sizeBytes)}
-            </div>
-          </div>
-          {attachment.status === "uploading" ? <Loader2Icon className="size-3.5 shrink-0 animate-spin" /> : null}
-          <button
-            type="button"
-            onClick={() => onRemove(attachment.id)}
-            className="shrink-0 rounded p-1 text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-surface)] hover:text-[color:var(--color-fg)]"
-            aria-label={`Remove ${attachment.name}`}
-          >
-            <XIcon className="size-3.5" />
-          </button>
-        </div>
-      ))}
     </div>
   );
 }

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -6,6 +6,7 @@ import {
   MessageTimeline,
   projectPendingApprovals,
   useComposer,
+  useFileAttachments,
   useGoal,
   useSession,
   useSessionEvents,
@@ -21,7 +22,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { isApiErrorStatus } from "@/api";
-import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
+import { ConsoleComposer } from "@/components/Composer";
 import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { MarkdownText } from "@/components/markdown";
 import {
@@ -207,7 +208,9 @@ function SessionChatPane(props: {
 }) {
   const context = useAppContext();
   const terminal = isTerminalSessionStatus(props.session.status);
-  const attachments = useDraftAttachments(props.session.workspaceId);
+  // Workspace-scoped: the provider (mounted on the workspace route) supplies
+  // the workspaceId, so the hook needs no positional argument.
+  const attachments = useFileAttachments();
   const { selectedCapabilityToolIds, model, reasoningEffort } = context;
   const composer = useComposer(props.session.id, {
     // Evaluated at send time: attachments and tools picked while the draft was

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -14,6 +14,8 @@ import type {
   CreateWorkspaceEnvironmentRequest,
   CreateWorkspaceRequest,
   EnablePackRequest,
+  FileAsset,
+  FileDownloadUrlResponse,
   ListPacksResponse,
   PackInstallation,
   RegisterCapabilityPackRequest,
@@ -26,6 +28,7 @@ import type {
   SessionTurn,
   SteerMessageResult,
   StreamSessionEventsOptions,
+  UploadFileInput,
   UpdateSessionGoalRequest,
   UpdateSessionTurnRequest,
   UpdateWorkspaceEnvironmentRequest,
@@ -413,6 +416,44 @@ export class MockOpenGeniClient implements SessionClientLike {
     return {
       balance: { accountId: ACCOUNT_ID, balanceMicros: 42_500_000, currency: "usd", updatedAt: new Date().toISOString() },
       usage: [],
+    };
+  }
+
+  async uploadFile(workspaceId: string, input: UploadFileInput): Promise<FileAsset> {
+    const sizeBytes = input.data instanceof Blob
+      ? input.data.size
+      : typeof input.data === "string"
+        ? new TextEncoder().encode(input.data).byteLength
+        : input.data instanceof Uint8Array
+          ? input.data.byteLength
+          : (input.data as ArrayBuffer).byteLength;
+    return this.fileAsset(workspaceId, { filename: input.filename, contentType: input.contentType, sizeBytes });
+  }
+
+  async getFile(workspaceId: string, fileId: string): Promise<FileAsset> {
+    return this.fileAsset(workspaceId, { id: fileId });
+  }
+
+  async createFileDownloadUrl(_workspaceId: string, fileId: string): Promise<FileDownloadUrlResponse> {
+    return { url: `https://example.invalid/files/${fileId}`, expiresAt: new Date(Date.now() + 3_600_000).toISOString() };
+  }
+
+  private fileAsset(workspaceId: string, overrides: Partial<FileAsset>): FileAsset {
+    const now = new Date().toISOString();
+    return {
+      id: overrides.id ?? `file-${Date.now()}`,
+      workspaceId,
+      status: "ready",
+      filename: overrides.filename ?? "file",
+      safeFilename: overrides.filename ?? "file",
+      contentType: overrides.contentType ?? "application/octet-stream",
+      sizeBytes: overrides.sizeBytes ?? 0,
+      sha256: null,
+      bucket: "mock",
+      objectKey: `mock/${overrides.id ?? "file"}`,
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
     };
   }
 

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -28,6 +28,10 @@ export type SessionClientLike = Pick<
   | "compactSessionContext"
   // Scheduled tasks
   | "listScheduledTasks"
+  // Files (upload + download-url minting for attachments)
+  | "uploadFile"
+  | "getFile"
+  | "createFileDownloadUrl"
   // Environments
   | "listEnvironments"
   | "createEnvironment"

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,14 +1,16 @@
 import type { SessionStatus } from "@opengeni/sdk";
-import { ArrowUpIcon, LoaderCircleIcon, SquareIcon } from "lucide-react";
+import { ArrowUpIcon, FileIcon, ImageIcon, LoaderCircleIcon, PaperclipIcon, SquareIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ClipboardEvent, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type KeyboardEvent, type ReactNode } from "react";
 import { argHint } from "../commands/registry";
 import type { Notice, SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
 import { shouldSubmitOnKey } from "../hooks/use-composer";
+import type { UseFileAttachmentsResult } from "../hooks/use-file-attachments";
 import { defaultCommands } from "../commands/registry";
 import { useSlashCommands, type ConfirmState, type SlashCommandContext } from "../hooks/use-slash-commands";
 import { cn } from "../lib/cn";
+import { formatBytes } from "../lib/format";
 import { CommandPalette } from "./command-palette";
 
 export type ChatComposerProps = {
@@ -26,6 +28,15 @@ export type ChatComposerProps = {
   header?: ReactNode | undefined;
   /** Paste hook on the textarea (e.g. paste-image-to-attach). */
   onPaste?: ((event: ClipboardEvent<HTMLTextAreaElement>) => void) | undefined;
+  /**
+   * Opt-in file attachments. When supplied (e.g. from {@link useFileAttachments}),
+   * the composer renders a built-in attach button (prepended to `controlsStart`),
+   * an attachment-chips strip (above the textarea, before any host `header`),
+   * routes paste through `addFromPaste` (image/* filter lives in the hook), and
+   * gates send while `uploading` so a message never departs without its files.
+   * Absent → no attachment UI renders and the composer behaves exactly as before.
+   */
+  attachments?: UseFileAttachmentsResult | undefined;
   className?: string | undefined;
   /**
    * Slash-command palette. Defaults to the built-in {@link defaultCommands};
@@ -65,13 +76,21 @@ export function ChatComposer({
   controlsStart,
   header,
   onPaste,
+  attachments,
   className,
   commands = defaultCommands,
   commandContext,
   onClearView,
 }: ChatComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const active = status != null && ACTIVE_STATUSES.has(status);
+
+  // Block sends while attachments are still uploading so a message never
+  // departs without the files the user attached to it. This gates BOTH the
+  // Enter-to-send path (which calls composer.send directly, bypassing canSend)
+  // and the send button — dropping either path could ship a fileless message.
+  const blockedByUpload = attachments?.uploading === true;
 
   const [notice, setNotice] = useState<Notice | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -166,9 +185,35 @@ export function ChatComposer({
         setNotice({ tone: "error", message: "That's a slash command — press Enter in the command list to run it, or edit the line to send a message." });
         return;
       }
+      if (blockedByUpload) {
+        // Files are still uploading: swallow the Enter so the message can't
+        // depart without them. The send button is disabled in the same state.
+        return;
+      }
       void composer.send();
     }
   };
+
+  // The host's onPaste still fires (model/tool/whatever paste handling); when
+  // attachments are wired, also feed the clipboard through addFromPaste so the
+  // image/* filter (owned by the hook) attaches pasted images.
+  const handlePaste = useCallback(
+    (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      onPaste?.(event);
+      attachments?.addFromPaste(event);
+    },
+    [onPaste, attachments],
+  );
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files) {
+        attachments?.addFiles(event.target.files);
+      }
+      event.target.value = "";
+    },
+    [attachments],
+  );
 
   const helpCommands = useMemo(
     () =>
@@ -212,6 +257,9 @@ export function ChatComposer({
             "focus-within:border-og-accent/60 focus-within:shadow-og-glow",
           )}
         >
+          {attachments && attachments.attachments.length > 0 ? (
+            <AttachmentChips attachments={attachments.attachments} onRemove={attachments.remove} />
+          ) : null}
           {header}
           <textarea
             ref={textareaRef}
@@ -219,7 +267,7 @@ export function ChatComposer({
             value={composer.value}
             onChange={(event) => composer.setValue(event.target.value)}
             onKeyDown={onKeyDown}
-            onPaste={onPaste}
+            onPaste={handlePaste}
             placeholder={placeholder ?? "Message the agent…"}
             disabled={disabled}
             autoFocus={autoFocus}
@@ -250,8 +298,35 @@ export function ChatComposer({
             />
           ) : (
             <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
-              {controlsStart ? (
-                <span className="flex min-w-0 items-center gap-1.5">{controlsStart}</span>
+              {attachments || controlsStart ? (
+                <span className="flex min-w-0 items-center gap-1.5">
+                  {attachments ? (
+                    <>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        onChange={handleFileChange}
+                      />
+                      <button
+                        type="button"
+                        disabled={disabled === true}
+                        onClick={() => fileInputRef.current?.click()}
+                        aria-label="Attach files"
+                        title="Attach files"
+                        className={cn(
+                          "inline-flex size-8 items-center justify-center rounded-og-md",
+                          "text-og-fg-muted transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
+                          "disabled:cursor-not-allowed disabled:opacity-50",
+                        )}
+                      >
+                        <PaperclipIcon className="size-4" />
+                      </button>
+                    </>
+                  ) : null}
+                  {controlsStart}
+                </span>
               ) : (
                 <span className="px-1.5 text-[11px] text-og-fg-subtle max-sm:hidden">
                   {hint ?? "Enter to send · Shift+Enter for a new line · / for commands"}
@@ -288,8 +363,13 @@ export function ChatComposer({
                 </AnimatePresence>
                 <button
                   type="button"
-                  onClick={() => void composer.send()}
-                  disabled={!composer.canSend || disabled === true || commandDraftBlocked}
+                  onClick={() => {
+                    if (blockedByUpload) {
+                      return;
+                    }
+                    void composer.send();
+                  }}
+                  disabled={!composer.canSend || disabled === true || commandDraftBlocked || blockedByUpload}
                   aria-label="Send message"
                   className={cn(
                     "inline-flex size-8 items-center justify-center rounded-og-md",
@@ -366,6 +446,58 @@ function ConfirmBar({ command, onCancel, onConfirm }: { command: SlashCommand; o
           Confirm
         </button>
       </span>
+    </div>
+  );
+}
+
+/**
+ * The attachment-chips strip rendered above the textarea while files are
+ * attached. Each chip shows an image preview (or a type icon), the filename,
+ * an upload/size/failed status line, and a remove control. Styled with the
+ * package's og-* tokens so it themes in any consumer.
+ */
+function AttachmentChips({ attachments, onRemove }: {
+  attachments: UseFileAttachmentsResult["attachments"];
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 border-b border-og-border px-3 py-2">
+      {attachments.map((attachment) => (
+        <div
+          key={attachment.id}
+          className={cn(
+            "flex min-w-0 max-w-[240px] items-center gap-2 rounded-og-md border px-2 py-1.5",
+            "border-og-border bg-og-surface-2 text-xs",
+          )}
+        >
+          {attachment.previewUrl ? (
+            <img src={attachment.previewUrl} alt="" className="size-8 shrink-0 rounded object-cover" />
+          ) : attachment.contentType.startsWith("image/") ? (
+            <ImageIcon className="size-4 shrink-0 text-og-fg-muted" />
+          ) : (
+            <FileIcon className="size-4 shrink-0 text-og-fg-muted" />
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-medium text-og-fg">{attachment.name}</div>
+            <div className={cn(
+              "truncate text-[11px]",
+              attachment.status === "failed" ? "text-og-status-failed" : "text-og-fg-subtle",
+            )}
+            >
+              {attachment.status === "uploading" ? "Uploading" : attachment.status === "failed" ? "Upload failed" : formatBytes(attachment.sizeBytes)}
+            </div>
+          </div>
+          {attachment.status === "uploading" ? <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" /> : null}
+          <button
+            type="button"
+            onClick={() => onRemove(attachment.id)}
+            className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg"
+            aria-label={`Remove ${attachment.name}`}
+          >
+            <XIcon className="size-3.5" />
+          </button>
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,0 +1,135 @@
+import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
+import { useCallback, useState } from "react";
+import { useOpenGeni, type ClientOverride } from "../provider";
+
+export type UseFileAttachmentsOptions = ClientOverride & {
+  /**
+   * Only files matching this predicate are accepted by {@link
+   * UseFileAttachmentsResult.addFromPaste} (the clipboard path). Defaults to
+   * `image/*` — the console's historical paste filter. {@link
+   * UseFileAttachmentsResult.addFiles} (the explicit picker / drop path)
+   * bypasses it.
+   */
+  pasteFilter?: ((file: File) => boolean) | undefined;
+};
+
+export type FileAttachment = {
+  id: string;
+  name: string;
+  contentType: string;
+  sizeBytes: number;
+  status: "uploading" | "ready" | "failed";
+  /** The SDK `FileAsset` once the upload finishes. */
+  file?: FileAsset | undefined;
+  /** Object-URL for an inline preview; minted for `image/*` files only. */
+  previewUrl?: string | undefined;
+  error?: string | undefined;
+};
+
+export type UseFileAttachmentsResult = {
+  attachments: FileAttachment[];
+  /**
+   * `FileResourceRef[]` for every attachment that finished uploading — feed
+   * straight into `useComposer`'s `sendExtras.resources`.
+   */
+  readyResources: FileResourceRef[];
+  /** True while any attachment is still uploading (drives the send-gate). */
+  uploading: boolean;
+  /** Explicit picker / drop path — uploads every file, no filter. */
+  addFiles: (files: Iterable<File>) => void;
+  /** Clipboard path — applies `pasteFilter` (default `image/*`) then uploads. */
+  addFromPaste: (event: { clipboardData: DataTransfer | null }) => void;
+  /** Remove one attachment; revokes its object-URL. */
+  remove: (id: string) => void;
+  /** Remove all; revokes every object-URL. Call from `useComposer`'s `onSent`. */
+  clear: () => void;
+};
+
+const isImage = (file: File): boolean => file.type.startsWith("image/");
+
+/**
+ * Upload-and-track state for files attached to the next message. Owns the
+ * full client-side upload layer: a per-file `uploading | ready | failed`
+ * status machine driven by the SDK's `client.uploadFile`, object-URL image
+ * previews with create/revoke lifecycle, the `image/*` clipboard paste filter,
+ * and a `FileResourceRef[]` projection that drops straight into a message's
+ * `resources`. Workspace-scoped, so it resolves both client and workspace from
+ * the {@link OpenGeniProvider} (or a per-call `{ client, workspaceId }`).
+ */
+export function useFileAttachments(options: UseFileAttachmentsOptions = {}): UseFileAttachmentsResult {
+  const { client, workspaceId } = useOpenGeni(options);
+  const pasteFilter = options.pasteFilter ?? isImage;
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+
+  const addFiles = useCallback((files: Iterable<File>) => {
+    for (const file of files) {
+      const id = crypto.randomUUID();
+      const previewUrl = isImage(file) ? URL.createObjectURL(file) : undefined;
+      setAttachments((current) => [...current, {
+        id,
+        name: file.name || "image",
+        contentType: file.type || "application/octet-stream",
+        sizeBytes: file.size,
+        status: "uploading",
+        ...(previewUrl ? { previewUrl } : {}),
+      }]);
+      void client.uploadFile(workspaceId, {
+        filename: file.name || "file",
+        contentType: file.type || "application/octet-stream",
+        data: file,
+      }).then((asset) => {
+        setAttachments((current) => current.map((attachment) => attachment.id === id
+          ? { ...attachment, status: "ready", file: asset, name: asset.filename, contentType: asset.contentType, sizeBytes: asset.sizeBytes }
+          : attachment));
+      }).catch((error: unknown) => {
+        setAttachments((current) => current.map((attachment) => attachment.id === id
+          ? { ...attachment, status: "failed", error: error instanceof Error ? error.message : String(error) }
+          : attachment));
+      });
+    }
+  }, [client, workspaceId]);
+
+  const addFromPaste = useCallback((event: { clipboardData: DataTransfer | null }) => {
+    const clipboardFiles = event.clipboardData?.files;
+    if (!clipboardFiles) {
+      return;
+    }
+    const files = [...clipboardFiles].filter(pasteFilter);
+    if (files.length > 0) {
+      addFiles(files);
+    }
+  }, [addFiles, pasteFilter]);
+
+  const remove = useCallback((id: string) => {
+    setAttachments((current) => {
+      const removed = current.find((attachment) => attachment.id === id);
+      if (removed?.previewUrl) {
+        URL.revokeObjectURL(removed.previewUrl);
+      }
+      return current.filter((attachment) => attachment.id !== id);
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setAttachments((current) => {
+      for (const attachment of current) {
+        if (attachment.previewUrl) {
+          URL.revokeObjectURL(attachment.previewUrl);
+        }
+      }
+      return [];
+    });
+  }, []);
+
+  return {
+    attachments,
+    readyResources: attachments.flatMap((attachment): FileResourceRef[] => attachment.status === "ready" && attachment.file
+      ? [{ kind: "file", fileId: attachment.file.id }]
+      : []),
+    uploading: attachments.some((attachment) => attachment.status === "uploading"),
+    addFiles,
+    addFromPaste,
+    remove,
+    clear,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -15,6 +15,8 @@ export { useSessionEvents } from "./hooks/use-session-events";
 export type { SessionEventsConnectionState, UseSessionEventsOptions, UseSessionEventsResult } from "./hooks/use-session-events";
 export { useComposer, composeSendInput, shouldSubmitOnKey } from "./hooks/use-composer";
 export type { ComposerMode, ComposerSendExtras, ComposerState, UseComposerOptions } from "./hooks/use-composer";
+export { useFileAttachments } from "./hooks/use-file-attachments";
+export type { FileAttachment, UseFileAttachmentsOptions, UseFileAttachmentsResult } from "./hooks/use-file-attachments";
 export {
   useTurnQueue,
   isTurnQueueEvent,
@@ -110,4 +112,4 @@ export type { FleetTileProps } from "./components/fleet-tile";
 
 // Utilities
 export { cn } from "./lib/cn";
-export { formatRelativeTime, stringifyPayload, truncate, tryParseJson } from "./lib/format";
+export { formatBytes, formatRelativeTime, stringifyPayload, truncate, tryParseJson } from "./lib/format";

--- a/packages/react/src/lib/format.ts
+++ b/packages/react/src/lib/format.ts
@@ -26,6 +26,22 @@ export function formatRelativeTime(iso: string, now: Date = new Date()): string 
   return new Date(iso).toLocaleDateString();
 }
 
+/** Human-readable byte size: "512 B", "8.0 KB", "1.4 MB", "3 GB". */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB"] as const;
+  let value = bytes / 1024;
+  for (const unit of units) {
+    if (value < 1024 || unit === "GB") {
+      return `${value.toFixed(value < 10 ? 1 : 0)} ${unit}`;
+    }
+    value /= 1024;
+  }
+  return `${bytes} B`;
+}
+
 /** Single-line preview of arbitrary text, for tiles and collapsed rows. */
 export function truncate(text: string, maxLength: number): string {
   const collapsed = text.replace(/\s+/g, " ").trim();

--- a/packages/react/test/chat-composer-uploads.test.tsx
+++ b/packages/react/test/chat-composer-uploads.test.tsx
@@ -1,0 +1,160 @@
+/* ----------------------------------------------------------------------------
+   ChatComposer's opt-in `attachments` prop: the built-in attach button, the
+   attachment-chips strip, the paste->addFromPaste wiring, and the send-gate
+   that blocks BOTH the button and Enter while files are uploading.
+   -------------------------------------------------------------------------- */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ChatComposer } from "../src/components/chat-composer";
+import type { ComposerState } from "../src/hooks/use-composer";
+import type { FileAttachment, UseFileAttachmentsResult } from "../src/hooks/use-file-attachments";
+import { registerDom } from "./render-hook";
+
+registerDom();
+
+let mounted: { root: Root; container: HTMLElement } | null = null;
+
+afterEach(async () => {
+  if (mounted) {
+    const current = mounted;
+    mounted = null;
+    await act(async () => {
+      current.root.unmount();
+    });
+    current.container.remove();
+  }
+});
+
+function makeComposer(overrides: Partial<ComposerState> = {}): ComposerState {
+  return {
+    value: "hello there",
+    setValue: () => {},
+    send: async () => true,
+    sending: false,
+    canSend: true,
+    mode: "queue",
+    setMode: () => {},
+    interrupt: async () => {},
+    interrupting: false,
+    error: null,
+    clearError: () => {},
+    ...overrides,
+  };
+}
+
+function makeAttachments(overrides: Partial<UseFileAttachmentsResult> = {}): UseFileAttachmentsResult {
+  return {
+    attachments: [],
+    readyResources: [],
+    uploading: false,
+    addFiles: () => {},
+    addFromPaste: () => {},
+    remove: () => {},
+    clear: () => {},
+    ...overrides,
+  };
+}
+
+function readyChip(name: string): FileAttachment {
+  return { id: crypto.randomUUID(), name, contentType: "image/png", sizeBytes: 2048, status: "ready" };
+}
+
+async function mount(node: React.ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+  });
+  mounted = { root, container };
+  return container;
+}
+
+function sendButton(container: HTMLElement): HTMLButtonElement | undefined {
+  return [...container.querySelectorAll("button")].find(
+    (b) => b.getAttribute("aria-label") === "Send message",
+  ) as HTMLButtonElement | undefined;
+}
+
+describe("ChatComposer attachments", () => {
+  test("with no attachments prop, no attach button renders (backward compatible)", async () => {
+    const container = await mount(<ChatComposer composer={makeComposer()} />);
+    const attach = [...container.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === "Attach files");
+    expect(attach).toBeUndefined();
+  });
+
+  test("the attach button and hidden file input render in controlsStart when attachments is present", async () => {
+    const container = await mount(<ChatComposer composer={makeComposer()} attachments={makeAttachments()} />);
+    const attach = [...container.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === "Attach files");
+    expect(attach).toBeTruthy();
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute("multiple")).not.toBeNull();
+  });
+
+  test("attachment chips render above the textarea when files are attached", async () => {
+    const attachments = makeAttachments({ attachments: [readyChip("screenshot.png")] });
+    const container = await mount(<ChatComposer composer={makeComposer()} attachments={attachments} />);
+    expect(container.textContent ?? "").toContain("screenshot.png");
+    // The remove control for the chip is present.
+    const remove = [...container.querySelectorAll("button")].find((b) => b.getAttribute("aria-label") === "Remove screenshot.png");
+    expect(remove).toBeTruthy();
+  });
+
+  test("while uploading, the send button is disabled and Enter does not call send", async () => {
+    let sent = 0;
+    const composer = makeComposer({ send: async () => { sent += 1; return true; } });
+    const attachments = makeAttachments({ uploading: true, attachments: [{ ...readyChip("a.png"), status: "uploading" }] });
+    const container = await mount(<ChatComposer composer={composer} attachments={attachments} />);
+
+    expect(sendButton(container)!.disabled).toBe(true);
+
+    const textarea = container.querySelector("textarea")!;
+    await act(async () => {
+      textarea.focus();
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(sent).toBe(0);
+    await act(async () => {
+      sendButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(sent).toBe(0);
+  });
+
+  test("with uploads settled, Enter sends and the button is enabled", async () => {
+    let sent = 0;
+    const composer = makeComposer({ send: async () => { sent += 1; return true; } });
+    const attachments = makeAttachments({ uploading: false, attachments: [readyChip("a.png")], readyResources: [{ kind: "file", fileId: "f1" }] });
+    const container = await mount(<ChatComposer composer={composer} attachments={attachments} />);
+
+    expect(sendButton(container)!.disabled).toBe(false);
+    const textarea = container.querySelector("textarea")!;
+    await act(async () => {
+      textarea.focus();
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(sent).toBe(1);
+  });
+
+  test("pasting into the textarea routes the clipboard through addFromPaste (and still calls host onPaste)", async () => {
+    let pastedThroughHook = 0;
+    let hostPaste = 0;
+    const attachments = makeAttachments({ addFromPaste: () => { pastedThroughHook += 1; } });
+    const container = await mount(
+      <ChatComposer composer={makeComposer()} attachments={attachments} onPaste={() => { hostPaste += 1; }} />,
+    );
+    const textarea = container.querySelector("textarea")!;
+    await act(async () => {
+      textarea.focus();
+      // happy-dom's ClipboardEvent carries a clipboardData the React handler reads.
+      textarea.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(pastedThroughHook).toBe(1);
+    expect(hostPaste).toBe(1);
+  });
+});

--- a/packages/react/test/use-file-attachments.test.tsx
+++ b/packages/react/test/use-file-attachments.test.tsx
@@ -1,0 +1,200 @@
+/* ----------------------------------------------------------------------------
+   Rendered-hook tests for useFileAttachments — the SDK-owned client-side upload
+   layer: object-URL preview lifecycle, the image/* paste filter, the
+   uploading->ready/failed status machine, the FileResourceRef projection, and
+   the single `uploading` boolean the composer's send-gate reads.
+   -------------------------------------------------------------------------- */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { FileAsset } from "@opengeni/sdk";
+import { act } from "react";
+import { useFileAttachments } from "../src/hooks/use-file-attachments";
+import { fakeClient, WORKSPACE_ID } from "./fake-client";
+import { flush, registerDom, renderHook } from "./render-hook";
+
+registerDom();
+
+/** Run a callback inside act-flushed microtasks so state updates settle. */
+async function flushing(run: () => Promise<void> | void): Promise<void> {
+  await act(async () => {
+    await run();
+  });
+}
+
+function fakeAsset(overrides: Partial<FileAsset> = {}): FileAsset {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: WORKSPACE_ID,
+    status: "ready",
+    filename: "asset.png",
+    safeFilename: "asset.png",
+    contentType: "image/png",
+    sizeBytes: 1234,
+    sha256: null,
+    bucket: "b",
+    objectKey: "k",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    updatedAt: "2026-06-12T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function imageFile(name = "shot.png"): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
+}
+
+function textFile(name = "notes.txt"): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "text/plain" });
+}
+
+// Spy on the object-URL lifecycle. happy-dom may or may not provide these; we
+// fully replace them so create/revoke calls are deterministically counted.
+let created: string[] = [];
+let revoked: string[] = [];
+let originalCreate: typeof URL.createObjectURL | undefined;
+let originalRevoke: typeof URL.revokeObjectURL | undefined;
+let urlCounter = 0;
+
+beforeEach(() => {
+  created = [];
+  revoked = [];
+  urlCounter = 0;
+  originalCreate = URL.createObjectURL;
+  originalRevoke = URL.revokeObjectURL;
+  URL.createObjectURL = ((_obj: unknown) => {
+    const url = `blob:mock/${urlCounter++}`;
+    created.push(url);
+    return url;
+  }) as typeof URL.createObjectURL;
+  URL.revokeObjectURL = ((url: string) => {
+    revoked.push(url);
+  }) as typeof URL.revokeObjectURL;
+});
+
+afterEach(() => {
+  if (originalCreate) {
+    URL.createObjectURL = originalCreate;
+  }
+  if (originalRevoke) {
+    URL.revokeObjectURL = originalRevoke;
+  }
+});
+
+describe("useFileAttachments", () => {
+  test("an image/* file mints exactly one object-URL preview", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    expect(created.length).toBe(1);
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]?.previewUrl).toBe(created[0]);
+    await hook.unmount();
+  });
+
+  test("a non-image file mints NO object-URL (previewUrl undefined)", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset({ contentType: "text/plain" }) });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([textFile()]));
+    expect(created.length).toBe(0);
+    expect(hook.result.current.attachments[0]?.previewUrl).toBeUndefined();
+    await hook.unmount();
+  });
+
+  test("remove(id) revokes the attachment's object-URL", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    const id = hook.result.current.attachments[0]!.id;
+    const url = hook.result.current.attachments[0]!.previewUrl!;
+
+    await flushing(() => hook.result.current.remove(id));
+    expect(hook.result.current.attachments).toHaveLength(0);
+    expect(revoked).toContain(url);
+    await hook.unmount();
+  });
+
+  test("clear() revokes every outstanding object-URL", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile("a.png"), imageFile("b.png")]));
+    expect(created.length).toBe(2);
+
+    await flushing(() => hook.result.current.clear());
+    expect(hook.result.current.attachments).toHaveLength(0);
+    expect(revoked.sort()).toEqual(created.slice().sort());
+    await hook.unmount();
+  });
+
+  test("addFromPaste applies the default image/* filter — only the image is enqueued", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    const clipboardData = { files: [imageFile("pasted.png"), textFile("pasted.txt")] } as unknown as DataTransfer;
+    await flushing(() => hook.result.current.addFromPaste({ clipboardData }));
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]?.contentType).toBe("image/png");
+    await hook.unmount();
+  });
+
+  test("a custom pasteFilter governs instead of the image/* default", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset({ contentType: "text/plain" }) });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID, pasteFilter: (f) => f.type === "text/plain" }),
+      undefined,
+    );
+
+    const clipboardData = { files: [imageFile("pasted.png"), textFile("pasted.txt")] } as unknown as DataTransfer;
+    await flushing(() => hook.result.current.addFromPaste({ clipboardData }));
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]?.contentType).toBe("text/plain");
+    await hook.unmount();
+  });
+
+  test("a ready upload flips status->ready and projects into readyResources", async () => {
+    const asset = fakeAsset({ filename: "uploaded.png", sizeBytes: 9999 });
+    const client = fakeClient({ uploadFile: async () => asset });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    // Let the upload promise settle.
+    await flush();
+    const attachment = hook.result.current.attachments[0]!;
+    expect(attachment.status).toBe("ready");
+    expect(attachment.name).toBe("uploaded.png");
+    expect(attachment.sizeBytes).toBe(9999);
+    expect(hook.result.current.readyResources).toEqual([{ kind: "file", fileId: asset.id }]);
+    expect(hook.result.current.uploading).toBe(false);
+    await hook.unmount();
+  });
+
+  test("a rejected upload flips status->failed, sets error, and is excluded from readyResources", async () => {
+    const client = fakeClient({ uploadFile: async () => { throw new Error("blob storage exploded"); } });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    await flush();
+    const attachment = hook.result.current.attachments[0]!;
+    expect(attachment.status).toBe("failed");
+    expect(attachment.error).toBe("blob storage exploded");
+    expect(hook.result.current.readyResources).toEqual([]);
+    expect(hook.result.current.uploading).toBe(false);
+    await hook.unmount();
+  });
+
+  test("uploading is true while an upload is pending and flips false once it resolves", async () => {
+    let resolveUpload!: (asset: FileAsset) => void;
+    const pending = new Promise<FileAsset>((resolve) => { resolveUpload = resolve; });
+    const client = fakeClient({ uploadFile: () => pending });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    expect(hook.result.current.uploading).toBe(true);
+
+    await flushing(() => resolveUpload(fakeAsset()));
+    expect(hook.result.current.uploading).toBe(false);
+    await hook.unmount();
+  });
+});


### PR DESCRIPTION
## Why

File uploads were already SDK-owned on the **backend** (`client.uploadFile` = begin → direct-to-blob presigned PUT → complete), but the **frontend** layer lived ad-hoc in the OpenGeni console (~260 lines in `apps/web/src/components/Composer.tsx`). A second consumer (the Geni app) had to re-derive all of it — so it shipped no upload UI at all, and file/image/paste silently did nothing.

This lifts the reusable frontend primitive into `@opengeni/react` so a consumer gets uploads by passing **one prop**.

## What

**`@opengeni/react`**
- **`useFileAttachments()`** — workspace-scoped hook (resolves client + workspaceId via `useOpenGeni`, like `useComposer`/`useSession`) owning per-file `client.uploadFile`, the `uploading|ready|failed` status machine, object-URL image previews with create/revoke lifecycle, the `image/*` paste filter (`addFromPaste`, overridable), `add/remove/clear`, and a `FileResourceRef[]` `readyResources` projection.
- Widen `SessionClientLike` with `uploadFile/getFile/createFileDownloadUrl` (prerequisite for the structural client type).
- Opt-in **`attachments` prop** on `ChatComposer` rendering the attach button (into `controlsStart`) + hidden file input, the chips strip (above the textarea), `onPaste → addFromPaste`, and folding `uploading` into the send-gate (Enter + button). **Backward-compatible**: no `attachments` prop → nothing new renders.
- `useComposer` untouched — attachment resources still flow through the existing `sendExtras` bag (lower blast radius).

**`apps/web` (console)** — migrated onto the package hook/prop, deleting the duplicated ad-hoc layer (`Composer.tsx` 305 → 138 lines). A thin `useDraftAttachments` shim remains so the untouched sessions list compiles.

## Consumer payoff
Geni (next PR) gets uploads by mounting `<ChatComposer composer={composer} attachments={useFileAttachments()} />` — attach button + chips + paste + upload + send-gate, no re-derivation.

## Verification
- react typecheck + **139/139** tests (15 new), web typecheck + **92/92** tests
- react / demo / web builds green
- **Headless render** of the migrated console composer: attach button visible, programmatic file select ran the real begin→PUT→complete and produced an image-preview chip with working remove, paste wiring present, send-gate verified live (disabled while uploading, re-enabled after), zero console errors, layout unchanged

Minor non-blocking delta: when uploads are *disabled*, the attach button now hides entirely instead of rendering disabled-with-tooltip. Equivalent on the enabled path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of composer attachment UX with opt-in API and broad test coverage; main behavioral nuance is hiding the attach control when uploads are disabled instead of showing a disabled button.
> 
> **Overview**
> Moves **client-side file attachment** logic from the web console into **`@opengeni/react`**, so consumers get uploads by wiring **`useFileAttachments`** into **`ChatComposer`'s `attachments` prop**.
> 
> **Package:** New **`useFileAttachments`** handles `client.uploadFile`, per-file upload state, image previews, paste filtering, and **`readyResources`** for **`useComposer`**. **`ChatComposer`** optionally renders attach UI, chips, paste handling, and **blocks send (Enter + button) while uploads are in flight**. **`SessionClientLike`** gains file APIs; **`formatBytes`** is exported. Mock client and tests cover the hook and composer behavior.
> 
> **Console:** **`Composer.tsx`** drops ~160 lines of duplicate upload/chip/gate code and passes **`attachments`** through when uploads are enabled; **`useDraftAttachments`** remains a thin shim for the new-session route. **`session.tsx`** uses **`useFileAttachments()`** from the provider instead of the local hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f4f9744b8ca8d3560c31ca18b9fd5216a111f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->