### PR TITLE
sdk: stop double-setting Content-Type on the upload PUT (fixes complete 422)

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -559,7 +559,13 @@ export class OpenGeniClient {
     });
     const putResponse = await this.fetchImpl(upload.putUrl, {
       method: "PUT",
-      headers: { "Content-Type": input.contentType, ...upload.requiredHeaders },
+      // The backend's requiredHeaders already carry the canonical lowercase
+      // `content-type` for every storage backend (Azure/S3/GCS). Do NOT also set
+      // a `Content-Type` key here: WHATWG Headers treats the two casings as the
+      // same header and comma-joins their values (e.g. "text/plain, text/plain"),
+      // which the object store persists verbatim and COMPLETE then rejects (422),
+      // and which breaks S3's presigned-URL signature.
+      headers: { ...upload.requiredHeaders },
       body,
     });
     if (!putResponse.ok) {

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -378,7 +378,12 @@ describe("OpenGeniClient files", () => {
       fileId: FILE_ID,
       uploadId: UPLOAD_ID,
       putUrl: "https://storage.example.test/put/abc",
-      requiredHeaders: { "x-amz-meta-sha256": "deadbeef" },
+      // Realistic backend shape: every real backend (Azure/S3/GCS) puts a
+      // lowercase `content-type` into requiredHeaders (see packages/storage/src
+      // index.ts:74/152/208). The SDK must rely on this and not also set its own
+      // `Content-Type` key, or WHATWG Headers comma-joins the two into
+      // "text/plain, text/plain" and the server's COMPLETE check 422s.
+      requiredHeaders: { "content-type": "text/plain", "x-ms-blob-type": "BlockBlob" },
       expiresAt: "2026-06-12T01:00:00.000Z",
       maxSizeBytes: 1024 * 1024,
     };
@@ -406,7 +411,12 @@ describe("OpenGeniClient files", () => {
     const put = requests[1]!;
     expect(put.method).toBe("PUT");
     expect(put.url).toBe(begin.putUrl);
-    expect(put.headers["x-amz-meta-sha256"]).toBe("deadbeef");
+    expect(put.headers["x-ms-blob-type"]).toBe("BlockBlob");
+    // Regression guard: the PUT must send exactly ONE content-type value. If the
+    // SDK redundantly sets a `Content-Type` key alongside the backend's lowercase
+    // `content-type`, WHATWG Headers comma-joins them to "text/plain, text/plain",
+    // the object store persists that verbatim, and COMPLETE rejects it with a 422
+    // ("uploaded object content type does not match file metadata").
     expect(put.headers["content-type"]).toBe("text/plain");
     // API credentials must never be sent to object storage.
     expect(put.headers.authorization).toBeUndefined();


### PR DESCRIPTION
## The bug

Every file upload through `client.uploadFile` (the web console **and** Geni) failed with **422 "uploaded object content type does not match file metadata"** on the `complete` endpoint. Prod logs: 3 begin (201) → 3 complete (422) = **100% failure**. Introduced in #54.

## Root cause

`uploadFile` set the PUT headers as `{ "Content-Type": input.contentType, ...upload.requiredHeaders }`, but every backend's `createPutUrl` already emits a lowercase `content-type` in `requiredHeaders` (Azure `storage:208`, S3 `:74`, GCS `:152`). `"Content-Type"` and `"content-type"` are distinct object keys but the **same HTTP header**, so WHATWG `fetch`/`Headers` **comma-joins** them → `"text/plain, text/plain"`. Azure persists that verbatim as the blob's stored Content-Type, and `complete`'s exact-string check (`apps/api/src/routes/files.ts:90`) then fails.

Reproduced live against staging with the real SDK: verbatim 422 body, and an inline blob HEAD showing stored `ContentType = "text/plain, text/plain"` vs recorded `"text/plain"`. A control PUT with a single header stored a clean `"text/plain"` and `complete` succeeded → `ready`.

## Fix

One line — send only `{ ...upload.requiredHeaders }`. Exactly one content-type header reaches the store. Server stays **strict** (genuinely mismatched uploads still 422). Also removes a latent S3 `SignatureDoesNotMatch` hazard (S3 signs ContentType into the presigned URL, so a comma-joined header would break the signature there too).

## Why CI didn't catch it (and now does)

Two compounding gaps:
1. The one SDK test checking PUT headers mocked `requiredHeaders` **without** a `content-type` (`{ "x-amz-meta-sha256": "deadbeef" }`) — so there was no duplicate to join and the assertion passed green. Production diverges because all real backends include lowercase `content-type`.
2. Every real `begin→PUT→complete` integration test runs against **MinIO only** and PUTs via raw `fetch` (single header), never through `client.uploadFile` — so the SDK's double-header path was never exercised, and the Azure HEAD-vs-record verify (`files.ts:86-97`) has never run against Azure output in CI.

This PR fixes gap #1: the test now uses a **realistic Azure-shaped** `requiredHeaders` and asserts a single `content-type` value. Verified it **fails on the old code** (`Received: "text/plain, text/plain"`) and **passes on the fix**. Plain `bun test`, no emulator. (An Azurite round-trip backstop for gap #2 is noted as durable follow-up — it wouldn't have caught *this* defect since the integration tests bypass `client.uploadFile`.)

## Verification
- `tsc` + SDK tests green; regression test fails-on-old / passes-on-new (independently confirmed).
- Live staging repro + control prove the fix end-to-end.

Note: Geni vendors this SDK, so a re-vendor + Geni redeploy follows to clear it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted SDK change to upload PUT headers plus test updates; restores intended upload behavior without relaxing server validation.
> 
> **Overview**
> **Fixes file uploads failing at complete with 422** when using `client.uploadFile` (console, Geni, etc.). The signed PUT no longer merges `input.contentType` as a separate `Content-Type` header on top of the lowercase `content-type` already in `requiredHeaders` from Azure/S3/GCS.
> 
> WHATWG `fetch` treats those keys as one header and **comma-joins** values (e.g. `text/plain, text/plain`). Object stores persist that string, so the API’s strict complete check rejects it; S3 presigned URLs can also break when the signed `ContentType` doesn’t match what is sent.
> 
> The PUT now uses **`headers: { ...upload.requiredHeaders }` only**, with an inline comment explaining why. The SDK unit test mocks **realistic** `requiredHeaders` (including `content-type` and `x-ms-blob-type`) and asserts the PUT sends exactly one `content-type` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef27662e4c27fd4b5269478b913145ef5c88add8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->