### PR TITLE
react: send file-only messages + drag-and-drop file drop zone

### DIFF
--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,7 +1,7 @@
 import type { SessionStatus } from "@opengeni/sdk";
 import { ArrowUpIcon, FileIcon, ImageIcon, LoaderCircleIcon, PaperclipIcon, SquareIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode } from "react";
 import { argHint } from "../commands/registry";
 import type { Notice, SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
@@ -91,6 +91,61 @@ export function ChatComposer({
   // Enter-to-send path (which calls composer.send directly, bypassing canSend)
   // and the send button — dropping either path could ship a fileless message.
   const blockedByUpload = attachments?.uploading === true;
+
+  // A ready attachment makes a file-only message (empty draft) sendable. The
+  // composer (when wired with `sendExtras.resources`) already reflects this in
+  // `canSend`; we OR it in here too so send-enablement is correct even for a
+  // composer whose canSend doesn't know about attachments — and so this stays
+  // the single home of the attachment send-gate.
+  const hasReadyAttachment = (attachments?.readyResources.length ?? 0) > 0;
+  // The send affordance: text OR a ready attachment, never mid-upload or mid-send.
+  const canSend = (composer.canSend || hasReadyAttachment) && !blockedByUpload && !composer.sending;
+
+  // Drag-and-drop file attach: only a drop target when `attachments` is wired,
+  // and only reacts to drags that actually carry files (so it never hijacks
+  // normal text drag/drop). `dragging` drives the drop overlay.
+  const [dragging, setDragging] = useState(false);
+  const dragCarriesFiles = (event: { dataTransfer: DataTransfer | null }): boolean =>
+    event.dataTransfer != null && [...event.dataTransfer.types].includes("Files");
+  const handleDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!attachments || !dragCarriesFiles(event)) {
+        return;
+      }
+      // preventDefault marks this a valid drop target so the browser fires drop.
+      event.preventDefault();
+      setDragging(true);
+    },
+    [attachments],
+  );
+  const handleDragLeave = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!attachments) {
+        return;
+      }
+      // Ignore leaves bubbling from children: only clear when the pointer left
+      // the composer bounds entirely (the related target is outside it).
+      if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+        return;
+      }
+      setDragging(false);
+    },
+    [attachments],
+  );
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!attachments || !dragCarriesFiles(event)) {
+        return;
+      }
+      event.preventDefault();
+      setDragging(false);
+      // Same path the picker uses: addFiles accepts ALL files (no image filter).
+      if (event.dataTransfer.files.length > 0) {
+        attachments.addFiles(event.dataTransfer.files);
+      }
+    },
+    [attachments],
+  );
 
   const [notice, setNotice] = useState<Notice | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -251,12 +306,35 @@ export function ChatComposer({
           />
         ) : null}
         <div
+          // Drag-and-drop file attach lives on the field wrapper, but only when
+          // `attachments` is wired — without it the composer is not a drop target
+          // and behaves exactly as before.
+          onDragOver={attachments ? handleDragOver : undefined}
+          onDragLeave={attachments ? handleDragLeave : undefined}
+          onDrop={attachments ? handleDrop : undefined}
           className={cn(
-            "rounded-og-lg border border-og-border bg-og-surface-1 shadow-og-sm",
+            "relative rounded-og-lg border border-og-border bg-og-surface-1 shadow-og-sm",
             "transition-[border-color,box-shadow] duration-200",
             "focus-within:border-og-accent/60 focus-within:shadow-og-glow",
+            // While files are dragged over, swap to a dashed accent border to
+            // signal a live drop target (the overlay carries the label).
+            dragging && "border-dashed border-og-accent",
           )}
         >
+          {dragging ? (
+            <div
+              aria-hidden
+              className={cn(
+                "pointer-events-none absolute inset-0 z-10 flex items-center justify-center",
+                "rounded-og-lg bg-og-surface-1/85 text-sm font-medium text-og-accent backdrop-blur-[1px]",
+              )}
+            >
+              <span className="inline-flex items-center gap-2">
+                <PaperclipIcon className="size-4" />
+                Drop files to attach
+              </span>
+            </div>
+          ) : null}
           {attachments && attachments.attachments.length > 0 ? (
             <AttachmentChips attachments={attachments.attachments} onRemove={attachments.remove} />
           ) : null}
@@ -369,7 +447,7 @@ export function ChatComposer({
                     }
                     void composer.send();
                   }}
-                  disabled={!composer.canSend || disabled === true || commandDraftBlocked || blockedByUpload}
+                  disabled={!canSend || disabled === true || commandDraftBlocked}
                   aria-label="Send message"
                   className={cn(
                     "inline-flex size-8 items-center justify-center rounded-og-md",

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -83,7 +83,11 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
     async (explicit?: string): Promise<boolean> => {
       const draftAtSend = value;
       const text = (explicit ?? draftAtSend).trim();
-      if (!text || !sessionId || sending) {
+      // Resolve the extras once: a file-only message (empty text + ≥1 ready
+      // resource) is legitimate, so we must not bail on empty text alone.
+      const extras = resolveSendExtras(sendExtrasRef.current);
+      const hasResources = (extras.resources?.length ?? 0) > 0;
+      if ((!text && !hasResources) || !sessionId || sending) {
         return false;
       }
       // Reuse the clientEventId across retries of the same draft so a
@@ -92,7 +96,11 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
       setSending(true);
       setError(null);
       try {
-        const input = composeSendInput(text, pendingClientEventId.current, sendExtrasRef.current);
+        // The wire contract requires non-empty text (z.string().min(1)) and the
+        // worker rejects whitespace-only text; a file-only message therefore
+        // carries a minimal default so the attachments still get delivered.
+        const sendText = text || FILE_ONLY_MESSAGE_TEXT;
+        const input = composeSendInput(sendText, pendingClientEventId.current, extras);
         if (modeRef.current === "steer") {
           await client.steerMessage(workspaceId, sessionId, input);
         } else {
@@ -104,7 +112,7 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
           // was in flight were never delivered and must survive.
           setValue((current) => (current === draftAtSend ? "" : current));
         }
-        onSent?.(text);
+        onSent?.(sendText);
         return true;
       } catch (cause) {
         setError(cause instanceof Error ? cause : new Error(String(cause)));
@@ -115,6 +123,13 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
     },
     [client, workspaceId, sessionId, value, sending, onSent],
   );
+
+  // A send is possible with non-empty text OR with ≥1 attached resource (a
+  // file-only message). Resources ride in `sendExtras`, so we resolve them here
+  // — keeping useComposer attachment-agnostic while still lighting up the send
+  // affordance the moment a file is ready. ChatComposer additionally gates this
+  // on its `attachments.uploading` flag so a message never departs mid-upload.
+  const hasReadyResources = (resolveSendExtras(sendExtrasRef.current).resources?.length ?? 0) > 0;
 
   const interrupt = useCallback(
     async (reason?: string): Promise<void> => {
@@ -144,7 +159,7 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
     setValue: updateValue,
     send,
     sending,
-    canSend: Boolean(sessionId) && !sending && value.trim().length > 0,
+    canSend: Boolean(sessionId) && !sending && (value.trim().length > 0 || hasReadyResources),
     mode,
     setMode,
     interrupt,
@@ -152,6 +167,21 @@ export function useComposer(sessionId: string | null | undefined, options: UseCo
     error,
     clearError: useCallback(() => setError(null), []),
   };
+}
+
+/**
+ * Default text for a file-only message (attachment(s) present, no typed draft).
+ * Kept non-empty so the wire contract (`text: z.string().min(1)`) and the
+ * worker's non-whitespace guard accept it; the attached files still ride in
+ * `resources`. Exported for tests.
+ */
+export const FILE_ONLY_MESSAGE_TEXT = "(see attached files)";
+
+/** Resolve possibly-deferred extras to a concrete bag (function evaluated now). */
+export function resolveSendExtras(
+  extras: ComposerSendExtras | (() => ComposerSendExtras) | undefined,
+): ComposerSendExtras {
+  return (typeof extras === "function" ? extras() : extras) ?? {};
 }
 
 /**
@@ -163,8 +193,7 @@ export function composeSendInput(
   clientEventId: string,
   extras: ComposerSendExtras | (() => ComposerSendExtras) | undefined,
 ): SendMessageInput {
-  const resolved = typeof extras === "function" ? extras() : extras;
-  return { ...resolved, text, clientEventId };
+  return { ...resolveSendExtras(extras), text, clientEventId };
 }
 
 /** Submit on plain Enter; Shift+Enter inserts a newline. Exported for tests. */

--- a/packages/react/test/chat-composer-uploads.test.tsx
+++ b/packages/react/test/chat-composer-uploads.test.tsx
@@ -77,6 +77,36 @@ function sendButton(container: HTMLElement): HTMLButtonElement | undefined {
   ) as HTMLButtonElement | undefined;
 }
 
+/**
+ * Dispatch a synthetic drag/drop event on `target`. Browsers report dragged
+ * files via `dataTransfer.types` including the literal "Files"; we mirror that
+ * (happy-dom's DragEvent leaves `dataTransfer` undefined, so we attach our own).
+ */
+function fireDrag(
+  target: HTMLElement,
+  type: "dragover" | "dragleave" | "drop",
+  options: { files?: File[]; types?: string[] } = {},
+): DragEvent {
+  const files = options.files ?? [];
+  const types = options.types ?? (files.length > 0 ? ["Files"] : []);
+  const fileList = {
+    ...files,
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+    [Symbol.iterator]: () => files[Symbol.iterator](),
+  } as unknown as FileList;
+  const dataTransfer = { types, files: fileList } as unknown as DataTransfer;
+  const event = new DragEvent(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer, configurable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function fieldWrapper(container: HTMLElement): HTMLElement {
+  // The field-chrome div (direct parent of the textarea) owns the drop handlers.
+  return container.querySelector("textarea")!.parentElement as HTMLElement;
+}
+
 describe("ChatComposer attachments", () => {
   test("with no attachments prop, no attach button renders (backward compatible)", async () => {
     const container = await mount(<ChatComposer composer={makeComposer()} />);
@@ -140,6 +170,33 @@ describe("ChatComposer attachments", () => {
     expect(sent).toBe(1);
   });
 
+  test("send is ENABLED with a ready attachment even when the draft is empty (file-only message)", async () => {
+    // A composer over an empty draft reports canSend=false; the ready attachment
+    // is what makes the message sendable, and ChatComposer ORs it in.
+    const composer = makeComposer({ value: "", canSend: false });
+    const attachments = makeAttachments({ attachments: [readyChip("a.png")], readyResources: [{ kind: "file", fileId: "f1" }] });
+    const container = await mount(<ChatComposer composer={composer} attachments={attachments} />);
+    expect(sendButton(container)!.disabled).toBe(false);
+  });
+
+  test("send stays DISABLED with an empty draft and no attachment", async () => {
+    const composer = makeComposer({ value: "", canSend: false });
+    const attachments = makeAttachments(); // no ready resources
+    const container = await mount(<ChatComposer composer={composer} attachments={attachments} />);
+    expect(sendButton(container)!.disabled).toBe(true);
+  });
+
+  test("send stays BLOCKED while an attachment is still uploading, even with a ready one alongside", async () => {
+    const composer = makeComposer({ value: "", canSend: false });
+    const attachments = makeAttachments({
+      uploading: true,
+      attachments: [readyChip("ready.png"), { ...readyChip("pending.png"), status: "uploading" }],
+      readyResources: [{ kind: "file", fileId: "f1" }],
+    });
+    const container = await mount(<ChatComposer composer={composer} attachments={attachments} />);
+    expect(sendButton(container)!.disabled).toBe(true);
+  });
+
   test("pasting into the textarea routes the clipboard through addFromPaste (and still calls host onPaste)", async () => {
     let pastedThroughHook = 0;
     let hostPaste = 0;
@@ -156,5 +213,69 @@ describe("ChatComposer attachments", () => {
     });
     expect(pastedThroughHook).toBe(1);
     expect(hostPaste).toBe(1);
+  });
+
+  test("dropping files onto the composer routes them through addFiles (the all-files picker path)", async () => {
+    const added: File[][] = [];
+    const attachments = makeAttachments({ addFiles: (files) => { added.push([...files]); } });
+    const container = await mount(<ChatComposer composer={makeComposer()} attachments={attachments} />);
+    const field = fieldWrapper(container);
+    const pdf = new File(["%PDF"], "doc.pdf", { type: "application/pdf" });
+    await act(async () => {
+      // A dragover sets the dragging state; the drop enqueues the files.
+      fireDrag(field, "dragover", { files: [pdf] });
+      fireDrag(field, "drop", { files: [pdf] });
+      await Promise.resolve();
+    });
+    expect(added).toHaveLength(1);
+    expect(added[0]!.map((f) => f.name)).toEqual(["doc.pdf"]);
+  });
+
+  test("a drag that carries no files is ignored (does not enqueue or show the overlay)", async () => {
+    let addCalls = 0;
+    const attachments = makeAttachments({ addFiles: () => { addCalls += 1; } });
+    const container = await mount(<ChatComposer composer={makeComposer()} attachments={attachments} />);
+    const field = fieldWrapper(container);
+    await act(async () => {
+      // A text drag: types is ["text/plain"], no "Files" entry.
+      fireDrag(field, "dragover", { types: ["text/plain"] });
+      fireDrag(field, "drop", { types: ["text/plain"] });
+      await Promise.resolve();
+    });
+    expect(addCalls).toBe(0);
+    expect(container.textContent ?? "").not.toContain("Drop files to attach");
+  });
+
+  test("the drop overlay appears on a files-dragover and clears on drop", async () => {
+    const attachments = makeAttachments();
+    const container = await mount(<ChatComposer composer={makeComposer()} attachments={attachments} />);
+    const field = fieldWrapper(container);
+    const img = new File(["x"], "shot.png", { type: "image/png" });
+    await act(async () => {
+      fireDrag(field, "dragover", { files: [img] });
+      await Promise.resolve();
+    });
+    expect(container.textContent ?? "").toContain("Drop files to attach");
+    await act(async () => {
+      fireDrag(field, "drop", { files: [img] });
+      await Promise.resolve();
+    });
+    expect(container.textContent ?? "").not.toContain("Drop files to attach");
+  });
+
+  test("a ChatComposer WITHOUT the attachments prop is not a drop target (dropped files are ignored)", async () => {
+    // No attachments prop at all → no addFiles to call; the drop must be inert
+    // and must not throw. We assert no overlay and that the textarea still works.
+    const container = await mount(<ChatComposer composer={makeComposer()} />);
+    const field = fieldWrapper(container);
+    const file = new File(["x"], "x.png", { type: "image/png" });
+    await act(async () => {
+      const event = fireDrag(field, "drop", { files: [file] });
+      // Without attachments wired, the handler is not attached, so the event is
+      // not preventDefaulted by the composer.
+      expect(event.defaultPrevented).toBe(false);
+      await Promise.resolve();
+    });
+    expect(container.textContent ?? "").not.toContain("Drop files to attach");
   });
 });

--- a/packages/react/test/composer.test.ts
+++ b/packages/react/test/composer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { composeSendInput, shouldSubmitOnKey } from "../src/hooks/use-composer";
+import { composeSendInput, FILE_ONLY_MESSAGE_TEXT, resolveSendExtras, shouldSubmitOnKey } from "../src/hooks/use-composer";
 
 describe("composeSendInput", () => {
   test("sends bare text with the idempotency key when no extras are configured", () => {
@@ -27,6 +27,23 @@ describe("composeSendInput", () => {
     expect(input.clientEventId).toBe("ce-2");
     expect(input.reasoningEffort).toBe("low");
     expect(input.resources).toEqual([{ kind: "file", fileId: "file-1" }]);
+  });
+});
+
+describe("resolveSendExtras", () => {
+  test("returns an empty bag for undefined extras", () => {
+    expect(resolveSendExtras(undefined)).toEqual({});
+  });
+
+  test("evaluates a function and surfaces its resources", () => {
+    const resolved = resolveSendExtras(() => ({ resources: [{ kind: "file", fileId: "f1" }] }));
+    expect(resolved.resources).toEqual([{ kind: "file", fileId: "f1" }]);
+  });
+});
+
+describe("FILE_ONLY_MESSAGE_TEXT", () => {
+  test("is non-empty so the wire contract (text.min(1)) and worker guard accept a file-only message", () => {
+    expect(FILE_ONLY_MESSAGE_TEXT.trim().length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -381,6 +381,74 @@ describe("useComposer queue-vs-steer", () => {
   });
 });
 
+describe("useComposer file-only send", () => {
+  test("canSend lights up with a ready resource even when the draft is empty", async () => {
+    const client = fakeClient({ sendMessage: async () => makeEvent(1, "user.message") });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, {
+        client,
+        workspaceId: WORKSPACE_ID,
+        sendExtras: () => ({ resources: [{ kind: "file", fileId: "file-1" }] }),
+      }),
+      undefined,
+    );
+    // Empty draft, but a resource is attached → sendable.
+    expect(hook.result.current.value).toBe("");
+    expect(hook.result.current.canSend).toBe(true);
+    await hook.unmount();
+  });
+
+  test("with no draft and no resources, canSend stays false and send() bails", async () => {
+    const calls: unknown[] = [];
+    const client = fakeClient({
+      sendMessage: async (_ws, _session, message) => {
+        calls.push(message);
+        return makeEvent(1, "user.message");
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    expect(hook.result.current.canSend).toBe(false);
+    let result = true;
+    await flushing(async () => {
+      result = await hook.result.current.send();
+    });
+    expect(result).toBe(false);
+    expect(calls).toEqual([]);
+    await hook.unmount();
+  });
+
+  test("sending a file-only message dispatches the resources with a minimal default text", async () => {
+    const sent: { text: string; resources?: unknown }[] = [];
+    const client = fakeClient({
+      sendMessage: async (_ws, _session, message) => {
+        sent.push(message as { text: string; resources?: unknown });
+        return makeEvent(1, "user.message");
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, {
+        client,
+        workspaceId: WORKSPACE_ID,
+        sendExtras: () => ({ resources: [{ kind: "file", fileId: "file-1" }] }),
+      }),
+      undefined,
+    );
+    // Empty draft (no explicit text) — the send path must still go through.
+    await flushing(async () => {
+      const ok = await hook.result.current.send();
+      expect(ok).toBe(true);
+    });
+    expect(sent).toHaveLength(1);
+    // Resources ride along, and the wire text is non-empty (contract: min(1)).
+    expect(sent[0]!.resources).toEqual([{ kind: "file", fileId: "file-1" }]);
+    expect(sent[0]!.text.trim().length).toBeGreaterThan(0);
+    await hook.unmount();
+  });
+});
+
 describe("useEnvironments", () => {
   test("lists environments and refreshes after each mutation", async () => {
     const log: string[] = [];


### PR DESCRIPTION
Two composer UX gaps, both in **`@opengeni/react`** behind the existing `attachments` prop, so the OpenGeni console and Geni both get them.

## 1. Send a file-only message
`useComposer.canSend` required `value.trim().length > 0` and `send()` bailed on empty text — so a ready attachment with no typed draft left **Send disabled**. Both are now **resource-aware**: a send is allowed when the draft is non-empty **OR** ≥1 ready resource rides in `sendExtras`.

The wire contract requires non-empty text (`user.message` `text: z.string().min(1)`) and the worker rejects whitespace-only text (verified at `apps/api/.../sessions.ts` + `apps/worker/.../run-input.ts`), so a file-only send **substitutes a minimal default** (`"(see attached files)"`) — the attachments still ride in `resources`. **No contract/worker change.** `useComposer` stays attachment-agnostic; `ChatComposer` is the single home of the send-gate (ORs a ready attachment into `canSend`, keeps `!uploading`/`!sending` on the button, Enter, and click paths).

## 2. Drag-and-drop file drop zone
When `attachments` is wired, the composer field becomes a drop target: reacts **only** to drags carrying files (`dataTransfer.types.includes("Files")` — never hijacks text drag/drop), `preventDefault`s to allow the drop, and routes files to the **same `addFiles` path the picker uses** (all files, not just images). A `dragging` state drives a dashed accent border + a "Drop files to attach" overlay, cleared on drop/leave (child-bubbling ignored via `contains(relatedTarget)`). Composers **without** the `attachments` prop are not drop targets and behave exactly as before.

## Verification
- react typecheck + **152 tests** (incl. file-only `canSend`/`send`, drop → `addFiles`, overlay show/clear, non-attachments composer unaffected) + build — all green.
- Headless: Send **enables** with a ready attachment + empty draft; a synthetic file **drop** produces a chip.

Note: Geni vendors this package, so a re-vendor + Geni redeploy follows (same as the upload fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and client-side send gating in the React package only; no API/worker contract changes beyond substituting placeholder text for file-only sends.
> 
> **Overview**
> **`@opengeni/react`** closes two composer gaps behind the existing opt-in **`attachments`** prop.
> 
> **File-only send:** `useComposer` now treats ≥1 ready resource in `sendExtras` as sendable when the draft is empty (`canSend` and `send()`). Empty text still satisfies the API/worker non-empty text rule via **`FILE_ONLY_MESSAGE_TEXT`** (`"(see attached files)"`); files stay in `resources`. `ChatComposer` centralizes the send gate (ready attachment OR composer `canSend`, still blocked while uploading or sending).
> 
> **Drag-and-drop:** When `attachments` is wired, the field wrapper accepts file drags only (`dataTransfer.types` includes `"Files"`), routes drops through **`addFiles`** (same as the picker), and shows a dashed border plus “Drop files to attach” overlay. Composers without `attachments` are unchanged.
> 
> Tests cover file-only send/enablement, upload blocking, drop routing, and backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e47b2270b095aef03448029919005c0961987e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->