### PR TITLE
ci(release): make the release pipeline dormant until opted in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,18 @@ name: Release
 # `published` output is 'true'), and tags images with the published release
 # version — so ordinary pushes to main no longer rebuild/re-push the image tags.
 #
-# REQUIRED REPO/ORG SETUP (publish is a no-op until these exist):
-#   - The @opengeni npm org must exist and the NPM_TOKEN secret must be set to
-#     an automation/granular token with publish rights to it. Until then the
-#     publish step is guarded and skipped (it does NOT red-fail pushes).
-#   - GHCR image publishing needs no extra secret — it uses the built-in
-#     GITHUB_TOKEN with `packages: write`.
+# REQUIRED REPO/ORG SETUP. This workflow is DORMANT until activated, so it does
+# not run — or red-fail — on pushes to main until you opt in:
+#   1. Set the repo variable RELEASE_ENABLED=true to activate the pipeline
+#      (Settings -> Secrets and variables -> Actions -> Variables).
+#   2. Claim the @opengeni npm org and set the NPM_TOKEN secret to an
+#      automation/granular token with publish rights (provenance via OIDC).
+#   3. Let the Version PR be opened: EITHER enable Settings -> Actions -> General
+#      -> "Allow GitHub Actions to create and approve pull requests", OR set a
+#      RELEASE_PAT secret (a PAT with repo + pull-requests scope) — this workflow
+#      prefers RELEASE_PAT over the default GITHUB_TOKEN for exactly that reason.
+#   - GHCR image publishing needs no extra secret (built-in GITHUB_TOKEN) and
+#     runs only when a release actually publishes.
 
 on:
   push:
@@ -32,6 +38,9 @@ jobs:
   release:
     name: Version or publish packages
     runs-on: ubuntu-latest
+    # Dormant until opted in: skips cleanly (no red) on pushes to main until the
+    # repo variable RELEASE_ENABLED is set to 'true'. See the header for setup.
+    if: ${{ vars.RELEASE_ENABLED == 'true' }}
     permissions:
       id-token: write # npm provenance (OIDC)
       contents: write # changesets opens the Version PR / pushes tags
@@ -86,7 +95,10 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT (repo + pull-requests scope) so the Version PR can be
+          # opened even if the org keeps "Actions may create PRs" disabled;
+          # falls back to the default token when the org setting is enabled.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 


### PR DESCRIPTION
The `release.yml` from #90 fired on merge and red-failed at the changesets step: **"GitHub Actions is not permitted to create or approve pull requests"** — the `Cloudgeni-ai` org has that setting off, so the Version PR can't be opened with the default token. (Nothing published; the GHCR job correctly skipped.)

This makes the pipeline **dormant until you opt in**, so pushes to main don't red-fail:
- Gate the `release` job on `vars.RELEASE_ENABLED == 'true'` → it **skips cleanly** (neutral, not failed) until you set that repo variable.
- Prefer a `RELEASE_PAT` secret over `GITHUB_TOKEN` for the changesets step, so the Version PR can be opened **even if** the org keeps "Actions may create PRs" disabled (a PAT with repo + pull-requests scope bypasses it). If you instead enable the org setting, the default token still works.

## Activation checklist (all yours, when ready)
1. Repo variable **`RELEASE_ENABLED=true`**.
2. Claim the **`@opengeni`** npm org + set **`NPM_TOKEN`** (automation/granular, publish rights).
3. Let the Version PR open: enable *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"*, **or** set a **`RELEASE_PAT`** secret.

The full checklist is now documented in the workflow header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only gating and token selection; no application runtime or publish behavior change until `RELEASE_ENABLED` is set.
> 
> **Overview**
> Stops the **release** workflow from red-failing on every push to `main` when the org disallows Actions from creating PRs.
> 
> The **`release` job** now runs only when the repo variable **`RELEASE_ENABLED`** is `'true'`; otherwise it is skipped (neutral). The workflow header documents the full opt-in checklist (`RELEASE_ENABLED`, `NPM_TOKEN`, and either org PR settings or **`RELEASE_PAT`**).
> 
> The changesets step’s **`GITHUB_TOKEN`** is **`secrets.RELEASE_PAT || secrets.GITHUB_TOKEN`**, so a PAT with repo + pull-requests scope can open the Version Packages PR even when the default Actions token cannot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bc364b91dfc602430eb8ff886d59a5ed15ee22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->