### PR TITLE
build: add repository field to published packages (fix provenance publish)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "Shared zod schemas and wire-contract types for the OpenGeni API.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/contracts"
+  },
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/react"
+  },
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "Framework-agnostic TypeScript SDK for the OpenGeni API: typed client, session lifecycle, SSE event streaming with reconnect + replay-by-sequence, and proxy re-streaming helpers.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/sdk"
+  },
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",


### PR DESCRIPTION
The CI publish of `0.2.0` failed with **E422 "Error verifying sigstore provenance bundle: package.json repository.url is '', expected to match https://github.com/Cloudgeni-ai/opengeni from provenance"**. npm provenance validates that each package's `repository.url` matches the repo the attestation came from; the three packages had no `repository` field.

Adds `repository` (`git+https://github.com/Cloudgeni-ai/opengeni.git` + monorepo `directory`) to `@opengeni/contracts`, `@opengeni/sdk`, `@opengeni/react`.

The publish pipeline otherwise worked end-to-end (auth, correct 0.2.0 versions, provenance generated + logged to the transparency log) — this was the only blocker. **Merging this re-triggers the release**, which publishes `0.2.0` with provenance and pushes the GHCR self-host images. (npm is currently at the manual `0.1.0`; nothing published at 0.2.0 yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package metadata only; no application code, auth, or runtime behavior changes.
> 
> **Overview**
> Adds a **`repository`** block to **`@opengeni/contracts`**, **`@opengeni/sdk`**, and **`@opengeni/react`** so each package’s `repository.url` is `git+https://github.com/Cloudgeni-ai/opengeni.git` with the correct monorepo **`directory`**.
> 
> This satisfies npm **provenance** validation (empty `repository.url` caused E422 on the `0.2.0` publish) and unblocks the release pipeline; no runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29c14743ba6b76e8cea5508b09c75f429d913bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->