### PR TITLE
Redesign navigation: Linear-style left rail with the session list in the sidebar

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -16,7 +16,9 @@ import {
   buildSessionMcpPermissionGroups,
   delegableApiKeyPermissions,
 } from "./lib/permissions";
-import { parseCheckoutOutcome, workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "./lib/routes";
+import { orgSettingsPath, parseCheckoutOutcome, workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath, workspaceSettingsPath } from "./lib/routes";
+import { groupSessionsForRail, recencyGroupFor, relativeTimeLabel } from "./lib/sessions-group";
+import { organizationsForSubject, orgLabel, workspacesInOrg } from "./lib/org";
 import {
   emptyAdvancedSessionDraft,
   submissionExtrasFromAdvancedSessionDraft,
@@ -62,6 +64,84 @@ describe("workspace route helpers", () => {
 
   test("does not build legacy unscoped session URLs", () => {
     expect(workspaceSessionPath("workspace-1", "session-1")).not.toBe("/sessions/session-1");
+  });
+
+  test("builds the new workspace-settings and organization-settings paths", () => {
+    expect(workspaceSettingsPath("workspace-1")).toBe("/workspaces/workspace-1/settings");
+    expect(orgSettingsPath("workspace-1")).toBe("/workspaces/workspace-1/organization");
+  });
+});
+
+describe("rail session grouping", () => {
+  const NOW = new Date("2026-06-19T12:00:00.000Z");
+  function railSession(patch: Partial<Session> & Pick<Session, "id">): Session {
+    return { ...session(), status: "idle", ...patch };
+  }
+
+  test("pins running sessions above the recency buckets, newest first", () => {
+    const grouped = groupSessionsForRail([
+      railSession({ id: "old-running", status: "running", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      railSession({ id: "today-idle", status: "idle", updatedAt: "2026-06-19T09:00:00.000Z" }),
+      railSession({ id: "new-running", status: "running", updatedAt: "2026-06-19T11:59:00.000Z" }),
+    ], NOW);
+
+    expect(grouped.running.map((entry) => entry.id)).toEqual(["new-running", "old-running"]);
+    expect(grouped.grouped[0]?.group).toBe("today");
+    expect(grouped.grouped[0]?.sessions.map((entry) => entry.id)).toEqual(["today-idle"]);
+  });
+
+  test("buckets non-running sessions by recency, most-recent first, dropping empty groups", () => {
+    const grouped = groupSessionsForRail([
+      railSession({ id: "today", updatedAt: "2026-06-19T08:00:00.000Z" }),
+      railSession({ id: "yesterday", updatedAt: "2026-06-18T08:00:00.000Z" }),
+      railSession({ id: "older", updatedAt: "2026-05-01T08:00:00.000Z" }),
+    ], NOW);
+
+    expect(grouped.running).toEqual([]);
+    expect(grouped.grouped.map((bucket) => bucket.group)).toEqual(["today", "yesterday", "older"]);
+  });
+
+  test("recencyGroupFor classifies calendar-local buckets", () => {
+    expect(recencyGroupFor(new Date("2026-06-19T01:00:00.000Z").getTime(), NOW)).toBe("today");
+    expect(recencyGroupFor(new Date("2026-06-18T23:00:00.000Z").getTime(), NOW)).toBe("yesterday");
+    expect(recencyGroupFor(new Date("2026-06-15T12:00:00.000Z").getTime(), NOW)).toBe("previous7");
+    expect(recencyGroupFor(new Date("2026-05-01T12:00:00.000Z").getTime(), NOW)).toBe("older");
+  });
+
+  test("relativeTimeLabel reads compactly", () => {
+    expect(relativeTimeLabel("2026-06-19T11:59:50.000Z", NOW)).toBe("now");
+    expect(relativeTimeLabel("2026-06-19T11:30:00.000Z", NOW)).toBe("30m");
+    expect(relativeTimeLabel("2026-06-19T09:00:00.000Z", NOW)).toBe("3h");
+    expect(relativeTimeLabel("2026-06-17T12:00:00.000Z", NOW)).toBe("2d");
+  });
+});
+
+describe("organization helpers", () => {
+  function ctx(patch: Partial<AccessContext> = {}): AccessContext {
+    return { mode: "managed", subjectId: "s", accountGrants: [], workspaceGrants: [], defaultAccountId: null, defaultWorkspaceId: null, ...patch };
+  }
+  function ws(id: string, accountId: string): Workspace {
+    return { id, accountId, name: id, slug: null, externalSource: null, externalId: null, agentInstructions: null, createdAt: "2026-06-11T00:00:00.000Z", updatedAt: "2026-06-11T00:00:00.000Z" };
+  }
+
+  test("derives a label, preferring an account name in grant metadata", () => {
+    expect(orgLabel("acc-12345678abc", [{ accountId: "acc-12345678abc", subjectId: "s", permissions: [], metadata: { accountName: "Acme" } }])).toBe("Acme");
+    expect(orgLabel("acc-12345678abc", [])).toBe("Org acc-1234");
+  });
+
+  test("lists every org the subject can reach, default first", () => {
+    const context = ctx({
+      defaultAccountId: "acc-b",
+      accountGrants: [{ accountId: "acc-a", subjectId: "s", permissions: ["billing:read"] }],
+    });
+    const orgs = organizationsForSubject(context, [ws("w1", "acc-b"), ws("w2", "acc-a")]);
+    expect(orgs.map((org) => org.accountId)).toEqual(["acc-b", "acc-a"]);
+    expect(orgs.find((org) => org.accountId === "acc-a")?.canManage).toBe(true);
+  });
+
+  test("workspacesInOrg filters and sorts by name", () => {
+    const filtered = workspacesInOrg([ws("beta", "acc-a"), ws("alpha", "acc-a"), ws("other", "acc-b")], "acc-a");
+    expect(filtered.map((workspace) => workspace.name)).toEqual(["alpha", "beta"]);
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,8 +10,10 @@
 //   /workspaces/:id/capabilities             → capability catalog + registry (incl. Packs subsection)
 //   /workspaces/:id/schedules                → scheduled tasks + run history
 //   /workspaces/:id/documents                → document bases + search
-//   /workspaces/:id/account                  → account, usage, API keys
-//   /billing?checkout=success|cancelled      → Stripe return → default account
+//   /workspaces/:id/settings                 → workspace settings (name, API keys, danger zone)
+//   /workspaces/:id/organization             → organization settings (billing, usage, plan, members)
+//   /workspaces/:id/account                  → legacy redirect to /organization
+//   /billing?checkout=success|cancelled      → Stripe return → default organization
 import {
   Navigate,
   RouterProvider,
@@ -23,13 +25,14 @@ import {
 import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
-import { AccountRoute } from "@/routes/account";
 import { CapabilitiesRoute } from "@/routes/capabilities";
 import { DocumentsRoute } from "@/routes/documents";
 import { EnvironmentsRoute } from "@/routes/environments";
+import { OrgSettingsRoute } from "@/routes/org-settings";
 import { SchedulesRoute } from "@/routes/schedules";
 import { SessionRoute } from "@/routes/session";
 import { SessionsIndexRoute } from "@/routes/sessions-index";
+import { WorkspaceSettingsRoute } from "@/routes/workspace-settings";
 import { WorkspaceShellRoute } from "@/routes/workspace";
 
 export { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "@/lib/routes";
@@ -45,8 +48,8 @@ const indexRoute = createRoute({
 });
 // Stripe checkout return target. The API bakes `/billing?checkout=…` into every
 // checkout session's success_url/cancel_url; this top-level route forwards the
-// shopper onto their default workspace account (where the balance lives) so the
-// redirect resolves instead of hitting the not-found page.
+// shopper onto their default workspace's organization settings (where the
+// balance lives) so the redirect resolves instead of hitting the not-found page.
 const billingReturnRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "billing",
@@ -114,16 +117,32 @@ const workspaceDocumentsRoute = createRoute({
   path: "documents",
   component: Documents,
 });
-const workspaceAccountRoute = createRoute({
+const workspaceSettingsRoute = createRoute({
   getParentRoute: () => workspaceRoute,
-  path: "account",
+  path: "settings",
+  component: WorkspaceSettings,
+});
+const workspaceOrganizationRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "organization",
   // `?checkout=success|cancelled` arrives via the /billing Stripe-return
-  // redirect so the account page can confirm the top-up.
+  // redirect so the organization page can confirm the top-up.
   validateSearch: (search: Record<string, unknown>): { checkout?: CheckoutOutcome } => {
     const checkout = parseCheckoutOutcome(search);
     return checkout ? { checkout } : {};
   },
-  component: Account,
+  component: Organization,
+});
+// Legacy URL: the old "account" surface is now "organization". Forward, keeping
+// the checkout outcome so post-payment confirmations still land.
+const workspaceAccountRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "account",
+  validateSearch: (search: Record<string, unknown>): { checkout?: CheckoutOutcome } => {
+    const checkout = parseCheckoutOutcome(search);
+    return checkout ? { checkout } : {};
+  },
+  component: AccountRedirect,
 });
 const routeTree = rootRoute.addChildren([
   indexRoute,
@@ -138,6 +157,8 @@ const routeTree = rootRoute.addChildren([
     workspaceCapabilitiesRoute,
     workspaceSchedulesRoute,
     workspaceDocumentsRoute,
+    workspaceSettingsRoute,
+    workspaceOrganizationRoute,
     workspaceAccountRoute,
   ]),
 ]);
@@ -215,10 +236,28 @@ function Documents() {
   return <DocumentsRoute workspaceId={workspaceId} />;
 }
 
-function Account() {
+function WorkspaceSettings() {
+  const { workspaceId } = workspaceSettingsRoute.useParams();
+  return <WorkspaceSettingsRoute workspaceId={workspaceId} />;
+}
+
+function Organization() {
+  const { workspaceId } = workspaceOrganizationRoute.useParams();
+  const { checkout } = workspaceOrganizationRoute.useSearch();
+  return <OrgSettingsRoute workspaceId={workspaceId} checkout={checkout} />;
+}
+
+function AccountRedirect() {
   const { workspaceId } = workspaceAccountRoute.useParams();
   const { checkout } = workspaceAccountRoute.useSearch();
-  return <AccountRoute workspaceId={workspaceId} checkout={checkout} />;
+  return (
+    <Navigate
+      to="/workspaces/$workspaceId/organization"
+      params={{ workspaceId }}
+      search={checkout ? { checkout } : {}}
+      replace
+    />
+  );
 }
 
 function BillingReturnRoute() {
@@ -230,7 +269,7 @@ function BillingReturnRoute() {
   }
   return (
     <Navigate
-      to="/workspaces/$workspaceId/account"
+      to="/workspaces/$workspaceId/organization"
       params={{ workspaceId }}
       search={checkout ? { checkout } : {}}
       replace

--- a/apps/web/src/components/rail/rail-context.tsx
+++ b/apps/web/src/components/rail/rail-context.tsx
@@ -1,0 +1,130 @@
+// Shared state for the left rail: collapsed (icon-only) persistence, the mobile
+// overlay-drawer toggle, and the workspace-scoped navigation helpers every rail
+// section reuses (open a workspace, start a new session, switch org/workspace).
+import { useNavigate } from "@tanstack/react-router";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+import { useAppContext } from "@/context";
+
+const RAIL_COLLAPSED_KEY = "opengeni.rail.collapsed";
+/** Below this viewport width the rail is an overlay drawer, not a fixed column. */
+export const RAIL_DRAWER_BREAKPOINT = 1024;
+
+export type RailContextValue = {
+  workspaceId: string;
+  /** Icon-only rail (desktop). Ignored while the mobile drawer is in play. */
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+  toggleCollapsed: () => void;
+  /** Whether the viewport is narrow enough to use the overlay drawer. */
+  isMobile: boolean;
+  /** Mobile overlay-drawer open state. */
+  drawerOpen: boolean;
+  setDrawerOpen: (open: boolean) => void;
+  /** Navigate to a workspace's sessions index (used by the switchers). */
+  openWorkspace: (workspaceId: string) => void;
+  /** Switch organization: navigate to the first workspace in the target org. */
+  openOrg: (accountId: string) => void;
+  /** Open a specific session in the current workspace. */
+  openSession: (sessionId: string) => void;
+  /** Start a new session (the sessions index composer). */
+  startNewSession: () => void;
+};
+
+const RailContext = createContext<RailContextValue | null>(null);
+
+export function useRail(): RailContextValue {
+  const value = useContext(RailContext);
+  if (!value) {
+    throw new Error("Rail context is not ready");
+  }
+  return value;
+}
+
+function readStoredCollapsed(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(RAIL_COLLAPSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function RailProvider({ workspaceId, children }: { workspaceId: string; children: ReactNode }) {
+  const navigate = useNavigate();
+  const appContext = useAppContext();
+  const [collapsed, setCollapsedState] = useState<boolean>(() => readStoredCollapsed());
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState<boolean>(() =>
+    typeof window !== "undefined" ? window.innerWidth < RAIL_DRAWER_BREAKPOINT : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const query = window.matchMedia(`(max-width: ${RAIL_DRAWER_BREAKPOINT - 1}px)`);
+    const apply = () => setIsMobile(query.matches);
+    apply();
+    query.addEventListener("change", apply);
+    return () => query.removeEventListener("change", apply);
+  }, []);
+
+  const setCollapsed = useCallback((next: boolean) => {
+    setCollapsedState(next);
+    try {
+      window.localStorage.setItem(RAIL_COLLAPSED_KEY, String(next));
+    } catch {
+      // localStorage may be unavailable (private mode); keep the in-memory value.
+    }
+  }, []);
+
+  const toggleCollapsed = useCallback(() => setCollapsed(!collapsed), [collapsed, setCollapsed]);
+
+  const openWorkspace = useCallback((nextWorkspaceId: string) => {
+    appContext.resetSessionView();
+    setDrawerOpen(false);
+    void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId: nextWorkspaceId } });
+  }, [appContext, navigate]);
+
+  const openOrg = useCallback((accountId: string) => {
+    const target = appContext.workspaces.find((workspace) => workspace.accountId === accountId);
+    if (!target) {
+      return;
+    }
+    appContext.resetSessionView();
+    setDrawerOpen(false);
+    void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId: target.id } });
+  }, [appContext, navigate]);
+
+  const openSession = useCallback((sessionId: string) => {
+    setDrawerOpen(false);
+    void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId } });
+  }, [navigate, workspaceId]);
+
+  const startNewSession = useCallback(() => {
+    appContext.resetSessionView();
+    setDrawerOpen(false);
+    void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } });
+  }, [appContext, navigate, workspaceId]);
+
+  const value = useMemo<RailContextValue>(() => ({
+    workspaceId,
+    // The drawer always renders expanded content; collapse only applies to the
+    // fixed desktop column.
+    collapsed: isMobile ? false : collapsed,
+    setCollapsed,
+    toggleCollapsed,
+    isMobile,
+    drawerOpen,
+    setDrawerOpen,
+    openWorkspace,
+    openOrg,
+    openSession,
+    startNewSession,
+  }), [workspaceId, collapsed, isMobile, drawerOpen, setCollapsed, toggleCollapsed, openWorkspace, openOrg, openSession, startNewSession]);
+
+  return <RailContext.Provider value={value}>{children}</RailContext.Provider>;
+}

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -1,0 +1,126 @@
+// Pinned rail footer: the collapse-toggle chevron and the signed-in user menu
+// (account/sign-out, depending on auth mode). Collapsed → just the avatar +
+// a collapse chevron, both with tooltips.
+import { Link } from "@tanstack/react-router";
+import {
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
+  LockIcon,
+  LogOutIcon,
+  SettingsIcon,
+  UserIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { useRail } from "@/components/rail/rail-context";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppContext } from "@/context";
+
+function userInitial(label: string): string {
+  return (label.trim()[0] ?? "U").toUpperCase();
+}
+
+export function RailFooter() {
+  const rail = useRail();
+  const context = useAppContext();
+  const managed = context.clientConfig.auth.mode === "managedSession";
+  const displayName = context.authSession?.user.name
+    ?? context.authSession?.user.email
+    ?? context.accessContext.subjectLabel
+    ?? context.accessContext.subjectId;
+  const secondary = context.authSession?.user.email ?? context.accessContext.subjectId;
+  const image = context.authSession?.user.image ?? undefined;
+
+  return (
+    <div className="mt-auto border-t border-[color:var(--color-border)] p-2">
+      <div className={rail.collapsed ? "grid justify-items-center gap-1" : "flex items-center gap-1.5"}>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Account menu"
+              className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+            >
+              <Avatar size="sm">
+                {image ? <AvatarImage src={image} alt="" /> : null}
+                <AvatarFallback className="bg-[color:var(--color-surface-3)] text-[11px] text-[color:var(--color-fg-muted)]">
+                  {userInitial(displayName)}
+                </AvatarFallback>
+              </Avatar>
+              {!rail.collapsed ? (
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-[color:var(--color-fg)]">{displayName}</span>
+                  {secondary && secondary !== displayName ? (
+                    <span className="block truncate text-[10px] text-[color:var(--color-fg-subtle)]">{secondary}</span>
+                  ) : null}
+                </span>
+              ) : null}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" side={rail.collapsed ? "right" : "top"} className="min-w-56">
+            <DropdownMenuLabel className="grid gap-0.5">
+              <span className="truncate text-sm">{displayName}</span>
+              {secondary && secondary !== displayName ? (
+                <span className="truncate text-xs font-normal text-[color:var(--color-fg-subtle)]">{secondary}</span>
+              ) : null}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId: rail.workspaceId }}>
+                <SettingsIcon className="size-4" />
+                Organization settings
+              </Link>
+            </DropdownMenuItem>
+            {managed ? (
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => {
+                  void context.handleManagedSignOut().catch((error) => toast.error("Sign out failed", { description: String(error) }));
+                }}
+              >
+                <LogOutIcon className="size-4" />
+                Sign out
+              </DropdownMenuItem>
+            ) : context.keyAuthRequired ? (
+              <DropdownMenuItem variant="destructive" onSelect={() => context.forgetAccessKey()}>
+                <LockIcon className="size-4" />
+                Clear access key
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem disabled>
+                <UserIcon className="size-4" />
+                {context.accessContext.mode} access
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
+              onClick={rail.toggleCollapsed}
+              className="shrink-0 text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg)]"
+            >
+              {rail.collapsed ? <ChevronsRightIcon className="size-4" /> : <ChevronsLeftIcon className="size-4" />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -1,0 +1,198 @@
+// The left-rail shell that wraps every workspace-scoped route. It owns the
+// fixed full-height rail (expanded 260px / collapsed 56px), the responsive
+// overlay drawer (<1024px), and the slim canvas top strip that carries
+// session-contextual actions on session routes. The rail itself is composed
+// from the brand, switcher, workspace nav, session list, and footer sections.
+import { SessionStatus as SessionStatusBadge } from "@opengeni/react";
+import { Link, useRouterState } from "@tanstack/react-router";
+import { LockIcon, MenuIcon, PanelRightIcon, SparkleIcon } from "lucide-react";
+import { useEffect, type ReactNode } from "react";
+
+import { ConnectionPill } from "@/components/common";
+import { RailFooter } from "@/components/rail/rail-footer";
+import { useRail } from "@/components/rail/rail-context";
+import { CollapsedSessionsButton, SessionList } from "@/components/rail/session-list";
+import { SwitcherBlock } from "@/components/rail/switcher-block";
+import { WorkspaceNav } from "@/components/rail/workspace-nav";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useAppContext } from "@/context";
+import { cn } from "@/lib/utils";
+
+/** The rail body — shared between the fixed desktop column and the mobile drawer. */
+function RailBody() {
+  const rail = useRail();
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-[color:var(--color-surface)]/40">
+      {/* Brand */}
+      <div className={cn("flex h-12 shrink-0 items-center", rail.collapsed ? "justify-center px-2" : "px-3")}>
+        <Link
+          to="/workspaces/$workspaceId/sessions"
+          params={{ workspaceId: rail.workspaceId }}
+          className="flex items-center gap-2 rounded-md text-[15px] font-semibold focus-visible:outline-none"
+          aria-label="OpenGeni home"
+        >
+          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+            <SparkleIcon className="size-3.5" />
+          </span>
+          {!rail.collapsed ? <span className="truncate">OpenGeni</span> : null}
+        </Link>
+      </div>
+
+      <SwitcherBlock />
+
+      <div className="mt-2">
+        <WorkspaceNav />
+      </div>
+
+      <div className="my-2 border-t border-[color:var(--color-border)]" />
+
+      {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
+
+      <RailFooter />
+    </div>
+  );
+}
+
+export function RailShell({ children }: { children: ReactNode }) {
+  const rail = useRail();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+
+  // Close the mobile drawer on route change.
+  useEffect(() => {
+    if (rail.drawerOpen) {
+      rail.setDrawerOpen(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // Global `c` shortcut → new session. Ignored while typing in a field or with
+  // a modifier held, so it never steals keystrokes from the composer.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "c" || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      if (target && (target.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) {
+        return;
+      }
+      event.preventDefault();
+      rail.startNewSession();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [rail]);
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden">
+        {/* Fixed desktop rail. */}
+        {!rail.isMobile ? (
+          <nav
+            aria-label="Primary"
+            data-collapsed={rail.collapsed}
+            className={cn(
+              "motion-safe:transition-[width] motion-safe:duration-150 shrink-0 border-r border-[color:var(--color-border)]",
+              rail.collapsed ? "w-[56px]" : "w-[260px]",
+            )}
+          >
+            <RailBody />
+          </nav>
+        ) : null}
+
+        {/* Mobile overlay drawer. */}
+        {rail.isMobile ? (
+          <Sheet open={rail.drawerOpen} onOpenChange={rail.setDrawerOpen}>
+            <SheetContent side="left" showCloseButton={false} className="w-[260px] gap-0 p-0">
+              <nav aria-label="Primary" className="h-full">
+                <RailBody />
+              </nav>
+            </SheetContent>
+          </Sheet>
+        ) : null}
+
+        {/* Main canvas. */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <CanvasTopStrip />
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * The slim canvas top strip. On mobile it always shows (hamburger + brand). On
+ * session routes it also carries the session title/status, the connection and
+ * lock pills, and the inspector toggle — moved here from the old top header.
+ */
+function CanvasTopStrip() {
+  const rail = useRail();
+  const context = useAppContext();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const isSessionRoute = /\/sessions\/[^/]+/.test(pathname);
+  const showSessionActions = Boolean(context.session) && isSessionRoute;
+
+  // On desktop, the strip only renders when there is something to show.
+  if (!rail.isMobile && !showSessionActions) {
+    return null;
+  }
+
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)]/75 px-3 backdrop-blur sm:px-4">
+      {rail.isMobile ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Open navigation"
+          onClick={() => rail.setDrawerOpen(true)}
+        >
+          <MenuIcon className="size-4" />
+        </Button>
+      ) : null}
+
+      {showSessionActions && context.session ? (
+        <>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{context.session.initialMessage}</div>
+            <div className="truncate text-xs text-[color:var(--color-fg-subtle)]">
+              {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")} · {context.session.sandboxBackend}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {context.keyAuthRequired ? (
+              <Button type="button" variant="ghost" size="icon-sm" onClick={context.forgetAccessKey} aria-label="Clear access key">
+                <LockIcon className="size-4" />
+              </Button>
+            ) : null}
+            <ConnectionPill state={context.connectionState} />
+            <SessionStatusBadge status={context.session.status} />
+            <Button
+              type="button"
+              variant={context.inspectorOpen ? "secondary" : "ghost"}
+              size="icon-sm"
+              onClick={() => context.setInspectorOpen((open) => !open)}
+              aria-label="Toggle session rail"
+            >
+              <PanelRightIcon className="size-4" />
+            </Button>
+          </div>
+        </>
+      ) : rail.isMobile ? (
+        <Link
+          to="/workspaces/$workspaceId/sessions"
+          params={{ workspaceId: rail.workspaceId }}
+          className="flex items-center gap-2 text-sm font-semibold"
+        >
+          <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+            <SparkleIcon className="size-3" />
+          </span>
+          OpenGeni
+        </Link>
+      ) : null}
+    </header>
+  );
+}

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -3,7 +3,7 @@
 // and supports ArrowUp/Down + Enter keyboard navigation. Each row is a status
 // dot + single-line truncated title + hover-revealed relative time. The active
 // session (from the URL) is highlighted with an accent bar.
-import { StatusDot, useWorkspaceSessions } from "@opengeni/react";
+import { useWorkspaceSessions } from "@opengeni/react";
 import { useRouterState } from "@tanstack/react-router";
 import { MessagesSquareIcon, PlusIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -77,8 +77,8 @@ export function SessionList() {
   }, [focusIndex]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center justify-between gap-2 px-3 pb-1 pt-1">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className="flex min-w-0 items-center justify-between gap-2 px-3 pb-1 pt-1">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
           Sessions
         </span>
@@ -105,7 +105,7 @@ export function SessionList() {
         aria-label="Sessions"
         tabIndex={0}
         onKeyDown={onKeyDown}
-        className="min-h-0 flex-1 overflow-y-auto px-2 pb-2 outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
+        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2 outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
       >
         {loading && sessions.length === 0 ? (
           <SessionListSkeleton />
@@ -159,11 +159,11 @@ function SessionGroup(props: {
   running?: boolean;
 }) {
   return (
-    <div className="mb-1.5">
+    <div className="mb-1.5 min-w-0">
       <p className="px-2 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
         {props.label}
       </p>
-      <div className="grid gap-px">
+      <div className="grid min-w-0 grid-cols-1 gap-px">
         {props.sessions.map((session) => {
           const index = props.flat.indexOf(session);
           return (
@@ -198,26 +198,55 @@ function SessionRow(props: {
       onClick={() => props.onSelect(props.session.id)}
       title={title}
       className={cn(
-        "group relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors",
+        "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-3 text-left text-sm transition-colors",
         "hover:bg-[color:var(--color-surface-2)]",
         props.active
-          ? "bg-[color:var(--color-surface-2)] text-[color:var(--color-fg)]"
+          ? "bg-[color:var(--color-surface-3)] font-medium text-[color:var(--color-fg)]"
           : "text-[color:var(--color-fg-muted)]",
         props.focused && !props.active ? "bg-[color:var(--color-surface-2)]/60" : "",
       )}
     >
       <span
         className={cn(
-          "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
+          "absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
           props.active ? "opacity-100" : "opacity-0",
         )}
       />
-      <StatusDot status={props.session.status} className="size-1.5 shrink-0" />
-      <span className="min-w-0 flex-1 truncate">{title}</span>
+      <RailStatusDot status={props.session.status} />
+      {/* min-w-0 + truncate: the title must always ellipsis, never butt the rail
+          border. The pr-1 keeps a gap before the hover time / right edge. */}
+      <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
       <span className="shrink-0 text-[10px] tabular-nums text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity group-hover:opacity-100">
         {relativeTimeLabel(props.session.updatedAt)}
       </span>
     </button>
+  );
+}
+
+/**
+ * Rail-local status dot with the rail's intent semantics: RUNNING reads as a
+ * positive, active state (brand blue) with a breathing pulse; FAILED is danger
+ * red; everything idle/terminal is a calm muted gray. This deliberately differs
+ * from the shared package badge (whose running hue is amber) so a running
+ * session in the list never reads as an error.
+ */
+function RailStatusDot({ status }: { status: Session["status"] }) {
+  const running = status === "running" || status === "queued";
+  const needsAttention = status === "requires_action";
+  const failed = status === "failed";
+  const color = running
+    ? "var(--color-brand)"
+    : needsAttention
+      ? "var(--color-status-running)" // app's amber "attention" hue
+      : failed
+        ? "var(--color-status-failed)"
+        : "var(--color-fg-subtle)";
+  return (
+    <span className="relative inline-flex size-1.5 shrink-0 rounded-full" style={{ backgroundColor: `color-mix(in oklch, ${color} 92%, transparent)` }}>
+      {running || needsAttention ? (
+        <span className="absolute inset-0 animate-og-pulse rounded-full" style={{ backgroundColor: color }} />
+      ) : null}
+    </span>
   );
 }
 

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -1,0 +1,296 @@
+// The session list — the rail's home. Reuses the same useWorkspaceSessions
+// hook the old sessions index used, groups by recency (running pinned on top),
+// and supports ArrowUp/Down + Enter keyboard navigation. Each row is a status
+// dot + single-line truncated title + hover-revealed relative time. The active
+// session (from the URL) is highlighted with an accent bar.
+import { StatusDot, useWorkspaceSessions } from "@opengeni/react";
+import { useRouterState } from "@tanstack/react-router";
+import { MessagesSquareIcon, PlusIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useRail } from "@/components/rail/rail-context";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { groupSessionsForRail, relativeTimeLabel } from "@/lib/sessions-group";
+import { cn } from "@/lib/utils";
+import type { Session } from "@/types";
+
+export function SessionList() {
+  const rail = useRail();
+  // Poll so running sessions surface and move to the top without a manual
+  // refresh; the previous index relied on a one-shot load.
+  const { sessions, loading, error, refresh } = useWorkspaceSessions({ limit: 50, pollIntervalMs: 15_000 });
+
+  const activeSessionId = useRouterState({
+    select: (state): string | null => {
+      const match = /\/sessions\/([^/]+)/.exec(state.location.pathname);
+      return match?.[1] ?? null;
+    },
+  });
+
+  // Flattened, ordered list (running first, then recency groups) — the keyboard
+  // navigation index walks this; the render groups it back into sections.
+  const { running, grouped } = useMemo(() => groupSessionsForRail(sessions), [sessions]);
+  const flat = useMemo<Session[]>(
+    () => [...running, ...grouped.flatMap((bucket) => bucket.sessions)],
+    [running, grouped],
+  );
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const [focusIndex, setFocusIndex] = useState<number>(-1);
+
+  // Keep the keyboard focus index pinned to the active session when the route
+  // changes (so ArrowDown continues from where the user is).
+  useEffect(() => {
+    const index = flat.findIndex((session) => session.id === activeSessionId);
+    if (index >= 0) {
+      setFocusIndex(index);
+    }
+  }, [activeSessionId, flat]);
+
+  const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (flat.length === 0) {
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setFocusIndex((current) => Math.min(flat.length - 1, current + 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setFocusIndex((current) => Math.max(0, current <= 0 ? 0 : current - 1));
+    } else if (event.key === "Enter" && focusIndex >= 0 && focusIndex < flat.length) {
+      event.preventDefault();
+      const session = flat[focusIndex];
+      if (session) {
+        rail.openSession(session.id);
+      }
+    }
+  }, [flat, focusIndex, rail]);
+
+  // Scroll the keyboard-focused row into view.
+  useEffect(() => {
+    if (focusIndex < 0 || !listRef.current) {
+      return;
+    }
+    const row = listRef.current.querySelector<HTMLElement>(`[data-session-index="${focusIndex}"]`);
+    row?.scrollIntoView({ block: "nearest" });
+  }, [focusIndex]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-between gap-2 px-3 pb-1 pt-1">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+          Sessions
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="New session"
+              onClick={rail.startNewSession}
+              className="text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+            >
+              <PlusIcon className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right">New session · c</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div
+        ref={listRef}
+        role="list"
+        aria-label="Sessions"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        className="min-h-0 flex-1 overflow-y-auto px-2 pb-2 outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
+      >
+        {loading && sessions.length === 0 ? (
+          <SessionListSkeleton />
+        ) : error && sessions.length === 0 ? (
+          <div className="px-2 py-3 text-xs text-[color:var(--color-fg-subtle)]">
+            Session history is unavailable.{" "}
+            <button type="button" className="underline hover:text-[color:var(--color-fg)]" onClick={() => void refresh()}>
+              Retry
+            </button>
+          </div>
+        ) : flat.length === 0 ? (
+          <EmptySessions onStart={rail.startNewSession} />
+        ) : (
+          <>
+            {running.length > 0 ? (
+              <SessionGroup
+                label="Running"
+                sessions={running}
+                flat={flat}
+                activeSessionId={activeSessionId}
+                focusIndex={focusIndex}
+                onSelect={rail.openSession}
+                running
+              />
+            ) : null}
+            {grouped.map((bucket) => (
+              <SessionGroup
+                key={bucket.group}
+                label={bucket.label}
+                sessions={bucket.sessions}
+                flat={flat}
+                activeSessionId={activeSessionId}
+                focusIndex={focusIndex}
+                onSelect={rail.openSession}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionGroup(props: {
+  label: string;
+  sessions: Session[];
+  flat: Session[];
+  activeSessionId: string | null;
+  focusIndex: number;
+  onSelect: (sessionId: string) => void;
+  running?: boolean;
+}) {
+  return (
+    <div className="mb-1.5">
+      <p className="px-2 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+        {props.label}
+      </p>
+      <div className="grid gap-px">
+        {props.sessions.map((session) => {
+          const index = props.flat.indexOf(session);
+          return (
+            <SessionRow
+              key={session.id}
+              session={session}
+              index={index}
+              active={session.id === props.activeSessionId}
+              focused={index === props.focusIndex}
+              onSelect={props.onSelect}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SessionRow(props: {
+  session: Session;
+  index: number;
+  active: boolean;
+  focused: boolean;
+  onSelect: (sessionId: string) => void;
+}) {
+  const title = props.session.initialMessage?.trim() || "Untitled session";
+  return (
+    <button
+      type="button"
+      role="listitem"
+      data-session-index={props.index}
+      onClick={() => props.onSelect(props.session.id)}
+      title={title}
+      className={cn(
+        "group relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors",
+        "hover:bg-[color:var(--color-surface-2)]",
+        props.active
+          ? "bg-[color:var(--color-surface-2)] text-[color:var(--color-fg)]"
+          : "text-[color:var(--color-fg-muted)]",
+        props.focused && !props.active ? "bg-[color:var(--color-surface-2)]/60" : "",
+      )}
+    >
+      <span
+        className={cn(
+          "absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
+          props.active ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <StatusDot status={props.session.status} className="size-1.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{title}</span>
+      <span className="shrink-0 text-[10px] tabular-nums text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity group-hover:opacity-100">
+        {relativeTimeLabel(props.session.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+function EmptySessions({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="mt-2 grid gap-2 rounded-lg border border-dashed border-[color:var(--color-border)] px-3 py-4 text-center">
+      <p className="text-xs text-[color:var(--color-fg-subtle)]">No sessions yet</p>
+      <Button type="button" size="sm" onClick={onStart} className="mx-auto">
+        <PlusIcon className="size-3.5" />
+        Start your first session
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Collapsed-rail stand-in for the list: a Sessions icon carrying a count badge
+ * of running sessions; clicking expands the rail to reveal the full list.
+ */
+export function CollapsedSessionsButton() {
+  const rail = useRail();
+  const { sessions } = useWorkspaceSessions({ limit: 50, pollIntervalMs: 15_000 });
+  const runningCount = useMemo(() => groupSessionsForRail(sessions).running.length, [sessions]);
+  return (
+    <div className="flex flex-1 flex-col items-center gap-1 px-2 pt-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Sessions${runningCount > 0 ? ` (${runningCount} running)` : ""}`}
+            onClick={() => rail.setCollapsed(false)}
+            className="relative text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+          >
+            <MessagesSquareIcon className="size-4" />
+            {runningCount > 0 ? (
+              <span className="absolute -right-0.5 -top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-[color:var(--color-brand-strong)] px-1 text-[9px] font-semibold leading-tight text-[color:var(--color-brand-fg)]">
+                {runningCount}
+              </span>
+            ) : null}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="right">Sessions</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="New session"
+            onClick={rail.startNewSession}
+            className="text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+          >
+            <PlusIcon className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="right">New session · c</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function SessionListSkeleton() {
+  return (
+    <div className="grid gap-1 px-1 pt-2">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div key={index} className="flex h-8 items-center gap-2 px-1">
+          <span className="size-1.5 shrink-0 rounded-full bg-[color:var(--color-surface-3)]" />
+          <span className="h-3 flex-1 animate-pulse rounded bg-[color:var(--color-surface-2)]" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -154,12 +154,13 @@ function OrgLine(props: {
   activeAccountId: string | null;
 }) {
   const rail = useRail();
+  // The org *name* renders in normal case (it's a name, not a section caption).
   // Exactly one org: a static muted label, no useless switcher.
   if (props.orgs.length <= 1) {
     return (
-      <span className="flex items-center gap-1 truncate px-0.5 text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)]" title={props.currentLabel}>
+      <span className="flex min-w-0 items-center gap-1 px-0.5 text-[11px] font-medium text-[color:var(--color-fg-subtle)]" title={props.currentLabel}>
         <BuildingIcon className="size-3 shrink-0" />
-        <span className="truncate">{props.currentLabel}</span>
+        <span className="min-w-0 truncate">{props.currentLabel}</span>
       </span>
     );
   }
@@ -169,10 +170,10 @@ function OrgLine(props: {
         <button
           type="button"
           aria-label="Switch organization"
-          className="flex items-center gap-1 truncate rounded px-0.5 py-0.5 text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)] focus-visible:outline-none"
+          className="flex min-w-0 items-center gap-1 rounded px-0.5 py-0.5 text-[11px] font-medium text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)] focus-visible:outline-none"
         >
           <BuildingIcon className="size-3 shrink-0" />
-          <span className="truncate">{props.currentLabel}</span>
+          <span className="min-w-0 truncate">{props.currentLabel}</span>
           <ChevronsUpDownIcon className="size-3 shrink-0" />
         </button>
       </DropdownMenuTrigger>

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -1,0 +1,262 @@
+// The rail's top switcher: a muted Organization line over a prominent Workspace
+// line. The org line is a menu only when the subject belongs to >1 org (a plain
+// label otherwise); the workspace line is always a menu listing the current
+// org's workspaces plus create / settings actions. Collapsed, the whole block
+// reduces to a workspace-initial avatar that opens the same workspace menu.
+import { Link } from "@tanstack/react-router";
+import { BuildingIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon, SettingsIcon } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { toast } from "sonner";
+
+import { WorkspaceNameDialog } from "@/components/rail/workspace-name-dialog";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppContext } from "@/context";
+import { useRail } from "@/components/rail/rail-context";
+import { organizationsForSubject, orgLabel, workspacesInOrg } from "@/lib/org";
+import { workspaceCreationAccountId } from "@/lib/workspaces";
+import type { Workspace } from "@/types";
+
+function workspaceInitial(workspace: Workspace | null): string {
+  return (workspace?.name.trim()[0] ?? "W").toUpperCase();
+}
+
+export function SwitcherBlock() {
+  const context = useAppContext();
+  const rail = useRail();
+  const activeWorkspace = context.workspaces.find((workspace) => workspace.id === rail.workspaceId) ?? null;
+  const activeAccountId = activeWorkspace?.accountId ?? context.accessContext.defaultAccountId ?? null;
+
+  const orgs = organizationsForSubject(context.accessContext, context.workspaces);
+  const currentOrgLabel = activeAccountId ? orgLabel(activeAccountId, context.accessContext.accountGrants) : "Organization";
+  const orgWorkspaces = activeAccountId ? workspacesInOrg(context.workspaces, activeAccountId) : context.workspaces;
+
+  const createAccountId = workspaceCreationAccountId(context.accessContext, activeWorkspace?.accountId ?? null);
+
+  const [dialog, setDialog] = useState<"create" | "rename" | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  function openDialog(mode: "create" | "rename") {
+    setNameDraft(mode === "rename" ? activeWorkspace?.name ?? "" : "");
+    setDialog(mode);
+  }
+
+  async function submitDialog() {
+    const name = nameDraft.trim();
+    if (!name || !dialog) {
+      return;
+    }
+    setBusy(true);
+    try {
+      if (dialog === "create") {
+        const created = await context.createWorkspace({ name, ...(createAccountId ? { accountId: createAccountId } : {}) });
+        if (!created) {
+          return;
+        }
+        toast.success(`Workspace ${created.name} created`);
+        rail.openWorkspace(created.id);
+      } else {
+        const renamed = await context.renameWorkspace(rail.workspaceId, name);
+        if (!renamed) {
+          return;
+        }
+        toast.success("Workspace renamed");
+      }
+      setDialog(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (rail.collapsed) {
+    return (
+      <>
+        <WorkspaceMenu
+          workspaces={orgWorkspaces}
+          activeWorkspaceId={rail.workspaceId}
+          canCreate={createAccountId !== null}
+          onSelect={rail.openWorkspace}
+          onCreate={() => openDialog("create")}
+          align="start"
+        >
+          <button
+            type="button"
+            aria-label={`Workspace: ${activeWorkspace?.name ?? "switch workspace"}`}
+            className="mx-auto flex size-9 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 text-sm font-semibold text-[color:var(--color-fg)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+          >
+            {workspaceInitial(activeWorkspace)}
+          </button>
+        </WorkspaceMenu>
+        <WorkspaceNameDialog
+          mode={dialog}
+          name={nameDraft}
+          busy={busy}
+          onNameChange={setNameDraft}
+          onOpenChange={(open) => !open && setDialog(null)}
+          onSubmit={() => void submitDialog()}
+        />
+      </>
+    );
+  }
+
+  return (
+    <div className="grid gap-1.5 px-3 pt-1">
+      <OrgLine orgs={orgs} currentLabel={currentOrgLabel} activeAccountId={activeAccountId} />
+
+      <WorkspaceMenu
+        workspaces={orgWorkspaces}
+        activeWorkspaceId={rail.workspaceId}
+        canCreate={createAccountId !== null}
+        onSelect={rail.openWorkspace}
+        onCreate={() => openDialog("create")}
+        align="start"
+      >
+        <button
+          type="button"
+          className="group flex w-full items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50 px-2 py-1.5 text-left transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+        >
+          <Avatar size="sm" className="rounded-md">
+            <AvatarFallback className="rounded-md bg-[color:var(--color-brand-strong)]/25 text-[11px] font-semibold text-[color:var(--color-brand)]">
+              {workspaceInitial(activeWorkspace)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="min-w-0 flex-1 truncate text-sm font-medium" title={activeWorkspace?.name}>
+            {activeWorkspace?.name ?? "Select workspace"}
+          </span>
+          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+        </button>
+      </WorkspaceMenu>
+
+      <WorkspaceNameDialog
+        mode={dialog}
+        name={nameDraft}
+        busy={busy}
+        onNameChange={setNameDraft}
+        onOpenChange={(open) => !open && setDialog(null)}
+        onSubmit={() => void submitDialog()}
+      />
+    </div>
+  );
+}
+
+function OrgLine(props: {
+  orgs: ReturnType<typeof organizationsForSubject>;
+  currentLabel: string;
+  activeAccountId: string | null;
+}) {
+  const rail = useRail();
+  // Exactly one org: a static muted label, no useless switcher.
+  if (props.orgs.length <= 1) {
+    return (
+      <span className="flex items-center gap-1 truncate px-0.5 text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)]" title={props.currentLabel}>
+        <BuildingIcon className="size-3 shrink-0" />
+        <span className="truncate">{props.currentLabel}</span>
+      </span>
+    );
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Switch organization"
+          className="flex items-center gap-1 truncate rounded px-0.5 py-0.5 text-[11px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)] focus-visible:outline-none"
+        >
+          <BuildingIcon className="size-3 shrink-0" />
+          <span className="truncate">{props.currentLabel}</span>
+          <ChevronsUpDownIcon className="size-3 shrink-0" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-56">
+        <DropdownMenuLabel className="text-[color:var(--color-fg-subtle)]">Organizations</DropdownMenuLabel>
+        {props.orgs.map((org) => (
+          <DropdownMenuItem
+            key={org.accountId}
+            onSelect={() => {
+              if (org.accountId !== props.activeAccountId) {
+                rail.openOrg(org.accountId);
+              }
+            }}
+          >
+            <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-surface-3)] text-[10px] font-semibold">
+              {org.label.replace(/^Org\s+/, "").slice(0, 2).toUpperCase()}
+            </span>
+            <span className="min-w-0 flex-1 truncate">{org.label}</span>
+            {org.accountId === props.activeAccountId ? <CheckIcon className="size-4 text-[color:var(--color-brand)]" /> : null}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId: rail.workspaceId }}>
+            <SettingsIcon className="size-4" />
+            Organization settings
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function WorkspaceMenu(props: {
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+  canCreate: boolean;
+  onSelect: (workspaceId: string) => void;
+  onCreate: () => void;
+  align: "start" | "end";
+  children: ReactNode;
+}) {
+  const rail = useRail();
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>{props.children}</DropdownMenuTrigger>
+        </TooltipTrigger>
+        {rail.collapsed ? <TooltipContent side="right">Switch workspace</TooltipContent> : null}
+      </Tooltip>
+      <DropdownMenuContent align={props.align} className="min-w-60" side={rail.collapsed ? "right" : "bottom"}>
+        <DropdownMenuLabel className="text-[color:var(--color-fg-subtle)]">Workspaces</DropdownMenuLabel>
+        {props.workspaces.map((workspace) => (
+          <DropdownMenuItem
+            key={workspace.id}
+            onSelect={() => props.onSelect(workspace.id)}
+          >
+            <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-surface-3)] text-[10px] font-semibold">
+              {workspaceInitial(workspace)}
+            </span>
+            <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
+            {workspace.id === props.activeWorkspaceId ? <CheckIcon className="size-4 text-[color:var(--color-brand)]" /> : null}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        {props.canCreate ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              props.onCreate();
+            }}
+          >
+            <PlusIcon className="size-4" />
+            New workspace…
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem asChild>
+          <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId: props.activeWorkspaceId }}>
+            <SettingsIcon className="size-4" />
+            Workspace settings
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/rail/workspace-name-dialog.tsx
+++ b/apps/web/src/components/rail/workspace-name-dialog.tsx
@@ -1,0 +1,64 @@
+// Create / rename workspace dialog — lifted verbatim out of the old top-nav
+// shell so both the switcher and Workspace settings can reuse it.
+import { CheckIcon, Loader2Icon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function WorkspaceNameDialog(props: {
+  mode: "create" | "rename" | null;
+  name: string;
+  busy: boolean;
+  onNameChange: (name: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: () => void;
+}) {
+  const creating = props.mode === "create";
+  return (
+    <Dialog open={props.mode !== null} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            props.onSubmit();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>{creating ? "New workspace" : "Rename workspace"}</DialogTitle>
+            <DialogDescription>
+              {creating
+                ? "A separate space with its own sessions, environments, packs, and API keys."
+                : "The new name shows everywhere this workspace appears."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4 grid gap-1.5">
+            <Label htmlFor="workspace-name">Name</Label>
+            <Input
+              id="workspace-name"
+              value={props.name}
+              onChange={(event) => props.onNameChange(event.target.value)}
+              placeholder="production"
+              autoFocus
+            />
+          </div>
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={props.busy || !props.name.trim()}>
+              {props.busy ? <Loader2Icon className="size-4 animate-spin" /> : <CheckIcon className="size-4" />}
+              {creating ? "Create workspace" : "Rename"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -1,0 +1,105 @@
+// Workspace configuration nav: the four config surfaces (Environments,
+// Capabilities, Schedules, Documents) as individual items, then a slightly
+// separated Settings (Workspace settings). Collapsed → centered icons with
+// tooltips. Active route gets a left accent bar + subtle surface tint.
+import { Link } from "@tanstack/react-router";
+import {
+  BoxIcon,
+  CalendarClockIcon,
+  FileSearchIcon,
+  PlugIcon,
+  SettingsIcon,
+  type LucideIcon,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { useRail } from "@/components/rail/rail-context";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type NavTarget =
+  | "/workspaces/$workspaceId/environments"
+  | "/workspaces/$workspaceId/capabilities"
+  | "/workspaces/$workspaceId/schedules"
+  | "/workspaces/$workspaceId/documents"
+  | "/workspaces/$workspaceId/settings";
+
+const CONFIG_ITEMS: Array<{ to: NavTarget; icon: LucideIcon; label: string }> = [
+  { to: "/workspaces/$workspaceId/environments", icon: BoxIcon, label: "Environments" },
+  { to: "/workspaces/$workspaceId/capabilities", icon: PlugIcon, label: "Capabilities" },
+  { to: "/workspaces/$workspaceId/schedules", icon: CalendarClockIcon, label: "Schedules" },
+  { to: "/workspaces/$workspaceId/documents", icon: FileSearchIcon, label: "Documents" },
+];
+
+export function WorkspaceNav() {
+  const rail = useRail();
+  return (
+    <nav aria-label="Workspace" className={cn("grid gap-0.5", rail.collapsed ? "px-2" : "px-2")}>
+      {!rail.collapsed ? (
+        <p className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+          Workspace
+        </p>
+      ) : null}
+      {CONFIG_ITEMS.map((item) => (
+        <RailNavItem
+          key={item.to}
+          to={item.to}
+          workspaceId={rail.workspaceId}
+          icon={<item.icon className="size-4" />}
+          label={item.label}
+          collapsed={rail.collapsed}
+        />
+      ))}
+      <div className={cn("mt-1 border-t border-[color:var(--color-border)]/60 pt-1", rail.collapsed ? "mx-1" : "")}>
+        <RailNavItem
+          to="/workspaces/$workspaceId/settings"
+          workspaceId={rail.workspaceId}
+          icon={<SettingsIcon className="size-4" />}
+          label="Settings"
+          collapsed={rail.collapsed}
+        />
+      </div>
+    </nav>
+  );
+}
+
+export function RailNavItem(props: {
+  to: NavTarget;
+  workspaceId: string;
+  icon: ReactNode;
+  label: string;
+  collapsed: boolean;
+  /** Optional search params (Capabilities Packs subsection, etc.). */
+  search?: Record<string, string>;
+}) {
+  const link = (
+    <Link
+      to={props.to}
+      params={{ workspaceId: props.workspaceId }}
+      {...(props.search ? { search: props.search } : {})}
+      activeProps={{ "data-active": "true" }}
+      aria-label={props.collapsed ? props.label : undefined}
+      className={cn(
+        "group relative flex h-8 items-center rounded-md text-sm font-medium text-[color:var(--color-fg-muted)] transition-colors",
+        "hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
+        "data-[active=true]:bg-[color:var(--color-surface-2)] data-[active=true]:text-[color:var(--color-fg)]",
+        props.collapsed ? "w-8 justify-center" : "gap-2.5 px-2.5",
+      )}
+    >
+      {/* Left accent bar on the active route. */}
+      <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
+      <span className="shrink-0">{props.icon}</span>
+      {!props.collapsed ? <span className="min-w-0 truncate">{props.label}</span> : null}
+    </Link>
+  );
+
+  if (!props.collapsed) {
+    return link;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{link}</TooltipTrigger>
+      <TooltipContent side="right">{props.label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/lib/org.ts
+++ b/apps/web/src/lib/org.ts
@@ -1,0 +1,64 @@
+// Organization (the tenant formerly surfaced as "account") helpers for the
+// rail's org switcher. The wire model has no account *name*, so a display
+// label is derived from the access grant — preferring a human subjectLabel,
+// falling back to a short, stable id fragment.
+import { hasAccountPermission } from "@/lib/permissions";
+import type { AccessContext, AccountGrant, Workspace } from "@/types";
+
+export type OrgOption = {
+  accountId: string;
+  label: string;
+  /** Whether the subject can open this org's settings (read billing/members). */
+  canManage: boolean;
+};
+
+/** A short, stable id fragment for an account that has no human name. */
+export function shortAccountId(accountId: string): string {
+  return accountId.length > 8 ? accountId.slice(0, 8) : accountId;
+}
+
+/** Human label for an organization: the grant's subjectLabel, else a short id. */
+export function orgLabel(accountId: string, grants: AccountGrant[]): string {
+  const grant = grants.find((candidate) => candidate.accountId === accountId);
+  const label = grant?.metadata && typeof grant.metadata.accountName === "string"
+    ? grant.metadata.accountName
+    : undefined;
+  return label?.trim() || `Org ${shortAccountId(accountId)}`;
+}
+
+/**
+ * The organizations the subject belongs to, in a stable order (default org
+ * first). Derived from account grants, unioned with the accounts that own the
+ * accessible workspaces so an org always shows even without an explicit grant.
+ */
+export function organizationsForSubject(context: AccessContext, workspaces: Workspace[]): OrgOption[] {
+  const ids = new Set<string>();
+  for (const grant of context.accountGrants) {
+    ids.add(grant.accountId);
+  }
+  for (const workspace of workspaces) {
+    ids.add(workspace.accountId);
+  }
+  const ordered = [...ids].sort((a, b) => {
+    if (a === context.defaultAccountId) {
+      return -1;
+    }
+    if (b === context.defaultAccountId) {
+      return 1;
+    }
+    return a.localeCompare(b);
+  });
+  return ordered.map((accountId) => ({
+    accountId,
+    label: orgLabel(accountId, context.accountGrants),
+    canManage: hasAccountPermission(context, accountId, "billing:read")
+      || hasAccountPermission(context, accountId, "account:read"),
+  }));
+}
+
+/** Workspaces that belong to a given organization, ordered by name. */
+export function workspacesInOrg(workspaces: Workspace[], accountId: string): Workspace[] {
+  return workspaces
+    .filter((workspace) => workspace.accountId === accountId)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -18,6 +18,16 @@ export function workspaceSessionPath(workspaceId: string, sessionId: string): st
   return `${workspaceSessionsPath(workspaceId)}/${encodeURIComponent(sessionId)}`;
 }
 
+/** Workspace settings: workspace name, API keys, environments link, danger zone. */
+export function workspaceSettingsPath(workspaceId: string): string {
+  return `${workspacePath(workspaceId)}/settings`;
+}
+
+/** Organization (formerly "account") settings: billing, usage, plan, members. */
+export function orgSettingsPath(workspaceId: string): string {
+  return `${workspacePath(workspaceId)}/organization`;
+}
+
 // Stripe checkout redirects land on `/billing?checkout=success|cancelled` (the
 // success_url/cancel_url baked into every checkout session by the API). The
 // `/billing` route forwards the shopper onto their account page, carrying this

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -1,0 +1,125 @@
+// Pure helpers behind the rail's session list: relative-time labels, recency
+// bucketing (Today / Yesterday / Previous 7 days / Older), and the ordering
+// rule — RUNNING sessions pinned to the very top, then most-recent activity
+// first within each recency group.
+import type { Session, SessionStatus } from "@/types";
+
+export type SessionRecencyGroup = "today" | "yesterday" | "previous7" | "older";
+
+export const SESSION_GROUP_LABELS: Record<SessionRecencyGroup, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  previous7: "Previous 7 days",
+  older: "Older",
+};
+
+/** The render order of recency groups, top → bottom. */
+export const SESSION_GROUP_ORDER: SessionRecencyGroup[] = ["today", "yesterday", "previous7", "older"];
+
+/** Live states that earn the pinned-to-top, breathing-dot treatment. */
+const RUNNING_STATUSES = new Set<SessionStatus>(["running", "queued", "requires_action"]);
+
+export function isRunningStatus(status: SessionStatus): boolean {
+  return RUNNING_STATUSES.has(status);
+}
+
+/** Most-recent activity timestamp for a session (updatedAt, then createdAt). */
+export function sessionActivityTime(session: Session): number {
+  const updated = Date.parse(session.updatedAt);
+  if (!Number.isNaN(updated)) {
+    return updated;
+  }
+  const created = Date.parse(session.createdAt);
+  return Number.isNaN(created) ? 0 : created;
+}
+
+/**
+ * Which recency bucket a timestamp falls into, relative to `now`. "Today" and
+ * "Yesterday" are calendar-local; "Previous 7 days" is the rest of the trailing
+ * week; everything earlier is "Older".
+ */
+export function recencyGroupFor(timestampMs: number, now: Date = new Date()): SessionRecencyGroup {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfYesterday = startOfToday - 24 * 60 * 60 * 1000;
+  const startOfWeekWindow = startOfToday - 7 * 24 * 60 * 60 * 1000;
+  if (timestampMs >= startOfToday) {
+    return "today";
+  }
+  if (timestampMs >= startOfYesterday) {
+    return "yesterday";
+  }
+  if (timestampMs >= startOfWeekWindow) {
+    return "previous7";
+  }
+  return "older";
+}
+
+export type SessionRecencyBucket = {
+  group: SessionRecencyGroup;
+  label: string;
+  sessions: Session[];
+};
+
+export type GroupedSessions = {
+  /** Running sessions, pinned above every recency group, most-recent first. */
+  running: Session[];
+  /** Non-running sessions bucketed by recency (empty buckets dropped). */
+  grouped: SessionRecencyBucket[];
+};
+
+/**
+ * Order + bucket the sessions for the rail. Running sessions are lifted into a
+ * synthetic, always-first position regardless of recency (rendered with a
+ * "running" marker); the remainder are bucketed by recency, most-recent first
+ * within each bucket. Empty groups are dropped.
+ */
+export function groupSessionsForRail(sessions: Session[], now: Date = new Date()): GroupedSessions {
+  const running = sessions
+    .filter((session) => isRunningStatus(session.status))
+    .sort((a, b) => sessionActivityTime(b) - sessionActivityTime(a));
+  const rest = sessions
+    .filter((session) => !isRunningStatus(session.status))
+    .sort((a, b) => sessionActivityTime(b) - sessionActivityTime(a));
+
+  const buckets = new Map<SessionRecencyGroup, Session[]>();
+  for (const session of rest) {
+    const group = recencyGroupFor(sessionActivityTime(session), now);
+    const list = buckets.get(group) ?? [];
+    list.push(session);
+    buckets.set(group, list);
+  }
+
+  const grouped: SessionRecencyBucket[] = [];
+  for (const group of SESSION_GROUP_ORDER) {
+    const list = buckets.get(group);
+    if (list && list.length > 0) {
+      grouped.push({ group, label: SESSION_GROUP_LABELS[group], sessions: list });
+    }
+  }
+  return { running, grouped };
+}
+
+/** Compact relative-time label, e.g. "now", "5m", "3h", "2d", "Mar 4". */
+export function relativeTimeLabel(value: string, now: Date = new Date()): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return "";
+  }
+  const diffSeconds = Math.max(0, Math.floor((now.getTime() - timestamp) / 1000));
+  if (diffSeconds < 45) {
+    return "now";
+  }
+  const minutes = Math.floor(diffSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 7) {
+    return `${days}d`;
+  }
+  return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -1,58 +1,46 @@
-// Account: identity, billing balance + usage (from /v1/billing/usage), plan
-// entitlements (from /v1/billing/entitlements), and workspace API keys with
-// the grouped delegable-permission picker.
+// Organization settings (formerly "Account"): identity, billing balance +
+// usage (from /v1/billing/usage), plan entitlements (from
+// /v1/billing/entitlements), and members. The workspace-scoped API keys section
+// moved to Workspace settings; this surface is the tenant-level console.
 import { useBillingUsage } from "@opengeni/react";
+import { Link } from "@tanstack/react-router";
 import {
   ActivityIcon,
-  CopyIcon,
+  BuildingIcon,
   GaugeIcon,
   Loader2Icon,
   LockIcon,
-  PlusIcon,
   RefreshCwIcon,
-  Trash2Icon,
-  UserIcon,
+  SettingsIcon,
+  UsersIcon,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
-import { PermissionGroupPicker } from "@/components/permission-picker";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useAppContext } from "@/context";
 import { entitlementEntries, formatMoneyMicros, formatTimestamp, validTopupAmount } from "@/lib/format";
-import {
-  apiKeyPermissionGroups,
-  defaultApiKeyPermissions,
-  delegableApiKeyPermissions,
-  hasAccountPermission,
-  hasWorkspacePermission,
-} from "@/lib/permissions";
-import type { ApiKey, BillingEntitlementsResponse, BillingSummary, UsageEvent } from "@/types";
+import { orgLabel } from "@/lib/org";
+import { hasAccountPermission } from "@/lib/permissions";
+import type { BillingEntitlementsResponse, BillingSummary, UsageEvent } from "@/types";
 
-export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; checkout?: "success" | "cancelled" }) {
+export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: string; checkout?: "success" | "cancelled" }) {
   const context = useAppContext();
   const client = context.client;
   const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
   const accountId = activeWorkspace?.accountId ?? "";
-  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
-  const [apiKeysError, setApiKeysError] = useState<Error | null>(null);
+  const organizationLabel = accountId ? orgLabel(accountId, context.accessContext.accountGrants) : "Organization";
   const [billing, setBilling] = useState<BillingSummary | null>(null);
   const [billingError, setBillingError] = useState<Error | null>(null);
   const [entitlements, setEntitlements] = useState<BillingEntitlementsResponse | null>(null);
   const [entitlementsError, setEntitlementsError] = useState<Error | null>(null);
-  const [apiKeyName, setApiKeyName] = useState("Default API key");
-  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(() => new Set(defaultApiKeyPermissions));
-  const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [topupAmount, setTopupAmount] = useState("25.00");
   const [busy, setBusy] = useState(false);
-  const canManageApiKeys = hasWorkspacePermission(context.accessContext, workspaceId, "api_keys:manage");
   const canManageBilling = hasAccountPermission(context.accessContext, accountId, "billing:manage");
   const canReadBilling = canManageBilling || hasAccountPermission(context.accessContext, accountId, "billing:read");
-  const workspaceGrant = context.accessContext.workspaceGrants.find((grant) => grant.workspaceId === workspaceId) ?? null;
-  const delegablePermissions = delegableApiKeyPermissions(workspaceGrant?.permissions ?? []);
-  const requestedPermissions = [...selectedPermissions].filter((permission) => delegablePermissions.has(permission));
+  const canManageMembers = hasAccountPermission(context.accessContext, accountId, "members:manage");
+  const accountGrant = context.accessContext.accountGrants.find((grant) => grant.accountId === accountId) ?? null;
   const usage = useBillingUsage({
     ...(accountId ? { accountId } : {}),
     workspaceId,
@@ -76,23 +64,6 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
       toast("Checkout cancelled", { description: "No charge was made." });
     }
   }, [checkout]);
-
-  // Each loader records its own failure: a failed request must render as an
-  // error with retry, never as "No API keys." or a quietly absent balance.
-  async function refreshApiKeys() {
-    if (!canManageApiKeys) {
-      setApiKeys([]);
-      setApiKeysError(null);
-      return;
-    }
-    try {
-      setApiKeys(await client.listApiKeys(workspaceId));
-      setApiKeysError(null);
-    } catch (error) {
-      setApiKeys([]);
-      setApiKeysError(error instanceof Error ? error : new Error(String(error)));
-    }
-  }
 
   async function refreshBilling() {
     if (!accountId || !canReadBilling) {
@@ -125,48 +96,14 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
   }
 
   async function refresh() {
-    await Promise.all([refreshApiKeys(), refreshBilling(), refreshEntitlements()]);
-  }
-
-  async function createKey() {
-    if (!apiKeyName.trim() || requestedPermissions.length === 0) {
-      toast.error("API key name and permissions are required");
-      return;
-    }
-    setBusy(true);
-    try {
-      const result = await client.createApiKey(workspaceId, {
-        name: apiKeyName.trim(),
-        permissions: requestedPermissions,
-      });
-      setCreatedToken(result.token);
-      setApiKeys((current) => [result.apiKey, ...current]);
-      toast.success("API key created");
-    } catch (error) {
-      toast.error("Failed to create API key", { description: error instanceof Error ? error.message : String(error) });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function revokeKey(apiKeyId: string) {
-    setBusy(true);
-    try {
-      const revoked = await client.deleteApiKey(workspaceId, apiKeyId);
-      setApiKeys((current) => current.map((key) => key.id === revoked.id ? revoked : key));
-      toast.success("API key revoked");
-    } catch (error) {
-      toast.error("Failed to revoke API key", { description: error instanceof Error ? error.message : String(error) });
-    } finally {
-      setBusy(false);
-    }
+    await Promise.all([refreshBilling(), refreshEntitlements()]);
   }
 
   async function startCheckout(amountUsd: number) {
     setBusy(true);
     try {
-      const checkout = await client.createBillingCheckout({ amountUsd, ...(accountId ? { accountId } : {}) });
-      window.location.assign(checkout.url);
+      const session = await client.createBillingCheckout({ amountUsd, ...(accountId ? { accountId } : {}) });
+      window.location.assign(session.url);
     } catch (error) {
       toast.error("Checkout failed", { description: error instanceof Error ? error.message : String(error) });
     } finally {
@@ -174,24 +111,12 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
     }
   }
 
-  function togglePermission(permission: string) {
-    setSelectedPermissions((current) => {
-      const next = new Set(current);
-      if (next.has(permission)) {
-        next.delete(permission);
-      } else {
-        next.add(permission);
-      }
-      return next;
-    });
-  }
-
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-6 lg:px-8">
       <section className="grid gap-5 text-left">
         <PageHeader
-          icon={<UserIcon className="size-4" />}
-          title="Account"
+          icon={<BuildingIcon className="size-4" />}
+          title="Organization"
           description={context.authSession?.user.email ?? context.accessContext.subjectLabel ?? context.accessContext.subjectId}
           actions={context.clientConfig.auth.mode === "managedSession" ? (
             <Button type="button" variant="ghost" size="sm" onClick={() => void context.handleManagedSignOut().catch((error) => toast.error("Sign out failed", { description: String(error) }))}>
@@ -203,13 +128,28 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
 
         <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
           <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-sm font-medium">Organization name</h2>
+              <p className="mt-1 truncate text-xs text-[color:var(--color-fg-muted)]">{organizationLabel}</p>
+            </div>
+            <Button asChild type="button" variant="ghost" size="sm">
+              <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId }}>
+                <SettingsIcon className="size-3.5" />
+                Workspace settings
+              </Link>
+            </Button>
+          </div>
+        </section>
+
+        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+          <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-medium">Credits</h2>
               <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
                 {billing
                   ? `${formatMoneyMicros(billing.balance.balanceMicros, billing.balance.currency)} available`
                   : !canReadBilling || !accountId
-                    ? "This subject cannot read billing for the account."
+                    ? "This subject cannot read billing for the organization."
                     : billingError
                       ? "Billing balance failed to load."
                       : "Billing balance unavailable"}
@@ -270,66 +210,11 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
           onRefresh={() => void usage.refresh()}
         />
 
-        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
-          <div>
-            <h2 className="text-sm font-medium">API keys</h2>
-            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Workspace-scoped keys for calling OpenGeni from another product.</p>
-          </div>
-          {createdToken ? (
-            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
-              <div className="text-xs font-medium text-emerald-200">Token shown once</div>
-              <div className="mt-2 flex min-w-0 items-center gap-2">
-                <code className="min-w-0 flex-1 truncate rounded bg-[color:var(--color-bg)] px-2 py-1.5 text-xs">{createdToken}</code>
-                <Button type="button" variant="ghost" size="icon-sm" onClick={() => void navigator.clipboard.writeText(createdToken)}>
-                  <CopyIcon className="size-3.5" />
-                </Button>
-              </div>
-            </div>
-          ) : null}
-          {canManageApiKeys ? (
-            <>
-              <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                <Input value={apiKeyName} onChange={(event) => setApiKeyName(event.target.value)} className="h-9" />
-                <Button type="button" disabled={busy} onClick={() => void createKey()}>
-                  {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
-                  Create
-                </Button>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-[color:var(--color-fg-subtle)]">A key can only carry permissions your own grant can delegate.</p>
-                <Button type="button" variant="ghost" size="sm" disabled={delegablePermissions.size === 0} onClick={() => setSelectedPermissions(new Set(delegablePermissions))}>
-                  Select all delegable
-                </Button>
-              </div>
-              <PermissionGroupPicker
-                groups={apiKeyPermissionGroups}
-                selected={selectedPermissions}
-                delegable={delegablePermissions}
-                onToggle={togglePermission}
-              />
-            </>
-          ) : (
-            <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot manage API keys for the selected workspace.</p>
-          )}
-          <div className="grid gap-2">
-            {apiKeysError ? (
-              <LoadErrorState title="Couldn't load API keys" error={apiKeysError} onRetry={() => void refreshApiKeys()} />
-            ) : apiKeys.length === 0 ? (
-              <EmptyState>No API keys.</EmptyState>
-            ) : apiKeys.map((apiKey) => (
-              <div key={apiKey.id} className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-medium">{apiKey.name}</div>
-                  <div className="mt-1 truncate text-xs text-[color:var(--color-fg-subtle)]">{apiKey.prefix}... · {apiKey.revokedAt ? "revoked" : "active"}</div>
-                </div>
-                <Button type="button" variant="ghost" size="sm" disabled={busy || Boolean(apiKey.revokedAt)} onClick={() => void revokeKey(apiKey.id)}>
-                  <Trash2Icon className="size-3.5" />
-                  Revoke
-                </Button>
-              </div>
-            ))}
-          </div>
-        </section>
+        <MembersSection
+          canManage={canManageMembers}
+          subjectLabel={accountGrant?.subjectLabel ?? context.accessContext.subjectLabel ?? context.accessContext.subjectId}
+          role={accountGrant?.role ?? null}
+        />
       </section>
     </div>
   );
@@ -339,7 +224,7 @@ export function AccountRoute({ workspaceId, checkout }: { workspaceId: string; c
 export function aggregateUsage(events: UsageEvent[]): Array<{ eventType: string; unit: string; total: number; count: number }> {
   const byKey = new Map<string, { eventType: string; unit: string; total: number; count: number }>();
   for (const event of events) {
-    const key = `${event.eventType}\u0000${event.unit}`;
+    const key = `${event.eventType} ${event.unit}`;
     const entry = byKey.get(key) ?? { eventType: event.eventType, unit: event.unit, total: 0, count: 0 };
     entry.total += event.quantity;
     entry.count += 1;
@@ -348,7 +233,7 @@ export function aggregateUsage(events: UsageEvent[]): Array<{ eventType: string;
   return [...byKey.values()].sort((a, b) => b.count - a.count || a.eventType.localeCompare(b.eventType));
 }
 
-/** Plan & entitlements (/v1/billing/entitlements): the limits the account runs under. */
+/** Plan & entitlements (/v1/billing/entitlements): the limits the org runs under. */
 function EntitlementsSection(props: {
   enabled: boolean;
   entitlements: BillingEntitlementsResponse | null;
@@ -362,9 +247,9 @@ function EntitlementsSection(props: {
         <div>
           <h2 className="flex items-center gap-1.5 text-sm font-medium">
             <GaugeIcon className="size-3.5 text-[color:var(--color-brand)]" />
-            Plan entitlements
+            Plan & entitlements
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">The limits and features this account runs under.</p>
+          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">The limits and features this organization runs under.</p>
         </div>
         <span className="rounded-full border border-[color:var(--color-border)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]">
           {props.entitlements?.mode ?? "unknown"}
@@ -372,7 +257,7 @@ function EntitlementsSection(props: {
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing entitlements for the account.</p>
+        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing entitlements for the organization.</p>
       ) : props.error ? (
         <LoadErrorState title="Couldn't load entitlements" error={props.error} onRetry={props.onRetry} />
       ) : !props.entitlements ? (
@@ -381,7 +266,7 @@ function EntitlementsSection(props: {
           Loading entitlements
         </div>
       ) : rows.length === 0 ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">No entitlement limits — this deployment does not restrict the account.</p>
+        <p className="text-xs text-[color:var(--color-fg-subtle)]">No entitlement limits — this deployment does not restrict the organization.</p>
       ) : (
         <div className="flex flex-wrap gap-2">
           {rows.map((row) => (
@@ -412,7 +297,7 @@ function UsageSection(props: {
             <ActivityIcon className="size-3.5 text-[color:var(--color-brand)]" />
             Usage
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Recent metered events for this account, straight from the billing ledger.</p>
+          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Recent metered events for this organization, straight from the billing ledger.</p>
         </div>
         <Button type="button" variant="ghost" size="sm" disabled={!props.enabled || props.loading} onClick={props.onRefresh}>
           <RefreshCwIcon className={props.loading ? "size-3.5 animate-spin" : "size-3.5"} />
@@ -421,7 +306,7 @@ function UsageSection(props: {
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing usage for the account.</p>
+        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing usage for the organization.</p>
       ) : props.error && props.usage.length === 0 ? (
         // Honest failed-load state: a failed usage read must never render as
         // "No usage recorded yet." (usage already on screen keeps rendering).
@@ -473,6 +358,37 @@ function UsageSection(props: {
           </div>
         </>
       )}
+    </section>
+  );
+}
+
+/** Members: the current subject's standing in the org. Full member management
+ *  is delivered by the API's members surface; the console surfaces the caller's
+ *  own role and a clear capability hint. */
+function MembersSection(props: { canManage: boolean; subjectLabel: string; role: string | null }) {
+  return (
+    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+      <div>
+        <h2 className="flex items-center gap-1.5 text-sm font-medium">
+          <UsersIcon className="size-3.5 text-[color:var(--color-brand)]" />
+          Members
+        </h2>
+        <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Who can act in this organization.</p>
+      </div>
+      <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{props.subjectLabel}</div>
+          <div className="mt-0.5 truncate text-xs text-[color:var(--color-fg-subtle)]">You{props.role ? ` · ${props.role}` : ""}</div>
+        </div>
+        <span className="shrink-0 rounded-full border border-[color:var(--color-border)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]">
+          {props.role ?? "member"}
+        </span>
+      </div>
+      <p className="text-xs text-[color:var(--color-fg-subtle)]">
+        {props.canManage
+          ? "You can manage members for this organization."
+          : "Only organization admins can invite or remove members."}
+      </p>
     </section>
   );
 }

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -224,7 +224,7 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
 export function aggregateUsage(events: UsageEvent[]): Array<{ eventType: string; unit: string; total: number; count: number }> {
   const byKey = new Map<string, { eventType: string; unit: string; total: number; count: number }>();
   for (const event of events) {
-    const key = `${event.eventType} ${event.unit}`;
+    const key = `${event.eventType}\u0000${event.unit}`;
     const entry = byKey.get(key) ?? { eventType: event.eventType, unit: event.unit, total: 0, count: 0 };
     entry.total += event.quantity;
     entry.count += 1;

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -1,9 +1,10 @@
-// The sessions index: composer-first session creation with the full create
-// surface (model, effort, sandbox backend, environment, repositories, tools,
-// goal, first-party MCP permissions) plus the workspace session list.
-import { SessionStatus as SessionStatusBadge, useEnvironments, useWorkspaceSessions, type ComposerState } from "@opengeni/react";
+// The sessions index: the centered "Start a session" composer with the full
+// create surface (model, effort, sandbox backend, environment, repositories,
+// tools, goal, first-party MCP permissions). The session list itself now lives
+// in the left rail, not on this page.
+import { useEnvironments, type ComposerState } from "@opengeni/react";
 import { useNavigate } from "@tanstack/react-router";
-import { BoxIcon, ChevronDownIcon, FlagIcon, RefreshCwIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
+import { BoxIcon, ChevronDownIcon, FlagIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
@@ -13,12 +14,10 @@ import {
   ModelPicker,
 } from "@/components/pickers";
 import { RepositoryContextPicker } from "@/components/repository-picker";
-import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppContext } from "@/context";
-import { displayModel } from "@/lib/format";
 import { sessionMcpPermissionGroups } from "@/lib/permissions";
 import {
   emptyAdvancedSessionDraft,
@@ -137,9 +136,6 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
             </button>
           ))}
         </div>
-        <WorkspaceSessions
-          onSelect={(id) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: id } })}
-        />
       </div>
     </div>
   );
@@ -334,44 +330,3 @@ function AdvancedSessionOptions(props: {
   );
 }
 
-function WorkspaceSessions({ onSelect }: { onSelect: (id: string) => void }) {
-  // Workspace + credentials come from <OpenGeniProvider>; a new access key
-  // produces a new client, which re-runs the hook.
-  const { sessions, loading, error, refresh } = useWorkspaceSessions({ limit: 50 });
-
-  return (
-    <section className="mt-12">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">Workspace sessions</h2>
-        {error ? (
-          <Button type="button" variant="ghost" size="sm" onClick={() => void refresh()}>
-            <RefreshCwIcon className="size-4" />
-            Retry
-          </Button>
-        ) : null}
-      </div>
-      <div className="mt-3 grid gap-2">
-        {loading ? (
-          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">Loading sessions...</div>
-        ) : error ? (
-          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">Session history is unavailable.</div>
-        ) : sessions.length === 0 ? (
-          <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 text-sm text-[color:var(--color-fg-muted)]">No sessions in this workspace yet.</div>
-        ) : sessions.map((item) => (
-          <button key={item.id} type="button" onClick={() => onSelect(item.id)} className="min-w-0 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-left text-sm hover:bg-[color:var(--color-surface-2)]">
-            <div className="flex min-w-0 items-center justify-between gap-3">
-              <div className="min-w-0 truncate font-medium">{item.initialMessage}</div>
-              <SessionStatusBadge status={item.status} />
-            </div>
-            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[color:var(--color-fg-subtle)]">
-              <span>{new Date(item.createdAt).toLocaleString()}</span>
-              <span>{displayModel(item.model)}</span>
-              <span>{item.sandboxBackend}</span>
-              {item.environmentId ? <span>env attached</span> : null}
-            </div>
-          </button>
-        ))}
-      </div>
-    </section>
-  );
-}

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -1,0 +1,284 @@
+// Workspace settings: workspace name/rename, the workspace-scoped API keys
+// (moved here out of the old account page), a link to Environments, and a
+// danger zone. The org/billing console lives at Organization settings.
+import { Link } from "@tanstack/react-router";
+import {
+  BoxIcon,
+  CheckIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  Loader2Icon,
+  PencilIcon,
+  PlusIcon,
+  SettingsIcon,
+  Trash2Icon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
+import { PermissionGroupPicker } from "@/components/permission-picker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAppContext } from "@/context";
+import { orgLabel } from "@/lib/org";
+import {
+  apiKeyPermissionGroups,
+  defaultApiKeyPermissions,
+  delegableApiKeyPermissions,
+  hasWorkspacePermission,
+} from "@/lib/permissions";
+import type { ApiKey } from "@/types";
+
+export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string }) {
+  const context = useAppContext();
+  const client = context.client;
+  const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
+  const accountId = activeWorkspace?.accountId ?? "";
+  const organizationLabel = accountId ? orgLabel(accountId, context.accessContext.accountGrants) : "Organization";
+
+  const [nameDraft, setNameDraft] = useState(activeWorkspace?.name ?? "");
+  const [renaming, setRenaming] = useState(false);
+  const canRename = activeWorkspace !== null && hasWorkspacePermission(context.accessContext, workspaceId, "workspace:admin");
+
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [apiKeysError, setApiKeysError] = useState<Error | null>(null);
+  const [apiKeyName, setApiKeyName] = useState("Default API key");
+  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(() => new Set(defaultApiKeyPermissions));
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const canManageApiKeys = hasWorkspacePermission(context.accessContext, workspaceId, "api_keys:manage");
+  const workspaceGrant = context.accessContext.workspaceGrants.find((grant) => grant.workspaceId === workspaceId) ?? null;
+  const delegablePermissions = delegableApiKeyPermissions(workspaceGrant?.permissions ?? []);
+  const requestedPermissions = [...selectedPermissions].filter((permission) => delegablePermissions.has(permission));
+
+  useEffect(() => {
+    setNameDraft(activeWorkspace?.name ?? "");
+  }, [activeWorkspace?.id, activeWorkspace?.name]);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+    void refreshApiKeys();
+  }, [workspaceId]);
+
+  async function refreshApiKeys() {
+    if (!canManageApiKeys) {
+      setApiKeys([]);
+      setApiKeysError(null);
+      return;
+    }
+    try {
+      setApiKeys(await client.listApiKeys(workspaceId));
+      setApiKeysError(null);
+    } catch (error) {
+      setApiKeys([]);
+      setApiKeysError(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  async function submitRename() {
+    const name = nameDraft.trim();
+    if (!name || name === activeWorkspace?.name) {
+      return;
+    }
+    setRenaming(true);
+    try {
+      const renamed = await context.renameWorkspace(workspaceId, name);
+      if (renamed) {
+        toast.success("Workspace renamed");
+      }
+    } finally {
+      setRenaming(false);
+    }
+  }
+
+  async function createKey() {
+    if (!apiKeyName.trim() || requestedPermissions.length === 0) {
+      toast.error("API key name and permissions are required");
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await client.createApiKey(workspaceId, {
+        name: apiKeyName.trim(),
+        permissions: requestedPermissions,
+      });
+      setCreatedToken(result.token);
+      setApiKeys((current) => [result.apiKey, ...current]);
+      toast.success("API key created");
+    } catch (error) {
+      toast.error("Failed to create API key", { description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revokeKey(apiKeyId: string) {
+    setBusy(true);
+    try {
+      const revoked = await client.deleteApiKey(workspaceId, apiKeyId);
+      setApiKeys((current) => current.map((key) => key.id === revoked.id ? revoked : key));
+      toast.success("API key revoked");
+    } catch (error) {
+      toast.error("Failed to revoke API key", { description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function togglePermission(permission: string) {
+    setSelectedPermissions((current) => {
+      const next = new Set(current);
+      if (next.has(permission)) {
+        next.delete(permission);
+      } else {
+        next.add(permission);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-6 lg:px-8">
+      <section className="grid gap-5 text-left">
+        <PageHeader
+          icon={<SettingsIcon className="size-4" />}
+          title="Workspace settings"
+          description={activeWorkspace ? `${activeWorkspace.name} · ${organizationLabel}` : organizationLabel}
+        />
+
+        {/* Workspace name / rename */}
+        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+          <div>
+            <h2 className="flex items-center gap-1.5 text-sm font-medium">
+              <PencilIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              Workspace name
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">The name shows everywhere this workspace appears.</p>
+          </div>
+          {canRename ? (
+            <form
+              className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void submitRename();
+              }}
+            >
+              <Input value={nameDraft} onChange={(event) => setNameDraft(event.target.value)} className="h-9" placeholder="production" />
+              <Button type="submit" disabled={renaming || !nameDraft.trim() || nameDraft.trim() === activeWorkspace?.name}>
+                {renaming ? <Loader2Icon className="size-3.5 animate-spin" /> : <CheckIcon className="size-3.5" />}
+                Save
+              </Button>
+            </form>
+          ) : (
+            <p className="text-xs text-[color:var(--color-fg-subtle)]">Only workspace admins can rename this workspace.</p>
+          )}
+        </section>
+
+        {/* Environments link */}
+        <section className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+          <div className="min-w-0">
+            <h2 className="flex items-center gap-1.5 text-sm font-medium">
+              <BoxIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              Environments
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Variable sets injected into sandboxes at session start.</p>
+          </div>
+          <Button asChild type="button" variant="secondary" size="sm">
+            <Link to="/workspaces/$workspaceId/environments" params={{ workspaceId }}>
+              Manage environments
+            </Link>
+          </Button>
+        </section>
+
+        {/* API keys (moved from the old account page) */}
+        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+          <div>
+            <h2 className="flex items-center gap-1.5 text-sm font-medium">
+              <KeyRoundIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              API keys
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Workspace-scoped keys for calling OpenGeni from another product.</p>
+          </div>
+          {createdToken ? (
+            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
+              <div className="text-xs font-medium text-emerald-200">Token shown once</div>
+              <div className="mt-2 flex min-w-0 items-center gap-2">
+                <code className="min-w-0 flex-1 truncate rounded bg-[color:var(--color-bg)] px-2 py-1.5 text-xs">{createdToken}</code>
+                <Button type="button" variant="ghost" size="icon-sm" onClick={() => void navigator.clipboard.writeText(createdToken)}>
+                  <CopyIcon className="size-3.5" />
+                </Button>
+              </div>
+            </div>
+          ) : null}
+          {canManageApiKeys ? (
+            <>
+              <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                <Input value={apiKeyName} onChange={(event) => setApiKeyName(event.target.value)} className="h-9" />
+                <Button type="button" disabled={busy} onClick={() => void createKey()}>
+                  {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
+                  Create
+                </Button>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-[color:var(--color-fg-subtle)]">A key can only carry permissions your own grant can delegate.</p>
+                <Button type="button" variant="ghost" size="sm" disabled={delegablePermissions.size === 0} onClick={() => setSelectedPermissions(new Set(delegablePermissions))}>
+                  Select all delegable
+                </Button>
+              </div>
+              <PermissionGroupPicker
+                groups={apiKeyPermissionGroups}
+                selected={selectedPermissions}
+                delegable={delegablePermissions}
+                onToggle={togglePermission}
+              />
+            </>
+          ) : (
+            <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot manage API keys for this workspace.</p>
+          )}
+          <div className="grid gap-2">
+            {apiKeysError ? (
+              <LoadErrorState title="Couldn't load API keys" error={apiKeysError} onRetry={() => void refreshApiKeys()} />
+            ) : apiKeys.length === 0 ? (
+              <EmptyState>No API keys.</EmptyState>
+            ) : apiKeys.map((apiKey) => (
+              <div key={apiKey.id} className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{apiKey.name}</div>
+                  <div className="mt-1 truncate text-xs text-[color:var(--color-fg-subtle)]">{apiKey.prefix}... · {apiKey.revokedAt ? "revoked" : "active"}</div>
+                </div>
+                <Button type="button" variant="ghost" size="sm" disabled={busy || Boolean(apiKey.revokedAt)} onClick={() => void revokeKey(apiKey.id)}>
+                  <Trash2Icon className="size-3.5" />
+                  Revoke
+                </Button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Danger zone */}
+        <section className="grid gap-3 rounded-lg border border-[color:var(--color-status-failed)]/30 bg-[color:var(--color-status-failed)]/5 p-4">
+          <div>
+            <h2 className="flex items-center gap-1.5 text-sm font-medium text-[color:var(--color-status-failed)]">
+              <TriangleAlertIcon className="size-3.5" />
+              Danger zone
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+              Workspace deletion is irreversible and removes every session, environment, and API key.
+            </p>
+          </div>
+          <div>
+            <Button type="button" variant="destructive" size="sm" disabled title="Workspace deletion is not yet available in the console.">
+              <Trash2Icon className="size-3.5" />
+              Delete workspace
+            </Button>
+            <p className="mt-1.5 text-[11px] text-[color:var(--color-fg-subtle)]">Contact an organization admin to delete a workspace.</p>
+          </div>
+        </section>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -1,50 +1,21 @@
-// The workspace shell: header (brand, nav, workspace switcher, session
-// status cluster) around every workspace-scoped route.
-import { OpenGeniProvider, SessionStatus as SessionStatusBadge } from "@opengeni/react";
-import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  ArrowLeftIcon,
-  BotIcon,
-  BoxIcon,
-  CalendarClockIcon,
-  CheckIcon,
-  FileSearchIcon,
-  Loader2Icon,
-  LockIcon,
-  PanelRightIcon,
-  PencilIcon,
-  PlugIcon,
-  SparkleIcon,
-  UserIcon,
-} from "lucide-react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+// The workspace shell: the Linear-style left rail (brand, org + workspace
+// switcher, workspace nav, the session list) plus a slim canvas top strip for
+// session-contextual actions around every workspace-scoped route.
+import { OpenGeniProvider } from "@opengeni/react";
+import { Link, Outlet } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
-import { ConnectionPill, ProblemPanel } from "@/components/common";
+import { ProblemPanel } from "@/components/common";
+import { RailProvider } from "@/components/rail/rail-context";
+import { RailShell } from "@/components/rail/rail-shell";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { useAppContext, workspaceLabel } from "@/context";
-import { hasWorkspacePermission } from "@/lib/permissions";
+import { useAppContext } from "@/context";
 import { isAbortError } from "@/lib/session-tools";
-import { cn } from "@/lib/utils";
-import { CREATE_WORKSPACE_OPTION, workspaceCreationAccountId } from "@/lib/workspaces";
-import type { Workspace } from "@/types";
 
 export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
-  const navigate = useNavigate();
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const activeWorkspace = context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
-  const isSessionRoute = /\/sessions\/[^/]+/.test(pathname);
   const previousWorkspaceId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -71,250 +42,25 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
 
   if (!activeWorkspace) {
     return (
-      <>
-        <WorkspaceHeader workspaceId={workspaceId} activeWorkspace={null} isSessionRoute={false} onChangeWorkspace={changeWorkspace} />
-        <ProblemPanel
-          title="Workspace unavailable"
-          description="The URL workspace is not available to this subject."
-          action={<Button asChild type="button" variant="secondary"><Link to="/">Open default workspace</Link></Button>}
-        />
-      </>
+      <RailProvider workspaceId={workspaceId}>
+        <RailShell>
+          <ProblemPanel
+            title="Workspace unavailable"
+            description="The URL workspace is not available to this subject."
+            action={<Button asChild type="button" variant="secondary"><Link to="/">Open default workspace</Link></Button>}
+          />
+        </RailShell>
+      </RailProvider>
     );
   }
 
   return (
     <OpenGeniProvider client={context.client} workspaceId={workspaceId}>
-      <WorkspaceHeader workspaceId={workspaceId} activeWorkspace={activeWorkspace} isSessionRoute={isSessionRoute} onChangeWorkspace={changeWorkspace} />
-      <Outlet />
+      <RailProvider workspaceId={workspaceId}>
+        <RailShell>
+          <Outlet />
+        </RailShell>
+      </RailProvider>
     </OpenGeniProvider>
-  );
-
-  async function changeWorkspace(nextWorkspaceId: string) {
-    context.resetSessionView();
-    await navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId: nextWorkspaceId } });
-  }
-}
-
-function WorkspaceHeader(props: {
-  workspaceId: string;
-  activeWorkspace: Workspace | null;
-  isSessionRoute: boolean;
-  onChangeWorkspace: (workspaceId: string) => void;
-}) {
-  const context = useAppContext();
-  // Workspace create (POST /workspaces) and rename (PATCH /workspaces/:id)
-  // live on the switcher: "New workspace…" as the last option, rename as a
-  // pencil next to it. Both hide when the subject lacks the permission.
-  const [workspaceDialog, setWorkspaceDialog] = useState<"create" | "rename" | null>(null);
-  const [workspaceNameDraft, setWorkspaceNameDraft] = useState("");
-  const [workspaceDialogBusy, setWorkspaceDialogBusy] = useState(false);
-  const createAccountId = workspaceCreationAccountId(context.accessContext, props.activeWorkspace?.accountId ?? null);
-  const canRenameWorkspace = props.activeWorkspace !== null
-    && hasWorkspacePermission(context.accessContext, props.workspaceId, "workspace:admin");
-
-  function openWorkspaceDialog(mode: "create" | "rename") {
-    setWorkspaceNameDraft(mode === "rename" ? props.activeWorkspace?.name ?? "" : "");
-    setWorkspaceDialog(mode);
-  }
-
-  async function submitWorkspaceDialog() {
-    const name = workspaceNameDraft.trim();
-    if (!name || !workspaceDialog) {
-      return;
-    }
-    setWorkspaceDialogBusy(true);
-    try {
-      if (workspaceDialog === "create") {
-        const created = await context.createWorkspace({ name, ...(createAccountId ? { accountId: createAccountId } : {}) });
-        if (!created) {
-          return;
-        }
-        toast.success(`Workspace ${created.name} created`);
-        props.onChangeWorkspace(created.id);
-      } else {
-        const renamed = await context.renameWorkspace(props.workspaceId, name);
-        if (!renamed) {
-          return;
-        }
-        toast.success("Workspace renamed");
-      }
-      setWorkspaceDialog(null);
-    } finally {
-      setWorkspaceDialogBusy(false);
-    }
-  }
-
-  return (
-    <header className="sticky top-0 z-40 flex h-14 items-center gap-2 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)]/75 px-3 backdrop-blur sm:gap-3 sm:px-6">
-      <Button asChild type="button" variant="ghost" size="sm" className="h-9 shrink-0 px-1.5 text-[15px] font-medium">
-        <Link to="/workspaces/$workspaceId/sessions" params={{ workspaceId: props.workspaceId }}>
-          <span className="flex size-6 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
-            <SparkleIcon className="size-3.5" />
-          </span>
-          <span className="hidden lg:inline">OpenGeni</span>
-        </Link>
-      </Button>
-
-      <nav className="flex min-w-0 items-center gap-1 overflow-x-auto rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-1">
-        <NavButton to="/workspaces/$workspaceId/sessions" workspaceId={props.workspaceId} icon={<BotIcon className="size-3.5" />} label="Sessions" />
-        <NavButton to="/workspaces/$workspaceId/environments" workspaceId={props.workspaceId} icon={<BoxIcon className="size-3.5" />} label="Environments" />
-        <NavButton to="/workspaces/$workspaceId/capabilities" workspaceId={props.workspaceId} icon={<PlugIcon className="size-3.5" />} label="Capabilities" />
-        <NavButton to="/workspaces/$workspaceId/schedules" workspaceId={props.workspaceId} icon={<CalendarClockIcon className="size-3.5" />} label="Schedules" />
-        <NavButton to="/workspaces/$workspaceId/documents" workspaceId={props.workspaceId} icon={<FileSearchIcon className="size-3.5" />} label="Documents" />
-        <NavButton to="/workspaces/$workspaceId/account" workspaceId={props.workspaceId} icon={<UserIcon className="size-3.5" />} label="Account" />
-      </nav>
-
-      {context.session && props.isSessionRoute ? (
-        <div className="hidden min-w-0 items-center gap-2 xl:flex">
-          <Button asChild type="button" variant="ghost" size="icon-sm" aria-label="Back to sessions">
-            <Link to="/workspaces/$workspaceId/sessions" params={{ workspaceId: props.workspaceId }}>
-              <ArrowLeftIcon className="size-4" />
-            </Link>
-          </Button>
-          <div className="min-w-0">
-            <div className="truncate text-sm font-medium">{context.session.initialMessage}</div>
-            <div className="truncate text-xs text-[color:var(--color-fg-subtle)]">
-              {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")} · {context.session.sandboxBackend}
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      <label className="ml-auto flex min-w-28 max-w-44 items-center gap-2 sm:min-w-40 sm:max-w-64">
-        <span className="sr-only">Workspace</span>
-        <select
-          value={props.activeWorkspace?.id ?? props.workspaceId}
-          onChange={(event) => {
-            if (event.target.value === CREATE_WORKSPACE_OPTION) {
-              openWorkspaceDialog("create");
-              return;
-            }
-            props.onChangeWorkspace(event.target.value);
-          }}
-          className="h-8 w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 text-xs text-[color:var(--color-fg)]"
-        >
-          {context.workspaces.map((workspace) => (
-            <option key={workspace.id} value={workspace.id}>{workspaceLabel(workspace, context.workspaces)}</option>
-          ))}
-          {createAccountId ? <option value={CREATE_WORKSPACE_OPTION}>New workspace…</option> : null}
-        </select>
-      </label>
-      {canRenameWorkspace ? (
-        <Button type="button" variant="ghost" size="icon-sm" onClick={() => openWorkspaceDialog("rename")} aria-label="Rename workspace">
-          <PencilIcon className="size-3.5" />
-        </Button>
-      ) : null}
-
-      <WorkspaceNameDialog
-        mode={workspaceDialog}
-        name={workspaceNameDraft}
-        busy={workspaceDialogBusy}
-        onNameChange={setWorkspaceNameDraft}
-        onOpenChange={(open) => {
-          if (!open) {
-            setWorkspaceDialog(null);
-          }
-        }}
-        onSubmit={() => void submitWorkspaceDialog()}
-      />
-
-      <div className="flex shrink-0 items-center gap-2">
-        {context.keyAuthRequired ? (
-          <Button type="button" variant="ghost" size="icon-sm" onClick={context.forgetAccessKey} aria-label="Clear access key">
-            <LockIcon className="size-4" />
-          </Button>
-        ) : null}
-        {context.session && props.isSessionRoute ? <ConnectionPill state={context.connectionState} /> : null}
-        {context.session && props.isSessionRoute ? <SessionStatusBadge status={context.session.status} /> : null}
-        {context.session && props.isSessionRoute ? (
-          <Button
-            type="button"
-            variant={context.inspectorOpen ? "secondary" : "ghost"}
-            size="icon-sm"
-            onClick={() => context.setInspectorOpen((open) => !open)}
-            aria-label="Toggle session rail"
-          >
-            <PanelRightIcon className="size-4" />
-          </Button>
-        ) : null}
-      </div>
-    </header>
-  );
-}
-
-function WorkspaceNameDialog(props: {
-  mode: "create" | "rename" | null;
-  name: string;
-  busy: boolean;
-  onNameChange: (name: string) => void;
-  onOpenChange: (open: boolean) => void;
-  onSubmit: () => void;
-}) {
-  const creating = props.mode === "create";
-  return (
-    <Dialog open={props.mode !== null} onOpenChange={props.onOpenChange}>
-      <DialogContent className="sm:max-w-sm">
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            props.onSubmit();
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{creating ? "New workspace" : "Rename workspace"}</DialogTitle>
-            <DialogDescription>
-              {creating
-                ? "A separate space with its own sessions, environments, packs, and API keys."
-                : "The new name shows everywhere this workspace appears."}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="mt-4 grid gap-1.5">
-            <Label htmlFor="workspace-name">Name</Label>
-            <Input
-              id="workspace-name"
-              value={props.name}
-              onChange={(event) => props.onNameChange(event.target.value)}
-              placeholder="production"
-              autoFocus
-            />
-          </div>
-          <DialogFooter className="mt-4">
-            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)}>Cancel</Button>
-            <Button type="submit" disabled={props.busy || !props.name.trim()}>
-              {props.busy ? <Loader2Icon className="size-4 animate-spin" /> : <CheckIcon className="size-4" />}
-              {creating ? "Create workspace" : "Rename"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function NavButton(props: {
-  to:
-    | "/workspaces/$workspaceId/sessions"
-    | "/workspaces/$workspaceId/environments"
-    | "/workspaces/$workspaceId/capabilities"
-    | "/workspaces/$workspaceId/schedules"
-    | "/workspaces/$workspaceId/documents"
-    | "/workspaces/$workspaceId/account";
-  workspaceId: string;
-  icon: ReactNode;
-  label: string;
-}) {
-  return (
-    <Link
-      to={props.to}
-      params={{ workspaceId: props.workspaceId }}
-      activeProps={{ "data-active": "true" }}
-      className={cn(
-        "inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2.5 text-xs font-medium text-[color:var(--color-fg-muted)] transition-colors hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
-        "data-[active=true]:bg-[color:var(--color-surface-2)] data-[active=true]:text-[color:var(--color-fg)]",
-      )}
-    >
-      {props.icon}
-      <span className="hidden md:inline">{props.label}</span>
-    </Link>
   );
 }


### PR DESCRIPTION
Replaces the top horizontal nav with a **Linear-style left rail** that owns navigation and hosts the **session list in the sidebar**. Design decisions were made to a "perfect UI/UX" bar and reviewed against rendered screenshots.

## The rail (top → bottom)
- **Brand** → **Organization** switcher (renamed from "Account"; static label for a single org, menu for >1) + **Workspace** switcher (list · New workspace · Workspace settings).
- **Workspace nav** — Environments · Capabilities · Schedules · Documents — then **Settings**.
- **Divider → Sessions (the home):** `+ New` and the **live session list**, grouped by recency (Today / Yesterday / Previous 7 days / Older) with **running sessions pinned & marked** (brand-blue breathing dot), graceful single-line truncation, and a clearly-highlighted active row.
- Pinned footer: collapse toggle + user menu.
- **Collapse** to a 56px icon rail (state persisted in `opengeni.rail.collapsed`; the session list condenses to a Sessions icon with a running-count badge). Under 1024px the rail becomes an **overlay drawer**.

## Canvas
- The top nav bar is gone (the rail owns navigation). A slim canvas strip keeps only session-contextual actions (title/status, connection + lock pills, inspector toggle).
- New/empty → centered "Start a session" composer (repo select retained).

## IA cleanup (fixes the old "Account page mixes scopes" smell)
- **Account → Organization.** Org settings: credits/billing, usage, plan & entitlements, members, org name.
- **Workspace-scoped API keys moved to Workspace settings** (rename · API keys + permission grid · Environments link · danger zone).
- Old routes preserved via redirects (`/account` → `/organization`, plus the existing agent/packs redirects).

## New structure
`components/rail/*` (rail-shell, rail-context, switcher-block, workspace-nav, session-list, rail-footer), `lib/sessions-group.ts` + `lib/org.ts` (pure, unit-tested), `routes/org-settings.tsx` (← account.tsx) and `routes/workspace-settings.tsx`.

## Verification
- `bun run typecheck`, `bun run build`: green. `bun test`: **100 pass / 0 fail** (+8 tests for grouping/org/route helpers). gitleaks: clean.
- Reviewed against 10 rendered screenshots across states/viewports; iterated one polish pass (truncation, status-dot semantics, org casing, active-row emphasis).

## Known limitations (honest)
- The app is **dark-only** today (no light theme in the design system) — not introduced here.
- Accounts have **no `name` field**; the org label derives from grant metadata (`Org <shortId>` fallback).
- **Members** is read-only and Workspace **delete** is disabled — pending the corresponding API surfaces.

Not deployed. Awaiting review for the merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large navigation and routing refactor touching billing checkout redirects and API key management URLs; behavior is preserved via redirects but every workspace-scoped entry point changes visually and structurally.
> 
> **Overview**
> Replaces the **sticky top header** (horizontal nav, workspace `<select>`, session chrome) with a **Linear-style left rail** on every workspace route: brand, org/workspace switchers, workspace config links, a **recency-grouped session list** (running pinned, 15s poll, keyboard nav), collapse persisted in `localStorage`, and a **&lt;1024px drawer**. Session title/connection/inspector controls move to a **slim canvas strip**; **`c`** starts a new session globally.
> 
> **Information architecture:** adds `/workspaces/:id/settings` and `/workspaces/:id/organization`; renames the old account surface to **Organization** (credits, usage, entitlements, read-only members); moves **workspace API keys** and rename to **Workspace settings**. `/account` and `/billing?checkout=…` redirect to **organization** so Stripe return toasts still work.
> 
> The sessions index page drops its inline session history (list lives in the rail). New pure helpers `lib/sessions-group.ts` and `lib/org.ts` plus unit tests cover grouping, labels, and route paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a15cbd1c123a238404d4678952abf0431a5cc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->