### PR TITLE
feat(models): dynamic multi-provider model support + Fireworks GLM 5.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,16 @@ OPENGENI_OPENAI_API_KEY=your-key
 # OPENGENI_AZURE_OPENAI_API_VERSION=2025-04-01-preview
 # OPENGENI_AZURE_OPENAI_AD_TOKEN=...
 
+# Extra (non-built-in) model providers. The built-in provider above (OpenAI or
+# Azure) is always present; this JSON registry exposes ADDITIONAL providers and
+# their models. Each entry has its own baseUrl, wire api ("responses" | "chat",
+# default "chat"), an inline apiKey OR an apiKeyEnv naming the env var that holds
+# the key (preferred), and the models it serves. The models a client can pick
+# are the union of OPENGENI_OPENAI_ALLOWED_MODELS and every registry model.
+# Example: add Fireworks AI serving GLM 5.2 (keep the key in its own env var).
+# OPENGENI_FIREWORKS_API_KEY=fw_...
+# OPENGENI_MODEL_PROVIDERS_JSON='[{"id":"fireworks","label":"Fireworks AI","api":"chat","baseUrl":"https://api.fireworks.ai/inference/v1","apiKeyEnv":"OPENGENI_FIREWORKS_API_KEY","models":[{"id":"accounts/fireworks/models/glm-5p2","label":"GLM 5.2","contextWindowTokens":1048576,"reasoningEffort":true,"hostedWebSearch":false}]}]'
+
 # Sandbox backend: docker, modal, local, or none.
 OPENGENI_SANDBOX_BACKEND=docker
 OPENGENI_DOCKER_IMAGE=opengeni-sandbox:local

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import {
   configuredAllowedModels,
   configuredAllowedReasoningEfforts,
+  configuredModels,
 } from "@opengeni/config";
 import { ClientConfig } from "@opengeni/contracts";
 import { createDocumentServices, indexDocumentNow, type DocumentServices } from "@opengeni/documents";
@@ -163,6 +164,18 @@ export function createApp(deps: AppDependencies): Hono {
     deploymentRevision: deps.settings.deploymentRevision,
     defaultModel: deps.settings.openaiModel,
     allowedModels: configuredAllowedModels(deps.settings),
+    // Provider-grouped model list for the picker. configuredModels() carries the
+    // union of the built-in allow-list and every registry provider's models, in
+    // selection order (default model first); project each to the client-safe
+    // ClientModel shape (ConfiguredModel.providerId → ClientModel.provider).
+    models: configuredModels(deps.settings).map((model) => ({
+      id: model.id,
+      label: model.label,
+      provider: model.providerId,
+      providerLabel: model.providerLabel,
+      api: model.api,
+      ...(model.contextWindowTokens === undefined ? {} : { contextWindowTokens: model.contextWindowTokens }),
+    })),
     defaultReasoningEffort: deps.settings.openaiReasoningEffort,
     allowedReasoningEfforts: configuredAllowedReasoningEfforts(deps.settings),
     mcpServers: deps.settings.mcpServers.map((server) => ({

--- a/apps/api/src/domain/scheduled-tasks.ts
+++ b/apps/api/src/domain/scheduled-tasks.ts
@@ -20,6 +20,7 @@ import type { SessionWorkflowClient } from "../dependencies";
 import type { ObjectStorageDependency } from "../dependencies";
 import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
 import { validateEnvironmentAttachment } from "./environments";
+import { assertConfiguredModel } from "./sessions";
 import {
   normalizeResources,
   validateFileResources,
@@ -268,6 +269,12 @@ async function validateScheduledTaskAgentConfig(input: {
   workspaceId: string;
   toolsProvided?: boolean;
 }): Promise<ScheduledTaskAgentConfig> {
+  // Reject a curated-out model before touching the DB: a scheduled task is a
+  // session the worker runs later, so it must pass the same allow-list as the
+  // session choke points (a `scheduled_tasks:manage` holder could otherwise set
+  // a model the host does not expose). An omitted model inherits the host
+  // default downstream, which is always configured.
+  assertConfiguredModel(input.settings, input.payload.agentConfig.model);
   const resources = normalizeResources(input.payload.agentConfig.resources ?? []);
   const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(input.db, input.workspaceId, input.settings);
   const requestedTools = validateToolRefs(input.payload.agentConfig.tools ?? [], runtimeSettings);

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -1,4 +1,4 @@
-import type { Settings } from "@opengeni/config";
+import { configuredAllowedModels, type Settings } from "@opengeni/config";
 import {
   CreateSessionRequest,
   reasoningEffortForMetadata,
@@ -220,6 +220,29 @@ export function workflowIdForSession(sessionId: string): string {
   return `session-${sessionId}`;
 }
 
+/**
+ * Reject an explicit model that the host does not expose. The set of usable
+ * models is the union surfaced by `configuredAllowedModels` (the built-in
+ * provider's allow-list plus every registry provider's ids); a `model` outside
+ * it cannot be resolved to a provider at run time, so we fail the request at
+ * the API edge with 422 rather than enqueuing a turn the worker can't honor.
+ *
+ * `model` is the explicit, caller-supplied value (null/undefined when omitted).
+ * An omitted model defaults to `settings.openaiModel` downstream — which is
+ * always first in `configuredAllowedModels` — so only an explicit value is
+ * checked. Centralized here so the three model-carrying choke points
+ * (create-session, user-message/turn-accept, queued-turn update) and the MCP
+ * surfaces that share them validate identically and cannot drift.
+ */
+export function assertConfiguredModel(settings: Settings, model: string | null | undefined): void {
+  if (model === null || model === undefined) {
+    return;
+  }
+  if (!configuredAllowedModels(settings).includes(model)) {
+    throw new HTTPException(422, { message: `model is not available: ${model}` });
+  }
+}
+
 export async function requireQueuedTurnForApi(db: Database, workspaceId: string, sessionId: string, turnId: string): Promise<SessionTurn> {
   const turn = await getSessionTurn(db, workspaceId, turnId);
   if (!turn || turn.sessionId !== sessionId) {
@@ -260,6 +283,9 @@ export async function postUserMessageTurn(input: {
   const { db, bus, workflowClient, settings, accountId, workspaceId, sessionId } = input;
   const requestedModel = input.model ?? null;
   const requestedReasoningEffort = input.reasoningEffort ?? null;
+  // Reject an explicit per-message model the host does not expose; an omitted
+  // model inherits the session's model downstream (always a configured id).
+  assertConfiguredModel(settings, requestedModel);
   const appended = await appendSessionEventsWithLockedSessionUpdate(db, workspaceId, sessionId, (lockedSession) => {
     // Cancelled is the one terminal state: an explicit user act. A FAILED
     // session stays revivable by talking to it — conversation truth lives in
@@ -364,6 +390,7 @@ export async function createSessionForRequest(
   const environment = payload.environmentId
     ? await validateEnvironmentAttachment({ settings, db }, grant, workspaceId, payload.environmentId)
     : null;
+  assertConfiguredModel(settings, payload.model);
   const model = payload.model ?? settings.openaiModel;
   const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
   // A session's first-party MCP token can carry a non-default permission set

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -230,9 +230,11 @@ export function workflowIdForSession(sessionId: string): string {
  * `model` is the explicit, caller-supplied value (null/undefined when omitted).
  * An omitted model defaults to `settings.openaiModel` downstream — which is
  * always first in `configuredAllowedModels` — so only an explicit value is
- * checked. Centralized here so the three model-carrying choke points
- * (create-session, user-message/turn-accept, queued-turn update) and the MCP
- * surfaces that share them validate identically and cannot drift.
+ * checked. Centralized here so every model-carrying choke point
+ * (create-session, user-message/turn-accept, queued-turn update, and
+ * scheduled-task agentConfig — a scheduled task is a session the worker runs
+ * later) and the MCP surfaces that share them validate identically and cannot
+ * drift.
  */
 export function assertConfiguredModel(settings: Settings, model: string | null | undefined): void {
   if (model === null || model === undefined) {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -36,6 +36,7 @@ import {
 } from "../domain/resources";
 import {
   acceptSessionUserMessage,
+  assertConfiguredModel,
   createSessionForRequest,
   requireQueuedTurnForApi,
   workflowIdForSession,
@@ -236,6 +237,9 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     await assertSessionExists(db, workspaceId, sessionId);
     const existing = await requireQueuedTurnForApi(db, workspaceId, sessionId, turnId);
     const payload = UpdateSessionTurnRequest.parse(await c.req.json());
+    // A turn-update may switch the queued turn's model; reject one the host
+    // does not expose (omitted leaves the existing model unchanged).
+    assertConfiguredModel(settings, payload.model);
     const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
     const resources = payload.resources !== undefined ? normalizeResources(payload.resources) : existing.resources;
     const tools = payload.tools !== undefined ? validateToolRefs(payload.tools, runtimeSettings) : existing.tools;

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -4,6 +4,7 @@ import { ScheduleNotFoundError, ScheduleOverlapPolicy } from "@temporalio/client
 import { HTTPException } from "hono/http-exception";
 import {
   allowedCorsOrigin,
+  createApp,
   httpStatusForError,
   normalizeResources,
   replaySessionEvents,
@@ -12,12 +13,14 @@ import {
   withDefaultEnabledCapabilityMcpTools,
   workflowIdForSession,
 } from "../src/app";
+import type { AppDependencies } from "../src/app";
 import { shouldCreateScheduleAfterUpdateError, temporalOverlapPolicy, temporalScheduleSpec } from "../src/index";
 import { stripeCheckoutSessionCreateParams, stripeCustomerProvider } from "../src/routes/billing";
 import { discoverMcpRegistryCapabilities, settingsWithMcpCapabilityServers, validateMcpCapabilityConnection } from "../src/domain/capabilities";
+import { configuredAllowedModels, type Settings } from "@opengeni/config";
 import { encryptEnvironmentValue } from "@opengeni/db";
 import { testSettings } from "@opengeni/testing";
-import type { CapabilityCatalogItem, SessionEvent } from "@opengeni/contracts";
+import { ClientConfig, type CapabilityCatalogItem, type SessionEvent } from "@opengeni/contracts";
 
 describe("API helpers", () => {
   test("normalizes repository resources into sandbox mount paths", () => {
@@ -425,6 +428,70 @@ describe("API helpers", () => {
       { after: 0, limit: 1000 },
       { after: 1000, limit: 1000 },
     ]);
+  });
+});
+
+describe("GET /v1/config/client", () => {
+  // The route only reads settings (+ the storage derived from them); db / bus /
+  // workflowClient are never touched, so we stub them. managedAuth is forced to
+  // null so createApp does not try to stand up Better Auth.
+  function appFor(settings: Settings) {
+    const deps = {
+      settings,
+      db: {} as never,
+      bus: {} as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+    } satisfies AppDependencies;
+    return createApp(deps);
+  }
+
+  async function fetchClientConfig(settings: Settings) {
+    const response = await appFor(settings).request("/v1/config/client");
+    expect(response.status).toBe(200);
+    return ClientConfig.parse(await response.json());
+  }
+
+  test("returns a models[] whose ids match configuredAllowedModels", async () => {
+    const settings = testSettings();
+    const config = await fetchClientConfig(settings);
+
+    expect(config.models.length).toBeGreaterThan(0);
+    expect(config.models.map((model) => model.id)).toEqual(configuredAllowedModels(settings));
+    // Built-in provider models project the openai/azure responses shape.
+    const defaultModel = config.models.find((model) => model.id === settings.openaiModel);
+    expect(defaultModel).toMatchObject({ provider: "openai", api: "responses" });
+  });
+
+  test("includes a registry model when OPENGENI_MODEL_PROVIDERS_JSON is set", async () => {
+    const settings = testSettings({
+      modelProvidersJson: JSON.stringify([{
+        id: "fireworks",
+        label: "Fireworks AI",
+        api: "chat",
+        baseUrl: "https://api.fireworks.ai/inference/v1",
+        apiKey: "fw_test",
+        models: [{
+          id: "accounts/fireworks/models/glm-5p2",
+          label: "GLM 5.2",
+          contextWindowTokens: 1_048_576,
+          reasoningEffort: true,
+          hostedWebSearch: false,
+        }],
+      }]),
+    });
+    const config = await fetchClientConfig(settings);
+
+    expect(config.models.map((model) => model.id)).toEqual(configuredAllowedModels(settings));
+    const glm = config.models.find((model) => model.id === "accounts/fireworks/models/glm-5p2");
+    expect(glm).toEqual({
+      id: "accounts/fireworks/models/glm-5p2",
+      label: "GLM 5.2",
+      provider: "fireworks",
+      providerLabel: "Fireworks AI",
+      api: "chat",
+      contextWindowTokens: 1_048_576,
+    });
   });
 });
 

--- a/apps/api/test/scheduled-tasks-model-guard.test.ts
+++ b/apps/api/test/scheduled-tasks-model-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { HTTPException } from "hono/http-exception";
+import { testSettings } from "@opengeni/testing";
+import type { AccessGrant, CreateScheduledTaskRequest } from "@opengeni/contracts";
+import { createValidatedScheduledTask } from "../src/domain/scheduled-tasks";
+
+// A scheduled task is a session the worker runs later, so its agentConfig.model
+// must pass the same host allow-list as the session choke points. The guard is
+// the first statement in the shared validator, so a curated-out model is
+// rejected with HTTPException(422) BEFORE any DB/object-storage access — which
+// lets these tests stay hermetic: the db/objectStorage stubs throw a sentinel
+// if (and only if) the guard let the request through.
+const SENTINEL = "reached-db-past-the-model-guard";
+
+const settings = testSettings(); // allow-list: scripted-model, gpt-5.5, gpt-5.4, gpt-5.4-mini
+
+function throwingDb(): never {
+  throw new Error(SENTINEL);
+}
+
+const grant: AccessGrant = {
+  workspaceId: crypto.randomUUID(),
+  accountId: crypto.randomUUID(),
+  subjectId: "tester",
+  permissions: ["scheduled_tasks:manage"],
+};
+
+function payload(model?: string): CreateScheduledTaskRequest {
+  return {
+    name: "nightly digest",
+    schedule: { type: "interval", everySeconds: 86400 },
+    runMode: "new_session_per_run",
+    overlapPolicy: "allow_concurrent",
+    status: "active",
+    metadata: {},
+    agentConfig: {
+      prompt: "Summarize yesterday's activity.",
+      resources: [],
+      tools: [],
+      metadata: {},
+      ...(model !== undefined ? { model } : {}),
+    },
+  };
+}
+
+function createWith(model?: string): Promise<unknown> {
+  return createValidatedScheduledTask({
+    settings,
+    // Stubs: only reached if the model guard passes. A curated-out model must
+    // never get here.
+    db: new Proxy({}, { get: throwingDb, apply: throwingDb }) as never,
+    objectStorage: undefined,
+    grant,
+    payload: payload(model),
+    toolsProvided: true,
+  });
+}
+
+describe("scheduled-task model allow-list guard", () => {
+  test("rejects a curated-out model with 422 before touching the db", async () => {
+    let thrown: unknown;
+    try {
+      await createWith("forbidden-model");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(HTTPException);
+    expect((thrown as HTTPException).status).toBe(422);
+    expect((thrown as HTTPException).message).toBe("model is not available: forbidden-model");
+  });
+
+  test("an allowed model passes the guard (fails only later, at the db)", async () => {
+    let thrown: unknown;
+    try {
+      await createWith("gpt-5.5");
+    } catch (error) {
+      thrown = error;
+    }
+    // The allowed model is NOT the thing that fails: we got past the guard and
+    // hit the stubbed db sentinel instead of an HTTPException model rejection.
+    expect(thrown).not.toBeInstanceOf(HTTPException);
+    expect((thrown as Error).message).toBe(SENTINEL);
+  });
+
+  test("an omitted model passes the guard (inherits the host default downstream)", async () => {
+    let thrown: unknown;
+    try {
+      await createWith(undefined);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).not.toBeInstanceOf(HTTPException);
+    expect((thrown as Error).message).toBe(SENTINEL);
+  });
+});

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -25,9 +25,13 @@ import {
 } from "./lib/session-create";
 import {
   buildTools,
+  effortOptionsFor,
   enabledWorkspaceCapabilityMcpServers,
   gitHubRepositoryResource,
+  initialReasoningEffort,
+  labelEffort,
   mergeMcpServerOptions,
+  reasoningEffortOrder,
   selectedAvailableCapabilityToolIds,
 } from "./lib/session-tools";
 import {
@@ -42,6 +46,7 @@ import { upsertWorkspace, workspaceCreationAccountId } from "./lib/workspaces";
 import type {
   AccessContext,
   CapabilityCatalogItem,
+  ClientConfig,
   GitHubRepository,
   ResourceRef,
   ScheduledTask,
@@ -521,6 +526,57 @@ describe("buildTools", () => {
       { id: "shared", name: "Configured Shared" },
       { id: "workspace", name: "Workspace" },
     ]);
+  });
+});
+
+describe("composer reasoning-effort picker (full host enum)", () => {
+  // Regression: the composer used to clamp the effort to a UI-only subset
+  // (low|medium|high|xhigh). A deployment whose default was `none`/`minimal`
+  // was silently overridden to "low" — the placeholder never synced and the
+  // picker could not even display `none`/`minimal` — so every web turn sent
+  // `reasoningEffort:"low"`, which the server treats as an override beating the
+  // deployer's configured default (a billing footgun). The picker is now driven
+  // faithfully by the host config over the FULL enum.
+  function clientConfig(patch: Partial<ClientConfig> = {}): ClientConfig {
+    return {
+      deploymentRevision: "rev-1",
+      defaultModel: "gpt-5.5",
+      allowedModels: ["gpt-5.5"],
+      models: [],
+      defaultReasoningEffort: "none",
+      allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+      mcpServers: [],
+      fileUploads: { enabled: false, maxSizeBytes: 0 },
+      productAccessMode: "local",
+      auth: { mode: "none" },
+      ...patch,
+    };
+  }
+
+  test("the composer initializes effort to the deployment default, even when it is `none`", () => {
+    // This is the exact value context.tsx writes into state when config lands.
+    // Before the fix the guard kept the "low" placeholder for a `none` default;
+    // now the default is honored verbatim, so the submitted turn carries "none".
+    expect(initialReasoningEffort(clientConfig({ defaultReasoningEffort: "none" }))).toBe("none");
+    expect(initialReasoningEffort(clientConfig({ defaultReasoningEffort: "minimal" }))).toBe("minimal");
+    expect(initialReasoningEffort(clientConfig({ defaultReasoningEffort: "high" }))).toBe("high");
+  });
+
+  test("the picker offers `none`/`minimal` when the host allows them, canonically ordered", () => {
+    // The old `isUiReasoningEffort` filter dropped these two entirely.
+    expect(effortOptionsFor(clientConfig())).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+
+  test("the picker honors a narrowed host allow-list, keeping canonical order", () => {
+    expect(effortOptionsFor(clientConfig({ allowedReasoningEfforts: ["high", "none", "low"] }))).toEqual(["none", "low", "high"]);
+  });
+
+  test("the picker falls back to the full enum when the host exposes no allow-list", () => {
+    expect(effortOptionsFor(null)).toEqual(reasoningEffortOrder);
+  });
+
+  test("labelEffort reads sensibly for every effort, including the previously-unrepresentable ones", () => {
+    expect(reasoningEffortOrder.map(labelEffort)).toEqual(["None", "Minimal", "Low", "Medium", "High", "Extra high"]);
   });
 });
 

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -20,6 +20,34 @@ import {
 import { cn } from "@/lib/utils";
 import type { ClientConfig } from "@/types";
 
+/**
+ * One row in the model dropdown: the id sent to the host plus the display label
+ * and the provider section it belongs under. Derived from the host-exposed
+ * {@link ClientConfig.models} (provider-grouped, with labels) when present, and
+ * falls back to the flat {@link ClientConfig.allowedModels} id list on older
+ * hosts (no provider grouping, label === id). Always includes the currently
+ * selected model so a stale/curated-out choice still renders its own row.
+ */
+type ModelChoice = { id: string; label: string; providerLabel: string | null };
+
+function modelChoices(config: ClientConfig | null, selected: string): ModelChoice[] {
+  const rich = config?.models ?? [];
+  const choices: ModelChoice[] = rich.length > 0
+    ? rich.map((model) => ({ id: model.id, label: model.label, providerLabel: model.providerLabel }))
+    : (config?.allowedModels ?? [selected]).map((id) => ({ id, label: displayModel(id), providerLabel: null }));
+  // Guarantee the active selection is always offered, even if the host has since
+  // curated it out of the exposed list (mirrors the old `[props.model]` fallback).
+  if (!choices.some((choice) => choice.id === selected)) {
+    choices.unshift({ id: selected, label: displayModel(selected), providerLabel: null });
+  }
+  return choices;
+}
+
+/** Trigger label for the active model: its display label from the exposed list. */
+function selectedModelLabel(choices: ModelChoice[], selected: string): string {
+  return choices.find((choice) => choice.id === selected)?.label ?? displayModel(selected);
+}
+
 export function ModelPicker(props: {
   config: ClientConfig | null;
   model: string;
@@ -30,7 +58,7 @@ export function ModelPicker(props: {
 }) {
   const allowedEfforts = props.config?.allowedReasoningEfforts.filter(isUiReasoningEffort) ?? uiReasoningEffortOrder;
   const effortOptions = uiReasoningEffortOrder.filter((option) => allowedEfforts.includes(option));
-  const modelOptions = props.config?.allowedModels ?? [props.model];
+  const choices = modelChoices(props.config, props.model);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -42,9 +70,9 @@ export function ModelPicker(props: {
           aria-label="Model and effort"
           className="h-8 max-w-[14rem] gap-1 rounded-full border border-transparent px-2.5 text-xs text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]"
         >
-          <span className="font-medium text-[color:var(--color-fg)]">{displayModel(props.model)}</span>
+          <span className="truncate font-medium text-[color:var(--color-fg)]">{selectedModelLabel(choices, props.model)}</span>
           <span>{labelEffort(props.effort)}</span>
-          <ChevronDownIcon className="size-3" />
+          <ChevronDownIcon className="size-3 shrink-0" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="top" sideOffset={8} className="w-56 rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 shadow-xl">
@@ -57,14 +85,41 @@ export function ModelPicker(props: {
         ))}
         <DropdownMenuSeparator className="my-2 bg-[color:var(--color-border)]" />
         <DropdownMenuLabel className="px-2 pt-0 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">Model</DropdownMenuLabel>
-        {modelOptions.map((option) => (
-          <DropdownMenuItem key={option} onSelect={() => props.onModelChange(option)} className="h-8 cursor-pointer rounded-md px-2 text-sm">
-            <span>{option}</span>
-            {option === props.model ? <CheckIcon className="ml-auto size-4" /> : null}
-          </DropdownMenuItem>
+        {choices.map((choice, index) => (
+          <ModelChoiceRow
+            key={choice.id}
+            choice={choice}
+            // Repeat a provider heading only when it changes from the row above,
+            // so multi-provider lists read as grouped sections; single-provider
+            // (and the flat allowedModels fallback) shows no heading at all.
+            showProviderLabel={choice.providerLabel !== null && choice.providerLabel !== choices[index - 1]?.providerLabel}
+            selected={choice.id === props.model}
+            onSelect={() => props.onModelChange(choice.id)}
+          />
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function ModelChoiceRow(props: {
+  choice: ModelChoice;
+  showProviderLabel: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <>
+      {props.showProviderLabel ? (
+        <DropdownMenuLabel className="px-2 pt-1 pb-0.5 text-[10px] font-normal uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+          {props.choice.providerLabel}
+        </DropdownMenuLabel>
+      ) : null}
+      <DropdownMenuItem onSelect={props.onSelect} className="h-8 cursor-pointer rounded-md px-2 text-sm">
+        <span className="truncate">{props.choice.label}</span>
+        {props.selected ? <CheckIcon className="ml-auto size-4 shrink-0" /> : null}
+      </DropdownMenuItem>
+    </>
   );
 }
 

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -11,9 +11,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { displayModel } from "@/lib/format";
 import {
-  isUiReasoningEffort,
+  effortOptionsFor,
   labelEffort,
-  uiReasoningEffortOrder,
   type IntelligenceEffort,
   type McpServerOption,
 } from "@/lib/session-tools";
@@ -56,8 +55,9 @@ export function ModelPicker(props: {
   onModelChange: (value: string) => void;
   onEffortChange: (value: IntelligenceEffort) => void;
 }) {
-  const allowedEfforts = props.config?.allowedReasoningEfforts.filter(isUiReasoningEffort) ?? uiReasoningEffortOrder;
-  const effortOptions = uiReasoningEffortOrder.filter((option) => allowedEfforts.includes(option));
+  // Host-curated effort allow-list, canonically ordered, full enum — mirrors how
+  // the model picker is driven by config.allowedModels (no lossy UI filter).
+  const effortOptions = effortOptionsFor(props.config);
   const choices = modelChoices(props.config, props.model);
   return (
     <DropdownMenu>

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -73,6 +73,15 @@ export type AppContextValue = {
   keyAuthRequired: boolean;
   model: string;
   setModel: Dispatch<SetStateAction<string>>;
+  /**
+   * The model chosen for a specific open session. Composer state (draft, mode)
+   * is session-scoped, and so is the model: each session remembers its own pick
+   * in-memory, falling back to the deployment default ({@link model}) until the
+   * operator overrides it. The new-session surface uses the bare {@link model}
+   * (no session id yet); the session route threads its id through these.
+   */
+  modelForSession: (sessionId: string) => string;
+  setModelForSession: (sessionId: string, value: string) => void;
   reasoningEffort: IntelligenceEffort;
   setReasoningEffort: Dispatch<SetStateAction<IntelligenceEffort>>;
   inspectorOpen: boolean;
@@ -147,6 +156,10 @@ export function RootRouteComponent() {
   const [accessLoading, setAccessLoading] = useState(false);
   const [accessError, setAccessError] = useState<string | null>(null);
   const [model, setModel] = useState("gpt-5.5");
+  // Per-session model overrides (session id → model). A session with no entry
+  // inherits the deployment default `model`; selecting in its picker writes here
+  // so each open session keeps its own choice independently.
+  const [modelBySession, setModelBySession] = useState<Record<string, string>>({});
   const [reasoningEffort, setReasoningEffort] = useState<IntelligenceEffort>("low");
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const [connectionState, setConnectionState] = useState<SessionEventsConnectionState>("idle");
@@ -524,6 +537,16 @@ export function RootRouteComponent() {
     setConnectionState("idle");
   }
 
+  // Session-scoped model: read the session's override or fall back to the
+  // deployment default; writing records it without disturbing other sessions
+  // (or the new-session surface, which reads the bare `model`).
+  function modelForSession(sessionId: string): string {
+    return modelBySession[sessionId] ?? model;
+  }
+  function setModelForSession(sessionId: string, value: string): void {
+    setModelBySession((current) => ({ ...current, [sessionId]: value }));
+  }
+
   function resetWorkspaceIntegrations() {
     setGithubStatus(null);
     setGithubRepos([]);
@@ -540,6 +563,8 @@ export function RootRouteComponent() {
     keyAuthRequired: keyAuthRequired === true,
     model,
     setModel,
+    modelForSession,
+    setModelForSession,
     reasoningEffort,
     setReasoningEffort,
     inspectorOpen,

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -40,8 +40,8 @@ import {
   buildTools,
   enabledWorkspaceCapabilityMcpServers,
   groupRepositories,
+  initialReasoningEffort,
   isAbortError,
-  isUiReasoningEffort,
   mergeMcpServerOptions,
   selectableMcpServers,
   selectedAvailableCapabilityToolIds,
@@ -215,9 +215,11 @@ export function RootRouteComponent() {
         setClientConfig(config);
         setConfigError(null);
         setModel(config.defaultModel);
-        if (isUiReasoningEffort(config.defaultReasoningEffort)) {
-          setReasoningEffort(config.defaultReasoningEffort);
-        }
+        // Sync to the deployment default UNCONDITIONALLY: the full enum is now
+        // representable, so a `none`/`minimal` default no longer gets clamped to
+        // the "low" placeholder (which the server treated as an override beating
+        // the deployer's configured default — a silent billing footgun).
+        setReasoningEffort(initialReasoningEffort(config));
       })
       .catch((error) => {
         if (cancelled) {

--- a/apps/web/src/lib/session-tools.ts
+++ b/apps/web/src/lib/session-tools.ts
@@ -1,17 +1,38 @@
 import type { CapabilityCatalogItem, ClientConfig, GitHubRepository, ReasoningEffort, ResourceRef, ToolRef } from "@/types";
 
 export type RepoDraft = { id: number; url: string; ref: string };
-export type IntelligenceEffort = Extract<ReasoningEffort, "low" | "medium" | "high" | "xhigh">;
+// The composer's effort picker spans the FULL host enum, not a UI-only subset:
+// the old `Extract<…,"low"|…>` silently dropped `none`/`minimal`, so a deployment
+// whose default is one of those was overridden to "low" on every web turn
+// (billing impact — "low" beats the deployer's configured default server-side).
+export type IntelligenceEffort = ReasoningEffort;
 export type McpServerOption = { id: string; name: string };
 
-export const uiReasoningEffortOrder: IntelligenceEffort[] = ["low", "medium", "high", "xhigh"];
-
-export function isUiReasoningEffort(value: ReasoningEffort): value is IntelligenceEffort {
-  return value === "low" || value === "medium" || value === "high" || value === "xhigh";
-}
+// Canonical low→high ordering over the full enum; the picker renders efforts in
+// this order, filtered to whatever the host curates in `allowedReasoningEfforts`.
+export const reasoningEffortOrder: IntelligenceEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh"];
 
 export function labelEffort(value: IntelligenceEffort): string {
-  return value === "xhigh" ? "Extra high" : value.slice(0, 1).toUpperCase() + value.slice(1);
+  if (value === "xhigh") {
+    return "Extra high";
+  }
+  return value.slice(0, 1).toUpperCase() + value.slice(1);
+}
+
+// The host-curated effort options for the picker, in canonical order. Falls back
+// to the full enum when the host exposes no allow-list. No lossy UI filter: every
+// effort the host allows (including `none`/`minimal`) is offered, so the deployer's
+// configured default is always representable/selectable.
+export function effortOptionsFor(config: Pick<ClientConfig, "allowedReasoningEfforts"> | null): IntelligenceEffort[] {
+  const allowed = config?.allowedReasoningEfforts ?? reasoningEffortOrder;
+  return reasoningEffortOrder.filter((effort) => allowed.includes(effort));
+}
+
+// The composer's initial effort once config lands: the deployment default,
+// faithfully — no clamping to a UI subset (the bug that pinned `none`/`minimal`
+// defaults to "low").
+export function initialReasoningEffort(config: Pick<ClientConfig, "defaultReasoningEffort">): IntelligenceEffort {
+  return config.defaultReasoningEffort;
 }
 
 export function buildTools(existing: ToolRef[] | undefined, mcpServerIds: string[] = []): ToolRef[] {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -211,7 +211,10 @@ function SessionChatPane(props: {
   // Workspace-scoped: the provider (mounted on the workspace route) supplies
   // the workspaceId, so the hook needs no positional argument.
   const attachments = useFileAttachments();
-  const { selectedCapabilityToolIds, model, reasoningEffort } = context;
+  const { selectedCapabilityToolIds, reasoningEffort } = context;
+  // The model is session-scoped: this session remembers its own pick (falling
+  // back to the deployment default), so a switch here doesn't bleed into others.
+  const model = context.modelForSession(props.session.id);
   const composer = useComposer(props.session.id, {
     // Evaluated at send time: attachments and tools picked while the draft was
     // being written ride along with the message.
@@ -342,10 +345,10 @@ function SessionChatPane(props: {
               <div className="flex min-w-0 items-center gap-1.5">
                 <ModelPicker
                   config={context.clientConfig}
-                  model={context.model}
+                  model={model}
                   effort={context.reasoningEffort}
                   disabled={composer.sending}
-                  onModelChange={context.setModel}
+                  onModelChange={(value) => context.setModelForSession(props.session.id, value)}
                   onEffortChange={context.setReasoningEffort}
                 />
                 <EnabledMcpToolPicker

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -51,7 +51,8 @@ export type {
   WorkspaceMember,
 } from "@opengeni/sdk";
 export type { CreateCapabilityCatalogItemRequest as CreateCapabilityInput } from "@opengeni/sdk";
-import type { GoalSpec, ReasoningEffort, ResourceRef, SandboxBackend, ToolRef } from "@opengeni/sdk";
+import type { ClientModel, GoalSpec, ReasoningEffort, ResourceRef, SandboxBackend, ToolRef } from "@opengeni/sdk";
+export type { ClientModel } from "@opengeni/sdk";
 
 export type TurnSubmission = {
   text: string;
@@ -69,6 +70,10 @@ export type ClientConfig = {
   deploymentRevision: string;
   defaultModel: string;
   allowedModels: string[];
+  // Richer provider-grouped model list the host exposes for the picker (labels +
+  // provider grouping). Empty on older hosts, where the picker falls back to the
+  // flat `allowedModels` id list. Mirrors the SDK's `ClientConfig.models`.
+  models: ClientModel[];
   defaultReasoningEffort: ReasoningEffort;
   allowedReasoningEfforts: ReasoningEffort[];
   mcpServers: Array<{

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -30,6 +30,7 @@ import {
   modelResponseUsageFromSdkEvent,
   normalizeSdkEvent,
   sanitizeHistoryItemsForModel,
+  summarizeForCompaction,
   type SandboxFileDownload,
   type OpenGeniRuntime,
 } from "@opengeni/runtime";
@@ -365,6 +366,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         openaiReasoningEffort: turn.reasoningEffort,
         sandboxBackend: turn.sandboxBackend,
       };
+      // Multi-provider per-turn model routing. When turn.model is in the
+      // provider registry, this gives the provider-bound Model instance + the
+      // gating (compaction mode, hosted web search, encrypted reasoning, context
+      // window) the agent and compaction summarizer must use; null falls back to
+      // the legacy global-client path (runSettings.openaiModel + the default
+      // client configureOpenAI set up). Cost accounting already covers registry
+      // models via configuredModelPricing.
+      const resolvedModel = runtime.resolveTurnModel(runSettings, turn.model);
       const turnResources = mergeResourceRefs(session.resources, turn.resources);
       const turnTools = mergeToolRefs(session.tools, turn.tools);
       const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, runSettings, input.workspaceId, session.environmentId);
@@ -390,6 +399,21 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         sandboxEnvironment,
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
+        // Resolved-model routing (legacy global-client path when null). The
+        // provider-bound Model instance plus its gating: server-side store/
+        // compaction follow the provider's compaction mode (registry providers
+        // resolve to "client"); encrypted reasoning is only round-tripped on the
+        // Responses wire API; hosted web search is attached only when the model
+        // opts in; the effective context window drives the compaction threshold.
+        ...(resolvedModel
+          ? {
+            model: resolvedModel.model,
+            compactionMode: resolvedModel.provider.compactionMode,
+            hostedWebSearch: resolvedModel.configured.hostedWebSearch,
+            encryptedReasoning: resolvedModel.provider.api === "responses" && runSettings.openaiReasoningEncryptedContent,
+            contextWindowTokens: resolvedModel.configured.contextWindowTokens ?? runSettings.contextWindowTokens,
+          }
+          : {}),
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(workspaceAgentInstructions ? { instructionsTemplate: workspaceAgentInstructions } : {}),
         ...(workspaceEnvironment
@@ -422,7 +446,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             runSettings,
             { accountId: input.accountId, workspaceId: input.workspaceId, sessionId: input.sessionId, turnId },
             session.lastInputTokens,
-            undefined,
+            // Provider-aware summarizer: when the turn's model resolved to a
+            // registry provider, summarize on THAT provider's client + wire API
+            // (a chat provider can't summarize through OpenAI/Azure). Null
+            // resolution keeps the default built-in Responses summarizer.
+            resolvedModel
+              ? (s, m) => summarizeForCompaction(s, m, {
+                client: resolvedModel.client,
+                api: resolvedModel.provider.api,
+                model: resolvedModel.configured.id,
+                maxOutputTokens: s.contextSummaryMaxTokens,
+              })
+              : undefined,
             forced ? { force: true } : {},
           );
           if (outcome.compacted) {

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -1,0 +1,265 @@
+# Multi-provider model support
+
+OpenGeni lets the **host/deployer** expose models from one or more LLM providers,
+and lets **any client** (SDK + React composer) discover the exposed models and pick
+between them at send time. This document is the authoritative design + integration
+contract for that capability. The first non-OpenAI provider shipped against it is
+**Fireworks AI**, serving **GLM 5.2** (`accounts/fireworks/models/glm-5p2`).
+
+## Architecture at a glance
+
+- A **built-in provider** (OpenAI **or** Azure, selected by `OPENGENI_OPENAI_PROVIDER`)
+  is configured by the existing flat env vars and is always present. It serves its
+  models through the **OpenAI Responses API**.
+- **Extra providers** are declared by the host via a JSON **provider registry**
+  (`OPENGENI_MODEL_PROVIDERS_JSON`). Each entry carries its own base URL, API key,
+  wire API (`responses` | `chat`), and the list of models it exposes.
+- The set of models a client may use is the **union** of the built-in provider's
+  allowed models and every registry provider's models. The host curates exposure by
+  editing `OPENGENI_OPENAI_ALLOWED_MODELS` and the registry.
+- At run time the chosen model string is **resolved to its provider**, a per-provider
+  `OpenAI` client is built, and an `@openai/agents` **`Model` instance** bound to that
+  client (`OpenAIResponsesModel` for `responses`, `OpenAIChatCompletionsModel` for
+  `chat`) is passed to the agent. This routes per-model to the right provider
+  **without** touching the global default client or forking the SDK. Concurrent
+  multi-provider works out of the box.
+
+### Why Fireworks uses the `chat` wire API (not Responses)
+
+Live probing of Fireworks (2026-06) showed its beta `/v1/responses` echoes the user
+input back as an output `message` item, emits reasoning inline as `output_text`, and
+accepts `web_search`/`reasoning.encrypted_content` params **without executing them** —
+all of which would corrupt the agent's conversation history or hand it a dead tool.
+Fireworks' `/v1/chat/completions` is clean and standard; GLM 5.2 there cleanly splits
+`reasoning_content` from `content` and supports `reasoning_effort` + streaming + tool
+calls. So Fireworks is wired as `api: "chat"`. OpenAI/Azure remain `responses`.
+
+## Config layer — `packages/config/src/index.ts`
+
+### New Settings field
+```ts
+modelProvidersJson: z.string().default("[]"),   // env: OPENGENI_MODEL_PROVIDERS_JSON
+```
+Parse it in `getSettings()` alongside the other `optional(...)` reads:
+`modelProvidersJson: optional("OPENGENI_MODEL_PROVIDERS_JSON")`.
+
+### New schemas + types (exported)
+```ts
+export const ModelProviderApi = z.enum(["responses", "chat"]);
+export type ModelProviderApi = z.infer<typeof ModelProviderApi>;
+
+const RegistryModelSchema = z.object({
+  id: z.string().min(1),                 // model id sent to the provider, e.g. "accounts/fireworks/models/glm-5p2"
+  label: z.string().min(1).optional(),   // display name; defaults to id
+  contextWindowTokens: z.number().int().positive().optional(),
+  reasoningEffort: z.boolean().optional(),  // model accepts a reasoning-effort control
+  hostedWebSearch: z.boolean().optional(),  // provider executes the hosted web_search tool for this model
+  pricing: ModelPricingSchema.optional(),
+});
+
+const RegistryProviderSchema = z.object({
+  id: z.string().min(1).regex(registryId),  // stable provider id, e.g. "fireworks" (same [A-Za-z0-9_-]+ shape as MCP server ids)
+  label: z.string().min(1).optional(),
+  api: ModelProviderApi.default("chat"),
+  baseUrl: z.string().url(),
+  apiKey: z.string().optional(),         // inline key (pragmatic) ...
+  apiKeyEnv: z.string().optional(),      // ... OR name of the env var holding the key (preferred)
+  defaultQuery: z.record(z.string()).optional(),
+  defaultHeaders: z.record(z.string()).optional(),
+  models: z.array(RegistryModelSchema).min(1),
+});
+export type RegistryProvider = z.infer<typeof RegistryProviderSchema>;
+
+// Runtime-resolved provider (built-in or registry), client-construction-ready.
+export interface ResolvedModelProvider {
+  id: string;                  // "openai" | "azure" | registry id
+  label: string;
+  api: ModelProviderApi;
+  builtin: boolean;
+  baseUrl?: string;
+  apiKey?: string;
+  defaultQuery?: Record<string, string>;
+  defaultHeaders?: Record<string, string>;
+  compactionMode: ContextCompactionMode;   // "server" only for built-in OpenAI; "client" otherwise
+}
+
+// A single exposed model + the provider that serves it.
+export interface ConfiguredModel {
+  id: string;
+  label: string;
+  providerId: string;
+  providerLabel: string;
+  api: ModelProviderApi;
+  contextWindowTokens?: number;
+  reasoningEffort: boolean;
+  hostedWebSearch: boolean;
+}
+```
+
+### New / changed functions
+- `parseModelProvidersJson(json: string): RegistryProvider[]` — parse + validate; `[]` on empty.
+- `resolveProviderApiKey(provider, source = process.env): string | undefined` — `apiKey ?? source[apiKeyEnv]`.
+- `configuredProviders(settings): ResolvedModelProvider[]` — built-in provider first
+  (id `openai`/`azure`, `api: "responses"`, `compactionMode: resolveContextCompactionMode(settings)`,
+  client inputs from the existing openai/azure fields), then registry providers
+  (`compactionMode: "client"`). Registry id may not collide with the built-in id (throw in `validateSettings`).
+- `configuredModels(settings): ConfiguredModel[]` — built-in models first
+  (`configuredAllowedModels`-from-openai mapped: `api: "responses"`,
+  `hostedWebSearch: settings.webSearchEnabled`, `contextWindowTokens: settings.contextWindowTokens`,
+  `reasoningEffort: true`), then each registry provider's models (defaults: label→id,
+  `hostedWebSearch` defaults `false`, `reasoningEffort` defaults `false`). De-dup by `id`, first wins, default model first.
+- `configuredAllowedModels(settings)` — **reimplement** as `configuredModels(settings).map(m => m.id)`
+  (keeps existing behaviour: `settings.openaiModel` first, then the openai allow-list, now plus registry ids).
+- `resolveModelProvider(settings, modelId): { provider: ResolvedModelProvider; model: ConfiguredModel } | undefined`.
+- `configuredModelPricing(settings)` — merge order: `defaultModelPricing` →
+  registry model `pricing` entries (keyed by model id) → `parseModelPricingJson(settings.modelPricingJson)` (explicit JSON wins).
+- `defaultModelPricing` — add a built-in entry so managed billing works out of the box:
+  ```ts
+  "accounts/fireworks/models/glm-5p2": {
+    inputMicrosPerMillionTokens: 1_400_000,
+    cachedInputMicrosPerMillionTokens: 260_000,
+    outputMicrosPerMillionTokens: 4_400_000,
+    marginBps: 2_500,
+  },
+  ```
+- `validateSettings` — parse the registry (surface JSON/zod errors at boot), reject a
+  registry id equal to the built-in id, and require a resolvable API key for every
+  registry provider. Existing managed-billing pricing check already covers registry
+  models because they flow through `configuredAllowedModels`.
+
+## Contracts — `packages/contracts/src/index.ts`
+
+Extend `ClientConfig` (keep `allowedModels: string[]` for back-compat):
+```ts
+export const ClientModel = z.object({
+  id: z.string(),
+  label: z.string(),
+  provider: z.string(),        // provider id
+  providerLabel: z.string(),
+  api: z.enum(["responses", "chat"]),
+  contextWindowTokens: z.number().int().positive().optional(),
+});
+export type ClientModel = z.infer<typeof ClientModel>;
+// in ClientConfig:
+models: z.array(ClientModel).default([]),
+```
+
+## Runtime — `packages/runtime/src/index.ts`
+
+- Import `OpenAIResponsesModel`, `OpenAIChatCompletionsModel` from the agents SDK
+  (use `@openai/agents-openai`; fall back to `@openai/agents` if re-exported — the
+  typecheck decides). Add `@openai/agents-openai` to `packages/runtime/package.json`
+  deps if the import needs it.
+- `buildProviderClient(provider: ResolvedModelProvider, settings: Settings): OpenAI`
+  — generalises `buildOpenAIClientFromSettings`. Built-in azure/openai keep their exact
+  current construction; registry providers →
+  `new OpenAI({ apiKey: resolveProviderApiKey(provider), baseURL: provider.baseUrl, maxRetries: settings.openaiMaxRetries, defaultQuery, defaultHeaders })`.
+  Cache one client per `provider.id` (module-level `Map`).
+- `buildModelInstance(provider, client, modelId): Model` —
+  `provider.api === "chat" ? new OpenAIChatCompletionsModel(client, modelId) : new OpenAIResponsesModel(client, modelId)`.
+- `resolveTurnModel(settings, modelId): { provider, client, model: Model, configured: ConfiguredModel } | null`
+  — looks up `resolveModelProvider`, builds client + Model instance. Returns `null`
+  (caller falls back to the legacy global-client path) when the model isn't in the registry.
+- Extend `BuildAgentOptions` with optional gating overrides (all default to today's behaviour when omitted):
+  ```ts
+  compactionMode?: ContextCompactionMode;   // default resolveContextCompactionMode(settings)
+  hostedWebSearch?: boolean;                 // default settings.webSearchEnabled
+  encryptedReasoning?: boolean;              // default settings.openaiReasoningEncryptedContent
+  contextWindowTokens?: number;              // default settings.contextWindowTokens
+  ```
+  In `buildOpenGeniAgent`: `hostedTools` gated on `options.hostedWebSearch ?? settings.webSearchEnabled`;
+  encrypted-reasoning `providerData.include` gated on `options.encryptedReasoning ?? settings.openaiReasoningEncryptedContent`;
+  `store: false` gated on the resolved compaction mode being `server`.
+- `buildAgentCapabilities` takes the resolved `compactionMode` (+ effective context
+  window) instead of calling `resolveContextCompactionMode(settings)` internally.
+- `summarizeForCompaction` becomes provider-aware: accept `{ client, api }`; for
+  `api === "chat"` call `client.chat.completions.create({...})` and read
+  `choices[0].message.content`; for `responses` keep the current
+  `client.responses.create` path. `extractResponseOutputText` must only read
+  `role === "assistant"` message items (guards against any input-echo).
+
+## Worker — `apps/worker/src/activities/agent-turn.ts`
+
+Resolve the turn's model once, then pass the Model instance + gating into `buildAgent`:
+```ts
+const resolved = runtime.resolveTurnModel(settings, turn.model);
+const agent = runtime.buildAgent(settings, turnResources, {
+  ...(resolved
+    ? {
+        model: resolved.model,
+        compactionMode: resolved.provider.compactionMode,
+        hostedWebSearch: resolved.configured.hostedWebSearch,
+        encryptedReasoning: resolved.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+        contextWindowTokens: resolved.configured.contextWindowTokens ?? settings.contextWindowTokens,
+      }
+    : {}),                       // legacy path: settings.openaiModel + global client
+  ...existingOptions,
+});
+```
+Thread `resolved.client` + `resolved.provider.api` into the client-side compaction
+summarizer call. Keep the `runSettings.openaiModel = turn.model` plumbing for the
+no-resolution fallback. Cost accounting (`configuredModelPricing(settings)[input.model]`)
+already covers registry models.
+
+## SDK — `packages/sdk/src/client.ts` + `types.ts`
+
+- Add `getClientConfig(): Promise<ClientConfig>` → `GET /v1/config/client`.
+- Re-export `ClientConfig` and `ClientModel` types from `packages/sdk/src/index.ts`.
+- No change to how `model` is sent (already `model?: string` on `SendMessageInput` etc.).
+
+## React — `packages/react`
+
+- `useAvailableModels(client)` hook → fetches `getClientConfig()`, returns
+  `{ models: ClientModel[], defaultModel, loading, error }`.
+- `<ModelPicker>` component (`packages/react/src/components/model-picker.tsx`) — a
+  dropdown grouped by `providerLabel`, showing each model's `label`; controlled via
+  `value` / `onChange`.
+- `ChatComposer` gains optional `models`, `selectedModel`, `onSelectModel` props; when
+  `models` is provided it renders `<ModelPicker>` in `controlsStart` and threads the
+  selection into `sendExtras` so `composeSendInput` carries `model`.
+- `demo/mock.ts` returns a multi-provider `getClientConfig()` fixture (OpenAI + Fireworks)
+  so the demo exercises the picker.
+
+## Web app — `apps/web`
+
+Wire `useAvailableModels` + the composer's new props into the real app composer so the
+deployed UI shows the host-exposed model list and remembers the selection per session.
+
+## Host configuration example (Fireworks + GLM 5.2)
+
+```bash
+# Built-in provider stays OpenAI (or Azure) as today.
+OPENGENI_OPENAI_PROVIDER=openai
+OPENGENI_OPENAI_MODEL=gpt-5.5
+OPENGENI_OPENAI_ALLOWED_MODELS=gpt-5.5,gpt-5.4
+
+# Add Fireworks as an extra provider exposing GLM 5.2.
+OPENGENI_FIREWORKS_API_KEY=fw_...
+OPENGENI_MODEL_PROVIDERS_JSON='[
+  {
+    "id": "fireworks",
+    "label": "Fireworks AI",
+    "api": "chat",
+    "baseUrl": "https://api.fireworks.ai/inference/v1",
+    "apiKeyEnv": "OPENGENI_FIREWORKS_API_KEY",
+    "models": [
+      {
+        "id": "accounts/fireworks/models/glm-5p2",
+        "label": "GLM 5.2",
+        "contextWindowTokens": 1048576,
+        "reasoningEffort": true,
+        "hostedWebSearch": false
+      }
+    ]
+  }
+]'
+```
+Clients then see `gpt-5.5`, `gpt-5.4`, and `GLM 5.2` in the picker and can select any of them.
+
+## Verification
+
+1. `bun run typecheck` (whole workspace) clean.
+2. `bun test` (unit) green, including new config/contracts/runtime/api tests.
+3. Live Fireworks e2e (`test/live/`, gated on `OPENGENI_FIREWORKS_API_KEY`): resolve
+   `accounts/fireworks/models/glm-5p2`, build the chat Model, run a one-turn agent with a
+   tool, assert a clean assistant response + correct provider routing.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -190,6 +190,13 @@ const SettingsSchema = z.object({
   openaiModel: z.string().default("gpt-5.5"),
   openaiAllowedModels: z.string().default("gpt-5.5,gpt-5.4,gpt-5.4-mini"),
   modelPricingJson: z.string().default("{}"),
+  // Extra (non-built-in) model providers, declared by the host as a JSON
+  // provider registry. Each entry carries its own base URL, API key, wire API
+  // ("responses" | "chat") and the models it exposes. The models a client may
+  // use are the UNION of the built-in provider's allowed models and every
+  // registry provider's models. validateSettings parses this at boot so a
+  // malformed registry / unresolvable key / id collision fails fast.
+  modelProvidersJson: z.string().default("[]"),
   openaiReasoningEffort: ReasoningEffort.default("low"),
   openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
@@ -334,6 +341,71 @@ const ModelPricingSchema = z.object({
   marginBps: z.number().int().min(0).max(100_000).optional(),
 });
 
+/**
+ * Wire API a provider speaks. The built-in OpenAI/Azure provider always uses
+ * "responses" (the OpenAI Responses API). Extra registry providers default to
+ * "chat" (the broadly compatible /v1/chat/completions surface); Fireworks is
+ * wired as "chat" because its beta Responses endpoint echoes input back and
+ * silently no-ops hosted tools (see docs/model-providers.md).
+ */
+export const ModelProviderApi = z.enum(["responses", "chat"]);
+export type ModelProviderApi = z.infer<typeof ModelProviderApi>;
+
+/** A single model exposed by a registry provider. */
+const RegistryModelSchema = z.object({
+  id: z.string().min(1),                 // model id sent to the provider, e.g. "accounts/fireworks/models/glm-5p2"
+  label: z.string().min(1).optional(),   // display name; defaults to id
+  contextWindowTokens: z.number().int().positive().optional(),
+  reasoningEffort: z.boolean().optional(),  // model accepts a reasoning-effort control
+  hostedWebSearch: z.boolean().optional(),  // provider executes the hosted web_search tool for this model
+  pricing: ModelPricingSchema.optional(),
+});
+
+/** A non-built-in provider declared by the host via OPENGENI_MODEL_PROVIDERS_JSON. */
+const RegistryProviderSchema = z.object({
+  id: z.string().min(1).regex(registryId),  // stable provider id, e.g. "fireworks"
+  label: z.string().min(1).optional(),
+  api: ModelProviderApi.default("chat"),
+  baseUrl: z.string().url(),
+  apiKey: z.string().optional(),         // inline key (pragmatic) ...
+  apiKeyEnv: z.string().optional(),      // ... OR name of the env var holding the key (preferred)
+  defaultQuery: z.record(z.string(), z.string()).optional(),
+  defaultHeaders: z.record(z.string(), z.string()).optional(),
+  models: z.array(RegistryModelSchema).min(1),
+});
+export type RegistryProvider = z.infer<typeof RegistryProviderSchema>;
+
+/**
+ * Runtime-resolved provider (built-in or registry), client-construction-ready.
+ * The built-in OpenAI/Azure provider is always present and always "responses";
+ * registry providers carry their own base URL / key / wire API. compactionMode
+ * is "server" only for the built-in OpenAI platform provider (its Responses API
+ * honors server-side context_management) and "client" for everything else.
+ */
+export interface ResolvedModelProvider {
+  id: string;                  // "openai" | "azure" | registry id
+  label: string;
+  api: ModelProviderApi;
+  builtin: boolean;
+  baseUrl?: string | undefined;
+  apiKey?: string | undefined;
+  defaultQuery?: Record<string, string> | undefined;
+  defaultHeaders?: Record<string, string> | undefined;
+  compactionMode: ContextCompactionMode;   // "server" only for built-in OpenAI; "client" otherwise
+}
+
+/** A single exposed model + the provider that serves it. */
+export interface ConfiguredModel {
+  id: string;
+  label: string;
+  providerId: string;
+  providerLabel: string;
+  api: ModelProviderApi;
+  contextWindowTokens?: number | undefined;
+  reasoningEffort: boolean;
+  hostedWebSearch: boolean;
+}
+
 export const defaultModelPricing: Record<string, ModelPricing> = {
   "gpt-5.5": {
     inputMicrosPerMillionTokens: 5_000_000,
@@ -395,6 +467,16 @@ export const defaultModelPricing: Record<string, ModelPricing> = {
     outputMicrosPerMillionTokens: 400_000,
     marginBps: 2_500,
   },
+  // Fireworks AI / GLM 5.2 — the first shipped non-OpenAI registry model. A
+  // built-in default pricing entry makes managed billing work out of the box
+  // for hosts that expose this model via OPENGENI_MODEL_PROVIDERS_JSON without
+  // also setting OPENGENI_MODEL_PRICING_JSON.
+  "accounts/fireworks/models/glm-5p2": {
+    inputMicrosPerMillionTokens: 1_400_000,
+    cachedInputMicrosPerMillionTokens: 260_000,
+    outputMicrosPerMillionTokens: 4_400_000,
+    marginBps: 2_500,
+  },
 };
 
 function optional(name: string): string | undefined {
@@ -454,6 +536,7 @@ export function getSettings(): Settings {
     openaiModel: optional("OPENGENI_OPENAI_MODEL"),
     openaiAllowedModels: optional("OPENGENI_OPENAI_ALLOWED_MODELS"),
     modelPricingJson: optional("OPENGENI_MODEL_PRICING_JSON"),
+    modelProvidersJson: optional("OPENGENI_MODEL_PROVIDERS_JSON"),
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),
     openaiAllowedReasoningEfforts: optional("OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"),
     openaiResponsesTransport: optional("OPENGENI_OPENAI_RESPONSES_TRANSPORT"),
@@ -550,14 +633,170 @@ export function collectSandboxEnvironment(settings: Settings, source: NodeJS.Pro
   return out;
 }
 
-export function configuredAllowedModels(settings: Settings): string[] {
-  return uniqueValues([settings.openaiModel, ...splitCsv(settings.openaiAllowedModels)]);
+/**
+ * Resolved API key for a registry provider: the inline `apiKey` when present,
+ * else the value of the env var named by `apiKeyEnv`. The preferred form is
+ * `apiKeyEnv` (the secret stays out of OPENGENI_MODEL_PROVIDERS_JSON). Reads
+ * from `source` (defaults to process.env) so callers can resolve against an
+ * explicit environment in tests.
+ */
+export function resolveProviderApiKey(
+  provider: Pick<RegistryProvider, "apiKey" | "apiKeyEnv">,
+  source: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (provider.apiKey) {
+    return provider.apiKey;
+  }
+  if (provider.apiKeyEnv) {
+    const value = source[provider.apiKeyEnv];
+    return value && value.trim().length > 0 ? value : undefined;
+  }
+  return undefined;
 }
 
+/** The built-in provider's stable id: "openai" on the OpenAI platform, "azure" on Azure. */
+function builtinProviderId(settings: Pick<Settings, "openaiProvider">): string {
+  return settings.openaiProvider === "azure" ? "azure" : "openai";
+}
+
+function builtinProviderLabel(settings: Pick<Settings, "openaiProvider">): string {
+  return settings.openaiProvider === "azure" ? "Azure OpenAI" : "OpenAI";
+}
+
+/**
+ * Every provider a client may route to: the built-in OpenAI/Azure provider
+ * first (id "openai"/"azure", always "responses", compactionMode from
+ * resolveContextCompactionMode), then each registry provider in declaration
+ * order (compactionMode "client"). Client-construction inputs are filled from
+ * the existing flat openai/azure settings for the built-in, and from the
+ * registry entry for the rest. Registry ids may not collide with the built-in
+ * id — validateSettings rejects that at boot.
+ */
+export function configuredProviders(settings: Settings): ResolvedModelProvider[] {
+  const builtin: ResolvedModelProvider = {
+    id: builtinProviderId(settings),
+    label: builtinProviderLabel(settings),
+    api: "responses",
+    builtin: true,
+    compactionMode: resolveContextCompactionMode(settings),
+  };
+  if (settings.openaiProvider === "azure") {
+    builtin.baseUrl = settings.azureOpenaiBaseUrl ?? settings.azureOpenaiEndpoint;
+    builtin.apiKey = settings.azureOpenaiApiKey ?? settings.azureOpenaiAdToken;
+  } else {
+    builtin.baseUrl = settings.openaiBaseUrl;
+    builtin.apiKey = settings.openaiApiKey;
+  }
+  const registry = parseModelProvidersJson(settings.modelProvidersJson).map((provider): ResolvedModelProvider => ({
+    id: provider.id,
+    label: provider.label ?? provider.id,
+    api: provider.api,
+    builtin: false,
+    baseUrl: provider.baseUrl,
+    apiKey: resolveProviderApiKey(provider),
+    defaultQuery: provider.defaultQuery,
+    defaultHeaders: provider.defaultHeaders,
+    compactionMode: "client",
+  }));
+  return [builtin, ...registry];
+}
+
+/**
+ * Every model a client may use, the built-in provider's models first
+ * (configuredAllowedModels-from-openai, mapped to "responses" with
+ * hostedWebSearch/contextWindow/reasoningEffort from the flat settings), then
+ * each registry provider's models (label→id, hostedWebSearch/reasoningEffort
+ * default false). De-duplicated by id (first wins) so the default model stays
+ * first and the built-in allow-list takes precedence over registry entries.
+ */
+export function configuredModels(settings: Settings): ConfiguredModel[] {
+  const builtinId = builtinProviderId(settings);
+  const builtinLabel = builtinProviderLabel(settings);
+  const out: ConfiguredModel[] = uniqueValues([settings.openaiModel, ...splitCsv(settings.openaiAllowedModels)]).map((id) => ({
+    id,
+    label: id,
+    providerId: builtinId,
+    providerLabel: builtinLabel,
+    api: "responses" as const,
+    contextWindowTokens: settings.contextWindowTokens,
+    reasoningEffort: true,
+    hostedWebSearch: settings.webSearchEnabled,
+  }));
+  for (const provider of parseModelProvidersJson(settings.modelProvidersJson)) {
+    const providerLabel = provider.label ?? provider.id;
+    for (const model of provider.models) {
+      out.push({
+        id: model.id,
+        label: model.label ?? model.id,
+        providerId: provider.id,
+        providerLabel,
+        api: provider.api,
+        ...(model.contextWindowTokens === undefined ? {} : { contextWindowTokens: model.contextWindowTokens }),
+        reasoningEffort: model.reasoningEffort ?? false,
+        hostedWebSearch: model.hostedWebSearch ?? false,
+      });
+    }
+  }
+  const seen = new Set<string>();
+  return out.filter((model) => {
+    if (seen.has(model.id)) {
+      return false;
+    }
+    seen.add(model.id);
+    return true;
+  });
+}
+
+/**
+ * Allowed model ids in selection order. Reimplemented on top of
+ * configuredModels so it is the union of the built-in allow-list and every
+ * registry provider's ids, de-duplicated. INVARIANT (existing callers + tests
+ * depend on it): settings.openaiModel is always first, then the rest of the
+ * openai allow-list, then registry ids.
+ */
+export function configuredAllowedModels(settings: Settings): string[] {
+  return configuredModels(settings).map((model) => model.id);
+}
+
+/**
+ * Resolve a model string to the provider that serves it and its configured
+ * shape. Returns undefined when the id is not exposed (built-in allow-list nor
+ * any registry provider), so the runtime can fall back to the legacy global
+ * client path.
+ */
+export function resolveModelProvider(
+  settings: Settings,
+  modelId: string,
+): { provider: ResolvedModelProvider; model: ConfiguredModel } | undefined {
+  const model = configuredModels(settings).find((candidate) => candidate.id === modelId);
+  if (!model) {
+    return undefined;
+  }
+  const provider = configuredProviders(settings).find((candidate) => candidate.id === model.providerId);
+  if (!provider) {
+    return undefined;
+  }
+  return { provider, model };
+}
+
+/**
+ * Effective per-model pricing. Merge order (later wins):
+ *   defaultModelPricing → registry model `pricing` entries (keyed by model id)
+ *   → parseModelPricingJson(settings.modelPricingJson) (explicit JSON wins).
+ */
 export function configuredModelPricing(settings: Settings): Record<string, ModelPricing> {
+  const registry: Record<string, ModelPricing> = {};
+  for (const provider of parseModelProvidersJson(settings.modelProvidersJson)) {
+    for (const model of provider.models) {
+      if (model.pricing) {
+        registry[model.id] = model.pricing;
+      }
+    }
+  }
   const configured = parseModelPricingJson(settings.modelPricingJson);
   return {
     ...defaultModelPricing,
+    ...registry,
     ...configured,
   };
 }
@@ -799,6 +1038,34 @@ export function parseModelPricingJson(raw: string): Record<string, ModelPricing>
   return out;
 }
 
+/**
+ * Parse + validate the extra-provider registry JSON. `[]` (or empty/whitespace)
+ * yields an empty list. Surfaces JSON and zod errors prefixed with the env-var
+ * name so a malformed registry fails fast at boot (validateSettings calls this).
+ */
+export function parseModelProvidersJson(raw: string): RegistryProvider[] {
+  if (!raw.trim() || raw.trim() === "[]") {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON must be valid JSON: ${message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("OPENGENI_MODEL_PROVIDERS_JSON must be a JSON array of providers");
+  }
+  return parsed.map((entry, index) => {
+    const result = RegistryProviderSchema.safeParse(entry);
+    if (!result.success) {
+      throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON provider[${index}] is invalid: ${result.error.message}`);
+    }
+    return result.data;
+  });
+}
+
 export function parseStaticUsageLimitsJson(raw: string): StaticUsageLimitsConfig {
   if (!raw.trim() || raw.trim() === "{}") {
     return {};
@@ -1033,6 +1300,28 @@ function validateSettings(settings: Settings): void {
       throw new Error(`OPENGENI_MCP_SERVERS contains duplicate id ${server.id}`);
     }
     serverIds.add(server.id);
+  }
+  // Model provider registry: parse it here so JSON/zod errors surface at boot,
+  // reject a registry id colliding with the built-in provider id (it would
+  // shadow the built-in in configuredProviders), reject duplicate registry
+  // ids, and require a resolvable API key for every registry provider (a
+  // provider with no usable key can never serve a turn). Registry models flow
+  // through configuredAllowedModels, so the managed-billing pricing check above
+  // already covers them.
+  const registryProviders = parseModelProvidersJson(settings.modelProvidersJson);
+  const builtinId = builtinProviderId(settings);
+  const providerIds = new Set<string>();
+  for (const provider of registryProviders) {
+    if (provider.id === builtinId) {
+      throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON provider id ${provider.id} collides with the built-in provider id`);
+    }
+    if (providerIds.has(provider.id)) {
+      throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON contains duplicate provider id ${provider.id}`);
+    }
+    providerIds.add(provider.id);
+    if (!resolveProviderApiKey(provider)) {
+      throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON provider ${provider.id} requires a resolvable API key (set apiKey or apiKeyEnv)`);
+    }
   }
 }
 

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, test } from "bun:test";
+import {
+  configuredAllowedModels,
+  configuredModelPricing,
+  configuredModels,
+  configuredProviders,
+  defaultModelPricing,
+  getSettings,
+  parseModelProvidersJson,
+  resolveModelProvider,
+  resolveProviderApiKey,
+} from "../src";
+
+// A reusable Fireworks/GLM-5.2 registry JSON mirroring the doc's host example.
+// Uses an inline apiKey so the registry resolves without touching process.env.
+const fireworksRegistry = JSON.stringify([
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    api: "chat",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    apiKey: "fw_inline",
+    models: [
+      {
+        id: "accounts/fireworks/models/glm-5p2",
+        label: "GLM 5.2",
+        contextWindowTokens: 1_048_576,
+        reasoningEffort: true,
+        hostedWebSearch: false,
+      },
+    ],
+  },
+]);
+
+describe("parseModelProvidersJson", () => {
+  test("returns an empty list for the default/empty value", () => {
+    expect(parseModelProvidersJson("[]")).toEqual([]);
+    expect(parseModelProvidersJson("")).toEqual([]);
+    expect(parseModelProvidersJson("   ")).toEqual([]);
+  });
+
+  test("parses a valid provider registry and applies defaults", () => {
+    const providers = parseModelProvidersJson(JSON.stringify([
+      {
+        id: "fireworks",
+        baseUrl: "https://api.fireworks.ai/inference/v1",
+        apiKeyEnv: "OPENGENI_FIREWORKS_API_KEY",
+        models: [{ id: "accounts/fireworks/models/glm-5p2" }],
+      },
+    ]));
+    expect(providers).toHaveLength(1);
+    const provider = providers[0]!;
+    // api defaults to "chat" for registry providers; label is optional here.
+    expect(provider.api).toBe("chat");
+    expect(provider.label).toBeUndefined();
+    expect(provider.models[0]?.id).toBe("accounts/fireworks/models/glm-5p2");
+  });
+
+  test("rejects non-array JSON", () => {
+    expect(() => parseModelProvidersJson('{"id":"fireworks"}')).toThrow("must be a JSON array");
+  });
+
+  test("rejects malformed JSON", () => {
+    expect(() => parseModelProvidersJson("[not json")).toThrow("must be valid JSON");
+  });
+
+  test("rejects an entry missing a required field, naming the index", () => {
+    // baseUrl is required; provider[0] omits it.
+    expect(() => parseModelProvidersJson(JSON.stringify([
+      { id: "fireworks", apiKey: "fw", models: [{ id: "m" }] },
+    ]))).toThrow("provider[0] is invalid");
+  });
+
+  test("rejects a provider id with illegal characters", () => {
+    expect(() => parseModelProvidersJson(JSON.stringify([
+      { id: "fire works", baseUrl: "https://x.test", apiKey: "fw", models: [{ id: "m" }] },
+    ]))).toThrow("provider[0] is invalid");
+  });
+
+  test("rejects a provider with an empty models list", () => {
+    expect(() => parseModelProvidersJson(JSON.stringify([
+      { id: "fireworks", baseUrl: "https://x.test", apiKey: "fw", models: [] },
+    ]))).toThrow("provider[0] is invalid");
+  });
+});
+
+describe("resolveProviderApiKey", () => {
+  test("prefers an inline apiKey", () => {
+    expect(resolveProviderApiKey({ apiKey: "inline", apiKeyEnv: "SOME_ENV" }, { SOME_ENV: "from-env" })).toBe("inline");
+  });
+
+  test("falls back to the named env var", () => {
+    expect(resolveProviderApiKey({ apiKeyEnv: "OPENGENI_FIREWORKS_API_KEY" }, { OPENGENI_FIREWORKS_API_KEY: "fw_env" })).toBe("fw_env");
+  });
+
+  test("returns undefined when neither inline nor env is resolvable", () => {
+    expect(resolveProviderApiKey({ apiKeyEnv: "MISSING" }, {})).toBeUndefined();
+    expect(resolveProviderApiKey({ apiKeyEnv: "BLANK" }, { BLANK: "  " })).toBeUndefined();
+    expect(resolveProviderApiKey({})).toBeUndefined();
+  });
+});
+
+describe("configuredProviders", () => {
+  test("built-in OpenAI provider first with server compaction, then registry providers with client compaction", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    const providers = configuredProviders(settings);
+    expect(providers.map((provider) => provider.id)).toEqual(["openai", "fireworks"]);
+    expect(providers[0]).toMatchObject({
+      id: "openai",
+      label: "OpenAI",
+      api: "responses",
+      builtin: true,
+      apiKey: "sk-test",
+      compactionMode: "server",
+    });
+    expect(providers[1]).toMatchObject({
+      id: "fireworks",
+      label: "Fireworks AI",
+      api: "chat",
+      builtin: false,
+      baseUrl: "https://api.fireworks.ai/inference/v1",
+      apiKey: "fw_inline",
+      compactionMode: "client",
+    });
+  });
+
+  test("built-in Azure provider id/label and client compaction", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_PROVIDER: "azure",
+      OPENGENI_AZURE_OPENAI_BASE_URL: "https://res.openai.azure.com/openai/v1",
+      OPENGENI_AZURE_OPENAI_API_KEY: "az-key",
+    }, () => getSettings());
+    const builtin = configuredProviders(settings)[0]!;
+    expect(builtin).toMatchObject({
+      id: "azure",
+      label: "Azure OpenAI",
+      api: "responses",
+      builtin: true,
+      baseUrl: "https://res.openai.azure.com/openai/v1",
+      apiKey: "az-key",
+      // Azure rejects server-side context_management, so it must run client compaction.
+      compactionMode: "client",
+    });
+  });
+});
+
+describe("configuredModels", () => {
+  test("with no registry returns exactly the built-in allow-list, default model first", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.4,gpt-5.4-mini",
+    }, () => getSettings());
+    const models = configuredModels(settings);
+    expect(models.map((model) => model.id)).toEqual(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]);
+    expect(models[0]).toMatchObject({
+      id: "gpt-5.5",
+      label: "gpt-5.5",
+      providerId: "openai",
+      providerLabel: "OpenAI",
+      api: "responses",
+      contextWindowTokens: settings.contextWindowTokens,
+      reasoningEffort: true,
+      hostedWebSearch: settings.webSearchEnabled,
+    });
+  });
+
+  test("unions built-in models first, then registry models in declaration order", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.4",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    const models = configuredModels(settings);
+    expect(models.map((model) => model.id)).toEqual([
+      "gpt-5.5",
+      "gpt-5.4",
+      "accounts/fireworks/models/glm-5p2",
+    ]);
+    const glm = models.find((model) => model.id === "accounts/fireworks/models/glm-5p2")!;
+    expect(glm).toMatchObject({
+      label: "GLM 5.2",
+      providerId: "fireworks",
+      providerLabel: "Fireworks AI",
+      api: "chat",
+      contextWindowTokens: 1_048_576,
+      reasoningEffort: true,
+      hostedWebSearch: false,
+    });
+  });
+
+  test("registry model defaults: label falls back to id, reasoningEffort/hostedWebSearch default false", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        {
+          id: "acme",
+          baseUrl: "https://api.acme.test/v1",
+          apiKey: "acme-key",
+          models: [{ id: "acme/model-a" }],
+        },
+      ]),
+    }, () => getSettings());
+    const model = configuredModels(settings).find((candidate) => candidate.id === "acme/model-a")!;
+    expect(model).toMatchObject({
+      label: "acme/model-a",
+      providerId: "acme",
+      providerLabel: "acme",
+      api: "chat",
+      reasoningEffort: false,
+      hostedWebSearch: false,
+    });
+    expect(model.contextWindowTokens).toBeUndefined();
+  });
+
+  test("de-dups by id with first (built-in) winning when a registry repeats it", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.4",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        {
+          id: "shadow",
+          baseUrl: "https://api.shadow.test/v1",
+          apiKey: "shadow-key",
+          // Redeclares the built-in default model id; built-in entry must win.
+          models: [{ id: "gpt-5.5", label: "Shadowed" }, { id: "shadow/only" }],
+        },
+      ]),
+    }, () => getSettings());
+    const models = configuredModels(settings);
+    expect(models.map((model) => model.id)).toEqual(["gpt-5.5", "gpt-5.4", "shadow/only"]);
+    const gpt = models.find((model) => model.id === "gpt-5.5")!;
+    expect(gpt.providerId).toBe("openai");
+    expect(gpt.label).toBe("gpt-5.5");
+  });
+});
+
+describe("configuredAllowedModels", () => {
+  test("with no registry is exactly today's behaviour: default model first, then the allow-list", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "custom-model",
+      OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.5,gpt-5.4",
+    }, () => getSettings());
+    expect(configuredAllowedModels(settings)).toEqual(["custom-model", "gpt-5.5", "gpt-5.4"]);
+  });
+
+  test("appends registry ids after the built-in allow-list", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_OPENAI_ALLOWED_MODELS: "gpt-5.4",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    expect(configuredAllowedModels(settings)).toEqual([
+      "gpt-5.5",
+      "gpt-5.4",
+      "accounts/fireworks/models/glm-5p2",
+    ]);
+  });
+});
+
+describe("resolveModelProvider", () => {
+  test("resolves a built-in model to the built-in provider", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    const resolved = resolveModelProvider(settings, "gpt-5.5");
+    expect(resolved).toBeDefined();
+    expect(resolved!.provider.id).toBe("openai");
+    expect(resolved!.provider.builtin).toBe(true);
+    expect(resolved!.provider.api).toBe("responses");
+    expect(resolved!.model.id).toBe("gpt-5.5");
+  });
+
+  test("resolves a registry model to its registry provider", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    const resolved = resolveModelProvider(settings, "accounts/fireworks/models/glm-5p2");
+    expect(resolved).toBeDefined();
+    expect(resolved!.provider.id).toBe("fireworks");
+    expect(resolved!.provider.builtin).toBe(false);
+    expect(resolved!.provider.api).toBe("chat");
+    expect(resolved!.provider.compactionMode).toBe("client");
+    expect(resolved!.model.contextWindowTokens).toBe(1_048_576);
+  });
+
+  test("returns undefined for a model that is not exposed", () => {
+    const settings = withEnv({ OPENGENI_OPENAI_API_KEY: "sk-test" }, () => getSettings());
+    expect(resolveModelProvider(settings, "not-a-real-model")).toBeUndefined();
+  });
+});
+
+describe("configuredModelPricing", () => {
+  test("includes the built-in GLM-5.2 default pricing entry", () => {
+    expect(defaultModelPricing["accounts/fireworks/models/glm-5p2"]).toEqual({
+      inputMicrosPerMillionTokens: 1_400_000,
+      cachedInputMicrosPerMillionTokens: 260_000,
+      outputMicrosPerMillionTokens: 4_400_000,
+      marginBps: 2_500,
+    });
+  });
+
+  test("merge precedence: registry model pricing overrides defaults, explicit JSON overrides registry", () => {
+    const settings = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        {
+          id: "fireworks",
+          baseUrl: "https://api.fireworks.ai/inference/v1",
+          apiKey: "fw",
+          models: [
+            {
+              id: "accounts/fireworks/models/glm-5p2",
+              // Registry override differs from the built-in default.
+              pricing: {
+                inputMicrosPerMillionTokens: 999_000,
+                outputMicrosPerMillionTokens: 999_000,
+              },
+            },
+            {
+              id: "fireworks/another",
+              pricing: {
+                inputMicrosPerMillionTokens: 111_000,
+                outputMicrosPerMillionTokens: 222_000,
+              },
+            },
+          ],
+        },
+      ]),
+      // Explicit JSON wins over the registry entry for the same id.
+      OPENGENI_MODEL_PRICING_JSON: JSON.stringify({
+        "accounts/fireworks/models/glm-5p2": {
+          inputMicrosPerMillionTokens: 1_000,
+          outputMicrosPerMillionTokens: 2_000,
+        },
+      }),
+    }, () => getSettings());
+    const pricing = configuredModelPricing(settings);
+    // explicit OPENGENI_MODEL_PRICING_JSON beats both registry + default.
+    expect(pricing["accounts/fireworks/models/glm-5p2"]).toEqual({
+      inputMicrosPerMillionTokens: 1_000,
+      outputMicrosPerMillionTokens: 2_000,
+    });
+    // registry-only model keeps its registry pricing.
+    expect(pricing["fireworks/another"]).toEqual({
+      inputMicrosPerMillionTokens: 111_000,
+      outputMicrosPerMillionTokens: 222_000,
+    });
+    // an untouched default stays intact.
+    expect(pricing["gpt-5.5"]).toEqual(defaultModelPricing["gpt-5.5"]!);
+  });
+});
+
+describe("validateSettings registry checks", () => {
+  test("rejects a registry id colliding with the built-in provider id", () => {
+    expect(() => withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        { id: "openai", baseUrl: "https://x.test/v1", apiKey: "k", models: [{ id: "m" }] },
+      ]),
+    }, () => getSettings())).toThrow("collides with the built-in provider id");
+  });
+
+  test("rejects duplicate registry provider ids", () => {
+    expect(() => withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        { id: "dup", baseUrl: "https://a.test/v1", apiKey: "k", models: [{ id: "m1" }] },
+        { id: "dup", baseUrl: "https://b.test/v1", apiKey: "k", models: [{ id: "m2" }] },
+      ]),
+    }, () => getSettings())).toThrow("duplicate provider id");
+  });
+
+  test("rejects a registry provider with no resolvable API key", () => {
+    expect(() => withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        { id: "fireworks", baseUrl: "https://x.test/v1", apiKeyEnv: "MISSING_KEY_ENV", models: [{ id: "m" }] },
+      ]),
+    }, () => getSettings())).toThrow("requires a resolvable API key");
+  });
+
+  test("accepts a registry provider whose key resolves from the environment", () => {
+    // configuredProviders resolves apiKeyEnv against process.env at CALL time,
+    // so both getSettings (boot validation) and configuredProviders must run
+    // inside the patched environment.
+    withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_FIREWORKS_API_KEY: "fw_from_env",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        {
+          id: "fireworks",
+          baseUrl: "https://api.fireworks.ai/inference/v1",
+          apiKeyEnv: "OPENGENI_FIREWORKS_API_KEY",
+          models: [{ id: "accounts/fireworks/models/glm-5p2" }],
+        },
+      ]),
+    }, () => {
+      const settings = getSettings();
+      expect(configuredProviders(settings)[1]?.apiKey).toBe("fw_from_env");
+    });
+  });
+
+  test("surfaces a malformed registry as a boot error", () => {
+    expect(() => withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: "[not valid json",
+    }, () => getSettings())).toThrow("OPENGENI_MODEL_PROVIDERS_JSON must be valid JSON");
+  });
+
+  test("managed billing requires pricing for registry models that lack a default", () => {
+    expect(() => withEnv({
+      OPENGENI_ENVIRONMENT: "production",
+      OPENGENI_PRODUCT_ACCESS_MODE: "managed",
+      OPENGENI_PUBLIC_BASE_URL: "https://managed.example.test",
+      OPENGENI_BETTER_AUTH_SECRET: "managed-better-auth-secret",
+      OPENGENI_DELEGATION_SECRET: "managed-delegation-secret",
+      OPENGENI_RESEND_API_KEY: "re_test",
+      OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
+      OPENGENI_BILLING_MODE: "stripe",
+      OPENGENI_STRIPE_SECRET_KEY: "sk_test",
+      OPENGENI_STRIPE_WEBHOOK_SECRET: "whsec_test",
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: JSON.stringify([
+        {
+          id: "acme",
+          baseUrl: "https://api.acme.test/v1",
+          apiKey: "acme-key",
+          // No default pricing and no pricing entry -> managed billing must reject.
+          models: [{ id: "acme/unpriced" }],
+        },
+      ]),
+    }, () => getSettings())).toThrow("Missing model pricing for managed billing");
+  });
+
+  test("managed billing accepts the GLM-5.2 registry model via its built-in default pricing", () => {
+    const settings = withEnv({
+      OPENGENI_ENVIRONMENT: "production",
+      OPENGENI_PRODUCT_ACCESS_MODE: "managed",
+      OPENGENI_PUBLIC_BASE_URL: "https://managed.example.test",
+      OPENGENI_BETTER_AUTH_SECRET: "managed-better-auth-secret",
+      OPENGENI_DELEGATION_SECRET: "managed-delegation-secret",
+      OPENGENI_RESEND_API_KEY: "re_test",
+      OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
+      OPENGENI_BILLING_MODE: "stripe",
+      OPENGENI_STRIPE_SECRET_KEY: "sk_test",
+      OPENGENI_STRIPE_WEBHOOK_SECRET: "whsec_test",
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    expect(configuredAllowedModels(settings)).toContain("accounts/fireworks/models/glm-5p2");
+  });
+});
+
+function withEnv<T>(env: NodeJS.ProcessEnv, fn: () => T): T {
+  const original = process.env;
+  process.env = { ...env };
+  try {
+    return fn();
+  } finally {
+    process.env = original;
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1454,10 +1454,30 @@ export const ClientAuthConfig = z.discriminatedUnion("mode", [
 ]);
 export type ClientAuthConfig = z.infer<typeof ClientAuthConfig>;
 
+/**
+ * A single host-exposed model + the provider that serves it, as surfaced to
+ * clients (SDK + React composer) by GET /v1/config/client. The wire `api`
+ * ("responses" | "chat") lets a client reason about provider capabilities; the
+ * provider id/label drive the picker's grouping. This mirrors the runtime's
+ * ConfiguredModel (packages/config) projected to the client-safe fields.
+ */
+export const ClientModel = z.object({
+  id: z.string(),
+  label: z.string(),
+  provider: z.string(),        // provider id
+  providerLabel: z.string(),
+  api: z.enum(["responses", "chat"]),
+  contextWindowTokens: z.number().int().positive().optional(),
+});
+export type ClientModel = z.infer<typeof ClientModel>;
+
 export const ClientConfig = z.object({
   deploymentRevision: z.string(),
   defaultModel: z.string(),
   allowedModels: z.array(z.string()).min(1),
+  // Richer model list (provider-grouped) for the picker. Defaults to [] for
+  // back-compat: callers that only read allowedModels are unaffected.
+  models: z.array(ClientModel).default([]),
   defaultReasoningEffort: ReasoningEffort,
   allowedReasoningEfforts: z.array(ReasoningEffort).min(1),
   mcpServers: z.array(z.object({

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -4,6 +4,7 @@ import {
   CapabilityCatalogResponse,
   CapabilityPack,
   ClientConfig,
+  ClientModel,
   ClientSessionEvent,
   CreateCapabilityCatalogItemRequest,
   CreateSocialConnectionRequest,
@@ -95,6 +96,52 @@ describe("contracts", () => {
     expect(payload.fileUploads.enabled).toBe(true);
     expect(payload.auth.mode).toBe("managedSession");
     expect(payload.mcpServers[0]?.id).toBe("opengeni");
+    // models defaults to [] for back-compat (callers reading only allowedModels
+    // are unaffected when the host hasn't populated the richer list).
+    expect(payload.models).toEqual([]);
+  });
+
+  test("round-trips the provider-grouped models list on client config", () => {
+    const models = [
+      {
+        id: "gpt-5.5",
+        label: "gpt-5.5",
+        provider: "openai",
+        providerLabel: "OpenAI",
+        api: "responses" as const,
+        contextWindowTokens: 1_050_000,
+      },
+      {
+        id: "accounts/fireworks/models/glm-5p2",
+        label: "GLM 5.2",
+        provider: "fireworks",
+        providerLabel: "Fireworks AI",
+        api: "chat" as const,
+        contextWindowTokens: 1_048_576,
+      },
+    ];
+    const payload = ClientConfig.parse({
+      deploymentRevision: "test-sha",
+      defaultModel: "gpt-5.5",
+      allowedModels: ["gpt-5.5", "accounts/fireworks/models/glm-5p2"],
+      models,
+      defaultReasoningEffort: "high",
+      allowedReasoningEfforts: ["low", "medium", "high"],
+      fileUploads: { enabled: true, maxSizeBytes: 5_000_000_000 },
+      productAccessMode: "managed",
+    });
+    expect(payload.models).toEqual(models);
+    expect(payload.models[1]?.api).toBe("chat");
+  });
+
+  test("rejects a client model with an unknown wire api", () => {
+    expect(() => ClientModel.parse({
+      id: "m",
+      label: "m",
+      provider: "p",
+      providerLabel: "P",
+      api: "grpc",
+    })).toThrow();
   });
 
   test("accepts checkout requests that use the caller default account", () => {

--- a/packages/react/demo/main.tsx
+++ b/packages/react/demo/main.tsx
@@ -7,6 +7,7 @@ import {
   MessageTimeline,
   OpenGeniProvider,
   SessionStatus,
+  useAvailableModels,
   useComposer,
   useOpenGeni,
   useScheduledTasks,
@@ -59,7 +60,16 @@ function OpsChannel() {
   const { client, workspaceId } = useOpenGeni();
   const { session } = useSession(MANAGER_SESSION_ID, { pollIntervalMs: 5000 });
   const { timeline, sessionStatus, connectionState } = useSessionEvents(MANAGER_SESSION_ID);
-  const composer = useComposer(MANAGER_SESSION_ID);
+  // Host-exposed models for the composer's <ModelPicker>; preselect the
+  // deployment default once it loads, then let the operator switch.
+  const { models, defaultModel } = useAvailableModels();
+  const [selectedModel, setSelectedModel] = useState<string | undefined>(undefined);
+  const model = selectedModel ?? defaultModel ?? undefined;
+  // Thread the chosen model into every send via sendExtras (evaluated at send
+  // time so it always reflects the current selection).
+  const composer = useComposer(MANAGER_SESSION_ID, {
+    sendExtras: () => (model ? { model } : {}),
+  });
   const status = sessionStatus ?? session?.status ?? null;
   // Surface the slash-command palette (type "/"): operator controls on this
   // session. The demo operator holds full control.
@@ -90,7 +100,16 @@ function OpsChannel() {
         onOpenSession={(sessionId) => window.alert(`Open worker session ${sessionId}`)}
       />
       <div className="shrink-0 px-4 pb-4 pt-1">
-        <ChatComposer composer={composer} status={status} placeholder="Message your infrastructure…" autoFocus commandContext={commandContext} />
+        <ChatComposer
+          composer={composer}
+          status={status}
+          placeholder="Message your infrastructure…"
+          autoFocus
+          commandContext={commandContext}
+          models={models}
+          selectedModel={model}
+          onSelectModel={setSelectedModel}
+        />
       </div>
     </section>
   );

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -11,6 +11,7 @@
 import type {
   BillingUsageResponse,
   CapabilityPack,
+  ClientConfig,
   CreateWorkspaceEnvironmentRequest,
   CreateWorkspaceRequest,
   EnablePackRequest,
@@ -118,6 +119,10 @@ export class MockOpenGeniClient implements SessionClientLike {
       this.buses.set(sessionId, bus);
     }
     return bus;
+  }
+
+  async getClientConfig(): Promise<ClientConfig> {
+    return CLIENT_CONFIG;
   }
 
   async getSession(_workspaceId: string, sessionId: string): Promise<Session> {
@@ -562,6 +567,35 @@ async function runOpsChannelScript(bus: SessionBus): Promise<void> {
 /* --- fixtures ------------------------------------------------------------------ */
 
 const ACCOUNT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+/**
+ * A two-provider deployment config so the demo composer exercises the
+ * <ModelPicker>: the built-in OpenAI provider serving gpt-5.5 (the default,
+ * `responses` wire API) plus a Fireworks AI registry provider serving GLM 5.2
+ * (`chat` wire API) — exactly the host config example in model-providers.md.
+ */
+const CLIENT_CONFIG: ClientConfig = {
+  deploymentRevision: "demo",
+  defaultModel: "gpt-5.5",
+  allowedModels: ["gpt-5.5", "accounts/fireworks/models/glm-5p2"],
+  models: [
+    { id: "gpt-5.5", label: "gpt-5.5", provider: "openai", providerLabel: "OpenAI", api: "responses" },
+    {
+      id: "accounts/fireworks/models/glm-5p2",
+      label: "GLM 5.2",
+      provider: "fireworks",
+      providerLabel: "Fireworks AI",
+      api: "chat",
+      contextWindowTokens: 1_048_576,
+    },
+  ],
+  defaultReasoningEffort: "medium",
+  allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+  mcpServers: [{ id: "opengeni", name: "OpenGeni" }],
+  fileUploads: { enabled: true, maxSizeBytes: 25 * 1024 * 1024 },
+  productAccessMode: "managed",
+  auth: { mode: "none" },
+};
 
 function fabricateTurn(sessionId: string, position: number, prompt: string): SessionTurn {
   const now = new Date(Date.now() - (10 - position) * 60_000).toISOString();

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -7,6 +7,8 @@ import type { OpenGeniClient } from "@opengeni/sdk";
  */
 export type SessionClientLike = Pick<
   OpenGeniClient,
+  // Deployment config (host-exposed models, auth, upload limits)
+  | "getClientConfig"
   // Sessions, events, composer
   | "getSession"
   | "listSessions"

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,4 +1,4 @@
-import type { SessionStatus } from "@opengeni/sdk";
+import type { ClientModel, SessionStatus } from "@opengeni/sdk";
 import { ArrowUpIcon, FileIcon, ImageIcon, LoaderCircleIcon, PaperclipIcon, SquareIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode } from "react";
@@ -12,6 +12,7 @@ import { useSlashCommands, type ConfirmState, type SlashCommandContext } from ".
 import { cn } from "../lib/cn";
 import { formatBytes } from "../lib/format";
 import { CommandPalette } from "./command-palette";
+import { ModelPicker } from "./model-picker";
 
 export type ChatComposerProps = {
   composer: ComposerState;
@@ -37,6 +38,20 @@ export type ChatComposerProps = {
    * Absent → no attachment UI renders and the composer behaves exactly as before.
    */
   attachments?: UseFileAttachmentsResult | undefined;
+  /**
+   * Opt-in model picker. When supplied (e.g. from {@link useAvailableModels}),
+   * the composer renders a {@link ModelPicker} at the start of `controlsStart`
+   * so the operator can choose which host-exposed model serves the next message.
+   * The host owns the selection (`selectedModel`/`onSelectModel`) and is
+   * responsible for threading it into the composer's `sendExtras` (typically
+   * `useComposer({ sendExtras: () => ({ model }) })`) so `composeSendInput`
+   * carries it. Absent → no picker renders and the composer behaves as before.
+   */
+  models?: ClientModel[] | undefined;
+  /** The currently selected model id (the picker's controlled value). */
+  selectedModel?: string | undefined;
+  /** Called with the chosen model id when the operator picks one. */
+  onSelectModel?: ((modelId: string) => void) | undefined;
   className?: string | undefined;
   /**
    * Slash-command palette. Defaults to the built-in {@link defaultCommands};
@@ -77,6 +92,9 @@ export function ChatComposer({
   header,
   onPaste,
   attachments,
+  models,
+  selectedModel,
+  onSelectModel,
   className,
   commands = defaultCommands,
   commandContext,
@@ -376,7 +394,7 @@ export function ChatComposer({
             />
           ) : (
             <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
-              {attachments || controlsStart ? (
+              {attachments || models || controlsStart ? (
                 <span className="flex min-w-0 items-center gap-1.5">
                   {attachments ? (
                     <>
@@ -402,6 +420,14 @@ export function ChatComposer({
                         <PaperclipIcon className="size-4" />
                       </button>
                     </>
+                  ) : null}
+                  {models ? (
+                    <ModelPicker
+                      models={models}
+                      value={selectedModel}
+                      onChange={(modelId) => onSelectModel?.(modelId)}
+                      disabled={disabled === true}
+                    />
                   ) : null}
                   {controlsStart}
                 </span>

--- a/packages/react/src/components/model-picker.tsx
+++ b/packages/react/src/components/model-picker.tsx
@@ -1,0 +1,87 @@
+import type { ClientModel } from "@opengeni/sdk";
+import { ChevronDownIcon } from "lucide-react";
+import { useId, useMemo } from "react";
+import { cn } from "../lib/cn";
+
+export type ModelPickerProps = {
+  /** The host-exposed models to choose from (typically {@link useAvailableModels}). */
+  models: ClientModel[];
+  /** Controlled selection — the model id, or undefined for "nothing chosen yet". */
+  value?: string | undefined;
+  /** Called with the chosen model id when the operator picks a row. */
+  onChange: (modelId: string) => void;
+  disabled?: boolean | undefined;
+  className?: string | undefined;
+};
+
+/**
+ * The model picker — a compact dropdown for the composer footer, grouping the
+ * host-exposed models by `providerLabel` (so "OpenAI" and "Fireworks AI" head
+ * their own sections) and showing each model's display `label`. A native
+ * `<select>` keeps it keyboard- and screen-reader-accessible for free and
+ * themes via the package's og-* tokens; the chevron is a decorative overlay.
+ *
+ * Controlled: the host owns `value`/`onChange` and threads the selection into
+ * the send path. Renders nothing when no models are exposed, so a single-model
+ * deployment shows no chrome.
+ */
+export function ModelPicker({ models, value, onChange, disabled, className }: ModelPickerProps) {
+  const selectId = useId();
+  // Group by provider, preserving first-seen order for both the providers and
+  // the models within each — the server already orders the list (default model
+  // and built-in provider first), so we must not re-sort it.
+  const groups = useMemo(() => {
+    const byProvider = new Map<string, { label: string; models: ClientModel[] }>();
+    for (const model of models) {
+      let group = byProvider.get(model.provider);
+      if (!group) {
+        group = { label: model.providerLabel, models: [] };
+        byProvider.set(model.provider, group);
+      }
+      group.models.push(model);
+    }
+    return [...byProvider.values()];
+  }, [models]);
+
+  if (models.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className={cn("relative inline-flex items-center", className)}>
+      <label htmlFor={selectId} className="sr-only">
+        Model
+      </label>
+      <select
+        id={selectId}
+        value={value ?? ""}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled === true}
+        aria-label="Model"
+        className={cn(
+          // Sized like the other footer controls; the chevron overlay needs the
+          // right padding so the value never collides with it.
+          "h-8 max-w-[180px] cursor-pointer appearance-none truncate rounded-og-md bg-transparent",
+          "py-0 pl-2 pr-6 text-[13px] text-og-fg-muted",
+          "transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
+          "focus:outline-none focus-visible:outline-none",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+        )}
+      >
+        {groups.map((group) => (
+          <optgroup key={group.label} label={group.label}>
+            {group.models.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.label}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+      <ChevronDownIcon
+        aria-hidden
+        className="pointer-events-none absolute right-1.5 size-3.5 text-og-fg-subtle"
+      />
+    </span>
+  );
+}

--- a/packages/react/src/hooks/use-available-models.ts
+++ b/packages/react/src/hooks/use-available-models.ts
@@ -1,0 +1,39 @@
+import type { ClientModel } from "@opengeni/sdk";
+import { useCallback } from "react";
+import { useOpenGeniClient, type ClientOverride } from "../provider";
+import { usePolledValue } from "./internal";
+
+export type UseAvailableModelsOptions = Pick<ClientOverride, "client"> & {
+  /** Refresh interval (ms). Off by default — the host model list rarely moves. */
+  pollIntervalMs?: number | undefined;
+  enabled?: boolean | undefined;
+};
+
+export type UseAvailableModelsResult = {
+  /** The provider-grouped models the host exposes (empty until loaded). */
+  models: ClientModel[];
+  /** The deployment's default model id, null until loaded. */
+  defaultModel: string | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * The host-exposed model list for a <ModelPicker>: fetches the deployment's
+ * public client config (`GET /v1/config/client`) and surfaces the richer
+ * provider-grouped `models` plus the `defaultModel` the picker should preselect.
+ * Deployment-scoped, so it only needs the client (no workspace).
+ */
+export function useAvailableModels(options: UseAvailableModelsOptions = {}): UseAvailableModelsResult {
+  const client = useOpenGeniClient(options);
+  const load = useCallback(async () => await client.getClientConfig(), [client]);
+  const state = usePolledValue(load, { pollIntervalMs: options.pollIntervalMs, enabled: options.enabled });
+  return {
+    models: state.data?.models ?? [],
+    defaultModel: state.data?.defaultModel ?? null,
+    loading: state.loading,
+    error: state.error,
+    refresh: state.refresh,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -43,6 +43,8 @@ export { useWorkspaces } from "./hooks/use-workspaces";
 export type { UseWorkspacesOptions, UseWorkspacesResult } from "./hooks/use-workspaces";
 export { useBillingUsage } from "./hooks/use-billing-usage";
 export type { UseBillingUsageOptions, UseBillingUsageResult } from "./hooks/use-billing-usage";
+export { useAvailableModels } from "./hooks/use-available-models";
+export type { UseAvailableModelsOptions, UseAvailableModelsResult } from "./hooks/use-available-models";
 
 // Pending-approvals projection
 export { approvalsFromRequiresAction, projectPendingApprovals } from "./approvals";
@@ -103,6 +105,8 @@ export type { CommandPaletteProps } from "./components/command-palette";
 // Components
 export { ChatComposer } from "./components/chat-composer";
 export type { ChatComposerProps } from "./components/chat-composer";
+export { ModelPicker } from "./components/model-picker";
+export type { ModelPickerProps } from "./components/model-picker";
 export { MessageTimeline } from "./components/message-timeline";
 export type { MessageTimelineProps } from "./components/message-timeline";
 export { SessionStatus, StatusDot, SESSION_STATUS_META } from "./components/session-status";

--- a/packages/react/test/composer.test.ts
+++ b/packages/react/test/composer.test.ts
@@ -15,6 +15,18 @@ describe("composeSendInput", () => {
     });
   });
 
+  test("carries the model selected in the picker (deferred extras read the current selection)", () => {
+    // Mirrors the ChatComposer + <ModelPicker> wiring: the host holds the
+    // selected model in state and threads it via a sendExtras closure, so the
+    // input composed at send time carries whichever model is selected then.
+    let selectedModel = "gpt-5.5";
+    const sendExtras = () => ({ model: selectedModel });
+    expect(composeSendInput("hi", "ce-a", sendExtras).model).toBe("gpt-5.5");
+    // Operator switches the picker to GLM 5.2 before the next send.
+    selectedModel = "accounts/fireworks/models/glm-5p2";
+    expect(composeSendInput("hi again", "ce-b", sendExtras).model).toBe("accounts/fireworks/models/glm-5p2");
+  });
+
   test("evaluates function extras at send time and never lets them override text or clientEventId", () => {
     const extras = () => ({
       reasoningEffort: "low" as const,

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -9,6 +9,7 @@ import type { SessionEvent, SessionTurn, WorkspaceEnvironment } from "@opengeni/
 import { registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, fakeGoal, fakeTurn, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import { OpenGeniApiError } from "@opengeni/sdk";
+import { useAvailableModels } from "../src/hooks/use-available-models";
 import { useBillingUsage } from "../src/hooks/use-billing-usage";
 import { useComposer } from "../src/hooks/use-composer";
 import { useEnvironments } from "../src/hooks/use-environments";
@@ -598,6 +599,55 @@ describe("useBillingUsage", () => {
     expect(seen).toEqual([{ accountId: "acc-1", workspaceId: WORKSPACE_ID }]);
     expect(hook.result.current.balance?.balanceMicros).toBe(12_000_000);
     expect(hook.result.current.usage).toHaveLength(1);
+    await hook.unmount();
+  });
+});
+
+describe("useAvailableModels", () => {
+  test("returns the host-exposed models and the default model from getClientConfig", async () => {
+    let calls = 0;
+    const client = fakeClient({
+      getClientConfig: async () => {
+        calls += 1;
+        return {
+          deploymentRevision: "rev-1",
+          defaultModel: "gpt-5.5",
+          allowedModels: ["gpt-5.5", "accounts/fireworks/models/glm-5p2"],
+          models: [
+            { id: "gpt-5.5", label: "gpt-5.5", provider: "openai", providerLabel: "OpenAI", api: "responses" },
+            {
+              id: "accounts/fireworks/models/glm-5p2",
+              label: "GLM 5.2",
+              provider: "fireworks",
+              providerLabel: "Fireworks AI",
+              api: "chat",
+            },
+          ],
+          defaultReasoningEffort: "medium",
+          allowedReasoningEfforts: ["medium"],
+          mcpServers: [],
+          fileUploads: { enabled: true, maxSizeBytes: 1024 },
+          productAccessMode: "managed",
+          auth: { mode: "none" },
+        } as never;
+      },
+    });
+    const hook = await renderHook(() => useAvailableModels({ client }), undefined);
+    await flush();
+    expect(calls).toBe(1);
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.defaultModel).toBe("gpt-5.5");
+    expect(hook.result.current.models.map((model) => model.label)).toEqual(["gpt-5.5", "GLM 5.2"]);
+    expect(hook.result.current.models.map((model) => model.providerLabel)).toEqual(["OpenAI", "Fireworks AI"]);
+    await hook.unmount();
+  });
+
+  test("starts with empty models and a null default before the config loads", async () => {
+    const client = fakeClient({ getClientConfig: async () => new Promise(() => {}) as never });
+    const hook = await renderHook(() => useAvailableModels({ client }), undefined);
+    expect(hook.result.current.loading).toBe(true);
+    expect(hook.result.current.models).toEqual([]);
+    expect(hook.result.current.defaultModel).toBeNull();
     await hook.unmount();
   });
 });

--- a/packages/react/test/model-picker.test.tsx
+++ b/packages/react/test/model-picker.test.tsx
@@ -1,0 +1,140 @@
+/* ----------------------------------------------------------------------------
+   <ModelPicker> + ChatComposer's opt-in `models` prop: the provider-grouped
+   dropdown, its controlled value/onChange, and the composer footer wiring that
+   stays backward-compatible when `models` is absent.
+   -------------------------------------------------------------------------- */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import type { ClientModel } from "@opengeni/sdk";
+import { createRoot, type Root } from "react-dom/client";
+import { ChatComposer } from "../src/components/chat-composer";
+import { ModelPicker } from "../src/components/model-picker";
+import type { ComposerState } from "../src/hooks/use-composer";
+import { registerDom } from "./render-hook";
+
+registerDom();
+
+let mounted: { root: Root; container: HTMLElement } | null = null;
+
+afterEach(async () => {
+  if (mounted) {
+    const current = mounted;
+    mounted = null;
+    await act(async () => {
+      current.root.unmount();
+    });
+    current.container.remove();
+  }
+});
+
+const MODELS: ClientModel[] = [
+  { id: "gpt-5.5", label: "gpt-5.5", provider: "openai", providerLabel: "OpenAI", api: "responses" },
+  { id: "gpt-5.4", label: "gpt-5.4", provider: "openai", providerLabel: "OpenAI", api: "responses" },
+  {
+    id: "accounts/fireworks/models/glm-5p2",
+    label: "GLM 5.2",
+    provider: "fireworks",
+    providerLabel: "Fireworks AI",
+    api: "chat",
+  },
+];
+
+function makeComposer(overrides: Partial<ComposerState> = {}): ComposerState {
+  return {
+    value: "hello",
+    setValue: () => {},
+    send: async () => true,
+    sending: false,
+    canSend: true,
+    mode: "queue",
+    setMode: () => {},
+    interrupt: async () => {},
+    interrupting: false,
+    error: null,
+    clearError: () => {},
+    ...overrides,
+  };
+}
+
+async function mount(node: React.ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+  });
+  mounted = { root, container };
+  return container;
+}
+
+function picker(container: HTMLElement): HTMLSelectElement | null {
+  return container.querySelector<HTMLSelectElement>('select[aria-label="Model"]');
+}
+
+describe("ModelPicker", () => {
+  test("renders one optgroup per provider, in first-seen order, with model labels", async () => {
+    const container = await mount(<ModelPicker models={MODELS} onChange={() => {}} />);
+    const select = picker(container)!;
+    const groups = [...select.querySelectorAll("optgroup")];
+    expect(groups.map((group) => group.label)).toEqual(["OpenAI", "Fireworks AI"]);
+    // OpenAI group holds its two models; Fireworks group holds GLM 5.2.
+    expect([...groups[0]!.querySelectorAll("option")].map((option) => option.textContent)).toEqual(["gpt-5.5", "gpt-5.4"]);
+    expect([...groups[1]!.querySelectorAll("option")].map((option) => option.value)).toEqual([
+      "accounts/fireworks/models/glm-5p2",
+    ]);
+  });
+
+  test("reflects the controlled value", async () => {
+    const container = await mount(<ModelPicker models={MODELS} value="gpt-5.4" onChange={() => {}} />);
+    expect(picker(container)!.value).toBe("gpt-5.4");
+  });
+
+  test("calls onChange with the chosen model id", async () => {
+    const chosen: string[] = [];
+    const container = await mount(<ModelPicker models={MODELS} value="gpt-5.5" onChange={(id) => chosen.push(id)} />);
+    const select = picker(container)!;
+    await act(async () => {
+      select.value = "accounts/fireworks/models/glm-5p2";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(chosen).toEqual(["accounts/fireworks/models/glm-5p2"]);
+  });
+
+  test("renders nothing when no models are exposed", async () => {
+    const container = await mount(<ModelPicker models={[]} onChange={() => {}} />);
+    expect(picker(container)).toBeNull();
+  });
+});
+
+describe("ChatComposer model picker", () => {
+  test("with no models prop, no picker renders (backward compatible)", async () => {
+    const container = await mount(<ChatComposer composer={makeComposer()} />);
+    expect(picker(container)).toBeNull();
+  });
+
+  test("renders the picker in the footer when models is present", async () => {
+    const container = await mount(
+      <ChatComposer composer={makeComposer()} models={MODELS} selectedModel="gpt-5.5" onSelectModel={() => {}} />,
+    );
+    expect(picker(container)).toBeTruthy();
+    expect(picker(container)!.value).toBe("gpt-5.5");
+  });
+
+  test("threads the selection out through onSelectModel", async () => {
+    const chosen: string[] = [];
+    const container = await mount(
+      <ChatComposer
+        composer={makeComposer()}
+        models={MODELS}
+        selectedModel="gpt-5.5"
+        onSelectModel={(id) => chosen.push(id)}
+      />,
+    );
+    const select = picker(container)!;
+    await act(async () => {
+      select.value = "accounts/fireworks/models/glm-5p2";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(chosen).toEqual(["accounts/fireworks/models/glm-5p2"]);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,5 @@
-import type { Settings } from "@opengeni/config";
-import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, collectSandboxEnvironment, contextServerCompactThreshold, parseExposedPorts, resolveContextCompactionMode, sandboxLifecycleHookIds } from "@opengeni/config";
+import type { ConfiguredModel, ContextCompactionMode, ModelProviderApi, ResolvedModelProvider, Settings } from "@opengeni/config";
+import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, collectSandboxEnvironment, contextServerCompactThreshold, parseExposedPorts, resolveContextCompactionMode, resolveModelProvider, sandboxLifecycleHookIds } from "@opengeni/config";
 import { isClearedRunStateBlob, signDelegatedAccessToken, type Permission, type ReasoningEffort, type ResourceRef, type SessionEventType, type ToolRef } from "@opengeni/contracts";
 import {
   Agent,
@@ -7,6 +7,17 @@ import {
   connectMcpServers,
   MaxTurnsExceededError,
   MCPServerStreamableHttp,
+  // Provider-bound Model instances. Both are re-exported from
+  // @openai/agents-openai via `export * from '@openai/agents-openai'` in
+  // @openai/agents' index (0.11.6), so the multi-provider routing imports them
+  // from the same entrypoint as the rest of the SDK rather than reaching into
+  // the openai subpackage. OpenAIChatCompletionsModel speaks /v1/chat/completions
+  // (the registry "chat" wire API, e.g. Fireworks); OpenAIResponsesModel speaks
+  // /v1/responses (the built-in OpenAI/Azure "responses" wire API). Both bind a
+  // model id to a specific OpenAI client, which is what routes a turn to its
+  // provider without touching the global default client.
+  OpenAIChatCompletionsModel,
+  OpenAIResponsesModel,
   RunState,
   isOpenAIResponsesRawModelStreamEvent,
   run,
@@ -66,6 +77,13 @@ import { enforceInputBudget, estimateItemTokens } from "./context-compaction";
 
 export { sanitizeHistoryItemsForModel } from "./history-sanitizer";
 export type { HistoryItem } from "./history-sanitizer";
+
+// The provider-bound Model classes used by buildModelInstance/resolveTurnModel.
+// Re-exported so callers (and routing tests) can assert which wire API a
+// resolved turn was bound to — OpenAIChatCompletionsModel for registry "chat"
+// providers (Fireworks), OpenAIResponsesModel for the built-in "responses" path
+// — without reaching into @openai/agents directly.
+export { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
 
 export {
   planCompaction,
@@ -168,6 +186,11 @@ export type SandboxFileDownload = {
 
 export type OpenGeniRuntime = {
   configure: (settings: Settings) => void;
+  // Multi-provider per-turn model routing. Returns the resolved provider, its
+  // (cached) client, the provider-bound Model instance, and the configured-model
+  // shape; null when the turn's model is not in the registry, so the caller
+  // falls back to the legacy global-client path (settings.openaiModel).
+  resolveTurnModel: (settings: Settings, modelId: string) => ReturnType<typeof resolveTurnModel>;
   buildAgent: (settings: Settings, resources: ResourceRef[], options?: BuildAgentOptions) => Agent<any, any>;
   prepareTools: (settings: Settings, tools: ToolRef[], options?: PrepareToolsOptions) => Promise<PreparedAgentTools>;
   prepareInput: (agent: Agent<any, any>, input: AgentSegmentInput, options?: PrepareInputOptions) => Promise<PreparedAgentInput>;
@@ -183,6 +206,11 @@ export type ProductionRuntimeOverrides = {
 export function createProductionAgentRuntime(overrides: ProductionRuntimeOverrides = {}): OpenGeniRuntime {
   return {
     configure: configureOpenAI,
+    // A test/override model shadows the registry routing entirely (the scripted
+    // model used in worker tests is not in any provider's allow-list), so when
+    // one is supplied resolveTurnModel reports "no resolution" and the caller
+    // keeps the legacy global-client path with the override model.
+    resolveTurnModel: (settings, modelId) => (overrides.model ? null : resolveTurnModel(settings, modelId)),
     buildAgent: (settings, resources, options) => buildOpenGeniAgent(settings, resources, {
       ...options,
       ...(overrides.model ? { model: overrides.model } : {}),
@@ -225,6 +253,79 @@ export function buildOpenAIClientFromSettings(settings: Settings): OpenAI {
   });
 }
 
+/**
+ * One OpenAI client per resolved provider id, built lazily and cached for the
+ * process. The built-in openai/azure provider reuses
+ * buildOpenAIClientFromSettings verbatim (so its Azure AD/api-version/base-URL
+ * construction stays byte-for-byte identical to configureOpenAI); a registry
+ * provider gets a plain client pointed at its base URL with its resolved key,
+ * the shared maxRetries budget, and its declared defaultQuery/defaultHeaders.
+ * Caching by provider.id keeps concurrent multi-provider turns sharing one
+ * connection pool per provider rather than reconstructing a client per turn.
+ */
+const providerClientCache = new Map<string, OpenAI>();
+
+export function buildProviderClient(provider: ResolvedModelProvider, settings: Settings): OpenAI {
+  const cached = providerClientCache.get(provider.id);
+  if (cached) {
+    return cached;
+  }
+  const client = provider.builtin
+    ? buildOpenAIClientFromSettings(settings)
+    // ResolvedModelProvider.apiKey is already the resolved key (configuredProviders
+    // ran resolveProviderApiKey at config time, collapsing apiKey/apiKeyEnv), so it
+    // is passed straight through here rather than re-resolved.
+    : new OpenAI({
+      ...(provider.apiKey ? { apiKey: provider.apiKey } : {}),
+      ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
+      maxRetries: settings.openaiMaxRetries,
+      ...(provider.defaultQuery ? { defaultQuery: provider.defaultQuery } : {}),
+      ...(provider.defaultHeaders ? { defaultHeaders: provider.defaultHeaders } : {}),
+    });
+  providerClientCache.set(provider.id, client);
+  return client;
+}
+
+/**
+ * Bind a model id to a provider's OpenAI client as an @openai/agents `Model`
+ * instance, choosing the wire API by the provider's declared `api`: the "chat"
+ * providers (e.g. Fireworks) get an OpenAIChatCompletionsModel that speaks
+ * /v1/chat/completions, the "responses" providers (built-in OpenAI/Azure) get
+ * an OpenAIResponsesModel that speaks /v1/responses. Passing this Model into
+ * the agent is what routes a turn to its provider without mutating the global
+ * default client.
+ */
+export function buildModelInstance(provider: ResolvedModelProvider, client: OpenAI, modelId: string): Model {
+  return provider.api === "chat"
+    ? new OpenAIChatCompletionsModel(client, modelId)
+    : new OpenAIResponsesModel(client, modelId);
+}
+
+/**
+ * Resolved per-turn model routing: the provider that serves `modelId`, its
+ * (cached) OpenAI client, the provider-bound `Model` instance, and the
+ * configured-model shape (label/api/contextWindow/reasoningEffort/hostedWebSearch).
+ * Returns null when the model is not in the registry — the caller then falls
+ * back to the legacy global-client path (settings.openaiModel + the default
+ * client configured by configureOpenAI), preserved byte-for-byte.
+ */
+export function resolveTurnModel(
+  settings: Settings,
+  modelId: string,
+): { provider: ResolvedModelProvider; client: OpenAI; model: Model; configured: ConfiguredModel } | null {
+  const resolved = resolveModelProvider(settings, modelId);
+  if (!resolved) {
+    return null;
+  }
+  const client = buildProviderClient(resolved.provider, settings);
+  return {
+    provider: resolved.provider,
+    client,
+    model: buildModelInstance(resolved.provider, client, resolved.model.id),
+    configured: resolved.model,
+  };
+}
+
 export function configureOpenAI(settings: Settings): void {
   setOpenAIResponsesTransport(settings.openaiResponsesTransport);
   if (settings.openaiProvider === "azure") {
@@ -241,24 +342,51 @@ export function configureOpenAI(settings: Settings): void {
 
 /**
  * Run the compaction summarizer as one plain, tool-less, non-streaming model
- * call against the configured provider. `system`/`user` come from
+ * call against the resolved provider. `system`/`user` come from
  * buildCompactionMessages. Returns the trimmed summary text, or null on any
  * failure (the caller treats a failed summarize as "skip compaction this turn"
  * — never fatal). The call deliberately does NOT request reasoning encryption,
  * tools, or server-side compaction; it is a self-contained summarize.
+ *
+ * Provider-aware: the summary always runs on the SAME provider that serves the
+ * turn (registry providers can't summarize through OpenAI/Azure, and vice
+ * versa). `api: "chat"` providers (Fireworks) speak /v1/chat/completions, where
+ * the summary is choices[0].message.content; `api: "responses"` (the default,
+ * built-in OpenAI/Azure) speaks /v1/responses as before. When no client/api is
+ * supplied it falls back to the built-in OpenAI/Azure Responses path so the
+ * legacy global-client callers are byte-for-byte unchanged. store:false is set
+ * only on the OpenAI-platform Responses path (Azure rejects it; chat ignores it).
  */
 export async function summarizeForCompaction(
   settings: Settings,
   messages: { system: string; user: string },
-  options: { client?: OpenAI; maxOutputTokens?: number; model?: string } = {},
+  options: { client?: OpenAI; api?: ModelProviderApi; maxOutputTokens?: number; model?: string } = {},
 ): Promise<string | null> {
   const client = options.client ?? buildOpenAIClientFromSettings(settings);
+  const api = options.api ?? "responses";
   const model = options.model ?? settings.openaiModel;
+  const maxTokens = options.maxOutputTokens ?? settings.contextSummaryMaxTokens;
   try {
+    if (api === "chat") {
+      const completion = await client.chat.completions.create({
+        model,
+        max_tokens: maxTokens,
+        messages: [
+          { role: "system", content: messages.system },
+          { role: "user", content: messages.user },
+        ],
+      } as any);
+      const text = (completion as { choices?: Array<{ message?: { content?: unknown } }> }).choices?.[0]?.message?.content;
+      const trimmed = typeof text === "string" ? text.trim() : "";
+      return trimmed.length > 0 ? trimmed : null;
+    }
     const response = await client.responses.create({
       model,
+      // store:false is the OpenAI-platform-only storeless precondition; Azure
+      // rejects it. The summarizer's resolved client is OpenAI/Azure on the
+      // built-in path (api "responses"), so gate it on the built-in provider.
       ...(settings.openaiProvider === "azure" ? {} : { store: false }),
-      max_output_tokens: options.maxOutputTokens ?? settings.contextSummaryMaxTokens,
+      max_output_tokens: maxTokens,
       input: [
         { role: "system", content: messages.system },
         { role: "user", content: messages.user },
@@ -273,7 +401,14 @@ export async function summarizeForCompaction(
   }
 }
 
-/** Pull the assistant text out of a Responses API result, shape-tolerant. */
+/**
+ * Pull the assistant text out of a Responses API result, shape-tolerant. Only
+ * `role === "assistant"` message items contribute: a provider whose Responses
+ * endpoint echoes the user input back as an output `message` item (Fireworks'
+ * beta /v1/responses does exactly this — see docs/model-providers.md) would
+ * otherwise corrupt the summary with the prompt it was given. The OpenAI/Azure
+ * Responses API only emits assistant messages, so this guard is a no-op there.
+ */
 export function extractResponseOutputText(response: unknown): string {
   if (!response || typeof response !== "object") {
     return "";
@@ -294,6 +429,10 @@ export function extractResponseOutputText(response: unknown): string {
     if ((item as { type?: unknown }).type !== "message") {
       continue;
     }
+    // Read assistant messages only; skip any input-echo (role "user"/"system").
+    if ((item as { role?: unknown }).role !== "assistant") {
+      continue;
+    }
     const content = (item as { content?: unknown }).content;
     if (!Array.isArray(content)) {
       continue;
@@ -310,6 +449,30 @@ export function extractResponseOutputText(response: unknown): string {
 export type BuildAgentOptions = {
   model?: Model;
   reasoningEffort?: ReasoningEffort;
+  // Per-turn gating overrides for the multi-provider path. Each defaults to
+  // today's settings-derived behaviour when omitted, so the legacy
+  // global-client callers (no model resolution) are byte-for-byte unchanged.
+  //
+  // - compactionMode: the resolved context-compaction path. Drives whether the
+  //   sandbox `compaction()` capability is attached AND whether `store: false`
+  //   is set (the OpenAI-platform-only storeless precondition). Registry
+  //   providers resolve to "client", so neither is applied to them.
+  //   Default: resolveContextCompactionMode(settings).
+  // - hostedWebSearch: attach the hosted web_search tool. Only the providers
+  //   that actually execute it (built-in OpenAI/Azure; a registry model that
+  //   opts in) should get it — Fireworks accepts the param but no-ops it, which
+  //   would hand the agent a dead tool. Default: settings.webSearchEnabled.
+  // - encryptedReasoning: round-trip reasoning.encrypted_content via
+  //   providerData.include. Only the Responses API carries it; the chat wire
+  //   API has no such field, so registry "chat" providers turn it off.
+  //   Default: settings.openaiReasoningEncryptedContent.
+  // - contextWindowTokens: the model's effective window, used to derive the
+  //   server-path compaction threshold. A registry model can declare its own
+  //   (e.g. GLM 5.2's 1,048,576). Default: settings.contextWindowTokens.
+  compactionMode?: ContextCompactionMode;
+  hostedWebSearch?: boolean;
+  encryptedReasoning?: boolean;
+  contextWindowTokens?: number;
   sandboxEnvironment?: Record<string, string>;
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
@@ -408,14 +571,25 @@ const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
 
 export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[], options: BuildAgentOptions = {}): Agent<any, any> {
+  // Resolved per-turn gating. Each override defaults to today's settings-derived
+  // behaviour, so the legacy global-client callers (no resolved model) build the
+  // exact same agent as before; the multi-provider worker path passes the
+  // resolved provider's mode/api/window/web-search instead.
+  const compactionMode = options.compactionMode ?? resolveContextCompactionMode(settings);
+  const hostedWebSearch = options.hostedWebSearch ?? settings.webSearchEnabled;
+  const encryptedReasoning = options.encryptedReasoning ?? settings.openaiReasoningEncryptedContent;
+  const contextWindowTokens = options.contextWindowTokens ?? settings.contextWindowTokens;
   // Native hosted tools attached to every constructed agent. webSearchEnabled
-  // is ON by default and provider-unconditional (the live Azure Responses path
-  // executes the hosted web_search tool). The SDK merges this explicit `tools`
-  // array with the MCP-server tools (Agent.getAllTools = [...mcpTools, ...tools])
-  // and, on the SandboxAgent path, with the sandbox capability tools
-  // (prepareSandboxAgent: tools = [...agent.tools, ...capability.tools()]), so
-  // hosted web_search coexists with both rather than overriding them.
-  const hostedTools = settings.webSearchEnabled ? [webSearchTool()] : [];
+  // is ON by default and provider-unconditional on the built-in path (the live
+  // Azure Responses path executes the hosted web_search tool); a registry model
+  // only gets it when it opts in (resolved via options.hostedWebSearch), since
+  // a provider that no-ops the param would hand the agent a dead tool. The SDK
+  // merges this explicit `tools` array with the MCP-server tools
+  // (Agent.getAllTools = [...mcpTools, ...tools]) and, on the SandboxAgent path,
+  // with the sandbox capability tools (prepareSandboxAgent: tools =
+  // [...agent.tools, ...capability.tools()]), so hosted web_search coexists with
+  // both rather than overriding them.
+  const hostedTools = hostedWebSearch ? [webSearchTool()] : [];
   const baseConfig = {
     name: "OpenGeni Agent",
     model: options.model ?? settings.openaiModel,
@@ -438,15 +612,19 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
       // the request rather than being anchored to a stored response. OpenGeni
       // already runs storeless (provider item ids stripped, encrypted reasoning
       // round-tripped), so this is consistent with the existing design and
-      // only set where the server compaction capability is attached.
-      ...(resolveContextCompactionMode(settings) === "server" ? { store: false } : {}),
+      // only set where the server compaction capability is attached. Gated on
+      // the RESOLVED compaction mode (registry providers resolve to "client",
+      // so they never carry store:false).
+      ...(compactionMode === "server" ? { store: false } : {}),
       // Round-trip the encrypted reasoning payload with every call so chains
       // of thought survive without provider-side response storage (which is
       // what stripped provider item ids opt us out of — see
       // stripProviderItemIds). providerData.include replaces any
       // tool-derived include entries; OpenGeni's tools are MCP/sandbox
-      // function tools, which contribute none.
-      ...(settings.openaiReasoningEncryptedContent
+      // function tools, which contribute none. Gated on the resolved
+      // encryptedReasoning flag: the chat wire API has no encrypted_content
+      // field, so registry "chat" providers turn it off.
+      ...(encryptedReasoning
         ? { providerData: { include: ["reasoning.encrypted_content"] } }
         : {}),
     },
@@ -467,7 +645,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     ...baseConfig,
     defaultManifest: buildManifest(settings, resources, options.sandboxEnvironment, options.fileResourceDownloads),
     ...(runAs ? { runAs } : {}),
-    capabilities: buildAgentCapabilities(settings, options.packSkills ?? []),
+    capabilities: buildAgentCapabilities(settings, options.packSkills ?? [], { compactionMode, contextWindowTokens }),
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
   agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources));
@@ -490,12 +668,24 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
  * is absent from the SDK's hardcoded context-window map and would otherwise hit
  * the wrong 240k fallback — gets the correct threshold. The SDK has no
  * window-registration API, so an explicit threshold is the only way to fix it.
+ *
+ * The resolved compaction mode and the effective context window are now passed
+ * IN (the multi-provider caller resolves them per provider/model) rather than
+ * re-derived from settings here. Both default to the settings-derived value so
+ * callers that don't route per-model (and the existing tests) keep today's exact
+ * behaviour; the effective window only changes the server-path threshold when a
+ * resolved model declares its own contextWindowTokens.
  */
-export function buildAgentCapabilities(settings: Settings, packSkills: PackSkill[]): ReturnType<typeof Capabilities.default> {
-  const mode = resolveContextCompactionMode(settings);
+export function buildAgentCapabilities(
+  settings: Settings,
+  packSkills: PackSkill[],
+  options: { compactionMode?: ContextCompactionMode; contextWindowTokens?: number } = {},
+): ReturnType<typeof Capabilities.default> {
+  const mode = options.compactionMode ?? resolveContextCompactionMode(settings);
+  const contextWindowTokens = options.contextWindowTokens ?? settings.contextWindowTokens;
   const caps: ReturnType<typeof Capabilities.default> = [filesystem(), shell()];
   if (mode === "server") {
-    caps.push(compaction({ policy: new StaticCompactionPolicy(contextServerCompactThreshold(settings)) }));
+    caps.push(compaction({ policy: new StaticCompactionPolicy(contextServerCompactThreshold({ ...settings, contextWindowTokens })) }));
   }
   caps.push(skills({ lazyFrom: lazySkillSourceWithPackSkills(packSkills) }));
   return caps;

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -524,14 +524,28 @@ describe("extractResponseOutputText", () => {
   test("reads output_text directly", () => {
     expect(extractResponseOutputText({ output_text: "hello" })).toBe("hello");
   });
-  test("reads message content parts", () => {
+  test("reads assistant message content parts", () => {
     const response = {
       output: [
         { type: "reasoning", content: [] },
-        { type: "message", content: [{ type: "output_text", text: "part-A" }, { type: "output_text", text: "-B" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "part-A" }, { type: "output_text", text: "-B" }] },
       ],
     };
     expect(extractResponseOutputText(response)).toBe("part-A-B");
+  });
+  test("skips input-echo message items (role !== assistant) so a provider that echoes the prompt back can't corrupt the summary", () => {
+    // Fireworks' beta /v1/responses echoes the user input back as an output
+    // `message` item (see docs/model-providers.md); only the assistant message
+    // is the real completion. The guard must read the assistant message and drop
+    // the echoed user/system ones.
+    const response = {
+      output: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "ECHOED PROMPT" }] },
+        { type: "message", role: "system", content: [{ type: "input_text", text: "SYSTEM ECHO" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "real-summary" }] },
+      ],
+    };
+    expect(extractResponseOutputText(response)).toBe("real-summary");
   });
   test("returns empty string for unknown shapes", () => {
     expect(extractResponseOutputText(null)).toBe("");

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
+import { configuredProviders, resolveModelProvider, type ResolvedModelProvider } from "@opengeni/config";
+import { testSettings } from "@opengeni/testing";
+import OpenAI from "openai";
+import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, resolveTurnModel } from "../src/index";
+
+// A host exposing the built-in OpenAI provider plus Fireworks (the `chat` wire
+// API) serving GLM 5.2, mirroring the canonical example in
+// docs/model-providers.md. webSearch and encrypted reasoning are OFF for the
+// Fireworks model (hostedWebSearch defaults false; chat has no encrypted
+// reasoning), which is exactly the gating the runtime must apply.
+function multiProviderSettings(overrides: Parameters<typeof testSettings>[0] = {}) {
+  return testSettings({
+    sandboxBackend: "none",
+    openaiProvider: "openai",
+    openaiModel: "gpt-5.5",
+    openaiAllowedModels: "gpt-5.5,gpt-5.4",
+    modelProvidersJson: JSON.stringify([
+      {
+        id: "fireworks",
+        label: "Fireworks AI",
+        api: "chat",
+        baseUrl: "https://api.fireworks.ai/inference/v1",
+        apiKey: "fw-test-key",
+        defaultHeaders: { "x-fireworks": "on" },
+        models: [
+          {
+            id: "accounts/fireworks/models/glm-5p2",
+            label: "GLM 5.2",
+            contextWindowTokens: 1_048_576,
+            reasoningEffort: true,
+            hostedWebSearch: false,
+          },
+        ],
+      },
+    ]),
+    ...overrides,
+  });
+}
+
+const FIREWORKS_MODEL = "accounts/fireworks/models/glm-5p2";
+
+describe("buildModelInstance — chat vs responses Model selection per provider api", () => {
+  const client = new OpenAI({ apiKey: "test" });
+
+  test("a chat provider yields an OpenAIChatCompletionsModel", () => {
+    const provider: ResolvedModelProvider = {
+      id: "fireworks",
+      label: "Fireworks AI",
+      api: "chat",
+      builtin: false,
+      compactionMode: "client",
+    };
+    const model = buildModelInstance(provider, client, FIREWORKS_MODEL);
+    expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
+    expect(model).not.toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("a responses provider yields an OpenAIResponsesModel", () => {
+    const provider: ResolvedModelProvider = {
+      id: "openai",
+      label: "OpenAI",
+      api: "responses",
+      builtin: true,
+      compactionMode: "server",
+    };
+    const model = buildModelInstance(provider, client, "gpt-5.5");
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    expect(model).not.toBeInstanceOf(OpenAIChatCompletionsModel);
+  });
+});
+
+describe("buildProviderClient", () => {
+  test("a registry provider gets a client pointed at its base URL with its key/headers, cached by id", () => {
+    const settings = multiProviderSettings();
+    const provider = configuredProviders(settings).find((candidate) => candidate.id === "fireworks")!;
+    expect(provider).toBeDefined();
+    const client = buildProviderClient(provider, settings);
+    expect(client.baseURL).toBe("https://api.fireworks.ai/inference/v1");
+    expect(client.apiKey).toBe("fw-test-key");
+    expect(client.maxRetries).toBe(settings.openaiMaxRetries);
+    // One client per provider id (module-level cache).
+    expect(buildProviderClient(provider, settings)).toBe(client);
+  });
+});
+
+describe("resolveTurnModel", () => {
+  test("returns null for a model not in any provider (legacy global-client fallback)", () => {
+    expect(resolveTurnModel(multiProviderSettings(), "model-that-does-not-exist")).toBeNull();
+  });
+
+  test("resolves a registry model to its provider, client, chat Model, and configured shape", () => {
+    const resolved = resolveTurnModel(multiProviderSettings(), FIREWORKS_MODEL);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.provider.id).toBe("fireworks");
+    expect(resolved!.provider.api).toBe("chat");
+    expect(resolved!.provider.compactionMode).toBe("client");
+    expect(resolved!.client.baseURL).toBe("https://api.fireworks.ai/inference/v1");
+    expect(resolved!.model).toBeInstanceOf(OpenAIChatCompletionsModel);
+    expect(resolved!.configured.id).toBe(FIREWORKS_MODEL);
+    expect(resolved!.configured.contextWindowTokens).toBe(1_048_576);
+    expect(resolved!.configured.hostedWebSearch).toBe(false);
+  });
+
+  test("resolves the built-in model to the responses provider + an OpenAIResponsesModel", () => {
+    const resolved = resolveTurnModel(multiProviderSettings(), "gpt-5.5");
+    expect(resolved).not.toBeNull();
+    expect(resolved!.provider.id).toBe("openai");
+    expect(resolved!.provider.api).toBe("responses");
+    expect(resolved!.model).toBeInstanceOf(OpenAIResponsesModel);
+  });
+});
+
+// The agent the worker builds for a Fireworks turn passes the resolved gating
+// into buildOpenGeniAgent. These tests pin that the gating actually changes the
+// constructed agent the way the multi-provider contract requires.
+function webSearchHostedTools(agent: ReturnType<typeof buildOpenGeniAgent>): Array<Record<string, unknown>> {
+  return ((agent as { tools?: Array<Record<string, unknown>> }).tools ?? []).filter((tool) =>
+    tool.type === "hosted_tool"
+    && (tool.providerData as { type?: unknown } | undefined)?.type === "web_search");
+}
+
+describe("multi-provider gating in buildOpenGeniAgent", () => {
+  test("a resolved chat provider turn: no web_search tool, no encrypted reasoning, no server store", () => {
+    const settings = multiProviderSettings();
+    const resolved = resolveTurnModel(settings, FIREWORKS_MODEL)!;
+    const agent = buildOpenGeniAgent(settings, [], {
+      model: resolved.model,
+      compactionMode: resolved.provider.compactionMode,
+      hostedWebSearch: resolved.configured.hostedWebSearch,
+      encryptedReasoning: resolved.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+      contextWindowTokens: resolved.configured.contextWindowTokens,
+    });
+    // hostedWebSearch off → no web_search tool and no explicit tools field at all.
+    expect(webSearchHostedTools(agent)).toHaveLength(0);
+    expect((agent as { tools?: unknown[] }).tools ?? []).toHaveLength(0);
+    // encryptedReasoning off (chat wire API) → no providerData.include.
+    expect((agent as { modelSettings: { providerData?: unknown } }).modelSettings.providerData).toBeUndefined();
+    // compactionMode "client" → store is NOT forced false.
+    expect((agent as { modelSettings: { store?: unknown } }).modelSettings.store).toBeUndefined();
+    // The provider-bound Model instance is the one passed in (chat routing).
+    expect((agent as { model?: unknown }).model).toBe(resolved.model);
+  });
+
+  test("the built-in responses turn keeps web_search, encrypted reasoning, and server store on", () => {
+    const settings = multiProviderSettings();
+    const resolved = resolveTurnModel(settings, "gpt-5.5")!;
+    const agent = buildOpenGeniAgent(settings, [], {
+      model: resolved.model,
+      compactionMode: resolved.provider.compactionMode,
+      hostedWebSearch: resolved.configured.hostedWebSearch,
+      encryptedReasoning: resolved.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+      contextWindowTokens: resolved.configured.contextWindowTokens,
+    });
+    expect(webSearchHostedTools(agent)).toHaveLength(1);
+    expect((agent as { modelSettings: { providerData?: unknown } }).modelSettings.providerData).toEqual({ include: ["reasoning.encrypted_content"] });
+    expect((agent as { modelSettings: { store?: unknown } }).modelSettings.store).toBe(false);
+  });
+
+  test("resolveModelProvider/configuredProviders agree on the registry provider's client gating", () => {
+    // Cross-check the config layer the runtime builds on: the resolved provider
+    // for the Fireworks model is the chat/client provider, and the built-in
+    // provider stays responses/server — the runtime never re-derives this.
+    const settings = multiProviderSettings();
+    const fireworks = resolveModelProvider(settings, FIREWORKS_MODEL);
+    expect(fireworks?.provider.compactionMode).toBe("client");
+    expect(fireworks?.provider.api).toBe("chat");
+    const builtin = resolveModelProvider(settings, "gpt-5.5");
+    expect(builtin?.provider.compactionMode).toBe("server");
+    expect(builtin?.provider.api).toBe("responses");
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -10,6 +10,7 @@ import type {
   CapabilityCatalogItem,
   CapabilityCatalogResponse,
   CapabilityInstallation,
+  ClientConfig,
   ClientSessionEventInput,
   CompactSessionContextResult,
   CompleteFileUploadResponse,
@@ -403,6 +404,17 @@ export class OpenGeniClient {
   }
 
   // --- Access + workspaces -----------------------------------------------------
+
+  /**
+   * The deployment's public client bootstrap config: the host-exposed models
+   * (provider-grouped in `models`, flat in `allowedModels` for back-compat),
+   * reasoning efforts, MCP servers, file-upload limits, and how the client is
+   * expected to authenticate. Drives a composer's model picker without prior
+   * knowledge of the host setup; safe to call before any auth is established.
+   */
+  async getClientConfig(): Promise<ClientConfig> {
+    return await this.requestJson<ClientConfig>("GET", "/v1/config/client");
+  }
 
   /** The caller's access context: subject, account + workspace grants, defaults. */
   async getAccessContext(): Promise<AccessContext> {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,8 @@ export type {
   CapabilityPackSkillFile,
   CapabilityRuntime,
   CapabilitySource,
+  ClientConfig,
+  ClientModel,
   CompactSessionContextResult,
   ClientSessionEventInput,
   CompleteFileUploadResponse,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -282,6 +282,53 @@ export type Permission = KnownPermission | (string & {});
 
 export type ProductAccessMode = "local" | "configured" | "managed";
 
+/**
+ * One model a client may select at send time, plus the provider that serves it.
+ * The wire API (`responses` | `chat`) lets a client reason about provider
+ * capabilities; the provider id/label drive a picker's grouping. Mirrors the
+ * `ClientModel` shape projected into `ClientConfig` by the server.
+ */
+export type ClientModel = {
+  id: string;
+  label: string;
+  /** Provider id (e.g. `openai`, `azure`, or a registry provider id). */
+  provider: string;
+  providerLabel: string;
+  api: "responses" | "chat";
+  contextWindowTokens?: number | undefined;
+};
+
+/**
+ * How a deployment expects clients to authenticate to it, surfaced so a UI can
+ * wire up the right header/cookie without prior knowledge of the host setup.
+ * Discriminated on `mode`; `none` is the back-compat default.
+ */
+export type ClientAuthConfig =
+  | { mode: "none" }
+  | { mode: "deploymentKey"; headerName: "x-opengeni-access-key" }
+  | { mode: "configuredToken"; headerName: "authorization"; scheme: "bearer" }
+  | { mode: "managedSession"; session: "cookie" };
+
+/**
+ * Public, unauthenticated-by-default client bootstrap config returned by
+ * `GET /v1/config/client`: which models + reasoning efforts are exposed, the
+ * MCP servers and file-upload limits a composer should offer, and how the
+ * deployment expects the client to authenticate. `allowedModels` is kept for
+ * back-compat; `models` carries the richer provider-grouped list for a picker.
+ */
+export type ClientConfig = {
+  deploymentRevision: string;
+  defaultModel: string;
+  allowedModels: string[];
+  models: ClientModel[];
+  defaultReasoningEffort: ReasoningEffort;
+  allowedReasoningEfforts: ReasoningEffort[];
+  mcpServers: { id: string; name: string }[];
+  fileUploads: { enabled: boolean; maxSizeBytes: number };
+  productAccessMode: ProductAccessMode;
+  auth: ClientAuthConfig;
+};
+
 export type AccountRole = "owner" | "admin" | "member";
 
 export type AccountGrant = {

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -320,6 +320,34 @@ describe("OpenGeniClient access + workspaces", () => {
     ]);
     expect(JSON.parse(requests[4]!.body!)).toEqual({ name: "Ops 2", slug: null });
   });
+
+  test("getClientConfig fetches the public bootstrap endpoint and returns the provider-grouped models", async () => {
+    const config = {
+      deploymentRevision: "rev-1",
+      defaultModel: "gpt-5.5",
+      allowedModels: ["gpt-5.5", "accounts/fireworks/models/glm-5p2"],
+      models: [
+        { id: "gpt-5.5", label: "GPT-5.5", provider: "openai", providerLabel: "OpenAI", api: "responses", contextWindowTokens: 400000 },
+        { id: "accounts/fireworks/models/glm-5p2", label: "GLM 5.2", provider: "fireworks", providerLabel: "Fireworks AI", api: "chat", contextWindowTokens: 1048576 },
+      ],
+      defaultReasoningEffort: "medium",
+      allowedReasoningEfforts: ["low", "medium", "high"],
+      mcpServers: [{ id: "documents", name: "Documents" }],
+      fileUploads: { enabled: true, maxSizeBytes: 26214400 },
+      productAccessMode: "managed",
+      auth: { mode: "managedSession", session: "cookie" },
+    };
+    const { client, requests } = makeClient(() => jsonResponse(config));
+    const result = await client.getClientConfig();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.method).toBe("GET");
+    expect(new URL(requests[0]!.url).pathname).toBe("/v1/config/client");
+    expect(result.defaultModel).toBe("gpt-5.5");
+    expect(result.models.map((model) => `${model.provider}:${model.id}:${model.api}`)).toEqual([
+      "openai:gpt-5.5:responses",
+      "fireworks:accounts/fireworks/models/glm-5p2:chat",
+    ]);
+  });
 });
 
 describe("OpenGeniClient scheduled tasks", () => {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -77,6 +77,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
         outputMicrosPerMillionTokens: 1,
       },
     }),
+    modelProvidersJson: "[]",
     openaiReasoningEffort: "high",
     openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
     openaiResponsesTransport: "http",

--- a/test/live/fireworks-glm.live.ts
+++ b/test/live/fireworks-glm.live.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { calculateModelUsageCostMicros } from "@opengeni/config";
+import { testSettings } from "@opengeni/testing";
+import {
+  buildOpenGeniAgent,
+  OpenAIChatCompletionsModel,
+  OpenAIResponsesModel,
+  resolveTurnModel,
+  runAgentStream,
+} from "@opengeni/runtime";
+
+// Live end-to-end proof that Fireworks GLM 5.2 routes through the new
+// multi-provider path. This is the design's "Verification step 3": resolve
+// accounts/fireworks/models/glm-5p2, confirm it binds to the chat wire API as a
+// OpenAIChatCompletionsModel (NOT a Responses model), run one real turn against
+// the live Fireworks endpoint, and confirm managed cost accounting can price
+// the model.
+//
+// Gated on the Fireworks key — skips entirely when OPENGENI_FIREWORKS_API_KEY
+// is absent (the unit suite must stay key-free):
+//
+//   OPENGENI_FIREWORKS_API_KEY=fw_... bun test test/live/fireworks-glm.live.ts
+const FIREWORKS_KEY = process.env.OPENGENI_FIREWORKS_API_KEY;
+const live = Boolean(FIREWORKS_KEY);
+
+const GLM_MODEL_ID = "accounts/fireworks/models/glm-5p2";
+
+// A registry exactly as the host would configure it (docs/model-providers.md
+// "Host configuration example"). The key is read from the env var the gate
+// already required, so the test never inlines the secret.
+const MODEL_PROVIDERS_JSON = JSON.stringify([
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    api: "chat",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    apiKeyEnv: "OPENGENI_FIREWORKS_API_KEY",
+    models: [
+      {
+        id: GLM_MODEL_ID,
+        label: "GLM 5.2",
+        contextWindowTokens: 1_048_576,
+        reasoningEffort: true,
+        hostedWebSearch: false,
+      },
+    ],
+  },
+]);
+
+function fireworksSettings() {
+  return testSettings({
+    sandboxBackend: "none",
+    modelProvidersJson: MODEL_PROVIDERS_JSON,
+    // The registry-resolved turn never consults these built-in OpenAI fields
+    // (it builds its own Fireworks client), but keep them inert so nothing
+    // accidentally hits OpenAI.
+    openaiApiKey: "unused-on-the-registry-path",
+  });
+}
+
+describe("live Fireworks GLM 5.2 (multi-provider path)", () => {
+  test.skipIf(!live)(
+    "resolves glm-5p2 to the fireworks chat provider as a chat-completions Model",
+    () => {
+      const settings = fireworksSettings();
+      const resolved = resolveTurnModel(settings, GLM_MODEL_ID);
+
+      // The model is in the registry, so it resolves (a null here would mean
+      // the worker silently fell back to the legacy global OpenAI client).
+      expect(resolved).not.toBeNull();
+      expect(resolved!.provider.id).toBe("fireworks");
+      expect(resolved!.provider.api).toBe("chat");
+      // Registry providers always compact client-side (server-side compaction is
+      // OpenAI-platform only).
+      expect(resolved!.provider.compactionMode).toBe("client");
+      expect(resolved!.configured.id).toBe(GLM_MODEL_ID);
+      expect(resolved!.configured.providerId).toBe("fireworks");
+      expect(resolved!.configured.hostedWebSearch).toBe(false);
+
+      // The load-bearing routing assertion: glm-5p2 must be a chat-completions
+      // Model, NOT a Responses model. Fireworks' /v1/responses echoes input and
+      // no-ops web_search/encrypted reasoning, so binding it to Responses would
+      // corrupt history — the chat wire API is the whole point.
+      expect(resolved!.model).toBeInstanceOf(OpenAIChatCompletionsModel);
+      expect(resolved!.model).not.toBeInstanceOf(OpenAIResponsesModel);
+    },
+  );
+
+  test.skipIf(!live)(
+    "runs one real GLM 5.2 turn with no hosted web_search attached",
+    async () => {
+      const settings = fireworksSettings();
+      const resolved = resolveTurnModel(settings, GLM_MODEL_ID);
+      expect(resolved).not.toBeNull();
+
+      // Build the agent exactly as apps/worker/src/activities/agent-turn.ts does
+      // for a registry-resolved turn: the resolved Model instance plus the
+      // provider-derived gating (client compaction, no hosted web_search, no
+      // encrypted reasoning — the chat wire API has no encrypted_content field).
+      const agent = buildOpenGeniAgent({ ...settings, sandboxBackend: "none" }, [], {
+        model: resolved!.model,
+        compactionMode: resolved!.provider.compactionMode,
+        hostedWebSearch: resolved!.configured.hostedWebSearch,
+        encryptedReasoning: resolved!.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+        contextWindowTokens: resolved!.configured.contextWindowTokens ?? settings.contextWindowTokens,
+      });
+
+      // Fireworks does NOT execute the hosted web_search tool, so the agent must
+      // carry no web_search descriptor — handing it one would be a dead tool.
+      const hostedToolNames = (agent.tools ?? []).map((tool) => tool.name);
+      expect(hostedToolNames).not.toContain("web_search");
+
+      const stream = await runAgentStream(
+        agent,
+        "Reply with exactly: glm-live-ok. Do not run any tools or commands.",
+        { ...settings, sandboxBackend: "none" },
+      );
+      for await (const _event of stream.toStream()) {
+        // Drain the stream to completion.
+      }
+      await stream.completed;
+
+      // A non-empty, clean assistant response — no input echo, no leaked
+      // reasoning. extractResponseOutputText-style cleanliness is enforced by
+      // the chat path naturally (content is choices[0].message.content).
+      const finalOutput = String(stream.finalOutput ?? "").trim();
+      expect(finalOutput.length).toBeGreaterThan(0);
+      expect(finalOutput.toLowerCase()).toContain("glm-live-ok");
+    },
+    180_000,
+  );
+
+  test.skipIf(!live)("prices glm-5p2 through managed cost accounting", () => {
+    const settings = fireworksSettings();
+
+    // The default built-in pricing entry for glm-5p2 (docs/model-providers.md)
+    // must make managed billing resolvable out of the box — a missing entry
+    // throws "Missing model pricing".
+    const cost = calculateModelUsageCostMicros(settings, GLM_MODEL_ID, {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    // input 1.4 + output 4.4 = 5.8 micros-per-token-million base, * 1M tokens
+    // each, with the 2_500 bps (25%) managed margin: ceil((1_400_000 +
+    // 4_400_000) * 1.25) = 7_250_000.
+    expect(cost).toBe(7_250_000);
+    expect(cost).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

Lets a host expose models from **multiple LLM providers** and lets any client (SDK + React composer) discover and pick between them at send time. First non-OpenAI provider: **Fireworks AI** serving **GLM 5.2**.

Backward compatible: with no `OPENGENI_MODEL_PROVIDERS_JSON` set, behavior is identical to today (the built-in OpenAI/Azure provider on the Responses API).

## How it works

- **Provider registry** (`OPENGENI_MODEL_PROVIDERS_JSON`) layered on the built-in OpenAI/Azure provider; clients see the host-curated **union** of models.
- Each model string **resolves to its provider** at run time → a per-provider `OpenAI` client + a bound `@openai/agents` `Model` instance (`OpenAIResponsesModel` for `responses`, `OpenAIChatCompletionsModel` for `chat`). No global-client disruption, no SDK fork.
- **Fireworks uses chat-completions** (its beta Responses API echoes input + no-ops hosted tools); OpenAI/Azure stay on Responses. Per-provider gating of hosted web-search / encrypted reasoning / compaction.
- `ClientConfig.models` → SDK `getClientConfig()` → React `<ModelPicker>`. Unknown models rejected with HTTP 422 at all model entry points.

Design + host config: `docs/model-providers.md`.

## Commits
- `feat(models)`: the feature across config, contracts, runtime, worker, api, sdk, react, web
- `fix(api)`: enforce the model allow-list on scheduled-task agentConfig (review-found gap)
- `fix(web)`: honor `none`/`minimal` deployment reasoning-effort default (pre-existing bug found in review)

## Verification
- Full workspace typecheck clean; **759 unit tests pass**
- **Live GLM 5.2 end-to-end** (`test/live/fireworks-glm.live.ts`, gated on `OPENGENI_FIREWORKS_API_KEY`) passes against the real Fireworks API
- Adversarial multi-agent review; confirmed findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker turn routing, compaction, and billing pricing paths for registry models; API model validation is new but centralized and covered by tests, and empty registry preserves prior behavior.
> 
> **Overview**
> Introduces **multi-provider model hosting** via `OPENGENI_MODEL_PROVIDERS_JSON`: extra providers (base URL, `responses` vs `chat` wire API, keys) union with the built-in OpenAI/Azure allow-list. Config resolves **providers and models** (`configuredModels`, pricing merge including GLM 5.2 defaults) and validates the registry at boot.
> 
> **Runtime/worker** resolves each turn’s model to a cached per-provider client and bound `Model` (`OpenAIResponsesModel` vs `OpenAIChatCompletionsModel`), with provider-specific agent gating (hosted web search, encrypted reasoning, compaction mode/window) and **chat-aware context compaction** summarization.
> 
> **API/contracts/SDK** add `ClientConfig.models` on `GET /v1/config/client` and **`assertConfiguredModel`** (HTTP 422) on session create, messages, queued-turn updates, and scheduled-task `agentConfig.model`.
> 
> **Web and `@opengeni/react`** consume the richer model list (provider-grouped picker, per-session model overrides), plus **`useAvailableModels` / `ModelPicker` on `ChatComposer`**. The web composer now honors the full reasoning-effort enum (`none`/`minimal` defaults no longer clamp to `low`).
> 
> Design and host example live in `docs/model-providers.md`; optional live Fireworks e2e is gated on `OPENGENI_FIREWORKS_API_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c1d982f919bb1cf7156e0670bae0be1dd2ed12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->