### PR TITLE
fix(worker): resolve provider gating against deployment-default settings

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -399,15 +399,21 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         sandboxEnvironment,
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
-        // Resolved-model routing (legacy global-client path when null). The
-        // provider-bound Model instance plus its gating: server-side store/
-        // compaction follow the provider's compaction mode (registry providers
-        // resolve to "client"); encrypted reasoning is only round-tripped on the
-        // Responses wire API; hosted web search is attached only when the model
-        // opts in; the effective context window drives the compaction threshold.
+        // Resolved-model routing + gating (legacy defaults when null). The model
+        // is passed as the model *string* (agent.model = runSettings.openaiModel),
+        // NOT a Model instance: an instance only survives the in-process
+        // ("none") run, whereas the SandboxAgent/Modal path drops it and
+        // re-resolves the model *name* through the global MultiProviderModelProvider
+        // configureOpenAI installed — so registry models (Fireworks GLM) route to
+        // their own client instead of 404ing against the built-in Azure/OpenAI
+        // client. The gating still comes from the resolved provider: server-side
+        // store/compaction follow the provider's compaction mode (registry
+        // providers resolve to "client"); encrypted reasoning is only
+        // round-tripped on the Responses wire API; hosted web search is attached
+        // only when the model opts in; the effective context window drives the
+        // compaction threshold.
         ...(resolvedModel
           ? {
-            model: resolvedModel.model,
             compactionMode: resolvedModel.provider.compactionMode,
             hostedWebSearch: resolvedModel.configured.hostedWebSearch,
             encryptedReasoning: resolvedModel.provider.api === "responses" && runSettings.openaiReasoningEncryptedContent,

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -366,14 +366,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         openaiReasoningEffort: turn.reasoningEffort,
         sandboxBackend: turn.sandboxBackend,
       };
-      // Multi-provider per-turn model routing. When turn.model is in the
-      // provider registry, this gives the provider-bound Model instance + the
-      // gating (compaction mode, hosted web search, encrypted reasoning, context
-      // window) the agent and compaction summarizer must use; null falls back to
-      // the legacy global-client path (runSettings.openaiModel + the default
-      // client configureOpenAI set up). Cost accounting already covers registry
+      // Multi-provider per-turn routing → the provider gating (compaction mode,
+      // hosted web search, encrypted reasoning, context window) the agent and
+      // compaction summarizer must use; null falls back to the legacy global
+      // client. Resolve against `capabilitySettings` (whose openaiModel is the
+      // deployment default), NOT `runSettings`: runSettings.openaiModel is the
+      // turn's model, so for a turn ON a registry model the built-in provider
+      // would otherwise claim that id (configuredModels builds the built-in's
+      // models from openaiModel) and shadow the registry entry — resolving the
+      // turn to the built-in (Azure) gating while the global model router routes
+      // the name to its registry provider. That mismatch attaches web_search to
+      // a chat-only Fireworks model. Resolving against the default-model settings
+      // keeps gating consistent with the router. Cost accounting covers registry
       // models via configuredModelPricing.
-      const resolvedModel = runtime.resolveTurnModel(runSettings, turn.model);
+      const resolvedModel = runtime.resolveTurnModel(capabilitySettings, turn.model);
       const turnResources = mergeResourceRefs(session.resources, turn.resources);
       const turnTools = mergeToolRefs(session.tools, turn.tools);
       const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, runSettings, input.workspaceId, session.environmentId);

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -144,6 +144,21 @@ export type ClientModel = z.infer<typeof ClientModel>;
 models: z.array(ClientModel).default([]),
 ```
 
+### Sandbox-path model routing (critical)
+
+Binding a provider's `Model` **instance** to `agent.model` only routes correctly
+on the in-process run (`sandboxBackend: "none"`). On the **SandboxAgent / Modal**
+path the instance is dropped and the model **name** is re-resolved through the
+run's model provider — which, by default, is the built-in (OpenAI/Azure) client,
+so a registry model 404s ("The API deployment for this resource does not exist").
+The fix: `configureOpenAI` installs a **`MultiProviderModelProvider`** as the
+process default model provider (`setDefaultModelProvider`). It routes any model
+name back to its provider via `resolveTurnModel` (falling back to the SDK default
+provider for unconfigured names). The worker therefore passes the model as a
+**string** (`agent.model = runSettings.openaiModel`), not an instance, so every
+path resolves through the router. Gating (compaction/web-search/encrypted
+reasoning/context window) still comes from `resolveTurnModel` in the worker.
+
 ## Runtime — `packages/runtime/src/index.ts`
 
 - Import `OpenAIResponsesModel`, `OpenAIChatCompletionsModel` from the agents SDK

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,8 @@ import {
   Agent,
   AgentsError,
   connectMcpServers,
+  OpenAIProvider,
+  setDefaultModelProvider,
   MaxTurnsExceededError,
   MCPServerStreamableHttp,
   // Provider-bound Model instances. Both are re-exported from
@@ -33,6 +35,7 @@ import {
   type CallModelInputFilter,
   type MCPServer,
   type Model,
+  type ModelProvider,
   type RunStreamEvent,
 } from "@openai/agents";
 import {
@@ -326,10 +329,51 @@ export function resolveTurnModel(
   };
 }
 
+/**
+ * Routes a model *name* to its provider-bound Model (Fireworks chat model for a
+ * registry model id, the built-in OpenAI/Azure responses model otherwise) via
+ * `resolveTurnModel`. This is the load-bearing piece for the sandbox path:
+ * passing a Model *instance* as `agent.model` only survives the in-process
+ * (`sandboxBackend: "none"`) run — on the SandboxAgent/Modal path the instance
+ * is dropped and the model *name* is re-resolved through the run's
+ * `modelProvider` (or the global default). Without this router that re-resolution
+ * hits the default client (e.g. Azure) and a registry model 404s
+ * ("deployment does not exist"); with it the name resolves back to the right
+ * provider. Installed both as the run-scoped `RunConfig.modelProvider` (see
+ * runAgentStream) and as the process default (see configureOpenAI), so whichever
+ * path the SDK takes, names route correctly. Falls back to the SDK default
+ * provider for a model that is in no provider's allow-list.
+ */
+export class MultiProviderModelProvider implements ModelProvider {
+  private fallback: OpenAIProvider | undefined;
+
+  constructor(private readonly settings: Settings) {}
+
+  async getModel(modelName?: string): Promise<Model> {
+    if (modelName) {
+      const resolved = resolveTurnModel(this.settings, modelName);
+      if (resolved) {
+        return resolved.model;
+      }
+    }
+    // A model in no provider's allow-list falls back to the SDK's default
+    // OpenAIProvider, which uses the global default client/key configureOpenAI
+    // set up (the built-in OpenAI/Azure provider).
+    this.fallback ??= new OpenAIProvider();
+    return this.fallback.getModel(modelName);
+  }
+}
+
 export function configureOpenAI(settings: Settings): void {
   setOpenAIResponsesTransport(settings.openaiResponsesTransport);
+  // Install the registry-aware router as the process default model provider so a
+  // model name re-resolved on the SandboxAgent/Modal path (where a Model instance
+  // does not survive) routes to its provider instead of the built-in client.
+  // Built before the default-client calls below so it captures the same settings.
+  const router = new MultiProviderModelProvider(settings);
   if (settings.openaiProvider === "azure") {
     setDefaultOpenAIClient(buildOpenAIClientFromSettings(settings));
+    setDefaultModelProvider(router);
     return;
   }
   if (settings.openaiApiKey) {
@@ -338,6 +382,7 @@ export function configureOpenAI(settings: Settings): void {
   if (settings.openaiBaseUrl) {
     setDefaultOpenAIClient(buildOpenAIClientFromSettings(settings));
   }
+  setDefaultModelProvider(router);
 }
 
 /**

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -3,7 +3,7 @@ import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents
 import { configuredProviders, resolveModelProvider, type ResolvedModelProvider } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import OpenAI from "openai";
-import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, resolveTurnModel } from "../src/index";
+import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, MultiProviderModelProvider, resolveTurnModel } from "../src/index";
 
 // A host exposing the built-in OpenAI provider plus Fireworks (the `chat` wire
 // API) serving GLM 5.2, mirroring the canonical example in
@@ -169,5 +169,50 @@ describe("multi-provider gating in buildOpenGeniAgent", () => {
     const builtin = resolveModelProvider(settings, "gpt-5.5");
     expect(builtin?.provider.compactionMode).toBe("server");
     expect(builtin?.provider.api).toBe("responses");
+  });
+});
+
+describe("MultiProviderModelProvider — routes a model NAME to its provider (the sandbox-path fix)", () => {
+  // The bug: on the SandboxAgent/Modal path the per-agent Model instance is
+  // dropped and the model NAME is re-resolved through the default model
+  // provider. Without this router that hit the built-in (Azure) client, so a
+  // Fireworks model 404'd ("deployment does not exist"). The router resolves
+  // names back to their provider regardless of path.
+  const FIREWORKS_MODEL = "accounts/fireworks/models/glm-5p2";
+
+  test("routes a registry model name to a chat-completions Model (NOT the built-in)", async () => {
+    const provider = new MultiProviderModelProvider(multiProviderSettings());
+    const model = await provider.getModel(FIREWORKS_MODEL);
+    expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
+    expect(model).not.toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("with an AZURE built-in (the staging config), glm still routes to Fireworks chat, not Azure", async () => {
+    const settings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+    });
+    const provider = new MultiProviderModelProvider(settings);
+    const glm = await provider.getModel(FIREWORKS_MODEL);
+    expect(glm).toBeInstanceOf(OpenAIChatCompletionsModel);
+    const builtin = await provider.getModel("gpt-5.5");
+    expect(builtin).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("falls back to the built-in default provider for a model in no provider's allow-list", async () => {
+    // In production configureOpenAI sets a global default key/client; mirror that
+    // so the SDK fallback OpenAIProvider can construct a model rather than erroring
+    // on missing credentials.
+    const prev = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-test-fallback";
+    try {
+      const provider = new MultiProviderModelProvider(multiProviderSettings());
+      const model = await provider.getModel("some-unconfigured-model");
+      expect(model).toBeDefined();
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = prev;
+    }
   });
 });

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -216,3 +216,31 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
     }
   });
 });
+
+describe("registry model shadowing — why the worker resolves gating against the deployment-default settings", () => {
+  // The worker overrides settings.openaiModel to the TURN's model. For a turn on
+  // a registry model that override makes the built-in provider claim the id
+  // (configuredModels derives the built-in's models from openaiModel) and shadow
+  // the registry entry — resolving the turn to built-in (Azure) gating while the
+  // global router routes the name to the registry provider, attaching web_search
+  // to a chat-only Fireworks model. So the worker MUST resolve against the
+  // default-model settings, asserted here.
+  const azure = () => multiProviderSettings({
+    openaiProvider: "azure",
+    azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+    azureOpenaiApiKey: "az-test-key",
+  });
+
+  test("against deployment-default settings, a registry model resolves to its registry provider with gating off", () => {
+    const resolved = resolveTurnModel(azure(), FIREWORKS_MODEL)!;
+    expect(resolved.provider.id).toBe("fireworks");
+    expect(resolved.provider.api).toBe("chat");
+    expect(resolved.configured.hostedWebSearch).toBe(false);
+  });
+
+  test("against turn-overridden settings (openaiModel = the registry id) the built-in shadows it — the trap the worker avoids", () => {
+    const shadowed = resolveTurnModel({ ...azure(), openaiModel: FIREWORKS_MODEL }, FIREWORKS_MODEL)!;
+    expect(shadowed.provider.builtin).toBe(true);
+    expect(shadowed.configured.hostedWebSearch).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to the routing fix. The worker resolved provider gating against runSettings (openaiModel overridden to the turn's model), so a turn on a registry model let the built-in provider shadow it → web_search attached to a chat-only Fireworks model. Resolve gating against capabilitySettings. Regression tests added. 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every multi-provider agent turn resolves models and tool gating on sandbox paths; mistakes could mis-route LLM calls or attach wrong tools, but behavior is covered by new regression tests.
> 
> **Overview**
> Fixes **multi-provider model routing** on SandboxAgent/Modal runs and **provider gating** when a turn uses a registry model (e.g. Fireworks GLM).
> 
> **Runtime:** Adds `MultiProviderModelProvider` and registers it via `setDefaultModelProvider` in `configureOpenAI`, so when the SDK re-resolves a model **by name** (sandbox path drops bound `Model` instances), registry IDs route to the right client instead of the built-in Azure/OpenAI client (404 “deployment does not exist”).
> 
> **Worker:** Stops passing `resolvedModel.model` into `buildAgent`; the agent uses the turn model **string** (`runSettings.openaiModel`) so routing goes through that global router. **`resolveTurnModel`** now uses **`capabilitySettings`** (deployment default `openaiModel`), not **`runSettings`** (turn-overridden model), so the built-in provider no longer **shadows** registry models and incorrectly enables **hosted web_search** on chat-only models.
> 
> **Docs + tests:** Documents sandbox-path routing in `model-providers.md`; adds tests for `MultiProviderModelProvider` and the shadowing regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c78f76fa188865fe0bc623c073b570383d402b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->