### PR TITLE
fix(worker): resolve provider gating against deployment-default settings

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -366,14 +366,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         openaiReasoningEffort: turn.reasoningEffort,
         sandboxBackend: turn.sandboxBackend,
       };
-      // Multi-provider per-turn model routing. When turn.model is in the
-      // provider registry, this gives the provider-bound Model instance + the
-      // gating (compaction mode, hosted web search, encrypted reasoning, context
-      // window) the agent and compaction summarizer must use; null falls back to
-      // the legacy global-client path (runSettings.openaiModel + the default
-      // client configureOpenAI set up). Cost accounting already covers registry
+      // Multi-provider per-turn routing → the provider gating (compaction mode,
+      // hosted web search, encrypted reasoning, context window) the agent and
+      // compaction summarizer must use; null falls back to the legacy global
+      // client. Resolve against `capabilitySettings` (whose openaiModel is the
+      // deployment default), NOT `runSettings`: runSettings.openaiModel is the
+      // turn's model, so for a turn ON a registry model the built-in provider
+      // would otherwise claim that id (configuredModels builds the built-in's
+      // models from openaiModel) and shadow the registry entry — resolving the
+      // turn to the built-in (Azure) gating while the global model router routes
+      // the name to its registry provider. That mismatch attaches web_search to
+      // a chat-only Fireworks model. Resolving against the default-model settings
+      // keeps gating consistent with the router. Cost accounting covers registry
       // models via configuredModelPricing.
-      const resolvedModel = runtime.resolveTurnModel(runSettings, turn.model);
+      const resolvedModel = runtime.resolveTurnModel(capabilitySettings, turn.model);
       const turnResources = mergeResourceRefs(session.resources, turn.resources);
       const turnTools = mergeToolRefs(session.tools, turn.tools);
       const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, runSettings, input.workspaceId, session.environmentId);

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -216,3 +216,31 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
     }
   });
 });
+
+describe("registry model shadowing — why the worker resolves gating against the deployment-default settings", () => {
+  // The worker overrides settings.openaiModel to the TURN's model. For a turn on
+  // a registry model that override makes the built-in provider claim the id
+  // (configuredModels derives the built-in's models from openaiModel) and shadow
+  // the registry entry — resolving the turn to built-in (Azure) gating while the
+  // global router routes the name to the registry provider, attaching web_search
+  // to a chat-only Fireworks model. So the worker MUST resolve against the
+  // default-model settings, asserted here.
+  const azure = () => multiProviderSettings({
+    openaiProvider: "azure",
+    azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+    azureOpenaiApiKey: "az-test-key",
+  });
+
+  test("against deployment-default settings, a registry model resolves to its registry provider with gating off", () => {
+    const resolved = resolveTurnModel(azure(), FIREWORKS_MODEL)!;
+    expect(resolved.provider.id).toBe("fireworks");
+    expect(resolved.provider.api).toBe("chat");
+    expect(resolved.configured.hostedWebSearch).toBe(false);
+  });
+
+  test("against turn-overridden settings (openaiModel = the registry id) the built-in shadows it — the trap the worker avoids", () => {
+    const shadowed = resolveTurnModel({ ...azure(), openaiModel: FIREWORKS_MODEL }, FIREWORKS_MODEL)!;
+    expect(shadowed.provider.builtin).toBe(true);
+    expect(shadowed.configured.hostedWebSearch).toBe(true);
+  });
+});


### PR DESCRIPTION
The worker resolved provider gating against runSettings (openaiModel = the turn's model), letting the built-in provider shadow a registry model id → web_search attached to a chat-only Fireworks model. Resolve gating against capabilitySettings. Regression tests added; 764 suite green. 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets multi-provider turn routing and tool gating in the worker agent path; wrong gating could break chat-only models or change compaction/web-search behavior, but the change is a narrow settings argument fix with explicit regression tests.
> 
> **Overview**
> Fixes **provider gating** for agent turns when the turn uses a **registry model** (e.g. Fireworks GLM) while the deployment default is Azure/built-in.
> 
> `runAgentTurn` now calls `resolveTurnModel` with **`capabilitySettings`** (deployment-default `openaiModel`) instead of **`runSettings`** (per-turn `openaiModel`). When `openaiModel` was set to the turn’s registry id, the built-in provider could **shadow** that id in the provider map, so gating (e.g. **hosted web search**) followed Azure while the global router still sent the name to the registry **chat** provider — incorrectly attaching `web_search` to a chat-only model.
> 
> Comments in `agent-turn.ts` explain the mismatch; **`model-providers.test.ts`** adds regression tests for correct resolution vs. the shadowing case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12ecdc64e34ed0cd89d019abf718100bb39231a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->