### PR TITLE
@opengeni/react: render markdown in chat timeline by default

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -202,13 +202,15 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@opengeni/sdk": "workspace:*",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
         "motion": "^12.0.0",
         "radix-ui": "^1.4.3",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
@@ -248,7 +250,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@opengeni/contracts": "workspace:*",
         "tsup": "^8.5.0",
@@ -2234,6 +2236,8 @@
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -560,9 +560,70 @@ async function runOpsChannelScript(bus: SessionBus): Promise<void> {
   await sleep(700);
 
   await streamText(bus, turn, "I'll report back when the worker has staging reachable. If the drift check finds anything that needs a decision (destructive changes, spend), I'll ask you here first.");
+  await sleep(600);
+
+  // A rich, formatted status report — exercises the full markdown surface
+  // (headings, emphasis, lists incl. nested + task lists, inline + fenced
+  // code, a blockquote, a table, a link, and a rule) so the timeline's
+  // default renderer can be judged end-to-end.
+  await streamText(bus, turn, MARKDOWN_REPORT, 6);
+
   bus.append("turn.completed", {}, turn);
   bus.setStatus("idle");
 }
+
+/** A formatted "staging is live" report covering every common markdown element. */
+const MARKDOWN_REPORT = `## Staging is live
+
+Staging for the **api** service is reachable and the prod drift check finished. Here's the rundown.
+
+### What landed
+
+- Namespace \`api-staging\` created on the cluster
+  - Ingress wired with a *temporary* TLS cert (auto-renews)
+  - HPA set to **2–6** replicas
+- Managed Postgres provisioned and migrated
+- Deploy pipeline connected to [the api repo](https://example.com/acme/api)
+
+### Drift check
+
+Prod is mostly clean. Outstanding items:
+
+1. One untracked security group rule (port 6379, Redis)
+2. A manually-bumped instance size on \`api-prod-2\`
+3. Two stale DNS records
+
+> **Heads up:** the Redis rule looks like a hotfix from last week — I'd confirm before reverting, since removing it could drop cache connectivity.
+
+### Cost delta
+
+| Resource | Before | After | Δ |
+| --- | ---: | ---: | ---: |
+| Compute | $420 | $510 | +$90 |
+| Postgres | $0 | $85 | +$85 |
+| Egress | $30 | $34 | +$4 |
+
+### Next steps
+
+- [x] Stand up staging namespace
+- [x] Run prod drift check
+- [ ] Decide on the Redis rule (needs you)
+- [ ] Schedule the DNS cleanup
+
+You can reach staging with:
+
+\`\`\`ts
+const res = await fetch("https://api-staging.acme.dev/healthz", {
+  headers: { authorization: \`Bearer \${process.env.STAGING_TOKEN}\` },
+});
+console.log(res.status); // 200
+\`\`\`
+
+Run \`og sessions tail\` to follow the worker, or reply here and I'll fold it into the plan.
+
+---
+
+Everything above is staged behind the \`staging\` flag — nothing prod-facing changed.`;
 
 /* --- fixtures ------------------------------------------------------------------ */
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,6 +45,8 @@
     "lucide-react": "^1.8.0",
     "motion": "^12.0.0",
     "radix-ui": "^1.4.3",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },
   "peerDependencies": {

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -1,0 +1,170 @@
+import { memo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "../lib/cn";
+
+/**
+ * The default renderer for chat message bodies in {@link MessageTimeline}.
+ *
+ * Agent (and user) messages arrive as GitHub-flavored markdown. This turns the
+ * raw text into styled HTML using `react-markdown` + `remark-gfm`, themed to the
+ * package's `og-*` design tokens so it reads as one cohesive dark surface — no
+ * stock Tailwind colors leak in.
+ *
+ * It re-parses on every render, which is exactly right for streaming: a body
+ * that is still arriving (an unterminated `**`, a half-open code fence, a table
+ * mid-row) renders as best-effort markdown and resolves cleanly as the rest of
+ * the tokens land. Consumers who want a different renderer can still pass
+ * `renderMessageText` to `MessageTimeline` to override this entirely.
+ */
+export type MarkdownProps = {
+  children: string;
+  className?: string | undefined;
+};
+
+/* --- element renderers (themed to og-* tokens) ------------------------------ */
+
+const components: Components = {
+  h1: ({ children, ...props }) => (
+    <h1 className="mt-5 mb-2.5 text-xl font-semibold tracking-tight text-og-fg first:mt-0" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="mt-5 mb-2 text-lg font-semibold tracking-tight text-og-fg first:mt-0" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="mt-4 mb-1.5 text-[15px] font-semibold tracking-tight text-og-fg first:mt-0" {...props}>
+      {children}
+    </h3>
+  ),
+  h4: ({ children, ...props }) => (
+    <h4 className="mt-4 mb-1.5 text-sm font-semibold uppercase tracking-[0.04em] text-og-fg-muted first:mt-0" {...props}>
+      {children}
+    </h4>
+  ),
+  p: ({ children, ...props }) => (
+    <p className="my-2.5 leading-7 first:mt-0 last:mb-0" {...props}>
+      {children}
+    </p>
+  ),
+  strong: ({ children, ...props }) => (
+    <strong className="font-semibold text-og-fg" {...props}>
+      {children}
+    </strong>
+  ),
+  em: ({ children, ...props }) => (
+    <em className="italic" {...props}>
+      {children}
+    </em>
+  ),
+  a: ({ children, ...props }) => (
+    <a
+      className="break-words font-medium text-og-accent underline-offset-2 hover:underline"
+      target="_blank"
+      rel="noreferrer noopener"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children, ...props }) => (
+    <ul className="my-2.5 ml-5 flex list-disc flex-col gap-1 marker:text-og-fg-subtle first:mt-0 last:mb-0" {...props}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }) => (
+    <ol className="my-2.5 ml-5 flex list-decimal flex-col gap-1 marker:text-og-fg-subtle first:mt-0 last:mb-0" {...props}>
+      {children}
+    </ol>
+  ),
+  // GFM task-list items carry a leading checkbox <input>; `list-none` + a
+  // negative margin pull the checkbox back to the bullet column so it aligns
+  // with the text.
+  li: ({ children, ...props }) => (
+    <li className="leading-7 marker:text-og-fg-subtle [&>ul]:my-1 [&>ol]:my-1 [&:has(>input)]:list-none [&:has(>input)]:-ml-5" {...props}>
+      {children}
+    </li>
+  ),
+  input: ({ type, ...props }) =>
+    type === "checkbox" ? (
+      <input
+        {...props}
+        type="checkbox"
+        disabled
+        className="mr-2 size-3.5 translate-y-[2px] cursor-default appearance-none rounded-[3px] border border-og-border bg-og-surface-1 align-baseline checked:border-og-accent checked:bg-og-accent checked:[background-image:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22white%22%20stroke-width%3D%221.6%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M2.5%206.2l2.2%202.2%204.6-4.8%22%2F%3E%3C%2Fsvg%3E')] checked:bg-[length:11px_11px] checked:bg-center checked:bg-no-repeat"
+      />
+    ) : (
+      <input type={type} {...props} />
+    ),
+  blockquote: ({ children, ...props }) => (
+    <blockquote
+      className="my-3 border-l-2 border-og-border-strong pl-3.5 text-og-fg-muted [&>p]:my-1.5 first:mt-0 last:mb-0"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  hr: (props) => <hr className="my-4 border-0 border-t border-og-border" {...props} />,
+  // Inline `code` vs fenced code blocks. react-markdown v10 no longer passes an
+  // `inline` flag; a fenced block is a <code> whose parent is <pre> (styled by
+  // the `pre` renderer), so a `code` reaching here is treated as inline.
+  code: ({ children, className: _className, ...props }) => (
+    <code
+      className="rounded-og-xs border border-og-border bg-og-surface-1 px-1 py-0.5 font-og-mono text-[0.85em] text-og-fg"
+      {...props}
+    >
+      {children}
+    </code>
+  ),
+  // Fenced code blocks — mirror the timeline's PayloadBlock <pre> styling for
+  // visual consistency (bordered, scrollable, mono, surface background).
+  pre: ({ children, ...props }) => (
+    <pre
+      className="my-3 max-h-96 overflow-auto rounded-og-md border border-og-border bg-og-bg/60 p-3 font-og-mono text-[12.5px] leading-5 text-og-fg-muted [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit first:mt-0 last:mb-0"
+      {...props}
+    >
+      {children}
+    </pre>
+  ),
+  table: ({ children, ...props }) => (
+    <div className="my-3 max-w-full overflow-x-auto rounded-og-md border border-og-border first:mt-0 last:mb-0">
+      <table className="w-full border-collapse text-[13px]" {...props}>
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children, ...props }) => (
+    <thead className="bg-og-surface-1" {...props}>
+      {children}
+    </thead>
+  ),
+  th: ({ children, ...props }) => (
+    <th className="border-b border-og-border px-3 py-1.5 text-left font-medium text-og-fg" {...props}>
+      {children}
+    </th>
+  ),
+  td: ({ children, ...props }) => (
+    <td className="border-b border-og-border px-3 py-1.5 align-top text-og-fg-muted [tr:last-child>&]:border-b-0" {...props}>
+      {children}
+    </td>
+  ),
+  img: ({ alt, ...props }) => <img alt={alt ?? ""} className="my-3 max-w-full rounded-og-md border border-og-border" {...props} />,
+};
+
+function MarkdownImpl({ children, className }: MarkdownProps) {
+  return (
+    // `min-w-0` lets the prose shrink inside flex parents (message bubbles) so
+    // long links and code blocks wrap/scroll instead of forcing overflow.
+    <div className={cn("min-w-0 break-words", className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+/** Memoized so streaming re-renders of the parent don't re-parse settled bodies. */
+export const Markdown = memo(MarkdownImpl);

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Collapsible } from "radix-ui";
 import { cn } from "../lib/cn";
 import { formatRelativeTime, stringifyPayload, truncate } from "../lib/format";
+import { Markdown } from "./markdown";
 import {
   buildTimeline,
   compactPayloadPreview,
@@ -175,8 +176,8 @@ function UserMessageRow({
 }) {
   return (
     <div className="animate-og-enter flex justify-end">
-      <div className="max-w-[85%] rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-[15px] leading-6 text-og-fg">
-        {renderMessageText ? renderMessageText(item.text, item) : <span className="whitespace-pre-wrap">{item.text}</span>}
+      <div className="max-w-[85%] min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-[15px] leading-6 text-og-fg">
+        {renderMessageText ? renderMessageText(item.text, item) : <Markdown>{item.text}</Markdown>}
       </div>
     </div>
   );
@@ -189,10 +190,25 @@ function AgentMessageRow({
   item: AgentMessageItem;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
 }) {
+  const caret = item.streaming ? (
+    <span className="ml-0.5 inline-block h-[1.1em] w-[2px] translate-y-[3px] animate-og-blink rounded-full bg-og-accent" aria-hidden />
+  ) : null;
   return (
-    <div className="animate-og-enter text-[15px] leading-7 text-og-fg">
-      {renderMessageText ? renderMessageText(item.text, item) : <span className="whitespace-pre-wrap">{item.text}</span>}
-      {item.streaming ? <span className="ml-0.5 inline-block h-[1.1em] w-[2px] translate-y-[3px] animate-og-blink rounded-full bg-og-accent" aria-hidden /> : null}
+    <div className="animate-og-enter min-w-0 text-[15px] leading-7 text-og-fg">
+      {renderMessageText ? (
+        <>
+          {renderMessageText(item.text, item)}
+          {caret}
+        </>
+      ) : (
+        // While streaming, let the caret ride the end of the last rendered line:
+        // the trailing block (usually a <p>) flows inline so the caret sits on
+        // its baseline instead of dropping to a new line.
+        <div className={item.streaming ? "[&_>div>:last-child]:inline" : undefined}>
+          <Markdown>{item.text}</Markdown>
+          {caret}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -109,6 +109,8 @@ export { ModelPicker } from "./components/model-picker";
 export type { ModelPickerProps } from "./components/model-picker";
 export { MessageTimeline } from "./components/message-timeline";
 export type { MessageTimelineProps } from "./components/message-timeline";
+export { Markdown } from "./components/markdown";
+export type { MarkdownProps } from "./components/markdown";
 export { SessionStatus, StatusDot, SESSION_STATUS_META } from "./components/session-status";
 export type { SessionStatusProps, StatusDotProps, SessionStatusMeta } from "./components/session-status";
 export { FleetTile, sessionDisplayTitle } from "./components/fleet-tile";


### PR DESCRIPTION
The chat `MessageTimeline` rendered message bodies as **plain text** by default — the `renderMessageText` prop existed ("plug a renderer, e.g. streamdown") but no markdown library was bundled and no default was provided, so agent messages showed raw `###`, `**bold**`, code fences, `- [x]`, and `| tables |` as literal text.

## Fix
Markdown now renders **by default**; `renderMessageText` still overrides it (published API unchanged).

- New `packages/react/src/components/markdown.tsx` — a default `Markdown` renderer (exported as `Markdown` + `MarkdownProps`), themed to the package's `og-*` dark tokens: h1–h4 hierarchy, bold/italic, ul/ol incl. nested + **GFM task-list checkboxes**, accent links, inline `code` chips, fenced code blocks (mono/bordered/scrollable, mirroring the existing `PayloadBlock` `<pre>`), blockquotes, bordered tables, hr — with `min-w-0`/`break-words` so nothing overflows the message width.
- `message-timeline.tsx` uses `<Markdown>` by default in both user and agent rows; the streaming caret rides the last rendered line, and partial markdown renders best-effort and resolves as tokens land.

**Renderer:** `react-markdown` + `remark-gfm` (both externalized by tsup, so the bundle stays lean; consumers get them transitively). Chose these over `streamdown`, which drags in `mermaid`/d3 and stock-Tailwind styling that fights the `og-*` tokens. No syntax highlighting (skipped to avoid shiki/prism weight — fenced blocks are mono/bordered).

## Verification
- `bun run typecheck`, `bun run build` (tsup): green. `bun test`: 162 pass / 0 fail. gitleaks: clean.
- Reviewed against before/after screenshots (raw-text → fully formatted incl. table, task checkboxes, code block, blockquote, links) and a mid-stream frame (caret + live partial markdown).

## Note
Needs a **changeset** (`@opengeni/react` minor) to publish to npm for downstream consumers (e.g. Geni); the OpenGeni web console picks it up via `workspace:*` on deploy. Can add the changeset on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default rendering in `@opengeni/react` with an explicit override hook; no auth, API, or data-path changes.
> 
> **Overview**
> **`MessageTimeline` now renders user and agent message bodies as GitHub-flavored markdown by default** instead of plain `whitespace-pre-wrap` text, so headings, emphasis, fences, task lists, and tables display formatted. **`renderMessageText` is unchanged** and still fully overrides the default.
> 
> Adds a themed **`Markdown`** component (`react-markdown` + `remark-gfm`) with custom `og-*` element styling (including GFM tables and task checkboxes), exported from `@opengeni/react`. Agent streaming keeps the blink caret at the end of the last rendered line via inline layout on the trailing block.
> 
> The demo mock streams a rich **`MARKDOWN_REPORT`** fixture to exercise the full markdown surface end-to-end. Workspace package versions bump **contracts / react / sdk to 0.2.0** in the lockfile alongside the new react dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a092f2dd66a4e43e586b71bf7eaafc7bd84c961a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->