### PR TITLE
changeset: @opengeni/react minor (chat markdown)

### DIFF
--- a/.changeset/chat-markdown-default.md
+++ b/.changeset/chat-markdown-default.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Chat `MessageTimeline` now renders message bodies as **markdown by default** (react-markdown + remark-gfm, themed to the `og-*` design tokens — headings, lists, GFM task lists, inline/fenced code, blockquotes, tables, links). The `renderMessageText` prop still overrides the default renderer.


### PR DESCRIPTION
Adds the changeset for the chat markdown-by-default change (PR #102) so the release pipeline cuts an @opengeni/react minor and publishes to npm for downstream consumers (Geni).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only; no application or library code changes in this diff.
> 
> **Overview**
> Adds a **Changesets** entry so the release pipeline publishes a **minor** `@opengeni/react` version for the chat markdown work (from PR #102).
> 
> The note records that **`MessageTimeline`** now renders message bodies as markdown by default (react-markdown + remark-gfm, `og-*` tokens), with **`renderMessageText`** still able to override that behavior. This PR does not change runtime code—only release metadata for downstream consumers (e.g. Geni).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43be69367cc736217ca930fb3773f8eaed46dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->