### PR TITLE
changeset: @opengeni/sdk patch (publish getClientConfig)

### DIFF
--- a/.changeset/sdk-getclientconfig.md
+++ b/.changeset/sdk-getclientconfig.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Publish the SDK source that adds `OpenGeniClient.getClientConfig()` (returns `ClientConfig`). The method was added to the source but never republished, while `@opengeni/react@0.3.0` already depends on it — so react@0.3.0 consumers could not typecheck against the published sdk@0.2.0. Released as a patch so it stays within react@0.3.0's `^0.2.0` range.


### PR DESCRIPTION
@opengeni/react@0.3.0 depends on `OpenGeniClient.getClientConfig()`, but the published @opengeni/sdk@0.2.0 lacks it (the method was added to source without a release). This patch-releases the current SDK source as 0.2.1 so it satisfies react@0.3.0's `^0.2.0` range and unbreaks all react@0.3.0 consumers (incl. Geni's markdown adoption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no runtime or API behavior changes beyond aligning the published package with existing source.
> 
> **Overview**
> This PR only adds a **changeset** for a **patch** release of `@opengeni/sdk` (0.2.1). No application or SDK source is modified in the diff.
> 
> The release publishes SDK source that already defines **`OpenGeniClient.getClientConfig()`** (returning `ClientConfig`). That API was never shipped in **@opengeni/sdk@0.2.0**, while **@opengeni/react@0.3.0** already calls it via `SessionClientLike` and `useAvailableModels`. Consumers on react@0.3.0 with sdk@0.2.0 therefore fail typechecking until the SDK is republished.
> 
> A patch keeps the version within react’s **`^0.2.0`** dependency range and restores compatibility for react@0.3.0 adopters (including Geni markdown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54914894263d0828bbe77acc073860313237a0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->