### PR TITLE
runtime: defer sandbox user to provider defaults

### DIFF
--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -93,6 +93,8 @@ type TerminableSession = {
   closed?: boolean;
 };
 
+type CreateSandboxClientForBackendFn = typeof createSandboxClientForBackend;
+
 /** The provider-terminate seam. Production wires the real resume-by-id +
  *  provider stop() (`terminateProviderBox`); a unit test injects a spy so the
  *  drain/CAS logic is exercised against a real DB without a live provider box. */
@@ -364,6 +366,7 @@ export async function terminateProviderBox(
   settings: ActivityServices["settings"],
   lease: NonNullable<Awaited<ReturnType<typeof readLease>>>,
   observability: ActivityServices["observability"],
+  createClientForBackend: CreateSandboxClientForBackendFn = createSandboxClientForBackend,
 ): Promise<void> {
   const backend = (lease.resumeBackendId ?? lease.backend) as string;
   // 'none' / no backend -> nothing to terminate.
@@ -377,7 +380,7 @@ export async function terminateProviderBox(
     return;
   }
 
-  const client = createSandboxClientForBackend(backend as never, settings) as TerminableClient | undefined;
+  const client = createClientForBackend(backend as never, settings) as TerminableClient | undefined;
   if (!client) {
     // 'none' backend resolved to no client.
     return;

--- a/apps/worker/test/reaper-terminate-roundtrip.test.ts
+++ b/apps/worker/test/reaper-terminate-roundtrip.test.ts
@@ -13,16 +13,13 @@
 // client (resume() throws the exact UserError when sandboxId is missing, exactly
 // like the SDK) over a PRODUCTION envelope built by the real
 // serializeEstablishedSandboxEnvelope. Pre-fix it threw; post-fix it resumes by
-// sandboxId and terminates. createSandboxClientForBackend is mock-injected; the
-// real deserialize/serialize/NotFound helpers run unmocked.
+// sandboxId and terminates. The provider client builder is injected explicitly so
+// this test does not mock @opengeni/runtime globally and poison unrelated tests.
 
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { testSettings } from "@opengeni/testing";
 import * as runtime from "@opengeni/runtime";
-
-// Snapshot the REAL runtime exports BEFORE mocking so the mock factory can spread
-// them (and the test can call the real serialize/deserialize directly).
-const realRuntime = { ...runtime };
+import { terminateProviderBox } from "../src/activities/sandbox-lease";
 
 // A Modal-faithful fake provider client. resume() enforces the SAME invariant the
 // real SDK does (throws when state.sandboxId is absent), so a regressed envelope
@@ -53,16 +50,6 @@ function makeFakeModalClient() {
   };
 }
 
-mock.module("@opengeni/runtime", () => ({
-  ...realRuntime,
-  createSandboxClientForBackend: (backend: string) =>
-    backend === "modal" ? makeFakeModalClient() : undefined,
-}));
-
-afterAll(() => {
-  mock.restore();
-});
-
 const observability = {
   info() {},
   warn() {},
@@ -79,19 +66,19 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
       instanceId: "sb-trap",
       backendId: "modal",
     };
-    const envelope = await realRuntime.serializeEstablishedSandboxEnvelope(established as never);
+    const envelope = await runtime.serializeEstablishedSandboxEnvelope(established as never);
     expect(envelope).toBeTruthy();
     // sandboxId lives at envelope.sessionState.providerState.sandboxId — NOT at
     // the top level. Feeding the WHOLE envelope to the deserializer reads
     // top-level `providerState` (undefined) → drops sandboxId (the bug).
-    const dropped = (await realRuntime.deserializeSandboxSessionStateEnvelope(
+    const dropped = (await runtime.deserializeSandboxSessionStateEnvelope(
       makeFakeModalClient() as never,
       envelope as never,
     )) as { sandboxId?: unknown };
     expect(dropped?.sandboxId).toBeUndefined();
     // Unwrapping `.sessionState` first (what the working path / the fix does)
     // preserves sandboxId.
-    const kept = (await realRuntime.deserializeSandboxSessionStateEnvelope(
+    const kept = (await runtime.deserializeSandboxSessionStateEnvelope(
       makeFakeModalClient() as never,
       (envelope as { sessionState?: unknown }).sessionState as never,
     )) as { sandboxId?: unknown };
@@ -102,10 +89,6 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
     resumeCalls.length = 0;
     deleteCalls.length = 0;
 
-    // Dynamic import AFTER the mock so terminateProviderBox binds the fake
-    // createSandboxClientForBackend.
-    const { terminateProviderBox } = await import("../src/activities/sandbox-lease");
-
     const established = {
       client: makeFakeModalClient(),
       session: {},
@@ -114,7 +97,7 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
       backendId: "modal",
     };
     // The exact resume_state shape the lease stores on a turn / Channel-A commit.
-    const resumeState = await realRuntime.serializeEstablishedSandboxEnvelope(established as never);
+    const resumeState = await runtime.serializeEstablishedSandboxEnvelope(established as never);
 
     const lease = {
       sandboxGroupId: "group-1",
@@ -127,7 +110,12 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
     const settings = testSettings({ sandboxBackend: "modal", sandboxOwnershipEnabled: true });
 
     // Pre-fix this threw the Modal UserError; post-fix it resolves cleanly.
-    await terminateProviderBox(settings, lease as never, observability);
+    await terminateProviderBox(
+      settings,
+      lease as never,
+      observability,
+      ((backend: string) => backend === "modal" ? makeFakeModalClient() : undefined) as never,
+    );
 
     expect(resumeCalls).toEqual(["sb-live-123"]); // resumed BY ID, not thrown
     expect(deleteCalls).toEqual(["sb-live-123"]); // and terminated BY ID

--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -36,6 +36,19 @@ EXPOSE 8000
 CMD ["bun", "run", "--cwd", "apps/api", "start"]
 
 FROM base AS worker
+# The docker sandbox backend needs the Docker CLI to talk to the mounted host
+# daemon socket. Install the client only; the daemon remains outside this image.
+USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends docker-ce-cli \
+  && rm -rf /var/lib/apt/lists/*
+USER bun
 CMD ["bun", "run", "--cwd", "apps/worker", "start"]
 
 FROM base AS web-build

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -69,7 +69,6 @@ import {
 import { ModalCloudBucketMountStrategy } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
-import { userInfo } from "node:os";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -786,13 +785,7 @@ export function buildAgentCapabilities(
   return caps;
 }
 
-export function sandboxRunAs(settings: Settings): string | undefined {
-  if (settings.sandboxBackend === "docker") {
-    return "sandbox";
-  }
-  if (settings.sandboxBackend === "local") {
-    return userInfo().username;
-  }
+export function sandboxRunAs(_settings: Settings): string | undefined {
   return undefined;
 }
 

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -214,14 +214,24 @@ export class SandboxChannelAService {
   async fsList(req: FsListRequest): Promise<FsListResponse> {
     const root = normalizeRelPath(req.path);
     // A single bounded `find` (NUL-delimited) builds the whole subtree in one
-    // round-trip — far cheaper than N listDir calls. GNU find (-printf) is on
-    // the Ubuntu-based images; a non-GNU find degrades to an empty tree node
-    // (the route still returns a coherent root, never throws).
+    // round-trip. Prefer GNU find's -printf on the Ubuntu-based images, but fall
+    // back to a POSIX-ish find+stat loop for unix_local on macOS/BSD.
     const findRoot = root === "" ? "." : shellQuote(root);
     const depthArg = Math.max(1, req.depth);
     const hidden = req.includeHidden ? "" : ` -not -path '*/.*'`;
-    const cmd = `find ${findRoot} -mindepth 1 -maxdepth ${depthArg}${hidden} -printf '%y\\t%s\\t%T@\\t%m\\t%p\\0' 2>/dev/null`;
-    const { stdout } = await this.run({ cmd, workdir: this.workspaceRoot || undefined });
+    const gnuFind = `find ${findRoot} -mindepth 1 -maxdepth ${depthArg}${hidden} -printf '%y\\t%s\\t%T@\\t%m\\t%p\\0' 2>/dev/null`;
+    let { stdout } = await this.run({ cmd: `bash -lc ${shellQuote(gnuFind)}`, workdir: this.workspaceRoot || undefined });
+    if (!stdout) {
+      const portableFind = [
+        `find ${findRoot} -mindepth 1 -maxdepth ${depthArg}${hidden} -print0 2>/dev/null | while IFS= read -r -d '' p; do`,
+        `if [ -d "$p" ]; then t=d; size=0; elif [ -f "$p" ]; then t=f; size=$(wc -c < "$p" | tr -d ' '); elif [ -L "$p" ]; then t=l; size=0; else t=o; size=0; fi;`,
+        `mtime=$(date -r "$p" +%s 2>/dev/null || stat -c %Y "$p" 2>/dev/null || echo 0);`,
+        `mode=$(stat -f %Lp "$p" 2>/dev/null || stat -c %a "$p" 2>/dev/null || echo 0);`,
+        `printf '%s\\t%s\\t%s\\t%s\\t%s\\0' "$t" "$size" "$mtime" "$mode" "$p";`,
+        `done`,
+      ].join(" ");
+      ({ stdout } = await this.run({ cmd: `bash -lc ${shellQuote(portableFind)}`, workdir: this.workspaceRoot || undefined }));
+    }
 
     const entries = stdout.split(NUL).filter((s) => s.length > 0);
     const rootNode: FsTreeNode = {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -379,11 +379,15 @@ describe("runtime event normalization", () => {
     expect(agent.mcpServers).toEqual([]);
   });
 
-  test("sets sandbox runAs only for backends that support manifest users", () => {
-    expect(sandboxRunAs(testSettings({ sandboxBackend: "docker" }))).toBe("sandbox");
+  test("does not override the sandbox provider's default execution user", () => {
+    // The sandbox provider is responsible for choosing a user that can write to
+    // its workspace. Supplying a synthetic runAs user can break normal writes.
+    expect(sandboxRunAs(testSettings({ sandboxBackend: "docker" }))).toBeUndefined();
+    expect(sandboxRunAs(testSettings({ sandboxBackend: "local" }))).toBeUndefined();
     expect(sandboxRunAs(testSettings({ sandboxBackend: "modal" }))).toBeUndefined();
     expect(sandboxRunAs(testSettings({ sandboxBackend: "none" }))).toBeUndefined();
-    expect((buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), []) as any).runAs).toBe("sandbox");
+    expect((buildOpenGeniAgent(testSettings({ sandboxBackend: "docker" }), []) as any).runAs).toBeUndefined();
+    expect((buildOpenGeniAgent(testSettings({ sandboxBackend: "local" }), []) as any).runAs).toBeUndefined();
     expect((buildOpenGeniAgent(testSettings({ sandboxBackend: "modal" }), []) as any).runAs).toBeUndefined();
     expect((buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []) as any).runAs).toBeUndefined();
   });

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -81,8 +81,8 @@ describe("createSandboxClient — per-backend matrix construction", () => {
     expect(client.options?.appName).toBe("my-app");
     expect(client.options?.tokenId).toBe("tok-id");
     expect(client.options?.tokenSecret).toBe("tok-secret");
-    // 900s default → ms.
-    expect(client.options?.timeoutMs).toBe(900_000);
+    // 3600s default → ms.
+    expect(client.options?.timeoutMs).toBe(3_600_000);
   });
 
   test("modal both-or-neither token validation fails fast (typed error)", () => {

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -788,6 +788,7 @@ describe("worker activities integration", () => {
     let observedDuringRun: { status?: string; activeTurnId?: string | null } | null = null;
     const runtime: OpenGeniRuntime = {
       configure: () => {},
+      resolveTurnModel: () => null,
       buildAgent: () => ({} as never),
       prepareTools: async () => ({ mcpServers: [], close: async () => {} }),
       prepareInput: async (_agent, input) => {


### PR DESCRIPTION
## Summary
- install the Docker CLI in the worker image so the Docker sandbox backend can talk to the mounted host daemon
- stop forcing synthetic sandbox users for Docker/local backends and let the sandbox provider choose its writable default user
- align the approval-rerun integration mock with the current OpenGeniRuntime interface

## Validation
- bun run typecheck
- bun test packages/runtime/test/runtime.test.ts
- bun test packages/runtime/test/ownership-inversion.test.ts
- bun test --timeout 30000 ./test/integration/worker-activity.integration.ts -t 'marks approval reruns running before resuming the agent'

Note: a broad local run of bun test packages/runtime/test apps/worker/test hit existing latest-main local ARM desktop/provider environment failures, starting with docker/desktop.Dockerfile failing to install firefox-esr on Ubuntu arm64. The targeted runtime and integration checks above pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing default sandbox execution identity affects Docker/local write behavior; worker Dockerfile changes affect deployed worker images.
> 
> **Overview**
> **Sandbox execution user** no longer forces `runAs` for Docker/local backends — `sandboxRunAs` always returns `undefined`, so `SandboxAgent` and lifecycle hooks use each provider’s default writable user instead of synthetic `"sandbox"` or the host username.
> 
> **Worker image** adds `docker-ce-cli` on the worker stage so the Docker sandbox backend can use a mounted host daemon socket.
> 
> **Reaper terminate tests** inject a fake Modal client via a new optional `createClientForBackend` argument on `terminateProviderBox`, replacing a global `@opengeni/runtime` mock that could affect other tests.
> 
> **Channel-A `fsList`** tries GNU `find -printf` first, then falls back to a portable find/stat loop for unix_local on macOS/BSD.
> 
> **Integration** approval-rerun mock implements `resolveTurnModel` on `OpenGeniRuntime`. Modal client registry test expects the **3600s** default timeout (aligned with config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a360ea5192c20e5d53171383b9e795017f1c1023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->