### PR TITLE
documents: add delete document endpoint

### DIFF
--- a/.changeset/document-delete-sdk.md
+++ b/.changeset/document-delete-sdk.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Add a `deleteDocument` client helper for removing documents from document bases.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -294,6 +294,7 @@ const routeLabelPatterns: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /^\/v1\/workspaces\/[^/]+\/scheduled-tasks\/[^/]+$/, label: "/v1/workspaces/:workspaceId/scheduled-tasks/:id" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases$/, label: "/v1/workspaces/:workspaceId/document-bases" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases\/[^/]+\/documents\/[^/]+\/reindex$/, label: "/v1/workspaces/:workspaceId/document-bases/:id/documents/:documentId/reindex" },
+  { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases\/[^/]+\/documents\/[^/]+$/, label: "/v1/workspaces/:workspaceId/document-bases/:id/documents/:documentId" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases\/[^/]+\/documents$/, label: "/v1/workspaces/:workspaceId/document-bases/:id/documents" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases\/[^/]+\/search$/, label: "/v1/workspaces/:workspaceId/document-bases/:id/search" },
   { pattern: /^\/v1\/workspaces\/[^/]+\/document-bases\/[^/]+$/, label: "/v1/workspaces/:workspaceId/document-bases/:id" },

--- a/apps/api/src/routes/documents.ts
+++ b/apps/api/src/routes/documents.ts
@@ -8,6 +8,7 @@ import {
 import {
   addDocumentToBase,
   createDocumentBase,
+  deleteDocumentFromBase,
   getDocument,
   getDocumentBase,
   listDocumentBases,
@@ -84,6 +85,22 @@ export function registerDocumentRoutes(app: Hono, deps: ApiRouteDeps): void {
     const workspaceId = c.req.param("workspaceId");
     await requireAccessGrant(c, deps, workspaceId, "documents:search");
     return c.json((await listDocuments(db, workspaceId, c.req.param("baseId"))).map((document) => Document.parse(document)));
+  });
+
+  app.delete("/v1/workspaces/:workspaceId/document-bases/:baseId/documents/:documentId", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "documents:manage");
+    try {
+      await deleteDocumentFromBase(db, {
+        accountId: grant.accountId,
+        workspaceId,
+        baseId: c.req.param("baseId"),
+        documentId: c.req.param("documentId"),
+      });
+      return c.body(null, 204);
+    } catch (error) {
+      throw documentHttpException(error);
+    }
   });
 
   app.post("/v1/workspaces/:workspaceId/document-bases/:baseId/documents/:documentId/reindex", async (c) => {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -142,6 +142,7 @@ describe("API helpers", () => {
     expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/turns/turn-1`)).toBe("/v1/workspaces/:workspaceId/sessions/:id/turns/:turnId");
     expect(routeLabel(`/v1/workspaces/${workspace}/files/uploads/upload-1/complete`)).toBe("/v1/workspaces/:workspaceId/files/uploads/:id/complete");
     expect(routeLabel(`/v1/workspaces/${workspace}/document-bases/base-1/documents`)).toBe("/v1/workspaces/:workspaceId/document-bases/:id/documents");
+    expect(routeLabel(`/v1/workspaces/${workspace}/document-bases/base-1/documents/document-1`)).toBe("/v1/workspaces/:workspaceId/document-bases/:id/documents/:documentId");
     expect(routeLabel(`/v1/workspaces/${workspace}/document-bases/base-1/documents/document-1/reindex`)).toBe("/v1/workspaces/:workspaceId/document-bases/:id/documents/:documentId/reindex");
     expect(routeLabel(`/v1/workspaces/${workspace}/scheduled-tasks/task-1/runs`)).toBe("/v1/workspaces/:workspaceId/scheduled-tasks/:id/runs");
     expect(routeLabel(`/v1/workspaces/${workspace}/capabilities`)).toBe("/v1/workspaces/:workspaceId/capabilities");

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -329,6 +329,25 @@ export async function addDocumentToBase(db: Database, input: AddDocumentRequest 
   });
 }
 
+export async function deleteDocumentFromBase(
+  db: Database,
+  input: { accountId: string; workspaceId: string; baseId: string; documentId: string },
+): Promise<void> {
+  await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const [document] = await scopedDb.select().from(schema.documents)
+      .where(and(eq(schema.documents.workspaceId, input.workspaceId), eq(schema.documents.id, input.documentId)))
+      .limit(1);
+    if (!document) {
+      throw new Error(`Document not found: ${input.documentId}`);
+    }
+    if (document.baseId !== input.baseId) {
+      throw new Error(`Document not found: ${input.documentId}`);
+    }
+    await scopedDb.delete(schema.documents)
+      .where(and(eq(schema.documents.workspaceId, input.workspaceId), eq(schema.documents.id, input.documentId)));
+  });
+}
+
 export async function listDocuments(db: Database, workspaceId: string, baseId: string): Promise<Document[]> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const rows = await scopedDb.select().from(schema.documents)

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -844,6 +844,17 @@ export class OpenGeniClient {
     );
   }
 
+  /**
+   * Delete a document from a base. Removes the document row and its indexed
+   * chunks while leaving the uploaded file asset available for other uses.
+   */
+  async deleteDocument(workspaceId: string, baseId: string, documentId: string): Promise<void> {
+    await this.requestVoid(
+      "DELETE",
+      `/v1/workspaces/${workspaceId}/document-bases/${baseId}/documents/${documentId}`,
+    );
+  }
+
   async searchDocuments(
     workspaceId: string,
     baseId: string,

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -502,6 +502,15 @@ describe("OpenGeniClient documents", () => {
     ]);
     expect(JSON.parse(requests[6]!.body!)).toEqual({ query: "rollback steps", limit: 3 });
   });
+
+  test("deleteDocument DELETEs the document and resolves on 204", async () => {
+    const { client, requests } = makeClient(() => new Response(null, { status: 204 }));
+    await client.deleteDocument(WORKSPACE_ID, BASE_ID, DOCUMENT_ID);
+    expect(requests.map((request) => `${request.method} ${new URL(request.url).pathname}`)).toEqual([
+      `DELETE /v1/workspaces/${WORKSPACE_ID}/document-bases/${BASE_ID}/documents/${DOCUMENT_ID}`,
+    ]);
+    expect(requests[0]!.body).toBeNull();
+  });
 });
 
 describe("OpenGeniClient packs", () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { allAccountPermissions, allWorkspacePermissions, appendSessionHistoryItems, applyCreditLedgerEntry, bootstrapWorkspace, consumeSessionCompactionRequest, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getActiveSessionHistoryItems, getBillingBalance, getCapabilityInstallation, getSession, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
+import { allAccountPermissions, allWorkspacePermissions, appendSessionHistoryItems, applyCreditLedgerEntry, bootstrapWorkspace, consumeSessionCompactionRequest, createDb, createSession, createWorkspaceEnvironment, dbSql, decryptEnvironmentValue, enableCapabilityInstallation, getActiveSessionHistoryItems, getBillingBalance, getCapabilityInstallation, getSession, getPackInstallation, getScheduledTask, getSessionGoal, getWorkspaceEnvironmentValuesForRun, listSessionEvents, listScheduledTasks, listSessionTurns, listUsageEvents, recordStripeWebhookEvent, recordUsageEvent, requireFile, requireSession, setSessionGoalStatus, setSessionStatus, sumUsageQuantity, updateScheduledTask, upsertCapabilityCatalogItem } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import { signDelegatedAccessToken, type AccessContext, type Permission, type SessionEvent } from "@opengeni/contracts";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
@@ -2894,6 +2894,31 @@ describe("API component integration", () => {
     const search = await searchResponse.json() as { results: Array<{ text: string; title: string }> };
     expect(search.results[0]?.text).toContain("network policy");
     expect(search.results[0]?.title).toBe("network-runbook.txt");
+
+    const deleteResponse = await app.request(workspacePath(workspaceId, `/document-bases/${base.id}/documents/${document.id}`), { method: "DELETE" });
+    expect(deleteResponse.status).toBe(204);
+    expect(await deleteResponse.text()).toBe("");
+
+    const deletedListResponse = await app.request(workspacePath(workspaceId, `/document-bases/${base.id}/documents`));
+    expect(deletedListResponse.status).toBe(200);
+    expect(await deletedListResponse.json()).toEqual([]);
+
+    const deletedSearchResponse = await app.request(workspacePath(workspaceId, `/document-bases/${base.id}/search`), {
+      method: "POST",
+      body: JSON.stringify({ query: "network policy", limit: 3 }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(deletedSearchResponse.status).toBe(200);
+    const deletedSearch = await deletedSearchResponse.json() as { results: unknown[] };
+    expect(deletedSearch.results).toEqual([]);
+
+    await expect(requireFile(dbClient.db, workspaceId, upload.fileId)).resolves.toMatchObject({
+      id: upload.fileId,
+      filename: "network-runbook.txt",
+    });
+
+    const missingDeleteResponse = await app.request(workspacePath(workspaceId, `/document-bases/${base.id}/documents/${document.id}`), { method: "DELETE" });
+    expect(missingDeleteResponse.status).toBe(404);
   });
 
   test("reindex returns queued document state when production indexer enqueues async work", async () => {


### PR DESCRIPTION
## Summary
- add DELETE /v1/workspaces/:workspaceId/document-bases/:baseId/documents/:documentId behind documents:manage
- add documents domain helper and SDK deleteDocument client method
- keep uploaded file assets intact while deleting the document row and indexed chunks
- add route-label, SDK, and integration coverage plus SDK changeset

## Validation
- bun run typecheck
- bun test apps/api/test/app.test.ts packages/sdk/test/client-coverage.test.ts packages/documents/test/documents.test.ts
- bun test --timeout 180000 ./test/integration/api.integration.ts -t 'indexes uploaded files into document bases and searches them'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped delete behind documents:manage with RLS; integration tests confirm search clears and files remain. Main caveat is irreversible removal of index membership without deleting storage objects.
> 
> **Overview**
> Adds **document removal** from a document base via a new `DELETE` API, domain helper, and SDK method.
> 
> The endpoint `DELETE /v1/workspaces/:workspaceId/document-bases/:baseId/documents/:documentId` requires **`documents:manage`**, returns **204**, and delegates to **`deleteDocumentFromBase`**, which deletes the document row under RLS after validating workspace and base membership (wrong/missing base → 404). Indexed **`document_chunks`** are removed via DB **ON DELETE CASCADE**; the underlying **file asset** is not deleted.
> 
> **`OpenGeniClient.deleteDocument`** issues that DELETE and expects 204. Metrics **`routeLabel`** includes the new path (ordered before the collection `.../documents` route). Tests cover SDK wiring, route labeling, and integration (empty list/search after delete, file still present, 404 on repeat delete). SDK patch changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a785787b0e36e6cef06258699176550b82877982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->