### PR TITLE
chore(changeset): credit timeline + sandbox surfacing (minor @opengeni/react)

### DIFF
--- a/.changeset/timeline-sandbox-surfacing.md
+++ b/.changeset/timeline-sandbox-surfacing.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/react": minor
+"@opengeni/sdk": minor
+---
+
+Add the world-class timeline tool-call renderer module and the sandbox-surfacing client surface to `@opengeni/react`.
+
+- **Timeline renderers**: per-tool disclosure cards (full-row toggle, keyboard-accessible), screenshots → lightbox, theme-aware Pierre diffs, turn-collapse summary chips, sub-agent worker/goal landmarks, a consumer-extensible tool registry, and complete state handling (running / complete / failed / cancelled), each with its own affordance.
+- **Sandbox surfacing**: file/terminal/git/desktop hooks and components (`useSandboxFiles`, `useSandboxTerminal`, `useSandboxGit`, `useDesktopStream`, `useTerminalStream`, `useSessionCapabilities`, `SandboxFiles`, `SandboxTerminal`, `DesktopViewer`, `WorkspaceDock`, Pierre diff/file views, `CodeEditor`).
+
+All additive; `MessageTimeline`'s `items` contract is unchanged. The internal `compactPayloadPreview` helper was removed from the public surface.


### PR DESCRIPTION
Adds a changeset so the next `@opengeni/react`/`@opengeni/sdk` release (Version PR #109) honestly credits the timeline renderer module (#110) and sandbox-surfacing client surface (#101) as a **minor** bump. No code change — changeset metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changeset with no runtime or build changes in this diff.
> 
> **Overview**
> Adds a **changeset only** — no application code in this PR.
> 
> It records a **minor** semver bump for `@opengeni/react` and `@opengeni/sdk` so the next release notes credit the timeline tool-call renderer work and the sandbox-surfacing client APIs. The changeset text documents those features (timeline disclosure cards, tool registry, sandbox hooks/components) and notes they are additive with an unchanged `MessageTimeline` `items` contract, plus removal of `compactPayloadPreview` from the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f07dd12f52b6f9d82d44762f382f0b12d37487a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->