### PR TITLE
fix(react): create-file apply_patch diff renders added lines when expanded

### DIFF
--- a/packages/react/src/lib/git-patch.ts
+++ b/packages/react/src/lib/git-patch.ts
@@ -22,10 +22,16 @@ export function gitFileDiffToPatch(file: GitFileDiff): string {
     lines.push(`+++ b/${newPath}`);
   }
   for (const hunk of file.hunks) {
-    const header =
-      hunk.header && hunk.header.startsWith("@@")
-        ? hunk.header
-        : `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
+    // Only trust a pre-parsed header if it carries the full unified range form
+    // `@@ -<o>[,<n>] +<o>[,<n>] @@`. A synthesized create_file hunk (parsers.ts)
+    // can carry a degenerate `@@ +1 @@` with no `-`/`+` ranges; a generic patch
+    // parser (Pierre) renders zero lines from it, so the expanded diff comes up
+    // empty while the collapsed chip still shows the (correct) addition count.
+    // In that case regenerate a valid header from the hunk's range fields.
+    const headerIsValid = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/.test(hunk.header ?? "");
+    const header = headerIsValid
+      ? hunk.header
+      : `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
     lines.push(header);
     for (const line of hunk.lines) {
       if (line.type === "meta") continue;

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -131,7 +131,12 @@ export function v4aToGitFileDiff(op: ApplyPatchOperation): GitFileDiff {
         hunks.push(cur);
       } else if (cur || op.type === "create_file") {
         if (!cur) {
-          cur = { oldStart: 0, oldLines: 0, newStart: 1, newLines: 0, header: "@@ +1 @@", lines: [] };
+          // No `@@` anchor on a create_file body: synthesize an add-only hunk.
+          // Leave `header` empty so `gitFileDiffToPatch` regenerates a valid
+          // `@@ -0,0 +1,N @@` from the range fields once newLines is counted — a
+          // pre-baked partial header (e.g. `@@ +1 @@`) renders zero lines in a
+          // generic unified-diff parser.
+          cur = { oldStart: 0, oldLines: 0, newStart: 1, newLines: 0, header: "", lines: [] };
           hunks.push(cur);
           oldNo = 0;
           newNo = 1;

--- a/packages/react/test/timeline-parsers.test.ts
+++ b/packages/react/test/timeline-parsers.test.ts
@@ -16,6 +16,7 @@ import {
   v4aToGitFileDiff,
   type ApplyPatchOperation,
 } from "../src/timeline";
+import { gitFileDiffToPatch } from "../src/index";
 
 /* ----------------------------------------------------------------------------
    Unit tests for the pure provider-shape parsers (src/timeline/parsers.ts).
@@ -140,6 +141,66 @@ describe("V4A apply_patch parsing", () => {
     const diff = v4aToGitFileDiff({ type: "update_file", path: "x.ts", diff: "" });
     expect(diff.status).toBe("modified");
     expect(diff.hunks).toHaveLength(0);
+  });
+
+  test("create_file with no @@ anchor round-trips to a valid unified patch (expanded diff is NOT empty)", () => {
+    // Regression: a create_file body without a `@@` anchor synthesized a hunk
+    // with a degenerate `@@ +1 @@` header. f.additions was counted correctly
+    // (the collapsed chip showed +N), but gitFileDiffToPatch emitted the broken
+    // header verbatim, so the generic unified-diff parser (Pierre) rendered ZERO
+    // lines on expand → collapsed +N / expanded +0. The emitted patch must carry
+    // a structurally valid `@@ -0,0 +1,N @@` header and all N added lines.
+    const N = 17;
+    const body = Array.from({ length: N }, (_, i) => `+line ${i + 1}`).join("\n");
+    const file = v4aToGitFileDiff({ type: "create_file", path: "src/new.ts", diff: body });
+
+    // The chip count (additions) is what the collapsed header shows.
+    expect(file.additions).toBe(N);
+
+    const patch = gitFileDiffToPatch(file);
+    const patchLines = patch.split("\n");
+
+    // A valid create header — NOT the degenerate `@@ +1 @@`.
+    const header = patchLines.find((l) => l.startsWith("@@"));
+    expect(header).toBe(`@@ -0,0 +1,${N} @@`);
+    expect(patch).not.toContain("@@ +1 @@");
+
+    // Every added line is present in the patch body — what Pierre renders on
+    // expand must equal the collapsed chip count.
+    const addedLines = patchLines.filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+    expect(addedLines).toHaveLength(N);
+    expect(addedLines[0]).toBe("+line 1");
+    expect(addedLines[N - 1]).toBe(`+line ${N}`);
+  });
+
+  test("gitFileDiffToPatch regenerates a header missing the unified range form", () => {
+    // Defense in depth: a hunk whose header lacks the `-x,y +a,b` ranges gets a
+    // regenerated header derived from the range fields rather than emitted as-is.
+    const patch = gitFileDiffToPatch({
+      path: "f.txt",
+      oldPath: null,
+      status: "added",
+      isBinary: false,
+      isImage: false,
+      additions: 2,
+      deletions: 0,
+      truncated: false,
+      hunks: [
+        {
+          oldStart: 0,
+          oldLines: 0,
+          newStart: 1,
+          newLines: 2,
+          header: "@@ +1 @@",
+          lines: [
+            { type: "add", oldNo: null, newNo: 1, text: "a" },
+            { type: "add", oldNo: null, newNo: 2, text: "b" },
+          ],
+        },
+      ],
+    });
+    expect(patch).toContain("@@ -0,0 +1,2 @@");
+    expect(patch).not.toContain("@@ +1 @@");
   });
 
   test("applyPatchOps normalizes both wire shapes", () => {


### PR DESCRIPTION
**Bug (hit live on staging):** an apply_patch that *creates* a file shows `+17 / −0` in the collapsed card but renders an **empty** diff (`+0 / −0`) when expanded.

**Root cause:** for a `create_file` op with no `@@` anchor, `v4aToGitFileDiff` synthesized a hunk with a malformed header `@@ +1 @@`; `gitFileDiffToPatch` emitted it verbatim, so the Pierre/unified-diff renderer produced zero lines — while the chip's count came from `f.additions` (17), masking the empty body.

**Fix:** leave the synthesized header empty so it's regenerated from the range fields; `git-patch.ts` regex-validates + regenerates a valid `@@ -0,0 +1,N @@`. Round-trip regression tests added. tsc 0; 29 parser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized diff serialization and V4A parsing for apply_patch display; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **timeline apply_patch UI bug** where **create_file** operations without a `@@` hunk anchor showed the right **+N** on the collapsed card but an **empty** expanded diff (Pierre/unified parser).
> 
> **`v4aToGitFileDiff`** no longer seeds a degenerate `@@ +1 @@` header for anchorless create bodies; it leaves **`header` empty** so line counts populate the hunk ranges first. **`gitFileDiffToPatch`** only reuses stored headers that match a full unified form (`@@ -<old> +<new> @@`); otherwise it **rebuilds** the header from `oldStart`/`newLines` (e.g. `@@ -0,0 +1,N @@`).
> 
> Regression tests cover **create_file → patch round-trip** and **malformed header regeneration**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e217ca6161407a6ac7a0263510e932b9a8e14249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->