### PR TITLE
fix(computer-use): backstop empty computer_call_output image_url (action-timeout 400)

### DIFF
--- a/packages/runtime/src/history-sanitizer.ts
+++ b/packages/runtime/src/history-sanitizer.ts
@@ -325,19 +325,97 @@ export function rewriteComputerCallsToActionsOnly(body: unknown): boolean {
 }
 
 /**
+ * The 1×1 transparent PNG placeholder used by the SDK for tool-approval-rejection
+ * screenshots (`TOOL_APPROVAL_REJECTION_SCREENSHOT_DATA_URL` in agents-core
+ * `toolExecution.mjs`). We reuse the exact same constant as a backstop for the
+ * action-timeout 400: when an action times out the SDK's catch sets output='' and
+ * builds `{type:"computer_call_output",output:{type:"computer_screenshot",image_url:""}}`.
+ * Azure rejects `image_url:""` with "400 Invalid input[N].output.image_url". This
+ * placeholder is a valid data URI the provider accepts, so the turn continues and
+ * the model receives the next real screenshot on its following step.
+ */
+const EMPTY_IMAGE_URL_PLACEHOLDER =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
+
+/**
+ * Backstop for the action-timeout 400: walk the `input` array of a serialized
+ * Responses request body and replace any `computer_call_output` item whose
+ * `output.image_url` is an empty string, null, undefined, or otherwise not a
+ * non-empty string with the 1×1 transparent PNG placeholder data URI.
+ *
+ * WHY THIS IS NEEDED. When a computer ACTION (click/type/scroll/drag) times out
+ * at the 15-second yield window `SandboxComputer.x()` throws `ComputerActionError`.
+ * The agents-core SDK `toolExecution.mjs` catch block sets `output = ''` and then
+ * builds the wire item:
+ *
+ *   `{type:"computer_call_output", output:{type:"computer_screenshot", image_url:""}}`
+ *
+ * Azure rejects the whole request with:
+ *
+ *   `400 Invalid 'input[N].output.image_url'. Expected a valid URL, but got a
+ *    value with an invalid format.`
+ *
+ * Our screenshot() fail-loud guard (which throws on empty frames) only runs when
+ * the SDK calls screenshot() on a SUCCESS path — not on this action-error catch
+ * path that sets output='' directly. This wire-level rewrite is the only seam that
+ * catches both paths regardless of how the empty image_url was produced. It runs
+ * in the same `computerCallNormalizingFetch` wrapper, so a single parse/rewrite
+ * pass covers both the action/actions-only rewrite and this placeholder injection.
+ *
+ * Mutates `body` in place (the caller has already JSON.parsed a private copy).
+ * Returns `true` iff at least one image_url was replaced.
+ */
+export function rewriteEmptyComputerCallOutputImageUrls(body: unknown): boolean {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+  const input = (body as Record<string, unknown>).input;
+  if (!Array.isArray(input)) {
+    return false;
+  }
+  let changed = false;
+  for (const item of input) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    if (record.type !== "computer_call_output") {
+      continue;
+    }
+    const output = record.output;
+    if (!output || typeof output !== "object") {
+      continue;
+    }
+    const out = output as Record<string, unknown>;
+    const imageUrl = out.image_url;
+    // Replace the image_url when it is not a non-empty string (covers: "", null, undefined, missing).
+    if (typeof imageUrl !== "string" || imageUrl.length === 0) {
+      out.image_url = EMPTY_IMAGE_URL_PLACEHOLDER;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+/**
  * Wrap a `fetch` so every outbound OpenAI Responses request body that contains a
  * `computer_call` is rewritten to the ACTIONS-ONLY shape (see
- * {@link rewriteComputerCallsToActionsOnly}) before it reaches the network.
+ * {@link rewriteComputerCallsToActionsOnly}) before it reaches the network, AND
+ * any `computer_call_output` item with an empty/missing `output.image_url` is
+ * patched with the 1×1 transparent PNG placeholder (see
+ * {@link rewriteEmptyComputerCallOutputImageUrls}).
  *
  * Installed as the `fetch:` option on the Azure OpenAI client, this is the
  * lowest reachable seam — below the agents-core input filter and below the SDK's
  * responses converter — so it neutralizes the converter's both-fields synthesis
- * regardless of what the input item carried.
+ * regardless of what the input item carried, and backstops the action-timeout
+ * empty image_url regardless of how it was produced.
  *
  * Surgical and cheap: it only parses the body when it is a string that contains
- * the literal `"computer_call"` (every other request — non-computer-use turns,
- * streaming SSE responses, non-string bodies — forwards untouched, the SAME
- * `init` reference, so streaming and other providers are unaffected). A JSON
+ * the prefix `"computer_call` (matching both `"computer_call"` action items and
+ * `"computer_call_output"` result items). Every other request — non-computer-use
+ * turns, streaming SSE responses, non-string bodies — forwards untouched, the
+ * SAME `init` reference, so streaming and other providers are unaffected. A JSON
  * parse failure or a no-op rewrite also forwards the original `init` unchanged.
  *
  * Typed structurally (the `(input, init) => Promise<Response>` call signature)
@@ -352,10 +430,15 @@ type FetchLike = (
 
 export function computerCallNormalizingFetch(base: FetchLike): FetchLike {
   return (input, init) => {
-    if (init && typeof init.body === "string" && init.body.includes("\"computer_call\"")) {
+    // Match any request that mentions either `computer_call` (the action call) or
+    // `computer_call_output` (the output/result item). Both strings begin with
+    // `"computer_call` so a single prefix-substring check covers both.
+    if (init && typeof init.body === "string" && init.body.includes("\"computer_call")) {
       try {
         const parsed = JSON.parse(init.body) as unknown;
-        if (rewriteComputerCallsToActionsOnly(parsed)) {
+        const changed1 = rewriteComputerCallsToActionsOnly(parsed);
+        const changed2 = rewriteEmptyComputerCallOutputImageUrls(parsed);
+        if (changed1 || changed2) {
           return base(input, { ...init, body: JSON.stringify(parsed) });
         }
       } catch {

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -179,8 +179,20 @@ export class SandboxComputer implements Computer {
     }
     const output = sandboxCommandOutput(result);
     if (sandboxCommandStillRunning(result)) {
-      // F3: the command exceeded the yield window — surface, don't treat as success.
-      throw new ComputerActionError(cmd, -1, `command did not finish before the yield window:\n${output}`);
+      // F3: the command exceeded the yield window. WARN AND RETURN rather than
+      // throw. Throwing here causes the SDK's catch in `_runComputerActionAndScreenshot`
+      // to set output='' and build `{image_url:""}` → Azure 400. By returning
+      // instead, the SDK proceeds past the action loop and calls computer.screenshot()
+      // so the model gets the REAL current frame for its next step.
+      //
+      // screenshot()'s FAIL-LOUD + retry contract is preserved: if scrot itself
+      // times out (very unlikely at 15 s), x() returns here, readScreenshotBytes
+      // produces empty bytes, and the retry loop eventually throws. The wire-level
+      // backstop in computerCallNormalizingFetch is also in place as a second net.
+      console.warn(
+        `[SandboxComputer] action command did not finish before the ${ACTION_YIELD_MS}ms yield window — proceeding to screenshot: ${cmd}`,
+      );
+      return output;
     }
     const exitCode = sandboxCommandExitCode(result);
     if (exitCode !== null && exitCode !== 0) {

--- a/packages/runtime/test/history-sanitizer.test.ts
+++ b/packages/runtime/test/history-sanitizer.test.ts
@@ -3,8 +3,14 @@ import {
   computerCallNormalizingFetch,
   normalizeComputerCallActions,
   rewriteComputerCallsToActionsOnly,
+  rewriteEmptyComputerCallOutputImageUrls,
   sanitizeHistoryItemsForModel,
 } from "../src/history-sanitizer";
+
+// The exact 1×1 transparent PNG placeholder used by the SDK (agents-core
+// toolExecution.mjs) and now also by our wire-level backstop.
+const PLACEHOLDER =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
 
 // Item shapes mirror the SDK's canonical history representation
 // (`type` discriminator, camelCase `callId`) that is persisted verbatim into
@@ -301,5 +307,211 @@ describe("computerCallNormalizingFetch", () => {
     const init = { method: "GET" };
     await wrapped("https://aoai/openai/v1/responses", init);
     expect(seenInit).toBe(init);
+  });
+});
+
+describe("rewriteEmptyComputerCallOutputImageUrls", () => {
+  // ROOT CAUSE: when an action (click/type/scroll/drag) times out at the 15 s
+  // yield window, SandboxComputer.x() throws ComputerActionError; agents-core
+  // toolExecution.mjs catch sets output='' and builds the wire item:
+  //   {type:"computer_call_output",output:{type:"computer_screenshot",image_url:""}}
+  // Azure rejects the whole request: "400 Invalid input[N].output.image_url".
+  // This rewriter is the wire-level backstop that replaces empty/missing
+  // image_urls with the 1×1 transparent PNG placeholder before Azure sees them.
+
+  test("replaces an empty image_url on a computer_call_output with the placeholder", () => {
+    // The exact wire shape the SDK produces on action-timeout: image_url is "".
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "click the button" }] },
+        {
+          type: "computer_call_output",
+          call_id: "cu_1",
+          output: { type: "computer_screenshot", image_url: "" },
+        },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(true);
+    const out = (body.input[1] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(out.image_url).toBe(PLACEHOLDER);
+    // Sibling fields and non-computer items are untouched.
+    expect(out.type).toBe("computer_screenshot");
+    expect((body.input[1] as Record<string, unknown>).call_id).toBe("cu_1");
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "click the button" }],
+    });
+  });
+
+  test("replaces a missing image_url (undefined) with the placeholder", () => {
+    const body = {
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "cu_2",
+          output: { type: "computer_screenshot" },
+        },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(true);
+    const out = (body.input[0] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(out.image_url).toBe(PLACEHOLDER);
+  });
+
+  test("replaces a null image_url with the placeholder", () => {
+    const body = {
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "cu_3",
+          output: { type: "computer_screenshot", image_url: null },
+        },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(true);
+    const out = (body.input[0] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(out.image_url).toBe(PLACEHOLDER);
+  });
+
+  test("leaves a valid non-empty data-URI image_url untouched (no change)", () => {
+    // A real screenshot — must never be overwritten by the backstop.
+    const realDataUri = "data:image/png;base64,abc123def456";
+    const body = {
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "cu_4",
+          output: { type: "computer_screenshot", image_url: realDataUri },
+        },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(false);
+    const out = (body.input[0] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(out.image_url).toBe(realDataUri);
+  });
+
+  test("leaves the placeholder itself untouched when already present (idempotent)", () => {
+    // If the item was already patched (e.g. replayed history from a prior turn)
+    // it must not be double-replaced.
+    const body = {
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "cu_5",
+          output: { type: "computer_screenshot", image_url: PLACEHOLDER },
+        },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(false);
+    const out = (body.input[0] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(out.image_url).toBe(PLACEHOLDER);
+  });
+
+  test("handles multiple items: patches empty, leaves valid, skips non-computer items", () => {
+    const realDataUri = "data:image/png;base64,validdata";
+    const body = {
+      input: [
+        { type: "message", role: "user", content: "go" },
+        { type: "computer_call_output", call_id: "cu_a", output: { type: "computer_screenshot", image_url: "" } },
+        { type: "function_call_result", call_id: "fn_1", output: { type: "text", text: "ok" } },
+        { type: "computer_call_output", call_id: "cu_b", output: { type: "computer_screenshot", image_url: realDataUri } },
+        { type: "computer_call_output", call_id: "cu_c", output: { type: "computer_screenshot", image_url: null } },
+      ],
+    };
+    const changed = rewriteEmptyComputerCallOutputImageUrls(body);
+    expect(changed).toBe(true);
+    // cu_a (empty "")  → replaced
+    const outA = (body.input[1] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(outA.image_url).toBe(PLACEHOLDER);
+    // function_call_result → untouched
+    expect((body.input[2] as Record<string, unknown>).call_id).toBe("fn_1");
+    // cu_b (valid) → untouched
+    const outB = (body.input[3] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(outB.image_url).toBe(realDataUri);
+    // cu_c (null) → replaced
+    const outC = (body.input[4] as Record<string, unknown>).output as Record<string, unknown>;
+    expect(outC.image_url).toBe(PLACEHOLDER);
+  });
+
+  test("returns false and is a no-op for non-array input, null, and non-object bodies", () => {
+    expect(rewriteEmptyComputerCallOutputImageUrls({ input: [{ type: "message" }] })).toBe(false);
+    expect(rewriteEmptyComputerCallOutputImageUrls({ input: "nope" })).toBe(false);
+    expect(rewriteEmptyComputerCallOutputImageUrls(null)).toBe(false);
+    expect(rewriteEmptyComputerCallOutputImageUrls("string")).toBe(false);
+  });
+});
+
+describe("computerCallNormalizingFetch — empty image_url backstop (action-timeout 400)", () => {
+  test("patches an empty image_url on a computer_call_output before sending to provider", async () => {
+    // The exact scenario: action timed out → SDK set image_url:"" → Azure would 400.
+    // The wrapping fetch must replace it with the placeholder so Azure accepts it.
+    let seenBody: string | undefined;
+    const base = (async (_url: unknown, init?: { body?: unknown }) => {
+      seenBody = init?.body as string;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+
+    const wrapped = computerCallNormalizingFetch(base);
+    const originalBody = JSON.stringify({
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "cu_timeout",
+          output: { type: "computer_screenshot", image_url: "" },
+        },
+      ],
+    });
+    await wrapped("https://aoai/openai/v1/responses", { method: "POST", body: originalBody });
+
+    expect(seenBody).toBeDefined();
+    const sent = JSON.parse(seenBody as string);
+    const out = sent.input[0].output;
+    expect(out.image_url).toBe(PLACEHOLDER);
+    // The type field is preserved.
+    expect(out.type).toBe("computer_screenshot");
+  });
+
+  test("applies both rewrites in one pass: actions-only + empty image_url fix", async () => {
+    // A body that has both problems: a computer_call with both fields AND a
+    // computer_call_output with an empty image_url. Both are fixed in one parse.
+    let seenBody: string | undefined;
+    const base = (async (_url: unknown, init?: { body?: unknown }) => {
+      seenBody = init?.body as string;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+
+    const wrapped = computerCallNormalizingFetch(base);
+    const originalBody = JSON.stringify({
+      input: [
+        {
+          type: "computer_call",
+          call_id: "cu_act",
+          action: { type: "click", x: 10, y: 20 },
+          actions: [{ type: "click", x: 10, y: 20 }],
+        },
+        {
+          type: "computer_call_output",
+          call_id: "cu_act",
+          output: { type: "computer_screenshot", image_url: "" },
+        },
+      ],
+    });
+    await wrapped("https://aoai/openai/v1/responses", { method: "POST", body: originalBody });
+
+    expect(seenBody).toBeDefined();
+    const sent = JSON.parse(seenBody as string);
+    // computer_call → actions-only
+    const cc = sent.input[0];
+    expect("action" in cc).toBe(false);
+    expect(cc.actions).toEqual([{ type: "click", x: 10, y: 20 }]);
+    // computer_call_output → placeholder
+    const out = sent.input[1].output;
+    expect(out.image_url).toBe(PLACEHOLDER);
   });
 });

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -158,10 +158,20 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
     await expect(c.click(1, 1, "left")).rejects.toBeInstanceOf(ComputerActionError);
   });
 
-  test("F3: a 'still running' yield is a retriable failure, not a success", async () => {
+  test("F3: a 'still running' action yield WARNS and resolves (does not throw) so screenshot() runs", async () => {
+    // CHANGED from throw to warn+return: if a click/move/type times out at the
+    // yield window and we throw, the SDK catch (toolExecution.mjs) sets output=''
+    // and builds `{image_url:""}` → Azure 400. By returning instead, the SDK
+    // proceeds to call computer.screenshot() after the action loop, and the model
+    // gets the real current frame. The wire-level backstop in
+    // computerCallNormalizingFetch is also in place as a second net. Non-zero exit
+    // codes (true command errors) still throw — only the still-running case is
+    // silenced. screenshot()'s fail-loud + retry contract is preserved.
     const { session } = makeMockSession({ stillRunning: true });
     const c = new SandboxComputer(session as never);
-    await expect(c.move(5, 5)).rejects.toBeInstanceOf(ComputerActionError);
+    // move() must RESOLVE (not reject) so the SDK action loop exits cleanly and
+    // screenshot() is called afterward.
+    await expect(c.move(5, 5)).resolves.toBeUndefined();
   });
 
   test("F5: scroll converts model pixel deltas to clamped wheel notches (not literal repeat counts)", async () => {


### PR DESCRIPTION
**Bug (hit live on staging during a desktop computer-use session):** a turn fails with `400 Invalid 'input[N].output.image_url'. Expected a valid URL, but got a value with an invalid format.`

**Root cause:** a computer **action** (a click) times out at the 15s yield window → `x()` throws `ComputerActionError` → the `@openai/agents` SDK catch (node_modules) turns it into `output=''` → serializes `{type:"computer_call_output", output:{image_url:""}}` → Azure rejects an empty image_url as "invalid format". Our earlier fix only guards the *screenshot* path (zero-byte frame); this is an *action* timing out **before** `screenshot()` runs. The wire-level fast-path guard also only matched `"computer_call"`, not `"computer_call_output"`, so it sailed through.

**Fix (two nets):**
1. **Wire seam** (`history-sanitizer.ts`): `rewriteEmptyComputerCallOutputImageUrls` replaces any empty/missing `computer_call_output.image_url` with a valid 1×1 PNG placeholder (the SDK's own rejection placeholder), wired into `computerCallNormalizingFetch`; guard widened to match `computer_call_output`. Catches the empty from any source (action timeout / SDK catch / replay).
2. **Action hardening** (`sandbox-computer.ts`): a yield-timed-out action now warns + returns instead of throwing, so the SDK proceeds to `screenshot()` and the model gets the **real** current frame (not a blank). Directly addresses the `xdotool --sync` hang. `screenshot()`'s fail-loud + retry contract is preserved.

10 new tests; `tsc` 0; runtime suite 301 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes computer-use error handling and mutates outbound Azure request bodies for computer items; wrong placeholder logic could mask real screenshot failures, but scope is narrow and well-tested.
> 
> **Overview**
> Fixes Azure **400 Invalid `input[N].output.image_url`** when a desktop computer-use **action** hits the 15s yield window: the SDK error path emits `computer_call_output` with `image_url: ""`, which the provider rejects.
> 
> **Wire backstop** (`history-sanitizer.ts`): adds `rewriteEmptyComputerCallOutputImageUrls` to swap empty/missing `computer_call_output` screenshot URLs for the SDK’s 1×1 PNG placeholder; runs alongside the existing actions-only rewrite inside `computerCallNormalizingFetch`. The body fast-path now matches `"computer_call` so **`computer_call_output`** bodies are rewritten too.
> 
> **Action behavior** (`sandbox-computer.ts`): when `sandboxCommandStillRunning` (F3), **`x()` warns and returns** instead of throwing `ComputerActionError`, so the SDK can continue to **`screenshot()`** and send a real frame. Non-zero exits still throw.
> 
> Tests cover the rewriter, combined fetch pass, and the updated F3 expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af289e30ea56e39db02de70a20599f5ac8599065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->