### PR TITLE
fix(db): jsonb-safe session event payloads (strip NUL / repair surrogates)

### DIFF
--- a/packages/db/src/event-payload-sanitizer.ts
+++ b/packages/db/src/event-payload-sanitizer.ts
@@ -1,0 +1,88 @@
+/**
+ * Last line of defense against a session event crashing a whole turn.
+ *
+ * Postgres `text`/`jsonb` cannot store a NUL byte (U+0000) nor lone UTF-16
+ * surrogates. Raw exec output routinely carries both -- chrome/crashpad logs,
+ * `cat` of a binary, random bytes -- and the worker persists that output verbatim
+ * inside `agent.toolCall.output` / `sandbox.command.output` event payloads. When
+ * such a payload reaches `INSERT INTO session_events`, the driver rejects it
+ * ("Failed query: insert into session_events") and the turn dies.
+ *
+ * `sanitizeEventPayload` deep-walks any payload value (objects, arrays, nested)
+ * and, for every string, strips NUL and rewrites invalid/lone UTF-16 surrogates
+ * to the Unicode replacement char (U+FFFD), so the result is always valid UTF-8
+ * that jsonb can store. It is cheap and total: only strings are touched, and only
+ * the two disallowed classes of code unit -- no meaningful text is lost, no
+ * truncation (truncation is handled elsewhere).
+ */
+
+const REPLACEMENT = "�";
+
+/**
+ * Strip NUL and repair invalid/lone UTF-16 surrogates in a single string.
+ * Returns the input unchanged (same reference) when it is already clean, so the
+ * common case allocates nothing.
+ */
+export function sanitizeEventString(value: string): string {
+  // Fast path: no NUL and no surrogate code unit at all -> nothing to do.
+  // Surrogates live in U+D800..U+DFFF; a quick scan avoids the rebuild cost.
+  let needsWork = false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0x0000 || (code >= 0xd800 && code <= 0xdfff)) {
+      needsWork = true;
+      break;
+    }
+  }
+  if (!needsWork) {
+    return value;
+  }
+
+  let out = "";
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0x0000) {
+      // Drop NUL entirely.
+      continue;
+    }
+    if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate: valid only when immediately followed by a low surrogate.
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += value[i]! + value[i + 1]!;
+        i += 1;
+        continue;
+      }
+      out += REPLACEMENT;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      // Lone low surrogate (a valid pair would have been consumed above).
+      out += REPLACEMENT;
+      continue;
+    }
+    out += value[i]!;
+  }
+  return out;
+}
+
+/**
+ * Deep-walk a session event payload and sanitize every string value. Mirrors the
+ * shape of the worker redaction deep-walk: objects, arrays, and nested
+ * combinations are traversed; non-string leaves pass through untouched.
+ */
+export function sanitizeEventPayload<T>(payload: T): T {
+  if (typeof payload === "string") {
+    return sanitizeEventString(payload) as unknown as T;
+  }
+  if (Array.isArray(payload)) {
+    return payload.map((item) => sanitizeEventPayload(item)) as unknown as T;
+  }
+  if (payload && typeof payload === "object") {
+    const entries = Object.entries(payload as Record<string, unknown>).map(
+      ([key, value]) => [sanitizeEventString(key), sanitizeEventPayload(value)] as const,
+    );
+    return Object.fromEntries(entries) as unknown as T;
+  }
+  return payload;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -55,10 +55,12 @@ import { and, asc, desc, eq, gt, gte, inArray, lt, sql, type SQL } from "drizzle
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { decryptEnvironmentValue } from "./environment-crypto";
+import { sanitizeEventPayload } from "./event-payload-sanitizer";
 import * as schema from "./schema";
 
 export { sql as dbSql } from "drizzle-orm";
 export { decryptEnvironmentValue, encryptEnvironmentValue } from "./environment-crypto";
+export { sanitizeEventPayload, sanitizeEventString } from "./event-payload-sanitizer";
 
 export type Database = PostgresJsDatabase<typeof schema>;
 
@@ -2212,7 +2214,13 @@ export async function appendSessionHistoryItems(db: Database, input: {
       sessionId: input.sessionId,
       turnId: input.turnId ?? null,
       position: entry.position,
-      item: entry.item,
+      // Mirror the session_events insert path: the durable SDK item JSON is the
+      // SEPARATE jsonb write that turn output (tool/command stdout) reaches, and
+      // it carries the same NUL/lone-surrogate bytes Postgres jsonb rejects.
+      // Sanitize at row-build so a NUL-bearing turn still persists its history
+      // (the insert is on-conflict-do-nothing, so an unsanitized row would 400
+      // and silently lose resumption history while the turn survives).
+      item: sanitizeEventPayload(entry.item),
     }))).onConflictDoNothing({
       target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
     });
@@ -2434,7 +2442,9 @@ export async function applyContextCompaction(db: Database, input: {
         sessionId: input.sessionId,
         turnId: input.turnId ?? null,
         position: input.summaryPosition,
-        item: input.summaryItem,
+        // Same jsonb-safety guarantee as the append path: the compaction summary
+        // item folds prior tool/command output and can carry NUL/lone surrogates.
+        item: sanitizeEventPayload(input.summaryItem),
         active: true,
       }).onConflictDoUpdate({
         target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
@@ -2567,7 +2577,9 @@ export async function clearSessionContext(db: Database, input: {
         sessionId: input.sessionId,
         turnId: null,
         position: markerPosition,
-        item: clearedContextMarkerItem(),
+        // Marker is a static clean literal; sanitize anyway so EVERY history-item
+        // insert path is uniformly jsonb-safe (no untrusted bytes can sneak in).
+        item: sanitizeEventPayload(clearedContextMarkerItem()),
         active: true,
       }).onConflictDoNothing({
         target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
@@ -3251,7 +3263,7 @@ export async function wakeParentSessionForChildCompletion(
       sessionId: parent.id,
       sequence: ++sequence,
       type: event.type,
-      payload: event.payload,
+      payload: sanitizeEventPayload(event.payload),
       clientEventId: event.clientEventId ?? null,
       turnId: null,
       producerId: null,
@@ -3291,7 +3303,7 @@ export async function wakeParentSessionForChildCompletion(
       sessionId: parent.id,
       sequence,
       type: "turn.queued",
-      payload: { turnId: turn.id, triggerEventId: triggerEvent.id, source: turn.source },
+      payload: sanitizeEventPayload({ turnId: turn.id, triggerEventId: triggerEvent.id, source: turn.source }),
       clientEventId: null,
       turnId: turn.id,
       producerId: null,
@@ -3476,7 +3488,7 @@ export async function appendSessionEvents(db: Database, workspaceId: string, ses
       sessionId,
       sequence: ++sequence,
       type: input.type,
-      payload: input.payload ?? {},
+      payload: sanitizeEventPayload(input.payload ?? {}),
       clientEventId: input.clientEventId ?? null,
       turnId: input.turnId ?? null,
       producerId: input.producerId ?? null,
@@ -3516,7 +3528,7 @@ export async function appendSessionEventsAndUpdateSession(db: Database, workspac
       sessionId,
       sequence: ++sequence,
       type: input.type,
-      payload: input.payload ?? {},
+      payload: sanitizeEventPayload(input.payload ?? {}),
       clientEventId: input.clientEventId ?? null,
       turnId: input.turnId ?? null,
       producerId: input.producerId ?? null,
@@ -3566,7 +3578,7 @@ export async function appendSessionEventsWithLockedSessionUpdate(db: Database, w
       sessionId,
       sequence: ++sequence,
       type: input.type,
-      payload: input.payload ?? {},
+      payload: sanitizeEventPayload(input.payload ?? {}),
       clientEventId: input.clientEventId ?? null,
       turnId: input.turnId ?? null,
       producerId: input.producerId ?? null,

--- a/packages/db/test/event-payload-sanitizer.test.ts
+++ b/packages/db/test/event-payload-sanitizer.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeEventPayload, sanitizeEventString } from "../src/event-payload-sanitizer";
+
+const NUL = String.fromCharCode(0);
+const REPLACEMENT = "�";
+const LONE_HIGH = "\uD800";
+const LONE_LOW = "\uDFFF";
+const VALID_PAIR = "😀"; // grinning face emoji, a valid surrogate pair
+
+/**
+ * A value Postgres `jsonb` accepts must contain no NUL bytes and no lone UTF-16
+ * surrogates. Mirror that check so the tests fail the same way the INSERT would.
+ */
+function isJsonbSafe(value: string): boolean {
+  if (value.includes(NUL)) {
+    return false;
+  }
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : 0;
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return false;
+      }
+      i += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return false; // lone low surrogate
+    }
+  }
+  return true;
+}
+
+describe("sanitizeEventString", () => {
+  test("strips NUL bytes", () => {
+    expect(sanitizeEventString(`a${NUL}b${NUL}`)).toBe("ab");
+  });
+
+  test("replaces a lone high surrogate with the replacement char", () => {
+    expect(sanitizeEventString(`x${LONE_HIGH}y`)).toBe(`x${REPLACEMENT}y`);
+  });
+
+  test("replaces a lone low surrogate with the replacement char", () => {
+    expect(sanitizeEventString(`x${LONE_LOW}y`)).toBe(`x${REPLACEMENT}y`);
+  });
+
+  test("preserves a valid surrogate pair (emoji)", () => {
+    expect(sanitizeEventString(`hi ${VALID_PAIR}!`)).toBe(`hi ${VALID_PAIR}!`);
+  });
+
+  test("returns the same reference when already clean (no allocation)", () => {
+    const clean = "ordinary log line with pässwörd ✓ and emoji 😀";
+    expect(sanitizeEventString(clean)).toBe(clean);
+  });
+});
+
+describe("sanitizeEventPayload (deep walk)", () => {
+  test("sanitizes nested strings in objects and arrays", () => {
+    const payload = {
+      type: "agent.toolCall.output",
+      output: `chrome log${NUL}line\nrandom ${LONE_HIGH} bytes`,
+      nested: {
+        list: [`ok`, `binary${NUL}cat`, { deep: `${LONE_LOW}tail` }],
+      },
+      count: 42,
+      flag: true,
+    };
+
+    const cleaned = sanitizeEventPayload(payload);
+
+    expect(cleaned.output).toBe(`chrome logline\nrandom ${REPLACEMENT} bytes`);
+    expect(cleaned.nested.list[1] as string).toBe("binarycat");
+    expect((cleaned.nested.list[2] as { deep: string }).deep).toBe(`${REPLACEMENT}tail`);
+    expect(cleaned.count).toBe(42);
+    expect(cleaned.flag).toBe(true);
+  });
+
+  test("sanitizes object keys carrying NUL / surrogates", () => {
+    const payload = { [`k${NUL}ey`]: "v", [`${LONE_HIGH}`]: "w" };
+    const cleaned = sanitizeEventPayload(payload) as Record<string, string>;
+    expect(Object.keys(cleaned)).toEqual(["key", REPLACEMENT]);
+  });
+
+  test("FAILURE-SENSITIVE: a payload that would crash the INSERT round-trips as valid jsonb", () => {
+    // Reproduces the turn-killer: exec output with a NUL byte AND a lone
+    // surrogate inside an agent.toolCall.output / sandbox.command.output event.
+    const rawExecOutput = `crashpad ${NUL} dump ${LONE_HIGH} ${VALID_PAIR} end`;
+    const eventPayload = {
+      kind: "sandbox.command.output",
+      command: `cat ${NUL} /bin/ls`,
+      output: rawExecOutput,
+      stream: "stdout",
+    };
+
+    // Before sanitization the raw string values are NOT jsonb-safe (the pg
+    // driver ships the actual UTF-8 bytes, so a NUL byte / lone surrogate in the
+    // value -- not a JSON-escaped form -- is what makes the INSERT throw).
+    expect(isJsonbSafe(eventPayload.output)).toBe(false);
+    expect(isJsonbSafe(eventPayload.command)).toBe(false);
+
+    const cleaned = sanitizeEventPayload(eventPayload);
+
+    // After sanitization every string value is jsonb-safe.
+    expect(isJsonbSafe(cleaned.output)).toBe(true);
+    expect(isJsonbSafe(cleaned.command)).toBe(true);
+
+    // ...and the cleaned payload survives a JSON serialize/parse round-trip.
+    const reparsed = JSON.parse(JSON.stringify(cleaned)) as typeof cleaned;
+    expect(reparsed.output).toBe(`crashpad  dump ${REPLACEMENT} ${VALID_PAIR} end`);
+    expect(reparsed.command).toBe("cat  /bin/ls");
+    expect(reparsed.kind).toBe("sandbox.command.output");
+    expect(reparsed.stream).toBe("stdout");
+  });
+});
+
+describe("session_history_items jsonb safety (durable SDK item)", () => {
+  test("FAILURE-SENSITIVE: a history item whose tool output carries a NUL byte is sanitized and jsonb-safe", () => {
+    // The durable agent-SDK history row stores the SDK item JSON in its jsonb
+    // `item` column. A function_call_result whose `output` folds raw exec stdout
+    // can carry a NUL byte AND a lone surrogate -- exactly what made the
+    // session_history_items INSERT throw "unsupported Unicode escape sequence",
+    // losing resumption history (the insert is on-conflict-do-nothing, so the
+    // turn survived but its history items were silently dropped). This mirrors
+    // how db.appendSessionHistoryItems wires sanitizeEventPayload at row-build.
+    const item = {
+      type: "function_call_result",
+      call_id: "call_42",
+      name: "run_command",
+      output: {
+        type: "text",
+        // String.fromCharCode(0) -- no literal NUL in source.
+        text: `installed${NUL} ${VALID_PAIR} ${LONE_HIGH}pkg`,
+      },
+    };
+
+    // Pre-sanitization the nested output text is NOT jsonb-safe.
+    expect(isJsonbSafe(item.output.text)).toBe(false);
+
+    const cleaned = sanitizeEventPayload(item);
+
+    // Post-sanitization the nested string is jsonb-safe; structure preserved.
+    expect(isJsonbSafe(cleaned.output.text)).toBe(true);
+    expect(cleaned.type).toBe("function_call_result");
+    expect(cleaned.call_id).toBe("call_42");
+    expect(cleaned.name).toBe("run_command");
+    expect(cleaned.output.type).toBe("text");
+
+    // NUL dropped, valid emoji preserved, lone surrogate -> replacement char.
+    expect(cleaned.output.text).toBe(`installed ${VALID_PAIR} ${REPLACEMENT}pkg`);
+
+    // Survives a JSON serialize/parse round-trip (jsonb storage proxy).
+    const reparsed = JSON.parse(JSON.stringify(cleaned)) as typeof cleaned;
+    expect(reparsed.output.text).toBe(`installed ${VALID_PAIR} ${REPLACEMENT}pkg`);
+  });
+});


### PR DESCRIPTION
## The bug

Raw tool/command output is persisted verbatim inside session event and history
payloads (e.g. `agent.toolCall.output`, `sandbox.command.output`, and the durable
agent-SDK history item JSON). That output routinely carries bytes that Postgres
`jsonb`/`text` columns simply cannot store:

- **NUL bytes** (U+0000) — from `cat` of a binary, crashpad/chrome logs, random bytes.
- **Lone / invalid UTF-16 surrogates** (U+D800..U+DFFF without a valid pair).

When such a payload reaches an `INSERT`, the pg driver rejects it
(`"unsupported Unicode escape sequence"` / `"Failed query: insert into session_events"`)
and **the turn dies**. Worse, on the `session_history_items` on-conflict-do-nothing
path the failing row is **silently dropped** — the turn appears to survive but its
resumption history is lost.

## The fix

Add `sanitizeEventPayload` / `sanitizeEventString` in `packages/db`:

- Deep-walks any payload (objects, arrays, nested combinations, and object keys).
- For every string, strips NUL and rewrites invalid/lone surrogates to the Unicode
  replacement char (U+FFFD), so the result is always valid UTF-8 that jsonb accepts.
- Fast path: a quick scan returns the input unchanged (same reference, zero
  allocation) when it is already clean — the common case. Only strings are touched,
  no truncation, no meaningful text lost.

Applied at **every** jsonb write site:

- `appendSessionHistoryItems` (durable SDK item)
- `applyContextCompaction` (compaction summary item)
- `clearSessionContext` (cleared-context marker — sanitized for uniformity)
- `wakeParentSessionForChildCompletion` (both the forwarded event payload and the
  `turn.queued` payload)
- `appendSessionEvents`, `appendSessionEventsAndUpdateSession`,
  `appendSessionEventsWithLockedSessionUpdate`

## Test coverage

`packages/db/test/event-payload-sanitizer.test.ts` (9 tests, all passing):

- NUL stripping, lone high/low surrogate repair, valid surrogate pair (emoji)
  preservation, clean-string same-reference (no-alloc) guarantee.
- Deep-walk over nested objects/arrays and over object keys.
- **Failure-sensitive** cases that assert raw exec output (NUL + lone surrogate) is
  jsonb-safe *only after* sanitization, mirroring both the `session_events` and the
  `session_history_items` insert paths, and that the cleaned payload survives a
  JSON serialize/parse round-trip.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` (packages/db): exit 0
- `bun test test/event-payload-sanitizer.test.ts`: 9 pass / 0 fail

## Note

This is an isolated bug-fix that was **split out of an unrelated session-titles
branch**. It contains only the jsonb-safety change — no title-related code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
