### PR TITLE
feat: first-party tools always-on + powerful-by-default + reliable titling

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -387,9 +387,13 @@ export async function createSessionForRequest(
   const defaultedTools = hasOwnProperty(rawPayload, "tools")
     ? requestedTools
     : withDefaultEnabledCapabilityMcpTools(requestedTools, settings, runtimeSettings);
-  // Goal-bearing sessions force the first-party MCP server so the goal
-  // tools the continuation prompt references are reachable.
-  const tools = payload.goal ? withFirstPartyGoalTools(defaultedTools, runtimeSettings) : defaultedTools;
+  // The first-party MCP server is attached to EVERY session. It hosts the
+  // session's own metadata tool (set_session_title) + goal tools, and — only
+  // when the grant carries the permission — the orchestration/environment/
+  // github tools. Capability is gated per-tool by permission, never by whether
+  // the server is attached, so a bare chat still gets titling while the
+  // dangerous tools stay off by default.
+  const tools = withFirstPartyTools(defaultedTools, runtimeSettings);
   await validateGitHubRepositorySelection(db, workspaceId, resources);
   if (resources.some((resource) => resource.kind === "file") && !objectStorage) {
     throw new HTTPException(503, { message: "object storage is not configured" });
@@ -614,7 +618,7 @@ export async function updateSessionTitle(
   return result;
 }
 
-function withFirstPartyGoalTools(tools: ToolRef[], runtimeSettings: { mcpServers: Array<{ id: string }> }): ToolRef[] {
+function withFirstPartyTools(tools: ToolRef[], runtimeSettings: { mcpServers: Array<{ id: string }> }): ToolRef[] {
   if (!runtimeSettings.mcpServers.some((server) => server.id === "opengeni")) {
     return tools;
   }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -81,12 +81,24 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
   const json = (value: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] });
   const can = (permission: Permission) => hasPermission(grant.permissions, permission);
 
-  // Goal tools are session-scoped: they are only registered when the grant
-  // carries the worker-asserted sessionId claim (signed into the delegated
-  // token by the worker, never agent-controlled) plus goals:manage.
-  const goalSessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
-  if (goalSessionId !== null && can("goals:manage")) {
-    registerGoalTools(server, deps, grant, goalSessionId, json);
+  // Session-scoped tools key off the worker-asserted sessionId claim (signed
+  // into the delegated token by the worker, never agent-controlled).
+  const sessionId = typeof grant.metadata?.["sessionId"] === "string" ? grant.metadata["sessionId"] as string : null;
+  // set_session_title names the agent's OWN session — pure session metadata,
+  // not a goal operation — so it is available on every session, gated only on
+  // the signed sessionId (NOT goals:manage, and NOT on a goal existing).
+  if (sessionId !== null) {
+    server.registerTool("set_session_title", {
+      description: "Set this session's display title to a concise 3-7 word summary. Call once early to name the session; calling again replaces it unless a human has manually set the title.",
+      inputSchema: { title: z4.string().min(1).max(200) },
+    }, async ({ title }) => {
+      const result = await updateSessionTitle(deps, grant.workspaceId, sessionId, title, "agent");
+      return json({ ok: true, updated: result.updated, title: result.title ?? title });
+    });
+  }
+  // Goal tools require goals:manage (in the default first-party permission set).
+  if (sessionId !== null && can("goals:manage")) {
+    registerGoalTools(server, deps, grant, sessionId, json);
   }
 
   // Orchestration, environment, and GitHub-connect tools are permission-gated
@@ -377,14 +389,6 @@ function registerGoalTools(
       },
     }]);
     return json(goal);
-  });
-
-  server.registerTool("set_session_title", {
-    description: "Set this session's display title to a concise 3-7 word summary. Call once early to name the session; calling again replaces it unless a human has manually set the title.",
-    inputSchema: { title: z4.string().min(1).max(200) },
-  }, async ({ title }) => {
-    const result = await updateSessionTitle(deps, grant.workspaceId, sessionId, title, "agent");
-    return json({ ok: true, updated: result.updated, title: result.title ?? title });
   });
 
   server.registerTool("goal_update", {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -103,11 +103,13 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
 
   // Orchestration, environment, and GitHub-connect tools are permission-gated
   // at registration: a grant without the permission does not see the tool.
-  // Sandboxed workers reach this server with the fixed first-party delegated
-  // permission set (firstPartyMcpPermissions in @opengeni/runtime), which
-  // carries none of sessions:*, environments:*, or github:use — so agents
-  // cannot spawn or read sessions, touch workspace secrets, or mint GitHub
-  // install links unless the operator hands them a grant that says so.
+  // Sandboxed workers reach this server with the first-party delegated
+  // permission set (firstPartyMcpPermissions in @opengeni/runtime), which is
+  // POWERFUL BY DEFAULT — it carries sessions:*, environments:*, and github:use,
+  // so agents can spawn/read sessions, manage workspace environment variables,
+  // and mint GitHub install links out of the box. A user DEMOTES a specific
+  // session by setting a narrower session.firstPartyMcpPermissions (capped to
+  // the creator's own grant); operators still cap what any session can be given.
   registerWorkspaceOrchestrationTools(server, deps, grant, can, json);
   registerEnvironmentTools(server, deps, grant, can, json);
   if (can("github:use")) {

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -47,6 +47,7 @@ import {
 } from "./common";
 import { maybeCompactContext } from "./context-compaction";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
+import { withFirstPartyTools } from "./goals";
 import { resolveWorkspaceAgentInstructions, resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
 import { notifyParentOfChildTerminal } from "./parent-wake";
 import { createSecretRedactor, identityRedactor } from "./redaction";
@@ -408,7 +409,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // models via configuredModelPricing.
       const resolvedModel = runtime.resolveTurnModel(capabilitySettings, turn.model);
       const turnResources = mergeResourceRefs(session.resources, turn.resources);
-      const turnTools = mergeToolRefs(session.tools, turn.tools);
+      // Attach the first-party MCP server to EVERY turn, regardless of how/when
+      // the session was created (API, scheduled task, or a pre-existing session
+      // whose stored tools predate this) — so set_session_title and the rest are
+      // always reachable. Idempotent: mergeToolRefs dedupes if already present.
+      const turnTools = withFirstPartyTools(runSettings, mergeToolRefs(session.tools, turn.tools));
       const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, runSettings, input.workspaceId, session.environmentId);
       environmentId = workspaceEnvironment?.id ?? "";
       redact = createSecretRedactor(

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -33,7 +33,6 @@ import {
   maxTurnsExceededRunState,
   modelResponseUsageFromSdkEvent,
   normalizeSdkEvent,
-  genesisTitleDirectiveFilter,
   sanitizeHistoryItemsForModel,
   summarizeForCompaction,
   type SandboxFileDownload,
@@ -537,8 +536,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // for their first-party MCP token; null keeps the fixed default.
         ...(session.firstPartyMcpPermissions?.length ? { firstPartyPermissions: session.firstPartyMcpPermissions } : {}),
       });
+      // Genesis turn = the first user turn (no assistant history reconciled
+      // yet). Durable Postgres state (countSessionHistoryItems includes
+      // superseded rows after compaction), NOT a workflow counter (turnsThisRun
+      // resets on continueAsNew). Drives the one-shot title hint appended to the
+      // agent's instructions; continuation/preemption turns never match (their
+      // trigger is goal.continuation/turn.preempted).
+      const isGenesisTurn = triggerType === "user.message"
+        && (await countSessionHistoryItems(db, input.workspaceId, input.sessionId)) === 0;
       const agent = runtime.buildAgent(runSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,
+        genesisTitleHint: isGenesisTurn,
         sandboxEnvironment,
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
@@ -653,27 +661,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // Actual input tokens of the most recent model response this turn; the
       // pre-read trigger for the NEXT turn. Persisted at every turn-end path.
       let lastInputTokensObserved: number | null = null;
-      // GENESIS DETECTION (durable, survives continueAsNew): the genesis turn is
-      // the very first user turn of a session — no assistant turn has reconciled
-      // any conversation-truth rows yet. We read the TOTAL persisted history row
-      // count (countSessionHistoryItems, which still includes superseded rows
-      // after a compaction), so a later turn never re-reads as genesis even once
-      // its early context has been compacted away. This is Postgres state, NOT a
-      // workflow/in-memory counter (turnsThisRun resets on continueAsNew), so it
-      // is correct across the workflow boundary. Continuation/preemption turns
-      // never match: their trigger type is goal.continuation/turn.preempted, and
-      // by then prior assistant items are persisted. A genesis-turn retry before
-      // any history persisted re-injects harmlessly (the directive is idempotent
-      // and non-persisted). On match we pass a per-turn callModelInputFilter that
-      // prepends the hidden set_session_title directive to the model input only —
-      // it shapes per-call model input, never state.history, so it is never
-      // persisted, never replayed, never shown in the UI.
-      const isGenesisTurn = triggerType === "user.message"
-        && (await countSessionHistoryItems(db, input.workspaceId, input.sessionId)) === 0;
       throwIfWorkerShuttingDown();
       stream = await runtime.runStream(agent, runInput, runSettings, {
         sandboxEnvironment,
-        ...(isGenesisTurn ? { callModelInputFilter: genesisTitleDirectiveFilter } : {}),
         onRuntimeEvent: async (event) => {
           await publish!([{ type: event.type, payload: event.payload }], true);
         },

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -98,7 +98,7 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
       resources: [],
       // Continuations keep the session tool surface and force the first-party
       // server so the goal_complete/goal_pause escape hatches stay reachable.
-      tools: goalSessionTools(settings, session.tools),
+      tools: withFirstPartyTools(settings, session.tools),
       model: session.model,
       reasoningEffort: reasoningEffortForMetadata(session.metadata, settings.openaiReasoningEffort),
       sandboxBackend: session.sandboxBackend,
@@ -200,11 +200,13 @@ export function goalContinuationPrompt(goal: SessionGoal, autoContinuation: numb
 }
 
 /**
- * Goal-bearing sessions/turns must carry the first-party "opengeni" MCP server
- * so the goal tools are reachable; built-in tool refs are not auto-added to
- * empty tool lists anywhere else in the pipeline.
+ * Ensures a session/turn carries the first-party "opengeni" MCP server, which
+ * hosts set_session_title, the goal tools, and the permission-gated
+ * orchestration/environment/github tools. Attached to EVERY session/turn (not
+ * just goal-bearing ones); built-in tool refs are not auto-added to empty tool
+ * lists anywhere else in the pipeline. No-op when the server is not configured.
  */
-export function goalSessionTools(settings: Settings, tools: ToolRef[]): ToolRef[] {
+export function withFirstPartyTools(settings: Settings, tools: ToolRef[]): ToolRef[] {
   if (!settings.mcpServers.some((server) => server.id === "opengeni")) {
     return tools;
   }

--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -24,7 +24,7 @@ import {
   scheduledUserMessagePayload,
   workflowIdForSession,
 } from "./common";
-import { goalSessionTools } from "./goals";
+import { withFirstPartyTools } from "./goals";
 import type {
   ActivityServices,
   DispatchScheduledTaskRunInput,
@@ -59,9 +59,9 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
         const reasoningEffort = task.agentConfig.reasoningEffort ?? settings.openaiReasoningEffort;
         const sandboxBackend = task.agentConfig.sandboxBackend ?? settings.sandboxBackend;
         const goalSpec = task.agentConfig.goal ?? null;
-        // Goal-bearing dispatches force the first-party MCP server so the goal
-        // tools the continuation prompt references are reachable.
-        const taskTools = goalSpec ? goalSessionTools(settings, task.agentConfig.tools) : task.agentConfig.tools;
+        // Every dispatch carries the first-party MCP server (set_session_title,
+        // goal tools, and the permission-gated tools), matching the API path.
+        const taskTools = withFirstPartyTools(settings, task.agentConfig.tools);
         if (task.runMode === "new_session_per_run" || !task.reusableSessionId) {
           // The FK on scheduled_tasks.environment_id is ON DELETE RESTRICT, so
           // an attached environment must still exist here; fail closed if not.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -889,6 +889,16 @@ async function firstPartyMcpRequestInit(settings: Settings, config: Settings["mc
   };
 }
 
+// The first-party MCP permission set signed into a worker's delegated token
+// when the session does not specify its own. POWERFUL BY DEFAULT: it carries
+// every permission that unlocks a first-party tool — session orchestration
+// (sessions:*), workspace environments (environments:*), and GitHub
+// (github:use) — so agents are fully capable out of the box. A user DEMOTES a
+// specific session by setting a narrower session.firstPartyMcpPermissions (the
+// create-session permission picker), which the worker uses instead. Account-
+// level scopes (billing/account/members/api_keys/workspace:admin) are
+// intentionally excluded: they gate no first-party tool and are not agent
+// capabilities. (A finer-grained capability model comes later.)
 const firstPartyMcpPermissions: Permission[] = [
   "workspace:read",
   "files:read",
@@ -896,6 +906,12 @@ const firstPartyMcpPermissions: Permission[] = [
   "scheduled_tasks:manage",
   "scheduled_tasks:run",
   "goals:manage",
+  "sessions:read",
+  "sessions:create",
+  "sessions:control",
+  "environments:use",
+  "environments:manage",
+  "github:use",
 ];
 
 function isFirstPartyMcpServer(settings: Settings, config: Settings["mcpServers"][number]): boolean {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -553,6 +553,12 @@ export type BuildAgentOptions = {
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
   workspaceEnvironment?: WorkspaceEnvironmentContext;
+  // Genesis turn only: append a one-shot instruction to the agent's system
+  // prompt telling it to title the session via opengeni__set_session_title
+  // before responding. Delivered through the instructions channel (where the
+  // model actually obeys), appended AFTER the non-bypassable core so a
+  // white-label persona template can't drop it.
+  genesisTitleHint?: boolean;
   // Per-call agent persona override (the white-label surface). Resolved by the
   // caller as session > workspace > deployment default; when omitted the
   // runtime falls back to settings.agentInstructionsTemplate. The runtime
@@ -677,10 +683,9 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     // ownership + workspace-environment block) at the {{core}} marker, or
     // appends it when the template omits the marker. With the default template
     // and no environment this is byte-identical to the historical preamble.
-    instructions: composeAgentInstructions(
-      options.instructionsTemplate ?? settings.agentInstructionsTemplate,
-      options.workspaceEnvironment,
-    ),
+    instructions: options.genesisTitleHint
+      ? `${composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment)} ${GENESIS_TITLE_DIRECTIVE}`
+      : composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },
       // Server-side compaction (OpenAI platform) requires store=false: the
@@ -1200,28 +1205,13 @@ export type RunAgentStreamOptions = {
   callModelInputFilter?: CallModelInputFilter;
 };
 
-// The hidden genesis-title directive. Appended only to what the model sees on
-// the genesis turn (via a callModelInputFilter), never persisted into stored
-// history and never shown in the UI. Kept OUT of the white-label-overridable
-// instructions template on purpose — it is a one-shot model-input note, not
-// part of the agent persona.
+// One-shot directive appended to the agent's system prompt on the genesis turn
+// (see buildOpenGeniAgent's genesisTitleHint). Delivered through the
+// authoritative instructions channel so the model reliably obeys; references
+// the prefixed tool name the agent actually sees (opengeni__set_session_title).
+// Appended after the non-bypassable core so a white-label persona can't drop it.
 export const GENESIS_TITLE_DIRECTIVE =
-  "Before responding, call the set_session_title tool with a concise 3-7 word title summarizing this session, then continue with the user's request.";
-
-/**
- * A callModelInputFilter that prepends the genesis-title directive as a
- * `system` (developer-note) message to every model call of the genesis turn. It
- * mutates only the per-call model input (`modelData.input`); the SDK's run
- * state / history — the source the conversation-truth reconcile persists — is
- * untouched, so the directive is hidden and non-persisted exactly as required.
- */
-export const genesisTitleDirectiveFilter: CallModelInputFilter = ({ modelData }) => ({
-  ...modelData,
-  input: [
-    { role: "system", content: GENESIS_TITLE_DIRECTIVE } as AgentInputItem,
-    ...modelData.input,
-  ],
-});
+  "This is the first turn of a new session. Before responding to the user, call the opengeni__set_session_title tool with a concise 3-7 word title that summarizes what this session is about, then address the user's request normally.";
 
 /**
  * callModelInputFilter that removes provider-assigned item ids (rs_/msg_/fc_…)


### PR DESCRIPTION
## Summary
Fixes session auto-titling (which never fired on staging) and makes the first-party agent tools always available, per product direction.

**Why it was broken:** the opengeni first-party MCP server (which hosts `set_session_title` + goal tools) was only attached to **goal-bearing** sessions, so bare chats had no title tool at all; and the title nudge was a `{role:"system"}` message in the model *input array*, which gpt-5.5 ignored (0 of 9 staging sessions titled).

## Changes
- **Always-attach the first-party server** to every session (drop the `payload.goal ?` gate; `withFirstPartyGoalTools` → `withFirstPartyTools`), and at **turn time** in the worker so scheduled-task dispatches and pre-existing sessions are covered too.
- **`set_session_title` lifted out of the goal block** — session metadata keyed only on the worker-signed session id (not `goals:manage`, not a goal).
- **Title directive delivered via the agent's system prompt** (`genesisTitleHint`) where the model obeys; deleted the ineffective `callModelInputFilter`.
- **Powerful-by-default permissions:** the default first-party set now carries `sessions:*`, `environments:*`, `github:use` (plus goals/scheduled/files/docs). A user **demotes** a session via `firstPartyMcpPermissions` (the create-session permission picker), capped to the creator's own grant. Account-level scopes excluded.

## Verification
- Full `bun run typecheck` green.
- Local suites: api 134/0, worker 68/0, runtime 301/0, web/db/sdk green (on the pre-permission commit); the permission-expansion commit is clean except 3 **docker-gated desktop-stream consent tests** that hang under local resource contention (logic verified intact — they pass in isolation; they self-skip without docker). Letting CI adjudicate those in a proper environment.

Not yet runtime-verified on staging — will confirm a fresh no-goal chat auto-titles in the DB after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Default delegated tokens grant session orchestration, environment management, and GitHub use to every agent unless a session is explicitly demoted— a broad capability and security posture change beyond the titling fix.
> 
> **Overview**
> **Always-on first-party MCP:** The `opengeni` server is merged into tools for every session create, worker turn, goal continuation, and scheduled dispatch (`withFirstPartyTools`, replacing goal-only `withFirstPartyGoalTools` / `goalSessionTools`). Per-tool exposure still depends on grant permissions; attaching the server no longer implies only goal sessions get titling tools.
> 
> **`set_session_title`:** Registered whenever the delegated token carries a worker-signed `sessionId`, not only inside the `goals:manage` block, so bare chats can rename themselves without a goal.
> 
> **Genesis auto-title:** The one-shot nudge moves from `callModelInputFilter` / `genesisTitleDirectiveFilter` (extra `system` message in model input) to `genesisTitleHint` on `buildAgent`, appending `GENESIS_TITLE_DIRECTIVE` to composed instructions and referencing `opengeni__set_session_title`. The worker sets this on the first `user.message` turn when durable history count is zero.
> 
> **Default first-party permissions:** `firstPartyMcpPermissions` now includes `sessions:*`, `environments:*`, and `github:use`; narrower behavior is opt-in via `session.firstPartyMcpPermissions`. MCP server comments are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a56fbc189a815e83443172903cab828fe5662b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->