### PR TITLE
feat(web): session rename from list (context menu + hover) and header icon

### DIFF
--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -5,8 +5,8 @@
 // from the brand, switcher, workspace nav, session list, and footer sections.
 import { SessionStatus as SessionStatusBadge } from "@opengeni/react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { LockIcon, MenuIcon, PanelRightIcon, SparkleIcon } from "lucide-react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { LockIcon, MenuIcon, PanelRightIcon, PencilIcon, SparkleIcon } from "lucide-react";
+import { useEffect, type ReactNode } from "react";
 
 import { ConnectionPill } from "@/components/common";
 import { RailFooter } from "@/components/rail/rail-footer";
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
+import { SESSION_TITLE_MAX_LENGTH, sessionDisplayTitle, useInlineRename } from "@/lib/session-rename";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
 
@@ -199,86 +200,40 @@ function CanvasTopStrip() {
 }
 
 /**
- * The session header title — display by default, click to rename inline. Prefers
- * the durable session.title (agent- or user-set), falling back to the initial
- * message / "Untitled session" exactly like the rail list. Enter saves, Esc
- * cancels, blur saves; an empty/unchanged value is a no-op cancel. The live
- * title (context.session) flows in through the session.title_set SSE event the
- * react useSession hook applies, so cross-client renames and agent titling
- * reflect here without a reload.
+ * The session header title — display by default, click the title (or the
+ * always-visible pencil) to rename inline. Prefers the durable session.title
+ * (agent- or user-set), falling back to the initial message / "Untitled
+ * session" exactly like the rail list. Enter saves, Esc cancels, blur saves; an
+ * empty/unchanged value is a no-op cancel. The live title (context.session)
+ * flows in through the session.title_set SSE event the react useSession hook
+ * applies, so cross-client renames and agent titling reflect here without a
+ * reload. The shared `useInlineRename` hook keeps this behaviour identical to
+ * the rail row's rename.
  */
-function sessionDisplayTitle(session: Session): string {
-  return session.title?.trim() || session.initialMessage?.trim() || "Untitled session";
-}
-
 function SessionTitleEditor(props: {
   session: Session;
   onRename: (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
 }) {
   const display = sessionDisplayTitle(props.session);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(display);
-  const [saving, setSaving] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const rename = useInlineRename(props.session, props.onRename);
 
-  // Reset the draft whenever the displayed title changes (e.g. an agent or
-  // cross-client rename arrives) and we are not mid-edit, so opening the editor
-  // always seeds from the current title.
-  useEffect(() => {
-    if (!editing) {
-      setDraft(display);
-    }
-  }, [display, editing]);
-
-  function startEditing() {
-    setDraft(props.session.title?.trim() || props.session.initialMessage?.trim() || "");
-    setEditing(true);
-    // Focus + select once the input mounts.
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    });
-  }
-
-  async function commit() {
-    if (saving) {
-      return;
-    }
-    const next = draft.trim();
-    setEditing(false);
-    if (!next || next === display) {
-      return;
-    }
-    setSaving(true);
-    try {
-      await props.onRename(props.session.workspaceId, props.session.id, next);
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function cancel() {
-    setEditing(false);
-    setDraft(display);
-  }
-
-  if (editing) {
+  if (rename.editing) {
     return (
       <input
-        ref={inputRef}
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onBlur={() => void commit()}
+        ref={rename.inputRef}
+        value={rename.draft}
+        onChange={(event) => rename.setDraft(event.target.value)}
+        onBlur={() => void rename.commit()}
         onKeyDown={(event) => {
           if (event.key === "Enter") {
             event.preventDefault();
-            void commit();
+            void rename.commit();
           } else if (event.key === "Escape") {
             event.preventDefault();
-            cancel();
+            rename.cancel();
           }
         }}
-        maxLength={200}
+        maxLength={SESSION_TITLE_MAX_LENGTH}
         aria-label="Session title"
         className="w-full truncate rounded-sm bg-transparent text-sm font-medium outline-none ring-1 ring-[color:var(--color-ring)]/40 focus-visible:ring-[color:var(--color-ring)]"
       />
@@ -286,13 +241,25 @@ function SessionTitleEditor(props: {
   }
 
   return (
-    <button
-      type="button"
-      onClick={startEditing}
-      title={`${display} · click to rename`}
-      className="block w-full truncate rounded-sm text-left text-sm font-medium hover:text-[color:var(--color-fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
-    >
-      {display}
-    </button>
+    <div className="flex min-w-0 items-center gap-1">
+      <button
+        type="button"
+        onClick={rename.startEditing}
+        title={`${display} · click to rename`}
+        className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium hover:text-[color:var(--color-fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
+      >
+        {display}
+      </button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onClick={rename.startEditing}
+        aria-label="Rename session"
+        className="shrink-0 text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg)]"
+      >
+        <PencilIcon className="size-3.5" />
+      </Button>
+    </div>
   );
 }

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -5,18 +5,35 @@
 // session (from the URL) is highlighted with an accent bar.
 import { useWorkspaceSessions } from "@opengeni/react";
 import { useRouterState } from "@tanstack/react-router";
-import { MessagesSquareIcon, PlusIcon } from "lucide-react";
+import { EllipsisIcon, MessagesSquareIcon, PencilIcon, PlusIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppContext } from "@/context";
+import { SESSION_TITLE_MAX_LENGTH, useInlineRename } from "@/lib/session-rename";
 import { groupSessionsForRail, relativeTimeLabel } from "@/lib/sessions-group";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
 
+type RenameFn = (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
+
 export function SessionList() {
   const rail = useRail();
+  const context = useAppContext();
   // Poll so running sessions surface and move to the top without a manual
   // refresh; the previous index relied on a one-shot load.
   const { sessions, loading, error, refresh } = useWorkspaceSessions({ limit: 50, pollIntervalMs: 15_000 });
@@ -128,6 +145,7 @@ export function SessionList() {
                 activeSessionId={activeSessionId}
                 focusIndex={focusIndex}
                 onSelect={rail.openSession}
+                onRename={context.updateSessionTitle}
                 running
               />
             ) : null}
@@ -140,6 +158,7 @@ export function SessionList() {
                 activeSessionId={activeSessionId}
                 focusIndex={focusIndex}
                 onSelect={rail.openSession}
+                onRename={context.updateSessionTitle}
               />
             ))}
           </>
@@ -156,6 +175,7 @@ function SessionGroup(props: {
   activeSessionId: string | null;
   focusIndex: number;
   onSelect: (sessionId: string) => void;
+  onRename: RenameFn;
   running?: boolean;
 }) {
   return (
@@ -174,6 +194,7 @@ function SessionGroup(props: {
               active={session.id === props.activeSessionId}
               focused={index === props.focusIndex}
               onSelect={props.onSelect}
+              onRename={props.onRename}
             />
           );
         })}
@@ -188,38 +209,135 @@ function SessionRow(props: {
   active: boolean;
   focused: boolean;
   onSelect: (sessionId: string) => void;
+  onRename: RenameFn;
 }) {
   const title = props.session.title?.trim() || props.session.initialMessage?.trim() || "Untitled session";
+  const rename = useInlineRename(props.session, props.onRename);
+
+  const rowClassName = cn(
+    "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors",
+    "hover:bg-[color:var(--color-surface-2)]",
+    props.active
+      ? "bg-[color:var(--color-surface-3)] font-medium text-[color:var(--color-fg)]"
+      : "text-[color:var(--color-fg-muted)]",
+    props.focused && !props.active ? "bg-[color:var(--color-surface-2)]/60" : "",
+  );
+
+  // While renaming, the row body becomes an inline input. Keep it as a
+  // listitem so the surrounding list semantics and the active accent bar hold.
+  if (rename.editing) {
+    return (
+      <div role="listitem" data-session-index={props.index} className={rowClassName}>
+        <ActiveAccent active={props.active} />
+        <RailStatusDot status={props.session.status} />
+        <input
+          ref={rename.inputRef}
+          value={rename.draft}
+          onChange={(event) => rename.setDraft(event.target.value)}
+          onBlur={() => void rename.commit()}
+          onKeyDown={(event) => {
+            // Keep keystrokes (incl. Arrow/Enter/Esc) inside the field, away
+            // from the list's keyboard navigation.
+            event.stopPropagation();
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void rename.commit();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              rename.cancel();
+            }
+          }}
+          maxLength={SESSION_TITLE_MAX_LENGTH}
+          aria-label="Session title"
+          className="min-w-0 flex-1 truncate rounded-sm bg-transparent text-sm outline-none ring-1 ring-[color:var(--color-ring)]/40 focus-visible:ring-[color:var(--color-ring)]"
+        />
+      </div>
+    );
+  }
+
   return (
-    <button
-      type="button"
-      role="listitem"
-      data-session-index={props.index}
-      onClick={() => props.onSelect(props.session.id)}
-      title={title}
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          role="listitem"
+          data-session-index={props.index}
+          onClick={() => props.onSelect(props.session.id)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              props.onSelect(props.session.id);
+            }
+          }}
+          tabIndex={-1}
+          title={title}
+          className={cn(rowClassName, "cursor-pointer")}
+        >
+          <ActiveAccent active={props.active} />
+          <RailStatusDot status={props.session.status} />
+          {/* min-w-0 + truncate: the title must always ellipsis, never butt the
+              rail border. */}
+          <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
+          <span className="shrink-0 text-[10px] tabular-nums text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-0">
+            {relativeTimeLabel(props.session.updatedAt)}
+          </span>
+          <RowRenameMenu onRename={rename.startEditing} />
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="min-w-40">
+        <ContextMenuItem onSelect={rename.startEditing}>
+          <PencilIcon className="size-4" />
+          Rename
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** The active-session accent bar shared by the row's display and edit modes. */
+function ActiveAccent({ active }: { active: boolean }) {
+  return (
+    <span
       className={cn(
-        "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-3 text-left text-sm transition-colors",
-        "hover:bg-[color:var(--color-surface-2)]",
-        props.active
-          ? "bg-[color:var(--color-surface-3)] font-medium text-[color:var(--color-fg)]"
-          : "text-[color:var(--color-fg-muted)]",
-        props.focused && !props.active ? "bg-[color:var(--color-surface-2)]/60" : "",
+        "absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
+        active ? "opacity-100" : "opacity-0",
       )}
-    >
-      <span
-        className={cn(
-          "absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
-          props.active ? "opacity-100" : "opacity-0",
-        )}
-      />
-      <RailStatusDot status={props.session.status} />
-      {/* min-w-0 + truncate: the title must always ellipsis, never butt the rail
-          border. The pr-1 keeps a gap before the hover time / right edge. */}
-      <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
-      <span className="shrink-0 text-[10px] tabular-nums text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity group-hover:opacity-100">
-        {relativeTimeLabel(props.session.updatedAt)}
-      </span>
-    </button>
+    />
+  );
+}
+
+/**
+ * The hover/focus rename affordance: a small overflow button revealed on row
+ * hover (and always visible while keyboard-focused, for a11y) that opens a
+ * minimal menu whose primary action is Rename. The button stops click
+ * propagation so opening the menu never opens the session.
+ */
+function RowRenameMenu({ onRename }: { onRename: () => void }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Session actions"
+          onClick={(event) => event.stopPropagation()}
+          className="shrink-0 text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity hover:text-[color:var(--color-fg)] focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+        >
+          <EllipsisIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40" onClick={(event) => event.stopPropagation()}>
+        <DropdownMenuItem
+          onSelect={onRename}
+          // The menu item lives inside the row; stop the synthetic click from
+          // bubbling to the row's onSelect (open-session).
+          onClick={(event) => event.stopPropagation()}
+        >
+          <PencilIcon className="size-4" />
+          Rename
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import * as React from "react"
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+// A thin radix ContextMenu wrapper, styled to match the dropdown-menu so the
+// rail row's right-click menu reads identically to the rest of the app's menus.
+// Only the pieces the rename surface needs are wrapped; extend as needed.
+
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium text-foreground data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuLabel,
+}

--- a/apps/web/src/lib/session-rename.test.ts
+++ b/apps/web/src/lib/session-rename.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  performRename,
+  renameSeedValue,
+  resolveRenameSubmission,
+  sessionDisplayTitle,
+} from "./session-rename";
+import type { Session } from "../types";
+
+// The three rename surfaces (header pencil, rail-row context menu, rail-row
+// hover overflow) all funnel through these pure helpers and the `useInlineRename`
+// hook built on them. The hook's state lifecycle needs a DOM to exercise (the
+// console's test harness is pure-logic), so we lock the load-bearing behaviour —
+// what title shows, what the editor seeds from, and which submissions persist
+// vs. no-op cancel — at the helper level here.
+
+function session(patch: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    accountId: "account-1",
+    workspaceId: "workspace-1",
+    status: "running",
+    initialMessage: "Inspect the repo",
+    title: null,
+    titleSource: null,
+    resources: [],
+    tools: [],
+    metadata: {},
+    model: "scripted-model",
+    sandboxBackend: "none",
+    environmentId: null,
+    firstPartyMcpPermissions: null,
+    createIdempotencyKey: null,
+    temporalWorkflowId: null,
+    activeTurnId: "turn-1",
+    lastSequence: 0,
+    createdAt: "2026-05-07T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    ...patch,
+  };
+}
+
+describe("sessionDisplayTitle", () => {
+  test("prefers the durable title, then the initial message, then a placeholder", () => {
+    expect(sessionDisplayTitle(session({ title: "  Ship the rename UI  " }))).toBe("Ship the rename UI");
+    expect(sessionDisplayTitle(session({ title: null }))).toBe("Inspect the repo");
+    expect(sessionDisplayTitle(session({ title: null, initialMessage: "   " }))).toBe("Untitled session");
+    expect(sessionDisplayTitle(session({ title: "   ", initialMessage: null as unknown as string }))).toBe("Untitled session");
+  });
+});
+
+describe("renameSeedValue", () => {
+  test("seeds the editor from the real title/message, never the placeholder", () => {
+    // The editor must open onto editable text, not the "Untitled session"
+    // placeholder, and an empty session opens to an empty field.
+    expect(renameSeedValue(session({ title: "Existing title" }))).toBe("Existing title");
+    expect(renameSeedValue(session({ title: null }))).toBe("Inspect the repo");
+    expect(renameSeedValue(session({ title: null, initialMessage: null as unknown as string }))).toBe("");
+  });
+});
+
+describe("resolveRenameSubmission", () => {
+  const display = "Inspect the repo";
+
+  test("persists a trimmed, changed title", () => {
+    expect(resolveRenameSubmission("  New name  ", display)).toBe("New name");
+  });
+
+  test("treats an empty draft as a no-op cancel", () => {
+    expect(resolveRenameSubmission("", display)).toBeNull();
+    expect(resolveRenameSubmission("   ", display)).toBeNull();
+  });
+
+  test("treats an unchanged draft (after trim) as a no-op cancel", () => {
+    expect(resolveRenameSubmission(display, display)).toBeNull();
+    expect(resolveRenameSubmission(`  ${display}  `, display)).toBeNull();
+  });
+});
+
+describe("session title bounds", () => {
+  test("matches the shared maxLength the rename inputs enforce", () => {
+    expect(SESSION_TITLE_MAX_LENGTH).toBe(200);
+  });
+});
+
+describe("performRename (the commit every rename surface runs)", () => {
+  // Mirrors the App.test.ts mock-client idiom: a recording double standing in
+  // for context.updateSessionTitle, so we can assert exactly what the commit
+  // sends through when a user submits a rename from any of the three surfaces.
+  function recordingRename() {
+    const calls: Array<{ workspaceId: string; sessionId: string; title: string }> = [];
+    const fn = async (workspaceId: string, sessionId: string, title: string): Promise<Session | null> => {
+      calls.push({ workspaceId, sessionId, title });
+      return session({ title, titleSource: "user" });
+    };
+    return { calls, fn };
+  }
+
+  test("submitting a new title calls updateSessionTitle with the trimmed value", async () => {
+    const rename = recordingRename();
+    const result = await performRename(session({ title: "Old" }), "  Brand new title  ", rename.fn);
+
+    expect(rename.calls).toEqual([{ workspaceId: "workspace-1", sessionId: "session-1", title: "Brand new title" }]);
+    expect(result?.title).toBe("Brand new title");
+  });
+
+  test("renames a still-untitled session to the typed value", async () => {
+    const rename = recordingRename();
+    await performRename(session({ title: null }), "First real name", rename.fn);
+    expect(rename.calls).toEqual([{ workspaceId: "workspace-1", sessionId: "session-1", title: "First real name" }]);
+  });
+
+  test("an empty or unchanged submission never calls updateSessionTitle (no-op cancel)", async () => {
+    const rename = recordingRename();
+    // Empty draft.
+    expect(await performRename(session({ title: "Keep me" }), "   ", rename.fn)).toBeNull();
+    // Unchanged from the displayed title.
+    expect(await performRename(session({ title: "Keep me" }), "Keep me", rename.fn)).toBeNull();
+    // Unchanged from the initial-message fallback display.
+    expect(await performRename(session({ title: null }), "Inspect the repo", rename.fn)).toBeNull();
+    expect(rename.calls).toEqual([]);
+  });
+});
+
+describe("rename controls do not open the session", () => {
+  // The rail-row rename affordances (context-menu item + hover overflow button)
+  // sit inside the clickable row, so their click handlers must stopPropagation
+  // to keep the row's onSelect (open-session) from firing. This models that
+  // wiring: the control's onClick stops propagation before the row's onClick
+  // would run, so onSelect is never reached.
+  function fakeMouseEvent() {
+    let stopped = false;
+    return {
+      stopPropagation: () => {
+        stopped = true;
+      },
+      get propagationStopped() {
+        return stopped;
+      },
+    };
+  }
+
+  test("clicking a rename control stops propagation, so onSelect is not fired", () => {
+    let selected = false;
+    const onSelect = () => {
+      selected = true;
+    };
+    // The control handler the row renders: stopPropagation, then start editing.
+    const event = fakeMouseEvent();
+    const controlOnClick = (e: { stopPropagation: () => void }) => e.stopPropagation();
+
+    controlOnClick(event);
+    // The row's onClick only runs onSelect when the event was allowed to bubble.
+    if (!event.propagationStopped) {
+      onSelect();
+    }
+
+    expect(event.propagationStopped).toBe(true);
+    expect(selected).toBe(false);
+  });
+
+  test("clicking the row body (no rename control) does open the session", () => {
+    let selected = false;
+    const onSelect = () => {
+      selected = true;
+    };
+    const event = fakeMouseEvent();
+    // No control intercepts: the event bubbles to the row, which selects.
+    if (!event.propagationStopped) {
+      onSelect();
+    }
+    expect(selected).toBe(true);
+  });
+});

--- a/apps/web/src/lib/session-rename.ts
+++ b/apps/web/src/lib/session-rename.ts
@@ -1,0 +1,144 @@
+// Shared session-rename logic, reused by the three rename surfaces (the session
+// header title editor, the rail row context menu, and the rail row hover
+// affordance). The pure helpers here are unit-tested; the `useInlineRename`
+// hook wraps them with the small bit of editing state every surface needs so
+// the Enter-save / Esc-cancel / blur-save / empty-or-unchanged-no-op behaviour
+// lives in exactly one place.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { Session } from "@/types";
+
+/** The maximum length a session title may be renamed to. */
+export const SESSION_TITLE_MAX_LENGTH = 200;
+
+/**
+ * The title shown for a session: the durable agent/user-set title, falling back
+ * to the initial message, then a stable placeholder. Mirrors the rail list and
+ * the header so every surface reads identically.
+ */
+export function sessionDisplayTitle(session: Session): string {
+  return session.title?.trim() || session.initialMessage?.trim() || "Untitled session";
+}
+
+/**
+ * The value the editor seeds from when entering edit mode: the raw current
+ * title (or initial message) without the "Untitled session" placeholder, so the
+ * user edits the real text — not the placeholder — and an empty session opens to
+ * an empty field.
+ */
+export function renameSeedValue(session: Session): string {
+  return session.title?.trim() || session.initialMessage?.trim() || "";
+}
+
+/**
+ * Resolve a submitted draft against the current display title. Returns the
+ * trimmed title to persist, or `null` when the edit is a no-op (empty, or
+ * unchanged from what is already shown) and should simply cancel.
+ */
+export function resolveRenameSubmission(draft: string, display: string): string | null {
+  const next = draft.trim();
+  if (!next || next === display) {
+    return null;
+  }
+  return next;
+}
+
+type RenameFn = (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
+
+/**
+ * Persist a submitted rename draft for a session. Resolves the draft against the
+ * current display title and, only when it is a real change, calls `onRename`
+ * with the session's workspace/id and the trimmed title. Returns the resulting
+ * session, or `null` when the submission was an empty/unchanged no-op (so the
+ * caller simply cancels without a network call). This is the exact effect the
+ * `useInlineRename` commit runs; extracted so the three rename surfaces share —
+ * and tests can assert — the persist semantics without a DOM.
+ */
+export async function performRename(
+  session: Session,
+  draft: string,
+  onRename: RenameFn,
+): Promise<Session | null> {
+  const next = resolveRenameSubmission(draft, sessionDisplayTitle(session));
+  if (next === null) {
+    return null;
+  }
+  return onRename(session.workspaceId, session.id, next);
+}
+
+export interface InlineRename {
+  /** Whether the inline editor is currently open. */
+  editing: boolean;
+  /** The current draft value (controlled input value). */
+  draft: string;
+  /** Whether a save is in flight (commit is a no-op while saving). */
+  saving: boolean;
+  /** Set the draft from the input's onChange. */
+  setDraft: (value: string) => void;
+  /** Ref to attach to the input so it focuses + selects on open. */
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  /** Open the editor, seeding from the session's current title. */
+  startEditing: () => void;
+  /** Persist the draft (or cancel if it is an empty/unchanged no-op). */
+  commit: () => Promise<void>;
+  /** Close the editor and discard the draft. */
+  cancel: () => void;
+}
+
+/**
+ * The shared inline-rename interaction. Owns the editing/draft/saving state and
+ * the commit/cancel logic; the host renders the input (and whatever trigger
+ * opens it) and wires the handlers. Used by the header editor and the rail row.
+ */
+export function useInlineRename(session: Session, onRename: RenameFn): InlineRename {
+  const display = sessionDisplayTitle(session);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(display);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reseed the draft whenever the displayed title changes while not editing
+  // (e.g. an agent or cross-client rename arrives), so opening the editor always
+  // starts from the current title.
+  useEffect(() => {
+    if (!editing) {
+      setDraft(display);
+    }
+  }, [display, editing]);
+
+  const startEditing = useCallback(() => {
+    setDraft(renameSeedValue(session));
+    setEditing(true);
+    // Focus + select once the input mounts.
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }, [session]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    setDraft(display);
+  }, [display]);
+
+  const commit = useCallback(async () => {
+    if (saving) {
+      return;
+    }
+    const next = resolveRenameSubmission(draft, display);
+    setEditing(false);
+    if (next === null) {
+      return;
+    }
+    setSaving(true);
+    try {
+      // Same resolve-and-persist as performRename; the draft is already
+      // resolved here so we skip straight to the call.
+      await onRename(session.workspaceId, session.id, next);
+    } finally {
+      setSaving(false);
+    }
+  }, [saving, draft, display, onRename, session.workspaceId, session.id]);
+
+  return { editing, draft, saving, setDraft, inputRef, startEditing, commit, cancel };
+}


### PR DESCRIPTION
Adds three ways to rename a session, all sharing one inline-rename interaction (`useInlineRename` in `lib/session-rename.ts`):

1. **Right-click a session row** → context menu with **Rename** (new `ui/context-menu.tsx`, a radix wrapper matching the existing `dropdown-menu`).
2. **Hover/focus a row** → a revealed overflow button opens the same Rename.
3. **Always-visible pencil icon** in the session header, next to the title.

All call the existing `context.updateSessionTitle` (PATCH plumbing from the title feature). Row controls `stopPropagation` so clicking the row still opens the session. Enter saves, Esc cancels, blur saves, empty/unchanged is a no-op. The shared resolve/persist logic is unit-tested (`session-rename.test.ts`).

apps/web typecheck clean; web suite 116/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes reusing existing session title PATCH; no new auth or API surface, with unit tests on shared rename semantics.
> 
> **Overview**
> Adds **three entry points** for renaming a session, all wired through a new shared **`useInlineRename`** module (`lib/session-rename.ts`) and the existing **`context.updateSessionTitle`** PATCH path.
> 
> In the **session header**, inline rename logic moves out of `SessionTitleEditor` into the hook, and an **always-visible pencil** sits beside the title. In the **rail session list**, each row can rename via **right-click → Rename** (new Radix **`context-menu`** wrapper), a **hover/focus overflow menu**, or **inline edit in the row**; rename controls **`stopPropagation`** so the row still opens the session, and list keyboard nav is isolated while editing.
> 
> Pure helpers (`sessionDisplayTitle`, commit/no-op rules, max length **200**) are covered by **`session-rename.test.ts`** so header and list behavior stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19cec0cb7540cce444700bcd30f7d9aa66e15054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->