### PR TITLE
fix(api): route viewer stream mint to the relay when the active sandbox is selfhosted

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -36,6 +36,7 @@ import {
   clearSessionContext,
   closePtySession,
   getOpenPtySession,
+  getSandbox,
   getSession,
   getSessionGoal,
   getStreamAcknowledgment,
@@ -61,7 +62,7 @@ import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { requireAccessGrant } from "../access";
 import type { ApiRouteDeps } from "../dependencies";
-import { attachViewer, detachViewer, heartbeatViewer, mintDesktopStream, mintTerminalStream, readGroupLease, type DesktopStreamMint, type TerminalStreamMint } from "../sandbox/viewer";
+import { attachViewer, detachViewer, heartbeatViewer, mintDesktopStream, mintTerminalStream, readGroupLease, viewerHeartbeatIntervalMs, type DesktopStreamMint, type TerminalStreamMint } from "../sandbox/viewer";
 import { settingsWithEnabledCapabilityMcpServers } from "../domain/capabilities";
 import {
   normalizeResources,
@@ -470,8 +471,8 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       settings.sandboxDesktopEnabled
       && !streamTokenDegraded(settings)
       && acknowledged
-      && (lease?.liveness === "warm" || lease?.liveness === "draining");
-    if (desktopUnlocked && lease) {
+      && (session.activeSandboxId != null || lease?.liveness === "warm" || lease?.liveness === "draining");
+    if (desktopUnlocked) {
       desktopStream = await mintDesktopStream({ db, settings, bus }, {
         accountId: grant.accountId,
         workspaceId,
@@ -481,7 +482,7 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
         // POST /viewers. A previousEpoch != current would have rotated already
         // via the warming-commit; the read does not itself drive rotation.
         viewerId: grant.subjectId,
-        lease,
+        ...(lease ? { lease } : {}),
       });
     }
 
@@ -494,14 +495,14 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     const terminalUnlocked =
       settings.sandboxTerminalEnabled
       && !streamTokenDegraded(settings)
-      && (lease?.liveness === "warm" || lease?.liveness === "draining");
-    if (terminalUnlocked && lease) {
-      terminalStream = await mintTerminalStream({ db, settings }, {
+      && (session.activeSandboxId != null || lease?.liveness === "warm" || lease?.liveness === "draining");
+    if (terminalUnlocked) {
+      terminalStream = await mintTerminalStream({ db, settings, bus }, {
         accountId: grant.accountId,
         workspaceId,
         session,
         viewerId: grant.subjectId,
-        lease,
+        ...(lease ? { lease } : {}),
       });
     }
 
@@ -628,51 +629,94 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
         throw new HTTPException(409, { message: "shared_acknowledgment_required" });
       }
     }
-    const result = await attachViewer({ db, settings }, {
-      accountId: grant.accountId,
-      workspaceId,
-      session,
-      ...(parsed.data.viewerId ? { viewerId: parsed.data.viewerId } : {}),
-    });
+    // SELFHOSTED ACTIVE: when the session's active sandbox is selfhosted, skip
+    // attachViewer (it warms the Modal group box — the wrong target). Synthesize a
+    // result shaped like ViewerAttachResult and mint relay cells directly.
+    const activeSandbox = session.activeSandboxId ? await getSandbox(db, workspaceId, session.activeSandboxId) : null;
+    const selfhostedActive = activeSandbox?.kind === "selfhosted";
 
-    // P4.2 — the viewer now holds a WARM box; mint the real pixel cell IN-PROCESS
-    // (resume by id → ensureDisplayStack → exposeStreamPort) scoped to THIS
-    // viewer holder, record data_plane_url, and fold the live address into the
-    // response. A degraded mint (no secret / headless / display-stack or tunnel
-    // failure) leaves dataPlaneUrl null — the client falls back to Channel-A. The
-    // box is warm here (attachViewer spun it up or attached), so the handshake's
-    // never-spin-up rule does not apply.
     let stream: DesktopStreamMint | null = null;
     let terminal: TerminalStreamMint | null = null;
-    if (
-      (settings.sandboxDesktopEnabled || settings.sandboxTerminalEnabled)
-      && !streamTokenDegraded(settings)
-    ) {
-      const lease = await readGroupLease({ db, settings }, { workspaceId, sandboxGroupId: session.sandboxGroupId });
-      if (lease) {
-        // The pixel cell is minted only when the caller asked for the desktop plane
-        // (and consented above). A terminal-only attach skips it — the box is warm,
-        // the terminal mint below still runs.
+
+    let result: Awaited<ReturnType<typeof attachViewer>>;
+    if (selfhostedActive) {
+      const viewerId = parsed.data.viewerId ?? crypto.randomUUID();
+      result = {
+        viewerId,
+        liveness: "warm",
+        leaseEpoch: session.activeEpoch,
+        sandboxGroupId: session.sandboxGroupId,
+        viewerHeartbeatIntervalMs: viewerHeartbeatIntervalMs(settings),
+        dataPlaneUrl: null,
+      };
+      if (
+        (settings.sandboxDesktopEnabled || settings.sandboxTerminalEnabled)
+        && !streamTokenDegraded(settings)
+      ) {
         if (wantDesktop && settings.sandboxDesktopEnabled) {
           stream = await mintDesktopStream({ db, settings, bus }, {
             accountId: grant.accountId,
             workspaceId,
             session,
-            viewerId: result.viewerId,
-            lease,
+            viewerId,
+            // No Modal lease for selfhosted-active; the mint routes to the relay.
           });
         }
-        // P5.t — the same warm-box viewer attach also mints the REAL PTY terminal
-        // address (independent of the desktop toggle). A degraded mint leaves the
-        // terminal fields null → the client falls back to the sse-events firehose.
         if (settings.sandboxTerminalEnabled) {
-          terminal = await mintTerminalStream({ db, settings }, {
+          terminal = await mintTerminalStream({ db, settings, bus }, {
             accountId: grant.accountId,
             workspaceId,
             session,
-            viewerId: result.viewerId,
-            lease,
+            viewerId,
+            // No Modal lease for selfhosted-active; the mint routes to the relay.
           });
+        }
+      }
+    } else {
+      result = await attachViewer({ db, settings }, {
+        accountId: grant.accountId,
+        workspaceId,
+        session,
+        ...(parsed.data.viewerId ? { viewerId: parsed.data.viewerId } : {}),
+      });
+
+      // P4.2 — the viewer now holds a WARM box; mint the real pixel cell IN-PROCESS
+      // (resume by id → ensureDisplayStack → exposeStreamPort) scoped to THIS
+      // viewer holder, record data_plane_url, and fold the live address into the
+      // response. A degraded mint (no secret / headless / display-stack or tunnel
+      // failure) leaves dataPlaneUrl null — the client falls back to Channel-A. The
+      // box is warm here (attachViewer spun it up or attached), so the handshake's
+      // never-spin-up rule does not apply.
+      if (
+        (settings.sandboxDesktopEnabled || settings.sandboxTerminalEnabled)
+        && !streamTokenDegraded(settings)
+      ) {
+        const lease = await readGroupLease({ db, settings }, { workspaceId, sandboxGroupId: session.sandboxGroupId });
+        if (lease) {
+          // The pixel cell is minted only when the caller asked for the desktop plane
+          // (and consented above). A terminal-only attach skips it — the box is warm,
+          // the terminal mint below still runs.
+          if (wantDesktop && settings.sandboxDesktopEnabled) {
+            stream = await mintDesktopStream({ db, settings, bus }, {
+              accountId: grant.accountId,
+              workspaceId,
+              session,
+              viewerId: result.viewerId,
+              lease,
+            });
+          }
+          // P5.t — the same warm-box viewer attach also mints the REAL PTY terminal
+          // address (independent of the desktop toggle). A degraded mint leaves the
+          // terminal fields null → the client falls back to the sse-events firehose.
+          if (settings.sandboxTerminalEnabled) {
+            terminal = await mintTerminalStream({ db, settings, bus }, {
+              accountId: grant.accountId,
+              workspaceId,
+              session,
+              viewerId: result.viewerId,
+              lease,
+            });
+          }
         }
       }
     }

--- a/apps/api/src/sandbox/enrollment.ts
+++ b/apps/api/src/sandbox/enrollment.ts
@@ -53,6 +53,7 @@ import {
   type DeviceEnrollmentRequestRecord,
   type EnrollmentOs,
 } from "@opengeni/db";
+import { relayDialBaseFromSettings } from "./routing";
 
 // The device-flow timing knobs (RFC 8628). Short TTL + a poll interval the agent
 // must honor (the route rate-limits to the same cadence). These mirror the proto's
@@ -325,7 +326,11 @@ async function buildEnrollmentCredentials(
     bearer,
     subjectPrefix,
     natsUrls,
-    relayUrl: settings.selfhostedRelayUrl ?? "",
+    // Hand the agent the canonical `/stream` dial base, NOT the raw configured URL.
+    // The agent's relay producer appends only its routing query and assumes the base
+    // already carries the relay's `/stream` route; a path-less base 400s the dial and
+    // makes the terminal/desktop streams unreachable (dossier §V5/§V6).
+    relayUrl: relayDialBaseFromSettings(settings),
     relayToken,
     // M-AUTH closes the placeholder: there is NO per-machine NATS Account creds
     // file. The agent presents the BEARER as the NATS connect auth-token; the

--- a/apps/api/src/sandbox/routing.ts
+++ b/apps/api/src/sandbox/routing.ts
@@ -53,6 +53,25 @@ export function relayConfigFromSettings(settings: Settings): SelfhostedRelayConf
   }
 }
 
+/** The canonical relay dial-BASE URL (`scheme://host[:port]/stream`) handed to the
+ *  agent PRODUCER. The agent's relay channel appends ONLY its routing query to
+ *  this base (`channel.rs`: `format!("{relay_url}{sep}{query}")`) and relies on the
+ *  base ALREADY carrying the relay's `/stream` route. `OPENGENI_SELFHOSTED_RELAY_URL`
+ *  is frequently pathless (e.g. `wss://relay.<env>.app.opengeni.ai`), which made the
+ *  producer dial a path-less URL the relay 400s. Derive the base from the SAME parser
+ *  the CONSUMER uses (`relayConfigFromSettings`) so producer + consumer always agree
+ *  on `/stream` — even when the configured URL omits it. An unconfigured relay maps to
+ *  `""` (graceful degrade: the agent reports no-relay rather than dialing a synthetic
+ *  host). Fixes preview AND managed prod with no agent rebuild (dossier §V5/§V6). */
+export function relayDialBaseFromSettings(settings: Settings): string {
+  if (!settings.selfhostedRelayUrl?.trim()) return "";
+  const { host, port, tls, path } = relayConfigFromSettings(settings);
+  const scheme = tls ? "wss" : "ws";
+  const defaultPort = tls ? 443 : 80;
+  const authority = port === defaultPort ? host : `${host}:${port}`;
+  return `${scheme}://${authority}${path}`;
+}
+
 function controlRpcFactory(bus: EventBus | undefined): () => ControlRpc {
   return () =>
     new NatsControlRpc(async (): Promise<NatsRequestConnection | null> => {

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -839,7 +839,12 @@ async function tryMintActiveSelfhostedStream(
       });
       shSession = await client.resume({ agentId: sandbox.enrollmentId });
     }
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[tryMintActiveSelfhostedStream] resume failed for agent=${sandbox.enrollmentId} ` +
+        `port=${input.port} epoch=${session.activeEpoch}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
     return null;
   }
   return mintSelfhostedStream(services, {
@@ -918,7 +923,14 @@ export async function mintSelfhostedStream(
     };
   } catch (error) {
     // A headless / offline / channel-ensure failure degrades the cell to
-    // transport:null rather than throwing (mirrors the Modal mint paths).
+    // transport:null rather than throwing (mirrors the Modal mint paths). The
+    // mint degrades SILENTLY to the client, so log WHY here — otherwise a relay
+    // ensure failure (agent display probe, producer dial) is invisible.
+    console.warn(
+      `[mintSelfhostedStream] relay stream mint degraded to transport:null ` +
+        `(session=${input.sessionId} port=${input.port} epoch=${input.activeEpoch}): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
     if (error instanceof StreamPortUnavailableError) {
       return null;
     }

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -26,6 +26,7 @@ import {
   acquireLease,
   commitWarmingToWarm,
   failWarmingToCold,
+  getSandbox,
   getSandboxSessionEnvelope,
   heartbeatLeaseHolder,
   loadWorkspaceEnvironmentForRun,
@@ -36,6 +37,7 @@ import {
   SandboxLeaseSupersededError,
   type Database,
   type LeaseSnapshot,
+  type SandboxRecord,
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
@@ -43,11 +45,14 @@ import { HTTPException } from "hono/http-exception";
 // The leaf — agent-loop-free. apps/api imports sandbox symbols ONLY from here
 // (enforced by sandbox-access-import-guard.test.ts).
 import {
+  DESKTOP_STREAM_PORT,
   ensureDisplayStack,
   ensureTerminalServer,
   establishSandboxSessionFromEnvelope,
   exposeStreamPort,
   desktopCapableBackend,
+  NatsControlRpc,
+  SelfhostedSandboxClient,
   serializeEstablishedSandboxEnvelope,
   mintStreamToken,
   STREAM_TOKEN_DEFAULT_TTL_SECONDS,
@@ -55,8 +60,11 @@ import {
   DisplayStackUnsupportedError,
   TerminalServerUnsupportedError,
   StreamPortUnavailableError,
+  type ControlRpc,
   type EstablishedSandboxSession,
+  type NatsRequestConnection,
 } from "@opengeni/runtime/sandbox";
+import { relayConfigFromSettings } from "./routing";
 
 /** The minimal services a viewer op needs: the DB + settings (lease cadence +
  *  the sandbox client construction the leaf reads from settings). The bus is
@@ -312,7 +320,7 @@ export async function readGroupLease(
 
 // The viewer heartbeat cadence: half the viewer-holder TTL, floored at 5s, so a
 // single missed beat never reaps a live viewer (two beats fit inside the TTL).
-function viewerHeartbeatIntervalMs(settings: Settings): number {
+export function viewerHeartbeatIntervalMs(settings: Settings): number {
   return Math.max(5_000, Math.floor(settings.sandboxViewerHolderTtlMs / 2));
 }
 
@@ -371,8 +379,9 @@ export type MintDesktopStreamInput = {
   session: Session;
   /** The viewer holder id the scoped token is minted for. */
   viewerId: string;
-  /** The live lease (must be warm/draining — the box is up). */
-  lease: LeaseSnapshot;
+  /** The live lease (must be warm/draining — the box is up). A selfhosted-active
+   *  session may have no Modal group lease; omit and the selfhosted branch handles it. */
+  lease?: LeaseSnapshot;
   /** The epoch the CALLER last observed the URL minted under. When the live
    *  lease epoch is greater, the box rolled over → emit stream.url.rotated to the
    *  other viewers. Omit on a first mint (no prior URL to rotate from). */
@@ -384,6 +393,9 @@ export type MintDesktopStreamInput = {
   establish?: (
     envelope: Record<string, unknown> | null,
   ) => Promise<EstablishedSandboxSession>;
+  /** Test seam: inject a fake relay-resolving session for the selfhosted-active
+   *  branch. Production NEVER passes this. */
+  resolveSelfhostedSession?: (sandbox: SandboxRecord) => Promise<{ resolveExposedPort?: (port: number) => Promise<unknown> }>;
 };
 
 /**
@@ -404,7 +416,8 @@ export async function mintDesktopStream(
   input: MintDesktopStreamInput,
 ): Promise<DesktopStreamMint | null> {
   const { db, settings, bus } = services;
-  const { accountId, workspaceId, session, lease } = input;
+  const { accountId, workspaceId, session } = input;
+  const lease = input.lease;
   // The scoped token's viewerId must be a UUID (StreamTokenPayload). The GET caps
   // handshake passes grant.subjectId, which is a non-UUID for an API-key principal
   // ("configured:key") — coerce it to a deterministic UUID so the mint never 500s
@@ -424,9 +437,23 @@ export async function mintDesktopStream(
   if (!secret) {
     return null;
   }
+
+  // SELFHOSTED ACTIVE: when the session's active sandbox is a selfhosted machine,
+  // route to the relay (NOT the Modal group-box path — it would resume the wrong
+  // box and return a Modal URL). No Modal lease required.
+  if (session.activeSandboxId) {
+    const active = await getSandbox(db, workspaceId, session.activeSandboxId);
+    if (active?.kind === "selfhosted") {
+      const m = await tryMintActiveSelfhostedStream(services, { session, viewerId: input.viewerId, workspaceId, port: DESKTOP_STREAM_PORT, sandbox: active }, input.resolveSelfhostedSession);
+      // mintSelfhostedStream returns no resolution; the desktop cell needs it.
+      return m ? { url: m.url, token: m.token, expiresAt: m.expiresAt, resolution: defaultResolution(settings), leaseEpoch: m.leaseEpoch } : null;
+    }
+    // A Modal swap target (or unknown) falls through to the existing group-box path.
+  }
+
   // GATE 2: the box must be live (the handshake never spins one up — a cold box
   // returns lease_cold; the viewer-attach path warms it first, then mints).
-  if (lease.liveness !== "warm" && lease.liveness !== "draining") {
+  if (!lease || (lease.liveness !== "warm" && lease.liveness !== "draining")) {
     return null;
   }
 
@@ -592,13 +619,17 @@ export type MintTerminalStreamInput = {
   session: Session;
   /** The viewer holder / principal id the scoped token is minted for. */
   viewerId: string;
-  /** The live lease (must be warm/draining — the box is up). */
-  lease: LeaseSnapshot;
+  /** The live lease (must be warm/draining — the box is up). A selfhosted-active
+   *  session may have no Modal group lease; omit and the selfhosted branch handles it. */
+  lease?: LeaseSnapshot;
   /** Test seam: override how the box is re-established by id (see
    *  MintDesktopStreamInput.establish). Production NEVER passes this. */
   establish?: (
     envelope: Record<string, unknown> | null,
   ) => Promise<EstablishedSandboxSession>;
+  /** Test seam: inject a fake relay-resolving session for the selfhosted-active
+   *  branch. Production NEVER passes this. */
+  resolveSelfhostedSession?: (sandbox: SandboxRecord) => Promise<{ resolveExposedPort?: (port: number) => Promise<unknown> }>;
 };
 
 /**
@@ -613,7 +644,8 @@ export async function mintTerminalStream(
   input: MintTerminalStreamInput,
 ): Promise<TerminalStreamMint | null> {
   const { db, settings } = services;
-  const { accountId, workspaceId, session, lease } = input;
+  const { accountId, workspaceId, session } = input;
+  const lease = input.lease;
   // Same caps-500 fix as the desktop mint: coerce a non-UUID principal id
   // (grant.subjectId = "configured:key" for an API key) to a deterministic UUID
   // so StreamTokenPayload.parse never throws an uncaught 500.
@@ -631,8 +663,21 @@ export async function mintTerminalStream(
   if (!secret) {
     return null;
   }
+
+  // SELFHOSTED ACTIVE: when the session's active sandbox is a selfhosted machine,
+  // route to the relay. NEVER fall through to the Modal group-box path (it would
+  // resume the wrong box / return a Modal URL).
+  if (session.activeSandboxId) {
+    const active = await getSandbox(db, workspaceId, session.activeSandboxId);
+    if (active?.kind === "selfhosted") {
+      return await tryMintActiveSelfhostedStream(services, { session, viewerId: input.viewerId, workspaceId, port: TERMINAL_STREAM_PORT, sandbox: active }, input.resolveSelfhostedSession);
+    }
+    // A Modal swap target (or unknown) falls through to the existing group-box path
+    // (unchanged — Modal swap-target streaming is out of scope for this fix).
+  }
+
   // GATE 2: the box must be live (the handshake never spins one up).
-  if (lease.liveness !== "warm" && lease.liveness !== "draining") {
+  if (!lease || (lease.liveness !== "warm" && lease.liveness !== "draining")) {
     return null;
   }
 
@@ -747,6 +792,65 @@ export async function mintTerminalStream(
 // session swapped off of. control ops are already active-epoch-fenced (the routing
 // proxy); this closes the STREAM side.
 // ============================================================================
+
+// Build a ControlRpc backed by the NATS events bus (mirrors fleet.ts:controlRpc).
+function controlRpc(bus: EventBus | undefined): ControlRpc {
+  return new NatsControlRpc(async (): Promise<NatsRequestConnection | null> => {
+    if (!bus) {
+      return null;
+    }
+    return bus.getRequestConnection();
+  });
+}
+
+/**
+ * Mint the relay stream cell against the session's ACTIVE selfhosted machine,
+ * fenced by active_epoch. Returns null (degrade, never throw) when the active
+ * sandbox is not selfhosted, the agent is offline, or the relay channel can't be
+ * ensured. `sandbox` is passed in already-fetched to avoid a duplicate getSandbox.
+ */
+async function tryMintActiveSelfhostedStream(
+  services: ViewerServices,
+  input: { session: Session; viewerId: string; workspaceId: string; port: number; sandbox: SandboxRecord },
+  // optional test seam (mirrors the existing `establish?` seam pattern): inject a
+  // fake relay-resolving session; production NEVER passes it.
+  resolveSelfhostedSession?: (sandbox: SandboxRecord) => Promise<{ resolveExposedPort?: (port: number) => Promise<unknown> }>,
+): Promise<TerminalStreamMint | null> {
+  const { settings, bus } = services;
+  const { session, workspaceId, port, sandbox } = input;
+  if (!sandbox.enrollmentId) {
+    return null;
+  }
+  // The relay needs NATS; degrade to null without a bus.
+  if (!bus && !resolveSelfhostedSession) {
+    return null;
+  }
+  let shSession: { resolveExposedPort?: (port: number) => Promise<unknown> };
+  try {
+    if (resolveSelfhostedSession) {
+      shSession = await resolveSelfhostedSession(sandbox);
+    } else {
+      const client = new SelfhostedSandboxClient({
+        workspaceId,
+        relay: relayConfigFromSettings(settings),
+        controlRpcFactory: () => controlRpc(bus),
+        agentId: sandbox.enrollmentId,
+        epoch: session.activeEpoch,
+      });
+      shSession = await client.resume({ agentId: sandbox.enrollmentId });
+    }
+  } catch {
+    return null;
+  }
+  return mintSelfhostedStream(services, {
+    workspaceId,
+    sessionId: session.id,
+    viewerId: input.viewerId,
+    activeEpoch: session.activeEpoch,
+    port,
+    session: shSession,
+  });
+}
 
 /** The structural slice of a selfhosted session the relay stream mint needs. */
 type RelayResolvableSession = {

--- a/apps/api/test/enrollment-routes.test.ts
+++ b/apps/api/test/enrollment-routes.test.ts
@@ -159,7 +159,12 @@ describe("M5 device-flow happy path: start -> approve -> poll -> EnrollmentCrede
     expect(creds.workspaceId).toBe(workspaceId);
     expect(creds.subjectPrefix).toBe(`agent.${workspaceId}.${approve.enrollmentId}`);
     expect(creds.natsUrls).toEqual(["nats://control.example:4222"]);
-    expect(creds.relayUrl).toBe("wss://relay.example");
+    // The agent-bound relay URL is the canonical `/stream` dial base, NOT the raw
+    // (path-less) configured `selfhostedRelayUrl`. The agent's producer appends only
+    // its routing query and assumes the base already carries `/stream`; without this
+    // normalization the producer dials a path-less URL the relay 400s and the
+    // terminal/desktop streams are unreachable (dossier §V5/§V6).
+    expect(creds.relayUrl).toBe("wss://relay.example/stream");
     // M-AUTH closed the placeholder: the agent presents the bearer as the NATS
     // connect auth-token (auth-callout), so natsAccountCreds is vestigial and
     // echoes the bearer (NOT the empty placeholder it used to be).

--- a/apps/api/test/relay-dial-base.test.ts
+++ b/apps/api/test/relay-dial-base.test.ts
@@ -1,0 +1,50 @@
+// `relayDialBaseFromSettings` — the canonical relay dial-BASE URL handed to the
+// agent PRODUCER. The agent appends only its routing query and assumes the base
+// already carries the relay's `/stream` route; a path-less base 400s the dial and
+// makes the terminal/desktop streams unreachable (dossier §V5/§V6). These lock the
+// normalization: pathless → `/stream`, explicit path honored, non-default port kept,
+// unconfigured → "" (graceful no-relay degrade), and producer/consumer agreement.
+import { describe, expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import { relayConfigFromSettings, relayDialBaseFromSettings } from "../src/sandbox/routing";
+
+const base = (selfhostedRelayUrl: string | undefined) =>
+  relayDialBaseFromSettings(testSettings({ selfhostedRelayUrl }));
+
+describe("relayDialBaseFromSettings — agent producer dial base", () => {
+  test("path-less wss URL gains the relay's /stream route", () => {
+    // The exact deployed-preview shape that 400'd the producer dial.
+    expect(base("wss://relay.preview.app.opengeni.ai")).toBe(
+      "wss://relay.preview.app.opengeni.ai/stream",
+    );
+    expect(base("wss://relay.example")).toBe("wss://relay.example/stream");
+  });
+
+  test("an explicit path is honored (idempotent — no double /stream)", () => {
+    expect(base("wss://relay.example/stream")).toBe("wss://relay.example/stream");
+    expect(base("wss://relay.example/custom")).toBe("wss://relay.example/custom");
+  });
+
+  test("a non-default port is preserved; default 443/80 is elided", () => {
+    expect(base("wss://relay.example:8443")).toBe("wss://relay.example:8443/stream");
+    expect(base("wss://relay.example:443")).toBe("wss://relay.example/stream");
+    expect(base("ws://relay.example:80")).toBe("ws://relay.example/stream");
+    expect(base("ws://relay.example:8080")).toBe("ws://relay.example:8080/stream");
+  });
+
+  test("an unconfigured relay maps to '' (graceful no-relay degrade)", () => {
+    // The agent must report no-relay, NOT dial a synthetic host.
+    expect(base(undefined)).toBe("");
+    expect(base("")).toBe("");
+    expect(base("   ")).toBe("");
+  });
+
+  test("the producer base agrees with the CONSUMER config (same /stream route)", () => {
+    const settings = testSettings({ selfhostedRelayUrl: "wss://relay.preview.app.opengeni.ai" });
+    const consumer = relayConfigFromSettings(settings);
+    const producer = relayDialBaseFromSettings(settings);
+    // Producer dial base ends with exactly the path the consumer dials.
+    expect(producer.endsWith(consumer.path)).toBe(true);
+    expect(consumer.path).toBe("/stream");
+  });
+});

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { resolveStreamTokenSecret } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import { verifyStreamToken } from "@opengeni/runtime/sandbox";
@@ -15,9 +15,15 @@ import { mintSelfhostedStream } from "../src/sandbox/viewer";
 // We drive mintSelfhostedStream with a FAKE selfhosted session whose
 // resolveExposedPort returns the relay endpoint shape (no live agent/relay needed),
 // and assert the minted token verifies + carries active_epoch as its fence.
+//
+// The second suite (below) tests the selfhosted-active dispatch path in
+// mintTerminalStream and mintDesktopStream via the `resolveSelfhostedSession`
+// test seam + a mock.module stub for getSandbox (the sandbox kind lookup).
 
 const WS = "11111111-1111-4111-8111-111111111111";
 const SESSION = "22222222-2222-4222-8222-222222222222";
+const VIEWER = "33333333-3333-4333-8333-333333333333";
+const ACTIVE_SANDBOX = "44444444-4444-4444-8444-444444444444";
 const AGENT = "55555555-5555-4555-8555-555555555555";
 
 /** A fake selfhosted session: only the structural `resolveExposedPort` the relay
@@ -35,6 +41,40 @@ function fakeSelfhostedSession(port: number) {
   };
 }
 
+// Mock @opengeni/db so getSandbox returns a controllable sandbox record for the
+// test workspace. Spreads all real exports so other test files sharing this
+// process are unaffected (only WS is intercepted).
+const realDb = await import("@opengeni/db");
+const realGetSandbox = realDb.getSandbox;
+mock.module("@opengeni/db", () => ({
+  ...realDb,
+  getSandbox: async (db: never, workspaceId: string, sandboxId: string) => {
+    if (workspaceId !== WS) {
+      return realGetSandbox(db, workspaceId, sandboxId);
+    }
+    if (sandboxId === ACTIVE_SANDBOX) {
+      return {
+        id: ACTIVE_SANDBOX,
+        accountId: "acc",
+        workspaceId: WS,
+        kind: "selfhosted",
+        name: "test-machine",
+        enrollmentId: AGENT,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    }
+    return null;
+  },
+}));
+
+// Import mints AFTER the db mock is installed so the mock binding is active.
+const { mintTerminalStream, mintDesktopStream } = await import("../src/sandbox/viewer");
+
+afterAll(() => {
+  mock.restore();
+});
+
 describe("mintSelfhostedStream — relay stream cell fenced by active_epoch (M8b)", () => {
   const settings = testSettings({ streamTokenSecret: "selfhosted-stream-secret" });
 
@@ -45,7 +85,7 @@ describe("mintSelfhostedStream — relay stream cell fenced by active_epoch (M8b
       {
         workspaceId: WS,
         sessionId: SESSION,
-        viewerId: "33333333-3333-4333-8333-333333333333",
+        viewerId: VIEWER,
         activeEpoch,
         port: 6080,
         session: fakeSelfhostedSession(6080),
@@ -75,7 +115,7 @@ describe("mintSelfhostedStream — relay stream cell fenced by active_epoch (M8b
       {
         workspaceId: WS,
         sessionId: SESSION,
-        viewerId: "33333333-3333-4333-8333-333333333333",
+        viewerId: VIEWER,
         activeEpoch: 1,
         port: 7681,
         session: fakeSelfhostedSession(7681),
@@ -90,7 +130,7 @@ describe("mintSelfhostedStream — relay stream cell fenced by active_epoch (M8b
       {
         workspaceId: WS,
         sessionId: SESSION,
-        viewerId: "33333333-3333-4333-8333-333333333333",
+        viewerId: VIEWER,
         activeEpoch: 1,
         port: 6080,
         session: {
@@ -100,6 +140,103 @@ describe("mintSelfhostedStream — relay stream cell fenced by active_epoch (M8b
         },
       },
     );
+    expect(cell).toBeNull();
+  });
+});
+
+// Base session shape shared by the active-selfhosted dispatch tests.
+const baseSession = {
+  id: SESSION,
+  workspaceId: WS,
+  sandboxBackend: "modal" as const,
+  sandboxOs: "linux" as const,
+  sandboxGroupId: "gg-1",
+  activeSandboxId: ACTIVE_SANDBOX,
+  activeEpoch: 7,
+  // Minimal remaining Session fields (types require them but mints don't read them).
+  accountId: "acc",
+  environmentId: null,
+  status: "idle" as const,
+  goal: null,
+  goalStatus: null,
+  goalUpdatedAt: null,
+  repoFullName: null,
+  repoBranch: null,
+  repoCommitSha: null,
+  repoInstallationId: null,
+  title: null,
+  titleSource: null,
+  errorCode: null,
+  errorMessage: null,
+  queuedTurnId: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// A `resolveSelfhostedSession` seam: returns a fake relay-resolving session
+// without hitting a real NATS bus or agent.
+function fakeResolveSession(port: number) {
+  return async (_sandbox: unknown) => fakeSelfhostedSession(port);
+}
+
+describe("mintTerminalStream / mintDesktopStream — selfhosted-active dispatch (M8b wiring)", () => {
+  const settings = testSettings({
+    streamTokenSecret: "selfhosted-stream-secret",
+    sandboxTerminalEnabled: true,
+    sandboxDesktopEnabled: true,
+  });
+  const services = { db: {} as never, settings };
+
+  test("mintTerminalStream: routes to relay when activeSandboxId is selfhosted", async () => {
+    const cell = await mintTerminalStream(services, {
+      accountId: "acc",
+      workspaceId: WS,
+      session: baseSession as never,
+      viewerId: VIEWER,
+      resolveSelfhostedSession: fakeResolveSession(7681),
+    });
+    expect(cell).not.toBeNull();
+    // URL must be the relay wss:// shape (NOT a Modal tunnel URL).
+    expect(cell?.url).toBe(
+      `wss://relay.opengeni.test/stream?ws=${WS}&agent=${AGENT}&port=7681&channel=ch-abc`,
+    );
+    // Token is fenced by the session's activeEpoch (7), not a Modal lease epoch.
+    const secret = resolveStreamTokenSecret(settings)!;
+    const claims = await verifyStreamToken(secret, cell!.token);
+    expect(claims?.leaseEpoch).toBe(7);
+    expect(cell?.leaseEpoch).toBe(7);
+    expect(cell?.url).not.toContain(cell!.token);
+  });
+
+  test("mintDesktopStream: routes to relay when activeSandboxId is selfhosted + attaches resolution", async () => {
+    const cell = await mintDesktopStream(services, {
+      accountId: "acc",
+      workspaceId: WS,
+      session: baseSession as never,
+      viewerId: VIEWER,
+      resolveSelfhostedSession: fakeResolveSession(6080),
+    });
+    expect(cell).not.toBeNull();
+    expect(cell?.url).toBe(
+      `wss://relay.opengeni.test/stream?ws=${WS}&agent=${AGENT}&port=6080&channel=ch-abc`,
+    );
+    const secret = resolveStreamTokenSecret(settings)!;
+    const claims = await verifyStreamToken(secret, cell!.token);
+    expect(claims?.leaseEpoch).toBe(7);
+    expect(cell?.leaseEpoch).toBe(7);
+    // Desktop cell must carry resolution.
+    expect(cell?.resolution).toBeDefined();
+    expect(Array.isArray(cell?.resolution)).toBe(true);
+  });
+
+  test("mintTerminalStream: no selfhosted branch when activeSandboxId is null (cold Modal path → null on absent lease)", async () => {
+    const cell = await mintTerminalStream(services, {
+      accountId: "acc",
+      workspaceId: WS,
+      session: { ...baseSession, activeSandboxId: null } as never,
+      viewerId: VIEWER,
+      // No lease → GATE 2 returns null (Modal path, not selfhosted).
+    });
     expect(cell).toBeNull();
   });
 });

--- a/packages/runtime/src/sandbox/select.ts
+++ b/packages/runtime/src/sandbox/select.ts
@@ -188,20 +188,26 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
     }
     // The REAL PTY (ttyd pty-ws) rides the SAME tunnel as the desktop, so it is
     // gated identically: a real-PTY backend (cap.pty), the terminal policy toggle
-    // ON, and a WARM box. Until those hold the cell advertises the read-only
+    // ON, and a live box. Until those hold the cell advertises the read-only
     // sse-events firehose (Channel-A command.output still works) with a typed
     // reason — degradation is a value, never an absent capability.
-    //   - cold lease           -> sse-events + lease_cold (the pty-ws address is
-    //                             minted by mintTerminalStream at viewer attach).
     //   - terminal off         -> sse-events + disabled_by_policy.
+    //   - cold lease + NO mint  -> sse-events + lease_cold (no live pty-ws address;
+    //                             the caller mints it via mintTerminalStream at
+    //                             viewer attach).
     //   - not a real-PTY backend-> sse-events (no reason; the firehose IS the cap).
+    // A PRESENT minted pty-ws url (ctx.terminalStream) is ITSELF proof of liveness:
+    // the box (Modal-warm OR selfhosted-online) actually served the ttyd port, so a
+    // cold MODAL-GROUP lease liveness must NOT degrade it. lease_cold only fires
+    // when nothing was minted. A selfhosted-active session has no warm Modal lease
+    // (liveness "cold") yet mints a valid RELAY pty-ws cell — honour it.
     const ptyCapable = cap.pty;
     let transport: "pty-ws" | "sse-events" = ptyCapable ? "pty-ws" : "sse-events";
     let reason: CapabilityUnavailableReason | null = null;
     if (ptyCapable && ctx.terminalEnabled === false) {
       transport = "sse-events";
       reason = "disabled_by_policy";
-    } else if (ptyCapable && ctx.liveness === "cold") {
+    } else if (ptyCapable && ctx.liveness === "cold" && !ctx.terminalStream) {
       transport = "sse-events";
       reason = "lease_cold";
     }
@@ -230,7 +236,8 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
 
   const desktop = (() => {
     const cap = descriptor.capabilities.DesktopStream;
-    // Reason precedence: OS > backend-tier feasibility > policy disable > cold lease.
+    // Reason precedence: OS > backend-tier feasibility > policy disable >
+    // stream-token-secret > cold lease WITHOUT a mint.
     let reason: CapabilityUnavailableReason | null = null;
     let available = cap.available;
     if (osReason) {
@@ -251,7 +258,13 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
       // reason rather than crashing the API.
       available = false;
       reason = "disabled_by_policy";
-    } else if (ctx.liveness === "cold") {
+    } else if (ctx.liveness === "cold" && !ctx.desktopStream) {
+      // A PRESENT minted pixel url (ctx.desktopStream) is ITSELF proof of liveness:
+      // the box (Modal-warm OR selfhosted-online) actually served the noVNC port,
+      // so a cold MODAL-GROUP lease liveness must NOT degrade it. lease_cold only
+      // fires when nothing was minted. A selfhosted-active session has no warm
+      // Modal lease (liveness "cold") yet mints a valid RELAY framebuffer cell —
+      // honour it (the un-redacted-pixel ack gate below still applies).
       available = false;
       reason = "lease_cold";
     }

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -22,7 +22,9 @@ import {
   StreamKind,
   type ExecRequest,
   type ExecResponse,
+  type StreamChannel,
 } from "@opengeni/agent-proto";
+import { DESKTOP_STREAM_PORT } from "@opengeni/contracts";
 // `Manifest` from the ALLOWED sandbox-leaf entrypoint (`@openai/agents/sandbox`
 // re-exports `@openai/agents-core/sandbox`, which exports the Manifest class) —
 // NOT the agent-loop `@openai/agents` root the sandbox leaf forbids. The live
@@ -512,17 +514,39 @@ export class SelfhostedSession {
    * producer by the routing key.
    */
   async resolveExposedPort(port: number): Promise<ExposedPortEndpoint> {
-    // Ask the agent to ensure a stream channel exists for the port. M8b still uses
-    // the desktopEnsure op as the "ensure a channel" RPC (the only stream-channel
-    // op in the proto); the returned channelId is the relay correlation hint.
-    const result = await this.call({
-      $case: "desktopEnsure",
-      desktopEnsure: { width: 0, height: 0 },
-    });
-    if (result.$case !== "desktopEnsure") {
-      throw new Error(`selfhosted resolveExposedPort: unexpected result ${result.$case}`);
+    // Ask the agent to ensure a relay PRODUCER channel exists for the port, using the
+    // PORT-APPROPRIATE op. The PTY plane (7681) is INDEPENDENT of the desktop display:
+    // route it through `ptyOpen` (which spawns/attaches a PTY and NEVER touches X11),
+    // and ONLY the desktop framebuffer plane (6080) through `desktopEnsure` (which
+    // hard-requires a live virtual display). Earlier M8b used `desktopEnsure` for
+    // EVERY port — that wrongly coupled the terminal to the desktop probe, so a
+    // headless (or display-degraded) machine could never get a terminal even though
+    // `ptyOpen` would have succeeded. The returned channelId is the relay
+    // correlation hint; both ops carry a `StreamChannel` on their response.
+    let channel: StreamChannel | undefined;
+    if (port === DESKTOP_STREAM_PORT) {
+      const result = await this.call({
+        $case: "desktopEnsure",
+        desktopEnsure: { width: 0, height: 0 },
+      });
+      if (result.$case !== "desktopEnsure") {
+        throw new Error(`selfhosted resolveExposedPort(${port}): unexpected result ${result.$case}`);
+      }
+      channel = result.desktopEnsure.channel;
+    } else {
+      // The PTY plane (7681) + any non-desktop stream port. `command: []` => the
+      // user's default login shell; the agent's pty_pump bridges the PTY master to
+      // the relay channel. Display-INDEPENDENT — works on a headless machine.
+      const result = await this.call({
+        $case: "ptyOpen",
+        ptyOpen: { command: [], cwd: "", env: {}, cols: 0, rows: 0, term: "xterm-256color" },
+      });
+      if (result.$case !== "ptyOpen") {
+        throw new Error(`selfhosted resolveExposedPort(${port}): unexpected result ${result.$case}`);
+      }
+      channel = result.ptyOpen.channel;
     }
-    const channelId = result.desktopEnsure.channel?.channelId ?? channelKey(this.workspaceId, this.agentId, port);
+    const channelId = channel?.channelId ?? channelKey(this.workspaceId, this.agentId, port);
     const tls = this.relay.tls ?? true;
     // The routing key the relay pairs producer↔consumer by — IDENTICAL to the
     // agent's `ChannelKey::query` — plus the channel-id correlation hint.
@@ -538,7 +562,7 @@ export class SelfhostedSession {
       // The relay's wss route (`/stream`); buildStreamUrl honors `path`.
       path: this.relay.path ?? SELFHOSTED_RELAY_STREAM_PATH,
       query: routingQuery,
-      protocol: kindToProtocol(result.desktopEnsure.channel?.kind),
+      protocol: kindToProtocol(channel?.kind),
     };
   }
 

--- a/packages/runtime/src/sandbox/selfhosted/testing.ts
+++ b/packages/runtime/src/sandbox/selfhosted/testing.ts
@@ -172,6 +172,18 @@ export class MockAgentResponder implements ControlRpc {
           },
         });
       }
+      case "ptyOpen": {
+        // The PTY plane is display-INDEPENDENT and has NO consent gate (unlike
+        // desktopEnsure) — a terminal works on a headless machine. Returns a PTY
+        // StreamChannel on the 7681 port.
+        return ok(req.requestId, {
+          $case: "ptyOpen",
+          ptyOpen: {
+            ptyId: "mock-pty",
+            channel: { channelId: "mock-pty", workspaceId: "", agentId: "", kind: 1, port: 7681 },
+          },
+        });
+      }
       default:
         return errorResponse(req.requestId, ErrorCode.ERROR_CODE_UNSUPPORTED, `mock does not implement ${op.$case}`, false);
     }

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -231,6 +231,90 @@ describe("negotiateCapabilities — coherent doc, degrades as a value", () => {
     expect(caps.DesktopStream.reason).toBe("lease_cold");
   });
 
+  // ── A successfully-minted relay/Modal stream url is ITSELF proof of liveness ──
+  // A selfhosted-active session has NO warm Modal GROUP lease, so ctx.liveness is
+  // "cold" — but the stream cells are minted against the selfhosted RELAY (the box
+  // actually served the port). A present minted url must therefore be HONOURED;
+  // lease_cold only fires when nothing was minted.
+  test("cold lease + minted terminalStream (selfhosted relay pty-ws) → honoured, NOT lease_cold", () => {
+    const minted = {
+      url: "wss://relay.preview.app.opengeni.ai/stream?ws=W&agent=A&port=7681&channel=C",
+      token: "ogs_terminaltoken",
+      expiresAt: "2026-06-20T01:00:00.000Z",
+    };
+    const caps = negotiateCapabilities({
+      ...base,
+      backend: "modal",
+      liveness: "cold",
+      terminalStream: minted,
+    });
+    expect(caps.Terminal.transport).toBe("pty-ws");
+    expect(caps.Terminal.url).toBe(minted.url);
+    expect(caps.Terminal.token).toBe(minted.token);
+    expect(caps.Terminal.expiresAt).toBe(minted.expiresAt);
+    expect(caps.Terminal.reason).toBeNull();
+  });
+
+  test("cold lease + minted+acked desktopStream (selfhosted relay framebuffer) → honoured, NOT lease_cold", () => {
+    const minted = {
+      url: "wss://relay.preview.app.opengeni.ai/stream?ws=W&agent=A&port=6080&channel=C",
+      token: "ogs_desktoptoken",
+      expiresAt: "2026-06-20T01:00:00.000Z",
+      resolution: [1280, 800] as [number, number],
+    };
+    const caps = negotiateCapabilities({
+      ...base,
+      backend: "modal",
+      liveness: "cold",
+      desktopEnabled: true,
+      streamTokenSecretAvailable: true,
+      desktopAcknowledged: true,
+      desktopStream: minted,
+    });
+    expect(caps.DesktopStream.transport).not.toBeNull();
+    expect(caps.DesktopStream.reason).toBeNull();
+    expect(caps.DesktopStream.url).toBe(minted.url);
+    expect(caps.DesktopStream.token).toBe(minted.token);
+    expect(caps.DesktopStream.resolution).toEqual(minted.resolution);
+  });
+
+  test("REGRESSION: cold lease + NO minted stream → still lease_cold (terminal degrades to sse-events)", () => {
+    const caps = negotiateCapabilities({ ...base, backend: "modal", liveness: "cold" });
+    // Desktop (regression of the unchanged path above).
+    expect(caps.DesktopStream.transport).toBeNull();
+    expect(caps.DesktopStream.reason).toBe("lease_cold");
+    expect(caps.DesktopStream.url).toBeNull();
+    // Terminal also degrades to the read-only firehose when nothing was minted.
+    expect(caps.Terminal.transport).toBe("sse-events");
+    expect(caps.Terminal.reason).toBe("lease_cold");
+    expect(caps.Terminal.url).toBeNull();
+  });
+
+  // The ack gate is NOT weakened by honouring a cold-but-minted desktop: a minted
+  // url with NO acknowledgment is still withheld (the un-redacted-pixel consent
+  // gate). The cell stays available (liveness honoured) but the live url is dropped.
+  test("cold lease + minted desktopStream but NOT acknowledged → ack gate still drops the url", () => {
+    const minted = {
+      url: "wss://relay.preview.app.opengeni.ai/stream?ws=W&agent=A&port=6080&channel=C",
+      token: "ogs_desktoptoken",
+      expiresAt: "2026-06-20T01:00:00.000Z",
+      resolution: [1280, 800] as [number, number],
+    };
+    const caps = negotiateCapabilities({
+      ...base,
+      backend: "modal",
+      liveness: "cold",
+      desktopEnabled: true,
+      streamTokenSecretAvailable: true,
+      desktopAcknowledged: false,
+      desktopStream: minted,
+    });
+    expect(caps.DesktopStream.transport).not.toBeNull();
+    expect(caps.DesktopStream.reason).toBeNull();
+    expect(caps.DesktopStream.url).toBeNull();
+    expect(caps.DesktopStream.acknowledged).toBe(false);
+  });
+
   test("unsupported OS knocks out every capability with os_unsupported", () => {
     const caps = negotiateCapabilities({ ...base, backend: "modal", os: "windows" });
     expect(caps.FileSystem.available).toBe(false);

--- a/packages/runtime/test/selfhosted-session.test.ts
+++ b/packages/runtime/test/selfhosted-session.test.ts
@@ -92,6 +92,27 @@ describe("SelfhostedSession — structural surface over a ControlRpc (mock)", ()
     expect(endpoint.query).toContain("channel=");
   });
 
+  test("resolveExposedPort(7681) routes to ptyOpen (NOT desktopEnsure) — the PTY plane is display-independent", async () => {
+    const mock = new MockAgentResponder();
+    const endpoint = await sessionWith(mock).resolveExposedPort(7681);
+    // The terminal port resolves a relay endpoint on 7681 …
+    expect(endpoint.host).toBe("relay.test");
+    expect(endpoint.path).toBe("/stream");
+    expect(endpoint.query).toContain("port=7681");
+    expect(endpoint.query).toContain("channel=mock-pty");
+    // … and crucially the agent op was `ptyOpen`, NEVER `desktopEnsure` — the
+    // terminal must not inherit the desktop's live-display requirement (the gap).
+    const op = mock.requests.at(-1)?.req.op?.$case;
+    expect(op).toBe("ptyOpen");
+    expect(mock.requests.some((r) => r.req.op?.$case === "desktopEnsure")).toBe(false);
+  });
+
+  test("resolveExposedPort(6080) still routes to desktopEnsure (the desktop plane)", async () => {
+    const mock = new MockAgentResponder();
+    await sessionWith(mock).resolveExposedPort(6080);
+    expect(mock.requests.at(-1)?.req.op?.$case).toBe("desktopEnsure");
+  });
+
   test("ping returns true against a live responder, false when offline", async () => {
     const mock = new MockAgentResponder();
     expect(await sessionWith(mock).ping()).toBe(true);

--- a/packages/runtime/test/stream-token.test.ts
+++ b/packages/runtime/test/stream-token.test.ts
@@ -112,8 +112,18 @@ describe("negotiateCapabilities — the minted pixel cell folds in ONLY behind t
     expect(caps.DesktopStream.acknowledged).toBe(false);
   });
 
-  test("cold lease -> transport null + lease_cold; a minted cell would never be passed but is dropped if it were", () => {
+  test("cold lease + a MINTED cell -> honored (a successful mint proves liveness; selfhosted-active has no warm Modal lease)", () => {
+    // A present minted url is itself proof the box served the port, so a cold
+    // MODAL-GROUP lease must NOT degrade it. This is the selfhosted-swap path:
+    // liveness "cold" (no warm Modal lease) yet a valid RELAY cell was minted.
     const caps = negotiateCapabilities({ ...warmAcked, liveness: "cold", desktopStream: minted });
+    expect(caps.DesktopStream.transport).toBe("vnc-ws");
+    expect(caps.DesktopStream.reason).toBeNull();
+    expect(caps.DesktopStream.url).toBe(minted.url);
+  });
+
+  test("cold lease + NO mint -> transport null + lease_cold (nothing was served)", () => {
+    const caps = negotiateCapabilities({ ...warmAcked, liveness: "cold" });
     expect(caps.DesktopStream.transport).toBeNull();
     expect(caps.DesktopStream.reason).toBe("lease_cold");
     expect(caps.DesktopStream.url).toBeNull();


### PR DESCRIPTION
## The gap (follow-up to #119)

PR #119 (`34f8b44`) shipped selfhosted swap — `setActiveSandbox` writes `active_sandbox_id` + `active_epoch` — and the relay stream cell `mintSelfhostedStream`. But the **viewer mint path never dispatched to it**: `mintTerminalStream`/`mintDesktopStream` always establish the **Modal group box** via `backendOverride: session.sandboxBackend`, which stays `"modal"` after a swap (a swap only touches the active-sandbox pointer). `mintSelfhostedStream` had **zero production callers**.

Net effect on the merged code: a session swapped onto an enrolled **selfhosted** machine resumes the Modal box and returns a **Modal tunnel URL** for the terminal (PTY `7681`) and desktop (VNC `6080`). The relay-backed interactive surfaces — review record **V5** (terminal over relay) and **V6** (desktop) over a *heterogeneous swap* — were unreachable as shipped. This is an oversight, not a deferral: the review record intends V5/V6 over the swapped-to active machine.

## The fix

In both mint functions, after the secret gate and **before** the Modal lease gate (GATE 2), look up `session.activeSandboxId` via `getSandbox`; when `kind === "selfhosted"` route to a new `tryMintActiveSelfhostedStream` helper that builds an **epoch-fenced** `SelfhostedSandboxClient` (`epoch: session.activeEpoch`) → `resume` → `mintSelfhostedStream`, and **never** falls through to the Modal path. Mirrors the canonical construction in `backend-resolver.ts`.

- `lease` is now **optional** on both mint inputs (a selfhosted-active session has no Modal group lease); the Modal GATE 2 treats absent lease as cold.
- Desktop branch attaches `defaultResolution(settings)` and **skips** `ensureDisplayStack` (the agent owns Xvfb via `--virtual-desktop`); terminal branch skips `ensureTerminalServer` (the agent's `pty_pump` serves `7681`).
- `controlRpc` helper added to viewer.ts, faithfully mirroring `fleet.ts`.

### `sessions.ts` route wiring
- **GET stream-capabilities**: `terminalUnlocked`/`desktopUnlocked` now also unlock on `session.activeSandboxId != null` (not just a warm Modal lease); `lease` threaded as optional; `bus` threaded into the terminal mint.
- **POST /viewers**: a selfhosted-active session **skips `attachViewer`** (it would warm the wrong Modal box), synthesizes a warm `ViewerAttachResult` fenced by `active_epoch`, and mints relay cells directly. The Modal path is otherwise byte-for-byte unchanged (plus `bus` threading).

## Non-negotiable outcome
A selfhosted-active session's stream cell now carries the relay `wss://.../stream?...&port=7681&channel=...` URL (**not** a Modal URL), with the scoped token's `leaseEpoch` claim **== `session.activeEpoch`**.

## Tests / verification (run independently)
- New `selfhosted-stream-mint.test.ts` block: terminal relay dispatch (relay wss URL + token `leaseEpoch == 7`), desktop relay dispatch (relay URL + `resolution`), and a null-active control (stays on Modal path → null on cold lease). **6 pass / 0 fail.**
- `apps/api` typecheck: **0 errors**. `packages/runtime` typecheck: **0 errors**. Import-guard `sandbox-access-import-guard.test.ts`: green.
- Live V5–V9 verification over a heterogeneous swap on a real enrolled VM to follow on the preview deploy of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches viewer attach, stream token minting, and enrollment relay URLs on security-sensitive streaming paths; Modal behavior is largely unchanged behind the selfhosted branch.
> 
> **Overview**
> Fixes **selfhosted swap** sessions where desktop/terminal mint still resumed the **Modal group box** and returned Modal tunnel URLs instead of relay `wss://…/stream` cells.
> 
> **Viewer mint routing:** `mintDesktopStream` / `mintTerminalStream` now detect `activeSandboxId` with `kind === "selfhosted"` and call `tryMintActiveSelfhostedStream` (NATS-backed `SelfhostedSandboxClient`, tokens fenced by **`active_epoch`**) before the Modal lease gate. Modal `lease` is **optional** on mint inputs. **GET stream-capabilities** and **POST /viewers** unlock/mint when `activeSandboxId` is set; selfhosted-active **POST /viewers** skips `attachViewer` and mints relay cells directly.
> 
> **Relay dial base:** Enrollment credentials and a new `relayDialBaseFromSettings` normalize pathless `selfhostedRelayUrl` to include **`/stream`** so agent producers match consumer routing (fixes relay 400s).
> 
> **PTY vs desktop on agent:** `resolveExposedPort(7681)` uses **`ptyOpen`** (display-independent); `6080` still uses **`desktopEnsure`**.
> 
> **Capabilities:** `negotiateCapabilities` treats a **present minted** terminal/desktop stream as liveness proof so cold Modal-group lease does not force `lease_cold` when a relay cell was minted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e12bb8898b39e2df86b1ce4d8a8ed5454b0d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->