### PR TITLE
feat(helm): un-gated public Ingress for installer + enrollment bootstrap (preview install.sh 401 fix)

### DIFF
--- a/deploy/helm/opengeni/templates/ingress.yaml
+++ b/deploy/helm/opengeni/templates/ingress.yaml
@@ -33,3 +33,50 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.publicIngress.enabled (or .Values.api.enabled .Values.web.enabled) }}
+---
+# A SECOND Ingress for the SAME host(s) that exposes ONLY the
+# unauthenticated-by-design public paths (the self-host installer scripts +
+# minisign pubkey, the release-asset redirect prefixes, and the device-flow
+# enrollment BOOTSTRAP endpoints a not-yet-credentialed machine calls).
+#
+# It deliberately carries NO `nginx.ingress.kubernetes.io/auth-*` annotations.
+# ingress-nginx merges Ingresses by host and applies auth per server-location,
+# so these more-specific un-gated locations win for EXACTLY these paths while the
+# primary Ingress keeps everything else (the web app, /v1/config/client, the
+# /device approval page, the rest of /v1) behind its basic-auth gate. This
+# mirrors how prod `get.opengeni.ai` serves these same assets ungated.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "opengeni.fullname" . }}-public
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+  {{- with .Values.ingress.publicIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.publicIngress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.publicIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "opengeni.fullname" $ }}-{{ .service }}
+                port:
+                  name: {{ .portName | default "http" }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -581,6 +581,57 @@ ingress:
           pathType: Exact
           service: api
   tls: []
+  # A SECOND, un-gated Ingress for the same host(s) that exposes ONLY the
+  # unauthenticated-by-design public paths. Used by edge-gated deployments
+  # (e.g. the preview environment, whose primary Ingress sits behind nginx
+  # basic-auth) so that a fresh, un-credentialed machine can still
+  # `curl -fsSL https://<host>/install.sh | sh` and complete device-flow
+  # enrollment, while the web app and the rest of the API stay gated.
+  #
+  # ingress-nginx merges Ingresses by host and applies auth per location, so the
+  # more-specific paths listed here win and are served WITHOUT the primary
+  # Ingress's auth annotations. Keep this set MINIMAL — anything added here is
+  # publicly reachable. Disabled by default (only edge-gated deployments need it).
+  publicIngress:
+    enabled: false
+    # No auth annotations here by design. cert-manager / proxy tuning may be set
+    # by the deployment if this Ingress owns its own TLS entry (otherwise it
+    # shares the primary Ingress's already-issued host cert).
+    annotations: {}
+    hosts:
+      - host: opengeni.local
+        paths:
+          # Installer scripts + the pinned minisign public key (served verbatim,
+          # no secrets) — the `curl | sh` entry point and its trust root.
+          - path: /install.sh
+            pathType: Exact
+            service: api
+          - path: /install.ps1
+            pathType: Exact
+            service: api
+          - path: /uninstall.sh
+            pathType: Exact
+            service: api
+          - path: /opengeni-agent-minisign.pub
+            pathType: Exact
+            service: api
+          # Release-asset redirects the installer follows (302 → GitHub Releases).
+          - path: /agent/latest
+            pathType: Prefix
+            service: api
+          - path: /agent/v
+            pathType: Prefix
+            service: api
+          # Device-flow enrollment BOOTSTRAP endpoints a not-yet-credentialed
+          # machine calls (POST). The user-authenticated approve/list/revoke
+          # routes live under different paths and stay on the gated Ingress.
+          - path: /v1/enrollments/device/start
+            pathType: Exact
+            service: api
+          - path: /v1/enrollments/device/poll
+            pathType: Exact
+            service: api
+    tls: []
 
 # Disposable dependency fixture for local Kubernetes, CI, previews, and smoke tests.
 # Use an existing NATS endpoint or the official NATS chart for production.


### PR DESCRIPTION
## Problem
On the preview environment, `curl -fsSL https://preview.app.opengeni.ai/install.sh | sh` returns `curl: (22) 401`. The preview host is fronted by a single k8s Ingress (`opengeni`, ns `opengeni-preview`) carrying nginx **basic-auth** annotations. nginx basic-auth is per-Ingress, so it 401s **every** path before the API — including the self-host installer assets and the device-flow enrollment bootstrap endpoints, which are **unauthenticated-by-design** (a fresh, un-credentialed machine has no browser basic-auth creds).

## Fix
Add an optional **second** Ingress (`ingress.publicIngress`, disabled by default) for the same host(s) that carries **no auth annotations** and exposes **only** the public path set. ingress-nginx merges Ingresses by host and applies auth per server-location, so these more-specific un-gated locations win for exactly these paths while everything else stays behind the primary Ingress's basic-auth gate. Mirrors how prod `get.opengeni.ai` serves these same assets ungated.

### Public paths exposed (and why each must be public)
| Path | Method | pathType | Why |
|---|---|---|---|
| `/install.sh`, `/install.ps1`, `/uninstall.sh` | GET | Exact | the `curl \| sh` entry point — served verbatim, no secrets |
| `/opengeni-agent-minisign.pub` | GET | Exact | the pinned signing pubkey (trust root the script references) |
| `/agent/latest`, `/agent/v` | GET | Prefix | release-asset redirects the installer follows (302 → GitHub Releases) |
| `/v1/enrollments/device/start`, `/v1/enrollments/device/poll` | POST | Exact | device-flow enrollment **bootstrap** endpoints a not-yet-credentialed machine calls |

All of these are already application-level auth-exempt (installer routes) or carry only the deployment access key (device start/poll) — the nginx basic-auth was the only thing 401ing them.

### Kept gated (NOT exposed)
The web app `/`, `/v1/config/client`, the `/device` browser approval page, `device/approve`, `GET …/enrollments` (list), revoke, `/machines`, and all other `/v1` API stay on the primary gated Ingress.

The `publicIngress` block is `enabled: false` by default — only edge-gated deployments (preview) turn it on. The preview values are supplied by the ops-repo Bootstrap Preview workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the publicly reachable surface on hosts where it is enabled; path list must stay minimal to avoid bypassing edge basic-auth for sensitive routes.
> 
> **Overview**
> Adds an optional **second Ingress** (`ingress.publicIngress`, **off by default**) on the same host as the primary Ingress, with **no nginx basic-auth annotations**, so edge-gated previews stop 401ing `curl | sh` and device enrollment bootstrap.
> 
> The new template renders `{{ fullname }}-public` when `ingress.enabled` and `publicIngress.enabled` are both true. Default values wire a **minimal** path list to the API: installer scripts, minisign pubkey, `/agent/latest` and `/agent/v` redirects, and `POST` `/v1/enrollments/device/start` and `/poll`. ingress-nginx merges by host so these locations bypass the gated Ingress while the web app and remaining API stay behind basic auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4e330df42dd83cd3f662a6f6e27d2bfd2ed37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->