### PR TITLE
fix(agent): reliable stream/desktop readiness for selfhosted boxes (V5/V6)

### DIFF
--- a/agent/crates/opengeni-agent-platform/src/virtual_desktop.rs
+++ b/agent/crates/opengeni-agent-platform/src/virtual_desktop.rs
@@ -215,7 +215,10 @@ mod tests {
         let _ = std::fs::remove_file(&lock);
         let _ = std::fs::remove_file(&socket);
 
-        assert!(lock_gone, "stale lock with no live server should be removed");
+        assert!(
+            lock_gone,
+            "stale lock with no live server should be removed"
+        );
         assert!(
             socket_gone,
             "stale socket file with no live server should be removed"

--- a/agent/crates/opengeni-agent-platform/src/virtual_desktop.rs
+++ b/agent/crates/opengeni-agent-platform/src/virtual_desktop.rs
@@ -28,15 +28,26 @@ pub struct VirtualXvfb {
 impl VirtualXvfb {
     /// Spawns an Xvfb server at `display` (e.g. `":99"`) with the given geometry
     /// and 24-bit depth, then exports `$DISPLAY` so subsequent X11 connections
-    /// target it. Waits briefly for the server socket to appear.
+    /// target it. Reclaims stale lock/socket remnants of a previously killed
+    /// server, then waits for the new server to actually accept connections
+    /// before returning.
     ///
     /// # Errors
     ///
     /// Returns [`PlatformError::Unsupported`] if `Xvfb` is not installed, or
-    /// [`PlatformError::Os`] if it cannot be spawned.
+    /// [`PlatformError::Os`] if it cannot be spawned or never becomes ready.
     pub fn spawn(display: &str, width: u32, height: u32) -> PlatformResult<Self> {
+        // A prior Xvfb that was SIGKILL'd (no clean Drop) leaves BOTH a stale lock
+        // (`/tmp/.XN-lock`) and a stale socket file (`/tmp/.X11-unix/XN`) behind.
+        // Clear those remnants up front so this Xvfb can bind its socket, and so the
+        // readiness wait below cannot be fooled by a leftover socket file.
+        let num = display.trim_start_matches(':').split('.').next();
+        if let Some(num) = num {
+            reclaim_stale_display(num);
+        }
+
         let geometry = format!("{width}x{height}x24");
-        let child = std::process::Command::new("Xvfb")
+        let mut child = std::process::Command::new("Xvfb")
             .arg(display)
             .arg("-screen")
             .arg("0")
@@ -56,11 +67,19 @@ impl VirtualXvfb {
                 }
             })?;
 
-        // Export DISPLAY for the X11 backend and any child processes (the terminal,
-        // GUI apps the agent launches). Wait briefly for the X socket to appear so a
-        // capture issued immediately after spawn does not race the server's startup.
+        // Wait until the server is actually accepting connections (or dies trying).
+        // A leftover socket FILE existing is not proof the server is listening, so we
+        // probe with a real connect rather than a path check. If readiness never
+        // arrives, kill + reap the child so we leave no orphan and report honestly.
+        if let Err(e) = wait_for_x_ready(num, &mut child) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
+
+        // Only publish DISPLAY once the server is confirmed ready, so the X11 backend
+        // and any child processes (terminal, GUI apps) never point at a dead display.
         std::env::set_var("DISPLAY", display);
-        wait_for_x_socket(display);
 
         Ok(Self {
             display: display.to_string(),
@@ -84,20 +103,68 @@ impl Drop for VirtualXvfb {
     }
 }
 
-/// Waits up to ~2s for the X11 unix socket of `display` to exist, so a capture
-/// issued right after spawn does not race Xvfb's startup. A miss is non-fatal (the
-/// first capture simply retries the connection).
-fn wait_for_x_socket(display: &str) {
-    let Some(num) = display.trim_start_matches(':').split('.').next() else {
+/// Removes stale lock + socket remnants of a previously killed Xvfb on display
+/// `num` (the bare number, e.g. `"99"`), but only when no real server is listening.
+///
+/// When an Xvfb is `kill -9`'d it never runs its clean teardown, so it leaves both
+/// `/tmp/.XN-lock` and `/tmp/.X11-unix/XN` behind. On the next start Xvfb refuses to
+/// boot ("Server is already active for display N … remove /tmp/.XN-lock"), and a
+/// path-only readiness check would also be fooled by the leftover socket file. We
+/// distinguish "stale remnant" from "live server" by attempting a connect: a live
+/// server accepts it (so we leave everything untouched — never clobber a running
+/// display), whereas a stale socket refuses the connection, marking it safe to clear.
+fn reclaim_stale_display(num: &str) {
+    let socket = format!("/tmp/.X11-unix/X{num}");
+    let lock = format!("/tmp/.X{num}-lock");
+
+    // Nothing left behind → nothing to reclaim.
+    if !std::path::Path::new(&socket).exists() && !std::path::Path::new(&lock).exists() {
         return;
+    }
+
+    // A successful connect means a REAL X server is already listening here — leave it
+    // alone (removing its lock/socket would corrupt a running display).
+    if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
+        return;
+    }
+
+    // No listener but the files exist → stale remnants of a killed server. Remove both
+    // (best-effort) so the freshly spawned Xvfb can claim the display.
+    let _ = std::fs::remove_file(&lock);
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// Waits up to ~4s for the Xvfb server on display `num` to actually accept a unix
+/// connection, so a capture issued right after spawn does not race startup. Unlike a
+/// path-existence check, a real connect cannot be fooled by a leftover socket file.
+///
+/// Also watches the spawned `child`: if Xvfb exits during startup (e.g. it could not
+/// claim the display), we surface that immediately rather than waiting out the full
+/// timeout.
+///
+/// # Errors
+///
+/// Returns [`PlatformError::Os`] if the child exits during startup or the server
+/// never becomes connectable within the timeout.
+fn wait_for_x_ready(num: Option<&str>, child: &mut std::process::Child) -> PlatformResult<()> {
+    // Without a parseable display number we cannot probe the socket; treat the server
+    // as ready and let the first real connection surface any problem.
+    let Some(num) = num else {
+        return Ok(());
     };
     let socket = format!("/tmp/.X11-unix/X{num}");
-    for _ in 0..40 {
-        if std::path::Path::new(&socket).exists() {
-            return;
+    for _ in 0..80 {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Err(PlatformError::os(format!(
+                "Xvfb exited during startup: {status}"
+            )));
+        }
+        if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
+            return Ok(());
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    Err(PlatformError::os("Xvfb did not become ready within 4s"))
 }
 
 #[cfg(test)]
@@ -121,5 +188,37 @@ mod tests {
             Ok(v) => drop(v),
             other => panic!("expected Unsupported or Ok, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn reclaim_removes_stale_lock_and_socket() {
+        // Use a high display number unlikely to collide with any real server. The
+        // socket path gets a plain dummy file (NOT a live listener), so the connect
+        // probe in `reclaim_stale_display` fails and the remnants are deemed stale.
+        let num = "991";
+        let socket = format!("/tmp/.X11-unix/X{num}");
+        let lock = format!("/tmp/.X{num}-lock");
+
+        std::fs::create_dir_all("/tmp/.X11-unix").expect("create /tmp/.X11-unix");
+        std::fs::write(&lock, b"12345\n").expect("write stale lock");
+        std::fs::write(&socket, b"not-a-real-socket").expect("write stale socket file");
+
+        assert!(std::path::Path::new(&lock).exists());
+        assert!(std::path::Path::new(&socket).exists());
+
+        reclaim_stale_display(num);
+
+        let lock_gone = !std::path::Path::new(&lock).exists();
+        let socket_gone = !std::path::Path::new(&socket).exists();
+
+        // Best-effort cleanup in case the assertions below fail.
+        let _ = std::fs::remove_file(&lock);
+        let _ = std::fs::remove_file(&socket);
+
+        assert!(lock_gone, "stale lock with no live server should be removed");
+        assert!(
+            socket_gone,
+            "stale socket file with no live server should be removed"
+        );
     }
 }

--- a/agent/crates/opengeni-agent-stream/src/framebuffer_pump.rs
+++ b/agent/crates/opengeni-agent-stream/src/framebuffer_pump.rs
@@ -24,12 +24,27 @@ use opengeni_agent_platform::DesktopBackend;
 
 use crate::channel::RelayChannel;
 use crate::codec::RelayMessage;
-use crate::error::StreamResult;
+use crate::error::{StreamError, StreamResult};
 
 /// The default desktop frame interval (~10 fps). A real codec / damage-tracking
 /// upgrade is a pump change, not a protocol change (dossier §10.5). Kept modest so
 /// a PNG-per-frame stream does not saturate the relay; M12 tunes it live.
 const DEFAULT_FRAME_INTERVAL: Duration = Duration::from_millis(100);
+
+/// How many times the pump retries the FIRST `capture()` before it gives up. Xvfb /
+/// the X server can take a beat to settle after `desktop_ensure` probed the display,
+/// so the framebuffer's first capture can fail transiently; we retry against that
+/// readiness rather than skipping the frame (which would leave the mint un-served).
+const FIRST_CAPTURE_MAX_ATTEMPTS: u32 = 20;
+/// The delay between first-capture retries (~20 × 100ms ≈ 2s of Xvfb settle budget,
+/// comfortably inside the owner's readiness timeout).
+const FIRST_CAPTURE_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// A one-shot pump-readiness signal: the framebuffer pump fires it once it has
+/// CAPTURED AND FORWARDED its first real frame, so a consumer dialing the minted URL
+/// is guaranteed a replayable frame. The owner (`register_desktop`) awaits it (with
+/// a timeout) before returning the descriptor.
+pub type ReadyTx = tokio::sync::oneshot::Sender<()>;
 
 /// Whether the agent is allowed to apply synthetic input on this channel. Set from
 /// the enrollment `consented_screen_control` grant; when `false` the pump captures
@@ -43,6 +58,10 @@ pub struct InputPolicy {
 /// Runs the framebuffer pump until the relay transport drops. Captures + ships a
 /// frame each interval and applies inbound computer-use input (when consented).
 ///
+/// `ready` (when `Some`) is fired once the FIRST real frame has been captured AND
+/// forwarded to the relay ring, so the owner's mint is gated on a serveable channel.
+/// It is only passed on the FIRST run — a reconnect re-enters with `ready = None`.
+///
 /// # Errors
 ///
 /// Propagates a [`StreamError::Transport`](crate::error::StreamError::Transport)
@@ -51,8 +70,9 @@ pub async fn run(
     desktop: &Arc<dyn DesktopBackend>,
     channel: &mut RelayChannel,
     policy: InputPolicy,
+    ready: Option<ReadyTx>,
 ) -> StreamResult<()> {
-    run_with_interval(desktop, channel, policy, DEFAULT_FRAME_INTERVAL).await
+    run_with_interval(desktop, channel, policy, DEFAULT_FRAME_INTERVAL, ready).await
 }
 
 /// [`run`] with an explicit frame interval (tests use a short one).
@@ -60,13 +80,26 @@ pub async fn run(
 /// # Errors
 ///
 /// Propagates a [`StreamError::Transport`](crate::error::StreamError::Transport)
-/// from the relay send/recv so the owner reconnects + resumes.
+/// from the relay send/recv so the owner reconnects + resumes, or
+/// [`StreamError::Platform`](crate::error::StreamError::Platform) if the FIRST
+/// capture never succeeds within the bounded Xvfb-settle retry budget.
 pub async fn run_with_interval(
     desktop: &Arc<dyn DesktopBackend>,
     channel: &mut RelayChannel,
     policy: InputPolicy,
     interval: Duration,
+    ready: Option<ReadyTx>,
 ) -> StreamResult<()> {
+    // First frame: retry transient capture failures against Xvfb readiness (the X
+    // server can still be settling right after `desktop_ensure` probed the display)
+    // rather than skipping the frame. Only the FIRST run carries `ready`; a reconnect
+    // resumes the steady-state loop directly.
+    if let Some(ready) = ready {
+        capture_and_forward_first_frame(desktop, channel).await?;
+        // The first real frame is now buffered in the relay ring — signal ready.
+        let _ = ready.send(());
+    }
+
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -105,6 +138,42 @@ pub async fn run_with_interval(
             }
         }
     }
+}
+
+/// Captures the FIRST framebuffer frame and forwards it to the relay, retrying a
+/// transient `capture()` failure against Xvfb readiness with a small bounded
+/// backoff. This is the readiness-barrier path: it does NOT cache a negative result,
+/// so a display that settles a beat after the probe still serves. A capture that is
+/// still failing after the budget surfaces as a typed [`StreamError::Platform`] (the
+/// owner returns it from the mint rather than minting a dead URL); a relay send
+/// failure surfaces as a retryable [`StreamError::Transport`].
+async fn capture_and_forward_first_frame(
+    desktop: &Arc<dyn DesktopBackend>,
+    channel: &mut RelayChannel,
+) -> StreamResult<()> {
+    let mut last_err = None;
+    for attempt in 1..=FIRST_CAPTURE_MAX_ATTEMPTS {
+        match desktop.capture().await {
+            Ok(frame) => {
+                channel.send_frame(bytes::Bytes::from(frame.png)).await?;
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::debug!(
+                    attempt,
+                    error = %e,
+                    "desktop first-capture failed; retrying against Xvfb readiness"
+                );
+                last_err = Some(e);
+                if attempt < FIRST_CAPTURE_MAX_ATTEMPTS {
+                    tokio::time::sleep(FIRST_CAPTURE_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+    Err(StreamError::Platform(last_err.unwrap_or_else(|| {
+        opengeni_agent_platform::PlatformError::os("desktop first capture produced no frame")
+    })))
 }
 
 #[cfg(test)]
@@ -204,6 +273,7 @@ mod tests {
             &mut channel,
             InputPolicy { allow_input: true },
             Duration::from_millis(10),
+            None,
         );
         // Bound the pump; we only need a couple frames + the inject to land.
         let _ = tokio::time::timeout(Duration::from_secs(2), pump).await;
@@ -263,6 +333,7 @@ mod tests {
             &mut channel,
             InputPolicy { allow_input: false },
             Duration::from_secs(1), // long interval: no capture noise
+            None,
         );
         let _ = tokio::time::timeout(Duration::from_secs(2), pump).await;
         let _ = relay.await;
@@ -270,6 +341,165 @@ mod tests {
         assert!(
             fake.injects.lock().unwrap().is_empty(),
             "unconsented input must not be injected"
+        );
+    }
+
+    /// A desktop whose first `fail_first` captures fail transiently (Xvfb still
+    /// settling) and succeed thereafter — models the cold-start race the readiness
+    /// barrier must absorb.
+    struct FlakyDesktop {
+        fail_first: u32,
+        captures: AtomicU32,
+    }
+
+    #[async_trait]
+    impl DesktopBackend for FlakyDesktop {
+        fn probe(&self) -> Option<v1::Display> {
+            Some(v1::Display {
+                id: ":99".to_string(),
+                width: 4,
+                height: 4,
+                r#virtual: true,
+            })
+        }
+        async fn capture(&self) -> PlatformResult<CapturedFrame> {
+            let n = self.captures.fetch_add(1, Ordering::SeqCst);
+            if n < self.fail_first {
+                return Err(opengeni_agent_platform::PlatformError::os(
+                    "x11 capture: display not ready",
+                ));
+            }
+            Ok(CapturedFrame {
+                png: b"\x89PNG-fake".to_vec(),
+                width: 4,
+                height: 4,
+            })
+        }
+        async fn inject(&self, _input: &v1::DesktopInput) -> PlatformResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn readiness_fires_only_after_the_first_frame_is_forwarded() {
+        // The pump must FORWARD a real frame to the relay BEFORE it fires readiness,
+        // so a consumer dialing the minted URL is guaranteed a replayable frame.
+        let desktop: Arc<dyn DesktopBackend> = Arc::new(FakeDesktop::default());
+        let (agent_side, mut relay_side) = MockTransport::pair();
+        let mut channel =
+            RelayChannel::with_transport(desktop_channel_config(), Box::new(agent_side));
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+        // The pump borrows locals, so drive it inline (not spawned). A long interval
+        // means it never produces a SECOND frame; the relay (unbounded mock) is held
+        // by THIS task so the pump always has a live peer. The only thing that
+        // resolves the race is the first frame firing readiness.
+        let pump = run_with_interval(
+            &desktop,
+            &mut channel,
+            InputPolicy { allow_input: false },
+            Duration::from_secs(3600), // no steady-state ticks: isolate the first frame
+            Some(ready_tx),
+        );
+        tokio::select! {
+            _ = pump => panic!("the long-interval pump should not return on its own"),
+            r = tokio::time::timeout(Duration::from_secs(2), ready_rx) => {
+                r.expect("readiness must fire within the budget")
+                    .expect("readiness sender must not be dropped");
+            }
+        }
+        // The first frame must be buffered in the relay ring (readiness gates on it).
+        assert!(
+            matches!(relay_side.recv().await, Ok(Some(RelayMessage::Frame(_)))),
+            "the relay must see the first frame"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn first_capture_retries_a_transient_failure_then_serves() {
+        // The first two captures fail (Xvfb settling); the pump must retry rather
+        // than skip/give-up, then forward the first good frame and fire readiness.
+        let flaky = Arc::new(FlakyDesktop {
+            fail_first: 2,
+            captures: AtomicU32::new(0),
+        });
+        let desktop: Arc<dyn DesktopBackend> = flaky.clone();
+        let (agent_side, mut relay_side) = MockTransport::pair();
+        let mut channel =
+            RelayChannel::with_transport(desktop_channel_config(), Box::new(agent_side));
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+        let pump = run_with_interval(
+            &desktop,
+            &mut channel,
+            InputPolicy { allow_input: false },
+            Duration::from_secs(3600),
+            Some(ready_tx),
+        );
+        tokio::select! {
+            _ = pump => panic!("the long-interval pump should not return on its own"),
+            r = tokio::time::timeout(Duration::from_secs(3), ready_rx) => {
+                r.expect("readiness must fire after the retried capture")
+                    .expect("readiness sender must not be dropped");
+            }
+        }
+        assert!(
+            matches!(relay_side.recv().await, Ok(Some(RelayMessage::Frame(_)))),
+            "after retrying the transient failures the relay must see a frame"
+        );
+        // Exactly: 2 failed + 1 succeeded = 3 capture attempts.
+        assert_eq!(flaky.captures.load(Ordering::SeqCst), 3);
+    }
+
+    /// A desktop whose capture always fails — models a display that never settles.
+    struct DeadDesktop;
+
+    #[async_trait]
+    impl DesktopBackend for DeadDesktop {
+        fn probe(&self) -> Option<v1::Display> {
+            Some(v1::Display {
+                id: ":99".to_string(),
+                width: 4,
+                height: 4,
+                r#virtual: true,
+            })
+        }
+        async fn capture(&self) -> PlatformResult<CapturedFrame> {
+            Err(opengeni_agent_platform::PlatformError::os(
+                "x11 capture: display gone",
+            ))
+        }
+        async fn inject(&self, _input: &v1::DesktopInput) -> PlatformResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn first_capture_that_never_succeeds_surfaces_a_typed_platform_error() {
+        // The retry budget is bounded: a capture that never succeeds must return a
+        // typed Platform error (and NOT fire readiness), so the owner fails the mint
+        // rather than minting a dead URL. `start_paused` auto-advances virtual time
+        // past the bounded retry backoff so the test does not actually sleep ~2s.
+        let desktop: Arc<dyn DesktopBackend> = Arc::new(DeadDesktop);
+        let (agent_side, _relay_side) = MockTransport::pair();
+        let mut channel =
+            RelayChannel::with_transport(desktop_channel_config(), Box::new(agent_side));
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+        let err = run_with_interval(
+            &desktop,
+            &mut channel,
+            InputPolicy { allow_input: false },
+            Duration::from_secs(3600),
+            Some(ready_tx),
+        )
+        .await
+        .expect_err("a never-settling display must error the first-frame barrier");
+        assert!(matches!(err, StreamError::Platform(_)), "got {err:?}");
+        // Readiness was never fired (the sender was dropped with the pump).
+        assert!(
+            ready_rx.await.is_err(),
+            "readiness must NOT fire when the first frame never lands"
         );
     }
 }

--- a/agent/crates/opengeni-agent-stream/src/hub.rs
+++ b/agent/crates/opengeni-agent-stream/src/hub.rs
@@ -331,10 +331,7 @@ fn spawn_desktop_pump(
 /// * the sender is DROPPED before firing (the pump died — e.g. a relay drop or a
 ///   non-retryable first-capture failure — before serving a byte) ⇒ `Os`,
 /// * the timeout elapses (the pump is wedged) ⇒ `Timeout`.
-async fn await_pump_ready(
-    ready_rx: oneshot::Receiver<()>,
-    kind: &str,
-) -> PlatformResult<()> {
+async fn await_pump_ready(ready_rx: oneshot::Receiver<()>, kind: &str) -> PlatformResult<()> {
     match tokio::time::timeout(PUMP_READY_TIMEOUT, ready_rx).await {
         Ok(Ok(())) => Ok(()),
         Ok(Err(_recv)) => Err(PlatformError::os(format!(

--- a/agent/crates/opengeni-agent-stream/src/hub.rs
+++ b/agent/crates/opengeni-agent-stream/src/hub.rs
@@ -27,13 +27,14 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use opengeni_agent_platform::{
     DesktopBackend, PlatformError, PlatformResult, PtyProcess, StreamRegistry,
 };
 use opengeni_agent_proto::v1::{self, DesktopEnsureRequest, PtyOpenResponse, StreamChannel};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::backoff::ChannelBackoff;
 use crate::channel::{ChannelConfig, RelayChannel};
@@ -42,6 +43,15 @@ use crate::pty_pump::{self, PtyCommand, PtyControlTx};
 
 /// The control-channel buffer per PTY (write/resize/close commands).
 const PTY_COMMAND_BUFFER: usize = 32;
+
+/// How long `register_pty`/`register_desktop` wait for the spawned pump to confirm
+/// it is LIVE and has buffered its first real byte(s)/frame before giving up. The
+/// mint is gated on this so a consumer dialing the minted URL always finds
+/// replayable bytes; on a timeout the op returns a typed error rather than minting a
+/// dead URL (or hanging forever). Generous enough for a cold Xvfb/X11 to settle and
+/// a login shell to print a prompt, tight enough that a wedged pump fails the mint
+/// fast.
+const PUMP_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The logical port a PTY (terminal) stream maps to. Mirrors the in-box ttyd port
 /// the existing terminal-server uses, so `resolveExposedPort(7681)` addresses it.
@@ -139,8 +149,29 @@ impl StreamRegistry for RelayHub {
         }
 
         // Spawn the supervised pump: it auto-reconnects + resumes on a relay blip,
-        // and de-registers the pty control entry when it ends.
-        spawn_pty_pump(process, channel, cmd_rx, pty_id.clone(), self.ptys.clone());
+        // and de-registers the pty control entry when it ends. The readiness signal
+        // is fired once the pump is live + has shipped the shell's first prompt
+        // byte(s) into the relay ring, so a consumer dialing the minted URL sees
+        // output WITHOUT having to type.
+        let (ready_tx, ready_rx) = oneshot::channel();
+        spawn_pty_pump(
+            process,
+            channel,
+            cmd_rx,
+            pty_id.clone(),
+            self.ptys.clone(),
+            ready_tx,
+        );
+
+        // Gate the mint on the pump being serveable: do not return the descriptor
+        // until the first byte(s) are buffered. On a timeout (or a pump that died
+        // before becoming ready) drop the half-registered control entry and surface
+        // a typed error rather than minting a dead URL.
+        await_pump_ready(ready_rx, "pty").await.inspect_err(|_| {
+            if let Ok(mut ptys) = self.ptys.lock() {
+                ptys.remove(&pty_id);
+            }
+        })?;
 
         Ok(PtyOpenResponse {
             pty_id,
@@ -163,7 +194,12 @@ impl StreamRegistry for RelayHub {
         let policy = InputPolicy {
             allow_input: self.config.allow_screen_control,
         };
-        spawn_desktop_pump(desktop, channel, config, policy);
+        // Gate the mint on the framebuffer pump having captured + forwarded its first
+        // real frame (retrying a transient first-capture against Xvfb readiness), so
+        // a consumer dialing the minted URL immediately replays a frame.
+        let (ready_tx, ready_rx) = oneshot::channel();
+        spawn_desktop_pump(desktop, channel, config, policy, ready_tx);
+        await_pump_ready(ready_rx, "desktop").await?;
 
         Ok(descriptor)
     }
@@ -214,11 +250,15 @@ fn spawn_pty_pump(
     mut commands: mpsc::Receiver<PtyCommand>,
     pty_id: String,
     ptys: Arc<Mutex<HashMap<String, PtyControlTx>>>,
+    ready: oneshot::Sender<()>,
 ) {
     tokio::spawn(async move {
+        // The readiness signal is fired by the pump on its FIRST run only; a
+        // reconnect re-enters the pump with `None`.
+        let mut ready = Some(ready);
         let mut backoff = ChannelBackoff::standard();
         loop {
-            match pty_pump::run(&mut process, &mut channel, &mut commands).await {
+            match pty_pump::run(&mut process, &mut channel, &mut commands, ready.take()).await {
                 Ok(()) => {
                     // Clean PTY exit: tear the channel down with PROCESS_EXIT.
                     channel
@@ -253,11 +293,15 @@ fn spawn_desktop_pump(
     mut channel: RelayChannel,
     _config: ChannelConfig,
     policy: InputPolicy,
+    ready: oneshot::Sender<()>,
 ) {
     tokio::spawn(async move {
+        // The readiness signal is fired by the pump on its FIRST run only (after the
+        // first frame is captured + forwarded); a reconnect re-enters with `None`.
+        let mut ready = Some(ready);
         let mut backoff = ChannelBackoff::standard();
         loop {
-            match framebuffer_pump::run(&desktop, &mut channel, policy).await {
+            match framebuffer_pump::run(&desktop, &mut channel, policy, ready.take()).await {
                 Ok(()) => {
                     channel
                         .close(v1::StreamCloseReason::Normal, "desktop closed")
@@ -278,6 +322,29 @@ fn spawn_desktop_pump(
             }
         }
     });
+}
+
+/// Awaits the pump's readiness signal with a bounded timeout, mapping the two
+/// failure modes to typed platform errors so the mint never hangs and never returns
+/// a dead URL:
+///
+/// * the sender is DROPPED before firing (the pump died — e.g. a relay drop or a
+///   non-retryable first-capture failure — before serving a byte) ⇒ `Os`,
+/// * the timeout elapses (the pump is wedged) ⇒ `Timeout`.
+async fn await_pump_ready(
+    ready_rx: oneshot::Receiver<()>,
+    kind: &str,
+) -> PlatformResult<()> {
+    match tokio::time::timeout(PUMP_READY_TIMEOUT, ready_rx).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_recv)) => Err(PlatformError::os(format!(
+            "{kind} stream pump ended before it became ready"
+        ))),
+        Err(_elapsed) => Err(PlatformError::Timeout(format!(
+            "{kind} stream pump did not become ready within {}s",
+            PUMP_READY_TIMEOUT.as_secs()
+        ))),
+    }
 }
 
 /// A fresh channel id (a random hex token). Avoids pulling a uuid crate for what is
@@ -330,5 +397,45 @@ mod tests {
         assert_eq!(d.agent_id, "ag");
         assert_eq!(d.port, PTY_STREAM_PORT);
         assert_eq!(d.kind(), v1::StreamKind::Pty);
+    }
+
+    #[tokio::test]
+    async fn await_pump_ready_returns_when_the_pump_signals() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(()).expect("send ready");
+        await_pump_ready(rx, "pty")
+            .await
+            .expect("a fired signal resolves Ok");
+    }
+
+    #[tokio::test]
+    async fn await_pump_ready_times_out_with_a_typed_error_rather_than_hanging() {
+        // A pump that never becomes ready must yield a typed Timeout (retryable at
+        // the control plane), NOT hang the mint forever. `pause`d time fast-forwards
+        // past the readiness timeout deterministically.
+        tokio::time::pause();
+        // Hold the sender so the channel is open but never fires.
+        let (_tx, rx) = oneshot::channel();
+        let waiter = tokio::spawn(async move { await_pump_ready(rx, "desktop").await });
+        // Advance virtual time past the readiness budget.
+        tokio::time::advance(PUMP_READY_TIMEOUT + Duration::from_secs(1)).await;
+        let err = waiter
+            .await
+            .expect("waiter task")
+            .expect_err("an un-fired pump must error");
+        assert!(matches!(err, PlatformError::Timeout(_)), "got {err:?}");
+        assert_eq!(err.code(), v1::ErrorCode::Timeout);
+    }
+
+    #[tokio::test]
+    async fn await_pump_ready_reports_a_pump_that_died_before_becoming_ready() {
+        // A pump that drops its sender (it died — a relay drop / non-retryable first
+        // capture — before serving a byte) must surface a typed Os error, not a hang.
+        let (tx, rx) = oneshot::channel();
+        drop(tx); // the pump ended without firing readiness.
+        let err = await_pump_ready(rx, "pty")
+            .await
+            .expect_err("a dropped sender must error");
+        assert!(matches!(err, PlatformError::Os { .. }), "got {err:?}");
     }
 }

--- a/agent/crates/opengeni-agent-stream/src/pty_pump.rs
+++ b/agent/crates/opengeni-agent-stream/src/pty_pump.rs
@@ -32,6 +32,21 @@ const OUTPUT_CHANNEL_BOUND: usize = 256;
 /// The PTY read chunk size.
 const READ_CHUNK: usize = 8 * 1024;
 
+/// A one-shot pump-readiness signal: the pump fires it the instant it has entered
+/// its select loop (so inbound keystrokes are received immediately) AND shipped its
+/// first real byte(s) into the relay ring, so a consumer dialing the freshly-minted
+/// URL is guaranteed replayable output WITHOUT having to type. The owner
+/// (`register_pty`) awaits it (with a timeout) before returning the descriptor.
+pub type ReadyTx = tokio::sync::oneshot::Sender<()>;
+
+/// Fires the one-shot readiness signal exactly once (a no-op if already fired or the
+/// owner stopped waiting). Takes the sender out so subsequent frames do not re-fire.
+fn fire_ready(ready: &mut Option<ReadyTx>) {
+    if let Some(tx) = ready.take() {
+        let _ = tx.send(());
+    }
+}
+
 /// A control command sent to a live PTY pump out-of-band of the relay stream — the
 /// programmatic `pty_write`/`pty_resize`/`pty_close` control ops (which arrive over
 /// NATS, not the relay byte stream). The pump applies it against the owned
@@ -63,6 +78,10 @@ pub type PtyControlTx = mpsc::Sender<PtyCommand>;
 /// closes the channel `PROCESS_EXIT`); a transport error propagates so the caller
 /// can reconnect + resume and re-enter the pump.
 ///
+/// `ready` is fired once the loop is live AND the first output frame has been
+/// shipped to the relay (so the owner's mint is gated on a serveable channel). It is
+/// only passed on the FIRST run — a reconnect re-enters the pump with `ready = None`.
+///
 /// # Errors
 ///
 /// Propagates a [`StreamError::Transport`](crate::error::StreamError::Transport)
@@ -71,6 +90,7 @@ pub async fn run(
     process: &mut PtyProcess,
     channel: &mut RelayChannel,
     commands: &mut mpsc::Receiver<PtyCommand>,
+    ready: Option<ReadyTx>,
 ) -> StreamResult<()> {
     // --- output: blocking reader → bounded channel ---------------------------
     let reader = process.take_reader();
@@ -109,7 +129,15 @@ pub async fn run(
         })
     });
 
-    let result = pump_loop(process, channel, commands, &mut out_rx, &in_tx).await;
+    // Nudge the shell to print a fresh prompt so a freshly-attaching consumer sees
+    // output WITHOUT having to type: writing a lone newline to the PTY master makes
+    // an interactive login shell re-emit its prompt. This produces the first real
+    // byte(s) the readiness barrier waits on. Best-effort — if the writer task has
+    // already ended (a command-only PTY that exits instantly) the pump still serves
+    // whatever the command printed, and EOF resolves readiness via the first frame.
+    let _ = in_tx.send(b"\n".to_vec()).await;
+
+    let result = pump_loop(process, channel, commands, &mut out_rx, &in_tx, ready).await;
 
     // Tear down: dropping the senders/receivers ends the blocking tasks.
     drop(in_tx);
@@ -125,12 +153,18 @@ pub async fn run(
 
 /// The select loop: forward tty output frames out, apply inbound frames + control
 /// commands to the PTY. Ends when output EOFs (PTY exit) or the relay drops.
+///
+/// `ready` (when `Some`) is fired the first time an output frame is shipped to the
+/// relay (or, defensively, on an immediate PTY EOF that produced no output) — the
+/// loop is already selecting on `channel.recv()` by then, so inbound keystrokes are
+/// received the instant a consumer sends them.
 async fn pump_loop(
     process: &mut PtyProcess,
     channel: &mut RelayChannel,
     commands: &mut mpsc::Receiver<PtyCommand>,
     out_rx: &mut mpsc::Receiver<Vec<u8>>,
     in_tx: &mpsc::Sender<Vec<u8>>,
+    mut ready: Option<ReadyTx>,
 ) -> StreamResult<()> {
     // Once the command sender is dropped, stop selecting on it so a closed channel
     // (which resolves immediately) does not spin the loop.
@@ -139,15 +173,17 @@ async fn pump_loop(
         tokio::select! {
             // tty output → relay frame.
             chunk = out_rx.recv() => {
-                match chunk {
-                    Some(bytes) => {
-                        channel.send_frame(bytes::Bytes::from(bytes)).await?;
-                    }
-                    None => {
-                        // The reader task ended (PTY EOF) — clean exit.
-                        return Ok(());
-                    }
-                }
+                let Some(bytes) = chunk else {
+                    // The reader task ended (PTY EOF) — clean exit. Release a
+                    // still-pending readiness waiter so the owner's mint does not
+                    // stall on a PTY that exited before printing anything.
+                    fire_ready(&mut ready);
+                    return Ok(());
+                };
+                channel.send_frame(bytes::Bytes::from(bytes)).await?;
+                // First real byte(s) are now buffered in the relay ring — a consumer
+                // dialing the minted URL will replay them. Signal ready.
+                fire_ready(&mut ready);
             }
             // relay inbound → tty input (or ignore non-frame control).
             inbound = channel.recv() => {
@@ -298,7 +334,7 @@ mod tests {
         });
 
         let (_cmd_tx, mut cmd_rx) = mpsc::channel::<PtyCommand>(8);
-        let pump = run(&mut proc, &mut channel, &mut cmd_rx);
+        let pump = run(&mut proc, &mut channel, &mut cmd_rx, None);
         // The PTY exits quickly; bound the test so a hang fails loudly.
         let _ = tokio::time::timeout(std::time::Duration::from_secs(10), pump).await;
         let seen = tokio::time::timeout(std::time::Duration::from_secs(2), collector)
@@ -320,5 +356,63 @@ mod tests {
             "relay never saw the pty marker; saw {:?}",
             String::from_utf8_lossy(&seen)
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pump_emits_an_initial_byte_and_fires_readiness_without_input() {
+        // The readiness contract: a freshly-attaching consumer must see output
+        // WITHOUT typing. The pump writes an initial newline to the PTY master; the
+        // tty driver echoes it (canonical mode), so the relay sees a frame and the
+        // pump fires readiness — all before the test sends a single keystroke.
+        //
+        // `cat` keeps the PTY open (it reads stdin forever), so the pump stays in its
+        // select loop with `channel.recv()` live — proving the inbound arm is polled
+        // the instant a consumer would send a keystroke.
+        let req = v1::PtyOpenRequest {
+            command: vec!["cat".to_string()],
+            cols: 80,
+            rows: 24,
+            ..Default::default()
+        };
+        let mut proc = spawn_pty_resilient(&req, &["/bin/sh".to_string()]).expect("spawn cat");
+
+        let (agent_side, mut relay_side) = MockTransport::pair();
+        let mut channel = RelayChannel::with_transport(pty_channel_config(), Box::new(agent_side));
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (_cmd_tx, mut cmd_rx) = mpsc::channel::<PtyCommand>(8);
+
+        // Drive the pump inline (it borrows locals); `cat` keeps it alive (it reads
+        // stdin forever) so it never returns on its own, and `relay_side` is held by
+        // THIS task so the pump always has a live peer — readiness firing is the only
+        // thing that resolves the race.
+        let pump = run(&mut proc, &mut channel, &mut cmd_rx, Some(ready_tx));
+        tokio::select! {
+            _ = pump => panic!("the cat-backed pump should not exit on its own"),
+            r = tokio::time::timeout(std::time::Duration::from_secs(3), ready_rx) => {
+                r.expect("readiness must fire within the budget")
+                    .expect("readiness sender must not be dropped");
+            }
+        }
+
+        // The relay must see at least one NON-EMPTY byte WITHOUT the test sending any
+        // input — the initial-newline nudge echoed by the tty driver. Readiness fires
+        // WITH the first frame, so it is already buffered in the unbounded mock ring.
+        let mut saw_byte = false;
+        for _ in 0..16 {
+            match tokio::time::timeout(std::time::Duration::from_secs(1), relay_side.recv()).await {
+                Ok(Ok(Some(RelayMessage::Frame(f)))) if !f.data.is_empty() => {
+                    saw_byte = true;
+                    break;
+                }
+                Ok(Ok(Some(_))) => {}
+                _ => break,
+            }
+        }
+        assert!(
+            saw_byte,
+            "the pump must ship a non-empty initial frame without input"
+        );
+        let _ = proc.kill();
     }
 }


### PR DESCRIPTION
Closes the agent-side half of the selfhosted stream gap: the interactive terminal (V5) and desktop framebuffer (V6) over a session swapped to an enrolled machine were intermittently unreachable.

## Two readiness fixes
1. **Pump readiness** (`opengeni-agent-stream`: hub/pty_pump/framebuffer_pump) — `register_pty`/`register_desktop` block on a oneshot until the producer pump serves its first byte before the RPC returns. PTY writes an initial newline (prompt without typing); desktop does a bounded first-capture retry against Xvfb readiness. Removes the empty-terminal-until-keystroke wart and the cached-negative desktop probe.
2. **Xvfb stale-socket readiness race** (`opengeni-agent-platform/virtual_desktop.rs`) — an unclean Xvfb death leaves a stale `/tmp/.X<N>-lock` + socket file; the old `wait_for_x_socket` returned "ready" instantly off the stale *file*, handing back a `$DISPLAY` pointing at a dead server (→ `display_unavailable` for the whole session). Fix: `reclaim_stale_display()` removes a stale lock+socket before spawn (only when no live server answers a `UnixStream` connect), and `wait_for_x_ready()` polls a real connection + detects a dead child so `spawn` fails honestly. Real hazard for long-lived BYO agents.

## Verification (live, enrolled Azure VM)
5× single-attempt driver runs with `kill -9` cleanup between each run → **23/23 every run**; V5-PTY and V6-FB both pass 5/5. The `kill -9` between runs means each run starts with a stale X lock, so 5/5 also proves the agent recovers from it.

| run | V5-PTY | V6-FB (frames) | result |
|----|----|----|----|
| 1 | PASS | PASS (10) | 23/23 |
| 2 | PASS | PASS (8) | 23/23 |
| 3 | PASS | PASS (8) | 23/23 |
| 4 | PASS | PASS (8) | 23/23 |
| 5 | PASS | PASS (8) | 23/23 |

Part of the selfhosted-stream gap-closing set (with the control-plane lease_cold fix #121 and the relay channel-affinity ingress fix, ops #17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `pty_open` / `desktop_ensure` succeed (adds up to 5s blocking and new failure modes) and touches `/tmp` X11 artifacts on Linux; behavior is well-tested but affects the critical self-hosted stream path.
> 
> **Overview**
> Fixes intermittent empty terminals and dead desktop streams on self-hosted agents by not returning stream descriptors until the relay actually has replayable data, and by making virtual Xvfb startup honest after unclean shutdowns.
> 
> **Relay hub (`register_pty` / `register_desktop`)** now waits up to 5s on a oneshot from the spawned pump before the RPC succeeds. PTY pumps signal readiness after the first output is framed to the relay (including a best-effort initial newline to elicit a prompt); desktop pumps signal only after the first PNG is captured, forwarded, and buffered. Timeouts and pumps that die early return typed `PlatformError::Timeout` / `Os` instead of minting URLs that attach to empty channels; failed PTY registration removes the half-registered control entry.
> 
> **Framebuffer pump** adds a first-frame barrier with bounded retries (~2s) for transient X11 capture failures during Xvfb settle; exhausting the budget yields `StreamError::Platform` so desktop mint fails rather than succeeding with no frames.
> 
> **Xvfb (`VirtualXvfb::spawn`)** reclaims stale `/tmp` lock and socket files only when no live server accepts a unix connect, replaces path-existence “ready” with ~4s connect polling plus child exit detection, sets `$DISPLAY` only after connect succeeds, and kills the child if readiness never arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957cf22da8859bf47abd56e669ff3282bfa13a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->