### PR TITLE
feat(install): deployed control plane self-serves its matching baked agent

### DIFF
--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -48,7 +48,13 @@ function Get-EnvOr($name, $default) {
   if ([string]::IsNullOrEmpty($v)) { return $default } else { return $v }
 }
 
-$BaseUrl = Get-EnvOr 'OPENGENI_INSTALL_BASE_URL' 'https://get.opengeni.ai'
+# A DEPLOYED control plane rewrites the next line to its own origin at serve time
+# (see apps/api/src/routes/install.ts DEFAULT_BASE_REWRITES), so this Windows
+# installer pulls the matching baked agent from the same host it was fetched from.
+# Keep the line's shape stable (rewritten by exact match). OPENGENI_INSTALL_BASE_URL
+# still wins.
+$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'
+$BaseUrl = Get-EnvOr 'OPENGENI_INSTALL_BASE_URL' $OpengeniInstallDefaultBaseUrl
 $Version = Get-EnvOr 'OPENGENI_AGENT_VERSION' 'latest'
 
 function Log($msg)  { Write-Host "opengeni-install: $msg" }

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -62,7 +62,16 @@ set -eu
 OPENGENI_MINISIGN_PUBKEY='RWSaqgF1EVFuci7hXvDJO7cBh2xf2k0XKhCpvl23aWKG+nMAGfZ6D2Pn'
 
 # --- Defaults / config -------------------------------------------------------
-BASE_URL="${OPENGENI_INSTALL_BASE_URL:-https://get.opengeni.ai}"
+# Default release-asset base URL. A DEPLOYED control plane REWRITES the next line
+# at serve time to its OWN origin, so `curl <control-plane>/install.sh | sh` pulls
+# the per-SHA agent baked into that exact deployment (zero version drift, and no
+# dependency on the public CDN — a private/air-gapped control plane may not even
+# resolve it). The committed default is the public archive, for a from-source or
+# standalone install. The OPENGENI_INSTALL_BASE_URL env override always wins.
+# Keep this line's shape stable: apps/api/src/routes/install.ts rewrites it by
+# exact match (DEFAULT_BASE_REWRITES).
+OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"
+BASE_URL="${OPENGENI_INSTALL_BASE_URL:-$OPENGENI_INSTALL_DEFAULT_BASE_URL}"
 VERSION="${OPENGENI_AGENT_VERSION:-latest}"
 
 log()  { printf '%s\n' "opengeni-install: $*" >&2; }

--- a/apps/api/src/routes/install.ts
+++ b/apps/api/src/routes/install.ts
@@ -56,6 +56,46 @@ async function loadAsset(file: string): Promise<string> {
   return body;
 }
 
+// "The agent ships inside the control-plane" (cont.): the committed install
+// scripts default their release-asset base URL to the public archive
+// (get.opengeni.ai) so a from-source / standalone copy still works. But a
+// DEPLOYED control plane must serve a script that pulls the agent from ITSELF —
+// the per-SHA binary baked into THIS image, via the /agent/* routes below — so
+// `curl https://<this-host>/install.sh | sh` installs the exact agent that
+// matches the API it enrolls against, with NO dependency on a public CDN (which a
+// private/air-gapped deploy may not even resolve). When a public base URL is
+// configured we therefore rewrite each script's default-base-URL marker line to
+// that origin before serving. The user's OPENGENI_INSTALL_BASE_URL env override
+// still wins at run time (the scripts use `:-default`); only the built-in DEFAULT
+// changes. The marker lines are kept shape-stable in agent/install/install.{sh,ps1}.
+const DEFAULT_BASE_REWRITES: Record<string, (base: string) => { from: string; to: string }> = {
+  "install.sh": (base) => ({
+    from: 'OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"',
+    to: `OPENGENI_INSTALL_DEFAULT_BASE_URL="${base}"`,
+  }),
+  "install.ps1": (base) => ({
+    from: "$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'",
+    to: `$OpengeniInstallDefaultBaseUrl = '${base}'`,
+  }),
+};
+
+// Rewrite a served script's default release-asset base URL to this deployment's
+// own public origin. A no-op when no public base URL is configured (the public
+// archive default stands), when the URL is not absolute http(s) (never serve a
+// script with a broken base), or when the file has no marker (script drift — fail
+// safe to serving it verbatim rather than crashing the install surface).
+function rewriteDefaultBaseUrl(file: string, body: string, publicBaseUrl: string | undefined): string {
+  if (!publicBaseUrl || !/^https?:\/\//.test(publicBaseUrl)) {
+    return body;
+  }
+  const base = publicBaseUrl.replace(/\/+$/, "");
+  const rule = DEFAULT_BASE_REWRITES[file]?.(base);
+  if (!rule || !body.includes(rule.from)) {
+    return body;
+  }
+  return body.replace(rule.from, rule.to);
+}
+
 // The content type for a baked release asset. The binary is an
 // application/octet-stream download; its `.sha256`/`.minisig` sidecars are short
 // text the install script parses line-by-line.
@@ -100,7 +140,10 @@ export function registerInstallRoutes(app: Hono, deps: ApiRouteDeps): void {
 
   for (const [path, { file, contentType }] of Object.entries(TEXT_ASSETS)) {
     app.get(path, async (c) => {
-      const body = await loadAsset(file);
+      // Serve the committed body, but rewrite the install scripts' default
+      // asset base URL to THIS deployment's origin so the agent is pulled from
+      // the same control plane it enrolls against (see rewriteDefaultBaseUrl).
+      const body = rewriteDefaultBaseUrl(file, await loadAsset(file), deps.settings.publicBaseUrl);
       return c.text(body, 200, {
         "content-type": contentType,
         // Short cache: the edge serves the latest committed copy; new installs

--- a/apps/api/src/sandbox/fleet.ts
+++ b/apps/api/src/sandbox/fleet.ts
@@ -428,8 +428,12 @@ export async function provisionSandbox(
       kind: "selfhosted",
       instructions:
         "Share these instructions with a human operator. They install the OpenGeni agent on the machine, run `opengeni-agent enroll`, complete the device-flow at the verification URL (the loud whole-machine + screen-control consent), and the machine then appears here as an attachable selfhosted sandbox.",
-      installCommandUnix: "curl -fsSL https://get.opengeni.ai/install.sh | sh",
-      installCommandWindows: "irm https://get.opengeni.ai/install.ps1 | iex",
+      // Install from THIS control plane's origin (not a hardcoded public CDN): the
+      // served install script is rewritten to pull the per-SHA agent baked into
+      // this exact deployment (see apps/api/src/routes/install.ts), so a deployed
+      // env is self-contained and a private/air-gapped one works with no public DNS.
+      installCommandUnix: `curl -fsSL ${base}/install.sh | sh`,
+      installCommandWindows: `irm ${base}/install.ps1 | iex`,
       verificationUri: `${base}/device`,
       note: "Whole-machine access requires explicit human consent in the device-flow web page; the agent cannot self-consent.",
     };

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -42,6 +42,36 @@ describe("get.<domain> install routes", () => {
     expect(body).toContain("opengeni-agent");
   });
 
+  // "The agent ships inside the control-plane": a DEPLOYED control plane self-serves
+  // its matching baked agent. The served install scripts must therefore default
+  // their asset base URL to THIS deployment's own public origin (so `curl
+  // <host>/install.sh | sh` pulls from the same host — no get.opengeni.ai dep),
+  // while the user's OPENGENI_INSTALL_BASE_URL override still wins.
+  test("GET /install.sh rewrites the default asset base URL to the deployment's own origin", async () => {
+    const settings = testSettings({ publicBaseUrl: "https://cp.example.com/" });
+    const res = await appFor(settings).request("/install.sh");
+    const body = await res.text();
+    expect(body).toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://cp.example.com"');
+    expect(body).not.toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"');
+    // The user-facing override var name is untouched (operator can still repoint).
+    expect(body).toContain("OPENGENI_INSTALL_BASE_URL");
+  });
+
+  test("GET /install.ps1 rewrites the default asset base URL to the deployment's own origin", async () => {
+    const settings = testSettings({ publicBaseUrl: "https://cp.example.com" });
+    const res = await appFor(settings).request("/install.ps1");
+    const body = await res.text();
+    expect(body).toContain("$OpengeniInstallDefaultBaseUrl = 'https://cp.example.com'");
+    expect(body).not.toContain("$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'");
+  });
+
+  test("GET /install.sh keeps the public-archive default when no public base URL is configured", async () => {
+    const settings = testSettings({ publicBaseUrl: undefined });
+    const res = await appFor(settings).request("/install.sh");
+    const body = await res.text();
+    expect(body).toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"');
+  });
+
   test("GET /install.ps1 serves the Windows installer", async () => {
     const res = await appFor(testSettings()).request("/install.ps1");
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Problem
`curl https://<deployed-host>/install.sh | sh` downloaded the agent binary from the public CDN (`get.opengeni.ai`) even when the script was fetched **from a deployed control plane**. On staging this failed hard:

```
opengeni-install: installing opengeni-agent-x86_64-unknown-linux-musl (version: latest) from https://get.opengeni.ai
curl: (6) Could not resolve host: get.opengeni.ai
```

The deployed API already **bakes the per-SHA signed agent** and serves it from `/agent/*` (the "agent ships inside the control-plane" decision, #34). The install script just never pointed back at the host it was fetched from.

## Fix (the ideal architecture, made real)
A deployed control plane is now **self-contained**: `curl https://<host>/install.sh | sh` installs the exact per-SHA agent baked into *that* deployment, with zero dependency on a public CDN (which a private/air-gapped control plane may not even resolve).

- **`agent/install/install.sh` + `install.ps1`** — lift the default asset base URL onto a shape-stable marker line. The committed default stays the public archive (for from-source/standalone installs); the `OPENGENI_INSTALL_BASE_URL` env override still wins.
- **`apps/api/src/routes/install.ts`** — when serving the scripts, rewrite that marker to the deployment's own `settings.publicBaseUrl`. Fails safe (no rewrite when `publicBaseUrl` is unset/non-absolute or the marker is absent → serve verbatim).
- **`apps/api/src/sandbox/fleet.ts`** — `provisionSandbox` install commands use the configured base instead of a hardcoded `get.opengeni.ai` (mirrors `web/src/lib/deployment.ts`, which already used the serving origin).
- **`apps/api/test/install.test.ts`** — assert the rewrite (origin-defaulting + public-archive fallback) for both scripts.

## Companion change (infra, separate repo)
The deployed ingress must route `/agent/*` → API. The chart's default `values.yaml` already does; a per-env override had dropped it. Fixed in the ops repo's staging values.

## Out of scope / follow-up
- Agent **self-update** default base (`agent/crates/.../update.rs`) still defaults to the public archive — tracked separately.

## Test
- `apps/api` `install.test.ts` 16 pass, `fleet-tools.test.ts` 7 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install URL defaults and serve-time string rewrites only; env override unchanged and rewrite fails safe on misconfiguration.
> 
> **Overview**
> **Deployed control planes now install agents from the same host that serves `install.sh` / `install.ps1`**, instead of always pulling binaries from `get.opengeni.ai` (which broke private/air-gapped deploys).
> 
> `install.sh` and `install.ps1` expose a **shape-stable default base URL marker** (committed default stays the public archive); `OPENGENI_INSTALL_BASE_URL` still overrides at runtime. **`apps/api/src/routes/install.ts`** rewrites that marker to `settings.publicBaseUrl` when serving the scripts (no-op if unset, non-http(s), or marker missing). **`fleet.ts`** selfhosted provision install commands use the configured public base instead of a hardcoded CDN URL. **Tests** cover rewrite for both scripts and fallback when `publicBaseUrl` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d826f0abe343c72f6be6a0b9976e78a22cc610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->