### PR TITLE
feat(mcp): expose targetSandboxId on session_create (create-time machine targeting)

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -628,6 +628,12 @@ function registerWorkspaceOrchestrationTools(
         model: z4.string().min(1).optional(),
         reasoningEffort: z4.string().optional(),
         sandboxBackend: z4.string().optional(),
+        // Create-time machine targeting: an enrolled sandbox id (from
+        // sandboxes_list) to run the spawned session on. Seeds the active-sandbox
+        // pointer at creation so the FIRST turn lands on the chosen machine
+        // (race-free). Ownership + liveness are validated in the domain via the
+        // same path as sandbox_swap; an unowned/offline/unknown target 422s.
+        targetSandboxId: z4.string().uuid().optional(),
         metadata: z4.record(z4.string(), z4.unknown()).optional(),
         // Workspace-scoped CREATE idempotency key: a retried session_create with
         // the same key returns the already-spawned worker instead of a duplicate.

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -184,6 +184,22 @@ describe("P1.4 shared-sandbox create resolution (real createSessionForRequest + 
     })).rejects.toMatchObject({ status: 422 });
   }, 60_000);
 
+  test("targetSandboxId is consumed (seedTargetSandbox path) — rejects on a backend:'none' session", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const bus = new MemoryEventBus();
+    // Create-time machine targeting (A-2a): a named targetSandboxId seeds the
+    // active-sandbox pointer inside createAndStartSession. The harness settings
+    // pin sandboxBackend:"none", so the seed guard fires — proving the payload
+    // field actually reaches finishStartSession's seedTargetSandbox (not parsed
+    // away). The ownership/liveness validation for a real target is covered by
+    // the swapActiveSandbox / setActiveSandbox enrollment tests.
+    await expect(createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "pin to a machine",
+      targetSandboxId: crypto.randomUUID(),
+    })).rejects.toMatchObject({ status: 422 });
+  }, 60_000);
+
   test("{groupId} explicit join (I13/OD-S5) ⇒ same group as the sibling", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3907,6 +3907,46 @@ describe("API component integration", () => {
     })).rejects.toThrow("monthly agent run limit reached");
   });
 
+  test("manager MCP session_create forwards targetSandboxId to the domain (create-time machine targeting)", async () => {
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const mcpDeps = {
+      settings: testSettings({ databaseUrl: services.databaseUrl, environmentsEncryptionKey: environmentsTestKey }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+      objectStorage: null,
+      githubStateSecret: "test-state-secret",
+      documentIndexer: { indexDocument: async () => undefined },
+      getDocumentServices: () => {
+        throw new Error("document services are not used by manager MCP tests");
+      },
+    };
+    const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
+
+    // Control: a backend:"none" create WITHOUT a target succeeds — no machine
+    // is pinned, so nothing exercises the create-time targeting path.
+    const plain = await callMcpTool<{ id: string; sandboxBackend: string }>(mcp, "session_create", {
+      initialMessage: "no target",
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    expect(plain.sandboxBackend).toBe("none");
+
+    // The fix: targetSandboxId is now declared on the session_create inputSchema,
+    // so the MCP SDK no longer strips it before the handler runs — it reaches
+    // createSessionForRequest's seedTargetSandbox path. With backend:"none" the
+    // seed guard rejects (you cannot pin a machine for a sandbox-less session),
+    // which PROVES the value flowed end-to-end. Before the fix the unknown key
+    // was dropped and this create would have succeeded, silently swallowing the
+    // agent's machine-targeting request.
+    await expect(callMcpTool(mcp, "session_create", {
+      initialMessage: "pin to a machine",
+      model: "scripted-model",
+      sandboxBackend: "none",
+      targetSandboxId: crypto.randomUUID(),
+    })).rejects.toThrow(/cannot target a machine for a session with no sandbox/);
+  });
+
   test("manager MCP environment tools set variables write-only and create environments by name", async () => {
     const grant = await bootstrapMcpGrant(dbClient.db);
     const mcpDeps = {


### PR DESCRIPTION
## What

Adds the optional `targetSandboxId` field to the MCP **`session_create`** tool's `inputSchema`, so a parent agent can pre-bind **which enrolled machine** a spawned sub-agent session runs on — at creation, race-free, before the first turn dispatches.

## Why this was the only missing link

Every layer **below** the MCP tool already threaded `targetSandboxId` end-to-end:

| Layer | Status |
|---|---|
| Contract (`CreateSessionRequest.targetSandboxId`) | ✅ already `z.string().uuid().optional()` |
| Domain (`createSessionForRequest` → `seedTargetSandbox` → `finishStartSession`'s epoch-fenced `swapActiveSandbox` seed, with ownership + liveness validation) | ✅ already consumed |
| REST (`POST /v1/workspaces/:id/sessions`) | ✅ re-parses the contract |
| SDK (`createSession`) | ✅ forwards it |
| **MCP `session_create` tool** | ❌ **field absent from `inputSchema`** |

The MCP SDK **strips any input key not declared in the schema** before the handler runs, and the handler forwards `args` whole to `createSessionForRequest`. So an agent-supplied `targetSandboxId` was silently dropped and never reached the domain — a parent agent could not target a sub-agent's machine through MCP.

The fix is a one-line schema addition (matching the contract's name + `.uuid()` type). No handler/domain/validation change needed — they already exist.

## Relationship to `sandbox` placement (the "I just want a new box" case)

`targetSandboxId` is **complementary**, not a replacement, for the already-exposed `sandbox` field:
- `sandbox: "new"` → spawn gets a **fresh** private box (no machine id needed)
- omit `sandbox` from inside a session → shares the creator's box (default)
- `sandbox: { groupId }` → join a named sibling's box
- `targetSandboxId` → run on **THIS** specific enrolled machine (by id)

An agent that just wants another sandbox uses `sandbox: "new"` and supplies no id; `targetSandboxId` is purely for the "pin to a known machine" case.

## Tests
- **MCP** (`test/integration/api.integration.ts`): a `session_create` carrying `targetSandboxId` now reaches the domain — proven via the `sandboxBackend:"none"` seed guard (pre-fix the unknown key was stripped and the create wrongly succeeded).
- **Domain** (`apps/api/test/sandbox-shared-and-viewer.test.ts`): `createSessionForRequest` consumes `targetSandboxId` (seed path).

Typecheck clean; both new tests green locally against throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only MCP exposure plus tests; domain validation and behavior are unchanged.
> 
> **Overview**
> Adds optional **`targetSandboxId`** to the MCP **`session_create`** tool `inputSchema` so parent agents can pin a spawned worker to a specific enrolled machine at creation (before the first turn), using the same domain path as **`sandbox_swap`**.
> 
> Previously the MCP SDK dropped undeclared keys, so **`targetSandboxId`** never reached **`createSessionForRequest`** / **`seedTargetSandbox`** even though REST, contracts, and domain already supported it.
> 
> New tests assert the field flows through MCP and domain: with **`sandboxBackend: "none"`**, create with a target now fails the seed guard instead of succeeding silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa8fc00bf6bd7b0a2d6c7fe2f74968a0932f7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->