### PR TITLE
test(sandbox): restore one-command path to the self-hosted V-matrix harness

### DIFF
--- a/apps/api/scripts/.gitignore
+++ b/apps/api/scripts/.gitignore
@@ -1,0 +1,1 @@
+proveit.local.env

--- a/apps/api/scripts/proveit-selfhosted-staging.ts
+++ b/apps/api/scripts/proveit-selfhosted-staging.ts
@@ -46,7 +46,7 @@ import { randomUUID } from "node:crypto";
 // ---- config (env-driven; the x5 orchestrator supplies the seeded ws/account) --
 function reqEnv(name: string): string {
   const v = process.env[name];
-  if (!v) throw new Error(`missing required env ${name}`);
+  if (!v) throw new Error(`missing required env ${name} — run via proveit-staging-x5.sh (it self-provisions the workspace + sources proveit.local.env)`);
   return v;
 }
 const NS = process.env.OGE_NS ?? "opengeni"; // staging namespace

--- a/apps/api/scripts/proveit-staging-x5.sh
+++ b/apps/api/scripts/proveit-staging-x5.sh
@@ -17,13 +17,18 @@
 #                OGE_TEARDOWN=1      reap the synthetic account after the runs
 set -euo pipefail
 
+# Operator config: source proveit.local.env (gitignored) if present, so a full run is a
+# single command. Copy proveit.local.env.example -> proveit.local.env and fill it in.
+HERE_EARLY="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HERE_EARLY/proveit.local.env" ]; then set -a; . "$HERE_EARLY/proveit.local.env"; set +a; fi
+
 NS="${OGE_NS:-opengeni}"
-API="${OGE_API:?set OGE_API to the deployment base URL}"
-RELAY_HOST="${OGE_RELAY_HOST:?set OGE_RELAY_HOST to the relay hostname}"
+API="${OGE_API:?set OGE_API (copy apps/api/scripts/proveit.local.env.example -> proveit.local.env)}"
+RELAY_HOST="${OGE_RELAY_HOST:?set OGE_RELAY_HOST (see proveit.local.env.example)}"
 RUNS="${OGE_RUNS:-5}"
-VM_IP="${OGE_VM_IP:?set OGE_VM_IP to the external verification VM public IP}"
-VM_USER="${OGE_VM_USER:?set OGE_VM_USER to the SSH user on the verification VM}"
-VM_HOST="${OGE_VM_HOST:?set OGE_VM_HOST to the verification VM hostname}"
+VM_IP="${OGE_VM_IP:?set OGE_VM_IP (see proveit.local.env.example)}"
+VM_USER="${OGE_VM_USER:?set OGE_VM_USER (see proveit.local.env.example)}"
+VM_HOST="${OGE_VM_HOST:?set OGE_VM_HOST (see proveit.local.env.example)}"
 SSH_KEY="${OGE_SSH_KEY:-/tmp/staging-verify/vm_key}"
 DEPLOYED_SHA="${OGE_DEPLOYED_SHA:-unknown}"
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/apps/api/scripts/proveit.local.env.example
+++ b/apps/api/scripts/proveit.local.env.example
@@ -1,0 +1,22 @@
+# proveit.local.env — operator config for the self-hosted V-matrix harness.
+#
+# Copy this file to `proveit.local.env` (gitignored) and fill in the values for YOUR
+# opengeni managed deployment. `proveit-staging-x5.sh` sources it automatically, so once
+# this is set up a full ×N verification is a single command:  ./proveit-staging-x5.sh
+#
+# You do NOT set a workspace/account id — the orchestrator self-provisions a throwaway
+# account + workspace for the run (and reaps it with OGE_TEARDOWN=1).
+
+export OGE_API=https://app.your-deployment.example     # control-plane base URL
+export OGE_RELAY_HOST=relay.your-deployment.example    # relay hostname (the wss stream ingress)
+export OGE_NS=opengeni                                  # k8s namespace of the api pod (kubectl ctx)
+export OGE_VM_IP=203.0.113.10                           # public IP of the external verification VM
+export OGE_VM_USER=youruser                             # SSH user on that VM
+export OGE_VM_HOST=verify-1                             # that VM's hostname (asserted in exec/PTY checks)
+export OGE_SSH_KEY=/path/to/vm_ssh_key                  # private key used to SSH into the VM
+
+# Optional:
+# export OGE_DEPLOYED_SHA=abc1234   # provenance stamp recorded in the evidence
+# export OGE_RUNS=5                 # iterations (default 5)
+# export OGE_TEARDOWN=1             # reap the synthetic account after the runs
+# export OGE_MACHINE_NAME=verify-linux   # label for the enrolled machine

--- a/docs/design/sandbox-surfacing/10-staging-verification.md
+++ b/docs/design/sandbox-surfacing/10-staging-verification.md
@@ -48,20 +48,22 @@ that closed the create-time machine-targeting gap by exposing `targetSandboxId` 
 `lease_cold` fix and the install-from-control-plane path (a baked, signed agent served from
 the API — no external download host).
 
-## Reproducing
+## Running it
 
-The harness lives at `apps/api/scripts/`:
+`proveit-staging-x5.sh` is the entry point. It **self-provisions** a throwaway account +
+workspace (you never supply a workspace id), runs the matrix N times, aggregates pass/fail,
+and — opt-in (`OGE_TEARDOWN=1`) — reaps the synthetic account. The single-run driver
+`proveit-selfhosted-staging.ts` is invoked by the orchestrator, which threads in every
+value; you don't run it directly.
 
-- `proveit-selfhosted-staging.ts` — the single-run matrix driver. Self-installs the agent on
-  a target VM over SSH, drives the MCP + REST + relay surfaces, and asserts each claim,
-  writing per-check evidence.
-- `proveit-staging-x5.sh` — orchestrates N consecutive runs against a seeded synthetic
-  account/workspace, aggregates pass/fail, and (opt-in) reaps the synthetic account.
+Configure your target **once**: copy `apps/api/scripts/proveit.local.env.example` →
+`proveit.local.env` (gitignored), fill in your values, then run `./proveit-staging-x5.sh`.
+The orchestrator sources that file automatically — no per-run flags needed.
 
-It is **deployment-agnostic**: point it at any managed-mode deployment via env
-(`OGE_API`, `OGE_RELAY_HOST`, `OGE_VM_IP`, `OGE_VM_USER`, `OGE_VM_HOST`, `OGE_NS`). The
-firewalled control-plane Postgres is reached through the API pod (the conventional
-firewalled-DB-via-pod pattern), using the role in `OPENGENI_DATABASE_URL`.
+This targets **an opengeni managed deployment you operate** — not a black-box client against
+an arbitrary URL. It reaches the firewalled control-plane Postgres *through the api pod*, so
+it needs `kubectl` access to that pod (it uses the in-pod `OPENGENI_DATABASE_URL`), and it
+mints a workspace-scoped token from the deployment's `OPENGENI_DELEGATION_SECRET`.
 
 ### RLS note (managed deployments)
 


### PR DESCRIPTION
Restores the easy path the public-safety scrub removed:

- `proveit-staging-x5.sh` sources an optional gitignored `proveit.local.env` (committed generic `.example`) → a full ×N run is a single command after one-time setup.
- No workspace id is ever supplied by hand — the orchestrator self-provisions a throwaway account+workspace.
- Friendlier required-var errors point at the example file / orchestrator.
- Corrects doc 10's overstated "deployment-agnostic" claim to state what the harness actually needs (kubectl + control-plane DB + delegation secret, against a managed deployment you operate).

No internal/staging detail introduced (grep-gate clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs, gitignore, shell env sourcing, and error-message tweaks only; no runtime product or auth logic changes.
> 
> **Overview**
> Restores a **one-time local config → single-command** workflow for the self-hosted V-matrix harness after operator env setup was removed from the public tree.
> 
> **`proveit-staging-x5.sh`** now auto-sources an optional gitignored **`proveit.local.env`** when present; a committed **`proveit.local.env.example`** documents generic `OGE_*` values (API, relay, VM SSH, etc.) without hand-supplying workspace/account IDs. **`proveit.local.env`** is added to **`apps/api/scripts/.gitignore`**.
> 
> Required-env failures in the orchestrator and **`proveit-selfhosted-staging.ts`** now point operators at the example file and **`proveit-staging-x5.sh`** (self-provisioned workspace).
> 
> **`docs/design/sandbox-surfacing/10-staging-verification.md`** reframes “Reproducing” as “Running it” and replaces an overstated deployment-agnostic claim with what the harness actually needs: a **managed deployment you operate**, **`kubectl`** to the API pod, in-pod DB access, and **`OPENGENI_DELEGATION_SECRET`** for token minting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4246316d0ac4ea503f1418d1a3c03b64cf1039b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->