### PR TITLE
fix(codex): accept codex/* models at the session-create edge when enabled

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -1,3 +1,4 @@
+import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex";
 import { configuredAllowedModels, type Settings } from "@opengeni/config";
 import {
   CreateSessionRequest,
@@ -288,9 +289,19 @@ export function assertConfiguredModel(settings: Settings, model: string | null |
   if (model === null || model === undefined) {
     return;
   }
-  if (!configuredAllowedModels(settings).includes(model)) {
-    throw new HTTPException(422, { message: `model is not available: ${model}` });
+  if (configuredAllowedModels(settings).includes(model)) {
+    return;
   }
+  // Codex subscription models (codex/<slug>) are injected per-workspace by the
+  // worker overlay at turn time, so they are never in the deployment-global
+  // allow-list. Accept them at the edge when the feature is enabled — the picker
+  // only surfaces them for a connected workspace, and the worker enforces the
+  // actual connection (an unconnected workspace fails the turn with a clear
+  // "no Codex subscription connected" error rather than a misleading 422 here).
+  if (settings.codexSubscriptionEnabled && model.startsWith(CODEX_MODEL_ID_PREFIX)) {
+    return;
+  }
+  throw new HTTPException(422, { message: `model is not available: ${model}` });
 }
 
 export async function requireQueuedTurnForApi(db: Database, workspaceId: string, sessionId: string, turnId: string): Promise<SessionTurn> {

--- a/apps/api/test/codex-model-guard.test.ts
+++ b/apps/api/test/codex-model-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { HTTPException } from "hono/http-exception";
+import { testSettings } from "@opengeni/testing";
+import { assertConfiguredModel } from "../src/domain/sessions";
+
+describe("assertConfiguredModel — codex subscription models", () => {
+  test("rejects a codex model when the feature is disabled", () => {
+    let thrown: unknown;
+    try {
+      assertConfiguredModel(testSettings({ codexSubscriptionEnabled: false }), "codex/gpt-5.5");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(HTTPException);
+    expect((thrown as HTTPException).status).toBe(422);
+    expect((thrown as HTTPException).message).toBe("model is not available: codex/gpt-5.5");
+  });
+
+  test("accepts a codex model at the edge when the feature is enabled", () => {
+    expect(() => assertConfiguredModel(testSettings({ codexSubscriptionEnabled: true }), "codex/gpt-5.5")).not.toThrow();
+  });
+
+  test("still rejects a non-codex unknown model even when the feature is enabled", () => {
+    expect(() => assertConfiguredModel(testSettings({ codexSubscriptionEnabled: true }), "totally-bogus-model")).toThrow(HTTPException);
+  });
+
+  test("a normal deployment-allowed model is unaffected", () => {
+    expect(() => assertConfiguredModel(testSettings(), "gpt-5.5")).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Bug:** on staging, starting a session with a connected Codex subscription failed with `OpenGeni API 422: model is not available: codex/gpt-5.5`.

**Cause:** `assertConfiguredModel` (the one edge guard shared by create-session / turn-accept / queued-turn update / scheduled-task) validates against the deployment-global `configuredAllowedModels`. Codex models (`codex/<slug>`) are injected **per-workspace** by the worker overlay at turn time, so they're never in the global list → 422 before the turn is even enqueued.

**Fix:** accept the `codex/` prefix at the edge when `OPENGENI_CODEX_SUBSCRIPTION_ENABLED` is on. The picker only offers codex models for a connected workspace, and the worker still enforces the real per-workspace connection (an unconnected workspace fails the turn with a clear "no Codex subscription connected" error). Non-codex unknown models are still rejected; normal models unaffected.

Tests: 4 new guard cases (rejected when off, accepted when on, non-codex still rejected, normal model unaffected) + existing guard suite green; api typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyp1UPqmS5kbXTg4m4Lpnk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow edge validation change behind a feature flag; worker still enforces workspace Codex connection and non-codex unknown models stay rejected.
> 
> **Overview**
> Fixes **422 `model is not available`** when creating or updating sessions with **`codex/<slug>`** models that never appear in the deployment-global `configuredAllowedModels` list (those ids are added per-workspace at turn time).
> 
> **`assertConfiguredModel`** now allows models with the **`codex/`** prefix when **`codexSubscriptionEnabled`** is on, while still rejecting other unknown models; normal allow-listed models behave as before. Worker-side connection checks remain the source of truth for whether a workspace actually has Codex.
> 
> Adds **four unit tests** covering disabled feature, enabled acceptance, bogus non-codex models, and unchanged standard models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac57b8a48c40a826e56a38fd779c5372ffe8f099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->