### PR TITLE
feat(enrollment): zero-friction self-hosted enrollment — origin-pinned one-liner + click-Grant page + headless token

### DIFF
--- a/agent/crates/opengeni-agent/src/enrollment.rs
+++ b/agent/crates/opengeni-agent/src/enrollment.rs
@@ -38,6 +38,11 @@ use thiserror::Error;
 /// constants beside the wire structs so a path rename is also a one-file change.
 const START_PATH: &str = "/v1/enrollments/device/start";
 const POLL_PATH: &str = "/v1/enrollments/device/poll";
+/// The non-interactive token-exchange endpoint (headless / fleet enroll). The
+/// caller-held enroll token IS the grant — there is no human approve step — so
+/// this exchanges it directly for the SAME credential shape the `poll` authorized
+/// branch returns (spec §A2.3).
+const EXCHANGE_PATH: &str = "/v1/enrollments/token/exchange";
 
 /// What the user offered at install time, sent in the start request so the
 /// consent page can present the right toggles.
@@ -249,6 +254,46 @@ async fn poll_until_resolved(
     }
 }
 
+/// Exchanges a non-interactive enroll token for credentials (headless / fleet
+/// path, spec §A2.3/§A2.4). The token IS the grant — there is no human approve —
+/// so this is a single `POST /v1/enrollments/token/exchange` carrying the SAME
+/// identity fields the device flow sends to `device/start` (`publicKey`, `os`,
+/// `arch`, `machineName?`, the display/screen-control offer), plus the opaque
+/// `token`. The workspace is NOT sent: it is encoded in (and authorized by) the
+/// token itself, so `req.workspace_id` is ignored on this path.
+///
+/// The response's `credentials` is the EXISTING [`wire::Credentials`] shape (the
+/// API's `EnrollmentCredentialsResponse`), reusing [`Credentials::into_proto`] —
+/// identical to the `poll` authorized branch.
+///
+/// # Errors
+///
+/// Returns an [`EnrollmentError`] on a transport failure, a non-success status
+/// (e.g. a 401 for an invalid/expired token), or a malformed response.
+pub async fn exchange_token(
+    req: &EnrollmentRequest,
+    identity: &InstallIdentity,
+    token: &str,
+) -> Result<EnrollmentCredentials, EnrollmentError> {
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("opengeni-agent/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let url = join_url(&req.api_base_url, EXCHANGE_PATH);
+    let body = wire::ExchangeRequest {
+        token: token.to_string(),
+        public_key: identity.public_key_base64(),
+        os: os_str(req.offer.os),
+        arch: arch_str(req.offer.arch),
+        machine_name: Some(req.machine_name.clone()),
+        can_offer_display: req.offer.offers_display,
+        requests_screen_control: req.offer.requests_screen_control,
+    };
+    let resp = client.post(&url).json(&body).send().await?;
+    let exchange = parse_json::<wire::ExchangeResponse>(resp, EXCHANGE_PATH).await?;
+    Ok(exchange.credentials.into_proto())
+}
+
 /// Joins a base URL and a path without doubling or dropping the separating slash.
 fn join_url(base: &str, path: &str) -> String {
     format!(
@@ -382,6 +427,44 @@ mod wire {
         pub state: PollState,
         #[serde(default)]
         pub credentials: Option<Credentials>,
+    }
+
+    /// Body of `POST /v1/enrollments/token/exchange` (spec §A2.3). Carries the
+    /// SAME identity fields as [`StartRequest`] — the agent's `publicKey`, `os`,
+    /// `arch`, optional `machineName`, and the display/screen-control offer —
+    /// plus the opaque enroll `token` that authorizes the exchange. The workspace
+    /// is NOT sent: it is encoded in the token. Like `StartRequest`, `exposure`
+    /// is omitted (the API defaults it to `whole-machine` server-side, the only
+    /// v1 exposure).
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(super) struct ExchangeRequest {
+        /// The opaque, short-TTL enroll token (the `oget_` token) — the grant.
+        pub token: String,
+        /// The agent's FULL ed25519 public key (base64) — the machine identity the
+        /// enrollment binds to (same as `StartRequest::public_key`).
+        pub public_key: String,
+        /// OS family (`linux`/`macos`/`windows`).
+        pub os: String,
+        /// CPU arch (`x86_64`/`aarch64`).
+        pub arch: String,
+        /// Human-friendly machine name (optional; serialized as `machineName`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub machine_name: Option<String>,
+        /// Whether this machine can offer a display (the API's `canOfferDisplay`).
+        pub can_offer_display: bool,
+        /// Whether the agent requests screen control (the API's
+        /// `requestsScreenControl`).
+        pub requests_screen_control: bool,
+    }
+
+    /// Response of `POST /v1/enrollments/token/exchange` (spec §A2.3). The
+    /// `credentials` object is the SAME [`Credentials`] shape (the API's
+    /// `EnrollmentCredentialsResponse`) the `poll` authorized branch returns, so
+    /// the exchange reuses [`Credentials::into_proto`].
+    #[derive(Debug, Deserialize)]
+    pub(super) struct ExchangeResponse {
+        pub credentials: Credentials,
     }
 
     /// The credentials sub-object on an authorized poll. Matches the API's
@@ -592,6 +675,74 @@ mod tests {
         assert!(value.get("installFingerprint").is_none());
         assert!(value.get("updateChannel").is_none());
         assert!(value.get("offersDisplay").is_none());
+    }
+
+    #[test]
+    fn exchange_request_serializes_camelcase_for_the_api() {
+        // The exchange body carries the same identity fields as start, plus the
+        // opaque enroll token, and the API reads camelCase keys (spec §A2.3).
+        let body = wire::ExchangeRequest {
+            token: "oget_secret".to_string(),
+            public_key: "pubkey-b64".to_string(),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            machine_name: Some("fleet-box".to_string()),
+            can_offer_display: false,
+            requests_screen_control: false,
+        };
+        let value: serde_json::Value = serde_json::to_value(&body).expect("serialize");
+        assert_eq!(value["token"], "oget_secret");
+        assert_eq!(value["publicKey"], "pubkey-b64");
+        assert_eq!(value["os"], "linux");
+        assert_eq!(value["arch"], "x86_64");
+        assert_eq!(value["machineName"], "fleet-box");
+        assert_eq!(value["canOfferDisplay"], false);
+        assert_eq!(value["requestsScreenControl"], false);
+        // The workspace is encoded in the token, never sent on the wire; and
+        // `exposure` is omitted (the API defaults it server-side).
+        assert!(value.get("workspaceId").is_none());
+        assert!(value.get("exposure").is_none());
+    }
+
+    #[test]
+    fn exchange_request_omits_machine_name_when_absent() {
+        let body = wire::ExchangeRequest {
+            token: "oget_secret".to_string(),
+            public_key: "pubkey-b64".to_string(),
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            machine_name: None,
+            can_offer_display: false,
+            requests_screen_control: false,
+        };
+        let value: serde_json::Value = serde_json::to_value(&body).expect("serialize");
+        assert!(value.get("machineName").is_none());
+    }
+
+    #[test]
+    fn exchange_response_parses_credentials_into_proto() {
+        // The API returns `{ credentials: EnrollmentCredentialsResponse }` —
+        // identical to the poll authorized branch — so the exchange reuses the
+        // same wire::Credentials parsing + into_proto conversion (spec §A2.3).
+        let json = r#"{
+            "credentials": {
+                "agentId": "a", "workspaceId": "w", "bearer": "oge_bearer",
+                "subjectPrefix": "agent.w.a", "natsUrls": ["tls://x:4222"],
+                "relayUrl": "https://r", "relayToken": "ogr_x",
+                "natsAccountCreds": "oge_bearer", "updatePublicKey": "k",
+                "consentedWholeMachine": true, "consentedScreenControl": true
+            }
+        }"#;
+        let exchange: wire::ExchangeResponse = serde_json::from_str(json).expect("parse");
+        let proto = exchange.credentials.into_proto();
+        assert_eq!(proto.agent_id, "a");
+        assert_eq!(proto.workspace_id, "w");
+        assert_eq!(proto.nats_credentials, "oge_bearer");
+        assert_eq!(proto.nats_urls, vec!["tls://x:4222".to_string()]);
+        assert_eq!(proto.relay_token, "ogr_x");
+        assert_eq!(proto.update_pubkey, "k");
+        assert!(proto.consented_whole_machine);
+        assert!(proto.consented_screen_control);
     }
 
     #[test]

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -240,7 +240,7 @@ async fn enroll_command(
         let token = args.token.clone().ok_or_else(|| {
             string_err("--non-interactive requires --token (or $OPENGENI_ENROLL_TOKEN)".to_string())
         })?;
-        return enroll_with_token(&args, api_url, &token);
+        return enroll_with_token(&args, api_url, &token).await;
     }
 
     // The device flow binds to a workspace the API requires at start. The user
@@ -305,29 +305,55 @@ async fn enroll_command(
     Ok(stored)
 }
 
-/// Non-interactive token enrollment (the CI/automation path, dossier §23.1). The
-/// token→credentials EXCHANGE is the M5 enrollment endpoint; the install scripts
-/// pass `OPENGENI_ENROLL_TOKEN` and the CLI surface is stable, but the agent does
-/// not fabricate credentials — until the token-exchange endpoint is wired it
-/// returns a precise error so an unattended install fails loudly (never silently
-/// falling back to a device flow that would hang). The `_api_url`/`_token` are
-/// threaded so the reconciliation against the M5 endpoint is a one-function change.
-fn enroll_with_token(
+/// Non-interactive token enrollment (the CI/automation / fleet path, dossier
+/// §23.1, spec §A2.4). A workspace-scoped enroll token IS the grant — there is no
+/// human approve step — so this exchanges it directly at the control plane's
+/// `POST /v1/enrollments/token/exchange` for the SAME credentials the device flow
+/// receives, then persists them `0600` exactly like the device path
+/// ([`config::save_credentials`]). The workspace is encoded in the token, so none
+/// is required on the CLI here.
+async fn enroll_with_token(
     args: &EnrollArgs,
-    _api_url: &str,
-    _token: &str,
+    api_url: &str,
+    token: &str,
 ) -> anyhow_lite::ResultOf<StoredCredentials> {
-    warn!(
-        channel = %args.channel,
-        "non-interactive token enrollment requested; the token-exchange endpoint is the M5 enrollment seam"
-    );
-    Err(string_err(
-        "non-interactive token enrollment is not yet wired to the control-plane \
-         token-exchange endpoint (the M5 enrollment seam). Use the interactive \
-         `opengeni-agent enroll` device flow, or set OPENGENI_API_URL to a control \
-         plane exposing the token exchange."
-            .to_string(),
-    ))
+    let platform = NativePlatform::new();
+    let identity = platform.host_identity();
+    let machine_name = args
+        .machine_name
+        .clone()
+        .unwrap_or_else(supervisor::hostname_or_default);
+
+    // The exchange carries the same identity fields as the device flow; the
+    // workspace_id is unused on this path (it is encoded in the token) but the
+    // EnrollmentRequest shape requires it, so pass an empty placeholder.
+    let request = EnrollmentRequest {
+        api_base_url: api_url.to_string(),
+        workspace_id: String::new(),
+        machine_name,
+        offer: EnrollmentOffer {
+            // M6 has no live display surface yet (that is M8); offer false so the
+            // control plane does not record screen-control we cannot serve.
+            os: identity.os,
+            arch: identity.arch,
+            offers_display: false,
+            // The agent does not request screen control; the token's
+            // allow_screen_control (set at mint time) is the authoritative consent.
+            requests_screen_control: false,
+        },
+    };
+
+    info!(channel = %args.channel, "non-interactive token enrollment; exchanging token for credentials");
+    let install = InstallIdentity::generate();
+    let creds_proto = enrollment::exchange_token(&request, &install, token)
+        .await
+        .map_err(to_boxed)?;
+
+    let stored = StoredCredentials::from_proto(creds_proto, args.channel.clone());
+    let path = config::save_credentials(&stored).map_err(to_boxed)?;
+    info!(agent_id = %stored.agent_id, path = %path.display(), "enrollment complete; credentials persisted");
+    println!("Enrolled. This machine is now registered with OpenGeni.");
+    Ok(stored)
 }
 
 /// Spawns a task that triggers a clean shutdown on SIGINT or (unix) SIGTERM.

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -30,12 +30,27 @@
 #                              URL is the documented fallback (see below).
 #   OPENGENI_INSTALL_DIR       Install dir. Default: ~/.local/bin (no sudo).
 #   OPENGENI_SYSTEM=1          Install to /usr/local/bin (needs sudo/root).
-#   OPENGENI_ENROLL_TOKEN      Non-interactive enroll token (CI/automation): the
-#                              script runs `enroll --non-interactive` itself.
+#   OPENGENI_ENROLL_TOKEN      Non-interactive enroll token (CI/automation/fleet):
+#                              the script runs `enroll --token <tok>
+#                              --non-interactive` itself — the token IS the grant,
+#                              so there is NO device-approve step. The workspace is
+#                              encoded in the token; OPENGENI_WORKSPACE_ID is not
+#                              needed on this path.
 #   OPENGENI_NO_RUN=1          Do not start a foreground run; just print the
 #                              enroll+run command (the default when stdin is not
 #                              a TTY, e.g. piped from curl).
-#   OPENGENI_API_URL           Control-plane API base URL for enrollment.
+#   OPENGENI_API_URL           Control-plane API base URL for enrollment. Carried
+#                              into BOTH the non-interactive enroll (forwarded as
+#                              --api-url below) and the interactive `enroll`/`run`
+#                              (the agent reads $OPENGENI_API_URL via clap). Set it
+#                              to target a specific deployment instead of the
+#                              api.opengeni.ai default.
+#   OPENGENI_WORKSPACE_ID      The workspace (UUID) an INTERACTIVE device-flow
+#                              enroll binds to (the user who approves must hold a
+#                              grant in it). Honored by the agent's `enroll`/`run`
+#                              via clap ($OPENGENI_WORKSPACE_ID); the one-liner
+#                              from the Machines page sets it so no UUID is typed.
+#                              Not used on the OPENGENI_ENROLL_TOKEN path.
 #
 # Immutable-per-version + GH-Releases fallback. The edge serves the latest
 # release at $BASE/install.sh and immutable copies at $BASE/v/<ver>/install.sh.
@@ -312,7 +327,16 @@ finish() {
   echo ""
   if [ -n "${OPENGENI_ENROLL_TOKEN:-}" ]; then
     log "non-interactive enroll (OPENGENI_ENROLL_TOKEN set)"
-    "$_bin" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
+    # Forward OPENGENI_API_URL explicitly so the exchange targets THIS deployment
+    # (not the api.opengeni.ai default) even when the agent's env-inherit path is
+    # ever bypassed. The agent also reads $OPENGENI_API_URL via clap, so the env
+    # alone would suffice — this is belt-and-suspenders. The workspace is encoded
+    # in the token, so no --workspace-id is needed on this path.
+    if [ -n "${OPENGENI_API_URL:-}" ]; then
+      "$_bin" --api-url "$OPENGENI_API_URL" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
+    else
+      "$_bin" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
+    fi
     log "enrolled. Start the agent (foreground) with:  $_bin run"
     return 0
   fi
@@ -321,6 +345,9 @@ finish() {
   printf '%s\n' ""
   printf '%s\n' "Next steps (the agent runs in the FOREGROUND — it does NOT install a service):"
   printf '%s\n' "  1. Enroll this machine:   $_bin enroll"
+  if [ -n "${OPENGENI_WORKSPACE_ID:-}" ] || [ -n "${OPENGENI_API_URL:-}" ]; then
+    printf '%s\n' "       (OPENGENI_WORKSPACE_ID / OPENGENI_API_URL in this environment are honored automatically.)"
+  fi
   printf '%s\n' "  2. Run it (online while this runs, offline when you stop it):"
   printf '%s\n' "       $_bin run"
   printf '%s\n' ""

--- a/apps/api/src/routes/enrollments.ts
+++ b/apps/api/src/routes/enrollments.ts
@@ -23,10 +23,18 @@
 import {
   DeviceEnrollmentApproveRequest,
   DeviceEnrollmentApproveResponse,
+  DeviceEnrollmentDenyRequest,
+  DeviceEnrollmentDenyResponse,
+  DeviceEnrollmentLookupRequest,
+  DeviceEnrollmentLookupResponse,
   DeviceEnrollmentPollRequest,
   DeviceEnrollmentStartRequest,
   EnrollmentSummary,
+  EnrollTokenExchangeRequest,
+  EnrollTokenExchangeResponse,
   ListEnrollmentsResponse,
+  MintEnrollTokenRequest,
+  MintEnrollTokenResponse,
   RevokeEnrollmentResponse,
   type EnrollmentArch,
   type EnrollmentOs,
@@ -42,8 +50,13 @@ import { requireAccessGrant } from "../access";
 import type { ApiRouteDeps } from "../dependencies";
 import {
   approveDeviceEnrollment,
+  denyDeviceEnrollment,
+  exchangeEnrollToken,
+  lookupDeviceEnrollment,
+  mintEnrollToken,
   pollDeviceEnrollment,
   startDeviceEnrollment,
+  toLookupResponse,
 } from "../sandbox/enrollment";
 
 export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
@@ -64,6 +77,12 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
   // acceptable for a bounded, access-key-gated, short-TTL flow.
   const startLimiter = new TokenBucket({ capacity: 10, refillPerSecond: 0.5 });
   const pollLimiter = new TokenBucket({ capacity: 60, refillPerSecond: 2 });
+  // The click-Grant approve-page lookup (authenticated, but capped against a
+  // user_code brute force — the lookup resolves a workspace from a short code).
+  const lookupLimiter = new TokenBucket({ capacity: 30, refillPerSecond: 1 });
+  // The headless token exchange (UNAUTHENTICATED — the token is the auth). Bounded
+  // against an enroll-token brute force; the `oget_` HMAC is the real boundary.
+  const exchangeLimiter = new TokenBucket({ capacity: 20, refillPerSecond: 0.5 });
 
   function rateLimit(c: Context, limiter: TokenBucket): void {
     const ip = clientIp(c);
@@ -114,6 +133,69 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
     return c.json(result, 200);
   });
 
+  // ── POST /enrollments/device/lookup (user-authed, NO workspace in path) ─────
+  // The click-Grant approve page reads machine details for a user_code WITHOUT
+  // consuming it. The user_code is globally unique among pending rows; we resolve
+  // its workspace, then assert the caller holds enrollments:read in THAT workspace.
+  // A failed grant OR no live pending row both → 404 (never reveal cross-workspace
+  // existence). Rate-limited against a user_code brute force.
+  app.post("/v1/enrollments/device/lookup", async (c) => {
+    assertSelfhostedEnabled();
+    rateLimit(c, lookupLimiter);
+    const parsed = DeviceEnrollmentLookupRequest.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: "invalid device-lookup request" });
+    }
+    const record = await lookupDeviceEnrollment({ db, settings }, { userCode: parsed.data.userCode });
+    if (!record) {
+      // Unknown / terminal / expired code → 404 (indistinguishable from an
+      // unauthorized one below, by design).
+      throw new HTTPException(404, { message: "no pending enrollment for that code" });
+    }
+    // Authorize the caller against the RESOLVED workspace. A missing grant throws
+    // 403/404 from requireAccessGrant; we normalize that to 404 so a caller cannot
+    // distinguish "code exists in a workspace I can't see" from "no such code".
+    try {
+      await requireAccessGrant(c, deps, record.workspaceId, "enrollments:read");
+    } catch {
+      throw new HTTPException(404, { message: "no pending enrollment for that code" });
+    }
+    return c.json(DeviceEnrollmentLookupResponse.parse(toLookupResponse(record)), 200);
+  });
+
+  // ── POST /enrollments/token/exchange (UNAUTHENTICATED — the token is the auth) ─
+  // The headless / fleet enroll path. The agent presents the same identity fields
+  // it sends to device/start plus the `oget_` enroll token. The token IS the grant
+  // (no human approve). On a valid token we perform the SAME finalize as approve and
+  // return the IDENTICAL EnrollmentCredentials shape the poll authorized branch
+  // returns. Rate-limited against an enroll-token brute force.
+  app.post("/v1/enrollments/token/exchange", async (c) => {
+    assertSelfhostedEnabled();
+    rateLimit(c, exchangeLimiter);
+    const parsed = EnrollTokenExchangeRequest.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: "invalid enroll-token-exchange request" });
+    }
+    const body = parsed.data;
+    const result = await exchangeEnrollToken({ db, settings }, {
+      token: body.token,
+      publicKey: body.publicKey,
+      os: body.os as EnrollmentOs,
+      arch: body.arch as EnrollmentArch,
+      machineName: body.machineName ?? null,
+      canOfferDisplay: body.canOfferDisplay,
+    });
+    if (!result.ok) {
+      if (result.reason === "disabled") {
+        // The credential plane is off for this deployment (no signing secret).
+        throw new HTTPException(503, { message: "enrollment credential plane is not configured" });
+      }
+      // An invalid / expired / wrong-typ token — the token is the auth, so 401.
+      throw new HTTPException(401, { message: "invalid or expired enroll token" });
+    }
+    return c.json(EnrollTokenExchangeResponse.parse({ credentials: result.credentials }), 201);
+  });
+
   // ── POST /workspaces/:workspaceId/enrollments/device/approve (user-authed) ──
   // The LOUD CONSENT step. requireAccessGrant BEFORE the Zod parse.
   app.post("/v1/workspaces/:workspaceId/enrollments/device/approve", async (c) => {
@@ -144,6 +226,51 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
       sandboxId: approved.sandboxId,
       allowScreenControl: approved.allowScreenControl,
     }), 201);
+  });
+
+  // ── POST /workspaces/:workspaceId/enrollments/device/deny (user-authed) ─────
+  // The explicit "no" at the approve page. Mirrors approve (enrollments:manage,
+  // requireAccessGrant BEFORE the parse). Idempotent: a non-pending code → denied:false.
+  app.post("/v1/workspaces/:workspaceId/enrollments/device/deny", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "enrollments:manage");
+    assertSelfhostedEnabled();
+    const parsed = DeviceEnrollmentDenyRequest.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: "invalid device-deny request" });
+    }
+    const result = await denyDeviceEnrollment({ db, settings }, {
+      accountId: grant.accountId,
+      workspaceId,
+      userCode: parsed.data.userCode,
+    });
+    return c.json(DeviceEnrollmentDenyResponse.parse({ denied: result.denied }), 200);
+  });
+
+  // ── POST /workspaces/:workspaceId/enrollments/token (user-authed) ───────────
+  // Mint a short-TTL headless enroll token. Mirrors approve (enrollments:manage,
+  // requireAccessGrant BEFORE the parse). The accountId comes from the grant. No
+  // signing secret → 503/disabled (mirror poll). The token is SECRET — never logged.
+  app.post("/v1/workspaces/:workspaceId/enrollments/token", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "enrollments:manage");
+    assertSelfhostedEnabled();
+    // All fields are optional/defaulted, so an empty POST body is valid (default
+    // allowScreenControl=false). Coalesce a missing/empty body to {} before parse.
+    const parsed = MintEnrollTokenRequest.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: "invalid mint-enroll-token request" });
+    }
+    const minted = await mintEnrollToken({ db, settings }, {
+      accountId: grant.accountId,
+      workspaceId,
+      allowScreenControl: parsed.data.allowScreenControl,
+    });
+    if (!minted) {
+      // The credential plane is off (no signing secret) — mirror poll's disabled path.
+      throw new HTTPException(503, { message: "enrollment credential plane is not configured" });
+    }
+    return c.json(MintEnrollTokenResponse.parse(minted), 201);
   });
 
   // ── GET /workspaces/:workspaceId/enrollments (user-authed) ──────────────────

--- a/apps/api/src/sandbox/enrollment.ts
+++ b/apps/api/src/sandbox/enrollment.ts
@@ -37,18 +37,26 @@ import {
 import {
   DeviceEnrollmentState,
   signEnrollmentBearer,
+  signEnrollToken,
   signRelayToken,
+  verifyEnrollToken,
+  type DeviceEnrollmentLookupResponse,
   type DeviceEnrollmentPollResponse,
   type DeviceEnrollmentStartResponse,
   type EnrollmentCredentialsResponse,
+  type EnrollTokenExchangeResponse,
+  type MintEnrollTokenResponse,
 } from "@opengeni/contracts";
 import {
   approveDeviceEnrollmentRequest,
   consumeDeviceEnrollmentRequest,
   createDeviceEnrollmentRequest,
+  denyDeviceEnrollmentRequest,
+  finalizeEnrollmentByToken,
   getDeviceEnrollmentRequestByDeviceCode,
   getEnrollment,
   getPendingDeviceEnrollmentRequestByUserCode,
+  getPendingDeviceEnrollmentRequestByUserCodeGlobal,
   type Database,
   type DeviceEnrollmentRequestRecord,
   type EnrollmentOs,
@@ -78,6 +86,10 @@ export const ENROLLMENT_BEARER_TTL_SECONDS = 30 * 24 * 3600;
 // scope) on every StreamOpen; a revoked enrollment's machine goes offline at the
 // control plane regardless, so a long-lived relay token cannot reach a dead agent.
 export const RELAY_TOKEN_TTL_SECONDS = 30 * 24 * 3600;
+// The headless enroll token (`oget_`; design 11 §A2.1) TTL. 1h: long enough to
+// script a fleet rollout, short enough to bound exposure of a workspace-scoped
+// secret that IS the grant (no human approve). Re-mintable by an authorized user.
+export const ENROLL_TOKEN_TTL_SECONDS = 3600;
 
 export type EnrollmentServices = {
   db: Database;
@@ -210,6 +222,147 @@ export async function approveDeviceEnrollment(
     sandboxId: result.sandbox.id,
     allowScreenControl: result.enrollment.allowScreenControl,
   };
+}
+
+/** LOOK UP a pending flow by user_code GLOBALLY (the click-Grant approve page;
+ *  design 11 §B.1). Returns the resolved pending record (carrying its workspaceId)
+ *  or null when no live pending row matches the code. The ROUTE authorizes the
+ *  caller against the resolved workspaceId (enrollments:read) BEFORE exposing
+ *  anything — a failed grant OR a null here both surface as 404 so cross-workspace
+ *  existence is never revealed. This does NOT consume the request. */
+export async function lookupDeviceEnrollment(
+  services: EnrollmentServices,
+  input: { userCode: string },
+): Promise<DeviceEnrollmentRequestRecord | null> {
+  const { db } = services;
+  return await getPendingDeviceEnrollmentRequestByUserCodeGlobal(db, input.userCode);
+}
+
+/** Project a resolved pending record to the presentational lookup response (no
+ *  secrets, no device_code) the approve screen (EnrollmentConsent) renders. */
+export function toLookupResponse(record: DeviceEnrollmentRequestRecord): DeviceEnrollmentLookupResponse {
+  return {
+    workspaceId: record.workspaceId,
+    userCode: record.userCode,
+    machine: {
+      machineName: record.machineName,
+      os: record.os,
+      arch: record.arch,
+      canOfferDisplay: record.canOfferDisplay,
+      requestsScreenControl: record.requestsScreenControl,
+    },
+    expiresAt: record.expiresAt,
+  };
+}
+
+/** DENY a flow by user_code (the explicit "no" at the approve page; design 11
+ *  §B.2). Workspace-scoped (the route asserts the grant). Returns whether a pending
+ *  row was flipped to denied (false for an unknown / already-terminal code). */
+export async function denyDeviceEnrollment(
+  services: EnrollmentServices,
+  input: { accountId: string; workspaceId: string; userCode: string },
+): Promise<{ denied: boolean }> {
+  const { db } = services;
+  const pending = await getPendingDeviceEnrollmentRequestByUserCode(db, input.workspaceId, input.userCode);
+  if (!pending) {
+    return { denied: false };
+  }
+  return await denyDeviceEnrollmentRequest(db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    requestId: pending.id,
+  });
+}
+
+/** MINT a headless enroll token (design 11 §A2.2). Signs an `oget_` token bound to
+ *  the workspace + account + the screen-control consent, with a 1h TTL. Returns
+ *  null when the credential plane is disabled (no signing secret) so the route can
+ *  mirror poll's "disabled" handling. The token value is NEVER logged. */
+export async function mintEnrollToken(
+  services: EnrollmentServices,
+  input: { accountId: string; workspaceId: string; allowScreenControl: boolean },
+): Promise<MintEnrollTokenResponse | null> {
+  const { settings } = services;
+  const secret = resolveEnrollmentSigningSecret(settings);
+  if (!secret) {
+    return null;
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const exp = nowSeconds + ENROLL_TOKEN_TTL_SECONDS;
+  const token = await signEnrollToken(secret, {
+    typ: "enroll",
+    workspaceId: input.workspaceId,
+    accountId: input.accountId,
+    allowScreenControl: input.allowScreenControl,
+    iat: nowSeconds,
+    exp,
+  });
+  return {
+    token,
+    expiresAt: new Date(exp * 1000).toISOString(),
+    expiresInSeconds: ENROLL_TOKEN_TTL_SECONDS,
+  };
+}
+
+/** Distinguishes the two exchange failure modes for the route. */
+export type ExchangeEnrollTokenResult =
+  | { ok: true; credentials: EnrollTokenExchangeResponse["credentials"] }
+  | { ok: false; reason: "disabled" }
+  | { ok: false; reason: "invalid" };
+
+/** EXCHANGE a headless enroll token (design 11 §A2.3) — the UNAUTHENTICATED path
+ *  where the token IS the auth. Verifies the `oget_` token, then performs the SAME
+ *  finalize as approve (upsert enrollment + ensure selfhosted sandbox,
+ *  consentedWholeMachine=true, consentedScreenControl=token.allowScreenControl) and
+ *  builds the IDENTICAL EnrollmentCredentials the poll authorized branch returns.
+ *  Returns reason "disabled" when no signing secret (mirror poll), "invalid" when
+ *  the token fails verification (the route 401s). */
+export async function exchangeEnrollToken(
+  services: EnrollmentServices,
+  input: {
+    token: string;
+    publicKey: string;
+    os: EnrollmentOs;
+    arch: string;
+    machineName?: string | null;
+    canOfferDisplay: boolean;
+  },
+): Promise<ExchangeEnrollTokenResult> {
+  const { db, settings } = services;
+  const secret = resolveEnrollmentSigningSecret(settings);
+  if (!secret) {
+    // The credential plane is off for this deployment — surface disabled, never a
+    // 500, never an unsigned credential (mirror poll's disabled handling).
+    return { ok: false, reason: "disabled" };
+  }
+  const claims = await verifyEnrollToken(secret, input.token);
+  if (!claims) {
+    // Bad prefix / signature / typ / expired — the token is not a valid grant.
+    return { ok: false, reason: "invalid" };
+  }
+
+  // The SAME finalize as approve, but driven by the token's claims (no pending row).
+  const sandboxName = (input.machineName?.trim() || `${input.os} machine`).slice(0, 256);
+  const { enrollment } = await finalizeEnrollmentByToken(db, {
+    accountId: claims.accountId,
+    workspaceId: claims.workspaceId,
+    pubkey: input.publicKey,
+    hasDisplay: input.canOfferDisplay,
+    // The token's allowScreenControl is the AUTHORITATIVE consent (NOT the agent's
+    // requestsScreenControl) — it was baked in at mint by the authorizing user.
+    allowScreenControl: claims.allowScreenControl,
+    os: input.os,
+    arch: input.arch,
+    sandboxName,
+  });
+
+  const credentials = await buildEnrollmentCredentials(services, {
+    secret,
+    workspaceId: claims.workspaceId,
+    agentId: enrollment.id,
+    consentedScreenControl: enrollment.allowScreenControl,
+  });
+  return { ok: true, credentials };
 }
 
 /**

--- a/apps/api/test/enrollment-route-discipline.test.ts
+++ b/apps/api/test/enrollment-route-discipline.test.ts
@@ -41,13 +41,21 @@ const AGENT_ROUTES = [
 ];
 const USER_ROUTES = [
   { method: "post", path: "/v1/workspaces/:workspaceId/enrollments/device/approve" },
+  { method: "post", path: "/v1/workspaces/:workspaceId/enrollments/device/deny" },
+  { method: "post", path: "/v1/workspaces/:workspaceId/enrollments/token" },
   { method: "get", path: "/v1/workspaces/:workspaceId/enrollments" },
   { method: "post", path: "/v1/workspaces/:workspaceId/enrollments/:enrollmentId/revoke" },
 ];
+// The enrollment-UX additions whose auth shape differs from the standard user
+// routes: lookup is authenticated but has NO workspace in the path (it authorizes
+// AGAINST the workspace it resolves from the code, so requireAccessGrant runs
+// AFTER the parse); exchange is UNAUTHENTICATED (the `oget_` token is the auth).
+const LOOKUP_ROUTE = { method: "post", path: "/v1/enrollments/device/lookup" };
+const EXCHANGE_ROUTE = { method: "post", path: "/v1/enrollments/token/exchange" };
 
 describe("M5 enrollment route discipline", () => {
   test("every handler asserts the selfhosted flag", () => {
-    for (const route of [...AGENT_ROUTES, ...USER_ROUTES]) {
+    for (const route of [...AGENT_ROUTES, ...USER_ROUTES, LOOKUP_ROUTE, EXCHANGE_ROUTE]) {
       const body = handlerBody(routesSrc, route.method, route.path);
       expect(body, `${route.method} ${route.path} must gate on the flag`).toContain("assertSelfhostedEnabled");
     }
@@ -97,5 +105,35 @@ describe("M5 enrollment route discipline", () => {
       expect(body).toContain(".safeParse(");
       expect(body).toContain("HTTPException(400");
     }
+  });
+
+  test("deny + token use enrollments:manage", () => {
+    const deny = handlerBody(routesSrc, "post", "/v1/workspaces/:workspaceId/enrollments/device/deny");
+    expect(deny).toContain('"enrollments:manage"');
+    const token = handlerBody(routesSrc, "post", "/v1/workspaces/:workspaceId/enrollments/token");
+    expect(token).toContain('"enrollments:manage"');
+  });
+
+  test("lookup is rate-limited + authorizes against the resolved workspace (enrollments:read)", () => {
+    const body = handlerBody(routesSrc, LOOKUP_ROUTE.method, LOOKUP_ROUTE.path);
+    expect(body).toContain("rateLimit(");
+    expect(body).toContain("assertSelfhostedEnabled");
+    // It DOES authorize — but against the workspace it resolves from the code, so
+    // (unlike the standard user routes) the grant check follows the lookup.
+    expect(body).toContain("requireAccessGrant(");
+    expect(body).toContain('"enrollments:read"');
+    expect(body).toContain(".safeParse(");
+    expect(body).toContain("HTTPException(400");
+  });
+
+  test("exchange is UNAUTHENTICATED (the token is the auth) + rate-limited", () => {
+    const body = handlerBody(routesSrc, EXCHANGE_ROUTE.method, EXCHANGE_ROUTE.path);
+    expect(body).toContain("rateLimit(");
+    expect(body).toContain("assertSelfhostedEnabled");
+    // No user authentication — the `oget_` token verification inside the service is
+    // the auth. The CALL form must be absent.
+    expect(body.includes("requireAccessGrant("), "exchange must NOT user-authenticate").toBe(false);
+    expect(body).toContain(".safeParse(");
+    expect(body).toContain("HTTPException(400");
   });
 });

--- a/apps/api/test/enrollment-routes.test.ts
+++ b/apps/api/test/enrollment-routes.test.ts
@@ -332,5 +332,245 @@ describe("M5 flag gate: selfhosted OFF -> routes 404", () => {
       body: JSON.stringify({ userCode: "AAAA-BBBB", allowScreenControl: false }),
     });
     expect(approveRes.status).toBe(404);
+
+    // The enrollment-UX additions are gated the same.
+    const lookupRes = await app.request("/v1/enrollments/device/lookup", {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ userCode: "AAAA-BBBB" }),
+    });
+    expect(lookupRes.status).toBe(404);
+    const denyRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ userCode: "AAAA-BBBB" }),
+    });
+    expect(denyRes.status).toBe(404);
+    const mintRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ allowScreenControl: false }),
+    });
+    expect(mintRes.status).toBe(404);
+    const exchangeRes = await app.request("/v1/enrollments/token/exchange", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: "oget_x.y", publicKey: "ed25519:OFF", os: "linux", arch: "x86_64" }),
+    });
+    expect(exchangeRes.status).toBe(404);
+  }, 60_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enrollment UX (design 11): the click-Grant approve-page lookup/deny + the
+// headless enroll-token mint/exchange, driven end-to-end through createApp + the
+// REAL db (same harness as the M5 device-flow tests above).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("design-11 B.1 lookup: resolve a pending flow by user_code (no workspace in path)", () => {
+  test("an authorized reader resolves the machine details WITHOUT consuming the request", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const readBearer = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
+
+    const start = await (await app.request("/v1/enrollments/device/start", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publicKey: "ed25519:LOOKUP", os: "macos", arch: "aarch64", machineName: "mac-mini", canOfferDisplay: true, requestsScreenControl: true, workspaceId }),
+    })).json() as { deviceCode: string; userCode: string };
+
+    const lookupRes = await app.request("/v1/enrollments/device/lookup", {
+      method: "POST", headers: { "content-type": "application/json", authorization: readBearer },
+      body: JSON.stringify({ userCode: start.userCode }),
+    });
+    expect(lookupRes.status).toBe(200);
+    const lookup = await lookupRes.json() as {
+      workspaceId: string; userCode: string; expiresAt: string;
+      machine: { machineName: string | null; os: string; arch: string; canOfferDisplay: boolean; requestsScreenControl: boolean };
+    };
+    expect(lookup.workspaceId).toBe(workspaceId);
+    expect(lookup.userCode).toBe(start.userCode);
+    expect(lookup.machine.machineName).toBe("mac-mini");
+    expect(lookup.machine.os).toBe("macos");
+    expect(lookup.machine.arch).toBe("aarch64");
+    expect(lookup.machine.canOfferDisplay).toBe(true);
+    expect(lookup.machine.requestsScreenControl).toBe(true);
+
+    // The request was NOT consumed — a poll still says pending.
+    const poll = await (await app.request("/v1/enrollments/device/poll", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deviceCode: start.deviceCode }),
+    })).json() as { state: string };
+    expect(poll.state).toBe("pending");
+  }, 90_000);
+
+  test("an unknown code → 404; an unauthenticated lookup of a REAL code → 404 (no disclosure)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const readBearer = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
+    const unknown = await app.request("/v1/enrollments/device/lookup", {
+      method: "POST", headers: { "content-type": "application/json", authorization: readBearer },
+      body: JSON.stringify({ userCode: "ZZZZ-ZZZZ" }),
+    });
+    expect(unknown.status).toBe(404);
+    // An unauthenticated caller looking up a REAL pending code: the route resolves
+    // the code, then requireAccessGrant rejects the anonymous caller — normalized
+    // to a flat 404 (never reveals the code exists). (An UNKNOWN code is also 404
+    // before auth is ever reached, so the two are indistinguishable — the intended
+    // no-disclosure property.)
+    const start = await (await app.request("/v1/enrollments/device/start", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publicKey: "ed25519:NOAUTHLOOKUP", workspaceId }),
+    })).json() as { userCode: string };
+    const noAuth = await app.request("/v1/enrollments/device/lookup", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userCode: start.userCode }),
+    });
+    expect(noAuth.status).toBe(404);
+  }, 90_000);
+
+  test("a workspace-B reader gets 404 for a code that lives in workspace A (no cross-workspace disclosure)", async () => {
+    if (!available) return;
+    const a = await freshWorkspace();
+    const b = await freshWorkspace();
+    const app = appFor();
+    const start = await (await app.request("/v1/enrollments/device/start", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publicKey: "ed25519:XWSLOOKUP", workspaceId: a.workspaceId }),
+    })).json() as { userCode: string };
+    // The code resolves to workspace A; a user holding a grant only in B must get a
+    // flat 404 (indistinguishable from "no such code") — never a 403 that confirms
+    // the code exists somewhere.
+    const res = await app.request("/v1/enrollments/device/lookup", {
+      method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${await bearer(b.accountId, b.workspaceId, ["enrollments:read"])}` },
+      body: JSON.stringify({ userCode: start.userCode }),
+    });
+    expect(res.status).toBe(404);
+  }, 90_000);
+});
+
+describe("design-11 B.2 deny: mark a pending flow denied", () => {
+  test("deny flips the pending row → a subsequent poll is denied; an unknown code → denied:false", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const manageBearer = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:manage"])}`;
+    const start = await (await app.request("/v1/enrollments/device/start", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publicKey: "ed25519:DENY", workspaceId }),
+    })).json() as { deviceCode: string; userCode: string };
+
+    const denyRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ userCode: start.userCode }),
+    });
+    expect(denyRes.status).toBe(200);
+    expect((await denyRes.json() as { denied: boolean }).denied).toBe(true);
+
+    const poll = await (await app.request("/v1/enrollments/device/poll", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deviceCode: start.deviceCode }),
+    })).json() as { state: string };
+    expect(poll.state).toBe("denied");
+
+    // An unknown / already-terminal code is a no-op.
+    const denyAgain = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ userCode: start.userCode }),
+    });
+    expect((await denyAgain.json() as { denied: boolean }).denied).toBe(false);
+  }, 90_000);
+
+  test("deny without enrollments:manage is rejected (403)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const res = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}` },
+      body: JSON.stringify({ userCode: "AAAA-BBBB" }),
+    });
+    expect(res.status).toBe(403);
+  }, 60_000);
+});
+
+describe("design-11 A2 headless: mint enroll token -> exchange -> identical credentials", () => {
+  test("mint + exchange lands an enrollment + sandbox and returns the SAME credential shape as poll", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const manageBearer = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:manage", "enrollments:read"])}`;
+
+    // 1. MINT (user-authenticated).
+    const mintRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: manageBearer },
+      body: JSON.stringify({ allowScreenControl: true }),
+    });
+    expect(mintRes.status).toBe(201);
+    const mint = await mintRes.json() as { token: string; expiresAt: string; expiresInSeconds: number };
+    expect(mint.token.startsWith("oget_")).toBe(true);
+    expect(mint.expiresInSeconds).toBe(3600);
+
+    // 2. EXCHANGE (UNAUTHENTICATED — the token is the auth).
+    const exchangeRes = await app.request("/v1/enrollments/token/exchange", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        token: mint.token, publicKey: "ed25519:HEADLESS", os: "linux", arch: "x86_64",
+        machineName: "fleet-node-1", canOfferDisplay: true, requestsScreenControl: false,
+      }),
+    });
+    expect(exchangeRes.status).toBe(201);
+    const exchange = await exchangeRes.json() as {
+      credentials: {
+        agentId: string; workspaceId: string; bearer: string; subjectPrefix: string;
+        natsUrls: string[]; relayUrl: string; natsAccountCreds: string; updatePublicKey: string;
+        consentedWholeMachine: boolean; consentedScreenControl: boolean;
+      };
+    };
+    const creds = exchange.credentials;
+    expect(creds.workspaceId).toBe(workspaceId);
+    expect(creds.agentId).toBeTruthy();
+    expect(creds.subjectPrefix).toBe(`agent.${workspaceId}.${creds.agentId}`);
+    expect(creds.natsUrls).toEqual(["nats://control.example:4222"]);
+    expect(creds.relayUrl).toBe("wss://relay.example/stream");
+    // Identical credential shape to the poll authorized branch: natsAccountCreds
+    // echoes the bearer, whole-machine consented, screen-control per the TOKEN.
+    expect(creds.natsAccountCreds).toBe(creds.bearer);
+    expect(creds.consentedWholeMachine).toBe(true);
+    expect(creds.consentedScreenControl).toBe(true);
+    // The signed bearer verifies + binds the identity.
+    const verified = await verifyEnrollmentBearer(SIGNING_SECRET, creds.bearer);
+    expect(verified).not.toBeNull();
+    expect(verified!.workspaceId).toBe(workspaceId);
+    expect(verified!.agentId).toBe(creds.agentId);
+
+    // The exchange landed a real machine (the SAME finalize as approve).
+    const list = await (await app.request(`/v1/workspaces/${workspaceId}/enrollments`, { headers: { authorization: manageBearer } })).json() as { enrollments: { id: string; status: string; allowScreenControl: boolean }[] };
+    expect(list.enrollments.length).toBe(1);
+    expect(list.enrollments[0]!.id).toBe(creds.agentId);
+    expect(list.enrollments[0]!.status).toBe("active");
+    expect(list.enrollments[0]!.allowScreenControl).toBe(true);
+  }, 120_000);
+
+  test("exchange with an invalid token → 401; an oge_ bearer is NOT accepted as an enroll token", async () => {
+    if (!available) return;
+    const app = appFor();
+    const bad = await app.request("/v1/enrollments/token/exchange", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: "oget_garbage.sig", publicKey: "ed25519:BAD", os: "linux", arch: "x86_64" }),
+    });
+    expect(bad.status).toBe(401);
+  }, 60_000);
+
+  test("mint without enrollments:manage is rejected (403); unauthenticated mint → 401", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const app = appFor();
+    const noPerm = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}` },
+      body: JSON.stringify({ allowScreenControl: false }),
+    });
+    expect(noPerm.status).toBe(403);
+    const noAuth = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ allowScreenControl: false }),
+    });
+    expect(noAuth.status).toBe(401);
   }, 60_000);
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@
 //   /workspaces/:id/organization             → organization settings (billing, usage, plan, members)
 //   /workspaces/:id/account                  → legacy redirect to /organization
 //   /billing?checkout=success|cancelled      → Stripe return → default organization
+//   /device?user_code=…                      → self-hosted enrollment approve page
 import {
   Navigate,
   RouterProvider,
@@ -26,6 +27,7 @@ import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
 import { CapabilitiesRoute } from "@/routes/capabilities";
+import { DeviceRoute } from "@/routes/device";
 import { DocumentsRoute } from "@/routes/documents";
 import { EnvironmentsRoute } from "@/routes/environments";
 import { MachinesRoute } from "@/routes/machines";
@@ -59,6 +61,17 @@ const billingReturnRoute = createRoute({
     return checkout ? { checkout } : {};
   },
   component: BillingReturnRoute,
+});
+// Self-hosted device-flow APPROVE page (design 11 §B). Top-level (sibling of
+// /billing, NOT workspace-scoped): the agent prints `${origin}/device?user_code=…`
+// when it starts an enrollment; the page resolves the owning workspace from the
+// code via `lookupDeviceEnrollment`, so no workspace lives in the URL.
+const deviceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "device",
+  validateSearch: (search: Record<string, unknown>): { user_code?: string } =>
+    typeof search.user_code === "string" && search.user_code ? { user_code: search.user_code } : {},
+  component: Device,
 });
 const workspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -153,6 +166,7 @@ const workspaceAccountRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   billingReturnRoute,
+  deviceRoute,
   workspaceRoute.addChildren([
     workspaceIndexRoute,
     workspaceAgentRoute,
@@ -270,6 +284,11 @@ function AccountRedirect() {
       replace
     />
   );
+}
+
+function Device() {
+  const { user_code } = deviceRoute.useSearch();
+  return <DeviceRoute userCode={user_code} />;
 }
 
 function BillingReturnRoute() {

--- a/apps/web/src/lib/deployment.ts
+++ b/apps/web/src/lib/deployment.ts
@@ -9,9 +9,31 @@ function originOf(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
-/** The install one-liner the user runs on the machine they want to enroll. */
-export function installOneLiner(baseUrl: string): string {
-  return `curl -fsSL ${originOf(baseUrl)}/install.sh | sh`;
+/**
+ * The install one-liner the user runs on the machine they want to enroll.
+ *
+ * It ALWAYS bakes `OPENGENI_API_URL=${origin}` so the agent targets *this*
+ * deployment rather than the hardcoded `api.opengeni.ai` default. Pass:
+ *  - `{ workspaceId }` for the interactive (human device-approve) path — adds
+ *    `OPENGENI_WORKSPACE_ID` so the user never hand-types the workspace UUID.
+ *  - `{ enrollToken }` for the headless / fleet path — adds
+ *    `OPENGENI_ENROLL_TOKEN` (a short-lived secret) so the machine enrolls with
+ *    zero approve clicks.
+ *  - nothing — the bare interactive install (still origin-pinned).
+ */
+export function installOneLiner(
+  baseUrl: string,
+  opts?: { workspaceId?: string; enrollToken?: string },
+): string {
+  const origin = originOf(baseUrl);
+  const env = [`OPENGENI_API_URL=${origin}`];
+  if (opts?.workspaceId) {
+    env.push(`OPENGENI_WORKSPACE_ID=${opts.workspaceId}`);
+  }
+  if (opts?.enrollToken) {
+    env.push(`OPENGENI_ENROLL_TOKEN=${opts.enrollToken}`);
+  }
+  return `curl -fsSL ${origin}/install.sh | ${env.join(" ")} sh`;
 }
 
 /** The same-origin device-flow approval page. */

--- a/apps/web/src/routes/device.tsx
+++ b/apps/web/src/routes/device.tsx
@@ -1,0 +1,281 @@
+// Device-flow APPROVE page (design 11 §B). The self-hosted agent prints this
+// page's URL (with `?user_code=…`) when it starts a device enrollment; the user
+// opens it in the console to render the LOUD whole-machine consent and grant or
+// deny access. This is a TOP-LEVEL route (sibling of /billing) — it is NOT
+// workspace-scoped, because the workspace is resolved from the code via
+// `lookupDeviceEnrollment` (the response's workspaceId is what approve/deny
+// target, never the user's default workspace).
+//
+// EnrollmentConsent (from @opengeni/react) is purely presentational; this parent
+// owns the lookup + the approve/deny API calls and drives the phase machine:
+//   review → approving → approved | error   (approve)
+//   review → denied                          (deny)
+//   error                                    (lookup failed / code invalid)
+import {
+  EnrollmentConsent,
+  type EnrollmentConsentMachine,
+  type EnrollmentConsentPhase,
+} from "@opengeni/react";
+import type { DeviceEnrollmentLookupResponse } from "@opengeni/sdk";
+import { Link } from "@tanstack/react-router";
+import { LaptopIcon, LogInIcon } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAppContext } from "@/context";
+
+/** The code the agent prints, e.g. `WXYZ-1234`. We do not enforce the exact
+ * shape (the server is authoritative) — we just trim + uppercase what the user
+ * pastes so the lookup matches. */
+function normalizeUserCode(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+/** Coalesce the wire machine (machineName is `string | null`, os is the
+ * EnrollmentOs union) into the consent component's prop shape (machineName is a
+ * non-null string, os is a plain string). */
+function toConsentMachine(machine: DeviceEnrollmentLookupResponse["machine"]): EnrollmentConsentMachine {
+  return {
+    machineName: machine.machineName ?? "This machine",
+    os: machine.os,
+    arch: machine.arch,
+    canOfferDisplay: machine.canOfferDisplay,
+    requestsScreenControl: machine.requestsScreenControl,
+  };
+}
+
+export function DeviceRoute({ userCode: userCodeFromUrl }: { userCode?: string | undefined }) {
+  const { client, authSession, clientConfig } = useAppContext();
+
+  // The code we are resolving. Seed from the URL (the agent's
+  // verificationUriComplete) when present; otherwise the user pastes it below.
+  const [userCode, setUserCode] = useState<string>(() =>
+    userCodeFromUrl ? normalizeUserCode(userCodeFromUrl) : "",
+  );
+  const [codeDraft, setCodeDraft] = useState<string>("");
+
+  const [lookup, setLookup] = useState<DeviceEnrollmentLookupResponse | null>(null);
+  const [phase, setPhase] = useState<EnrollmentConsentPhase>("review");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [lookingUp, setLookingUp] = useState(false);
+
+  // Resolve the machine details for the current code (without consuming the
+  // request). A 404 / throw means the code is unknown, expired, or the signed-in
+  // user lacks the grant in its workspace — all surfaced as the same opaque
+  // "invalid or expired" error (no cross-workspace disclosure).
+  useEffect(() => {
+    if (!userCode) {
+      setLookup(null);
+      return;
+    }
+    let cancelled = false;
+    setLookingUp(true);
+    setPhase("review");
+    setErrorMessage("");
+    void client
+      .lookupDeviceEnrollment(userCode)
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setLookup(result);
+        setPhase("review");
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setLookup(null);
+        setPhase("error");
+        setErrorMessage("This enrollment code isn't valid or has expired.");
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLookingUp(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, userCode]);
+
+  // Managed deployments require a signed-in session to authorize the approve
+  // (the lookup itself is grant-checked server-side). When the console runs in a
+  // mode that yields no managed session, prompt the user to sign in first while
+  // preserving the code so they return straight to this page. Mirrors the app's
+  // own auth gate (RootRouteComponent renders the sign-in panel at "/").
+  if (clientConfig.auth.mode === "managedSession" && !authSession) {
+    return <SignInPrompt userCode={userCode || (userCodeFromUrl ? normalizeUserCode(userCodeFromUrl) : "")} />;
+  }
+
+  // No code yet (the user opened the bare /device URL): let them paste it.
+  if (!userCode) {
+    return (
+      <CodeEntry
+        value={codeDraft}
+        onChange={setCodeDraft}
+        onSubmit={() => {
+          const next = normalizeUserCode(codeDraft);
+          if (next) {
+            setUserCode(next);
+          }
+        }}
+      />
+    );
+  }
+
+  async function approve(allowScreenControl: boolean) {
+    if (!lookup) {
+      return;
+    }
+    setPhase("approving");
+    try {
+      // The workspace comes from the LOOKUP RESPONSE — not the user's default.
+      await client.approveDeviceEnrollment(lookup.workspaceId, {
+        userCode: lookup.userCode,
+        allowScreenControl,
+      });
+      setPhase("approved");
+    } catch (error) {
+      setPhase("error");
+      setErrorMessage(error instanceof Error ? error.message : "Could not approve this machine. Try again.");
+    }
+  }
+
+  async function deny() {
+    if (!lookup) {
+      return;
+    }
+    try {
+      await client.denyDeviceEnrollment(lookup.workspaceId, { userCode: lookup.userCode });
+      setPhase("denied");
+    } catch (error) {
+      setPhase("error");
+      setErrorMessage(error instanceof Error ? error.message : "Could not deny this machine. Try again.");
+    }
+  }
+
+  // While the very first lookup is in flight (and we have nothing to render
+  // yet), show a light loading shell rather than flashing the consent panel.
+  if (lookingUp && !lookup && phase !== "error") {
+    return (
+      <DeviceShell>
+        <div className="mx-auto flex w-full max-w-md items-center justify-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6 text-sm text-[color:var(--color-fg-muted)]">
+          <LaptopIcon className="size-4 animate-pulse" />
+          Looking up <span className="font-mono text-[color:var(--color-fg)]">{userCode}</span>…
+        </div>
+      </DeviceShell>
+    );
+  }
+
+  return (
+    <DeviceShell>
+      <EnrollmentConsent
+        userCode={lookup ? lookup.userCode : userCode}
+        machine={lookup ? toConsentMachine(lookup.machine) : EMPTY_MACHINE}
+        phase={phase}
+        onApprove={(allowScreenControl) => void approve(allowScreenControl)}
+        onDeny={() => void deny()}
+        errorMessage={errorMessage}
+      />
+    </DeviceShell>
+  );
+}
+
+// A placeholder machine for the error phase (when no lookup succeeded). The
+// consent component only reads `machineName` for the error copy, which we
+// override via `errorMessage`.
+const EMPTY_MACHINE: EnrollmentConsentMachine = {
+  machineName: "This machine",
+  os: "linux",
+  arch: "x86_64",
+  canOfferDisplay: false,
+  requestsScreenControl: false,
+};
+
+/** Centered page chrome shared by every device-page state. */
+function DeviceShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="flex min-h-dvh flex-1 items-center justify-center bg-[color:var(--color-bg)] px-4 py-10 text-[color:var(--color-fg)]">
+      <div className="w-full max-w-md">{children}</div>
+    </main>
+  );
+}
+
+/** Prompt to sign in (managed mode, no session) while preserving the code so the
+ * user lands back on this exact page after authenticating. */
+function SignInPrompt({ userCode }: { userCode: string }) {
+  return (
+    <DeviceShell>
+      <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6 text-center">
+        <span className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <LogInIcon className="size-5" />
+        </span>
+        <h1 className="text-base font-semibold">Sign in to approve this machine</h1>
+        <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-[color:var(--color-fg-muted)]">
+          You need to be signed in to the workspace that owns this machine before you can grant it access. Sign in, then
+          you'll return here to review the request.
+        </p>
+        <div className="mt-4 flex justify-center">
+          <Button asChild>
+            {/* Return to the app root (which renders the sign-in panel when no
+                session), carrying the code so the user can come straight back. */}
+            <Link to="/device" search={userCode ? { user_code: userCode } : {}}>
+              <LogInIcon className="size-4" />
+              Sign in
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </DeviceShell>
+  );
+}
+
+/** Controlled input for pasting the code when the URL carried none. */
+function CodeEntry({
+  value,
+  onChange,
+  onSubmit,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <DeviceShell>
+      <form
+        className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+            <LaptopIcon className="size-4" />
+          </span>
+          <div>
+            <h1 className="text-base font-semibold">Approve a machine</h1>
+            <p className="text-sm text-[color:var(--color-fg-muted)]">
+              Enter the code shown on the machine you're enrolling.
+            </p>
+          </div>
+        </div>
+        <Input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="XXXX-XXXX"
+          autoComplete="off"
+          autoCapitalize="characters"
+          spellCheck={false}
+          className="font-mono tracking-widest uppercase"
+          autoFocus
+        />
+        <Button type="submit" className="mt-4 w-full" disabled={!normalizeUserCode(value)}>
+          Continue
+        </Button>
+      </form>
+    </DeviceShell>
+  );
+}

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -10,11 +10,13 @@ import {
   useMachines,
   type DeviceFlowPhase,
 } from "@opengeni/react";
-import { LaptopIcon } from "lucide-react";
+import { AlertTriangleIcon, CheckIcon, CopyIcon, LaptopIcon, Loader2Icon, TerminalIcon } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { apiBaseUrl } from "@/api";
 import { PageHeader } from "@/components/common";
+import { Button } from "@/components/ui/button";
 import { deviceVerificationUri, installOneLiner } from "@/lib/deployment";
 import {
   Dialog,
@@ -23,16 +25,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useAppContext } from "@/context";
 
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   const machines = useMachines({ pollIntervalMs: 5000 });
   const [enrollOpen, setEnrollOpen] = useState(false);
-  void workspaceId;
 
   // The install/approve URLs are deployment-relative: same origin as the API
   // (falling back to the page origin), never a hardcoded marketing domain.
   const origin = apiBaseUrl || (typeof window !== "undefined" ? window.location.origin : "");
-  const installCommand = installOneLiner(origin);
+  // The default (interactive) one-liner now carries the workspace id so the user
+  // never hand-types the UUID; the agent prints a code to approve at /device.
+  const installCommand = installOneLiner(origin, { workspaceId });
   const verificationUri = deviceVerificationUri(origin);
 
   return (
@@ -77,8 +81,123 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
             onCopyInstall={() => void navigator.clipboard.writeText(installCommand)}
             className="border-0 shadow-none"
           />
+          <HeadlessEnrollSection workspaceId={workspaceId} origin={origin} />
         </DialogContent>
       </Dialog>
     </div>
   );
+}
+
+/**
+ * A2.5 — the headless / CI / fleet enroll path. Visually separated from the
+ * interactive one-liner above so users aren't confused about which to run. It
+ * mints a short-lived enroll token (the `oget_` SECRET — shown once, never
+ * re-readable) and renders the headless one-liner that bakes it in, with a loud
+ * copy-now warning + the expiry. The token IS the grant — machines that run this
+ * one-liner enroll with zero approve clicks.
+ */
+function HeadlessEnrollSection({ workspaceId, origin }: { workspaceId: string; origin: string }) {
+  const { client } = useAppContext();
+  const [open, setOpen] = useState(false);
+  const [minting, setMinting] = useState(false);
+  const [token, setToken] = useState<{ value: string; expiresAt: string; expiresInSeconds: number } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function mint() {
+    setMinting(true);
+    try {
+      // Headless tokens never carry screen-control consent (no human at the
+      // approve page to make that call) — `false` is the only safe default.
+      const result = await client.mintEnrollToken(workspaceId, { allowScreenControl: false });
+      setToken({ value: result.token, expiresAt: result.expiresAt, expiresInSeconds: result.expiresInSeconds });
+      setCopied(false);
+    } catch (error) {
+      toast.error("Could not create an enroll token", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setMinting(false);
+    }
+  }
+
+  const headlessCommand = token ? installOneLiner(origin, { enrollToken: token.value }) : "";
+
+  function copyCommand() {
+    if (!headlessCommand) {
+      return;
+    }
+    void navigator.clipboard.writeText(headlessCommand);
+    setCopied(true);
+    toast.success("Headless install command copied");
+  }
+
+  if (!open) {
+    return (
+      <div className="mt-1 border-t border-[color:var(--color-border)] pt-3">
+        <Button type="button" variant="ghost" size="sm" className="w-full justify-start text-[color:var(--color-fg-muted)]" onClick={() => setOpen(true)}>
+          <TerminalIcon className="size-4" />
+          Advanced: headless / CI enrollment
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-1 flex flex-col gap-3 border-t border-[color:var(--color-border)] pt-3">
+      <div>
+        <h3 className="flex items-center gap-1.5 text-[13px] font-semibold text-[color:var(--color-fg)]">
+          <TerminalIcon className="size-3.5 text-[color:var(--color-fg-muted)]" />
+          Headless / CI enrollment
+        </h3>
+        <p className="mt-1 text-[12px] leading-4 text-[color:var(--color-fg-muted)]">
+          Mint a short-lived token to enroll a machine with no approval click — for fleet rollouts and CI. Use the
+          interactive one-liner above for a normal machine.
+        </p>
+      </div>
+
+      {token ? (
+        <>
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-[12px] leading-4 text-amber-200">
+            <AlertTriangleIcon className="mt-px size-3.5 shrink-0" />
+            <span>
+              <span className="font-semibold">Secret — copy it now.</span> This token grants enrollment into this
+              workspace until it expires and won't be shown again. Anyone who has it can enroll a machine here.
+            </span>
+          </div>
+          <div className="flex items-center justify-between rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-2.5 py-1.5 text-[11px] text-[color:var(--color-fg-muted)]">
+            <span>Expires {formatExpiry(token.expiresAt, token.expiresInSeconds)}</span>
+            <Button type="button" variant="ghost" size="xs" onClick={() => void mint()} disabled={minting}>
+              {minting ? <Loader2Icon className="size-3 animate-spin" /> : null}
+              Regenerate
+            </Button>
+          </div>
+          <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-2.5">
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-4 text-[color:var(--color-fg)]">
+              {headlessCommand}
+            </pre>
+          </div>
+          <Button type="button" variant="secondary" size="sm" className="w-full" onClick={copyCommand}>
+            {copied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+            {copied ? "Copied" : "Copy headless install command"}
+          </Button>
+        </>
+      ) : (
+        <Button type="button" variant="outline" size="sm" className="w-full" onClick={() => void mint()} disabled={minting}>
+          {minting ? <Loader2Icon className="size-4 animate-spin" /> : <TerminalIcon className="size-4" />}
+          Generate enroll token
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** Human-readable expiry from the mint response. Prefers the absolute time and
+ * falls back to a relative "in N minutes" when the timestamp is unparseable. */
+function formatExpiry(expiresAt: string, expiresInSeconds: number): string {
+  const at = new Date(expiresAt);
+  if (!Number.isNaN(at.getTime())) {
+    return `at ${at.toLocaleString()}`;
+  }
+  const minutes = Math.max(1, Math.round(expiresInSeconds / 60));
+  return `in ~${minutes} min`;
 }

--- a/docs/design/sandbox-surfacing/11-enrollment-ux.md
+++ b/docs/design/sandbox-surfacing/11-enrollment-ux.md
@@ -1,0 +1,222 @@
+# 11 — Self-hosted enrollment UX: one-command + click-Grant + headless token
+
+**Status:** design frozen; implementation in progress on `claude/enroll-ux-easy-path`.
+
+## Why
+
+Enrolling a self-hosted machine is not "super easy" today. Three concrete breaks (all
+verified against `main`):
+
+1. **The user must hand-type the workspace UUID.** The web Machines page has the
+   workspace id in scope but discards it (`apps/web/src/routes/machines.tsx:30` `void
+   workspaceId`); the copied one-liner is a bare `curl .../install.sh | sh` that carries
+   nothing. On the machine the agent then bails *"enrollment requires a workspace id"*
+   (`agent/.../main.rs:249`).
+2. **The approve page is a dead link.** The agent prints `<origin>/device` to approve, but
+   there is no `/device` route in `apps/web/src/App.tsx` — it 404s. The `EnrollmentConsent`
+   component that renders the "Grant access?" screen is exported from `@opengeni/react` but
+   mounted nowhere.
+3. **No headless path.** `OPENGENI_ENROLL_TOKEN` / `--non-interactive` exist on the agent
+   CLI and in `install.sh`, but `enroll_with_token` (`main.rs:315-331`) is a deliberate
+   stub — there is no control-plane token-exchange endpoint.
+
+This doc specifies the fix in three coherent parts. **A1+B ship without an agent rebuild;
+A2 requires the per-SHA agent binary to be re-baked into the API image** (see §Build).
+
+---
+
+## A1 — carry the workspace (and control-plane origin) into the one-liner
+
+Non-secret. Keeps the human device-approve step.
+
+**Web** (`apps/web`):
+- `src/lib/deployment.ts`: `installOneLiner(baseUrl, opts?: { workspaceId?: string; enrollToken?: string })`.
+  - Interactive (workspaceId): `` curl -fsSL ${origin}/install.sh | OPENGENI_API_URL=${origin} OPENGENI_WORKSPACE_ID=${ws} sh ``
+  - Headless (enrollToken, see A2): `` curl -fsSL ${origin}/install.sh | OPENGENI_API_URL=${origin} OPENGENI_ENROLL_TOKEN=${tok} sh ``
+  - `origin` is `originOf(baseUrl)` exactly as today. Always include `OPENGENI_API_URL=${origin}`
+    so the agent targets *this* deployment, not the `api.opengeni.ai` default (latent bug).
+  - Keep `deviceVerificationUri` returning `${origin}/device` (page resolves workspace from the code, see B — no workspace in the URL needed).
+- `src/routes/machines.tsx`: drop `void workspaceId` (line 30); call
+  `installOneLiner(origin, { workspaceId })` at line 35. The default rendered command is the
+  interactive one. (Headless token UI is A2.)
+
+**install.sh** (`agent/install/install.sh`) — ships immediately (served verbatim):
+- Document `OPENGENI_WORKSPACE_ID` and `OPENGENI_API_URL` in the env block (lines 22-53).
+- The agent already reads both via clap `env=` (`cli.rs:106`, `cli.rs:31`) and inherits the
+  script's environment, so the interactive `exec "$_bin" run` (line 334) and the printed
+  `enroll` guidance (line 323) already pick them up. Make the printed guidance reflect this
+  (e.g. note that `OPENGENI_WORKSPACE_ID`/`OPENGENI_API_URL` are honored). No behavioral
+  change is required beyond docs + forwarding `--api-url`/`--workspace-id` explicitly on the
+  non-interactive enroll call (line 315) for robustness.
+
+**Agent:** no functional change required for A1 (clap already supports it). Do NOT rebuild for A1.
+
+---
+
+## B — wire the `/device` approve page (mounts existing `EnrollmentConsent`)
+
+Pure web + API. No agent change. Baseline UX works even if the agent prints the bare
+`/device` URL (user pastes the code); the `?user_code=` form pre-fills it.
+
+### B.1 New API read endpoint — pending lookup by user_code
+
+`EnrollmentConsent` is presentational; it needs `{ userCode, machine }`. There is no read
+endpoint today (only `device/approve` consumes the code). Add a lookup that resolves the
+workspace **from the (globally-unique-among-pending) user_code**, authorizes, and returns
+machine details without consuming:
+
+- **`POST /v1/enrollments/device/lookup`** — **authenticated** (session cookie), **no
+  workspace in the path**. Body `{ userCode }`.
+- Behavior: `getPendingDeviceEnrollmentRequestByUserCode` is per-workspace, but `user_code`
+  is globally unique among `status='pending'` (partial unique index
+  `db/.../schema.ts:692`). Resolve the pending request by code → get its `workspaceId` →
+  `requireAccessGrant(c, deps, workspaceId, "enrollments:read")`. If the grant check fails
+  or no live pending row → **404** (do not reveal cross-workspace existence). Else return:
+  - `{ workspaceId, userCode, machine: { machineName, os, arch, canOfferDisplay, requestsScreenControl }, expiresAt }`.
+- Rate-limit with a new `lookupLimiter` (reuse the `TokenBucket` pattern,
+  `enrollments.ts:202`). Gate behind `sandboxSelfhostedEnabled` like the others.
+- New contracts: `DeviceEnrollmentLookupRequest` / `DeviceEnrollmentLookupResponse`
+  (`packages/contracts/src/index.ts`, beside the existing device-flow contracts ~2813-2939).
+
+### B.2 Approve / deny
+
+- Approve already exists: `POST /v1/workspaces/:workspaceId/enrollments/device/approve`
+  (`enrollments.ts:119`). Reuse as-is.
+- Add **`POST /v1/workspaces/:workspaceId/enrollments/device/deny`** mirroring approve
+  (auth `enrollments:manage`, body `{ userCode }`), calling the existing
+  `denyDeviceEnrollmentRequest` DAO (`db/.../index.ts:4517`) — the DAO exists but has no
+  route. Response `{ denied: boolean }`.
+
+### B.3 SDK methods (`packages/sdk/src/client.ts`, beside `listMachines` ~205)
+
+- `lookupDeviceEnrollment(userCode): Promise<DeviceEnrollmentLookupResponse>` →
+  `requestJson("POST", "/v1/enrollments/device/lookup", { userCode })`.
+- `approveDeviceEnrollment(workspaceId, { userCode, allowScreenControl })` →
+  `POST /v1/workspaces/${ws}/enrollments/device/approve`.
+- `denyDeviceEnrollment(workspaceId, { userCode })` →
+  `POST /v1/workspaces/${ws}/enrollments/device/deny`.
+
+### B.4 Web route (`apps/web`)
+
+- New `apps/web/src/routes/device.tsx` mounting `EnrollmentConsent` from `@opengeni/react`.
+- `apps/web/src/App.tsx`: a **top-level** `createRoute({ getParentRoute: () => rootRoute,
+  path: "device", validateSearch })` (model on `billingReturnRoute` ~54-62), added to
+  `rootRoute.addChildren([...])` (~153), with a `Device()` wrapper. `validateSearch` parses
+  `?user_code` (from `verificationUriComplete`).
+- Page flow (via `useAppContext()` — `client`, `authSession`, `accessContext`):
+  1. If `authSession` is null → prompt sign-in (return to `/device?user_code=…`).
+  2. Read `user_code` from search; if absent, render a small input for it.
+  3. `client.lookupDeviceEnrollment(userCode)` → `{ workspaceId, machine }`. On 404 →
+     `phase="error"` ("This code isn't valid or has expired").
+  4. Render `<EnrollmentConsent userCode machine phase onApprove onDeny />`.
+     - `onApprove(allowScreenControl)` → `client.approveDeviceEnrollment(workspaceId,
+       { userCode, allowScreenControl })`; set `phase` review→approving→approved/error.
+     - `onDeny()` → `client.denyDeviceEnrollment(workspaceId, { userCode })`; `phase="denied"`.
+
+No change to the `@opengeni/react` package — `EnrollmentConsent` props already suffice.
+
+---
+
+## A2 — non-interactive enroll-token exchange (headless / fleet, zero clicks)
+
+Secret, short-TTL, multi-use-within-TTL, workspace-scoped. The token **is** the grant (no
+human approve). Stateless-signed — **no DB table, no migration**.
+
+### A2.1 Token format & signing (`packages/contracts/src/index.ts`, beside `signEnrollmentBearer` ~636)
+
+- Reuse the **existing** `OPENGENI_ENROLLMENT_SIGNING_SECRET`
+  (`packages/config/.../index.ts:941`) — already provisioned on staging (the device bearer
+  is signed with it). **No new deploy secret.**
+- `signEnrollToken(secret, { typ: "enroll", workspaceId, accountId, allowScreenControl, iat,
+  exp })` → opaque token with prefix **`oget_`**. `verifyEnrollToken(secret, token)` →
+  validates prefix + HMAC + `typ === "enroll"` + `exp`. **Domain separation:** the `typ`
+  claim + `oget_` prefix make an enroll token unusable as an `oge_` bearer and vice-versa,
+  even though the signing secret is shared. Mirror the bearer's encoding style.
+- TTL: `ENROLL_TOKEN_TTL_SECONDS` default **3600** (1h). Long enough to script a fleet
+  rollout, short enough to bound exposure.
+
+### A2.2 Mint endpoint — authenticated
+
+- **`POST /v1/workspaces/:workspaceId/enrollments/token`** — auth `enrollments:manage`
+  (`requireAccessGrant`, mirror approve). Body `{ allowScreenControl?: boolean = false }`.
+- `accountId` from the grant. `signEnrollToken(...)` with `exp = now + TTL`. If no signing
+  secret → 503/"disabled" (mirror poll's `disabled` path, `enrollment.ts:253`).
+- Response `{ token, expiresAt, expiresInSeconds }`. The web UI shows it **once** with a
+  clear "secret — copy now, won't be shown again" warning.
+
+### A2.3 Exchange endpoint — unauthenticated (the token is the auth)
+
+- **`POST /v1/enrollments/token/exchange`** — unauthenticated, rate-limited
+  (`exchangeLimiter`, reuse `TokenBucket`), gated behind `sandboxSelfhostedEnabled`.
+- Body (same identity fields the agent sends to `device/start`): `{ token, publicKey, os,
+  arch, machineName?, exposure?, canOfferDisplay?, requestsScreenControl? }`.
+- Behavior: `verifyEnrollToken` → on failure 401/`disabled`. Extract
+  `workspaceId/accountId/allowScreenControl`. Then perform the **same finalize as approve**:
+  upsert the `enrollments` row (idempotent on `(workspace_id, pubkey)`, via
+  `createEnrollment` `db/.../index.ts:4153`) and ensure a `kind='selfhosted'` sandbox row,
+  `consentedWholeMachine=true`, `consentedScreenControl=allowScreenControl`. Then
+  `buildEnrollmentCredentials(...)` (`enrollment.ts:293`) and return
+  `{ credentials: EnrollmentCredentialsResponse }` — **identical credential shape** to the
+  `poll` authorized branch (so the agent's existing `wire::Credentials` parsing is reused).
+- **Reuse, don't fork:** factor the "upsert enrollment + ensure sandbox + build
+  credentials" core so both `approve` and `exchange` call it. The existing approve path and
+  its tests **must still pass** unchanged.
+
+### A2.4 Agent (Rust — requires rebuild)
+
+- `agent/.../enrollment.rs`: add `EXCHANGE_PATH = "/v1/enrollments/token/exchange"` and an
+  `exchange_token(req, identity, token)` that POSTs `{ token, publicKey, os, arch,
+  machineName?, ... }` and parses the **existing** `wire::Credentials` from
+  `{ credentials }`. Reuse `Credentials::into_proto`.
+- `agent/.../main.rs:315-331`: replace the `enroll_with_token` stub with a call to
+  `exchange_token`, then `config::save_credentials(&stored)` (same persistence as the device
+  path, `main.rs:301`). Dispatch already routes here when `--non-interactive`/`--token`/
+  `OPENGENI_ENROLL_TOKEN` is set (`main.rs:239-244`).
+- Optional nicety (include since we're rebuilding anyway): have the device-flow prompt print
+  `verificationUriComplete` (pre-filled `?user_code=`) rather than the bare URL, improving B.
+
+### A2.5 Web headless UI (`apps/web/src/routes/machines.tsx`)
+
+- Add a "Headless / fleet enroll token" action that calls `client.mintEnrollToken(workspaceId,
+  { allowScreenControl })` (new SDK method →
+  `POST /v1/workspaces/${ws}/enrollments/token`), then renders
+  `installOneLiner(origin, { enrollToken })` with the copy-once secret warning + the expiry.
+
+### A2.6 install.sh
+
+- Already invokes `enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive` (line 315) and
+  documents `OPENGENI_ENROLL_TOKEN` (line 38). Only add `OPENGENI_API_URL` forwarding (A1).
+
+---
+
+## Security notes (owner analysis)
+
+- The enroll token grants enrollment of **one machine identity (the agent's pubkey) into one
+  workspace** until expiry. Holding it ⇒ can enroll a rogue machine into that workspace.
+  This is the intended fleet semantic and is the same trust class as the existing `oge_`
+  bearer (also a stateless bearer secret). Bounded by: short TTL (1h), workspace scope (not
+  account-wide), post-hoc revocation (revoke endpoint, `enrollments.ts:174`), and copy-once
+  UI with an explicit secret warning. Acceptable for v1 self-hosted.
+- Domain separation (`typ` + `oget_` prefix) prevents cross-use of enroll token ↔ bearer.
+- `device/lookup` returns nothing unless the caller holds an `enrollments:read` grant in the
+  code's workspace → no cross-workspace disclosure; rate-limited against code brute force.
+- The workspace id baked into the A1 one-liner is **not** a secret (it is already in URLs);
+  only the A2 token is.
+
+## Build / deploy
+
+- **A1 + B**: web + API + `install.sh` only → ship on a normal deploy; verifiable on staging
+  immediately, **no agent rebuild**.
+- **A2**: agent-crate change → the new per-SHA `opengeni-agent` binary must be rebuilt,
+  re-signed, and baked into the API image (`apps/api/src/routes/install.ts:161`) for the
+  staging SHA before end-to-end A2 verification. Confirm the CI bake step ran for the
+  deployed SHA, else the install pulls an older agent with the stub.
+
+## Verification plan (staging)
+
+1. A1: copy the one-liner from Machines → it carries `OPENGENI_API_URL` + `OPENGENI_WORKSPACE_ID`; run on the verify VM → agent device-enrolls with no UUID typing.
+2. B: open the printed `/device?user_code=…` while signed in → consent screen renders machine
+   details → Grant → agent proceeds; machine appears in the dock.
+3. A2: mint a headless token in the UI → run the headless one-liner on a fresh box → agent
+   enrolls with **zero** approve clicks; machine appears.
+4. Regression: existing device-flow approve path + the 26-check V-matrix still green.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -661,6 +661,76 @@ export async function verifyEnrollmentBearer(secret: string, token: string, nowS
   return payload.data;
 }
 
+// --- Non-interactive enroll token (self-hosted enrollment UX §A2.1) ----------
+//
+// The SHORT-TTL, secret, workspace-scoped token the headless/fleet enroll path
+// presents to /v1/enrollments/token/exchange. The token IS the grant — there is
+// no human approve step — so it is stateless-signed (no DB row): the holder of an
+// unexpired token can enroll ONE machine identity into ONE workspace.
+//
+// It REUSES the SAME HMAC envelope as signEnrollmentBearer (base64Url payload +
+// hmacSha256Base64Url) with a DISTINCT `oget_` prefix and a `typ: "enroll"` claim.
+// DOMAIN SEPARATION: even though it shares the signing secret with the `oge_`
+// bearer, the prefix + typ claim make an enroll token unusable as an `oge_`
+// bearer (verifyEnrollmentBearer's `oge_` prefix check rejects it) and vice-versa
+// (verifyEnrollToken's `oget_` prefix + typ check rejects an `oge_` bearer). The
+// secret value is NEVER logged.
+export const EnrollTokenPayload = z.object({
+  // Domain-separation claim — fixed "enroll" so an `oge_`/`ogd_`/`ogs_` payload (no
+  // typ, or a different typ) can never satisfy verifyEnrollToken even past the prefix.
+  typ: z.literal("enroll"),
+  workspaceId: z.string().uuid(),
+  accountId: z.string().uuid(),
+  // The screen-control consent baked into the token at mint (the minting user's
+  // decision); the exchange records it as consentedScreenControl on the enrollment.
+  allowScreenControl: z.boolean(),
+  iat: z.number().int().nonnegative(),
+  exp: z.number().int().positive(),
+});
+export type EnrollTokenPayload = z.infer<typeof EnrollTokenPayload>;
+
+export async function signEnrollToken(secret: string, payload: EnrollTokenPayload): Promise<string> {
+  const encodedPayload = base64UrlEncode(JSON.stringify(EnrollTokenPayload.parse(payload)));
+  const signature = await hmacSha256Base64Url(secret, encodedPayload);
+  return `oget_${encodedPayload}.${signature}`;
+}
+
+/**
+ * Verify an enroll token: rejects (returns null) on a bad prefix (NOT `oget_`),
+ * a malformed envelope, a bad HMAC signature (constant-time), schema-invalid
+ * claims (which includes `typ !== "enroll"` — the `z.literal` rejects it), or an
+ * expired token (`exp < now`). Mirrors verifyEnrollmentBearer exactly. An `oge_`
+ * bearer fails the prefix gate; a same-secret token that lacks the typ claim fails
+ * the schema gate — both halves of the domain separation are enforced here.
+ */
+export async function verifyEnrollToken(secret: string, token: string, nowSeconds = Math.floor(Date.now() / 1000)): Promise<EnrollTokenPayload | null> {
+  if (!token.startsWith("oget_")) {
+    return null;
+  }
+  const withoutPrefix = token.slice("oget_".length);
+  const dot = withoutPrefix.lastIndexOf(".");
+  if (dot <= 0) {
+    return null;
+  }
+  const encodedPayload = withoutPrefix.slice(0, dot);
+  const signature = withoutPrefix.slice(dot + 1);
+  const expected = await hmacSha256Base64Url(secret, encodedPayload);
+  if (!constantTimeEqual(signature, expected)) {
+    return null;
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(base64UrlDecode(encodedPayload));
+  } catch {
+    return null;
+  }
+  const payload = EnrollTokenPayload.safeParse(decoded);
+  if (!payload.success || payload.data.exp < nowSeconds) {
+    return null;
+  }
+  return payload.data;
+}
+
 // --- Scoped data-plane stream token (master-spine §C.3 / crosscut PART 1.3) ---
 //
 // REUSES the existing HMAC envelope (sign/verifyDelegatedAccessToken's
@@ -2938,6 +3008,99 @@ export const RevokeEnrollmentResponse = z.object({
   revoked: z.boolean(),
 });
 export type RevokeEnrollmentResponse = z.infer<typeof RevokeEnrollmentResponse>;
+
+// =============================================================================
+// Enrollment UX (self-hosted enrollment UX, design 11): the click-Grant approve
+// page lookup/deny + the headless enroll-token mint/exchange. These sit beside the
+// device-flow contracts above and REUSE EnrollmentCredentialsResponse for the
+// exchange's credential payload (identical shape to the poll authorized branch).
+// =============================================================================
+
+// POST /v1/enrollments/device/lookup (USER-authenticated, NO workspace in the
+// path). The approve page (EnrollmentConsent) needs the machine details for a
+// user_code WITHOUT consuming the request. The user_code is globally unique among
+// pending rows; the route resolves its workspace, authorizes (enrollments:read),
+// and returns the machine details — or 404 (never revealing cross-workspace
+// existence) when the grant check fails or no live pending row matches.
+export const DeviceEnrollmentLookupRequest = z.object({
+  userCode: z.string().min(1).max(64),
+});
+export type DeviceEnrollmentLookupRequest = z.infer<typeof DeviceEnrollmentLookupRequest>;
+
+// The presentational machine details the consent screen renders (a subset of the
+// pending request — NO secrets, NO device_code).
+export const DeviceEnrollmentLookupMachine = z.object({
+  machineName: z.string().nullable(),
+  os: EnrollmentOs,
+  arch: z.string(),
+  canOfferDisplay: z.boolean(),
+  requestsScreenControl: z.boolean(),
+});
+export type DeviceEnrollmentLookupMachine = z.infer<typeof DeviceEnrollmentLookupMachine>;
+
+export const DeviceEnrollmentLookupResponse = z.object({
+  workspaceId: z.string().uuid(),
+  userCode: z.string(),
+  machine: DeviceEnrollmentLookupMachine,
+  expiresAt: z.string(),
+});
+export type DeviceEnrollmentLookupResponse = z.infer<typeof DeviceEnrollmentLookupResponse>;
+
+// POST /v1/workspaces/:workspaceId/enrollments/device/deny (USER-authenticated,
+// enrollments:manage). The explicit "no" at the approve page — mirrors approve.
+export const DeviceEnrollmentDenyRequest = z.object({
+  userCode: z.string().min(1).max(64),
+});
+export type DeviceEnrollmentDenyRequest = z.infer<typeof DeviceEnrollmentDenyRequest>;
+
+export const DeviceEnrollmentDenyResponse = z.object({
+  denied: z.boolean(),
+});
+export type DeviceEnrollmentDenyResponse = z.infer<typeof DeviceEnrollmentDenyResponse>;
+
+// POST /v1/workspaces/:workspaceId/enrollments/token (USER-authenticated,
+// enrollments:manage). Mints the short-TTL headless enroll token (the `oget_`
+// token). allowScreenControl bakes the screen-control consent into the token.
+export const MintEnrollTokenRequest = z.object({
+  allowScreenControl: z.boolean().default(false),
+});
+export type MintEnrollTokenRequest = z.infer<typeof MintEnrollTokenRequest>;
+
+export const MintEnrollTokenResponse = z.object({
+  // The `oget_` token. SECRET — the UI shows it once with a copy-now warning.
+  token: z.string(),
+  expiresAt: z.string(),
+  expiresInSeconds: z.number().int().positive(),
+});
+export type MintEnrollTokenResponse = z.infer<typeof MintEnrollTokenResponse>;
+
+// POST /v1/enrollments/token/exchange (UNAUTHENTICATED — the token IS the auth).
+// The agent presents the same identity fields it sends to device/start plus the
+// enroll token. On a valid token the control plane performs the SAME finalize as
+// approve and returns the IDENTICAL EnrollmentCredentialsResponse shape (so the
+// agent's existing credential parsing is reused).
+export const EnrollTokenExchangeRequest = z.object({
+  // The `oget_` enroll token (the auth + the workspace/account/consent grant).
+  token: z.string().min(1),
+  // The agent's ed25519 public key (the machine identity the enrollment binds to).
+  publicKey: z.string().min(1).max(1024),
+  os: EnrollmentOs.default("linux"),
+  arch: EnrollmentArch.default("x86_64"),
+  machineName: z.string().min(1).max(256).optional(),
+  // v1 only supports whole-machine; kept explicit so the consent is recorded.
+  exposure: z.literal("whole-machine").default("whole-machine"),
+  canOfferDisplay: z.boolean().default(false),
+  // The agent's REQUEST; the token's allowScreenControl is the AUTHORITATIVE consent.
+  requestsScreenControl: z.boolean().default(false),
+});
+export type EnrollTokenExchangeRequest = z.infer<typeof EnrollTokenExchangeRequest>;
+
+// The exchange wraps the EXISTING EnrollmentCredentialsResponse — IDENTICAL to the
+// poll authorized branch's `credentials` (NOT a redefined credential shape).
+export const EnrollTokenExchangeResponse = z.object({
+  credentials: EnrollmentCredentialsResponse,
+});
+export type EnrollTokenExchangeResponse = z.infer<typeof EnrollTokenExchangeResponse>;
 
 // ── Machines dashboard + per-machine metrics (M10, dossier §10.7) ────────────
 //

--- a/packages/contracts/test/enroll-token.test.ts
+++ b/packages/contracts/test/enroll-token.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EnrollTokenPayload,
+  type EnrollTokenPayload as EnrollTokenPayloadType,
+  signEnrollToken,
+  signEnrollmentBearer,
+  verifyEnrollToken,
+  verifyEnrollmentBearer,
+} from "../src/index";
+
+// Self-hosted enrollment UX §A2.1 — the headless `oget_` enroll token. The token
+// IS the grant (no human approve), so the sign/verify pair + its DOMAIN SEPARATION
+// from the `oge_` bearer (shared signing secret) is the whole security boundary.
+
+const SECRET = "test-enroll-token-secret";
+
+// Valid v4 UUIDs (Zod v4 enforces the RFC 4122 version+variant bits).
+const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_B = "44444444-4444-4444-8444-444444444444";
+const ACCOUNT_A = "22222222-2222-4222-8222-222222222222";
+
+function payload(overrides: Partial<EnrollTokenPayloadType> = {}): EnrollTokenPayloadType {
+  const now = Math.floor(Date.now() / 1000);
+  return EnrollTokenPayload.parse({
+    typ: "enroll",
+    workspaceId: WORKSPACE_A,
+    accountId: ACCOUNT_A,
+    allowScreenControl: false,
+    iat: now,
+    exp: now + 3600,
+    ...overrides,
+  });
+}
+
+describe("EnrollTokenPayload sign/verify", () => {
+  test("mint -> verify round-trip recovers the exact claims with the oget_ prefix", async () => {
+    const claims = payload({ allowScreenControl: true });
+    const token = await signEnrollToken(SECRET, claims);
+    // The `oget_` prefix is what keeps the enroll token from being confused with
+    // the `oge_` bearer (note: `oget_` is NOT a prefix of `oge_` and vice-versa is
+    // false; the verifier checks the FULL `oget_` prefix).
+    expect(token.startsWith("oget_")).toBe(true);
+    const verified = await verifyEnrollToken(SECRET, token);
+    expect(verified).toEqual(claims);
+  });
+
+  test("verify rejects a token signed with a different secret (bad signature)", async () => {
+    const token = await signEnrollToken(SECRET, payload());
+    expect(await verifyEnrollToken("a-different-secret", token)).toBeNull();
+  });
+
+  test("verify rejects an expired token (exp < now)", async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const token = await signEnrollToken(SECRET, payload({ iat: nowSeconds - 10, exp: nowSeconds - 1 }));
+    expect(await verifyEnrollToken(SECRET, token, nowSeconds)).toBeNull();
+    // ...and it still verifies fine BEFORE expiry.
+    expect(await verifyEnrollToken(SECRET, token, nowSeconds - 5)).not.toBeNull();
+  });
+
+  test("verify rejects a tampered payload (signature no longer matches)", async () => {
+    const token = await signEnrollToken(SECRET, payload({ workspaceId: WORKSPACE_A }));
+    const [encoded, signature] = token.slice("oget_".length).split(".");
+    // Swap the workspaceId in the payload but keep the original signature.
+    const tamperedClaims = payload({ workspaceId: WORKSPACE_B });
+    const tamperedEncoded = Buffer.from(JSON.stringify(tamperedClaims), "utf8").toString("base64url");
+    expect(tamperedEncoded).not.toBe(encoded);
+    const tamperedToken = `oget_${tamperedEncoded}.${signature}`;
+    expect(await verifyEnrollToken(SECRET, tamperedToken)).toBeNull();
+  });
+
+  test("verify rejects a wrong typ (the typ literal is the second domain-separation half)", async () => {
+    // Hand-craft a same-secret, otherwise-valid token whose typ is NOT "enroll".
+    // It is correctly SIGNED (so HMAC passes) but the schema's z.literal("enroll")
+    // rejects it — a token from another plane that reused this prefix is refused.
+    const now = Math.floor(Date.now() / 1000);
+    const claims = { typ: "bearer", workspaceId: WORKSPACE_A, accountId: ACCOUNT_A, allowScreenControl: false, iat: now, exp: now + 3600 };
+    const encoded = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+    const { createHmac } = await import("node:crypto");
+    const signature = createHmac("sha256", SECRET).update(encoded).digest("base64url");
+    const token = `oget_${encoded}.${signature}`;
+    expect(await verifyEnrollToken(SECRET, token)).toBeNull();
+  });
+
+  test("verify rejects an oge_ bearer + other malformed input (prefix discipline)", async () => {
+    // An `oge_` enrollment bearer (same signing secret!) is NOT a valid enroll
+    // token — the `oget_` prefix gate rejects it. This is the first half of the
+    // domain separation; the typ literal is the second (above).
+    const bearer = await signEnrollmentBearer(SECRET, {
+      workspaceId: WORKSPACE_A,
+      agentId: "33333333-3333-4333-8333-333333333333",
+      enrollmentId: "33333333-3333-4333-8333-333333333333",
+      subjectPrefix: `agent.${WORKSPACE_A}.x`,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    expect(bearer.startsWith("oge_")).toBe(true);
+    expect(await verifyEnrollToken(SECRET, bearer)).toBeNull();
+    expect(await verifyEnrollToken(SECRET, "oge_abc.def")).toBeNull();
+    expect(await verifyEnrollToken(SECRET, "not-a-token")).toBeNull();
+    expect(await verifyEnrollToken(SECRET, "oget_no-dot")).toBeNull();
+    expect(await verifyEnrollToken(SECRET, "oget_.sig")).toBeNull();
+  });
+
+  test("the reverse half: an oget_ enroll token is NOT a valid oge_ bearer", async () => {
+    // Symmetric domain separation — verifyEnrollmentBearer's `oge_` prefix check
+    // rejects an `oget_` token, so the two planes never cross-verify even though
+    // they share the signing secret.
+    const token = await signEnrollToken(SECRET, payload());
+    expect(await verifyEnrollmentBearer(SECRET, token)).toBeNull();
+  });
+});

--- a/packages/db/drizzle/0026_device_enrollment_user_code_resolver.sql
+++ b/packages/db/drizzle/0026_device_enrollment_user_code_resolver.sql
@@ -1,0 +1,44 @@
+-- The user_code → (account_id, workspace_id) resolver for the click-Grant approve
+-- page lookup (self-hosted enrollment UX, design 11 §B.1). Companion to the
+-- device_code resolver in 0025 (resolve_device_enrollment_request).
+--
+-- WHY a SECURITY DEFINER resolver: POST /v1/enrollments/device/lookup is the
+-- approve page reading machine details for a user_code WITHOUT a workspace in the
+-- path — the user_code is globally unique among LIVE (status='pending') rows (the
+-- 0025 partial unique index device_enrollment_requests_user_code_pending_idx). A
+-- scoped opengeni_app connection is under FORCE RLS and cannot read a row to learn
+-- which workspace it belongs to, so — exactly like 0025's device_code resolver —
+-- this returns ONLY the (account_id, workspace_id) for the PENDING row matching the
+-- code. The DAO then re-reads the FULL row under the resolved workspace's RLS scope
+-- and the ROUTE re-checks the caller holds an enrollments:read grant in THAT
+-- workspace, so the user_code is the capability and no broad read escapes RLS.
+--
+-- PENDING-ONLY: the partial unique index guarantees AT MOST ONE pending row per
+-- user_code, so the resolver is unambiguous; a terminal (approved/denied/consumed)
+-- row's recycled code is intentionally invisible here (lookup is for the live
+-- approve decision only).
+--
+-- ROLLBACK (forward-only repo, but cleanly reversible):
+--   DROP FUNCTION IF EXISTS opengeni_private.resolve_pending_device_enrollment_by_user_code(text);
+
+CREATE OR REPLACE FUNCTION opengeni_private.resolve_pending_device_enrollment_by_user_code(
+  p_user_code text
+)
+RETURNS TABLE (account_id uuid, workspace_id uuid)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, opengeni_private
+AS $$
+  SELECT d.account_id, d.workspace_id
+  FROM device_enrollment_requests d
+  WHERE d.user_code = p_user_code
+    AND d.status = 'pending'
+  LIMIT 1
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.resolve_pending_device_enrollment_by_user_code(text) TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4387,6 +4387,145 @@ export async function getPendingDeviceEnrollmentRequestByUserCode(db: Database, 
   });
 }
 
+// Look up the PENDING request for a user_code GLOBALLY (no workspace context) —
+// the click-Grant approve page lookup (design 11 §B.1). The user_code is globally
+// unique among LIVE (pending) rows, so — exactly like getDeviceEnrollmentRequestByDeviceCode
+// resolves a device_code — this resolves (account_id, workspace_id) via the 0026
+// SECURITY DEFINER resolver, then re-reads the FULL pending row under that
+// workspace's RLS scope. The ROUTE then re-checks the caller holds a grant in the
+// resolved workspace before returning anything. Returns null when no live pending
+// row matches (an unknown / terminal / expired code).
+export async function getPendingDeviceEnrollmentRequestByUserCodeGlobal(db: Database, userCode: string): Promise<DeviceEnrollmentRequestRecord | null> {
+  const resolved = await db.execute<{ account_id: string; workspace_id: string }>(sql`
+    select account_id, workspace_id from opengeni_private.resolve_pending_device_enrollment_by_user_code(${userCode})
+  `);
+  const ctx = resolved[0];
+  if (!ctx) {
+    return null;
+  }
+  return await withRlsContext(db, { accountId: ctx.account_id, workspaceId: ctx.workspace_id }, async (scopedDb) => {
+    const [row] = await scopedDb.select().from(schema.deviceEnrollmentRequests)
+      .where(and(
+        eq(schema.deviceEnrollmentRequests.userCode, userCode),
+        eq(schema.deviceEnrollmentRequests.status, "pending"),
+      ))
+      .limit(1);
+    return row ? mapDeviceEnrollmentRequest(row) : null;
+  });
+}
+
+// The SHARED finalize core (design 11 §A2.3 "reuse, don't fork"): "upsert the
+// enrollment (idempotent on (workspace_id, pubkey)) + ensure a kind='selfhosted'
+// sandbox row" — the exact end state BOTH the device approve and the headless
+// token exchange must produce. Takes an ALREADY-RLS-SCOPED `scopedDb` so the
+// caller controls the transaction boundary:
+//   * approveDeviceEnrollmentRequest calls it INSIDE its FOR-UPDATE txn (so the
+//     re-read fence + the request stamp stay in ONE txn — semantics unchanged), and
+//   * finalizeEnrollmentByToken calls it inside its OWN txn (no pending row exists
+//     for a stateless token).
+// Idempotent: a re-run for the same (workspace, pubkey) re-activates the existing
+// enrollment (M2 upsert) and REUSES its selfhosted sandbox — never a duplicate.
+async function finalizeEnrollmentInScope(scopedDb: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  pubkey: string;
+  hasDisplay: boolean;
+  allowScreenControl: boolean;
+  os: EnrollmentOs;
+  arch: string;
+  sandboxName: string;
+  now: Date;
+}): Promise<{ enrollment: EnrollmentRecord; sandbox: SandboxRecord }> {
+  // createEnrollment (idempotent upsert) — whole-machine is mandatory; display +
+  // screen-control come from the agent's offer + the consenting decision. We inline
+  // the insert here (rather than calling createEnrollment, which opens its OWN
+  // scope) so it shares the caller's transaction.
+  const [enrollmentRow] = await scopedDb.insert(schema.enrollments).values({
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    pubkey: input.pubkey,
+    exposure: "whole-machine",
+    hasDisplay: input.hasDisplay,
+    allowScreenControl: input.allowScreenControl,
+    os: input.os,
+    arch: input.arch,
+    status: "active",
+  }).onConflictDoUpdate({
+    target: [schema.enrollments.workspaceId, schema.enrollments.pubkey],
+    set: {
+      exposure: "whole-machine",
+      hasDisplay: input.hasDisplay,
+      allowScreenControl: input.allowScreenControl,
+      os: input.os,
+      arch: input.arch,
+      status: "active",
+      revokedAt: null,
+      updatedAt: input.now,
+    },
+  }).returning();
+  if (!enrollmentRow) {
+    throw new Error("Failed to create enrollment during finalize");
+  }
+  const enrollment = mapEnrollment(enrollmentRow);
+
+  // Ensure a selfhosted sandbox for this enrollment. A re-finalize of the SAME
+  // machine reuses the existing sandbox rather than creating a duplicate.
+  const [existingSandbox] = await scopedDb.select().from(schema.sandboxes)
+    .where(and(
+      eq(schema.sandboxes.workspaceId, input.workspaceId),
+      eq(schema.sandboxes.enrollmentId, enrollment.id),
+    ))
+    .limit(1);
+  let sandbox: SandboxRecord;
+  if (existingSandbox) {
+    sandbox = mapSandbox(existingSandbox);
+  } else {
+    const [sandboxRow] = await scopedDb.insert(schema.sandboxes).values({
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      kind: "selfhosted",
+      name: input.sandboxName,
+      enrollmentId: enrollment.id,
+    }).returning();
+    if (!sandboxRow) {
+      throw new Error("Failed to create sandbox during finalize");
+    }
+    sandbox = mapSandbox(sandboxRow);
+  }
+  return { enrollment, sandbox };
+}
+
+// FINALIZE a headless enroll-token exchange (design 11 §A2.3). Produces the SAME
+// end state as approveDeviceEnrollmentRequest — an enrollments row + a selfhosted
+// sandbox row — but WITHOUT a pending device-flow request (a stateless `oget_`
+// token carries the grant). Idempotent via the shared finalize core's upsert.
+export async function finalizeEnrollmentByToken(db: Database, input: {
+  accountId: string;
+  workspaceId: string;
+  pubkey: string;
+  hasDisplay: boolean;
+  allowScreenControl: boolean;
+  os: EnrollmentOs;
+  arch: string;
+  sandboxName: string;
+  now?: Date;
+}): Promise<{ enrollment: EnrollmentRecord; sandbox: SandboxRecord }> {
+  const now = input.now ?? new Date();
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    return await finalizeEnrollmentInScope(scopedDb, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      pubkey: input.pubkey,
+      hasDisplay: input.hasDisplay,
+      allowScreenControl: input.allowScreenControl,
+      os: input.os,
+      arch: input.arch,
+      sandboxName: input.sandboxName,
+      now,
+    });
+  });
+}
+
 // THE LOUD-CONSENT APPROVE (the user's POST /approve). In ONE transaction:
 //   1. re-read the pending row FOR UPDATE (fence against a double-approve / a
 //      concurrent expiry),
@@ -4435,64 +4574,23 @@ export async function approveDeviceEnrollmentRequest(db: Database, input: {
       return { approved: false, enrollment: null, sandbox: null };
     }
 
-    // createEnrollment (idempotent upsert) — whole-machine is mandatory; the
-    // display + screen-control consent come from the agent's offer + the user's
-    // decision. RLS already set on scopedDb's session; call the raw insert here so
-    // it shares the transaction (createEnrollment opens its own scope — re-entering
-    // withRlsContext is safe but we inline to keep ONE txn).
-    const [enrollmentRow] = await scopedDb.insert(schema.enrollments).values({
+    // The SHARED finalize core: upsert the enrollment (idempotent) + ensure a
+    // selfhosted sandbox. RLS is already set on scopedDb's session and this call
+    // runs INSIDE this FOR-UPDATE txn, so the re-read fence + the stamp below + the
+    // enrollment/sandbox writes all commit atomically (semantics unchanged from the
+    // pre-refactor inline block — acceptance #2 stays one machine). The headless
+    // token exchange (finalizeEnrollmentByToken) calls the SAME core.
+    const { enrollment, sandbox } = await finalizeEnrollmentInScope(scopedDb, {
       accountId: input.accountId,
       workspaceId: input.workspaceId,
       pubkey: pending.pubkey,
-      exposure: "whole-machine",
       hasDisplay: pending.canOfferDisplay,
       allowScreenControl: input.allowScreenControl,
       os: pending.os as EnrollmentOs,
       arch: pending.arch,
-      status: "active",
-    }).onConflictDoUpdate({
-      target: [schema.enrollments.workspaceId, schema.enrollments.pubkey],
-      set: {
-        exposure: "whole-machine",
-        hasDisplay: pending.canOfferDisplay,
-        allowScreenControl: input.allowScreenControl,
-        os: pending.os as EnrollmentOs,
-        arch: pending.arch,
-        status: "active",
-        revokedAt: null,
-        updatedAt: now,
-      },
-    }).returning();
-    if (!enrollmentRow) {
-      throw new Error("Failed to create enrollment during device approve");
-    }
-    const enrollment = mapEnrollment(enrollmentRow);
-
-    // createSandbox (selfhosted, enrollment_id). A re-approve of the SAME machine
-    // reuses the existing selfhosted sandbox for this enrollment rather than
-    // creating a duplicate (idempotent re-enroll, acceptance #2 stays one machine).
-    const [existingSandbox] = await scopedDb.select().from(schema.sandboxes)
-      .where(and(
-        eq(schema.sandboxes.workspaceId, input.workspaceId),
-        eq(schema.sandboxes.enrollmentId, enrollment.id),
-      ))
-      .limit(1);
-    let sandbox: SandboxRecord;
-    if (existingSandbox) {
-      sandbox = mapSandbox(existingSandbox);
-    } else {
-      const [sandboxRow] = await scopedDb.insert(schema.sandboxes).values({
-        accountId: input.accountId,
-        workspaceId: input.workspaceId,
-        kind: "selfhosted",
-        name: input.sandboxName,
-        enrollmentId: enrollment.id,
-      }).returning();
-      if (!sandboxRow) {
-        throw new Error("Failed to create sandbox during device approve");
-      }
-      sandbox = mapSandbox(sandboxRow);
-    }
+      sandboxName: input.sandboxName,
+      now,
+    });
 
     // Stamp the request approved + the LOUD CONSENT record (who/when/what).
     await scopedDb.update(schema.deviceEnrollmentRequests)

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -32,6 +32,12 @@ import type {
   CreateSessionRequest,
   CreateWorkspaceEnvironmentRequest,
   CreateWorkspaceRequest,
+  // Enrollment UX (design 11): the click-Grant approve-page lookup/deny + headless
+  // enroll-token mint.
+  DeviceEnrollmentApproveResponse,
+  DeviceEnrollmentDenyResponse,
+  DeviceEnrollmentLookupResponse,
+  MintEnrollTokenResponse,
   DiscoverMcpCapabilitiesResponse,
   Document,
   DocumentBase,
@@ -224,6 +230,66 @@ export class OpenGeniClient {
       { ...(options.window !== undefined ? { window: options.window } : {}) },
     );
     return response.samples;
+  }
+
+  // --- Self-hosted enrollment UX (design 11) --------------------------------
+
+  /**
+   * Resolve a pending device-enrollment flow by its user_code for the click-Grant
+   * approve page (EnrollmentConsent). NO workspace in the path — the server
+   * resolves the workspace from the (globally-unique-among-pending) code, then
+   * authorizes the caller against it (enrollments:read). Rejects (404) when the
+   * code is unknown/expired OR the caller lacks the grant — the two are
+   * indistinguishable by design (no cross-workspace disclosure). Does not consume
+   * the request.
+   */
+  async lookupDeviceEnrollment(userCode: string): Promise<DeviceEnrollmentLookupResponse> {
+    return await this.requestJson<DeviceEnrollmentLookupResponse>("POST", "/v1/enrollments/device/lookup", { userCode });
+  }
+
+  /**
+   * Approve a pending device-enrollment flow (the LOUD consent step). `allowScreenControl`
+   * is the authoritative screen-control consent (whole-machine is mandatory/implicit).
+   * Lands an enrollment + a selfhosted sandbox and unblocks the agent's poll.
+   */
+  async approveDeviceEnrollment(
+    workspaceId: string,
+    request: { userCode: string; allowScreenControl?: boolean },
+  ): Promise<DeviceEnrollmentApproveResponse> {
+    return await this.requestJson<DeviceEnrollmentApproveResponse>(
+      "POST",
+      `/v1/workspaces/${workspaceId}/enrollments/device/approve`,
+      { userCode: request.userCode, allowScreenControl: request.allowScreenControl ?? false },
+    );
+  }
+
+  /** Deny a pending device-enrollment flow (the explicit "no" at the approve page). */
+  async denyDeviceEnrollment(
+    workspaceId: string,
+    request: { userCode: string },
+  ): Promise<DeviceEnrollmentDenyResponse> {
+    return await this.requestJson<DeviceEnrollmentDenyResponse>(
+      "POST",
+      `/v1/workspaces/${workspaceId}/enrollments/device/deny`,
+      { userCode: request.userCode },
+    );
+  }
+
+  /**
+   * Mint a short-TTL headless enroll token (the `oget_` token) for the fleet /
+   * non-interactive enroll path. The returned `token` is SECRET — surface it once
+   * with a copy-now warning; it cannot be re-read. `allowScreenControl` bakes the
+   * screen-control consent into the token.
+   */
+  async mintEnrollToken(
+    workspaceId: string,
+    request: { allowScreenControl?: boolean } = {},
+  ): Promise<MintEnrollTokenResponse> {
+    return await this.requestJson<MintEnrollTokenResponse>(
+      "POST",
+      `/v1/workspaces/${workspaceId}/enrollments/token`,
+      { allowScreenControl: request.allowScreenControl ?? false },
+    );
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -258,4 +258,19 @@ export type {
   // Bring-your-own-compute: the user-authenticated active-sandbox swap (M7).
   SwapActiveSandboxRequest,
   SwapActiveSandboxResponse,
+  // Self-hosted enrollment UX (design 11): click-Grant approve-page lookup/deny +
+  // headless enroll-token mint/exchange.
+  EnrollmentOs,
+  DeviceEnrollmentLookupRequest,
+  DeviceEnrollmentLookupResponse,
+  DeviceEnrollmentLookupMachine,
+  DeviceEnrollmentApproveRequest,
+  DeviceEnrollmentApproveResponse,
+  DeviceEnrollmentDenyRequest,
+  DeviceEnrollmentDenyResponse,
+  MintEnrollTokenRequest,
+  MintEnrollTokenResponse,
+  EnrollmentCredentials,
+  EnrollTokenExchangeRequest,
+  EnrollTokenExchangeResponse,
 } from "./types";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1601,3 +1601,102 @@ export type SwapActiveSandboxResponse = {
   activeEpoch: number;
   reason?: string;
 };
+
+// ── Self-hosted enrollment UX (design 11) ────────────────────────────────────
+// Hand-written mirrors of the `@opengeni/contracts` enrollment-UX request/response
+// shapes (the SDK keeps zero runtime deps). The click-Grant approve-page
+// lookup/deny + the headless enroll-token mint/exchange.
+
+/** Mirror of `@opengeni/contracts` EnrollmentOs. */
+export type EnrollmentOs = "linux" | "macos" | "windows";
+
+/** POST /v1/enrollments/device/lookup body. */
+export type DeviceEnrollmentLookupRequest = {
+  userCode: string;
+};
+
+/** The presentational machine details the consent screen renders. */
+export type DeviceEnrollmentLookupMachine = {
+  machineName: string | null;
+  os: EnrollmentOs;
+  arch: string;
+  canOfferDisplay: boolean;
+  requestsScreenControl: boolean;
+};
+
+/** POST /v1/enrollments/device/lookup response (no secrets, no device_code). */
+export type DeviceEnrollmentLookupResponse = {
+  workspaceId: string;
+  userCode: string;
+  machine: DeviceEnrollmentLookupMachine;
+  expiresAt: string;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/device/approve body. */
+export type DeviceEnrollmentApproveRequest = {
+  userCode: string;
+  allowScreenControl?: boolean;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/device/approve response. */
+export type DeviceEnrollmentApproveResponse = {
+  approved: boolean;
+  enrollmentId: string;
+  sandboxId: string;
+  allowScreenControl: boolean;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/device/deny body. */
+export type DeviceEnrollmentDenyRequest = {
+  userCode: string;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/device/deny response. */
+export type DeviceEnrollmentDenyResponse = {
+  denied: boolean;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/token body. */
+export type MintEnrollTokenRequest = {
+  allowScreenControl?: boolean;
+};
+
+/** POST /v1/workspaces/:ws/enrollments/token response. The `token` is SECRET. */
+export type MintEnrollTokenResponse = {
+  token: string;
+  expiresAt: string;
+  expiresInSeconds: number;
+};
+
+/** The credential payload the headless exchange returns (a subset of the agent's
+ *  EnrollmentCredentials — IDENTICAL to the device-flow poll authorized branch). */
+export type EnrollmentCredentials = {
+  agentId: string;
+  workspaceId: string;
+  bearer: string;
+  subjectPrefix: string;
+  natsUrls: string[];
+  relayUrl: string;
+  relayToken: string;
+  natsAccountCreds: string;
+  updatePublicKey: string;
+  consentedWholeMachine: boolean;
+  consentedScreenControl: boolean;
+};
+
+/** POST /v1/enrollments/token/exchange body (the headless / fleet enroll path). */
+export type EnrollTokenExchangeRequest = {
+  token: string;
+  publicKey: string;
+  os?: EnrollmentOs;
+  arch?: string;
+  machineName?: string;
+  exposure?: "whole-machine";
+  canOfferDisplay?: boolean;
+  requestsScreenControl?: boolean;
+};
+
+/** POST /v1/enrollments/token/exchange response (wraps the credential shape). */
+export type EnrollTokenExchangeResponse = {
+  credentials: EnrollmentCredentials;
+};


### PR DESCRIPTION
## Why

Enrolling a self-hosted machine was a *bad* user experience: the console one-liner forced the user to **hand-type the workspace UUID**, and the agent it installed only targeted the hardcoded `api.opengeni.ai` default — so it was **broken against any non-default deployment**. This makes enrollment easy from the user's point of view and correct against any deployment. Design: `docs/design/sandbox-surfacing/11-enrollment-ux.md` (§A1 / §B / §A2).

## What

### A1 — origin-pinned install one-liner (no rebuild)
`installOneLiner()` now **always** bakes `OPENGENI_API_URL=${origin}` so the agent targets *this* deployment, and threads `OPENGENI_WORKSPACE_ID` straight from the machines page so the user never types the UUID. `install.sh` documents + forwards both (plus `OPENGENI_ENROLL_TOKEN`). The agent already reads these via clap — no agent rebuild needed for A1.

### B — click-Grant approve page (no rebuild)
New **top-level `/device` route**. It resolves the owning workspace from the `user_code` via an authenticated, **no-workspace-in-path** lookup (`POST /v1/enrollments/device/lookup`), backed by a `SECURITY DEFINER` resolver (**migration 0026**, companion to 0025's `device_code` resolver) that escapes FORCE-RLS *only* to discover `(account_id, workspace_id)`. The route then re-checks the caller's `enrollments:read` grant **in that workspace**, and `approve`/`deny` target the `workspaceId` from the **lookup response** — never the user's default. Adds a `deny` endpoint + SDK methods + mounts `EnrollmentConsent`.

### A2 — headless / fleet enrollment (requires per-SHA agent bake)
Stateless **signed enroll token** (`oget_` prefix, reuses the existing `OPENGENI_ENROLLMENT_SIGNING_SECRET`, domain-separated by `typ:"enroll"`, TTL 3600s, **no DB table / no new deploy secret**). Minted by an authenticated `enrollments:manage` endpoint; exchanged by an **unauthenticated, rate-limited** `POST /v1/enrollments/token/exchange`. The agent gains `enroll_with_token`; the machines page surfaces an *"Advanced: headless / CI"* section that mints the token into a zero-click one-liner.

## Security notes
- Lookup is `enrollments:read`-gated and collapses every failure (unknown / expired / no grant) into one opaque "invalid or expired" — **no cross-workspace disclosure**.
- The resolver returns only `(account_id, workspace_id)` for a **pending** row (0025's partial-unique index guarantees ≤1), mirroring the audited 0025 `device_code` pattern.
- Token domain separation: `oget_` (enroll) vs `oge_` (bearer); the `typ` literal in the Zod schema rejects a bearer presented as an enroll token. The exchange endpoint ignores the agent's `requestsScreenControl` — the token's `allowScreenControl` is authoritative.

## Verification (local)
- Full-repo **typecheck clean** (17 pkgs) · `build:packages` green
- `bun test` **1558 pass / 0 fail** (125 files) · `apps/web` 116 pass · contracts `enroll-token` 7 pass
- Rust agent **compiles** + **15 enrollment tests pass** (incl. 3 new exchange) · `install.sh` `sh -n` clean
- `publish-closure-guard` + workspace-billing static guard + react `demo:build` all green

## Rollout
A1 + B ship with the next image (no agent rebuild). **A2 requires the per-SHA signed agent bake** (`scripts/bake-agent.sh`, already wired into the staging/release image build) to run for the deployed SHA before headless enrollment works end-to-end — verified post-deploy on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds unauthenticated token exchange (bearer-like `oget_` grants), new SECURITY DEFINER lookup resolver, and shared enrollment finalize paths—security-sensitive enrollment and credential issuance.
> 
> **Overview**
> Self-hosted enrollment is wired end-to-end so installs target the right control plane, humans can approve from the console, and fleet/CI can enroll without a device-code step.
> 
> **Install & console (A1):** `installOneLiner` always sets `OPENGENI_API_URL` and can embed `OPENGENI_WORKSPACE_ID` or `OPENGENI_ENROLL_TOKEN`; the Machines dialog uses the workspace-scoped interactive command. `install.sh` documents those env vars and forwards `--api-url` on token enroll.
> 
> **Click-grant (B):** New top-level `/device` route drives `EnrollmentConsent` via lookup/approve/deny SDK calls. API adds `POST /v1/enrollments/device/lookup` (grant-checked after resolving workspace from `user_code`, failures → 404), deny, and migration **0026**’s SECURITY DEFINER resolver. DB refactors approve and token exchange through shared `finalizeEnrollmentInScope`.
> 
> **Headless (A2):** Stateless `oget_` enroll tokens (`signEnrollToken` / `verifyEnrollToken`, 1h TTL) with mint (`enrollments:manage`) and unauthenticated, rate-limited `POST /v1/enrollments/token/exchange` returning the same credentials as poll. The agent implements `exchange_token` and replaces the `enroll_with_token` stub; Machines adds “Advanced: headless / CI” mint + one-liner UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729bda52ba7b33ccdc5822e4a1011a38cd5b9b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->