### PR TITLE
fix(bake-agent): install ziglang independently of the cargo-zigbuild cache (warm-cache zig regression)

### DIFF
--- a/scripts/bake-agent.sh
+++ b/scripts/bake-agent.sh
@@ -51,11 +51,26 @@ sha256_of_file() {
 mkdir -p "$BAKED_DIR"
 
 # --- Toolchain: cargo-zigbuild gives a robust static musl cross-link with no
-# system musl-gcc (the agent-release.yml pattern). Idempotent installs.
+# system musl-gcc (the agent-release.yml pattern). It needs BOTH its own binary
+# AND a `zig` compiler, and the two cache DIFFERENTLY: cargo-zigbuild lands in
+# ~/.cargo/bin (restored by Swatinem/rust-cache), but `zig` comes from the
+# `ziglang` pip wheel, which is NOT part of the cargo cache. Gating the wheel
+# install on the binary's absence (the old behaviour) therefore SKIPPED zig on
+# every warm-cache run → "Error: Failed to find zig". Install each against its
+# OWN presence check so a cached cargo-zigbuild can never mask a missing zig.
+# Idempotent.
 if ! command -v cargo-zigbuild >/dev/null 2>&1; then
-  log "installing cargo-zigbuild + ziglang"
-  pip install ziglang >/dev/null 2>&1 || pip install --user ziglang
+  log "installing cargo-zigbuild"
   cargo install --locked cargo-zigbuild
+fi
+# cargo-zigbuild resolves zig from PATH or the `python -m ziglang` wheel; ensure
+# one of them is present regardless of the cargo-zigbuild cache state.
+if ! command -v zig >/dev/null 2>&1 \
+  && ! python3 -m ziglang version >/dev/null 2>&1 \
+  && ! python -m ziglang version >/dev/null 2>&1; then
+  log "installing ziglang (pip wheel — provides zig for cargo-zigbuild)"
+  pip install ziglang >/dev/null 2>&1 || pip3 install ziglang >/dev/null 2>&1 \
+    || pip install --user ziglang || pip3 install --user ziglang
 fi
 
 # --- Signing key presence (mirrors agent-release.yml's loud key-absent handling).


### PR DESCRIPTION
## Why

The per-SHA agent **bake** (`scripts/bake-agent.sh`) builds the static musl agent binaries via `cargo-zigbuild`, which the deployed-env image builds run before `docker build`/`az acr build`. It failed in the staging image build with:

```
bake-agent: building opengeni-agent-x86_64-unknown-linux-musl (static musl) via cargo-zigbuild
Error: Failed to find zig
Caused by: cannot find binary path
```

### Root cause — warm cargo cache masks a missing zig
`cargo-zigbuild` needs **both** its own binary **and** a `zig` compiler. They cache differently:
- `cargo-zigbuild` → `~/.cargo/bin`, restored by `Swatinem/rust-cache` (the ops preview/staging/production image builds share the `bake-musl` cache key).
- `zig` → the **`ziglang` pip wheel**, which is **not** part of the cargo cache.

The old code installed the wheel only inside `if ! command -v cargo-zigbuild`. On a **warm** cache the binary is already present → the block is skipped → `zig` is never installed → "Failed to find zig". The prior staging deploy only succeeded because its cache was **cold** (first run installed the wheel); this is the first warm-cache run.

## Fix
Probe `cargo-zigbuild` and `zig` **independently**, each against its own presence check, so a cached `cargo-zigbuild` can never mask a missing `zig`. `zig` is probed via `PATH` or the `python -m ziglang` wheel (how `cargo-zigbuild` resolves it). Idempotent; fixes the bake for **every** deployed-env consumer (`release.yml` + ops preview/staging/production image builds).

```sh
if ! command -v cargo-zigbuild >/dev/null 2>&1; then
  cargo install --locked cargo-zigbuild
fi
if ! command -v zig >/dev/null 2>&1 \
  && ! python3 -m ziglang version >/dev/null 2>&1 \
  && ! python -m ziglang version >/dev/null 2>&1; then
  pip install ziglang || pip3 install ziglang || pip install --user ziglang || pip3 install --user ziglang
fi
```

## Verification
`bash -n` clean. The bake is not exercised by repo CI (release/ops-only), so this is validated by re-running the ops **Build Staging Artifacts** workflow against the merged SHA, which previously failed at this exact step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI bootstrap-only change in `scripts/bake-agent.sh`; no runtime or auth behavior, with idempotent install logic.
> 
> **Overview**
> Fixes **warm-cache CI failures** (`Failed to find zig`) during the per-SHA agent bake in `scripts/bake-agent.sh`.
> 
> **`cargo-zigbuild` and `zig` are now installed on separate presence checks.** Previously `ziglang` was only installed inside the `cargo-zigbuild` block, so a restored Rust cache could leave `cargo-zigbuild` present while the pip `ziglang` wheel was never installed. The script now installs `cargo-zigbuild` only when missing, then installs `ziglang` when neither `zig` on `PATH` nor `python -m ziglang` is available (with `pip`/`pip3` fallbacks). Comments document the split cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e235e0ea4edf579cd23fd219ea2a2b506b58be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->