### PR TITLE
fix(selfhosted): macOS agent install + headless-VM session selectability

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -355,6 +355,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Maintain a MOVING `agent-latest` release pointing at the SAME assets as the
+      # per-version `agent-v<ver>` release above. The API's `/agent/latest/<asset>`
+      # redirect (apps/api/src/routes/install.ts) targets
+      # `releases/download/agent-latest/<asset>` rather than GitHub's repo-global
+      # `releases/latest` alias — in this monorepo that alias is shadowed by the
+      # frequent changesets package releases (no agent binaries → 404).
+      #
+      # softprops/action-gh-release updates an EXISTING release in place but does NOT
+      # move its tag to the new commit, so we delete+recreate via the gh CLI to force
+      # the tag to MOVE and the assets to refresh idempotently. `--latest=false` keeps
+      # it from stealing the repo-global "latest" away from changeset releases.
+      - name: Update the moving agent-latest release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Idempotent reset: drop any prior release AND its tag so the tag moves.
+          gh release delete agent-latest --cleanup-tag --yes || true
+          gh release create agent-latest \
+            dist/* \
+            agent/install/install.sh \
+            agent/install/install.ps1 \
+            agent/install/uninstall.sh \
+            agent/install/opengeni-agent-minisign.pub \
+            --target "$GITHUB_SHA" \
+            --title "opengeni-agent (latest)" \
+            --latest=false \
+            --prerelease=false \
+            --notes "Moving pointer to the newest opengeni-agent build (currently v${{ needs.guard.outputs.version }}).
+
+          Maintained automatically so that \`https://get.opengeni.ai/agent/latest/<asset>\` always resolves to the most recent signed agent binaries. For a pinned version, use the corresponding \`agent-v<ver>\` release instead."
+
       # Publish the signed channel manifest (the CONTROL surface OpenGeni flips to
       # promote a build). Promotion (5→25→50→100) + kill-switch are a re-run of this
       # step with new params — NO rebuild (dossier §23.2/§23.3).

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -218,6 +218,18 @@ fn parse_geometry(geometry: &str) -> (u32, u32) {
     (w, h)
 }
 
+/// Probes whether this host currently has a usable display surface (a real X11
+/// screen or an Xvfb virtual framebuffer), the value advertised as the offer's
+/// `offers_display` at enroll. Mirrors how [`Supervisor::capabilities`] derives the
+/// `desktop` capability: `probe()` does a synchronous x11rb connect, so run it on
+/// the blocking pool — a wedged X server must not stall this async enroll task.
+async fn probe_offers_display() -> bool {
+    let desktop = opengeni_agent_platform::resolve_desktop();
+    tokio::task::spawn_blocking(move || desktop.probe().is_some())
+        .await
+        .unwrap_or(false)
+}
+
 /// The `enroll` command: drive the device flow, persist the credentials, and
 /// return them (so `run` can chain straight into serving).
 async fn enroll_command(
@@ -262,6 +274,10 @@ async fn enroll_command(
         .clone()
         .unwrap_or_else(supervisor::hostname_or_default);
 
+    // Probe the live display surface so a display-capable host enrolls as such
+    // (rather than the old M6 hardcode that recorded every machine headless).
+    let offers_display = probe_offers_display().await;
+
     let request = EnrollmentRequest {
         api_base_url: api_url.to_string(),
         workspace_id,
@@ -269,9 +285,10 @@ async fn enroll_command(
         offer: EnrollmentOffer {
             os: identity.os,
             arch: identity.arch,
-            // M6 has no live display surface yet (that is M8); offer false so the
-            // consent page does not promise screen-control we cannot serve.
-            offers_display: false,
+            // Whether this host currently has a probeable display (a real screen or
+            // an Xvfb virtual framebuffer) — mirrors the supervisor's `desktop`
+            // capability so the consent page only promises screen-control we can serve.
+            offers_display,
             // The agent does not request screen control by default (the user's
             // approve-time allow_screen_control is the authoritative consent anyway).
             requests_screen_control: false,
@@ -324,6 +341,10 @@ async fn enroll_with_token(
         .clone()
         .unwrap_or_else(supervisor::hostname_or_default);
 
+    // Probe the live display surface so a display-capable host enrolls as such
+    // (rather than the old M6 hardcode that recorded every machine headless).
+    let offers_display = probe_offers_display().await;
+
     // The exchange carries the same identity fields as the device flow; the
     // workspace_id is unused on this path (it is encoded in the token) but the
     // EnrollmentRequest shape requires it, so pass an empty placeholder.
@@ -332,11 +353,12 @@ async fn enroll_with_token(
         workspace_id: String::new(),
         machine_name,
         offer: EnrollmentOffer {
-            // M6 has no live display surface yet (that is M8); offer false so the
-            // control plane does not record screen-control we cannot serve.
             os: identity.os,
             arch: identity.arch,
-            offers_display: false,
+            // Whether this host currently has a probeable display (a real screen or
+            // an Xvfb virtual framebuffer) — mirrors the supervisor's `desktop`
+            // capability so the control plane only records screen-control we can serve.
+            offers_display,
             // The agent does not request screen control; the token's
             // allow_screen_control (set at mint time) is the authoritative consent.
             requests_screen_control: false,

--- a/apps/api/src/routes/install.ts
+++ b/apps/api/src/routes/install.ts
@@ -178,13 +178,20 @@ export function registerInstallRoutes(app: Hono, deps: ApiRouteDeps): void {
     return new Response(null, { status: 302, headers: { location: redirectUrl } });
   }
 
-  // `latest` → the BAKED binary if present, else the GitHub "latest release" alias.
+  // `latest` → the BAKED binary if present, else the dedicated moving
+  // `agent-latest` GitHub Release. We deliberately do NOT use GitHub's
+  // repo-global `releases/latest` alias here: in this monorepo that alias is
+  // perpetually shadowed by the frequent changesets package releases (e.g.
+  // `@opengeni/contracts@x.y.z`), which carry no agent binaries → 404. The
+  // `agent-latest` release is maintained by .github/workflows/agent-release.yml
+  // as a moving tag that always points at the newest signed mac/windows
+  // binaries (+ checksums, install scripts, minisign pubkey).
   app.get("/agent/latest/:asset", async (c) => {
     const asset = c.req.param("asset");
     if (!ASSET_NAME.test(asset)) {
       throw new HTTPException(400, { message: "invalid asset name" });
     }
-    return serveAsset(asset, `${releasesBase}/latest/download/${asset}`);
+    return serveAsset(asset, `${releasesBase}/download/agent-latest/${asset}`);
   });
 
   // The version segment is the literal `v<ver>` (e.g. `v1.2.3`) — Hono cannot bind

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -97,11 +97,11 @@ describe("get.<domain> install routes", () => {
   // An asset that is NEVER baked (mac universal) always falls through to the
   // GitHub-Releases redirect, so these assertions hold whether or not a Linux
   // binary happens to be baked into the local tree.
-  test("GET /agent/latest/<unbaked-asset> redirects to the GitHub latest-release alias", async () => {
+  test("GET /agent/latest/<unbaked-asset> redirects to the moving agent-latest release", async () => {
     const res = await appFor(testSettings()).request("/agent/latest/opengeni-agent-universal-apple-darwin");
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/latest/download/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-latest/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -118,7 +118,7 @@ describe("get.<domain> install routes", () => {
     const res = await appFor(settings).request("/agent/latest/opengeni-agent-universal-apple-darwin");
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://mirror.example.com/rel/latest/download/opengeni-agent-universal-apple-darwin",
+      "https://mirror.example.com/rel/download/agent-latest/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -195,6 +195,8 @@ describe("get.<domain> install routes — baked binary serving", () => {
   test("an un-baked asset still 302s to GitHub Releases even while another asset is baked", async () => {
     const res = await appFor(testSettings()).request("/agent/latest/opengeni-agent-universal-apple-darwin");
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toContain("/releases/latest/download/opengeni-agent-universal-apple-darwin");
+    expect(res.headers.get("location")).toContain(
+      "/releases/download/agent-latest/opengeni-agent-universal-apple-darwin",
+    );
   });
 });

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -18,13 +18,14 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 
 const CLOUD_SANDBOX_LABEL = "Cloud sandbox";
 
 /** Whether a machine can be a swap target right now (the active one always can,
- *  since selecting it is a harmless no-op; otherwise it must be online). */
+ *  since selecting it is a harmless no-op; otherwise it must be compute-selectable). */
 function isSelectable(machine: MachineView): boolean {
-  return machine.active || machine.state === "online";
+  return machine.active || isMachineComputeSelectable(machine.state);
 }
 
 export function SessionSandboxSwitcher({

--- a/apps/web/src/lib/machine-selectability.test.ts
+++ b/apps/web/src/lib/machine-selectability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { isMachineComputeSelectable } from "./machine-selectability";
+
+// The session "Run on" pickers (sessions-index machine <select> + the in-session
+// sandbox-switcher) gate selectability through this helper. The backend attach
+// gate is liveness-only, so an online-but-headless machine (display_unavailable)
+// must be selectable for compute-only sessions, while consent/offline/reconnecting
+// must stay gated.
+describe("isMachineComputeSelectable", () => {
+  test("a headless online machine (display_unavailable) is selectable", () => {
+    expect(isMachineComputeSelectable("display_unavailable")).toBe(true);
+  });
+
+  test("an online machine is selectable", () => {
+    expect(isMachineComputeSelectable("online")).toBe(true);
+  });
+
+  test("an offline machine is not selectable", () => {
+    expect(isMachineComputeSelectable("offline")).toBe(false);
+  });
+
+  test("consent_required / reconnecting / enrolling stay gated", () => {
+    expect(isMachineComputeSelectable("consent_required")).toBe(false);
+    expect(isMachineComputeSelectable("reconnecting")).toBe(false);
+    expect(isMachineComputeSelectable("enrolling")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/machine-selectability.ts
+++ b/apps/web/src/lib/machine-selectability.ts
@@ -1,0 +1,11 @@
+// Compute-selectability for an enrolled machine in the session "Run on" pickers.
+//
+// The backend create-time attach gate checks LIVENESS only — compute-only
+// sessions (terminal/files/git/exec) are fully supported, so `display_unavailable`
+// means "no desktop stream", NOT "can't attach". A machine is selectable iff its
+// liveness is online: `online` or `display_unavailable`. `consent_required` must
+// still gate (consent), and `offline` / `reconnecting` / `enrolling` genuinely
+// can't attach.
+export function isMachineComputeSelectable(state: string): boolean {
+  return state === "online" || state === "display_unavailable";
+}

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppContext } from "@/context";
 import { useCodexModels } from "@/lib/use-codex-models";
+import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 import { sessionMcpPermissionGroups } from "@/lib/permissions";
 import {
   emptyAdvancedSessionDraft,
@@ -254,7 +255,7 @@ function AdvancedSessionOptions(props: {
               >
                 <option value="">Cloud sandbox</option>
                 {selfhostedMachines.map((machine) => (
-                  <option key={machine.sandboxId} value={machine.sandboxId} disabled={machine.state !== "online"}>
+                  <option key={machine.sandboxId} value={machine.sandboxId} disabled={!isMachineComputeSelectable(machine.state)}>
                     {machine.name}
                     {machine.state !== "online" ? ` (${machine.state})` : ""}
                   </option>


### PR DESCRIPTION
Two self-hosted install/onboarding bugs surfaced from real staging use.

## 1. macOS agent install → 404
`curl .../install.sh | sh` on macOS resolves the asset to `opengeni-agent-universal-apple-darwin` and fetches `<API>/agent/latest/<asset>`, which **302-redirects to GitHub's repo-global `releases/latest/download/` alias**. In this monorepo that alias is permanently shadowed by the frequent changesets package releases (`@opengeni/contracts@x.y.z`), which carry **no agent binaries** → final 404. (Linux works only because it's baked into the API image; the image build is Linux-only, so mac/windows are *designed* to come from a GitHub agent release.) Compounding it: **no `agent-v*` release had ever been cut**.

**Fix:** `/agent/latest/<asset>` now redirects to a dedicated **moving `agent-latest`** release instead of the repo-global alias. `agent-release.yml` maintains it (delete+recreate via `gh` so the tag *moves*, same signed `dist/*` assets, `--latest=false` so it never steals the repo-global latest from changeset releases). The per-version `/agent/v<ver>/` route was already correct. Fixes mac **and** windows.

> Requires an `agent-release.yml` run to publish the first `agent-v<ver>` + `agent-latest` (done as part of shipping this).

## 2. Headless self-hosted VM grayed out in "start a session"
The session machine picker (and in-session swap dropdown) disabled any machine whose `state !== "online"`, so an **online-but-headless** VM showed `(display_unavailable)` and was unselectable. But the backend create-time attach gate checks **liveness only** — compute-only sessions (terminal/files/git/exec) are fully supported; `display_unavailable` means "no desktop *stream*", not "can't attach".

**Fix:** shared `isMachineComputeSelectable(state)` = `online | display_unavailable`; both pickers gate on it, keeping the `(display_unavailable)` suffix as an informational hint. `consent_required` / `offline` / `reconnecting` stay non-selectable.

## 3. Agent display-probe hardcode (latent)
The agent hardcoded `offers_display: false` at **both** enroll sites (an M6 placeholder), so *every* machine — even display-capable ones — was recorded headless. Now probes the live display surface (`resolve_desktop().probe()`, on the blocking pool, mirroring `Supervisor::capabilities`) at enroll. Rides the agent release cut for #1.

## Tests
- `apps/api/test/install.test.ts` — redirect now asserts `…/releases/download/agent-latest/…` (16 pass)
- `apps/web/src/lib/machine-selectability.test.ts` — display_unavailable selectable, offline/consent not (4 pass)
- agent `cargo check -p opengeni-agent` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install redirects and release automation affect how all non-baked agent binaries are fetched; UI and enroll display flags change self-hosted onboarding behavior but are localized with tests.
> 
> **Overview**
> Fixes **macOS/Windows agent install 404s** by pointing `/agent/latest/<asset>` at a dedicated moving **`agent-latest`** GitHub release instead of the repo-global `releases/latest` alias (shadowed by changesets). **`agent-release.yml`** now deletes and recreates that release so the tag and assets stay current, with `--latest=false` so package releases keep the global “latest.”
> 
> **Session “Run on”** pickers (start session + in-session swap) now treat **`display_unavailable`** machines as selectable via **`isMachineComputeSelectable`**, matching backend liveness-only attach for compute-only work; consent/offline/reconnecting stay disabled.
> 
> The **agent** sets **`offers_display`** from a live desktop probe at enroll (device flow and token exchange), replacing the always-false placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7005b262a4d61b5be922a892cc88c94c54d68dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->