### PR TITLE
fix(codex): allowlist request body for the strict ChatGPT backend + fail-loud routing + codex_apps connectors MCP

### DIFF
--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -85,7 +85,20 @@ export function CodexConnectionCard({ workspaceId, canManage }: { workspaceId: s
       const interval = Math.max(2, start.intervalSeconds) * 1000;
       const poll = async (): Promise<void> => {
         if (cancelled.current) return;
-        const result = await client.codexConnectPoll(workspaceId, start.state);
+        // The recursive poll runs detached via setTimeout, so a rejection here
+        // (a 500/502/400 from the poll route) would otherwise be swallowed,
+        // leaving the card stuck on "Waiting for authorization…" forever with no
+        // credential ever persisted. Catch it, surface a toast, and clear pending
+        // so the failure is visible and the user can retry instead of believing
+        // the (OpenAI-side) login worked.
+        let result: Awaited<ReturnType<typeof client.codexConnectPoll>>;
+        try {
+          result = await client.codexConnectPoll(workspaceId, start.state);
+        } catch (error) {
+          setPending(null);
+          toast.error(error instanceof Error ? error.message : "Failed to verify Codex authorization. Try again.");
+          return;
+        }
         if (result.status === "connected") {
           setPending(null);
           toast.success(`Codex connected${result.plan ? ` (${result.plan} plan)` : ""}`);

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -55,7 +55,7 @@ import {
 } from "./common";
 import { maybeCompactContext } from "./context-compaction";
 import { loadWorkspaceEnvironmentForRun, sandboxEnvironmentForRun } from "./environment";
-import { withFirstPartyTools } from "./goals";
+import { withCodexAppsTool, withFirstPartyTools } from "./goals";
 import { resolveWorkspaceAgentInstructions, resolveWorkspacePackRuntime, settingsWithPackSandboxImage } from "./packs";
 import { notifyParentOfChildTerminal } from "./parent-wake";
 import { createSecretRedactor, identityRedactor } from "./redaction";
@@ -446,7 +446,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // the session was created (API, scheduled task, or a pre-existing session
       // whose stored tools predate this) — so set_session_title and the rest are
       // always reachable. Idempotent: mergeToolRefs dedupes if already present.
-      const turnTools = withFirstPartyTools(runSettings, mergeToolRefs(session.tools, turn.tools));
+      // Attach codex_apps (the ChatGPT/Codex connectors MCP) when the codex
+      // overlay injected it into runSettings.mcpServers (active subscription +
+      // connector scopes); no-op for every other turn. Its refreshing bearer is
+      // resolved at connect time from the codex ALS (see the withCodex-wrapped
+      // prepareTools call below).
+      const turnTools = withCodexAppsTool(runSettings, withFirstPartyTools(runSettings, mergeToolRefs(session.tools, turn.tools)));
       const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, runSettings, input.workspaceId, session.environmentId);
       environmentId = workspaceEnvironment?.id ?? "";
       redact = createSecretRedactor(
@@ -587,7 +592,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
 
       const fileResourceDownloads = await sandboxFileDownloadsForRun(runSettings, db, objectStorage, input.workspaceId, turnResources);
       throwIfWorkerShuttingDown();
-      preparedTools = await runtime.prepareTools(runSettings, turnTools, {
+      // Wrap MCP prep in the codex ALS so the codex_apps connect handshake
+      // (initialize + tools/list) can resolve the per-workspace bearer from
+      // codexRequestStorage (runtime/codexAppsMcpRequestInit). withCodex is the
+      // identity on every non-codex turn, so this is a no-op for existing paths.
+      preparedTools = await withCodex(() => runtime.prepareTools(runSettings, turnTools, {
         accountId: input.accountId,
         workspaceId: input.workspaceId,
         sessionId: input.sessionId,
@@ -596,7 +605,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // Manager-style sessions carry a creation-validated permission set
         // for their first-party MCP token; null keeps the fixed default.
         ...(session.firstPartyMcpPermissions?.length ? { firstPartyPermissions: session.firstPartyMcpPermissions } : {}),
-      });
+      }));
       // Genesis turn = the first user turn (no assistant history reconciled
       // yet). Durable Postgres state (countSessionHistoryItems includes
       // superseded rows after compaction), NOT a workflow counter (turnsThisRun

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -3,7 +3,6 @@ import {
   CODEX_APPS_MCP_SERVER_ID,
   CODEX_APPS_MCP_SERVER_NAME,
   CODEX_APPS_MCP_URL,
-  CODEX_APPS_REQUIRED_SCOPES,
   CODEX_APPS_STARTUP_TIMEOUT_MS,
   CODEX_FALLBACK_MODEL_SLUGS,
   CODEX_MODEL_ID_PREFIX,
@@ -39,38 +38,30 @@ export async function settingsWithCodexCredential(db: Database, workspaceId: str
     return settings; // not connected / needs_relogin / error -> leave settings unchanged
   }
   const withProvider = withCodexProvider(settings);
-  // Additive: append the synthetic codex_apps connectors MCP server ONLY when
-  // the credential also carries the connector scopes (no-op otherwise). The
-  // bearer is NOT baked here — it is injected dynamically at connect time from
-  // codexRequestStorage (runtime/codexAppsMcpRequestInit).
-  return withCodexAppsMcpServer(withProvider, status.scopes);
+  // Additive: append the synthetic codex_apps connectors MCP server for ANY
+  // active credential. Connector access is gated SERVER-SIDE per ChatGPT account
+  // (via chatgpt-account-id), NOT by token scopes — confirmed live: a `pro` token
+  // whose only scopes are openid/profile/email/offline_access still lists all 217
+  // connector tools at .../ps/mcp. So we inject unconditionally and let
+  // runtime-discovery decide: an account with no connectors yields an empty
+  // tools/list, and a connect failure best-effort-drops the server without
+  // failing the turn. The bearer is injected dynamically at connect time
+  // (runtime/codexAppsMcpRequestInit).
+  return withCodexAppsMcpServer(withProvider);
 }
 
 /**
- * True only when BOTH connector scopes were granted (browser-authorize path).
- * Device-code logins generally lack them, so this returns false and the apps
- * MCP stays off. Tolerant of extra scopes and arbitrary whitespace delimiters.
+ * Pure: append the synthetic codex_apps MCP server, idempotently. Connector
+ * access is gated SERVER-SIDE per ChatGPT account (chatgpt-account-id), not by
+ * token scopes, so we inject for any active credential and let runtime-discovery
+ * resolve the actual tool set (empty list / dropped server when unavailable).
+ * No secrets here — the refreshing bearer is injected at connect time from
+ * codexRequestStorage (runtime/codexAppsMcpRequestInit). The connectors backend
+ * tolerates serial and parallel tool invocation, so no per-server serialization
+ * is enforced (the SDK exposes no per-server parallel-tool-calls flag in
+ * @openai/agents 0.11.6).
  */
-export function codexConnectorsAvailable(scopes: string | null | undefined): boolean {
-  if (!scopes) {
-    return false;
-  }
-  const granted = new Set(scopes.split(/\s+/).filter(Boolean));
-  return CODEX_APPS_REQUIRED_SCOPES.every((scope) => granted.has(scope));
-}
-
-/**
- * Pure: append the synthetic codex_apps MCP server, idempotently, ONLY when the
- * connector scopes are present. No secrets here — the refreshing bearer is
- * injected at connect time from codexRequestStorage (runtime/mcpServerRequestInit).
- * The connectors backend tolerates serial and parallel tool invocation, so no
- * per-server serialization is enforced (the SDK exposes no per-server
- * parallel-tool-calls flag in @openai/agents 0.11.6).
- */
-export function withCodexAppsMcpServer(settings: Settings, scopes: string | null | undefined): Settings {
-  if (!codexConnectorsAvailable(scopes)) {
-    return settings;
-  }
+export function withCodexAppsMcpServer(settings: Settings): Settings {
   if (settings.mcpServers.some((server) => server.id === CODEX_APPS_MCP_SERVER_ID)) {
     return settings; // already injected
   }

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -1,5 +1,10 @@
 import { environmentsEncryptionKeyBytes, parseModelProvidersJson, type RegistryProvider, type Settings } from "@opengeni/config";
 import {
+  CODEX_APPS_MCP_SERVER_ID,
+  CODEX_APPS_MCP_SERVER_NAME,
+  CODEX_APPS_MCP_URL,
+  CODEX_APPS_REQUIRED_SCOPES,
+  CODEX_APPS_STARTUP_TIMEOUT_MS,
   CODEX_FALLBACK_MODEL_SLUGS,
   CODEX_MODEL_ID_PREFIX,
   CODEX_PROVIDER_BASE_URL,
@@ -33,7 +38,58 @@ export async function settingsWithCodexCredential(db: Database, workspaceId: str
   if (!status || status.status !== "active") {
     return settings; // not connected / needs_relogin / error -> leave settings unchanged
   }
-  return withCodexProvider(settings);
+  const withProvider = withCodexProvider(settings);
+  // Additive: append the synthetic codex_apps connectors MCP server ONLY when
+  // the credential also carries the connector scopes (no-op otherwise). The
+  // bearer is NOT baked here — it is injected dynamically at connect time from
+  // codexRequestStorage (runtime/codexAppsMcpRequestInit).
+  return withCodexAppsMcpServer(withProvider, status.scopes);
+}
+
+/**
+ * True only when BOTH connector scopes were granted (browser-authorize path).
+ * Device-code logins generally lack them, so this returns false and the apps
+ * MCP stays off. Tolerant of extra scopes and arbitrary whitespace delimiters.
+ */
+export function codexConnectorsAvailable(scopes: string | null | undefined): boolean {
+  if (!scopes) {
+    return false;
+  }
+  const granted = new Set(scopes.split(/\s+/).filter(Boolean));
+  return CODEX_APPS_REQUIRED_SCOPES.every((scope) => granted.has(scope));
+}
+
+/**
+ * Pure: append the synthetic codex_apps MCP server, idempotently, ONLY when the
+ * connector scopes are present. No secrets here — the refreshing bearer is
+ * injected at connect time from codexRequestStorage (runtime/mcpServerRequestInit).
+ * The connectors backend tolerates serial and parallel tool invocation, so no
+ * per-server serialization is enforced (the SDK exposes no per-server
+ * parallel-tool-calls flag in @openai/agents 0.11.6).
+ */
+export function withCodexAppsMcpServer(settings: Settings, scopes: string | null | undefined): Settings {
+  if (!codexConnectorsAvailable(scopes)) {
+    return settings;
+  }
+  if (settings.mcpServers.some((server) => server.id === CODEX_APPS_MCP_SERVER_ID)) {
+    return settings; // already injected
+  }
+  return {
+    ...settings,
+    mcpServers: [
+      ...settings.mcpServers,
+      {
+        id: CODEX_APPS_MCP_SERVER_ID,
+        name: CODEX_APPS_MCP_SERVER_NAME,
+        url: CODEX_APPS_MCP_URL,
+        timeoutMs: CODEX_APPS_STARTUP_TIMEOUT_MS,
+        // Connector availability is per-credential and must re-discover each
+        // run; never poison a process-global tools-list cache.
+        cacheToolsList: false,
+        // deliberately NO `headers` — the refreshing bearer is dynamic
+      },
+    ],
+  };
 }
 
 /** Pure: append the synthetic codex-subscription provider, idempotently. */

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -214,6 +214,20 @@ export function withFirstPartyTools(settings: Settings, tools: ToolRef[]): ToolR
 }
 
 /**
+ * Ensures a turn references the synthetic codex_apps connectors MCP server when
+ * the codex overlay injected it (active subscription + connector scopes). A
+ * registry entry is inert until a ToolRef references its id, so this wires the
+ * server into the run. No-op when the server is not configured (every non-codex
+ * turn), and idempotent via mergeToolRefs.
+ */
+export function withCodexAppsTool(settings: Settings, tools: ToolRef[]): ToolRef[] {
+  if (!settings.mcpServers.some((server) => server.id === "codex_apps")) {
+    return tools;
+  }
+  return mergeToolRefs(tools, [{ kind: "mcp", id: "codex_apps" }]);
+}
+
+/**
  * Non-throwing variant of the scheduled-run admission check: returns a human
  * readable reason when balance or monthly caps block another agent run.
  */

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { parseModelProvidersJson } from "@opengeni/config";
+import * as opengeniDb from "@opengeni/db";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
 import {
@@ -118,26 +119,26 @@ describe("settingsWithCodexCredential", () => {
 });
 
 /**
- * Swaps @opengeni/db's getCodexCredentialStatus (the ONLY db read on the overlay
- * path) for a stub, so settingsWithCodexCredential can be exercised end-to-end
- * without a live Postgres. Returns a restorer that reinstates the real module.
+ * Spies on @opengeni/db's getCodexCredentialStatus (the ONLY db read on the
+ * overlay path) so settingsWithCodexCredential can be exercised end-to-end
+ * without a live Postgres. Uses spyOn (NOT mock.module) deliberately: mock.module
+ * registers a PROCESS-GLOBAL override that bleeds into other test files in the
+ * same `bun test` run (notably packages/db's codex_subscription_credentials
+ * integration test) and is NOT undone by mock.restore(). spyOn is scoped to the
+ * namespace and the returned restorer fully reinstates the real implementation.
  */
 function mockCredentialStatus(overrides: { status: string; scopes: string | null }): () => void {
-  const actual = require("@opengeni/db");
-  mock.module("@opengeni/db", () => ({
-    ...actual,
-    getCodexCredentialStatus: async () => ({
-      connected: overrides.status === "active",
-      chatgptAccountId: "acct-1",
-      scopes: overrides.scopes,
-      planType: "pro",
-      status: overrides.status,
-      expiresAt: null,
-      lastRefreshAt: null,
-      lastError: null,
-    }),
-  }));
+  const spy = spyOn(opengeniDb, "getCodexCredentialStatus").mockResolvedValue({
+    connected: overrides.status === "active",
+    chatgptAccountId: "acct-1",
+    scopes: overrides.scopes,
+    planType: "pro",
+    status: overrides.status,
+    expiresAt: null,
+    lastRefreshAt: null,
+    lastError: null,
+  } as Awaited<ReturnType<typeof opengeniDb.getCodexCredentialStatus>>);
   return () => {
-    mock.module("@opengeni/db", () => actual);
+    spy.mockRestore();
   };
 }

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -3,7 +3,6 @@ import { parseModelProvidersJson } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
 import {
-  codexConnectorsAvailable,
   settingsWithCodexCredential,
   withCodexAppsMcpServer,
   withCodexProvider,
@@ -41,28 +40,13 @@ describe("withCodexProvider", () => {
   });
 });
 
-describe("codexConnectorsAvailable", () => {
-  test("true only when BOTH connector scopes are granted", () => {
-    expect(codexConnectorsAvailable(BOTH_SCOPES)).toBe(true);
-    expect(codexConnectorsAvailable("api.connectors.read")).toBe(false);
-    expect(codexConnectorsAvailable("api.connectors.invoke")).toBe(false);
-  });
-
-  test("tolerates extra scopes and arbitrary whitespace delimiters", () => {
-    expect(codexConnectorsAvailable("openid  api.connectors.read\tapi.connectors.invoke\nprofile")).toBe(true);
-  });
-
-  test("false for null, empty, or undefined scopes (device-code path gate)", () => {
-    expect(codexConnectorsAvailable(null)).toBe(false);
-    expect(codexConnectorsAvailable("")).toBe(false);
-    expect(codexConnectorsAvailable(undefined)).toBe(false);
-  });
-});
-
 describe("withCodexAppsMcpServer", () => {
+  // Connector access is gated SERVER-SIDE per ChatGPT account (chatgpt-account-id),
+  // NOT by token scopes — so injection is unconditional for any active credential
+  // and the actual tool set is discovered at runtime.
   test("appends exactly one codex_apps entry with the right metadata and NO headers", () => {
     const settings = testSettings({ mcpServers: [] });
-    const result = withCodexAppsMcpServer(settings, BOTH_SCOPES);
+    const result = withCodexAppsMcpServer(settings);
     const apps = result.mcpServers.filter((s) => s.id === "codex_apps");
     expect(apps).toHaveLength(1);
     const entry = apps[0]!;
@@ -74,23 +58,15 @@ describe("withCodexAppsMcpServer", () => {
   });
 
   test("is idempotent — a second call does not double-inject", () => {
-    const once = withCodexAppsMcpServer(testSettings({ mcpServers: [] }), BOTH_SCOPES);
-    const twice = withCodexAppsMcpServer(once, BOTH_SCOPES);
+    const once = withCodexAppsMcpServer(testSettings({ mcpServers: [] }));
+    const twice = withCodexAppsMcpServer(once);
     expect(twice).toBe(once); // same reference, no change
     expect(twice.mcpServers.filter((s) => s.id === "codex_apps")).toHaveLength(1);
   });
 
-  test("is a no-op when scopes are null, empty, or missing one connector scope", () => {
-    for (const scopes of [null, "", "api.connectors.read"]) {
-      const settings = testSettings({ mcpServers: [] });
-      const result = withCodexAppsMcpServer(settings, scopes);
-      expect(result).toBe(settings); // same reference, nothing injected
-    }
-  });
-
   test("preserves pre-existing mcp servers", () => {
     const settings = testSettings({ mcpServers: [{ id: "opengeni", name: "OpenGeni", url: "http://x/mcp", cacheToolsList: false }] });
-    const result = withCodexAppsMcpServer(settings, BOTH_SCOPES);
+    const result = withCodexAppsMcpServer(settings);
     const ids = result.mcpServers.map((s) => s.id);
     expect(ids).toContain("opengeni");
     expect(ids).toContain("codex_apps");
@@ -104,13 +80,14 @@ describe("settingsWithCodexCredential", () => {
     expect(result).toBe(settings); // same reference, no db access
   });
 
-  test("active credential WITHOUT connector scopes => provider injected, no codex_apps server", async () => {
+  test("active credential WITHOUT connector scopes => provider AND codex_apps server (scopes do not gate)", async () => {
     const restore = mockCredentialStatus({ status: "active", scopes: null });
     try {
       const settings = testSettings({ codexSubscriptionEnabled: true, modelProvidersJson: "[]", mcpServers: [] });
       const result = await settingsWithCodexCredential({} as unknown as Database, "ws_1", settings);
       expect(parseModelProvidersJson(result.modelProvidersJson).some((p) => p.id === "codex-subscription")).toBe(true);
-      expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(false);
+      // Connectors are account-gated server-side; a scope-less pro token still lists tools.
+      expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(true);
     } finally {
       restore();
     }

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { parseModelProvidersJson } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
-import { settingsWithCodexCredential, withCodexProvider } from "../src/activities/capabilities";
+import {
+  codexConnectorsAvailable,
+  settingsWithCodexCredential,
+  withCodexAppsMcpServer,
+  withCodexProvider,
+} from "../src/activities/capabilities";
+
+const BOTH_SCOPES = "api.connectors.read api.connectors.invoke";
 
 describe("withCodexProvider", () => {
   test("appends one codex-subscription provider with namespaced models", () => {
@@ -34,10 +41,126 @@ describe("withCodexProvider", () => {
   });
 });
 
+describe("codexConnectorsAvailable", () => {
+  test("true only when BOTH connector scopes are granted", () => {
+    expect(codexConnectorsAvailable(BOTH_SCOPES)).toBe(true);
+    expect(codexConnectorsAvailable("api.connectors.read")).toBe(false);
+    expect(codexConnectorsAvailable("api.connectors.invoke")).toBe(false);
+  });
+
+  test("tolerates extra scopes and arbitrary whitespace delimiters", () => {
+    expect(codexConnectorsAvailable("openid  api.connectors.read\tapi.connectors.invoke\nprofile")).toBe(true);
+  });
+
+  test("false for null, empty, or undefined scopes (device-code path gate)", () => {
+    expect(codexConnectorsAvailable(null)).toBe(false);
+    expect(codexConnectorsAvailable("")).toBe(false);
+    expect(codexConnectorsAvailable(undefined)).toBe(false);
+  });
+});
+
+describe("withCodexAppsMcpServer", () => {
+  test("appends exactly one codex_apps entry with the right metadata and NO headers", () => {
+    const settings = testSettings({ mcpServers: [] });
+    const result = withCodexAppsMcpServer(settings, BOTH_SCOPES);
+    const apps = result.mcpServers.filter((s) => s.id === "codex_apps");
+    expect(apps).toHaveLength(1);
+    const entry = apps[0]!;
+    expect(entry.name).toBe("codex_apps");
+    expect(entry.url).toBe("https://chatgpt.com/backend-api/ps/mcp");
+    expect(entry.timeoutMs).toBe(30000);
+    expect(entry.cacheToolsList).toBe(false);
+    expect("headers" in entry).toBe(false); // refreshing bearer is dynamic, never baked
+  });
+
+  test("is idempotent — a second call does not double-inject", () => {
+    const once = withCodexAppsMcpServer(testSettings({ mcpServers: [] }), BOTH_SCOPES);
+    const twice = withCodexAppsMcpServer(once, BOTH_SCOPES);
+    expect(twice).toBe(once); // same reference, no change
+    expect(twice.mcpServers.filter((s) => s.id === "codex_apps")).toHaveLength(1);
+  });
+
+  test("is a no-op when scopes are null, empty, or missing one connector scope", () => {
+    for (const scopes of [null, "", "api.connectors.read"]) {
+      const settings = testSettings({ mcpServers: [] });
+      const result = withCodexAppsMcpServer(settings, scopes);
+      expect(result).toBe(settings); // same reference, nothing injected
+    }
+  });
+
+  test("preserves pre-existing mcp servers", () => {
+    const settings = testSettings({ mcpServers: [{ id: "opengeni", name: "OpenGeni", url: "http://x/mcp", cacheToolsList: false }] });
+    const result = withCodexAppsMcpServer(settings, BOTH_SCOPES);
+    const ids = result.mcpServers.map((s) => s.id);
+    expect(ids).toContain("opengeni");
+    expect(ids).toContain("codex_apps");
+  });
+});
+
 describe("settingsWithCodexCredential", () => {
   test("is a no-op when the feature is disabled (never touches the db)", async () => {
     const settings = testSettings({ codexSubscriptionEnabled: false, modelProvidersJson: "[]" });
     const result = await settingsWithCodexCredential(undefined as unknown as Database, "ws_1", settings);
     expect(result).toBe(settings); // same reference, no db access
   });
+
+  test("active credential WITHOUT connector scopes => provider injected, no codex_apps server", async () => {
+    const restore = mockCredentialStatus({ status: "active", scopes: null });
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true, modelProvidersJson: "[]", mcpServers: [] });
+      const result = await settingsWithCodexCredential({} as unknown as Database, "ws_1", settings);
+      expect(parseModelProvidersJson(result.modelProvidersJson).some((p) => p.id === "codex-subscription")).toBe(true);
+      expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("active credential WITH connector scopes => both provider and codex_apps server", async () => {
+    const restore = mockCredentialStatus({ status: "active", scopes: BOTH_SCOPES });
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true, modelProvidersJson: "[]", mcpServers: [] });
+      const result = await settingsWithCodexCredential({} as unknown as Database, "ws_1", settings);
+      expect(parseModelProvidersJson(result.modelProvidersJson).some((p) => p.id === "codex-subscription")).toBe(true);
+      expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  test("inactive credential => nothing new (no codex_apps server)", async () => {
+    const restore = mockCredentialStatus({ status: "needs_relogin", scopes: BOTH_SCOPES });
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true, modelProvidersJson: "[]", mcpServers: [] });
+      const result = await settingsWithCodexCredential({} as unknown as Database, "ws_1", settings);
+      expect(result).toBe(settings); // untouched
+    } finally {
+      restore();
+    }
+  });
 });
+
+/**
+ * Swaps @opengeni/db's getCodexCredentialStatus (the ONLY db read on the overlay
+ * path) for a stub, so settingsWithCodexCredential can be exercised end-to-end
+ * without a live Postgres. Returns a restorer that reinstates the real module.
+ */
+function mockCredentialStatus(overrides: { status: string; scopes: string | null }): () => void {
+  const actual = require("@opengeni/db");
+  mock.module("@opengeni/db", () => ({
+    ...actual,
+    getCodexCredentialStatus: async () => ({
+      connected: overrides.status === "active",
+      chatgptAccountId: "acct-1",
+      scopes: overrides.scopes,
+      planType: "pro",
+      status: overrides.status,
+      expiresAt: null,
+      lastRefreshAt: null,
+      lastError: null,
+    }),
+  }));
+  return () => {
+    mock.module("@opengeni/db", () => actual);
+  };
+}

--- a/apps/worker/test/goals.test.ts
+++ b/apps/worker/test/goals.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { isSteerInterrupt } from "../src/activities/goals";
+import { testSettings } from "@opengeni/testing";
+import type { ToolRef } from "@opengeni/contracts";
+import { isSteerInterrupt, withCodexAppsTool } from "../src/activities/goals";
 
 // The steer-vs-stop ruling: a `user.interrupt` tagged `reason: "steer"`
 // (sent by OpenGeniClient.steerMessage) redirects the work instead of
@@ -20,5 +22,29 @@ describe("isSteerInterrupt", () => {
     expect(isSteerInterrupt({ type: "user.message", payload: { reason: "steer" } })).toBe(false);
     expect(isSteerInterrupt(null)).toBe(false);
     expect(isSteerInterrupt(undefined)).toBe(false);
+  });
+});
+
+describe("withCodexAppsTool", () => {
+  const appsServer = { id: "codex_apps", name: "codex_apps", url: "https://chatgpt.com/backend-api/ps/mcp", cacheToolsList: false };
+
+  test("appends the codex_apps ToolRef when the server is configured", () => {
+    const settings = testSettings({ mcpServers: [appsServer] });
+    const result = withCodexAppsTool(settings, []);
+    expect(result).toContainEqual({ kind: "mcp", id: "codex_apps" });
+  });
+
+  test("is a no-op when the codex_apps server is not configured (every non-codex turn)", () => {
+    const settings = testSettings({ mcpServers: [] });
+    const tools: ToolRef[] = [{ kind: "mcp", id: "opengeni" }];
+    const result = withCodexAppsTool(settings, tools);
+    expect(result).toBe(tools); // same reference, untouched
+  });
+
+  test("is idempotent — does not double-add when already present", () => {
+    const settings = testSettings({ mcpServers: [appsServer] });
+    const once = withCodexAppsTool(settings, []);
+    const twice = withCodexAppsTool(settings, once);
+    expect(twice.filter((t) => t.kind === "mcp" && t.id === "codex_apps")).toHaveLength(1);
   });
 });

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -43,3 +43,15 @@ export const CODEX_CLIENT_VERSION = "0.142.4";
 
 export const CODEX_REFRESH_WINDOW_MS = 5 * 60 * 1000; // proactive refresh when within 5 min of exp (spec §1.1)
 export const CODEX_REFRESH_FALLBACK_MS = 8 * 24 * 60 * 60 * 1000; // 8 days when exp is unparseable
+
+// ── Apps / connectors MCP (spec §1.10, §E) ───────────────────────────────────
+// One server-side MCP exposes ALL the user's ChatGPT/Codex connectors
+// (gmail/github/linear/slack/sentry/drive/calendar/…). Streamable HTTP, always.
+export const CODEX_APPS_MCP_SERVER_ID = "codex_apps";        // tools surface as mcp__codex_apps__<tool>
+export const CODEX_APPS_MCP_SERVER_NAME = "codex_apps";      // MCP `name` — MUST equal the id so the SDK namespaces tools as mcp__codex_apps__*
+export const CODEX_APPS_MCP_URL = "https://chatgpt.com/backend-api/ps/mcp"; // live URL (NOT /codex, NOT the legacy /wham/apps)
+export const CODEX_APPS_STARTUP_TIMEOUT_MS = 30_000;         // startup_timeout 30s (spec §1.10) — maps to timeoutMs on this server only
+// Connector scopes that the apps MCP requires. Present ONLY when granted at
+// browser-authorize time; the device-code path CANNOT be confirmed to grant
+// them, so treat connector availability as runtime-discovered (spec §1.10 / §E).
+export const CODEX_APPS_REQUIRED_SCOPES = ["api.connectors.read", "api.connectors.invoke"] as const;

--- a/packages/codex/src/normalize.ts
+++ b/packages/codex/src/normalize.ts
@@ -13,6 +13,28 @@
 
 const MINIMAL = "minimal";
 
+// The ChatGPT/Codex backend is a STRICT ALLOWLIST: it 400s on ANY top-level field
+// the Codex CLI itself does not send (confirmed live against the backend —
+// "Unsupported parameter: temperature / top_p / metadata / previous_response_id /
+// logprobs / service_tier / user / safety_identifier / truncation / max_tool_calls /
+// background / conversation", and "Unsupported tool type: mcp"). Our @openai/agents
+// stack adds several of these, so after our transforms we keep ONLY the codex
+// Responses payload fields (CODEX-SUBSCRIPTION-SPEC §1 field table).
+const CODEX_ALLOWED_TOP_LEVEL_KEYS = new Set<string>([
+  "model",
+  "instructions",
+  "input",
+  "tools",
+  "tool_choice",
+  "parallel_tool_calls",
+  "reasoning",
+  "store",
+  "stream",
+  "include",
+  "prompt_cache_key",
+  "text",
+]);
+
 /** Mutates a parsed Responses request body in place and returns it. Pure + synchronous + unit-testable. */
 export function normalizeCodexRequestBody(
   body: Record<string, unknown>,
@@ -20,8 +42,6 @@ export function normalizeCodexRequestBody(
 ): Record<string, unknown> {
   body.store = false; // ChatGPT backend REQUIRES store=false (spec §1.3)
   body.stream = true; // ChatGPT backend REQUIRES stream=true (confirmed live: 400 "Stream must be set to true").
-  delete body.max_output_tokens; // rejected -> strip (spec §1.3)
-  delete body.max_completion_tokens;
 
   // include MUST contain reasoning.encrypted_content (stateless continuity, spec §1.6)
   const include = Array.isArray(body.include) ? (body.include as unknown[]).filter((v): v is string => typeof v === "string") : [];
@@ -47,6 +67,24 @@ export function normalizeCodexRequestBody(
       if (item && typeof item === "object" && "id" in item) {
         delete (item as Record<string, unknown>).id;
       }
+    }
+  }
+
+  // Drop hosted-MCP tool entries: the backend rejects them ("Unsupported tool
+  // type: mcp"). OpenGeni's MCP servers are client-connected, so their tools
+  // already arrive as `function` tools — this only sheds a stray `mcp` entry.
+  if (Array.isArray(body.tools)) {
+    body.tools = (body.tools as unknown[]).filter(
+      (t) => !(t && typeof t === "object" && (t as Record<string, unknown>).type === "mcp"),
+    );
+  }
+
+  // Final allowlist: shed every other top-level field our @openai/agents stack
+  // may have added (temperature, top_p, metadata, previous_response_id,
+  // max_output_tokens, truncation, …) so the strict backend does not 400.
+  for (const key of Object.keys(body)) {
+    if (!CODEX_ALLOWED_TOP_LEVEL_KEYS.has(key)) {
+      delete body[key];
     }
   }
   return body;

--- a/packages/codex/test/normalize.test.ts
+++ b/packages/codex/test/normalize.test.ts
@@ -60,6 +60,54 @@ describe("normalizeCodexRequestBody", () => {
     expect(body.text).toEqual(original.text);
   });
 
+  test("allowlists top-level fields: strips everything the strict backend rejects", () => {
+    const body = normalizeCodexRequestBody({
+      model: "gpt-5.5",
+      instructions: "be helpful",
+      input: [{ type: "message", role: "user", content: [] }],
+      tools: [{ type: "function", name: "f" }],
+      tool_choice: "auto",
+      parallel_tool_calls: true,
+      reasoning: { effort: "medium" },
+      text: { verbosity: "low" },
+      prompt_cache_key: "thread_1",
+      // All of these are rejected by the ChatGPT/Codex backend (confirmed live:
+      // "Unsupported parameter: …" / "Unsupported service_tier") and MUST be stripped.
+      temperature: 0.7,
+      top_p: 0.9,
+      metadata: { a: "b" },
+      previous_response_id: "resp_123",
+      logprobs: true,
+      top_logprobs: 5,
+      service_tier: "auto",
+      user: "u",
+      safety_identifier: "s",
+      truncation: "auto",
+      max_tool_calls: 10,
+      background: false,
+      conversation: "conv_1",
+    }, identity);
+    for (const k of ["model", "instructions", "input", "tools", "tool_choice", "parallel_tool_calls", "reasoning", "store", "stream", "include", "prompt_cache_key", "text"]) {
+      expect(k in body).toBe(true); // allowlisted -> kept
+    }
+    for (const k of ["temperature", "top_p", "metadata", "previous_response_id", "logprobs", "top_logprobs", "service_tier", "user", "safety_identifier", "truncation", "max_tool_calls", "background", "conversation"]) {
+      expect(k in body).toBe(false); // not on the allowlist -> stripped
+    }
+  });
+
+  test("drops hosted-MCP tool entries (Unsupported tool type: mcp), keeps function tools", () => {
+    const body = normalizeCodexRequestBody({
+      tools: [
+        { type: "function", name: "keep_me" },
+        { type: "mcp", server_label: "x", server_url: "https://x/mcp" },
+        { type: "function", name: "keep_me_too" },
+      ],
+    }, identity);
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools.map((t) => t.type)).toEqual(["function", "function"]);
+    expect(tools.map((t) => t.name)).toEqual(["keep_me", "keep_me_too"]);
+  });
+
   test("applies the model resolver to body.model", () => {
     const body = normalizeCodexRequestBody({ model: "gpt-5.2-codex-high" }, buildModelResolver(["gpt-5.2-codex", "gpt-5.5"], "gpt-5.5"));
     expect(body.model).toBe("gpt-5.2-codex");

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
-import { CODEX_APPS_MCP_SERVER_ID, CODEX_MODEL_ID_PREFIX, codexRequestStorage, codexSubscriptionFetch } from "@opengeni/codex";
+import { CODEX_APPS_MCP_SERVER_ID, CODEX_MODEL_ID_PREFIX, CODEX_ORIGINATOR, codexRequestStorage, codexSubscriptionFetch } from "@opengeni/codex";
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -995,6 +995,13 @@ async function codexAppsMcpRequestInit(settings: Settings): Promise<{ requestIni
   }
   const headers: Record<string, string> = {
     authorization: `Bearer ${token.accessToken}`,
+    // The ChatGPT backend sits behind Cloudflare, which 403s requests bearing a
+    // default runtime User-Agent (confirmed live: an HTML bot-block page, NOT an
+    // auth failure). Send the codex client identity — the same originator/version/
+    // User-Agent the model fetch uses — so the MCP connect handshake passes the edge.
+    originator: CODEX_ORIGINATOR,
+    "user-agent": `${CODEX_ORIGINATOR}/${ctx.clientVersion}`,
+    version: ctx.clientVersion,
   };
   if (token.chatgptAccountId) {
     headers["chatgpt-account-id"] = token.chatgptAccountId;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
-import { CODEX_MODEL_ID_PREFIX, codexSubscriptionFetch } from "@opengeni/codex";
+import { CODEX_APPS_MCP_SERVER_ID, CODEX_MODEL_ID_PREFIX, codexRequestStorage, codexSubscriptionFetch } from "@opengeni/codex";
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -887,7 +887,7 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       throw new Error(`Unknown MCP server id: ${tool.id}`);
     }
     const url = firstPartyMcpServerUrlForRun(settings, config, options.workspaceId) ?? config.url;
-    return new PrefixedMcpServer(new MCPServerStreamableHttp({
+    const server = new PrefixedMcpServer(new MCPServerStreamableHttp({
       url,
       name: config.name ?? config.id,
       cacheToolsList: config.cacheToolsList,
@@ -897,20 +897,42 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
         clientSessionTimeoutSeconds: Math.ceil(config.timeoutMs / 1000),
       } : {}),
     }), config.id, config.allowedTools);
+    // codex_apps connector availability is RUNTIME-DISCOVERED: the device-code
+    // login may lack the connector scopes, and the backend can reject the bearer
+    // at the initialize/tools-list handshake. Connect it best-effort so a 401/403
+    // (or a missing/failed token) drops the server rather than failing the turn.
+    return { server, bestEffort: isCodexAppsMcpServer(config) };
   }));
-  const connected = await connectMcpServers(servers, {
+  const requiredServers = servers.filter((entry) => !entry.bestEffort).map((entry) => entry.server);
+  const bestEffortServers = servers.filter((entry) => entry.bestEffort).map((entry) => entry.server);
+  const connectedRequired = await connectMcpServers(requiredServers, {
     connectInParallel: true,
     strict: true,
   });
+  const connectedBestEffort = bestEffortServers.length
+    ? await connectMcpServers(bestEffortServers, {
+        connectInParallel: true,
+        strict: false,
+      })
+    : null;
   return {
-    mcpServers: connected.active,
+    mcpServers: [...connectedRequired.active, ...(connectedBestEffort?.active ?? [])],
     close: async () => {
-      await connected.close();
+      await connectedRequired.close();
+      if (connectedBestEffort) {
+        await connectedBestEffort.close();
+      }
     },
   };
 }
 
 async function mcpServerRequestInit(settings: Settings, config: Settings["mcpServers"][number], options: PrepareToolsOptions): Promise<{ requestInit: { headers: Record<string, string> } } | {}> {
+  // codex_apps is checked FIRST so the static-headers path can never apply to
+  // it: its refreshing ChatGPT/Codex bearer is resolved per-connect from the
+  // codex ALS, never from a baked `config.headers` value.
+  if (isCodexAppsMcpServer(config)) {
+    return await codexAppsMcpRequestInit(settings);
+  }
   if (isFirstPartyMcpServer(settings, config)) {
     return await firstPartyMcpRequestInit(settings, config, options);
   }
@@ -952,6 +974,37 @@ async function firstPartyMcpRequestInit(settings: Settings, config: Settings["mc
   };
 }
 
+/**
+ * Builds the connect-time auth headers for the codex_apps connectors MCP. The
+ * bearer is resolved from codexRequestStorage — the SAME refreshing token source
+ * the model fetch uses (proactive refresh + single-flight + db persist) — so the
+ * token is valid at connect. A missing store (non-codex turn, or prepareTools
+ * ran outside the ALS) or a token failure (needs_relogin) returns {} so the
+ * best-effort connect drops the server rather than crashing the turn.
+ */
+async function codexAppsMcpRequestInit(settings: Settings): Promise<{ requestInit: { headers: Record<string, string> } } | {}> {
+  const ctx = codexRequestStorage.getStore();
+  if (!ctx) {
+    return {};
+  }
+  let token;
+  try {
+    token = await ctx.getToken();
+  } catch {
+    return {};
+  }
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${token.accessToken}`,
+  };
+  if (token.chatgptAccountId) {
+    headers["chatgpt-account-id"] = token.chatgptAccountId;
+  }
+  if (settings.codexProductSku) {
+    headers["X-OpenAI-Product-Sku"] = settings.codexProductSku;
+  }
+  return { requestInit: { headers } };
+}
+
 // The first-party MCP permission set signed into a worker's delegated token
 // when the session does not specify its own. POWERFUL BY DEFAULT: it carries
 // every permission that unlocks a first-party tool — session orchestration
@@ -976,6 +1029,14 @@ const firstPartyMcpPermissions: Permission[] = [
   "environments:manage",
   "github:use",
 ];
+
+// codex_apps is third-party-by-trust (the external ChatGPT connectors backend)
+// but needs DYNAMIC auth, so it is its own category — deliberately NOT folded
+// into the first-party allowlist, which would wrongly sign an OpenGeni delegated
+// token to chatgpt.com.
+function isCodexAppsMcpServer(config: Settings["mcpServers"][number]): boolean {
+  return config.id === CODEX_APPS_MCP_SERVER_ID;
+}
 
 function isFirstPartyMcpServer(settings: Settings, config: Settings["mcpServers"][number]): boolean {
   if (!["opengeni", "files", "docs"].includes(config.id)) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
-import { codexSubscriptionFetch } from "@opengeni/codex";
+import { CODEX_MODEL_ID_PREFIX, codexSubscriptionFetch } from "@opengeni/codex";
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -416,12 +416,45 @@ export class MultiProviderModelProvider implements ModelProvider {
       if (resolved) {
         return resolved.model;
       }
+      // A `codex/<slug>` id only resolves when the per-workspace worker overlay
+      // (settingsWithCodexCredential) has injected the synthetic codex-subscription
+      // provider — which it does ONLY for a workspace with an *active* connected
+      // Codex subscription. If it did not resolve, the subscription is not
+      // connected for this workspace, so the codex provider is absent. Falling
+      // through to the built-in OpenAIProvider below would ship `codex/<slug>` to
+      // the global default (Azure) client as a deployment name and surface a
+      // misleading "DeploymentNotFound" 404. Throw a clear, user-actionable error
+      // instead; it propagates through the worker's agentRunFailurePayload as the
+      // turn.failed message the session UI shows. Mirrors the codex-prefix
+      // awareness of assertConfiguredModel at apps/api/src/domain/sessions.ts.
+      if (modelName.startsWith(CODEX_MODEL_ID_PREFIX)) {
+        throw new CodexSubscriptionUnavailableError(modelName);
+      }
     }
-    // A model in no provider's allow-list falls back to the SDK's default
-    // OpenAIProvider, which uses the global default client/key configureOpenAI
-    // set up (the built-in OpenAI/Azure provider).
+    // A non-codex model in no provider's allow-list falls back to the SDK's
+    // default OpenAIProvider, which uses the global default client/key
+    // configureOpenAI set up (the built-in OpenAI/Azure provider).
     this.fallback ??= new OpenAIProvider();
     return this.fallback.getModel(modelName);
+  }
+}
+
+/**
+ * A `codex/<slug>` turn reached the model router but the workspace has no active
+ * Codex subscription connected (the worker overlay never injected the synthetic
+ * provider, so resolveTurnModel returned nothing). Thrown instead of silently
+ * routing the id to the built-in Azure/OpenAI client — that produced an opaque
+ * "DeploymentNotFound" 404. The message is user-actionable (connect/reconnect)
+ * and carries no status/code, so agentRunFailurePayload surfaces it verbatim as
+ * a non-retryable turn.failed the session UI shows.
+ */
+export class CodexSubscriptionUnavailableError extends Error {
+  constructor(modelName: string) {
+    super(
+      `Codex subscription model "${modelName}" is unavailable: no active Codex subscription is connected for this workspace. `
+      + `Connect (or reconnect) your ChatGPT/Codex subscription in Settings, then retry.`,
+    );
+    this.name = "CodexSubscriptionUnavailableError";
   }
 }
 

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -3,7 +3,7 @@ import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents
 import { configuredProviders, resolveModelProvider, type ResolvedModelProvider } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import OpenAI from "openai";
-import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, MultiProviderModelProvider, resolveTurnModel } from "../src/index";
+import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, CodexSubscriptionUnavailableError, MultiProviderModelProvider, resolveTurnModel } from "../src/index";
 
 // A host exposing the built-in OpenAI provider plus Fireworks (the `chat` wire
 // API) serving GLM 5.2, mirroring the canonical example in
@@ -200,6 +200,34 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
     expect(glm).toBeInstanceOf(OpenAIChatCompletionsModel);
     const builtin = await provider.getModel("gpt-5.5");
     expect(builtin).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("a codex/<slug> id with NO codex provider in settings throws the actionable error (NOT an Azure fallback)", async () => {
+    // The staging failure: codex_subscription_credentials empty → the worker
+    // overlay never injects the codex provider → resolveTurnModel returns null
+    // for "codex/gpt-5.5". The router must NOT fall through to the built-in
+    // (Azure) client (which 404'd with "DeploymentNotFound"); it must throw a
+    // user-actionable error telling the user to connect their subscription.
+    const settings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+    });
+    const provider = new MultiProviderModelProvider(settings);
+    let thrown: unknown;
+    try {
+      await provider.getModel("codex/gpt-5.5");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(CodexSubscriptionUnavailableError);
+    expect((thrown as Error).message).toContain("codex/gpt-5.5");
+    expect((thrown as Error).message).toContain("Codex subscription");
+    expect((thrown as Error).message).toContain("Settings");
+    // No status/code → agentRunFailurePayload surfaces it as a non-retryable
+    // turn.failed (not a rate-limit retry).
+    expect((thrown as { status?: unknown }).status).toBeUndefined();
+    expect((thrown as { code?: unknown }).code).toBeUndefined();
   });
 
   test("falls back to the built-in default provider for a model in no provider's allow-list", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -6,6 +6,19 @@ import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQu
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
+import { codexRequestStorage, type CodexRequestContext, type CodexTokenSnapshot } from "@opengeni/codex";
+
+function makeCodexContext(overrides: { token?: CodexTokenSnapshot; tokenError?: Error } = {}): CodexRequestContext {
+  const token: CodexTokenSnapshot = overrides.token ?? { accessToken: "tok-123", chatgptAccountId: "acct-9", isFedramp: false };
+  return {
+    clientVersion: "0.0.0-test",
+    getToken: overrides.tokenError ? async () => { throw overrides.tokenError; } : async () => token,
+    refresh: async () => token,
+    resolveModel: (slug: string) => slug,
+  };
+}
+
+const CODEX_APPS_ENTRY = (url: string) => ({ id: "codex_apps", name: "codex_apps", url, cacheToolsList: false });
 
 describe("runtime event normalization", () => {
   test("does not send legacy Azure api-version query for v1 base URLs", () => {
@@ -1043,6 +1056,91 @@ describe("runtime event normalization", () => {
       }), [{ kind: "mcp", id: "cap-secure" }])).rejects.toThrow();
     } finally {
       mcp.close();
+    }
+  });
+
+  test("codex_apps: injects the dynamic ChatGPT bearer + account-id from the codex ALS at connect", async () => {
+    const mcp = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123", "chatgpt-account-id": "acct-9" } });
+    const prepared = await codexRequestStorage.run(makeCodexContext(), () =>
+      prepareAgentTools(testSettings({ mcpServers: [CODEX_APPS_ENTRY(mcp.url)] }), [{ kind: "mcp", id: "codex_apps" }]));
+    try {
+      expect(prepared.mcpServers).toHaveLength(1);
+      const tools = await prepared.mcpServers[0]!.listTools();
+      expect(tools.map((tool) => tool.name)).toContain("codex_apps__search_documents");
+      const result = await prepared.mcpServers[0]!.callTool("codex_apps__search_documents", { query: "gmail" });
+      expect(JSON.stringify(result)).toContain("found document for gmail");
+    } finally {
+      await prepared.close();
+      mcp.close();
+    }
+  });
+
+  test("codex_apps: emits X-OpenAI-Product-Sku only when configured", async () => {
+    const withSku = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123", "X-OpenAI-Product-Sku": "plus" } });
+    const preparedWith = await codexRequestStorage.run(makeCodexContext(), () =>
+      prepareAgentTools(testSettings({ codexProductSku: "plus", mcpServers: [CODEX_APPS_ENTRY(withSku.url)] }), [{ kind: "mcp", id: "codex_apps" }]));
+    try {
+      expect(preparedWith.mcpServers).toHaveLength(1); // connected => SKU header accepted
+    } finally {
+      await preparedWith.close();
+      withSku.close();
+    }
+
+    // With the SKU unset, a server that REQUIRES the header rejects the connect,
+    // and the best-effort drop leaves codex_apps absent (no throw).
+    const requiresSku = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123", "X-OpenAI-Product-Sku": "plus" } });
+    const preparedWithout = await codexRequestStorage.run(makeCodexContext(), () =>
+      prepareAgentTools(testSettings({ mcpServers: [CODEX_APPS_ENTRY(requiresSku.url)] }), [{ kind: "mcp", id: "codex_apps" }]));
+    try {
+      expect(preparedWithout.mcpServers).toHaveLength(0); // header absent => connect rejected => dropped
+    } finally {
+      await preparedWithout.close();
+      requiresSku.close();
+    }
+  });
+
+  test("codex_apps: no ALS store => no auth => graceful best-effort drop (turn does not throw)", async () => {
+    const mcp = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123" } });
+    // No codexRequestStorage.run wrapper: the bearer cannot be resolved, the
+    // server fails auth at connect, and because codex_apps is best-effort the
+    // call resolves with codex_apps simply absent (contrast the strict
+    // third-party test above, which throws).
+    const prepared = await prepareAgentTools(testSettings({ mcpServers: [CODEX_APPS_ENTRY(mcp.url)] }), [{ kind: "mcp", id: "codex_apps" }]);
+    try {
+      expect(prepared.mcpServers).toHaveLength(0);
+    } finally {
+      await prepared.close();
+      mcp.close();
+    }
+  });
+
+  test("codex_apps: getToken rejection (needs_relogin) => graceful best-effort drop", async () => {
+    const mcp = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123" } });
+    const prepared = await codexRequestStorage.run(makeCodexContext({ tokenError: new Error("needs_relogin") }), () =>
+      prepareAgentTools(testSettings({ mcpServers: [CODEX_APPS_ENTRY(mcp.url)] }), [{ kind: "mcp", id: "codex_apps" }]));
+    try {
+      expect(prepared.mcpServers).toHaveLength(0);
+    } finally {
+      await prepared.close();
+      mcp.close();
+    }
+  });
+
+  test("codex_apps best-effort partition does NOT weaken strict guarantees for sibling servers", async () => {
+    // A required (non-codex) server that fails auth must still throw even when a
+    // codex_apps server rides alongside it in the same prepare call.
+    const required = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    const apps = startTestMcpServer({ requiredHeaders: { authorization: "Bearer tok-123" } });
+    try {
+      await expect(codexRequestStorage.run(makeCodexContext(), () => prepareAgentTools(testSettings({
+        mcpServers: [
+          { id: "cap-secure", name: "Secure capability MCP", url: required.url, cacheToolsList: false }, // no headers => fails strict
+          CODEX_APPS_ENTRY(apps.url),
+        ],
+      }), [{ kind: "mcp", id: "cap-secure" }, { kind: "mcp", id: "codex_apps" }]))).rejects.toThrow();
+    } finally {
+      required.close();
+      apps.close();
     }
   });
 


### PR DESCRIPTION
Follow-ups to the Codex subscription feature (#127/#131), all verified live against the real ChatGPT/Codex backend with a `pro` token.

### 1. Fail-loud routing (was: silent Azure fallthrough → cryptic 404)
`MultiProviderModelProvider.getModel` fell back to the global Azure client for any unresolved model id, so a `codex/gpt-5.5` turn with no active credential hit Azure and returned `DeploymentNotFound`. It now throws `CodexSubscriptionUnavailableError` with an actionable "connect your Codex subscription" message for `codex/*` ids; non-codex routing unchanged.

### 2. Request-body allowlist (was: bodyless 400 on every codex turn)
The `/codex/responses` backend is a **strict allowlist** — it 400s on any field the Codex CLI doesn't send. Our `@openai/agents` stack attaches `temperature`, `top_p`, `metadata`, `previous_response_id`, `truncation`, `user`, `service_tier`, … and a hosted `mcp` tool, each rejected (`Unsupported parameter/tool`). `normalizeCodexRequestBody` now keeps only the supported Responses fields (spec §1) and drops `mcp`-type tools. **Verified live: a worker-shaped dirty body, post-normalize, returns `200 OK`.**

### 3. `codex_apps` connectors MCP (§E) + corrections
Wires the server-side `codex_apps` MCP (`…/ps/mcp`) so the agent gets the user's ChatGPT connectors as `mcp__codex_apps__*` tools, with the refreshing bearer + `chatgpt-account-id` injected dynamically at connect. Two corrections from a live probe (which returned **217 connector tools**):
- Connectors are gated **server-side per ChatGPT account**, not by `api.connectors.*` token scopes — removed the over-strict scope gate that would have blocked every real token.
- The connect now sends `originator`/`User-Agent`/`version`, since the backend sits behind Cloudflare (bare runtime UA → 403).

### Tests
typecheck green (codex/runtime/worker); normalize, codex-overlay, runtime codex_apps, goals, agent-turn suites all pass; plus the live `200 OK` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent turn MCP prep and Codex model HTTP payloads on the subscription path; mis-normalization or routing could break codex turns, while best-effort `codex_apps` limits blast radius when connectors are unavailable.
> 
> **Overview**
> Follow-ups to Codex subscription support: **request shaping**, **routing/errors**, **ChatGPT connectors MCP**, and a small **settings UI** fix.
> 
> **Codex `/responses` body** — `normalizeCodexRequestBody` now keeps only backend-allowed top-level fields, strips SDK extras (`temperature`, `metadata`, `previous_response_id`, etc.), and removes hosted `mcp` tool entries so client-connected MCP tools stay as `function` tools. Stops strict-backend 400s on every codex turn.
> 
> **Model routing** — Unresolved `codex/*` model ids throw `CodexSubscriptionUnavailableError` (connect in Settings) instead of falling through to Azure and `DeploymentNotFound`.
> 
> **`codex_apps` connectors** — For any active Codex credential, the worker injects the synthetic `codex_apps` MCP (`…/ps/mcp`) without gating on connector OAuth scopes; turns wire it via `withCodexAppsTool`, and `prepareTools` runs under `codexRequestStorage` so connect uses the refreshing bearer plus Codex client headers (`originator`, `User-Agent`, `chatgpt-account-id`). Connect is **best-effort** (auth/empty tools drop the server without failing the turn).
> 
> **Settings** — Codex device-code polling catches poll-route failures, clears the pending state, and shows a toast so the card does not stay on “Waiting for authorization…” forever.
> 
> Tests cover normalization allowlist, overlay injection, `withCodexAppsTool`, model provider error, and runtime `codex_apps` auth paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27348a0947a948b7b7573a1794eed676bd9fbaa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->