### PR TITLE
fix(codex): codex-subscription turns consume zero OpenGeni credits (billing/entitlements integration)

### DIFF
--- a/apps/api/src/billing/limits.ts
+++ b/apps/api/src/billing/limits.ts
@@ -5,6 +5,7 @@ import {
   countScheduledTasksForWorkspace,
   countWorkspacesForAccount,
   getBillingBalance,
+  isCodexBilledTurn,
   recordUsageEvent,
   sumUsageQuantity,
 } from "@opengeni/db";
@@ -16,6 +17,13 @@ export type LimitCheckInput = {
   workspaceId?: string;
   action: LimitAction;
   quantity?: number;
+  // The turn's model id, when the action represents an agent turn. When this is a
+  // Codex-billed turn (codex/<slug> + feature enabled + active workspace
+  // credential) the turn is paid by the user's ChatGPT/Codex plan and consumes
+  // ZERO OpenGeni credits, so the credit-balance + model-cost + token gates are
+  // skipped. Non-model infra actions (workspace/api_key/schedule create) leave
+  // this undefined and are unaffected.
+  model?: string | null;
 };
 
 export async function requireLimit(deps: ApiRouteDeps, input: LimitCheckInput): Promise<void> {
@@ -27,17 +35,26 @@ export async function requireLimit(deps: ApiRouteDeps, input: LimitCheckInput): 
 }
 
 export async function checkLimit(deps: ApiRouteDeps, input: LimitCheckInput): Promise<LimitDecision> {
-  const creditDecision = await checkCreditBalance(deps, input);
+  // Resolve the canonical codex-billed predicate ONCE. Returns false for any
+  // action that carries no model (infra caps) or any codex/<slug> model without
+  // an active credential — so the bypass never triggers on the prefix alone.
+  const codexBilled = input.workspaceId
+    ? await isCodexBilledTurn({ db: deps.db, settings: deps.settings, workspaceId: input.workspaceId, model: input.model })
+    : false;
+  const creditDecision = await checkCreditBalance(deps, input, codexBilled);
   if (!creditDecision.allowed) {
     return creditDecision;
   }
   if (deps.settings.usageLimitsMode !== "static" && deps.settings.usageLimitsMode !== "managed") {
     return { allowed: true };
   }
-  return await checkStaticCaps(deps, input);
+  return await checkStaticCaps(deps, input, codexBilled);
 }
 
-async function checkCreditBalance(deps: ApiRouteDeps, input: LimitCheckInput): Promise<LimitDecision> {
+async function checkCreditBalance(deps: ApiRouteDeps, input: LimitCheckInput, codexBilled: boolean): Promise<LimitDecision> {
+  if (codexBilled) {
+    return { allowed: true }; // paid by the user's ChatGPT/Codex plan — zero OpenGeni credits
+  }
   if (!usesCreditLimits(deps) || !isCostlyAction(input.action)) {
     return { allowed: true };
   }
@@ -48,9 +65,9 @@ async function checkCreditBalance(deps: ApiRouteDeps, input: LimitCheckInput): P
   return { allowed: false, code: "insufficient_credits", message: "insufficient OpenGeni credits" };
 }
 
-async function checkStaticCaps(deps: ApiRouteDeps, input: LimitCheckInput): Promise<LimitDecision> {
+async function checkStaticCaps(deps: ApiRouteDeps, input: LimitCheckInput, codexBilled: boolean): Promise<LimitDecision> {
   const limits = configuredStaticUsageLimits(deps.settings);
-  if (limits.maxMonthlyCostMicrosPerAccount && isCostlyAction(input.action)) {
+  if (limits.maxMonthlyCostMicrosPerAccount && isCostlyAction(input.action) && !codexBilled) {
     const used = await sumUsageQuantity(deps.db, {
       accountId: input.accountId,
       eventType: "model.cost",
@@ -111,7 +128,7 @@ async function checkStaticCaps(deps: ApiRouteDeps, input: LimitCheckInput): Prom
         : blocked("max_monthly_agent_runs_per_workspace", `monthly agent run limit reached (${limits.maxMonthlyAgentRunsPerWorkspace})`);
     }
     case "tokens:consume": {
-      if (!limits.maxMonthlyTokensPerWorkspace || !input.workspaceId) {
+      if (codexBilled || !limits.maxMonthlyTokensPerWorkspace || !input.workspaceId) {
         return { allowed: true };
       }
       const used = await sumUsageQuantity(deps.db, {

--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -535,7 +535,7 @@ export async function createSessionForRequest(
     inheritedBackend = member.sandboxBackend;
   }
   // else "new": leave sandboxGroupId null → own singleton group (group ≡ id).
-  await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
+  await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1, model });
   const session = await createAndStartSession({
     db,
     bus,
@@ -609,12 +609,21 @@ export async function acceptSessionUserMessage(
   const requestedTools = input.toolsProvided
     ? validatedTools
     : withDefaultEnabledCapabilityMcpTools(validatedTools, settings, runtimeSettings);
-  await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
+  // Hoisted above requireLimit so the codex-billed predicate can resolve the
+  // turn's effective model (a follow-up turn inherits the session's model). A
+  // pure read with no side effects.
+  const existingSession = await requireSession(db, workspaceId, sessionId);
+  await requireLimit(deps, {
+    accountId: grant.accountId,
+    workspaceId,
+    action: "agent_run:create",
+    quantity: 1,
+    model: input.model ?? existingSession.model,
+  });
   if (requestedResources.some((resource) => resource.kind === "file") && !objectStorage) {
     throw new HTTPException(503, { message: "object storage is not configured" });
   }
   await validateFileResources(db, workspaceId, requestedResources);
-  const existingSession = await requireSession(db, workspaceId, sessionId);
   await validateGitHubRepositorySelection(db, workspaceId, [...existingSession.resources, ...requestedResources]);
   const { accepted, turn } = await postUserMessageTurn({
     db,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -337,7 +337,7 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
     inputSchema: { id: z4.string().uuid(), triggerId: z4.string().min(1).max(128).optional() },
   }, async ({ id, triggerId }) => {
     const task = await requireScheduledTask(deps.db, grant.workspaceId, id);
-    await requireLimit(deps, { accountId: grant.accountId, workspaceId: grant.workspaceId, action: "agent_run:create", quantity: 1 });
+    await requireLimit(deps, { accountId: grant.accountId, workspaceId: grant.workspaceId, action: "agent_run:create", quantity: 1, model: task.agentConfig.model ?? deps.settings.openaiModel });
     const triggerToken = scheduledTaskTriggerToken(triggerId);
     const agentRunUsageIdempotencyKey = manualScheduledTaskTriggerUsageKey(grant.workspaceId, task.id, triggerToken);
     const triggerWorkflowId = manualScheduledTaskTriggerWorkflowId(task.id, triggerToken);

--- a/apps/api/src/routes/scheduled-tasks.ts
+++ b/apps/api/src/routes/scheduled-tasks.ts
@@ -82,8 +82,10 @@ export function registerScheduledTaskRoutes(app: Hono, deps: ApiRouteDeps): void
   app.post("/v1/workspaces/:workspaceId/scheduled-tasks/:taskId/trigger", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "scheduled_tasks:run");
-    await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1 });
+    // Load the task before the gate so a codex-model scheduled task can be
+    // recognised as codex-billed and skip the credit/cost gates at the edge.
     const task = await requireScheduledTaskForApi(db, workspaceId, c.req.param("taskId"));
+    await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1, model: task.agentConfig.model ?? deps.settings.openaiModel });
     // Body is optional (a bare POST is still a valid trigger); only a present,
     // non-empty body must parse against the contract.
     const body = await c.req.json().catch(() => ({}));

--- a/apps/api/test/limits-codex.test.ts
+++ b/apps/api/test/limits-codex.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import * as opengeniDb from "@opengeni/db";
+import { testSettings } from "@opengeni/testing";
+import type { Settings } from "@opengeni/config";
+import { checkLimit, requireLimit } from "../src/billing/limits";
+import type { ApiRouteDeps } from "../src/dependencies";
+
+const ACCOUNT = "acct-1";
+const WORKSPACE = "ws-1";
+
+// Live config that reproduces the bug: billingMode=stripe + usageLimitsMode=managed,
+// codex feature enabled, account has 0 OpenGeni credits.
+function billedSettings(overrides: Partial<Settings> = {}): Settings {
+  return testSettings({ billingMode: "stripe", usageLimitsMode: "managed", codexSubscriptionEnabled: true, ...overrides });
+}
+
+function deps(settings: Settings): ApiRouteDeps {
+  return { settings, db: {} as opengeniDb.Database } as ApiRouteDeps;
+}
+
+function mockZeroBalance(): () => void {
+  const spy = spyOn(opengeniDb, "getBillingBalance").mockResolvedValue({
+    accountId: ACCOUNT, balanceMicros: 0, currency: "usd", updatedAt: new Date().toISOString(),
+  });
+  return () => spy.mockRestore();
+}
+
+function mockCredentialStatus(status: string): () => void {
+  const spy = spyOn(opengeniDb, "getCodexCredentialStatus").mockResolvedValue({
+    connected: status === "active", chatgptAccountId: "a", scopes: null, planType: "pro",
+    status, expiresAt: null, lastRefreshAt: null, lastError: null,
+  } as Awaited<ReturnType<typeof opengeniDb.getCodexCredentialStatus>>);
+  return () => spy.mockRestore();
+}
+
+describe("API edge credit gate — codex bypass", () => {
+  test("(a) codex model + ACTIVE credential bypasses the 0-credit gate", async () => {
+    const restoreBal = mockZeroBalance();
+    const restoreCred = mockCredentialStatus("active");
+    try {
+      const decision = await checkLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "codex/gpt-5.5",
+      });
+      expect(decision.allowed).toBe(true);
+      // requireLimit must NOT throw a 402 for a codex-billed turn.
+      await requireLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "codex/gpt-5.5",
+      });
+    } finally { restoreCred(); restoreBal(); }
+  });
+
+  test("(b) codex MODEL but NO active credential is still gated (402, no free bypass)", async () => {
+    const restoreBal = mockZeroBalance();
+    const restoreCred = mockCredentialStatus("needs_relogin");
+    try {
+      const decision = await checkLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "codex/gpt-5.5",
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.code).toBe("insufficient_credits");
+      await expect(requireLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "codex/gpt-5.5",
+      })).rejects.toMatchObject({ status: 402 });
+    } finally { restoreCred(); restoreBal(); }
+  });
+
+  test("(c) a normal model with 0 credits is still gated exactly as before (402)", async () => {
+    const restoreBal = mockZeroBalance();
+    // No credential spy: a normal model never triggers a credential read.
+    try {
+      const decision = await checkLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "scripted-model",
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.code).toBe("insufficient_credits");
+      await expect(requireLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "scripted-model",
+      })).rejects.toMatchObject({ status: 402 });
+    } finally { restoreBal(); }
+  });
+
+  test("(c2) a normal model with a positive balance is allowed (control: gate logic intact)", async () => {
+    const spy = spyOn(opengeniDb, "getBillingBalance").mockResolvedValue({
+      accountId: ACCOUNT, balanceMicros: 1_000_000, currency: "usd", updatedAt: new Date().toISOString(),
+    });
+    try {
+      const decision = await checkLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, workspaceId: WORKSPACE, action: "agent_run:create", quantity: 1, model: "scripted-model",
+      });
+      expect(decision.allowed).toBe(true);
+    } finally { spy.mockRestore(); }
+  });
+
+  test("infra cap (workspace:create) never reads codex credential and is unaffected", async () => {
+    const restoreBal = mockZeroBalance();
+    // workspace:create is a non-costly action with no workspaceId/model: getBillingBalance
+    // is never even consulted (not costly), so 0 credits does not block it.
+    try {
+      const decision = await checkLimit(deps(billedSettings()), {
+        accountId: ACCOUNT, action: "workspace:create", quantity: 1,
+      });
+      expect(decision.allowed).toBe(true);
+    } finally { restoreBal(); }
+  });
+});

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -8,6 +8,7 @@ import {
   getSessionEvent,
   getSessionGoal,
   getSessionTurn,
+  isCodexBilledTurn,
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
@@ -336,7 +337,15 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         throw new Error(`Session turn not found for trigger: ${input.triggerEventId}`);
       }
       turnId = turn.id;
-      await ensureRunAllowed(settings, db, input.accountId, input.workspaceId);
+      // Canonical codex-billed predicate (codex/<slug> + feature enabled + active
+      // workspace credential). Computed once and threaded through every billing
+      // gate + the usage recorder so a turn paid by the user's ChatGPT/Codex plan
+      // consumes ZERO OpenGeni credits and never feeds an OpenGeni cap. Resolved
+      // here (before resolvedModel at the routing step) because the pre-turn gate
+      // below needs it; mirrors the same active-credential read the codex provider
+      // overlay uses, so billing and routing agree on what "codex" is.
+      const isCodexTurn = await isCodexBilledTurn({ db, settings, workspaceId: input.workspaceId, model: turn.model });
+      await ensureRunAllowed(settings, db, input.accountId, input.workspaceId, isCodexTurn);
       const activityContext = currentActivityContext();
       // Setup (environment load, MCP connects, sandbox restore) does not
       // stream and so never observes cancellation on its own; these explicit
@@ -776,6 +785,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               sessionId: input.sessionId,
               turnId,
               model: turn.model,
+              isCodexTurn,
               usage: responseUsage.usage,
               sourceKey: modelUsageSourceKey({
                 responseId: responseUsage.responseId,
@@ -785,7 +795,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             });
             await reconcileConversationTruth();
             try {
-              await ensureRunAllowed(settings, db, input.accountId, input.workspaceId);
+              await ensureRunAllowed(settings, db, input.accountId, input.workspaceId, isCodexTurn);
             } catch (limitError) {
               // Capture the run state at the boundary so the budget valve in
               // the outer catch can end this segment gracefully with full
@@ -833,6 +843,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           sessionId: input.sessionId,
           turnId,
           model: turn.model,
+          isCodexTurn,
           usage: stream.state.usage,
           sourceKey: modelUsageSourceKey({ responseId: null, dispatchId, positionalKey: "aggregate" }),
         });
@@ -1288,8 +1299,12 @@ class BudgetExhaustedError extends Error {
   }
 }
 
-async function ensureRunAllowed(settings: Settings, db: ActivityServices["db"], accountId: string, workspaceId: string): Promise<void> {
-  if (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed") {
+// Exported for unit testing the codex-billed bypass; not part of the activity surface.
+export async function ensureRunAllowed(settings: Settings, db: ActivityServices["db"], accountId: string, workspaceId: string, isCodexTurn: boolean): Promise<void> {
+  // Codex-billed turns are paid by the user's ChatGPT/Codex plan: skip the
+  // credit-balance gate and the monthly token cap. The agent-run COUNT cap below
+  // is a volume/fairness quota (not a credit/cost gate) and is intentionally kept.
+  if (!isCodexTurn && (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed")) {
     const balance = await getBillingBalance(db, accountId);
     if (balance.balanceMicros <= 0) {
       throw new Error("insufficient OpenGeni credits");
@@ -1310,7 +1325,7 @@ async function ensureRunAllowed(settings: Settings, db: ActivityServices["db"], 
           throw new Error(`monthly agent run limit reached (${limits.maxMonthlyAgentRunsPerWorkspace})`);
         }
     }
-    if (limits.maxMonthlyTokensPerWorkspace) {
+    if (!isCodexTurn && limits.maxMonthlyTokensPerWorkspace) {
       const used = await sumUsageQuantity(db, {
         workspaceId,
         eventType: "model.tokens",
@@ -1323,12 +1338,14 @@ async function ensureRunAllowed(settings: Settings, db: ActivityServices["db"], 
   }
 }
 
-async function recordModelUsageAndDebitCredits(settings: Settings, db: ActivityServices["db"], input: {
+// Exported for unit testing the codex-billed bypass; not part of the activity surface.
+export async function recordModelUsageAndDebitCredits(settings: Settings, db: ActivityServices["db"], input: {
   accountId: string;
   workspaceId: string;
   sessionId: string;
   turnId: string;
   model: string;
+  isCodexTurn: boolean;
   usage?: ModelUsageInput | null;
   sourceKey: string;
 }): Promise<void> {
@@ -1338,6 +1355,28 @@ async function recordModelUsageAndDebitCredits(settings: Settings, db: ActivityS
   const inputTokens = positiveInt(input.usage.inputTokens);
   const outputTokens = positiveInt(input.usage.outputTokens);
   const totalTokens = positiveInt(input.usage.totalTokens) || inputTokens + outputTokens;
+  // A codex-subscription turn is paid by the user's ChatGPT/Codex plan, so it
+  // consumes ZERO OpenGeni credits and must never feed an OpenGeni cap. A
+  // codex/<slug> model has no entry in configuredModelPricing, so the normal path
+  // below would throw "Missing model pricing". We:
+  //   - do NOT emit the cap-feeding `model.tokens` event (ensureRunAllowed and
+  //     the API tokens:consume cap sum `model.tokens` with NO cost dimension, so
+  //     any row would count against maxMonthlyTokensPerWorkspace);
+  //   - record a `model.cost = 0` audit marker (harmless to the monthly cost cap);
+  //   - never look up pricing and never debit credits.
+  if (input.isCodexTurn) {
+    await recordUsageEvent(db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      eventType: "model.cost",
+      quantity: 0,
+      unit: "usd_micros",
+      sourceResourceType: "model_response",
+      sourceResourceId: `${input.turnId}:${input.sourceKey}`,
+      idempotencyKey: `usage:model.cost:${input.turnId}:${input.sourceKey}`,
+    });
+    return;
+  }
   if (totalTokens > 0) {
     await recordUsageEvent(db, {
       accountId: input.accountId,

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -11,8 +11,8 @@ import {
 } from "@opengeni/codex";
 import {
   decryptedCapabilityHeaders,
-  getCodexCredentialStatus,
   listEnabledMcpCapabilityServers,
+  workspaceCodexSubscriptionActive,
   type Database,
   type EnabledMcpCapabilityServer,
 } from "@opengeni/db";
@@ -30,12 +30,10 @@ export async function settingsWithEnabledCapabilityMcpServers(db: Database, work
  * codexRequestStorage. Idempotent and a no-op when not applicable.
  */
 export async function settingsWithCodexCredential(db: Database, workspaceId: string, settings: Settings): Promise<Settings> {
-  if (!settings.codexSubscriptionEnabled) {
-    return settings;
-  }
-  const status = await getCodexCredentialStatus(db, workspaceId);
-  if (!status || status.status !== "active") {
-    return settings; // not connected / needs_relogin / error -> leave settings unchanged
+  // Same active-credential predicate the billing bypass uses, so provider
+  // injection and billing can never disagree on what an "active codex" turn is.
+  if (!(await workspaceCodexSubscriptionActive(db, settings, workspaceId))) {
+    return settings; // disabled / not connected / needs_relogin / error -> leave settings unchanged
   }
   const withProvider = withCodexProvider(settings);
   // Additive: append the synthetic codex_apps connectors MCP server for ANY

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -11,6 +11,7 @@ import {
   getBillingBalance,
   getSessionEvent,
   getSessionGoal,
+  isCodexBilledTurn,
   recordUsageEvent,
   requireSession,
   setSessionGoalLastContinuationTurn,
@@ -34,10 +35,18 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
     if (!existingGoal || existingGoal.status !== "active") {
       return { action: "none" };
     }
+    // Loaded before the budget check so the codex-billed predicate can read the
+    // continuation turn's model (session.model). Kept below the goal-less fast
+    // path above so a non-goal session still skips this read entirely.
+    const session = await requireSession(db, input.workspaceId, input.sessionId);
+    // A codex-model goal continuation is paid by the user's ChatGPT/Codex plan,
+    // so it must not be budget-paused for zero OpenGeni credits. This file uses
+    // BASE settings (no codex overlay); the predicate does its own credential read.
+    const isCodexRun = await isCodexBilledTurn({ db, settings, workspaceId: input.workspaceId, model: session.model });
     // Budget exhaustion pauses the goal visibly instead of failing the
     // session. Computed up front and applied inside the locked decision so a
     // limits pause never consumes continuation budget.
-    const budgetBlocked = await goalRunBudgetBlocked(settings, db, input.accountId, input.workspaceId);
+    const budgetBlocked = await goalRunBudgetBlocked(settings, db, input.accountId, input.workspaceId, isCodexRun);
     const decision = await evaluateGoalContinuation(db, {
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
@@ -62,7 +71,6 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
       }]);
       return { action: "paused" };
     }
-    const session = await requireSession(db, input.workspaceId, input.sessionId);
     // Stop/continue race guard: a concurrent goal_complete/goal_pause/operator
     // PATCH between the locked decision and this synthesis must win. The
     // version check also catches a replace. A pause landing after this point
@@ -231,8 +239,11 @@ export function withCodexAppsTool(settings: Settings, tools: ToolRef[]): ToolRef
  * Non-throwing variant of the scheduled-run admission check: returns a human
  * readable reason when balance or monthly caps block another agent run.
  */
-async function goalRunBudgetBlocked(settings: Settings, db: Database, accountId: string, workspaceId: string): Promise<string | null> {
-  if (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed") {
+async function goalRunBudgetBlocked(settings: Settings, db: Database, accountId: string, workspaceId: string, isCodexRun: boolean): Promise<string | null> {
+  // Codex-billed continuations are paid by the user's ChatGPT/Codex plan: skip
+  // the credit-balance gate and the monthly model-cost cap. The agent-run COUNT
+  // cap below is a volume quota (not a credit/cost gate) and is intentionally kept.
+  if (!isCodexRun && (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed")) {
     const balance = await getBillingBalance(db, accountId);
     if (balance.balanceMicros <= 0) {
       return "insufficient OpenGeni credits";
@@ -240,7 +251,7 @@ async function goalRunBudgetBlocked(settings: Settings, db: Database, accountId:
   }
   if (settings.usageLimitsMode === "static" || settings.usageLimitsMode === "managed") {
     const limits = configuredStaticUsageLimits(settings);
-    if (limits.maxMonthlyCostMicrosPerAccount) {
+    if (!isCodexRun && limits.maxMonthlyCostMicrosPerAccount) {
       const used = await sumUsageQuantity(db, {
         accountId,
         eventType: "model.cost",

--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -6,6 +6,7 @@ import {
   enqueueSessionTurn,
   getBillingBalance,
   getWorkspaceEnvironment,
+  isCodexBilledTurn,
   recordUsageEvent,
   requireScheduledTask,
   requireSession,
@@ -36,7 +37,13 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
     dispatchScheduledTaskRun: async (input: DispatchScheduledTaskRunInput): Promise<DispatchScheduledTaskRunResult> => {
       const { settings, db, bus } = await services();
       const task = await requireScheduledTask(db, input.workspaceId, input.taskId);
-      await ensureScheduledRunAllowed(settings, db, task.accountId, task.workspaceId, input.agentRunUsageIdempotencyKey ? 0 : 1);
+      // The scheduled task's model can be codex/<slug>; resolve it here so the
+      // admission gate can skip the credit/cost gates for a codex-billed run
+      // (paid by the user's ChatGPT/Codex plan). This file uses BASE settings (no
+      // codex overlay), so the predicate does its own active-credential read.
+      const model = task.agentConfig.model ?? settings.openaiModel;
+      const isCodexRun = await isCodexBilledTurn({ db, settings, workspaceId: task.workspaceId, model });
+      await ensureScheduledRunAllowed(settings, db, task.accountId, task.workspaceId, input.agentRunUsageIdempotencyKey ? 0 : 1, isCodexRun);
       const run = await createScheduledTaskRun(db, {
         workspaceId: task.workspaceId,
         taskId: task.id,
@@ -55,7 +62,6 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
       });
       let result: DispatchScheduledTaskRunResult;
       try {
-        const model = task.agentConfig.model ?? settings.openaiModel;
         const reasoningEffort = task.agentConfig.reasoningEffort ?? settings.openaiReasoningEffort;
         const sandboxBackend = task.agentConfig.sandboxBackend ?? settings.sandboxBackend;
         const goalSpec = task.agentConfig.goal ?? null;
@@ -298,8 +304,12 @@ async function ensureScheduledRunAllowed(
   accountId: string,
   workspaceId: string,
   requestedAgentRuns: number,
+  isCodexRun: boolean,
 ): Promise<void> {
-  if (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed") {
+  // Codex-billed runs are paid by the user's ChatGPT/Codex plan: skip the
+  // credit-balance gate and the monthly model-cost cap. The agent-run COUNT cap
+  // below is a volume quota (not a credit/cost gate) and is intentionally kept.
+  if (!isCodexRun && (settings.billingMode === "stripe" || settings.usageLimitsMode === "managed")) {
     const balance = await getBillingBalance(db, accountId);
     if (balance.balanceMicros <= 0) {
       throw new Error("insufficient OpenGeni credits");
@@ -307,7 +317,7 @@ async function ensureScheduledRunAllowed(
   }
 	  if (settings.usageLimitsMode === "static" || settings.usageLimitsMode === "managed") {
 	    const limits = configuredStaticUsageLimits(settings);
-	    if (limits.maxMonthlyCostMicrosPerAccount) {
+	    if (!isCodexRun && limits.maxMonthlyCostMicrosPerAccount) {
 	      const used = await sumUsageQuantity(db, {
 	        accountId,
 	        eventType: "model.cost",

--- a/apps/worker/test/codex-billing.test.ts
+++ b/apps/worker/test/codex-billing.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import * as opengeniDb from "@opengeni/db";
+import { testSettings } from "@opengeni/testing";
+import type { Database } from "@opengeni/db";
+import { ensureRunAllowed, recordModelUsageAndDebitCredits } from "../src/activities/agent-turn";
+
+const ACCOUNT = "acct-1";
+const WORKSPACE = "ws-1";
+const db = {} as Database;
+
+// Live config that reproduces the bug: stripe + managed, 0 OpenGeni credits.
+function billedSettings() {
+  return testSettings({ billingMode: "stripe", usageLimitsMode: "managed" });
+}
+
+function mockZeroBalance(): () => void {
+  const spy = spyOn(opengeniDb, "getBillingBalance").mockResolvedValue({
+    accountId: ACCOUNT, balanceMicros: 0, currency: "usd", updatedAt: new Date().toISOString(),
+  });
+  return () => spy.mockRestore();
+}
+
+describe("worker ensureRunAllowed — codex bypass", () => {
+  test("(a) codex turn with 0 credits does NOT throw (credit gate skipped, balance never read)", async () => {
+    let balanceRead = false;
+    const spy = spyOn(opengeniDb, "getBillingBalance").mockImplementation(async () => {
+      balanceRead = true;
+      return { accountId: ACCOUNT, balanceMicros: 0, currency: "usd", updatedAt: new Date().toISOString() };
+    });
+    try {
+      await ensureRunAllowed(billedSettings(), db, ACCOUNT, WORKSPACE, /* isCodexTurn */ true);
+      expect(balanceRead).toBe(false); // short-circuited before any balance read
+    } finally { spy.mockRestore(); }
+  });
+
+  test("(c) a normal turn with 0 credits still throws insufficient OpenGeni credits", async () => {
+    const restore = mockZeroBalance();
+    try {
+      await expect(ensureRunAllowed(billedSettings(), db, ACCOUNT, WORKSPACE, /* isCodexTurn */ false))
+        .rejects.toThrow("insufficient OpenGeni credits");
+    } finally { restore(); }
+  });
+});
+
+describe("worker recordModelUsageAndDebitCredits — codex usage recording", () => {
+  test("(d) codex turn records model.cost=0, does NOT throw 'Missing model pricing', and never debits", async () => {
+    const recorded: Array<{ eventType: string; quantity: number; unit: string }> = [];
+    const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockImplementation(async (_db, input) => {
+      recorded.push({ eventType: input.eventType, quantity: input.quantity, unit: input.unit });
+    });
+    const debitSpy = spyOn(opengeniDb, "applyCreditDebitUpToBalance").mockImplementation(async () => {
+      throw new Error("credits must NOT be debited for a codex turn");
+    });
+    try {
+      await recordModelUsageAndDebitCredits(billedSettings(), db, {
+        accountId: ACCOUNT,
+        workspaceId: WORKSPACE,
+        sessionId: "sess-1",
+        turnId: "turn-1",
+        model: "codex/gpt-5.5", // has NO OpenGeni pricing
+        isCodexTurn: true,
+        usage: { inputTokens: 1000, outputTokens: 500, totalTokens: 1500 },
+        sourceKey: "response-1",
+      });
+      // Exactly one event: a zero-cost audit marker. NO model.tokens row (it would
+      // feed the OpenGeni token cap a codex turn is exempt from).
+      expect(recorded).toEqual([{ eventType: "model.cost", quantity: 0, unit: "usd_micros" }]);
+      expect(debitSpy).not.toHaveBeenCalled();
+    } finally { recordSpy.mockRestore(); debitSpy.mockRestore(); }
+  });
+
+  test("(control) a normal turn still records model.tokens and a non-zero model.cost", async () => {
+    const recorded: Array<{ eventType: string; quantity: number }> = [];
+    const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockImplementation(async (_db, input) => {
+      recorded.push({ eventType: input.eventType, quantity: input.quantity });
+    });
+    const debitSpy = spyOn(opengeniDb, "applyCreditDebitUpToBalance").mockResolvedValue(undefined as never);
+    try {
+      // A model the test settings price (the default openaiModel). testSettings
+      // ships pricing for "scripted-model"; if cost is 0 the debit is skipped, but
+      // the model.tokens row and a model.cost row must still be written.
+      await recordModelUsageAndDebitCredits(billedSettings(), db, {
+        accountId: ACCOUNT,
+        workspaceId: WORKSPACE,
+        sessionId: "sess-1",
+        turnId: "turn-2",
+        model: "scripted-model",
+        isCodexTurn: false,
+        usage: { inputTokens: 1000, outputTokens: 500, totalTokens: 1500 },
+        sourceKey: "response-1",
+      });
+      expect(recorded.some((r) => r.eventType === "model.tokens" && r.quantity === 1500)).toBe(true);
+      expect(recorded.some((r) => r.eventType === "model.cost")).toBe(true);
+    } finally { recordSpy.mockRestore(); debitSpy.mockRestore(); }
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -180,6 +180,7 @@
       "name": "@opengeni/db",
       "version": "0.1.0",
       "dependencies": {
+        "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
         "drizzle-orm": "^0.45.2",

--- a/packages/codex/src/billing.ts
+++ b/packages/codex/src/billing.ts
@@ -1,0 +1,15 @@
+import { CODEX_MODEL_ID_PREFIX } from "./constants";
+
+/**
+ * Pure NECESSARY condition for a Codex-billed turn: the model id is namespaced
+ * for the Codex subscription provider (`codex/<slug>`).
+ *
+ * This is NOT sufficient to bypass billing — an active, connected workspace
+ * credential and the deployment flag (`settings.codexSubscriptionEnabled`) are
+ * ALSO required (see `isCodexBilledTurn`/`workspaceCodexSubscriptionActive` in
+ * `@opengeni/db`). Used only as a cheap, synchronous short-circuit so the common
+ * non-codex path never issues a credential read.
+ */
+export function isCodexBilledModel(model: string | null | undefined): boolean {
+  return typeof model === "string" && model.startsWith(CODEX_MODEL_ID_PREFIX);
+}

--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
+export * from "./billing";
 export * from "./device-code";
 export * from "./refresh";
 export * from "./normalize";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@opengeni/codex": "workspace:*",
     "@opengeni/config": "workspace:*",
     "@opengeni/contracts": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -53,6 +53,10 @@ import type {
 } from "@opengeni/contracts";
 import { reasoningEffortForMetadata, CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
 import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
+import { isCodexBilledModel } from "@opengeni/codex";
+// Re-exported so consumers get the whole codex-billed detection surface (the pure
+// prefix test + the credential-aware predicates below) from a single import.
+export { isCodexBilledModel } from "@opengeni/codex";
 import { and, asc, desc, eq, gt, gte, inArray, lt, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
@@ -2174,6 +2178,51 @@ export async function getCodexCredentialStatus(db: Database, workspaceId: string
     }
     return { connected: row.status === "active", ...row };
   });
+}
+
+/**
+ * Single source of truth for "this workspace has an ACTIVE ChatGPT/Codex
+ * subscription connected AND the feature is enabled for this deployment."
+ *
+ * This is the SAME condition `settingsWithCodexCredential` (worker) uses to
+ * decide whether to inject the synthetic codex-subscription provider, so billing
+ * and provider-injection cannot drift. Metadata-only read (never the secret).
+ */
+export async function workspaceCodexSubscriptionActive(
+  db: Database,
+  settings: Pick<Settings, "codexSubscriptionEnabled">,
+  workspaceId: string,
+): Promise<boolean> {
+  if (!settings.codexSubscriptionEnabled) {
+    return false;
+  }
+  const status = await getCodexCredentialStatus(db, workspaceId);
+  return status?.status === "active";
+}
+
+/**
+ * CANONICAL "is this a Codex-billed turn?" predicate.
+ *
+ * True iff: the turn's model is a `codex/<slug>` id (`isCodexBilledModel`) AND
+ * the deployment flag is on AND the workspace has an ACTIVE credential. A true
+ * result means the turn is paid by the USER's ChatGPT/Codex plan and MUST consume
+ * ZERO OpenGeni credits: callers skip the credit-balance / model-cost / token
+ * gates and skip OpenGeni pricing + credit debit.
+ *
+ * The prefix ALONE never returns true: an unconnected user typing `codex/...`
+ * gets the normal gates (and the worker fails the turn for a missing credential),
+ * so there is no free/uncapped-run bypass.
+ */
+export async function isCodexBilledTurn(input: {
+  db: Database;
+  settings: Pick<Settings, "codexSubscriptionEnabled">;
+  workspaceId: string;
+  model: string | null | undefined;
+}): Promise<boolean> {
+  if (!isCodexBilledModel(input.model)) {
+    return false; // cheap; no db hit on the common path
+  }
+  return workspaceCodexSubscriptionActive(input.db, input.settings, input.workspaceId);
 }
 
 /** Disconnect: delete the workspace's codex credential. Returns true if a row was removed. */

--- a/packages/db/test/codex-billing.test.ts
+++ b/packages/db/test/codex-billing.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import * as db from "../src/index";
+import type { Database } from "../src/index";
+import { isCodexBilledModel, isCodexBilledTurn, workspaceCodexSubscriptionActive } from "../src/index";
+
+/**
+ * Spies on the ONLY db read the codex-billed predicate performs
+ * (getCodexCredentialStatus) so the canonical detection can be exercised without
+ * a live Postgres. Mirrors apps/worker/test/codex-overlay.test.ts.
+ */
+function mockCredentialStatus(status: string | null): () => void {
+  if (status === null) {
+    const spy = spyOn(db, "getCodexCredentialStatus").mockResolvedValue(null);
+    return () => spy.mockRestore();
+  }
+  const spy = spyOn(db, "getCodexCredentialStatus").mockResolvedValue({
+    connected: status === "active",
+    chatgptAccountId: "acct-1",
+    scopes: null,
+    planType: "pro",
+    status,
+    expiresAt: null,
+    lastRefreshAt: null,
+    lastError: null,
+  } as Awaited<ReturnType<typeof db.getCodexCredentialStatus>>);
+  return () => spy.mockRestore();
+}
+
+describe("isCodexBilledModel (pure prefix test)", () => {
+  test("true for a codex/<slug> id", () => {
+    expect(isCodexBilledModel("codex/gpt-5.5")).toBe(true);
+  });
+  test("false for a normal model id, null, and undefined", () => {
+    expect(isCodexBilledModel("gpt-5")).toBe(false);
+    expect(isCodexBilledModel("scripted-model")).toBe(false);
+    expect(isCodexBilledModel(null)).toBe(false);
+    expect(isCodexBilledModel(undefined)).toBe(false);
+  });
+});
+
+describe("workspaceCodexSubscriptionActive", () => {
+  test("false when the feature is disabled (never reads the db)", async () => {
+    // Pass a poisoned db: if it were read the call would throw, proving no read.
+    const poison = new Proxy({}, { get() { throw new Error("db must not be read when feature disabled"); } }) as unknown as Database;
+    const settings = testSettings({ codexSubscriptionEnabled: false });
+    expect(await workspaceCodexSubscriptionActive(poison, settings, "ws_1")).toBe(false);
+  });
+  test("true for an active credential when enabled", async () => {
+    const restore = mockCredentialStatus("active");
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true });
+      expect(await workspaceCodexSubscriptionActive({} as Database, settings, "ws_1")).toBe(true);
+    } finally { restore(); }
+  });
+  test("false for a needs_relogin credential", async () => {
+    const restore = mockCredentialStatus("needs_relogin");
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true });
+      expect(await workspaceCodexSubscriptionActive({} as Database, settings, "ws_1")).toBe(false);
+    } finally { restore(); }
+  });
+  test("false when no credential row exists", async () => {
+    const restore = mockCredentialStatus(null);
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true });
+      expect(await workspaceCodexSubscriptionActive({} as Database, settings, "ws_1")).toBe(false);
+    } finally { restore(); }
+  });
+});
+
+describe("isCodexBilledTurn (canonical predicate)", () => {
+  test("codex model + active credential + enabled => true", async () => {
+    const restore = mockCredentialStatus("active");
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true });
+      expect(await isCodexBilledTurn({ db: {} as Database, settings, workspaceId: "ws_1", model: "codex/gpt-5.5" })).toBe(true);
+    } finally { restore(); }
+  });
+
+  test("codex model but NO active credential => false (no free bypass)", async () => {
+    const restore = mockCredentialStatus("needs_relogin");
+    try {
+      const settings = testSettings({ codexSubscriptionEnabled: true });
+      expect(await isCodexBilledTurn({ db: {} as Database, settings, workspaceId: "ws_1", model: "codex/gpt-5.5" })).toBe(false);
+    } finally { restore(); }
+  });
+
+  test("codex model but feature disabled => false", async () => {
+    const poison = new Proxy({}, { get() { throw new Error("db must not be read when feature disabled"); } }) as unknown as Database;
+    const settings = testSettings({ codexSubscriptionEnabled: false });
+    expect(await isCodexBilledTurn({ db: poison, settings, workspaceId: "ws_1", model: "codex/gpt-5.5" })).toBe(false);
+  });
+
+  test("non-codex model => false WITHOUT a credential read (prefix is a necessary condition)", async () => {
+    // Poisoned db proves the common non-codex path issues no credential read.
+    const poison = new Proxy({}, { get() { throw new Error("db must not be read for a non-codex model"); } }) as unknown as Database;
+    const settings = testSettings({ codexSubscriptionEnabled: true });
+    expect(await isCodexBilledTurn({ db: poison, settings, workspaceId: "ws_1", model: "scripted-model" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Codex turns are paid by the user's ChatGPT/Codex subscription, so they must consume **zero OpenGeni credits**. The original codex feature never integrated with billing/entitlements, so on a `stripe`/`managed` deployment (e.g. staging) a codex turn was blocked exactly like a paid run — `POST /sessions` returned **402 insufficient credits**, the worker `ensureRunAllowed` would block, and usage recording threw `Missing model pricing for codex/gpt-5.5`.

### One canonical predicate (never the prefix alone)
`isCodexBilledTurn` = codex/ model **AND** `codexSubscriptionEnabled` **AND** an **active** workspace credential — the *same* triple `settingsWithCodexCredential` uses to inject the codex provider (refactored onto a shared `workspaceCodexSubscriptionActive` so billing and routing can't drift). A `codex/` model with no active credential is **still fully gated** (verified).

### What changes
- **Edge** (`billing/limits.ts` + `domain/sessions.ts`): `LimitCheckInput` gains `model`; codex-billed turns skip the credit-balance + monthly model-cost + token caps. Infra caps (workspace/api-key/schedule create) untouched.
- **Worker** (`agent-turn.ts`, `scheduled-tasks.ts`, `goals.ts`): `ensureRunAllowed`/scheduled/goal gates skip credit + model-cost/token caps for codex turns.
- **Usage recording**: a codex turn writes a single `model.cost=0` audit row — no pricing lookup, no debit, no `model.tokens` row (which would re-introduce the token cap).
- Monthly agent-run **count** cap is intentionally kept (volume/fairness quota, not a money gate).

### Tests
19 new (db/api/worker) + codex suite (37) + regression (codex-routes/model-guard/auth/overlay) + session-domain integration, all green; typecheck clean across api/worker/codex/config/db. Adversarially verified: no prefix-alone bypass, normal path unchanged, predicate identical at every site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)