### PR TITLE
[codex] fix web session state churn

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -17,6 +17,7 @@ import {
   delegableApiKeyPermissions,
 } from "./lib/permissions";
 import { orgSettingsPath, parseCheckoutOutcome, workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath, workspaceSettingsPath } from "./lib/routes";
+import { sameSessionForContext } from "./lib/session-context";
 import { groupSessionsForRail, recencyGroupFor, relativeTimeLabel } from "./lib/sessions-group";
 import { organizationsForSubject, orgLabel, workspacesInOrg } from "./lib/org";
 import {
@@ -118,6 +119,22 @@ describe("rail session grouping", () => {
     expect(relativeTimeLabel("2026-06-19T11:30:00.000Z", NOW)).toBe("30m");
     expect(relativeTimeLabel("2026-06-19T09:00:00.000Z", NOW)).toBe("3h");
     expect(relativeTimeLabel("2026-06-17T12:00:00.000Z", NOW)).toBe("2d");
+  });
+});
+
+describe("session context equality", () => {
+  test("treats equivalent live-status overlay objects as unchanged", () => {
+    const current = session({ status: "running" });
+    const next = { ...current };
+
+    expect(sameSessionForContext(current, next)).toBe(true);
+  });
+
+  test("detects meaningful session changes", () => {
+    const current = session({ status: "queued", activeTurnId: null });
+    const next = { ...current, status: "running" as const, activeTurnId: "turn-1" };
+
+    expect(sameSessionForContext(current, next)).toBe(false);
   });
 });
 

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -11,6 +11,7 @@ import {
   createContext,
   type Dispatch,
   type SetStateAction,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -35,6 +36,7 @@ import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { sameSessionForContext } from "@/lib/session-context";
 import {
   buildResources,
   buildTools,
@@ -152,7 +154,7 @@ export function workspaceLabel(workspace: Workspace, workspaces: Workspace[]): s
 }
 
 export function RootRouteComponent() {
-  const [session, setSession] = useState<Session | null>(null);
+  const [session, setSessionState] = useState<Session | null>(null);
   const [clientConfig, setClientConfig] = useState<ClientConfig | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
   const [authSession, setAuthSession] = useState<AuthSession | null | undefined>(undefined);
@@ -209,6 +211,14 @@ export function RootRouteComponent() {
   // headers are read per request; a new identity per key version makes the
   // hooks re-fetch and the event streams reconnect with the new credentials.
   const client = useMemo(() => createOpenGeniClient(), [accessKeyVersion]);
+  const setSession = useCallback<Dispatch<SetStateAction<Session | null>>>((value) => {
+    setSessionState((current) => {
+      const next = typeof value === "function"
+        ? (value as (previous: Session | null) => Session | null)(current)
+        : value;
+      return sameSessionForContext(current, next) ? current : next;
+    });
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/lib/queue.test.ts
+++ b/apps/web/src/lib/queue.test.ts
@@ -11,7 +11,6 @@ import {
   deliveryModeExplanation,
   editedTurnFate,
   finishedTurns,
-  isMidTurn,
   moveTurnInQueue,
   reorderQueueByDrag,
   turnElapsedSeconds,
@@ -150,24 +149,6 @@ describe("deliveryModeExplanation", () => {
   test("unknown/null status reads as a plain send", () => {
     expect(deliveryModeExplanation("steer", null)).toContain("Nothing is running");
     expect(deliveryModeExplanation("queue", undefined)).toContain("starts immediately");
-  });
-});
-
-describe("isMidTurn", () => {
-  // Drives the steer-mode reset: an armed steer toggle falls back to queue
-  // once there is nothing left to steer, never across a live turn or queue.
-  test("running, queued, and requires_action keep steer armed", () => {
-    expect(isMidTurn("running")).toBe(true);
-    expect(isMidTurn("queued")).toBe(true);
-    expect(isMidTurn("requires_action")).toBe(true);
-  });
-
-  test("idle, terminal, and unknown statuses reset steer to the queue default", () => {
-    expect(isMidTurn("idle")).toBe(false);
-    expect(isMidTurn("failed")).toBe(false);
-    expect(isMidTurn("cancelled")).toBe(false);
-    expect(isMidTurn(null)).toBe(false);
-    expect(isMidTurn(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -91,15 +91,6 @@ export function turnSourceLabel(source: SessionTurn["source"]): string {
 }
 
 /**
- * Session statuses during which steering has something to act on (interrupt
- * a turn, or jump a queue). Outside these the composer falls back to the
- * queue default so a stale steer toggle cannot surprise a later send.
- */
-export function isMidTurn(status: SessionStatus | null | undefined): boolean {
-  return status === "running" || status === "queued" || status === "requires_action";
-}
-
-/**
  * Honest one-liner for the compose-time delivery choice, aligned with what
  * `OpenGeniClient.steerMessage` actually does per status: it interrupts only
  * `running` and `requires_action` sessions (steering a session paused on an

--- a/apps/web/src/lib/session-context.ts
+++ b/apps/web/src/lib/session-context.ts
@@ -1,0 +1,21 @@
+import type { Session } from "@/types";
+
+export function sameSessionForContext(a: Session | null, b: Session | null): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  const aKeys = Object.keys(a) as Array<keyof Session>;
+  const bKeys = Object.keys(b) as Array<keyof Session>;
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key) || !Object.is(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -45,7 +45,6 @@ import { WorkspaceDock, type WorkspaceTab } from "@opengeni/react";
 import { useAppContext } from "@/context";
 import { useCodexModels } from "@/lib/use-codex-models";
 import { isTerminalSessionStatus, projectSessionTimeline, summarizeSessionFailure } from "@/lib/events";
-import { isMidTurn } from "@/lib/queue";
 import { buildTools } from "@/lib/session-tools";
 import type { Session, SessionEvent } from "@/types";
 
@@ -159,10 +158,6 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     />
   );
 
-  if (!context.inspectorOpen) {
-    return <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">{chatPane}</div>;
-  }
-
   return (
     <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <SessionDock
@@ -174,6 +169,8 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
         goal={goal}
         connectionState={connectionState}
         primary={chatPane}
+        dockCollapsed={!context.inspectorOpen}
+        onDockCollapsedChange={(collapsed) => context.setInspectorOpen(!collapsed)}
       />
     </div>
   );
@@ -201,6 +198,8 @@ function SessionDock(props: {
   goal: ReturnType<typeof useGoal>;
   connectionState: ReturnType<typeof useSessionEvents>["connectionState"];
   primary: React.ReactNode;
+  dockCollapsed: boolean;
+  onDockCollapsedChange: (collapsed: boolean) => void;
 }) {
   // Track the dock's active tab so the Files surface can hold the box WARM only
   // while it's actually on screen (fast ~100ms Channel-A ops instead of a cold
@@ -210,7 +209,7 @@ function SessionDock(props: {
     workspaceId: props.workspaceId,
     sessionId: props.sessionId,
     events: props.events,
-    filesActive: activeTab === "files",
+    filesActive: !props.dockCollapsed && activeTab === "files",
   });
 
   const tabs: WorkspaceTab[] = [
@@ -241,6 +240,8 @@ function SessionDock(props: {
       autoSaveId="og.session.dock"
       activeTab={activeTab}
       onActiveTabChange={setActiveTab}
+      collapsed={props.dockCollapsed}
+      onCollapsedChange={props.onDockCollapsedChange}
     />
   );
 }
@@ -297,14 +298,6 @@ function SessionChatPane(props: {
     }),
     [context.client, props.session.workspaceId, props.session.id, props.session.status, workspacePermissions],
   );
-
-  // Steering needs something to interrupt: when the turn ends, fall back to
-  // the queue default so a stale steer toggle cannot surprise a later send.
-  useEffect(() => {
-    if (!isMidTurn(props.session.status) && composer.mode !== "queue") {
-      composer.setMode("queue");
-    }
-  }, [props.session.status, composer.mode, composer.setMode]);
 
   const renderMessageText = useCallback((text: string, item: AgentMessageItem | UserMessageItem) => {
     if (item.kind === "user-message") {

--- a/docs/design/sandbox-surfacing/ui-spec.md
+++ b/docs/design/sandbox-surfacing/ui-spec.md
@@ -148,8 +148,8 @@ the chat, not inside a fixed strip. It replaces the `grid-cols-[…390px]` aside
 - **Drag handle** sets the dock width (percent of the session area). `minSize` ~22 % keeps the tree
   legible; `maxSize` ~70 % lets the desktop/terminal dominate without hiding chat entirely.
 - **Collapse** to `collapsedSize={0}` hides the dock and gives chat the full width; a thin **rail
-  tab** on the right edge re-opens it (and the existing header toggle stays). State persists via
-  `autoSaveId`.
+  tab** on the right edge re-opens it, and the existing header toggle drives the same collapsed
+  state. Width persists via `autoSaveId`.
 - **Maximize-to-full-workspace** is a *mode above the PanelGroup*, not a panel size. A maximize
   button in the dock header flips a `maximized` boolean; when true the dock renders as an
   **`fixed inset-0 z-40`** overlay covering the whole session area (chat hidden behind it), with a

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useState } from "react";
 import {
   ChevronsLeftRightIcon,
   Maximize2Icon,
@@ -30,6 +30,9 @@ export type WorkspaceDockProps = {
   /** Controlled active tab. Falls back to the first tab. */
   activeTab?: string | undefined;
   onActiveTabChange?: ((id: string) => void) | undefined;
+  /** Controlled collapsed state for hosts that expose their own dock toggle. */
+  collapsed?: boolean | undefined;
+  onCollapsedChange?: ((collapsed: boolean) => void) | undefined;
   /** Persisted layout id (localStorage key) for react-resizable-panels. */
   autoSaveId?: string | undefined;
   /** Default dock width as a percent of the session area. */
@@ -47,11 +50,15 @@ export type WorkspaceDockProps = {
  * `autoSaveId`. Maximize is a mode ABOVE the Group (a `fixed inset-0` overlay) —
  * pushing a Panel to ~100% still fights min sizes and leaves a chat sliver.
  */
+const useDockLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
 export function WorkspaceDock({
   primary,
   tabs,
   activeTab,
   onActiveTabChange,
+  collapsed: collapsedProp,
+  onCollapsedChange,
   autoSaveId = "og.session.dock",
   defaultSize = 34,
   minSize = 22,
@@ -59,9 +66,10 @@ export function WorkspaceDock({
   className,
 }: WorkspaceDockProps) {
   const dockPanelRef = usePanelRef();
-  const [collapsed, setCollapsed] = useState(false);
+  const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [maximized, setMaximized] = useState(false);
   const [internalTab, setInternalTab] = useState(tabs[0]?.id ?? "");
+  const collapsed = collapsedProp ?? internalCollapsed;
 
   // Persisted layout (width split) keyed by autoSaveId.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -71,6 +79,8 @@ export function WorkspaceDock({
   } as Parameters<typeof useDefaultLayout>[0]);
 
   const current = activeTab ?? internalTab;
+  const tabIds = tabs.map((tab) => tab.id).join("\u0000");
+  const firstTabId = tabs[0]?.id ?? "";
   const setTab = useCallback(
     (id: string) => {
       setInternalTab(id);
@@ -78,13 +88,34 @@ export function WorkspaceDock({
     },
     [onActiveTabChange],
   );
+  const setCollapsed = useCallback(
+    (next: boolean) => {
+      setInternalCollapsed((previous) => (previous === next ? previous : next));
+      onCollapsedChange?.(next);
+    },
+    [onCollapsedChange],
+  );
+
+  useDockLayoutEffect(() => {
+    if (collapsedProp === undefined) {
+      return;
+    }
+    if (collapsedProp) {
+      dockPanelRef.current?.collapse();
+      setMaximized(false);
+    } else {
+      dockPanelRef.current?.expand();
+    }
+  }, [collapsedProp, dockPanelRef]);
 
   // Keep the active tab valid if the available tabs change.
   useEffect(() => {
-    if (tabs.length > 0 && !tabs.some((t) => t.id === current)) {
-      setTab(tabs[0]!.id);
+    if (firstTabId && !tabs.some((t) => t.id === current)) {
+      setTab(firstTabId);
     }
-  }, [tabs, current, setTab]);
+    // Depend on tab identity, not the tab content objects. Session live events
+    // rebuild tab JSX frequently; only id changes can invalidate the active tab.
+  }, [tabIds, firstTabId, current, setTab]);
 
   // Esc restores from maximize.
   useEffect(() => {
@@ -99,11 +130,11 @@ export function WorkspaceDock({
   const collapse = useCallback(() => {
     dockPanelRef.current?.collapse();
     setCollapsed(true);
-  }, [dockPanelRef]);
+  }, [dockPanelRef, setCollapsed]);
   const expand = useCallback(() => {
     dockPanelRef.current?.expand();
     setCollapsed(false);
-  }, [dockPanelRef]);
+  }, [dockPanelRef, setCollapsed]);
 
   const dockChrome = (
     <DockChrome
@@ -142,16 +173,19 @@ export function WorkspaceDock({
           defaultSize={`${defaultSize}%`}
           minSize={`${minSize}%`}
           maxSize={`${maxSize}%`}
-          onResize={(size) => {
+          onResize={(size, _id, previousSize) => {
             // `asPercentage` is 0..100; treat a near-zero panel as collapsed.
             const isCollapsed = size.asPercentage <= 1;
-            setCollapsed((prev) => (prev !== isCollapsed ? isCollapsed : prev));
+            const canInferCollapse = collapsedProp === undefined || previousSize !== undefined;
+            if (canInferCollapse && isCollapsed !== collapsed) {
+              setCollapsed(isCollapsed);
+            }
           }}
           className="min-h-0 min-w-0"
         >
           {/* Hidden behind the overlay while maximized (avoids double-mounting
               the surfaces). */}
-          {!maximized && (
+          {!collapsed && !maximized && (
             <div className="flex h-full min-h-0 min-w-0 flex-col border-l border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-bg,var(--color-bg,#0d0d0d))]">
               {dockChrome}
             </div>

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -42,6 +42,8 @@ export type UseGoalResult = {
 export function useGoal(sessionId: string | null | undefined, options: UseGoalOptions = {}): UseGoalResult {
   const { client, workspaceId } = useOpenGeni(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
+  const sharedEvents = options.events;
+  const sharedFeed = sharedEvents !== undefined;
   const [goal, setGoal] = useState<SessionGoal | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
@@ -87,6 +89,12 @@ export function useGoal(sessionId: string | null | undefined, options: UseGoalOp
       setLoading(false);
       return;
     }
+    if (sharedFeed) {
+      setLoading(false);
+      return () => {
+        generation.current += 1;
+      };
+    }
     setLoading(true);
     void load();
     const pollIntervalMs = options.pollIntervalMs;
@@ -100,12 +108,12 @@ export function useGoal(sessionId: string | null | undefined, options: UseGoalOp
       clearInterval(timer);
       generation.current += 1;
     };
-  }, [load, enabled, workspaceId, sessionId, options.pollIntervalMs]);
+  }, [load, enabled, workspaceId, sessionId, options.pollIntervalMs, sharedFeed]);
 
   const scheduleRefresh = useDebouncedCallback(() => void load());
   useSessionEventTrigger(client, workspaceId, sessionId, isGoalEvent, scheduleRefresh, {
     enabled,
-    ...(options.events !== undefined ? { events: options.events } : {}),
+    ...(sharedEvents !== undefined ? { events: sharedEvents } : {}),
   });
 
   const pause = useCallback(

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -219,7 +219,7 @@ describe("useGoal", () => {
     const goal = fakeGoal({ autoContinuations: 7, noProgressStreak: 2 });
     const client = fakeClient({ getGoal: async () => goal });
     const hook = await renderHook(
-      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
       undefined,
     );
     await flush();
@@ -236,12 +236,31 @@ describe("useGoal", () => {
       },
     });
     const hook = await renderHook(
-      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
       undefined,
     );
     await flush();
     expect(hook.result.current.goal).toBeNull();
     expect(hook.result.current.error).toBeNull();
+    expect(hook.result.current.loading).toBe(false);
+    await hook.unmount();
+  });
+
+  test("shared empty event logs do not probe the goal endpoint", async () => {
+    let reads = 0;
+    const client = fakeClient({
+      getGoal: async () => {
+        reads += 1;
+        return fakeGoal();
+      },
+    });
+    const hook = await renderHook(
+      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      undefined,
+    );
+    await flush();
+    expect(reads).toBe(0);
+    expect(hook.result.current.goal).toBeNull();
     expect(hook.result.current.loading).toBe(false);
     await hook.unmount();
   });
@@ -280,7 +299,7 @@ describe("useGoal", () => {
     const client = fakeClient({
       getGoal: async () => {
         reads += 1;
-        return fakeGoal({ status: reads > 1 ? "paused" : "active" });
+        return fakeGoal({ status: "paused" });
       },
     });
     const hook = await renderHook(
@@ -288,11 +307,42 @@ describe("useGoal", () => {
       [] as SessionEvent[],
     );
     await flush();
-    expect(reads).toBe(1);
+    expect(reads).toBe(0);
     await hook.rerender([makeEvent(1, "goal.paused")]);
     await flush(250);
-    expect(reads).toBe(2);
+    expect(reads).toBe(1);
     expect(hook.result.current.isPaused).toBe(true);
+    await hook.unmount();
+  });
+
+  test("shared-feed goal refreshes are discarded after the session changes", async () => {
+    const initialSessionId: string = SESSION_ID;
+    const otherSessionId = "33333333-3333-4333-8333-333333333333";
+    const reads: string[] = [];
+    let resolveGoal: ((goal: ReturnType<typeof fakeGoal>) => void) | null = null;
+    const client = fakeClient({
+      getGoal: async (_workspaceId, sessionId) => {
+        reads.push(sessionId);
+        return await new Promise<ReturnType<typeof fakeGoal>>((resolve) => {
+          resolveGoal = resolve;
+        });
+      },
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useGoal(sessionId, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      initialSessionId,
+    );
+    await flush();
+
+    const pendingRefresh = hook.result.current.refresh();
+    expect(reads).toEqual([SESSION_ID]);
+    await hook.rerender(otherSessionId);
+    await flushing(async () => {
+      resolveGoal!(fakeGoal({ text: "stale goal from the previous session" }));
+      await pendingRefresh;
+    });
+
+    expect(hook.result.current.goal).toBeNull();
     await hook.unmount();
   });
 });

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { WorkspaceDock } from "../src/components/workspace-dock";
+import { registerDom, renderComponent } from "./render-hook";
+
+registerDom();
+
+async function click(element: Element | null): Promise<void> {
+  expect(element).not.toBeNull();
+  await act(async () => {
+    element!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+function ControlledDock(props: { onCollapsedChange: (collapsed: boolean) => void }) {
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <WorkspaceDock
+      autoSaveId="og.test.workspace-dock"
+      primary={<div>Chat pane</div>}
+      tabs={[{ id: "run", label: "Run", content: <div>Run content</div> }]}
+      collapsed={collapsed}
+      onCollapsedChange={(next) => {
+        props.onCollapsedChange(next);
+        setCollapsed(next);
+      }}
+    />
+  );
+}
+
+describe("WorkspaceDock", () => {
+  test("dock collapse controls can be owned by the host", async () => {
+    const changes: boolean[] = [];
+    const rendered = await renderComponent(
+      <ControlledDock onCollapsedChange={(collapsed) => changes.push(collapsed)} />,
+    );
+
+    expect(rendered.container.textContent ?? "").toContain("Run content");
+    expect(rendered.container.querySelector('[title="Open workspace"]')).toBeNull();
+
+    await click(rendered.container.querySelector('[title="Collapse"]'));
+
+    expect(changes.at(-1)).toBe(true);
+    expect(rendered.container.textContent ?? "").not.toContain("Run content");
+    expect(rendered.container.querySelector('[title="Open workspace"]')).not.toBeNull();
+
+    await click(rendered.container.querySelector('[title="Open workspace"]'));
+
+    expect(changes.at(-1)).toBe(false);
+    expect(rendered.container.textContent ?? "").toContain("Run content");
+
+    await rendered.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- keep queue/steer composer mode user-owned while a session is idle
- avoid redundant session context churn from shallow-equal live status overlays
- make the workspace dock collapse state host-controlled so the empty right pane and real dock stay in sync
- avoid shared-feed goal-hook 404 probes and discard stale refreshes after session changes

## Root Cause
The web shell had two independent state owners for session send mode and right-dock visibility. The goal hook also treated shared session event feeds like standalone goal subscriptions, so goal-less sessions could probe `/goal` unnecessarily during first-token streaming.

## Validation
- `bun test apps/web/src/App.test.ts apps/web/src/lib/queue.test.ts packages/react/test/hooks.test.tsx packages/react/test/turn-queue-helpers.test.ts packages/react/test/workspace-dock.test.tsx`
- `cd packages/react && bun run typecheck`
- `cd apps/web && bun run typecheck`
- `git diff --check`
- `cd packages/react && bun run build`
- `cd apps/web && bun run build`

The web build still reports the pre-existing large-chunk warning only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/state-layer fixes with targeted tests; no auth, API contract, or payment changes.
> 
> **Overview**
> Reduces unnecessary React re-renders and fixes split ownership of session UI state in the web console.
> 
> **Session context** adds `sameSessionForContext` and wraps app `setSession` so shallow-equal session objects (e.g. live status overlays with identical fields) keep the previous reference instead of forcing downstream updates.
> 
> **Composer steer mode** no longer auto-resets to queue when the session goes idle: `isMidTurn` and its session-route `useEffect` are removed, so queue/steer stays user-controlled across status changes.
> 
> **Workspace dock** is always mounted; collapse is driven by `inspectorOpen` via new controlled `collapsed` / `onCollapsedChange` on `WorkspaceDock`, with layout sync, safer resize→collapse inference when controlled, tab effects keyed on tab ids (not rebuilt JSX), and dock content unmounted when collapsed (including sandbox Files warmup only when expanded).
> 
> **`useGoal`** with a shared event feed skips the initial `getGoal` probe (waits for `goal.*` events); stale in-flight refreshes after session change are discarded via existing generation handling.
> 
> Tests and docs updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db4b13443d4708f14dc4315655c26560cd64d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->