### PR TITLE
feat(machines): connected-machine DX + safety fixes + design docs

### DIFF
--- a/agent/crates/opengeni-agent/src/metrics.rs
+++ b/agent/crates/opengeni-agent/src/metrics.rs
@@ -435,7 +435,11 @@ fn parse_top_cpu_busy(text: &str) -> f64 {
     for seg in after.split(',') {
         let seg = seg.trim();
         if seg.ends_with("user") || seg.ends_with("sys") {
-            if let Some(pct) = seg.split('%').next().and_then(|p| p.trim().parse::<f64>().ok()) {
+            if let Some(pct) = seg
+                .split('%')
+                .next()
+                .and_then(|p| p.trim().parse::<f64>().ok())
+            {
                 busy += pct;
             }
         }
@@ -631,13 +635,21 @@ Buffers:          500000 kB
         let blocks = 262_144u64; // 262144 × 4096 == 1 GiB
         let avail = 131_072u64; // half free
         let (used, total) = disk_used_total(frsize, blocks, avail);
-        assert_eq!(total, 1024 * 1024 * 1024, "1 GiB total, counted in frsize units");
+        assert_eq!(
+            total,
+            1024 * 1024 * 1024,
+            "1 GiB total, counted in frsize units"
+        );
         assert_eq!(used, 512 * 1024 * 1024, "half used");
 
         // Documents the bug the fix removes: had we used f_bsize (1 MiB) as the
         // multiplier the total would have been exactly 256x too large.
         let buggy_block = frsize.max(1024 * 1024);
-        assert_eq!(blocks * buggy_block, total * 256, "the 256x inflation, gone");
+        assert_eq!(
+            blocks * buggy_block,
+            total * 256,
+            "the 256x inflation, gone"
+        );
     }
 
     #[test]
@@ -677,7 +689,10 @@ Processes: 500 total, 3 running\n\
 CPU usage: 4.76% user, 9.52% sys, 85.71% idle\n\
 PhysMem: 8G used\n";
         let busy = parse_top_cpu_busy(fixture);
-        assert!((busy - 14.28).abs() < 1e-9, "second sample: 4.76 + 9.52, not the first");
+        assert!(
+            (busy - 14.28).abs() < 1e-9,
+            "second sample: 4.76 + 9.52, not the first"
+        );
     }
 
     #[test]
@@ -735,6 +750,9 @@ Pages free:                              100000.\n";
     fn parse_vm_stat_page_size_defaults_to_4096_when_absent() {
         // No header → fall back to 4096 (the parser returns None, caller defaults).
         assert!(parse_vm_stat_page_size("Pages free: 1.\n").is_none());
-        assert_eq!(parse_vm_stat_page_size("foo (page size of 16384 bytes)\n"), Some(16384));
+        assert_eq!(
+            parse_vm_stat_page_size("foo (page size of 16384 bytes)\n"),
+            Some(16384)
+        );
     }
 }

--- a/agent/crates/opengeni-agent/src/metrics.rs
+++ b/agent/crates/opengeni-agent/src/metrics.rs
@@ -19,18 +19,26 @@
 //!
 //! # Cross-platform posture
 //!
-//! The richer `/proc`-based readings are Linux-only (gated on `target_os`); on
-//! other OSes those fields stay zero == "not reported" until their native
-//! sources land (the same honest-degradation rule the M6 seam used). The
-//! load-average reading is unix-wide via `/proc` on Linux. **No `unsafe`** — the
-//! one syscall (`statvfs`) goes through the safe `nix` crate.
+//! Linux reads the rich `/proc` sources. **macOS** reads the same signals from
+//! its native tools via subprocess — the SAME no-FFI strategy the GPU reader
+//! uses for `nvidia-smi`, so the workspace `unsafe_code = forbid` holds with no
+//! `libc`/`mach` bindings of our own: load from `sysctl vm.loadavg`, mem total
+//! from `sysctl hw.memsize` (used best-effort from `vm_stat`), and cpu% from
+//! `top -l 2` (its second sample reflects a real interval — the macOS analog of
+//! the `/proc/stat` delta). The macOS run-queue has no cheap source, so it stays
+//! zero == "not reported"; any other OS likewise degrades every rich field to
+//! zero (the honest-degradation rule the M6 seam used). **No `unsafe`** —
+//! `statvfs` goes through the safe `nix` crate and every macOS reading is a
+//! subprocess parse, never our own FFI.
 //!
 //! # Determinism / testing
 //!
-//! The `/proc` parsing is factored into pure functions over text
-//! (`parse_meminfo`, `parse_loadavg`, `cpu_busy_total_from_stat`) so the unit
-//! tests parse committed fixtures with NO live host dependency — bounds, the
-//! null-when-absent contract, and the CPU delta are all deterministic.
+//! Every text/number reading is factored into pure functions
+//! (`parse_meminfo`, `parse_loadavg`, `cpu_busy_total_from_stat`, the macOS
+//! `parse_sysctl_loadavg` / `parse_vm_stat_used` / `parse_top_cpu_busy`, and the
+//! cross-platform `disk_used_total`) so the unit tests parse committed fixtures
+//! with NO live host dependency — bounds, the null-when-absent contract, the CPU
+//! delta, and the disk fragment-size unit are all deterministic.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -116,6 +124,15 @@ fn read_loadavg() -> (f64, f64, f64, f64) {
             return parse_loadavg(&text);
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(text) = run_sysctl("vm.loadavg") {
+            let (l1, l5, l15) = parse_sysctl_loadavg(&text);
+            // The runnable run-queue count has no cheap macOS source (it is the
+            // 4th `/proc/loadavg` field on Linux); 0 == "not reported".
+            return (l1, l5, l15, 0.0);
+        }
+    }
     (0.0, 0.0, 0.0, 0.0)
 }
 
@@ -139,9 +156,14 @@ fn parse_loadavg(text: &str) -> (f64, f64, f64, f64) {
 
 // ── cpu% (/proc/stat delta) ──────────────────────────────────────────────────
 
-/// Whole-machine CPU utilization 0..100, the delta of two `/proc/stat` reads
-/// over [`CPU_SAMPLE_INTERVAL`]. Returns 0.0 on non-Linux or any read failure
-/// (zero == "not reported").
+/// Whole-machine CPU utilization 0..100.
+///
+/// Linux: the delta of two `/proc/stat` reads over [`CPU_SAMPLE_INTERVAL`]
+/// (~200ms). macOS: `top -l 2 -n 0`, whose SECOND `CPU usage:` line reflects a
+/// real sampling interval (the first is cumulative-since-boot, so a single read
+/// is meaningless — the same reason the Linux path needs a delta); `top`'s
+/// default interval is ~1s, so the macOS sample blocks ~1s rather than 200ms.
+/// Returns 0.0 on any read failure or an unsupported OS (zero == "not reported").
 fn read_cpu_percent() -> f64 {
     #[cfg(target_os = "linux")]
     {
@@ -155,7 +177,13 @@ fn read_cpu_percent() -> f64 {
         let Some(second) = read() else { return 0.0 };
         cpu_percent_from_deltas(first, second)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        run_capture("top", &["-l", "2", "-n", "0"])
+            .map(|text| parse_top_cpu_busy(&text))
+            .unwrap_or(0.0)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         0.0
     }
@@ -210,6 +238,18 @@ fn read_memory() -> (u64, u64) {
             return parse_meminfo(&text);
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        // total is authoritative (`hw.memsize`, already bytes). used is
+        // best-effort from `vm_stat`; if that is unreadable we still report the
+        // correct total with used == 0 (the bounds invariant used <= total holds).
+        if let Some(total) = run_sysctl("hw.memsize").and_then(|t| t.trim().parse::<u64>().ok()) {
+            let used = run_capture("vm_stat", &[])
+                .map(|t| parse_vm_stat_used(&t, total))
+                .unwrap_or(0);
+            return (used.min(total), total);
+        }
+    }
     (0, 0)
 }
 
@@ -255,21 +295,39 @@ fn read_disk(root: &str) -> (u64, u64) {
         let Ok(stat) = statvfs(root.as_bytes()) else {
             return (0, 0);
         };
-        // statvfs widths are platform-dependent: the block size is `c_ulong` (u64 on
-        // both targets) but the block COUNTS are `fsblkcnt_t` — u64 on Linux (glibc),
-        // u32 on macOS. Cast the counts to the u64 wire type (a no-op on Linux,
-        // widening on macOS) before the saturating arithmetic (which never overflows).
-        let block: u64 = stat.fragment_size().max(stat.block_size());
-        let total: u64 = (stat.blocks() as u64).saturating_mul(block);
-        let avail: u64 = (stat.blocks_available() as u64).saturating_mul(block);
-        let used: u64 = total.saturating_sub(avail);
-        (used, total)
+        // POSIX counts f_blocks/f_bavail in units of f_frsize (the FRAGMENT size),
+        // NOT f_bsize. On Linux f_frsize == f_bsize so the distinction never bit;
+        // on macOS f_bsize == f_iosize (~1 MiB) while f_frsize == 4096 and the
+        // counts are in 4 KiB units, so multiplying by the larger f_bsize inflated
+        // every figure by 1 MiB / 4 KiB == 256x (the reported ~237146 GB). Multiply
+        // by f_frsize ALONE.
+        //
+        // The block COUNTS are `fsblkcnt_t` — u64 on Linux (glibc), u32 on macOS;
+        // cast to the u64 wire type (a no-op on Linux, widening on macOS) before the
+        // saturating arithmetic in `disk_used_total` (which never overflows).
+        disk_used_total(
+            stat.fragment_size(),
+            stat.blocks() as u64,
+            stat.blocks_available() as u64,
+        )
     }
     #[cfg(not(unix))]
     {
         let _ = root;
         (0, 0)
     }
+}
+
+/// Pure disk arithmetic: `bytes = block-count × fragment_size`, with
+/// `used = total − available` (available clamped to `total`). Factored out of
+/// [`read_disk`] so the fragment-size unit — the source of the macOS 256x bug —
+/// is deterministically unit-testable without a live `statvfs`.
+#[cfg_attr(not(unix), allow(dead_code))]
+fn disk_used_total(fragment_size: u64, blocks: u64, blocks_available: u64) -> (u64, u64) {
+    let total = blocks.saturating_mul(fragment_size);
+    let avail = blocks_available.saturating_mul(fragment_size).min(total);
+    let used = total.saturating_sub(avail);
+    (used, total)
 }
 
 // ── gpu (best-effort nvidia-smi) ─────────────────────────────────────────────
@@ -318,6 +376,118 @@ fn parse_nvidia_smi(text: &str) -> Vec<GpuSample> {
             })
         })
         .collect()
+}
+
+// ── macOS native readers (subprocess; no FFI → unsafe_code = forbid holds) ────
+//
+// The wrappers shell out exactly like `read_gpus` does for `nvidia-smi`; the
+// parsers are pure functions over the tools' text so they unit-test on ANY host
+// (the macOS branches above are the only macOS-gated code). The wrappers compile
+// on every target (so a non-macOS `cargo check` still type-checks them) but are
+// dead outside macOS — hence the `allow(dead_code)`.
+
+/// Runs `cmd args…` and returns its stdout as a `String`, or `None` if the
+/// process fails to spawn or exits non-zero. The macOS-metrics analog of the
+/// `nvidia-smi` spawn in [`read_gpus`] — never panics, never blocks on input.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn run_capture(cmd: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(cmd).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `sysctl -n <name>` → its trimmed-on-use stdout (e.g. `vm.loadavg`,
+/// `hw.memsize`). A thin convenience over [`run_capture`].
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn run_sysctl(name: &str) -> Option<String> {
+    run_capture("sysctl", &["-n", name])
+}
+
+/// Parse `sysctl -n vm.loadavg` output — `{ 0.52 0.48 0.45 }` → `(0.52, 0.48,
+/// 0.45)`. Tolerant of the surrounding braces and extra whitespace; any field it
+/// cannot parse degrades to `0.0`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn parse_sysctl_loadavg(text: &str) -> (f64, f64, f64) {
+    let nums: Vec<f64> = text
+        .replace(['{', '}'], " ")
+        .split_whitespace()
+        .filter_map(|tok| tok.parse::<f64>().ok())
+        .collect();
+    let l1 = nums.first().copied().unwrap_or(0.0);
+    let l5 = nums.get(1).copied().unwrap_or(0.0);
+    let l15 = nums.get(2).copied().unwrap_or(0.0);
+    (l1, l5, l15)
+}
+
+/// Whole-machine busy% from `top -l 2 -n 0` output: the LAST `CPU usage:` line
+/// (the second sample, a real interval), summing the `user` + `sys` percentages.
+/// A line like `CPU usage: 4.76% user, 9.52% sys, 85.71% idle` → `14.28`. Missing
+/// or unparseable → `0.0`; the result is clamped to `0..=100`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn parse_top_cpu_busy(text: &str) -> f64 {
+    let Some(line) = text.lines().rfind(|l| l.contains("CPU usage:")) else {
+        return 0.0;
+    };
+    let after = line.split("CPU usage:").nth(1).unwrap_or("");
+    let mut busy = 0.0;
+    for seg in after.split(',') {
+        let seg = seg.trim();
+        if seg.ends_with("user") || seg.ends_with("sys") {
+            if let Some(pct) = seg.split('%').next().and_then(|p| p.trim().parse::<f64>().ok()) {
+                busy += pct;
+            }
+        }
+    }
+    busy.clamp(0.0, 100.0)
+}
+
+/// "Used" bytes from `vm_stat`, given the authoritative `total_bytes`
+/// (`hw.memsize`). macOS has no single "available" figure, so we treat the
+/// reclaimable pages (free + inactive + speculative + purgeable) as available and
+/// report `used = total − available` — the same memory-pressure framing as the
+/// Linux `MemTotal − MemAvailable`. The page size is read from the `vm_stat`
+/// header (4 KiB on Intel, 16 KiB on Apple Silicon); a missing field degrades to
+/// 0 pages. `used` is clamped to `0..=total`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn parse_vm_stat_used(text: &str, total_bytes: u64) -> u64 {
+    let page = parse_vm_stat_page_size(text).unwrap_or(4096);
+    let reclaimable_pages = vm_stat_value(text, "Pages free")
+        .saturating_add(vm_stat_value(text, "Pages inactive"))
+        .saturating_add(vm_stat_value(text, "Pages speculative"))
+        .saturating_add(vm_stat_value(text, "Pages purgeable"));
+    let available = reclaimable_pages.saturating_mul(page).min(total_bytes);
+    total_bytes.saturating_sub(available)
+}
+
+/// The page size (bytes) from a `vm_stat` header line —
+/// `…(page size of 16384 bytes)` → `16384`. `None` if the header is absent or
+/// malformed (callers fall back to 4096).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn parse_vm_stat_page_size(text: &str) -> Option<u64> {
+    text.lines()
+        .next()?
+        .split("page size of")
+        .nth(1)?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+}
+
+/// The page count for a `vm_stat` row keyed by `key` (e.g. `Pages free`). The
+/// value is the count before the trailing `.`; a missing or unparseable row is 0.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn vm_stat_value(text: &str, key: &str) -> u64 {
+    for line in text.lines() {
+        if let Some((k, v)) = line.split_once(':') {
+            if k.trim() == key {
+                return v.trim().trim_end_matches('.').parse::<u64>().unwrap_or(0);
+            }
+        }
+    }
+    0
 }
 
 #[cfg(test)]
@@ -449,5 +619,122 @@ Buffers:          500000 kB
         // platform without statvfs).
         let (used, total) = read_disk(".");
         assert!(used <= total || total == 0);
+    }
+
+    #[test]
+    fn disk_used_total_counts_blocks_in_fragment_size_units() {
+        // POSIX counts f_blocks/f_bavail in f_frsize units. On macOS f_frsize is
+        // 4096 while f_bsize == f_iosize (~1 MiB); the pre-fix code multiplied by
+        // max(frsize, bsize) == 1 MiB, a 1 MiB / 4 KiB == 256x inflation (the
+        // reported ~237146 GB). The fix multiplies by f_frsize alone.
+        let frsize = 4096u64;
+        let blocks = 262_144u64; // 262144 × 4096 == 1 GiB
+        let avail = 131_072u64; // half free
+        let (used, total) = disk_used_total(frsize, blocks, avail);
+        assert_eq!(total, 1024 * 1024 * 1024, "1 GiB total, counted in frsize units");
+        assert_eq!(used, 512 * 1024 * 1024, "half used");
+
+        // Documents the bug the fix removes: had we used f_bsize (1 MiB) as the
+        // multiplier the total would have been exactly 256x too large.
+        let buggy_block = frsize.max(1024 * 1024);
+        assert_eq!(blocks * buggy_block, total * 256, "the 256x inflation, gone");
+    }
+
+    #[test]
+    fn disk_used_total_clamps_available_and_saturates() {
+        // A pathological avail > blocks still yields used == 0 (clamped), total
+        // honest — never an underflow panic.
+        let (used, total) = disk_used_total(4096, 10, 1_000);
+        assert_eq!(total, 10 * 4096);
+        assert_eq!(used, 0);
+        // Saturating multiply: an absurd count cannot overflow u64.
+        let (_, big) = disk_used_total(u64::MAX, u64::MAX, 0);
+        assert_eq!(big, u64::MAX);
+    }
+
+    #[test]
+    fn parse_sysctl_loadavg_extracts_three_loads() {
+        let (l1, l5, l15) = parse_sysctl_loadavg("{ 0.52 0.48 0.45 }\n");
+        assert!((l1 - 0.52).abs() < 1e-9);
+        assert!((l5 - 0.48).abs() < 1e-9);
+        assert!((l15 - 0.45).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_sysctl_loadavg_degrades_on_garbage() {
+        assert_eq!(parse_sysctl_loadavg("not loadavg"), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn parse_top_cpu_busy_uses_the_second_sample_and_sums_user_sys() {
+        // `top -l 2` prints two summaries; the FIRST is cumulative-since-boot, the
+        // SECOND is the real interval. We must read the second and sum user + sys.
+        let fixture = "\
+Processes: 500 total, 2 running\n\
+CPU usage: 1.00% user, 1.00% sys, 98.00% idle\n\
+PhysMem: 8G used\n\
+Processes: 500 total, 3 running\n\
+CPU usage: 4.76% user, 9.52% sys, 85.71% idle\n\
+PhysMem: 8G used\n";
+        let busy = parse_top_cpu_busy(fixture);
+        assert!((busy - 14.28).abs() < 1e-9, "second sample: 4.76 + 9.52, not the first");
+    }
+
+    #[test]
+    fn parse_top_cpu_busy_clamps_and_degrades() {
+        assert_eq!(parse_top_cpu_busy("no cpu line here"), 0.0);
+        // A pathological >100 sum clamps to 100.
+        let busy = parse_top_cpu_busy("CPU usage: 80.00% user, 40.00% sys, 0.00% idle\n");
+        assert!((busy - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_vm_stat_used_is_total_minus_reclaimable() {
+        // 4096-byte pages. reclaimable = free + inactive + speculative + purgeable
+        // = (10 + 20 + 5 + 5) = 40 pages == 163840 bytes available.
+        let fixture = "\
+Mach Virtual Memory Statistics: (page size of 4096 bytes)\n\
+Pages free:                                  10.\n\
+Pages active:                               100.\n\
+Pages inactive:                              20.\n\
+Pages speculative:                            5.\n\
+Pages wired down:                            50.\n\
+Pages purgeable:                              5.\n\
+Pages occupied by compressor:                30.\n";
+        let total = 1_000_000u64;
+        let used = parse_vm_stat_used(fixture, total);
+        let available = (10 + 20 + 5 + 5) * 4096;
+        assert_eq!(used, total - available);
+        assert!(used < total);
+    }
+
+    #[test]
+    fn parse_vm_stat_used_reads_apple_silicon_page_size() {
+        // 16 KiB pages (Apple Silicon); a missing purgeable row degrades to 0.
+        let fixture = "\
+Mach Virtual Memory Statistics: (page size of 16384 bytes)\n\
+Pages free:                                  10.\n\
+Pages inactive:                              10.\n\
+Pages speculative:                            0.\n";
+        let total = 10_000_000u64;
+        let used = parse_vm_stat_used(fixture, total);
+        let available = (10 + 10) * 16384;
+        assert_eq!(used, total - available);
+    }
+
+    #[test]
+    fn parse_vm_stat_used_clamps_when_reclaimable_exceeds_total() {
+        // If reclaimable pages exceed the (tiny) total, used clamps to 0.
+        let fixture = "\
+Mach Virtual Memory Statistics: (page size of 4096 bytes)\n\
+Pages free:                              100000.\n";
+        assert_eq!(parse_vm_stat_used(fixture, 4096), 0);
+    }
+
+    #[test]
+    fn parse_vm_stat_page_size_defaults_to_4096_when_absent() {
+        // No header → fall back to 4096 (the parser returns None, caller defaults).
+        assert!(parse_vm_stat_page_size("Pages free: 1.\n").is_none());
+        assert_eq!(parse_vm_stat_page_size("foo (page size of 16384 bytes)\n"), Some(16384));
     }
 }

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -344,9 +344,29 @@ finish() {
   printf '%s\n' "opengeni-agent installed at: $_bin"
   printf '%s\n' ""
   printf '%s\n' "Next steps (the agent runs in the FOREGROUND — it does NOT install a service):"
-  printf '%s\n' "  1. Enroll this machine:   $_bin enroll"
-  if [ -n "${OPENGENI_WORKSPACE_ID:-}" ] || [ -n "${OPENGENI_API_URL:-}" ]; then
-    printf '%s\n' "       (OPENGENI_WORKSPACE_ID / OPENGENI_API_URL in this environment are honored automatically.)"
+  # The interactive device-flow enroll needs the workspace id (and, for a
+  # non-default deployment, the api url). When this script ran as `curl | sh`,
+  # those env vars existed ONLY for this piped process — they do NOT survive
+  # into the user's interactive shell, and the pipe has no TTY so we cannot run
+  # the interactive enroll here. So a bare `enroll` they paste later would fail
+  # with "enrollment requires a workspace id". Bake the known values into the
+  # command we print so it is copy-paste correct.
+  _enroll_env=""
+  if [ -n "${OPENGENI_WORKSPACE_ID:-}" ]; then
+    _enroll_env="OPENGENI_WORKSPACE_ID=$OPENGENI_WORKSPACE_ID"
+  fi
+  if [ -n "${OPENGENI_API_URL:-}" ]; then
+    if [ -n "$_enroll_env" ]; then
+      _enroll_env="$_enroll_env OPENGENI_API_URL=$OPENGENI_API_URL"
+    else
+      _enroll_env="OPENGENI_API_URL=$OPENGENI_API_URL"
+    fi
+  fi
+  if [ -n "$_enroll_env" ]; then
+    printf '%s\n' "  1. Enroll this machine:"
+    printf '%s\n' "       $_enroll_env \"$_bin\" enroll"
+  else
+    printf '%s\n' "  1. Enroll this machine:   $_bin enroll"
   fi
   printf '%s\n' "  2. Run it (online while this runs, offline when you stop it):"
   printf '%s\n' "       $_bin run"

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -3,15 +3,25 @@
 // (CPU/load/mem/disk/GPU), and an enroll affordance. The session-scoped attach/
 // swap is exercised inside a session (the dock), where the active-sandbox pointer
 // + the synthetic Modal group box are in scope. Here at the workspace level the
-// fleet is the read-first overview + the device-flow enrollment entry.
+// fleet is the read-first overview + the zero-click enroll-token entry (with a
+// manual device-flow approve kept as a secondary option).
 import {
   EnrollmentDeviceFlow,
   MachinesDashboard,
   useMachines,
   type DeviceFlowPhase,
 } from "@opengeni/react";
-import { AlertTriangleIcon, CheckIcon, CopyIcon, LaptopIcon, Loader2Icon, TerminalIcon } from "lucide-react";
-import { useState } from "react";
+import {
+  AlertTriangleIcon,
+  ArrowLeftIcon,
+  CheckIcon,
+  CopyIcon,
+  LaptopIcon,
+  Loader2Icon,
+  MonitorIcon,
+  TerminalIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { apiBaseUrl } from "@/api";
@@ -34,17 +44,13 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   // The install/approve URLs are deployment-relative: same origin as the API
   // (falling back to the page origin), never a hardcoded marketing domain.
   const origin = apiBaseUrl || (typeof window !== "undefined" ? window.location.origin : "");
-  // The default (interactive) one-liner now carries the workspace id so the user
-  // never hand-types the UUID; the agent prints a code to approve at /device.
-  const installCommand = installOneLiner(origin, { workspaceId });
-  const verificationUri = deviceVerificationUri(origin);
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
       <PageHeader
         icon={<LaptopIcon className="size-4" />}
         title="Machines"
-        description="Your own computers, enrolled as agent sandboxes. Run the install one-liner on a machine, approve the loud whole-machine consent, and it appears here — driveable from any session alongside the Modal sandbox."
+        description="Your own computers, enrolled as agent sandboxes. Run the install one-liner on a machine and it appears here — driveable from any session alongside the Modal sandbox."
       />
 
       <div className="mt-5">
@@ -66,127 +72,208 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
           <DialogHeader>
             <DialogTitle>Enroll a machine</DialogTitle>
             <DialogDescription>
-              Run the install one-liner on the machine you want to share. It prints a short code; confirm it on the approval
-              page to grant access.
+              Run a one-liner on the machine you want to share as an agent sandbox.
             </DialogDescription>
           </DialogHeader>
-          <EnrollmentDeviceFlow
-            // The agent mints the real code via the device-flow start; until the
-            // user runs the one-liner this panel shows the install step + where to
-            // approve. (A live code arrives once the agent calls /enrollments/start.)
-            userCode="——————"
-            verificationUri={verificationUri}
-            installCommand={installCommand}
-            phase={"pending" satisfies DeviceFlowPhase}
-            onCopyInstall={() => void navigator.clipboard.writeText(installCommand)}
-            className="border-0 shadow-none"
-          />
-          <HeadlessEnrollSection workspaceId={workspaceId} origin={origin} />
+          {/* Gated on `enrollOpen` so the body mounts (and mints a fresh token)
+              each time the dialog is opened, and unmounts on close — Radix already
+              unmounts closed content, this just makes the mint-on-open explicit. */}
+          {enrollOpen ? <EnrollDialogBody workspaceId={workspaceId} origin={origin} /> : null}
         </DialogContent>
       </Dialog>
     </div>
   );
 }
 
+type EnrollToken = { value: string; expiresAt: string; expiresInSeconds: number };
+
 /**
- * A2.5 — the headless / CI / fleet enroll path. Visually separated from the
- * interactive one-liner above so users aren't confused about which to run. It
- * mints a short-lived enroll token (the `oget_` SECRET — shown once, never
- * re-readable) and renders the headless one-liner that bakes it in, with a loud
- * copy-now warning + the expiry. The token IS the grant — machines that run this
- * one-liner enroll with zero approve clicks.
+ * The enroll dialog body. The PRIMARY path is zero-click: it mints a short-lived
+ * enroll token (the `oget_` SECRET) on open and renders the install one-liner
+ * that bakes it in — running that command enrolls the machine with no approval
+ * step. An "Allow screen control" checkbox bakes the screen-control consent into
+ * the minted token (toggling re-mints). The interactive device-flow approve is
+ * kept as a SECONDARY "Approve manually instead" option (it is not required to
+ * grant screen control — the checkbox above already covers that).
  */
-function HeadlessEnrollSection({ workspaceId, origin }: { workspaceId: string; origin: string }) {
+function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin: string }) {
   const { client } = useAppContext();
-  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<"token" | "manual">("token");
+  const [allowScreenControl, setAllowScreenControl] = useState(false);
+  const [token, setToken] = useState<EnrollToken | null>(null);
   const [minting, setMinting] = useState(false);
-  const [token, setToken] = useState<{ value: string; expiresAt: string; expiresInSeconds: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  // Only the latest mint may apply its result — guards against an out-of-order
+  // resolve when the user toggles screen control faster than the round-trip.
+  const mintSeq = useRef(0);
 
-  async function mint() {
-    setMinting(true);
-    try {
-      // Headless tokens never carry screen-control consent (no human at the
-      // approve page to make that call) — `false` is the only safe default.
-      const result = await client.mintEnrollToken(workspaceId, { allowScreenControl: false });
-      setToken({ value: result.token, expiresAt: result.expiresAt, expiresInSeconds: result.expiresInSeconds });
-      setCopied(false);
-    } catch (error) {
-      toast.error("Could not create an enroll token", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setMinting(false);
-    }
-  }
+  const mint = useCallback(
+    async (screenControl: boolean) => {
+      const seq = ++mintSeq.current;
+      setMinting(true);
+      setError(null);
+      try {
+        const result = await client.mintEnrollToken(workspaceId, { allowScreenControl: screenControl });
+        if (seq !== mintSeq.current) {
+          return;
+        }
+        setToken({ value: result.token, expiresAt: result.expiresAt, expiresInSeconds: result.expiresInSeconds });
+        setCopied(false);
+      } catch (err) {
+        if (seq !== mintSeq.current) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setToken(null);
+        toast.error("Could not create an enroll token", { description: message });
+      } finally {
+        if (seq === mintSeq.current) {
+          setMinting(false);
+        }
+      }
+    },
+    [client, workspaceId],
+  );
 
-  const headlessCommand = token ? installOneLiner(origin, { enrollToken: token.value }) : "";
+  // Mint on open and re-mint whenever the screen-control consent flips so the
+  // baked-in token always matches the checkbox.
+  useEffect(() => {
+    void mint(allowScreenControl);
+  }, [mint, allowScreenControl]);
+
+  const command = token ? installOneLiner(origin, { enrollToken: token.value }) : "";
 
   function copyCommand() {
-    if (!headlessCommand) {
+    if (!command) {
       return;
     }
-    void navigator.clipboard.writeText(headlessCommand);
+    void navigator.clipboard.writeText(command);
     setCopied(true);
-    toast.success("Headless install command copied");
+    toast.success("Install command copied");
   }
 
-  if (!open) {
+  if (mode === "manual") {
+    const installCommand = installOneLiner(origin, { workspaceId });
+    const verificationUri = deviceVerificationUri(origin);
     return (
-      <div className="mt-1 border-t border-[color:var(--color-border)] pt-3">
-        <Button type="button" variant="ghost" size="sm" className="w-full justify-start text-[color:var(--color-fg-muted)]" onClick={() => setOpen(true)}>
-          <TerminalIcon className="size-4" />
-          Advanced: headless / CI enrollment
+      <div className="flex flex-col gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="-ml-1 w-fit text-[color:var(--color-fg-muted)]"
+          onClick={() => setMode("token")}
+        >
+          <ArrowLeftIcon className="size-4" />
+          Back to one-click enroll
         </Button>
+        <EnrollmentDeviceFlow
+          // The agent mints the real code via the device-flow start; until the
+          // user runs the one-liner this panel shows the install step + where to
+          // approve. (A live code arrives once the agent calls /enrollments/start.)
+          userCode="——————"
+          verificationUri={verificationUri}
+          installCommand={installCommand}
+          phase={"pending" satisfies DeviceFlowPhase}
+          onCopyInstall={() => void navigator.clipboard.writeText(installCommand)}
+          className="border-0 shadow-none"
+        />
+        <p className="text-center text-[11px] leading-4 text-[color:var(--color-fg-muted)]">
+          Screen control is granted on the approval page when you confirm the code.
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="mt-1 flex flex-col gap-3 border-t border-[color:var(--color-border)] pt-3">
-      <div>
-        <h3 className="flex items-center gap-1.5 text-[13px] font-semibold text-[color:var(--color-fg)]">
-          <TerminalIcon className="size-3.5 text-[color:var(--color-fg-muted)]" />
-          Headless / CI enrollment
-        </h3>
-        <p className="mt-1 text-[12px] leading-4 text-[color:var(--color-fg-muted)]">
-          Mint a short-lived token to enroll a machine with no approval click — for fleet rollouts and CI. Use the
-          interactive one-liner above for a normal machine.
-        </p>
+    <div className="flex flex-col gap-3">
+      <p className="text-[12px] leading-4 text-[color:var(--color-fg-muted)]">
+        Run this on the machine you want to share. It enrolls instantly as an agent sandbox — no approval step.
+      </p>
+
+      <label className="flex items-start gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/40 px-2.5 py-2 text-[12px] leading-4 text-[color:var(--color-fg)]">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          checked={allowScreenControl}
+          disabled={minting}
+          onChange={(event) => setAllowScreenControl(event.target.checked)}
+        />
+        <span className="flex flex-col gap-0.5">
+          <span className="flex items-center gap-1.5 font-medium">
+            <MonitorIcon className="size-3.5 text-[color:var(--color-fg-muted)]" />
+            Allow screen control
+          </span>
+          <span className="text-[11px] text-[color:var(--color-fg-muted)]">
+            Let agents view and control this machine&apos;s screen (mouse + keyboard). Leave off for a headless sandbox.
+          </span>
+        </span>
+      </label>
+
+      <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-[12px] leading-4 text-amber-200">
+        <AlertTriangleIcon className="mt-px size-3.5 shrink-0" />
+        <span>
+          <span className="font-semibold">Secret — copy it now.</span> This command embeds a one-time enroll token that
+          grants enrollment into this workspace until it expires. Anyone who has it can enroll a machine here.
+        </span>
       </div>
 
-      {token ? (
+      {minting ? (
+        <div className="flex items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-2.5 text-[12px] text-[color:var(--color-fg-muted)]">
+          <Loader2Icon className="size-4 animate-spin" />
+          Minting enroll token…
+        </div>
+      ) : error ? (
+        <div className="flex flex-col gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2.5 text-[12px] leading-4 text-red-200">
+          <span>Could not create an enroll token. {error}</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => void mint(allowScreenControl)}
+          >
+            <TerminalIcon className="size-4" />
+            Try again
+          </Button>
+        </div>
+      ) : token ? (
         <>
-          <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-[12px] leading-4 text-amber-200">
-            <AlertTriangleIcon className="mt-px size-3.5 shrink-0" />
-            <span>
-              <span className="font-semibold">Secret — copy it now.</span> This token grants enrollment into this
-              workspace until it expires and won't be shown again. Anyone who has it can enroll a machine here.
-            </span>
-          </div>
           <div className="flex items-center justify-between rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-2.5 py-1.5 text-[11px] text-[color:var(--color-fg-muted)]">
             <span>Expires {formatExpiry(token.expiresAt, token.expiresInSeconds)}</span>
-            <Button type="button" variant="ghost" size="xs" onClick={() => void mint()} disabled={minting}>
-              {minting ? <Loader2Icon className="size-3 animate-spin" /> : null}
+            <Button type="button" variant="ghost" size="xs" onClick={() => void mint(allowScreenControl)} disabled={minting}>
               Regenerate
             </Button>
           </div>
           <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-2.5">
             <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-4 text-[color:var(--color-fg)]">
-              {headlessCommand}
+              {command}
             </pre>
           </div>
           <Button type="button" variant="secondary" size="sm" className="w-full" onClick={copyCommand}>
             {copied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
-            {copied ? "Copied" : "Copy headless install command"}
+            {copied ? "Copied" : "Copy install command"}
           </Button>
         </>
-      ) : (
-        <Button type="button" variant="outline" size="sm" className="w-full" onClick={() => void mint()} disabled={minting}>
-          {minting ? <Loader2Icon className="size-4 animate-spin" /> : <TerminalIcon className="size-4" />}
-          Generate enroll token
+      ) : null}
+
+      <div className="mt-1 border-t border-[color:var(--color-border)] pt-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-full justify-between text-[color:var(--color-fg-muted)]"
+          onClick={() => setMode("manual")}
+        >
+          <span className="flex items-center gap-2">
+            <TerminalIcon className="size-4" />
+            Approve manually instead
+          </span>
+          <span className="text-[11px]">device flow</span>
         </Button>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -4,6 +4,8 @@ import {
   applyCreditDebitUpToBalance,
   finishTurn,
   getBillingBalance,
+  getSandbox,
+  readActiveSandbox,
   requireFile,
   getSessionEvent,
   getSessionGoal,
@@ -193,6 +195,55 @@ export function historyRowsToAppend(
     item: item as Record<string, unknown>,
   }));
   return { rows, nextWatermark: sanitized.length, nextPosition: nextPosition + rows.length };
+}
+
+/**
+ * Resolve the EFFECTIVE/active compute backend a turn should gate
+ * filesystem-touching agent lifecycle hooks on (today: the repository clone).
+ *
+ * WHY (Case B — clone-onto-real-disk hazard): a session keeps its CLOUD HOME
+ * backend (`settings.sandboxBackend`, e.g. "modal") but its ACTIVE sandbox may
+ * have been swapped to a connected machine (`active_sandbox_id` → a selfhosted
+ * lease). `runtime.buildAgent`'s repository-clone hook keys off the backend it is
+ * told; if the worker passes nothing it defaults to the HOME backend and the hook
+ * would `git clone` a private GitHub-App repo onto the user's REAL disk — a
+ * bring-your-own machine owns its own filesystem and must NEVER be cloned onto. So
+ * we look at where the agent ACTUALLY runs, not where the session was created.
+ *
+ * Returns "selfhosted" ONLY when the selfhosted feature is on AND the session has
+ * a non-null active pointer whose sandbox `kind` is "selfhosted". Otherwise
+ * returns undefined so buildAgent falls back to the home backend — byte-for-byte
+ * unchanged cloud behavior.
+ *
+ * Total + best-effort by contract: it NEVER throws (a lookup failure is logged and
+ * falls back to the home default), so wiring it at turn start can't fail the turn.
+ * The DB I/O is injected (the real call site passes readActiveSandbox + getSandbox,
+ * the same helpers wrapTurnBoxWithRouting reuses) so the gate/decision/safety
+ * contract is unit-testable without a live database.
+ */
+export async function resolveActiveSandboxBackend(
+  routingOn: boolean,
+  loadPointer: () => Promise<{ activeSandboxId: string | null } | null>,
+  loadSandboxKind: (sandboxId: string) => Promise<string | null>,
+): Promise<Settings["sandboxBackend"] | undefined> {
+  // The active pointer + swap tools only exist when selfhosted routing is on; with
+  // the flag off there is nothing to resolve and we keep the home-backend default.
+  if (!routingOn) {
+    return undefined;
+  }
+  try {
+    const pointer = await loadPointer();
+    // A null pointer (no swap) means "use the session's own cloud group box" — the
+    // home backend already governs that path, so leave the override unset.
+    if (!pointer?.activeSandboxId) {
+      return undefined;
+    }
+    const kind = await loadSandboxKind(pointer.activeSandboxId);
+    return kind === "selfhosted" ? "selfhosted" : undefined;
+  } catch (error) {
+    console.error("active sandbox backend resolution failed (turn proceeds on home backend)", error);
+    return undefined;
+  }
 }
 
 export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
@@ -614,10 +665,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // trigger is goal.continuation/turn.preempted).
       const isGenesisTurn = triggerType === "user.message"
         && (await countSessionHistoryItems(db, input.workspaceId, input.sessionId)) === 0;
+      // Clone-onto-real-disk hazard (Case B). A session keeps its CLOUD HOME
+      // backend (runSettings.sandboxBackend, e.g. "modal") but its ACTIVE sandbox
+      // may have been swapped to a connected machine (active_sandbox_id → a
+      // selfhosted lease). buildAgent's repository-clone lifecycle hook keys off
+      // the EFFECTIVE backend; if we let it default to the home backend it would
+      // `git clone` a private GitHub-App repo onto the user's REAL disk. So resolve
+      // the session's effective backend here and pass "selfhosted" through when the
+      // active sandbox is a connected machine; otherwise leave it undefined so
+      // buildAgent defaults to the home backend (byte-for-byte unchanged cloud
+      // behavior). Reuse the SAME DB helpers wrapTurnBoxWithRouting uses:
+      // readActiveSandbox (the per-session pointer) + getSandbox (the sandboxes-by-id
+      // loader, for its `kind`). The gate (routingEnabled), best-effort try/catch,
+      // and decision live in resolveActiveSandboxBackend (tested in isolation);
+      // resolving once at turn start is correct because the clone hook runs at
+      // beforeAgentStart, so a mid-turn swap can't affect this decision.
+      const activeSandboxBackend = await resolveActiveSandboxBackend(
+        routingEnabled(settings),
+        () => readActiveSandbox(db, input.workspaceId, input.sessionId),
+        async (sandboxId) => (await getSandbox(db, input.workspaceId, sandboxId))?.kind ?? null,
+      );
       const agent = runtime.buildAgent(runSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,
         genesisTitleHint: isGenesisTurn,
         sandboxEnvironment,
+        ...(activeSandboxBackend ? { activeSandboxBackend } : {}),
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,
         // Resolved-model routing + gating (legacy defaults when null). The model

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
-import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 
 // Item shapes mirror the SDK history representation persisted into
 // session_history_items (type discriminator, camelCase callId).
@@ -284,6 +284,66 @@ describe("model usage source key (re-dispatch charge stability)", () => {
     // the key falls back to the positional value rather than throwing.
     expect(modelUsageSourceKey({ responseId: null, dispatchId: null, positionalKey: "aggregate" }))
       .toBe("aggregate");
+  });
+});
+
+describe("active sandbox backend resolution (Case B: clone-onto-real-disk gate)", () => {
+  const selfhostedPointer = async () => ({ activeSandboxId: "sbx_machine" });
+  const selfhostedKind = async () => "selfhosted";
+
+  test("returns 'selfhosted' when an active swap points at a connected machine", async () => {
+    // Home backend stays cloud (e.g. modal) but the active sandbox is a BYO
+    // machine — buildAgent must be told "selfhosted" so the repository clone hook
+    // is skipped (never `git clone` onto the user's real disk).
+    expect(await resolveActiveSandboxBackend(true, selfhostedPointer, selfhostedKind)).toBe("selfhosted");
+  });
+
+  test("returns undefined when routing is off (flag gated; home backend default)", async () => {
+    // The active pointer is only meaningful when the selfhosted feature is on; with
+    // it off we never even query, and the cloud home backend governs unchanged.
+    let queried = false;
+    const backend = await resolveActiveSandboxBackend(
+      false,
+      async () => {
+        queried = true;
+        return { activeSandboxId: "sbx_machine" };
+      },
+      selfhostedKind,
+    );
+    expect(backend).toBeUndefined();
+    expect(queried).toBe(false);
+  });
+
+  test("returns undefined when there is no active swap (null pointer == cloud group box)", async () => {
+    expect(await resolveActiveSandboxBackend(true, async () => null, selfhostedKind)).toBeUndefined();
+    expect(
+      await resolveActiveSandboxBackend(true, async () => ({ activeSandboxId: null }), selfhostedKind),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when the active swap target is itself a cloud (modal) box", async () => {
+    // A swap to a sibling cloud box is still cloud — the clone hook stays enabled.
+    expect(
+      await resolveActiveSandboxBackend(true, selfhostedPointer, async () => "modal"),
+    ).toBeUndefined();
+  });
+
+  test("never throws: a pointer-load failure falls back to the home backend default", async () => {
+    const backend = await resolveActiveSandboxBackend(
+      true,
+      async () => {
+        throw new Error("db unreachable");
+      },
+      selfhostedKind,
+    );
+    expect(backend).toBeUndefined();
+  });
+
+  test("never throws: a sandbox-kind-load failure falls back to the home backend default", async () => {
+    const backend = await resolveActiveSandboxBackend(true, selfhostedPointer, async () => {
+      throw new Error("db unreachable");
+    });
+    expect(backend).toBeUndefined();
   });
 });
 

--- a/docs/design/connected-machines/00-primitives.md
+++ b/docs/design/connected-machines/00-primitives.md
@@ -1,0 +1,78 @@
+# Connected Machines — Primitives (v0 proposal, orchestrator-owned)
+
+Grounds: the sandbox-vs-machine map (see brief). Today self-hosted compute is an
+OVERLAY (`active_sandbox_id` pointer) on a mandatory Modal "home box"; a machine
+session still provisions a Modal lease, fakes a `/workspace` root, and can clone a
+repo into the user's real filesystem. This redesign makes a machine a first-class
+compute target.
+
+## The split — one `ComputeTarget` choice with two kinds
+- **Managed Sandbox** — ephemeral, *platform-owned*. Platform provisions (clones
+  repos into `/workspace`) and tears down. (today's modal/docker/local/…)
+- **Connected Machine** — persistent, *user-owned*. Platform ATTACHES to what's
+  already there; never provisions, clones, or tears down; uses the machine's OWN
+  git auth.
+
+They are SIBLINGS under one top-level choice — not a backend overlay on a
+mandatory cloud box.
+
+## Decisions (D#)
+- **D1 — Machine is the session's PRIMARY compute, not an overlay.** A
+  machine-bound session has NO home Modal box. Kills the manifest/env-parity hack,
+  the rival-cold-recreate guard, and the `/workspace` virtual root at the root.
+  *(Core refactor.)*
+- **D2 — No token distribution to machines.** Skip the per-turn GitHub
+  installation-token mint + `GH_TOKEN`/askpass/`http.extraheader` env injection for
+  a machine target. The machine uses its own git auth (ssh / `gh` / credential
+  helper). *(User call: when a machine has NO git auth → v1 = detect + surface a
+  hint, don't manage it.)*
+- **D3 — Repo selection is grayed for a machine.** No clone. A Project may DISPLAY
+  its repo (derived from `git remote`), read-only — never to clone.
+- **D4 — The work unit is a Project / Path.** A Project = a named registered path
+  on a machine (optionally knows its repo for display). A machine has a default
+  ROOT (the agent's launch dir) + zero-or-more named Projects (sub-paths). A session
+  binds to: machine + a working path (Project / root / sub-folder).
+- **D5 — Per-session working directory.** Today the agent cwd is fixed at launch
+  (`std::env::current_dir`). A machine session must specify the working path → add a
+  per-session `working_dir` to the agent protocol + `session_create`. This REPLACES
+  the leaky `/workspace` virtual root (root = the chosen path, agent-reported).
+  *(Core: agent protocol + runtime change.)*
+- **D6 — Worktrees are an AGENT concern.** Platform gives a working path +
+  fs/git/exec; the agent makes worktrees (orchestrator-at-root →
+  worktree-per-subagent). Sub-agent sessions bind via `session_create.workingDir` =
+  the worktree path. No platform worktree primitive.
+- **D7 — Multi-session on one machine** = multiple working paths/worktrees, isolated
+  by directory; the agent multiplexes (already does over NATS). Deeper isolation
+  (resource limits, separate processes) = future.
+
+## Session binding (tool + UI must match)
+- `session_create`: a `computeTarget` (managed sandbox | machine id) + for a
+  machine, a `workingDir` (host path / Project). Repos attached to a machine session
+  do NOT clone.
+- UI composer: compute-target is the FIRST, top-level choice and GATES everything.
+  Sandbox → repo + branch (workdir `/workspace`). Machine → Project/path picker
+  (repo grayed, optional sub-folder).
+
+## Concrete bug to fix now (independent of the big refactor)
+`repositoryUsesSandboxClone` (`packages/runtime/src/index.ts:2068`) gates the clone
+on `settings.sandboxBackend` (the HOME box), so a machine-targeted session carrying a
+private GitHub-App repo (`githubInstallationId` + `githubRepositoryId`) runs the
+`beforeAgentStart` clone hook and `git clone`s into the user's REAL filesystem at the
+agent's launch dir. **Fix: never clone onto a selfhosted active target.**
+
+## Staging (smallest-correct first)
+1. **Safe now (no big refactor):** clone-gating footgun fix; macOS metrics fix;
+   install.sh no-token honesty; enroll dialog zero-click default.
+2. **Core refactor (needs sign-off):** machine as primary compute (D1) + skip the
+   token path (D2) + per-session `working_dir` (D5) + drop the `/workspace` virtual
+   root for machines.
+3. **Product surface:** Project primitive + registry (D4); composer redesign;
+   session_create `computeTarget`/`workingDir`.
+
+## Open calls for the user
+- (a) Machine with no git auth → v1 = detect + hint, don't manage. OK?
+- (b) Project creation: UI (register a path) AND an agent tool — or start with a
+  free-form `workingDir` + named Projects as sugar?
+- (c) Should a machine session ever accept a platform-cloned repo (into the machine's
+  workspace)? Default NO. Confirm.
+- (d) "[Pasted text #1]" (your path/project example) never came through — resend.

--- a/docs/design/connected-machines/10-macos-display.md
+++ b/docs/design/connected-machines/10-macos-display.md
@@ -1,0 +1,391 @@
+# Connected Machines — macOS DISPLAY backend (feasibility + plan)
+
+Status: **proposal / not started.** macOS desktop is a compile-only structured
+stub today (Apple's own "M12" deferral marker). This doc grounds *why* it is
+headless, *what* a real backend costs, *how* to satisfy the workspace
+`unsafe_code = forbid` constraint, the *TCC consent problem* that makes it
+fundamentally un-CI-able, and a staged plan with a clear ship/defer call.
+
+Sibling docs: `00-primitives.md` (the managed-sandbox vs connected-machine
+split). The desktop stream itself (relay framebuffer pump + computer-use input
+plane) is platform-agnostic and already built for Linux — this doc is *only*
+about filling in the one missing per-OS backend so a connected Mac can join it.
+
+All citations are `file:line` against this worktree
+(`agent/crates/opengeni-agent-platform/...` unless noted).
+
+---
+
+## TL;DR / recommendation
+
+**Defer the live backend; ship the cheap honest fixes now; spike ScreenCaptureKit
+behind a feature flag only once we have a dedicated, signed, persistently-logged-in
+Mac to verify on.** The blocker is not Rust difficulty — the trait shape is fixed
+and the Apple APIs are well-trodden — it is that **Screen Recording + Accessibility
+grants are user-interactive, per-code-signing-identity, and cannot be granted by
+CI or by the platform on the user's behalf.** Until there is (a) a stable Developer
+ID signing identity for the agent binary and (b) a real Mac with a logged-in Aqua
+session to click the grant, a "live-verified" macOS desktop is unreachable, and our
+whole posture (dossier §10.4) is "no unverified backend lands." See
+[Recommendation](#7-recommendation-spike-now-vs-defer) for the precise unblock list.
+
+---
+
+## 1. Why macOS is headless today
+
+There is **no macOS screen-capture or input backend at all** — only a zero-sized
+structured seam. The single abstraction is the `DesktopBackend` trait
+(`desktop.rs:57-83`): `probe() -> Option<v1::Display>`, `capture()`, `inject()`.
+`resolve_desktop()` (`desktop.rs:120-143`) dispatches per-OS; the macOS arm
+(`desktop.rs:131-134`) returns `crate::macos::MacosDesktop::new()` — and that type
+is a stub whose three methods are hardcoded negatives:
+
+- `probe()` returns `None` — `macos.rs:61-64`, comment *"No display reported until
+  ScreenCaptureKit capture is live (M12)."*
+- `capture()` returns `PlatformError::Unsupported("macOS desktop capture
+  (ScreenCaptureKit) is not yet wired (M12)")` — `macos.rs:66-70`.
+- `inject()` returns `PlatformError::Unsupported("macOS computer-use input (CGEvent)
+  is not yet wired (M12)")` — `macos.rs:72-76`.
+
+Because `probe()` is `None`, "No display" surfaces through **two** paths:
+
+1. `Platform::desktop_ensure` (`lib.rs:202-229`) runs `desktop.probe()` on the
+   blocking pool, gets `None`, and returns `Unsupported("no desktop display
+   available on this host (display_unavailable)")` (`lib.rs:216-220`).
+2. The heartbeat/connect capability set in `supervisor.rs::capabilities()`
+   (`supervisor.rs:364-385`) computes `desktop: has_relay && display.is_some()`
+   (`supervisor.rs:380`). On macOS `display` is `None`, so the control plane
+   degrades the desktop cell to `display_unavailable` — *a value, never a crash*
+   (the contract spelled out at `desktop.rs:5-9`).
+
+**Contrast — Linux is fully real.** `LinuxDesktop::probe()` (`linux.rs:113-123`)
+opens the X11 display via the safe `x11rb` crate, reads `screen_geometry`, and
+returns a populated `v1::Display { id, width, height, virtual }`. `open_default()`
+(`linux.rs:84-99`) even *verifies* a live connection + the `XTEST` extension before
+claiming a desktop. Capture is `GetImage` → PNG (`linux.rs:146-169`); input is
+`XTEST FakeInput` (`linux.rs:172-339`). All through `x11rb` — **no `unsafe`.**
+
+**No virtual-framebuffer escape hatch on macOS.** The Xvfb opt-in
+(`pub mod virtual_desktop`) is `#[cfg(target_os = "linux")]` only (`lib.rs:48-49`).
+There is deliberately no "spawn a headless framebuffer" path on macOS — *"a virtual
+framebuffer is not the macOS/Windows model"* (`lib.rs:46-47`). A Mac's display is
+the real, attached/virtual Aqua session or nothing. That means **a macOS connected
+machine can only ever offer a desktop when a human is logged into the GUI session.**
+This is the single most important architectural fact for the rest of this doc.
+
+So macOS is headless because the native backend was never written — the Linux-first
+design left macOS (and Windows) as compile-only seams with the *exact* trait shape
+so dispatch + capability paths don't reshape when the bodies land (`macos.rs:9-20`).
+
+---
+
+## 2. What implementing it entails
+
+The trait shape is already fixed; we fill three method bodies on `MacosDesktop`,
+mirroring the Linux split. The relay-side plumbing (framebuffer pump, input
+channel, capability gating, `desktop_ensure`) is **done and platform-agnostic** —
+it consumes `Arc<dyn DesktopBackend>` and a `v1::Display`, so a correct macOS
+backend slots straight in with zero relay/control-plane changes.
+
+| Trait method (`desktop.rs`) | Linux today | macOS to build |
+|---|---|---|
+| `probe() -> Option<v1::Display>` (`:62`) | `x11rb` connect + RANDR geometry (`linux.rs:113`) | Enumerate the active display via **`SCShareableContent`** (preferred) or **`CGMainDisplayID` / `CGDisplayBounds`**; return `v1::Display { id, width, height, virtual }`. `None` if no Aqua session / no Screen-Recording grant. |
+| `capture() -> CapturedFrame` (`:70`) | `GetImage` ZPixmap → RGBA → PNG (`linux.rs:146`) | **ScreenCaptureKit** one-shot: `SCScreenshotManager.captureImage` (macOS 14+) or an `SCStream` frame → `CGImage`/`IOSurface` → RGBA → reuse the existing `image` PNG encoder. |
+| `inject(&DesktopInput)` (`:82`) | `XTEST FakeInput` (`linux.rs:172`) | **CGEvent**: `CGEventCreateMouseEvent` / `CGEventCreateKeyboardEvent` / scroll-wheel events, posted with `CGEventPost(kCGHIDEventTap, ...)`. Map `PointerButton`/`PointerAction`/`KeyEvent`/`ScrollEvent` exactly as `inject_pointer`/`inject_key`/`inject_scroll` do for X11. |
+
+Notes that make this concrete:
+
+- **Capture API choice is forced.** `CGDisplayCreateImage` (the old, simple Quartz
+  one-call grab) is **deprecated as of macOS 14 and removed/non-functional under
+  Sequoia's privacy regime** — Apple actively steers to ScreenCaptureKit. So the
+  honest target is `SCScreenshotManager` / `SCStream` (macOS 12.3+; the clean
+  `captureImage` convenience is 14.0+). Our self-hosted Macs are modern, so target
+  14+ and keep a CoreGraphics fallback only if we must support 12–13.
+- **`capture()` must stay off the async runtime**, exactly like Linux runs
+  `capture_blocking` on `spawn_blocking` (`linux.rs:125-132`). A `SCStream` callback
+  is itself async/dispatch-queue-driven, so the macOS backend will likely hold a
+  long-lived stream + a frame channel rather than open-per-call; either way the
+  trait's `async fn capture` already accommodates it.
+- **Geometry / Retina scaling.** `v1::Display.width/height` should be the *pixel*
+  dimensions the viewer canvas needs. macOS reports points; multiply by the
+  display's backing-scale factor (`CGDisplayModeGetPixelWidth` or the
+  `SCDisplay.frame` × scale). Get this wrong and the computer-use coordinate space
+  (which `inject` consumes) won't match the captured frame — the same point-vs-pixel
+  footgun the Linux RANDR-vs-root path navigates (`linux.rs:410-429`).
+- **`inject` needs a keymap.** X11 resolves keysyms→keycodes off the server keymap
+  (`linux.rs:354-368`); CGEvent takes a virtual keycode (`CGKeyCode`) + Unicode via
+  `CGEventKeyboardSetUnicodeString`. For text typing prefer the Unicode-string path
+  (no per-character keycode table); for named keys (`Enter`/`Tab`/arrows, the set in
+  `named_key_to_keysym` `linux.rs:373-403`) keep a small `&str -> CGKeyCode` table.
+- **`virtual` flag.** Set `v1::Display.virtual = true` when the display is a virtual
+  one (headless Mac with a virtual display / screen-sharing aggregate). Heuristic
+  TBD; harmless if wrong (it only labels the UI, same posture as `linux.rs:431-442`).
+
+No new wire types, no `desktop_ensure`/relay changes, no proto bump. This is a
+single-module fill-in plus its Cargo deps.
+
+---
+
+## 3. FFI strategy under `unsafe_code = forbid`
+
+The workspace lint is hard: `unsafe_code = "forbid"` (`agent/Cargo.toml:115`), and
+the whole agent's selling point is that *every* native capability rides a **safe
+binding crate** — `x11rb` for X11, `portable-pty` for PTYs, `nix` (fs feature only)
+for statvfs, `minisign-verify`/`self-replace` for updates. `desktop.rs:10-20` states
+the posture explicitly: *"Every backend here is built on a safe binding crate …
+Wiring [macOS/Windows] through safe crates (or a narrowly-scoped `allow(unsafe_code)`
+module) is the M12 task."* The macОS deps would be `[target.'cfg(target_os =
+"macos")'.dependencies]`, mirroring how `x11rb` is already linux-gated
+(`platform/Cargo.toml:31-32`) so non-mac builds never pull them.
+
+The honest reality: **unlike X11, there is no pure-Rust, zero-FFI binding for
+ScreenCaptureKit or CGEvent.** Every option ultimately calls Objective-C / C. The
+question is *where the `unsafe` lives and whether we own it.*
+
+**Option A — lean on `objc2` framework crates (recommended).**
+The `objc2` project (madsmtm) auto-generates maintained, typed bindings for Apple
+frameworks: `objc2-screen-capture-kit`, `objc2-core-graphics`,
+`objc2-core-foundation`, `objc2-app-kit`. These expose Rust types over the
+Objective-C/C surface; the `unsafe` is *inside the crate*, and most call sites are
+ordinary safe Rust, with `unsafe` only at genuine soundness boundaries (raw message
+sends, pointer handoff). Pros: actively maintained, comprehensive, the de-facto
+modern standard, follows the same "delegate the unsafe to a vetted crate" pattern as
+x11rb. Con: objc message sends are *inherently* `unsafe fn`, so a thin layer of our
+own `unsafe` blocks at the FFI seam is unavoidable — `forbid` cannot stand at the
+crate root.
+
+**Option B — older "safe-ish" wrappers (`core-graphics`, `screencapturekit`/
+`screencapturekit-rs`).** The servo `core-graphics` crate wraps Quartz (CGEvent,
+CGDisplay) with a mostly-safe API; the `screencapturekit` crate wraps SCK on top of
+`objc2`. Pros: higher-level, less boilerplate for capture. Cons: `core-graphics`'s
+capture path leans on the *deprecated* CGDisplay route; the SCK wrappers are younger
+and thinner than `objc2`'s generated coverage; you still inherit objc `unsafe`
+transitively. Net: fine for `inject` (CGEvent is stable), weaker for `capture`.
+
+**Option C — a blanket `allow(unsafe_code)` on the macos module.** Rejected. It
+violates the explicit "NOT a blanket relaxation" instruction in both stubs
+(`macos.rs:17-20`, `windows.rs` header) and discards the auditability the posture
+buys.
+
+### Recommendation
+
+**Use `objc2-screen-capture-kit` + `objc2-core-graphics` (Option A), and confine
+all `unsafe` to one narrowly-scoped module with a `#![allow(unsafe_code)]` and a
+written justification — not a workspace-wide relax.** Concretely:
+
+- Keep `unsafe_code = "forbid"` at the workspace and on every other crate
+  (`agent/Cargo.toml:115` unchanged).
+- Add a `#[cfg(target_os = "macos")] #[allow(unsafe_code)] mod macos_ffi;` *inside*
+  `opengeni-agent-platform`, holding *only* the SCK/CGEvent calls, with a module
+  doc-comment justifying each `unsafe` block (the objc message-send boundary). The
+  public `MacosDesktop` impl stays safe and calls into it. This is precisely the
+  "narrowly-scoped `allow(unsafe_code)` module with a justification" the stubs
+  pre-authorize (`macos.rs:17-20`).
+- Prefer `objc2`'s generated crates over hand-rolled `extern "C"` blocks: less of
+  *our* `unsafe`, and the soundness-critical parts (selector dispatch, ARC) are the
+  crate's problem, mirroring how we never hand-rolled X11 wire framing.
+- Optionally use servo `core-graphics` for `inject` only (CGEvent is a small, stable
+  surface) if `objc2-core-graphics` ergonomics disappoint — but standardize on one.
+
+This keeps the lint meaningful (one audited module, not a global escape hatch) while
+acknowledging the inescapable truth that Apple FFI cannot be fully `unsafe`-free the
+way x11rb let Linux be.
+
+---
+
+## 4. The TCC permission problem (the real blocker)
+
+macOS gates both capabilities behind **TCC (Transparency, Consent & Control)**:
+
+- **Screen Recording** (`kTCCServiceScreenCapture`) — required for *any*
+  ScreenCaptureKit capture. The first `SCShareableContent`/`SCStream` call triggers
+  a one-time system prompt; until the user approves in **System Settings → Privacy
+  & Security → Screen Recording**, capture returns empty/black frames or errors.
+- **Accessibility** (`kTCCServiceAccessibility`) — required for `CGEventPost` to be
+  *delivered* to other applications (synthetic input). Without it, posted events are
+  silently dropped for most targets. Granted in **Privacy & Security →
+  Accessibility**.
+
+Why this is categorically different from Linux/Windows and **cannot be CI'd**:
+
+1. **User-interactive, by SIP design.** The TCC database is SIP-protected; there is
+   no supported API to grant yourself Screen Recording or Accessibility. A human
+   must toggle it (or an MDM PPPC profile must — see below). This is exactly the
+   constraint `macos.rs:11-15` calls out: grants *"cannot be auto-clicked on an
+   ephemeral CI runner."* It is *why* the backend is a compile-only seam and the
+   feature is deferred to M12 with a "live-verify on the user's real Mac" gate.
+2. **Per-code-signing-identity, and our agent self-updates.** A TCC grant is keyed
+   to the binary's code-signing identity (designated requirement / cdhash). The
+   agent ships a **self-update** path (M11: `self-replace` + minisign-verified
+   artifacts). An ad-hoc-signed or unsigned binary is keyed by cdhash, so **every
+   self-update would change the cdhash and silently revoke the grant** → the desktop
+   goes dark mid-life with no error the user understands. The *only* fix is a stable
+   **Developer ID** signature whose designated requirement is anchored to our Team
+   ID (cdhash-independent), so a re-signed update inherits the grant. **This makes
+   Apple Developer ID code-signing + notarization a hard prerequisite, not a nicety.**
+3. **Requires a live GUI (Aqua) session.** Capture/input only work when a user is
+   logged into the graphical session. The agent already chose a **LaunchAgent**
+   (not a LaunchDaemon) *for exactly this reason*: `service.rs:16-19` — *"LaunchAgent
+   NOT LaunchDaemon deliberately: desktop/computer-use needs the user's GUI Aqua
+   session + TCC."* The rendered plist (`service.rs:146-176`,
+   `ai.opengeni.agent.plist`, `RunAtLoad`+`KeepAlive`) runs in the user's session.
+   But a Mac sitting at the login window (no user logged in) still has **no display
+   to offer** — `probe()` must honestly return `None` there.
+4. **Sequoia adds periodic re-consent.** macOS 15 re-prompts for Screen Recording
+   on a recurring basis (roughly monthly) for non-MDM apps — a recurring interruption
+   for an unattended agent. MDM-managed Macs are exempt; self-hosted personal Macs
+   typically are not.
+
+### Proposed enrollment-time consent + grant UX
+
+The plumbing for *intent* already exists end-to-end; what's missing is the *grant*
+choreography. Today:
+
+- The enrollment offer carries `offers_display` (API `canOfferDisplay`) and
+  `requests_screen_control` (API `requestsScreenControl`) — `enrollment.rs:47-62`.
+- The user's approval at the consent page is the authoritative
+  `allowScreenControl`, persisted as `consented_screen_control` /
+  `consented_whole_machine` creds (`config.rs:131-134`), threaded into the relay hub
+  (`main.rs:160`) and reported in `capabilities()` (`supervisor.rs:381-382`). The
+  `inject` path is gated on the caller having verified `consented_screen_control`
+  (contract at `lib.rs:231-236`, `desktop.rs:72-82`).
+
+**The gap:** our `consented_screen_control` is *platform authorization to drive the
+machine*; it is **not** the OS-level TCC grant. A Mac can have
+`consented_screen_control = true` and still produce black frames because macOS
+itself hasn't been told to allow it. So enrollment on macOS needs a second,
+*OS-level* grant step that the install flow walks the human through:
+
+1. **Detect, don't assume.** On macOS the agent should report TCC status it *can*
+   read without prompting: `CGPreflightScreenCaptureAccess()` (screen recording,
+   non-prompting preflight) and `AXIsProcessTrusted()` (accessibility). Surface
+   these as a *machine health* signal distinct from `consented_screen_control` —
+   e.g. `display: Some(..)` only once Screen Recording is actually granted, so the
+   capability stays honest (`supervisor.rs:380` already does the right thing if
+   `probe()` returns `None` until granted).
+2. **Trigger the prompts intentionally, once, at enrollment.** Right after the user
+   approves screen control on the web consent page, the **agent** (running in the
+   Aqua session) calls `CGRequestScreenCaptureAccess()` and
+   `AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: true})` to fire the
+   two system dialogs. These can *only* be triggered by the process itself making
+   the protected call — the platform/web side cannot do it remotely.
+3. **Deep-link the user to the panes for the toggle.** The prompts only get the user
+   *to* the pane; they still flip the switch. Open
+   `x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture`
+   and `...?Privacy_Accessibility` and show a short "flip these two toggles for
+   *OpenGeni Agent*, then return here" step in the installer.
+4. **Verify, then advertise.** After the grants land, the agent re-probes; only then
+   does `probe()` return a real `Display` and the desktop capability flips on. If the
+   user declines, the machine enrolls fine for exec/fs/git — the desktop cell just
+   stays `display_unavailable` (graceful, already the contract). This matches the
+   primitives note about an *"enroll dialog zero-click default"* — desktop is opt-in,
+   never blocking the core enroll.
+5. **Fleet / MDM path (optional, later).** For org-managed self-hosted Macs, a
+   **PPPC (Privacy Preferences Policy Control) configuration profile** can pre-grant
+   Accessibility and (MDM-supervised) Screen Recording keyed to our Developer ID, so
+   no human click is needed. This is the *only* way to "auto-approve," and it
+   requires both MDM enrollment and our stable signing identity — out of scope for a
+   v1 personal-Mac spike, but the reason §3's Developer ID requirement pays off twice.
+
+Net: the consent *model* is already the right shape (offer → authoritative approve →
+creds → capability gate). macOS just inserts a mandatory **OS-grant sub-flow** that
+only the on-machine agent can drive, and which depends on a stable code-signing
+identity to survive self-update.
+
+---
+
+## 5. Effort estimate + staged plan
+
+Rough order-of-magnitude (one engineer who can test on a real Mac; the long pole is
+verification + signing, not Rust):
+
+| Stage | Scope | Est. | Gate |
+|---|---|---|---|
+| **0. Honest stub stays + groundwork** | Confirm seam; add macOS deps cfg-gated; stand up the `#[allow(unsafe_code)]` ffi module skeleton; decide `objc2` vs servo crates. | 0.5–1 day | builds on mac CI (no runtime) |
+| **S1. `probe()` only** | Enumerate display via `SCShareableContent`/CGDisplay, real `v1::Display` with correct pixel geometry + scale. Gates the whole capability (`supervisor.rs:380`). | 2–3 days | desktop cell flips from `display_unavailable` to present on a granted Mac |
+| **S2. `capture()`** | SCK one-shot/stream → CGImage → RGBA → existing PNG encoder; off-runtime like Linux. Wire into the framebuffer pump (already generic). | 3–5 days | live frames render in the browser viewer |
+| **S3. `inject()`** | CGEvent mouse/key/scroll mapping mirroring `inject_pointer/key/scroll`; Unicode-string typing + named-key table; Accessibility gate. | 3–5 days | live computer-use drives a real Mac |
+| **X. Signing + consent UX** | Developer ID signing + notarization of the agent binary (so TCC survives self-update); the §4 grant sub-flow in install + enrollment. | 3–5 days + Apple Developer account/ops | grants persist across an update; enroll walks a human through grants |
+| **T. Test strategy** | macOS build/`cargo test` matrix entry already keeps the seam from rotting (`macos.rs:5-7`). Add an *opt-in*, *gated* live smoke that runs only on the self-hosted Mac runner (never ephemeral CI). | 1–2 days | a manual/self-hosted "real Mac" verification recipe |
+
+**Total to a live, signed, verified macOS desktop: ~3 weeks of engineering** plus
+the procurement/ops cost of an Apple Developer ID and a dedicated always-logged-in
+Mac. The Rust is the cheap part; **signing + a persistent GUI session + the
+interactive grant are the schedule risk.**
+
+Staging discipline (mirrors the trait-first design): land **S1 probe-only** first —
+it's the smallest change that makes a granted Mac advertise a desktop, it exercises
+the full capability/`desktop_ensure` path end-to-end (`lib.rs:202-229`,
+`supervisor.rs:380`) with zero streaming risk, and it's independently verifiable.
+Capture and inject follow as separable PRs because the pump and input channel are
+already generic.
+
+---
+
+## 6. What does NOT block, and a cheap win to take now
+
+Independent of the big backend: the macOS **metrics** bugs in the same brief (CPU/
+mem/load report 0; disk inflated ~256×) are unrelated to TCC and unrelated to this
+backend. The disk fix in particular is a one-line cross-platform unit bug
+(`metrics.rs:262`, `fragment_size().max(block_size())` over-counts on APFS) that
+benefits Linux correctness too and should ship on its own track. Mentioned here only
+to keep scopes clean: **a Mac can be a perfectly good headless exec/fs/git connected
+machine today** — the display backend is the *only* thing this doc gates.
+
+---
+
+## 7. Recommendation: spike now vs defer
+
+**Defer the live macOS desktop backend. Do not start S2/S3 until the unblock list
+below is satisfied; an S1 probe-only spike is reasonable *now* only if a signed
+binary + a real granted Mac are available to verify it — otherwise it cannot leave
+the "unverified" state our posture forbids (`desktop.rs:17-20`, `macos.rs:11-15`).**
+
+Reasoning: every cost in §5 except the Rust is dominated by the TCC reality. We
+cannot CI it, we cannot grant it for the user, and without Developer ID signing the
+grant evaporates on the next self-update — so a backend "finished" in code but
+unverifiable is worse than the honest stub, which at least degrades cleanly to
+`display_unavailable` (a value, never a crash). The Linux path earns its keep
+precisely because it's safe *and* live-verifiable; macOS isn't there yet.
+
+**What unblocks a real spike (do these first, in order):**
+
+1. **An Apple Developer ID** + a notarization/codesign step in the agent release
+   pipeline, with a designated requirement anchored to the Team ID (so a self-update
+   re-sign keeps the TCC grant). *Hard prerequisite — nothing below survives an
+   update without it.*
+2. **A dedicated, always-logged-into-the-GUI Mac** (Apple Silicon, modern macOS 14+)
+   reachable as a self-hosted runner for live verification — the equivalent of the
+   "interactive Azure VM" the Windows stub assumes (`windows.rs` header), except
+   macOS additionally needs the human-clicked TCC grants once.
+3. **Pick the FFI crates** (§3 recommendation: `objc2-screen-capture-kit` +
+   `objc2-core-graphics`, scoped `allow(unsafe_code)` module) and land the
+   cfg-gated dep + ffi-module skeleton — this is safe to do now, builds on mac CI,
+   and de-risks S1.
+4. **Build the §4 OS-grant sub-flow** in install/enrollment (preflight detect →
+   intentional prompt → deep-link → re-probe). Needed before any of this is usable
+   by a non-engineer.
+
+If all four exist, start with **S1 (probe-only)** as the first PR. If they don't,
+the right move is to **leave the honest stub in place** and revisit when a signed
+release + a verification Mac are available — the trait shape guarantees zero rework
+when we do.
+
+---
+
+## 8. Open questions for the user
+
+- (a) Is acquiring an **Apple Developer ID** and adding codesign/notarization to the
+  agent release pipeline in scope? Without it the TCC grant cannot survive
+  self-update — it's the true gate, not the Rust.
+- (b) Is there a **persistently-logged-in Mac** we can dedicate as a verification
+  host? (No GUI session ⇒ no desktop, by macOS design — `lib.rs:46-47`.)
+- (c) Acceptable to add a **single narrowly-scoped `#[allow(unsafe_code)]` ffi
+  module** (workspace lint otherwise intact), per §3 and the pre-authorization in
+  `macos.rs:17-20`? Confirm we won't insist on a literally-zero-`unsafe` macOS path
+  (it doesn't exist for Apple FFI).
+- (d) Target macOS floor **14+** (clean ScreenCaptureKit `captureImage`, drop the
+  deprecated CGDisplay path)? Or must we support 12–13 with a CoreGraphics fallback?
+- (e) Sequoia's recurring re-consent for non-MDM Macs is a real UX papercut for an
+  unattended agent — acceptable for v1 self-hosted personal Macs, or do we want the
+  MDM/PPPC fleet path (§4.5) sooner?

--- a/docs/design/connected-machines/20-composer-redesign.md
+++ b/docs/design/connected-machines/20-composer-redesign.md
@@ -1,0 +1,456 @@
+# Connected Machines — Composer / Session-Setup UX Redesign (v0, orchestrator-owned)
+
+Grounds: `00-primitives.md` (source of truth; this UX implements it), the COMPOSER +
+BINDING map sections, and the requirements brief (item D). All file:line citations are
+against this `machines-hacks` worktree, which is **up to date with origin/main** — it
+already has the `selfhosted` backend (`packages/contracts/src/index.ts:18-31`), the
+`CAPABILITY_DESCRIPTORS` table (`:101`), the `MachineView` contract (`:3161`), and a
+Machine `<select>` in the composer (`apps/web/src/routes/sessions-index.tsx:250-263`).
+
+> Scope: this is a DESIGN doc. No code edits. It defines the redesigned model, the
+> wireframes, the gating state machine, the component/state restructure, and the
+> migration path (additive-first → full redesign).
+
+---
+
+## 0. What exists today (verified) — and why it is worse than the brief described
+
+The brief said the compute target is "a flat `sandboxBackend` `<select>` buried in a
+collapsed disclosure." That is still true, but the machine-targeting work landed on top
+**without fixing the shape** — it made it worse by adding a *second, overlapping* compute
+control as yet another independent sibling:
+
+`apps/web/src/routes/sessions-index.tsx`:
+- `SessionControlStrip` (`:151-199`) — always-visible inline pills: `ModelPicker`,
+  `RepositoryContextPicker` (repos — which only make sense once compute exists),
+  `EnabledMcpToolPicker`.
+- `AdvancedSessionOptions` (`:201-388`) — a **collapsed "Session setup" disclosure**
+  (`advancedOpen` defaults `false`, `:52`) that now contains *three* orthogonal compute-ish
+  controls stacked as siblings:
+  1. **Machine `<select>`** (`:250-263`) — "Cloud sandbox" vs an enrolled selfhosted
+     machine; threaded as `targetSandboxId` (a top-level `CreateSessionRequest` field that
+     seeds the *active-sandbox overlay pointer*, `session-create.ts:9-11`).
+  2. **Environment `<select>`** (`:273-285`) — "Variables are injected into the sandbox at
+     start" (`:286-288`).
+  3. **Sandbox-backend override** (`:294-319`) — nested one level *deeper* inside a
+     `<details>`, a hand-maintained 5-item literal `sandboxBackendOptions` (`:39-45`) that
+     sets the session's **home box** backend.
+
+So there are now **two compute controls that mean different things** (the Machine picker =
+an *overlay* on a mandatory home box; the backend override = the *home box itself*) and the
+UI presents them as unrelated siblings. This is the exact "machine is an overlay on a
+mandatory cloud box" conflation `00-primitives.md` D1 exists to kill — surfaced verbatim in
+the form.
+
+### The two split stores (still split)
+
+1. **Global app context** (`apps/web/src/context.tsx`): `model` (`:163`), `reasoningEffort`
+   (`:168`), `manualRepos` (`:171`), `selectedRepoIds` (`:174`), `selectedRepoRefs`
+   (`:175`), `selectedCapabilityToolIds` (`:181`). Workspace-sticky; **shared with the
+   in-session strip** (`session.tsx:399-413`).
+2. **Local `advanced: AdvancedSessionDraft`** (`sessions-index.tsx:53`; shape in
+   `apps/web/src/lib/session-create.ts:6-19`): `targetSandboxId`, `sandboxBackend`,
+   `environmentId`, `goalText/goalSuccessCriteria/goalMaxAutoContinuations`,
+   `customMcpPermissions`, `mcpPermissions`. **Reset to `emptyAdvancedSessionDraft()` on
+   every mount** (`:53`).
+
+Payload assembly is two-stage and crosses the stores only at submit:
+`submissionExtrasFromAdvancedSessionDraft(advanced)` (`session-create.ts:42-57`) +
+`targetSandboxIdFromAdvancedSessionDraft(advanced)` (`:37-39`) → spread into
+`context.startSession(...)` (`sessions-index.tsx:79-87`), which then merges the global
+`model`/`reasoningEffort`/`tools`/`currentResources` (`context.tsx:444-463`).
+`targetSandboxId` is cast through because the SDK request type doesn't surface it yet
+(`context.tsx:460-462`).
+
+### Nothing is gated on the compute choice
+
+There is no `disabled`/hide branch keyed off the picked machine or backend anywhere. Pick a
+selfhosted machine and the form *still* shows the full Repository picker (which would
+`git clone` into the user's real disk — the `00-primitives.md` clone-gating footgun,
+`packages/runtime/src/index.ts:2068`), the Environment injector ("injected into the
+sandbox," meaningless for a user-owned machine that uses its own auth — D2), and offers no
+folder/workdir at all (`workspaceRoot` is a per-backend constant: modal `/workspace`
+`contracts:123`, selfhosted `/` `:398` — never user-selectable). Repo branch is buried
+per-repo (`repository-picker.tsx:263-275`); there is no top-level branch.
+
+**In-session asymmetry:** the in-session strip (`session.tsx:397-415`) shows only Model +
+Tools; compute lives in a *separate* header pill `SessionSandboxSwitcher` ("Run on:",
+`apps/web/src/components/session/sandbox-switcher.tsx`) that live-swaps via `attachMachine`;
+the inspector shows a read-only `InfoRow label="Sandbox" value={session.sandboxBackend}`
+(`apps/web/src/components/session/inspector.tsx:72`) — i.e. the **home backend**, NOT the
+active machine, so a machine-targeted session reads "Sandbox: modal" while running on a
+selfhosted box. Three different surfaces, three different mental models, none consistent
+with the create form.
+
+There is **no Project primitive and no `workingDir`/`workdir` field anywhere** (greenfield;
+confirmed by grep — `00-primitives.md` D4/D5).
+
+---
+
+## 1. The redesigned model — one top-level `ComputeTarget` that GATES the form
+
+The root question, per `00-primitives.md` and brief D, is **"Where should this run?"** — a
+single first-class choice with exactly two *kinds* (siblings, not an overlay):
+
+```
+ComputeTarget
+├── Managed Sandbox   (ephemeral, platform-owned — clones repos into workspaceRoot, tears down)
+│      backend: deployment-default | <a specific managed backend>
+└── Connected Machine (persistent, user-owned — platform ATTACHES; no clone, no teardown, machine's own auth)
+       machine: <one enrolled selfhosted MachineView>
+       project: root | named-project | host-path | + optional sub-folder
+```
+
+This choice is the **parent** that drives everything below it. It collapses BOTH of today's
+overlapping compute controls into one: "Managed Sandbox" *is* the home-backend choice (the
+old `sandboxBackend` override demoted to an Advanced detail *inside* this kind), and
+"Connected Machine" *is* `targetSandboxId` (no separate overlay concept the user has to
+reason about). The user never again picks "an overlay on a mandatory box."
+
+### Data-driven from `CAPABILITY_DESCRIPTORS`
+
+Both kinds are populated from data already in `packages/contracts/src/index.ts`, not
+hand-maintained literals:
+
+- **Managed Sandbox options** = `CAPABILITY_DESCRIPTORS` entries where
+  `backend !== "selfhosted"` (`:101`). Default = deployment default (`sandboxBackend: ""`).
+  Each option renders capability chips straight from its descriptor: `tier`
+  (desktop/headless/dev), `capabilities.DesktopStream.available`,
+  `capabilities.Recording.available`, `lifetime.hardLifetimeMs` (e.g. modal "Desktop ·
+  Recording · 24h"). This replaces the 5-item `sandboxBackendOptions` literal
+  (`sessions-index.tsx:39-45`) and finally surfaces the metadata the map flagged as ignored.
+- **Connected Machine options** = `useMachines({ pollIntervalMs })` filtered to
+  `kind === "selfhosted"` (already done at `sessions-index.tsx:212-213`). Selectability =
+  `isMachineComputeSelectable(machine.state)` (`apps/web/src/lib/machine-selectability.ts:9`
+  → `online || display_unavailable`). Each machine row shows live `MachineView` fields
+  (`contracts:3161-3177`): `name`, `os`/`arch`, `hasDisplay`, `state`, `metrics`, plus the
+  static `CAPABILITY_DESCRIPTORS.selfhosted` (`:371`) chips (FileSystem/Terminal/Git always;
+  DesktopStream consent-gated).
+
+### What each kind binds (the `00-primitives.md` mapping)
+
+| Concern | Managed Sandbox | Connected Machine |
+|---|---|---|
+| Repo + branch | **Primary control** — clone source into `workspaceRoot` | **Grayed / read-only** (D3: no clone; may *display* a repo derived from `git remote`, never clone) |
+| Workdir / folder | Fixed `workspaceRoot` (`/workspace`, info-only) | **Project / path picker** (D4): machine default root + named Projects + optional sub-folder (D5 `workingDir`) |
+| Environment injection | Shown (vars injected at start) | **Hidden** — replaced by "uses this machine's own environment & git auth" (D2: no token mint, no env injection) |
+| Backend override | Demoted to an Advanced detail *inside* this kind | n/a (kind *is* `selfhosted`) |
+| Model / Tools / Goal / MCP perms | Shown, unchanged | Shown, unchanged (compute-independent) |
+
+---
+
+## 2. Wireframes — both states
+
+The composer becomes top-down: **(A) message → (B) Where this runs → (C) compute-dependent
+binding → (D) compute-independent options.** "Where this runs" is a top-level segmented
+control, NOT a buried disclosure.
+
+### State 1 — Managed Sandbox selected (default)
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  What should the agent do?                                                 │
+│  ┌──────────────────────────────────────────────────────────────────┐     │
+│  │ Describe a task for the agent...                                  │     │
+│  │                                                                   │     │
+│  │  [Model ▾] [Tools ▾]                                    [ Send ⏎] │     │ ← strip: compute-independent
+│  └──────────────────────────────────────────────────────────────────┘     │
+│                                                                            │
+│  WHERE SHOULD THIS RUN?                                                    │
+│  ┌────────────────────────────┐ ┌────────────────────────────┐            │
+│  │ ●  Managed Sandbox         │ │ ○  Connected Machine        │            │ ← TOP-LEVEL segmented (parent)
+│  │    Ephemeral · we provision│ │    Your enrolled machines   │            │
+│  └────────────────────────────┘ └────────────────────────────┘            │
+│        │ (selected → gates ↓)                                              │
+│        ▼                                                                   │
+│  ┌──────────────────────────────────────────────────────────────────┐     │
+│  │ Repository + branch                                               │     │ ← SHOWN (clone source)
+│  │   [▣ acme/api   branch: main      ▾]  [+ add repo]                │     │
+│  │   Folder:  /workspace            (sandbox root, fixed)            │     │ ← workdir = workspaceRoot, info-only
+│  ├──────────────────────────────────────────────────────────────────┤     │
+│  │ Environment   [ staging (4 vars) ▾ ]                             │     │ ← SHOWN (injected at start)
+│  │   Variables are injected into the sandbox at start.              │     │
+│  ├──────────────────────────────────────────────────────────────────┤     │
+│  │ ▸ Advanced: backend = Deployment default  ·  Desktop · Rec · 24h │     │ ← backend override DEMOTED here,
+│  └──────────────────────────────────────────────────────────────────┘     │    chips from CAPABILITY_DESCRIPTORS
+│                                                                            │
+│  ▸ Goal · OpenGeni tool permissions               (collapsed, optional)   │ ← compute-INDEPENDENT options
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### State 2 — Connected Machine selected
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  What should the agent do?                                                 │
+│  ┌──────────────────────────────────────────────────────────────────┐     │
+│  │ Describe a task for the agent...                       [ Send ⏎]  │     │
+│  │  [Model ▾] [Tools ▾]                                              │     │
+│  └──────────────────────────────────────────────────────────────────┘     │
+│                                                                            │
+│  WHERE SHOULD THIS RUN?                                                    │
+│  ┌────────────────────────────┐ ┌────────────────────────────┐            │
+│  │ ○  Managed Sandbox         │ │ ●  Connected Machine        │            │
+│  └────────────────────────────┘ └────────────────────────────┘            │
+│                                          │ (selected → gates ↓)            │
+│                                          ▼                                 │
+│  ┌──────────────────────────────────────────────────────────────────┐     │
+│  │ Machine   [ jorgen-mbp  ·  macos/arm64 · ●online · no display ▾ ] │     │ ← PRIMARY control (MachineView)
+│  │           FileSystem · Terminal · Git            (selfhosted caps)│     │ ← chips from CAPABILITY_DESCRIPTORS
+│  ├──────────────────────────────────────────────────────────────────┤     │
+│  │ Project / folder                                                  │     │ ← workdir picker (D4/D5)
+│  │   ( ) Machine root  (the agent's launch dir)                      │     │
+│  │   (●) Project:  opengeni   →  ~/repos/opengeni                    │     │
+│  │   ( ) Custom path:  [ /Users/jorgen/...            ]              │     │
+│  │   Sub-folder (optional):  [ packages/runtime        ]            │     │
+│  ├──────────────────────────────────────────────────────────────────┤     │
+│  │ ▨ Repositories                          (disabled on a machine)   │     │ ← GRAYED (D3: no clone)
+│  │   This machine uses its own checkout & git auth.                  │     │
+│  │   Detected remote: github.com/Cloudgeni-ai/opengeni  (display)    │     │ ← optional, from `git remote`, never cloned
+│  ├──────────────────────────────────────────────────────────────────┤     │
+│  │ ⌀ Environment injection — not used on a connected machine.        │     │ ← HIDDEN/replaced (D2)
+│  │   The machine's own environment & git credentials apply.         │     │
+│  └──────────────────────────────────────────────────────────────────┘     │
+│                                                                            │
+│  ▸ Goal · OpenGeni tool permissions               (collapsed, optional)   │ ← UNCHANGED, compute-independent
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Legend: `▣`/`▨` = enabled/grayed control · `⌀` = removed-with-explanation · `▸` = collapsed
+section. The only thing that *moves* between states is the compute-dependent band (the
+middle card); the strip and the optional band are stable.
+
+---
+
+## 3. The gating state machine
+
+`compute.kind` is the single discriminant. `compute.backend` (sandbox) and
+`compute.machine.state` (machine) are secondary inputs to enable/disable *within* a kind.
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │           ComputeTarget (parent)            │
+                 └─────────────────────────────────────────────┘
+                        │                          │
+            kind = "sandbox"               kind = "machine"
+                        │                          │
+        ┌───────────────┴───────────┐   ┌──────────┴───────────────────────┐
+        ▼                           ▼   ▼                                   ▼
+  backend picker (Advanced)   repo+branch    machine picker            project/path picker
+  default = "" (deploy default) SHOWN,       SHOWN (required to submit) SHOWN (default = root)
+  options from                 enabled       options from              field from
+  CAPABILITY_DESCRIPTORS,      (clone src)   useMachines(selfhosted),  selfhosted.workspaceRoot
+  backend!=="selfhosted"                     gate=isMachineComputeSel.  + D5 workingDir
+```
+
+### Per-field reflow table (authoritative)
+
+| Field | Source / file:line | `kind="sandbox"` | `kind="machine"` |
+|---|---|---|---|
+| Backend select | `sessions-index.tsx:39-45,294-319` | **shown** (Advanced detail), default = deployment default; options = managed descriptors | **hidden** (forced `selfhosted`) |
+| Machine select | `sessions-index.tsx:250-263` | **hidden** | **shown** — primary; `disabled` per `isMachineComputeSelectable` (`machine-selectability.ts:9`); empty fleet → kind disabled with "enroll a machine" CTA |
+| Repo + branch | `repository-picker.tsx:39`, `session-tools.ts:54` | **shown** (clone into `workspaceRoot`); promote a single primary repo+branch row | **grayed/read-only** (D3) — optional `git remote` display only; never assembled into `resources[]` for clone |
+| Workdir / folder | new; driven by `workspaceRoot` (`contracts:123,398`) | **fixed** `/workspace`, info-only | **Project/path picker** (D4): root \| named project \| custom path \| + sub-folder → becomes `workingDir` (D5) |
+| Environment injection | `sessions-index.tsx:273-288` | **shown** (injected at start) | **hidden**, replaced by "machine's own env/auth applies" (D2) |
+| Model | `pickers.tsx`/strip | shown | shown (identical) |
+| Tools | `EnabledMcpToolPicker` | shown | shown (identical) |
+| Goal (+criteria/max-cont) | `sessions-index.tsx:326-349` | shown; criteria/max disabled until `goalText` (`:336-348`) | shown (identical) |
+| MCP permissions | `sessions-index.tsx:352-383` | shown | shown (identical) |
+
+### Transition rules
+
+- **`sandbox → machine`**: hide backend+env; **keep** repo selection in state but stop
+  contributing it to `resources[]` (so toggling back is lossless), render it grayed with the
+  D3 explanation; reveal machine + project pickers; if no machine yet picked, **submit is
+  blocked** with "choose a machine."
+- **`machine → sandbox`**: hide machine+project pickers; re-enable repo (its preserved
+  selection re-activates) and env; backend reverts to its last value (default deployment
+  default).
+- **Invalid states are unreachable by construction** (discriminated union), so there is no
+  "machine + clone repo into my disk" path the user can assemble — which is the whole point
+  of gating (and the UI half of the `repositoryUsesSandboxClone` footgun fix; the runtime
+  half lands separately per `00-primitives.md`).
+- **Submit mapping** (one place, replacing the two-stage spread):
+  - `sandbox` → `sandboxBackend = backend || undefined`, `targetSandboxId = null`,
+    `workingDir = undefined` (sandbox root is `workspaceRoot`).
+  - `machine` → `targetSandboxId = machine.sandboxId`, `sandboxBackend = undefined`
+    (until D1 drops the mandatory home box, the create still seeds one server-side; the UI
+    no longer asks), `workingDir = resolvedProjectPath` (D5; until that field ships,
+    `workingDir` is omitted and the agent runs at its launch root — see Migration).
+
+---
+
+## 4. Component tree + state restructure
+
+### 4.1 Collapse the two stores into one `SessionDraft`
+
+Replace the split between global-context selection fields and the per-mount
+`AdvancedSessionDraft` with a single discriminated `SessionDraft` owned by one hook,
+`useSessionDraft()`:
+
+```ts
+type ManagedSandboxTarget = {
+  kind: "sandbox";
+  backend: SandboxBackend | "";          // "" = deployment default
+};
+type ConnectedMachineTarget = {
+  kind: "machine";
+  sandboxId: string;                      // a selfhosted MachineView.sandboxId
+  project:                                // the working path (D4/D5)
+    | { kind: "root" }                    // agent's launch dir (workspace_root)
+    | { kind: "project"; projectId: string } // a registered Project (named path) — D4, future
+    | { kind: "path"; absolutePath: string }; // free-form host path
+  subfolder?: string;                     // optional sub-path under the chosen base (D6: agent may still worktree)
+};
+type ComputeTarget = ManagedSandboxTarget | ConnectedMachineTarget;
+
+type SessionDraft = {
+  compute: ComputeTarget;                 // PROMOTED — the parent
+  // repo selection is retained across kind toggles but only contributes resources when compute.kind==="sandbox"
+  repos: { selectedRepoIds: Set<number>; selectedRepoRefs: Record<number,string>; manualRepos: RepoDraft[] };
+  environmentId: string;                  // ignored when compute.kind==="machine"
+  model: string; reasoningEffort: IntelligenceEffort;
+  tools: Set<string>;
+  goal: { text: string; successCriteria: string; maxAutoContinuations: string };
+  mcp: { custom: boolean; permissions: Set<string> };
+};
+```
+
+- **Persistence is now explicit, not accidental.** Today some fields are workspace-sticky
+  (global context) and some evaporate per-mount (local advanced) with no signal to the user
+  (map conflation #4). In `SessionDraft`, persistence is a declared concern: persist
+  *last-used* `compute` + `model`/`tools` to `localStorage` (sticky is a feature for those),
+  and treat `goal`/`environmentId`/`repos` as draft-scoped (cleared on submit). One rule,
+  visible in one place.
+- `targetSandboxId` stops being a special cast-through (`context.tsx:460-462`): it is just
+  `compute.kind==="machine" ? compute.sandboxId : null` computed at the single submit
+  mapper.
+
+### 4.2 Component tree (new-session surface)
+
+```
+SessionsIndexRoute                                  (sessions-index.tsx:47)
+└── useSessionDraft()                               ← NEW single store (replaces split)
+├── ConsoleComposer  (controls = SessionControlStrip)
+│   └── SessionControlStrip                         (:151) — compute-INDEPENDENT only
+│         ├── ModelPicker                           (binds draft.model)
+│         └── EnabledMcpToolPicker                  (binds draft.tools)
+├── <ComputeTargetControl>                          ← NEW top-level, REPLACES the buried
+│     ├── segmented: Managed Sandbox | Connected Machine        Machine/backend selects
+│     ├── kind="sandbox"  → <ManagedSandboxFields>
+│     │      ├── <RepositoryContextPicker>          (repository-picker.tsx:39 — promote primary repo+branch)
+│     │      ├── workdir = workspaceRoot (info)
+│     │      ├── <EnvironmentPicker>                (was sessions-index.tsx:273-285)
+│     │      └── ▸ Advanced backend  (descriptor-driven, was :294-319)
+│     └── kind="machine"  → <ConnectedMachineFields>
+│            ├── <MachinePicker>                    (was sessions-index.tsx:250-263; chips from MachineView + descriptor)
+│            ├── <ProjectPathPicker>                ← NEW (root | project | path | +subfolder)
+│            ├── <RepositoryContextPicker disabled> (grayed; optional remote display — D3)
+│            └── env-injection note (D2)
+└── <OptionalSessionOptions>                        (collapsed) — compute-INDEPENDENT
+      ├── Goal + criteria + max-continuations        (was :326-349)
+      └── MCP permission scope                        (was :352-383)
+```
+
+`<ComputeTargetControl>` is a **shared component** used in three places so the strips are
+consistent (map conflation #8):
+1. **new-session** (here) — editable, gates the form;
+2. **in-session header** — replaces the standalone `SessionSandboxSwitcher`
+   (`sandbox-switcher.tsx`); shows the *active* target, allows the existing live swap
+   (`attachMachine` / `SwapActiveSandboxRequest` `contracts:3198`);
+3. **inspector** — the `InfoRow label="Sandbox"` (`inspector.tsx:72`) is changed to render
+   the **active machine** (resolve `activeSandboxId`→`MachineView.name`) instead of the home
+   `sandboxBackend`, so all three surfaces agree.
+
+### 4.3 What gets deleted / replaced
+
+- `sandboxBackendOptions` literal (`sessions-index.tsx:39-45`) → derived from
+  `CAPABILITY_DESCRIPTORS` (managed subset).
+- `AdvancedSessionDraft` + `emptyAdvancedSessionDraft` + the two mapper fns
+  (`session-create.ts:6-57`) → folded into `SessionDraft` + one `submitMapper(draft)`.
+- The collapsed "Session setup" disclosure (`AdvancedSessionOptions`, `:201-388`) is split:
+  compute → top-level `<ComputeTargetControl>`; goal/MCP → `<OptionalSessionOptions>`.
+- `SessionSandboxSwitcher` (`sandbox-switcher.tsx`) → its swap logic moves behind the shared
+  `<ComputeTargetControl>` in-session variant.
+
+---
+
+## 5. Migration notes — additive-first, then the full redesign
+
+Per `00-primitives.md §Staging` (smallest-correct first). The composer redesign decomposes
+into PRs that ship value without waiting on the core refactor.
+
+### PR 1 — pure-UI promotion + gating (additive, NON-breaking, no contract change)
+
+Reuses the existing wire fields exactly as they are today (`targetSandboxId` +
+`sandboxBackend`); only the *form shape* changes.
+- Promote `<ComputeTargetControl>` to top-level; segmented Managed Sandbox / Connected
+  Machine; demote the backend `<select>` into the sandbox kind's Advanced detail.
+- Gate repo (gray on machine), env (hide on machine), per §3. Repo selection is *retained*
+  but excluded from `resources[]` when `kind==="machine"` — this is the **UI half** of the
+  clone-gating footgun (the runtime half — `repositoryUsesSandboxClone`,
+  `runtime/src/index.ts:2068` — ships independently per `00-primitives.md §Concrete bug`).
+- Make backend options descriptor-driven (`CAPABILITY_DESCRIPTORS`).
+- Workdir for a machine defaults to `{ kind: "root" }` (the agent's launch dir) — **no
+  `workingDir` field is sent yet**, so behavior is identical to today; the picker simply
+  shows "Machine root" with custom-path/sub-folder controls *disabled* + a "coming soon"
+  note. This keeps PR 1 free of any protocol change.
+- Unify the two stores into `useSessionDraft` (internal refactor; no contract change).
+- Fix the in-session/inspector inconsistency: shared `<ComputeTargetControl>` +
+  inspector shows active machine.
+
+Result: the worst confusion (buried compute, repos-offered-for-a-machine, two overlapping
+compute controls) is gone with zero backend risk.
+
+### PR 2+ — needs sign-off (the core refactor, `00-primitives.md` D1/D2/D4/D5)
+
+Breaking / additive-contract changes, each gated on the corresponding primitive decision:
+- **`workingDir` on `CreateSessionRequest` + `session_create` MCP + agent protocol** (D5):
+  enables the real Project/path/sub-folder picker (replaces the `/workspace` virtual root for
+  machines). *Additive field*; UI lights up the disabled controls from PR 1.
+- **Project primitive + registry** (D4): a registered named path on a machine (UI to
+  register + an agent tool). Until it lands, `<ProjectPathPicker>` offers only root + custom
+  host-path; "named Project" is the additive third option.
+- **Machine as primary compute, drop the mandatory home box** (D1) + **skip token
+  distribution** (D2): lets the submit mapper send `sandboxBackend: undefined` for a machine
+  with no home box provisioned, and removes the env-injection path entirely for machines
+  (the UI already hides it in PR 1, so this is backend-only).
+- The in-session live swap already exists (`SwapActiveSandboxRequest`, `contracts:3198`); no
+  new surface needed — it just re-homes under the shared control.
+
+### Open calls inherited from `00-primitives.md` (UI must follow the rulings)
+
+- (b) Project creation = UI *and* agent tool, or start free-form `workingDir` + named
+  Projects as sugar → determines whether PR 2 needs the registry or just the `workingDir`
+  field. The `<ProjectPathPicker>` design above supports both (root/path now, named project
+  additive).
+- (c) Default NO platform-cloned repo onto a machine → encoded as the grayed repo + "uses
+  its own checkout" copy (D3); confirm before allowing any machine-side clone toggle.
+
+---
+
+## Appendix — file:line index used
+
+- `apps/web/src/routes/sessions-index.tsx` — `:39-45` backend literal; `:52` advancedOpen;
+  `:53` local advanced state; `:79-87` submit; `:116` controls; `:151-199` strip;
+  `:201-388` AdvancedSessionOptions; `:212-213` useMachines/selfhosted filter; `:250-263`
+  Machine select; `:273-288` Environment; `:294-319` backend override; `:326-349` goal;
+  `:352-383` MCP perms.
+- `apps/web/src/lib/session-create.ts` — `:6-19` AdvancedSessionDraft; `:21-32` empty;
+  `:37-39` targetSandboxIdFrom…; `:42-57` submissionExtrasFrom….
+- `apps/web/src/context.tsx` — `:163,168,171,174,175,181` global selection; `:433-477`
+  startSession; `:444-463` merge; `:460-462` targetSandboxId cast-through.
+- `apps/web/src/components/repository-picker.tsx` — `:39` picker; `:203-215` GitHub-App gate;
+  `:226-227` cross-installation block; `:263-275` per-repo branch input.
+- `apps/web/src/lib/machine-selectability.ts:9` — `isMachineComputeSelectable`.
+- `apps/web/src/lib/session-tools.ts` — `:54` buildResources; `:77,99` `mountPath = repos/<repo>`.
+- `apps/web/src/routes/session.tsx:397-415` — in-session strip (Model+Tools only).
+- `apps/web/src/components/session/sandbox-switcher.tsx` — `SessionSandboxSwitcher` "Run on:".
+- `apps/web/src/components/session/inspector.tsx:72` — `InfoRow label="Sandbox"` (home backend).
+- `packages/contracts/src/index.ts` — `:18-31` SandboxBackend(11); `:55-85` CapabilityDescriptor;
+  `:101` CAPABILITY_DESCRIPTORS; `:123` modal workspaceRoot `/workspace`; `:371-401` selfhosted
+  descriptor; `:398` selfhosted workspaceRoot `/`; `:3140-3148` MachineState; `:3150-3151`
+  MachineKind; `:3161-3177` MachineView; `:3198-3201` SwapActiveSandboxRequest.
+- `packages/runtime/src/index.ts` — `:1770` buildManifest root `/workspace`; `:2068`
+  repositoryUsesSandboxClone (clone-gating footgun).
+- `docs/design/connected-machines/00-primitives.md` — D1–D7, §Session binding, §Concrete bug, §Staging.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -613,6 +613,19 @@ export type BuildAgentOptions = {
   encryptedReasoning?: boolean;
   contextWindowTokens?: number;
   sandboxEnvironment?: Record<string, string>;
+  // The EFFECTIVE/active compute backend for this turn. `settings.sandboxBackend`
+  // is the session's HOME backend (the default cloud group box it was created
+  // with); when a session has swapped its active sandbox to a connected machine
+  // (active_sandbox_id → a selfhosted lease, while the home backend stays the
+  // cloud default), the worker passes that machine's backend here so
+  // filesystem-touching lifecycle hooks key off where the agent ACTUALLY runs,
+  // not where it was created. The one such hook today is the repository clone
+  // (sandboxRepositoryCloneHooks): a bring-your-own machine owns its real disk,
+  // so the platform must NEVER `git clone` onto it. Defaults to
+  // settings.sandboxBackend, so the legacy cloud paths are byte-for-byte
+  // unchanged and a session whose HOME backend is "selfhosted" is gated with no
+  // caller change.
+  activeSandboxBackend?: Settings["sandboxBackend"];
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
   workspaceEnvironment?: WorkspaceEnvironmentContext;
@@ -792,7 +805,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     capabilities: buildAgentCapabilities(settings, options.packSkills ?? [], { compactionMode, contextWindowTokens }),
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
-  agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources));
+  agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources, options.activeSandboxBackend));
   return agent;
 }
 
@@ -2227,9 +2240,13 @@ function sandboxRepositoryCloneHooksForAgent(agent: Agent<any, any>): SandboxLif
   return agentRepositoryCloneHooks.get(agent) ?? [];
 }
 
-function sandboxRepositoryCloneHooks(settings: Settings, resources: ResourceRef[]): SandboxLifecycleHook[] {
+function sandboxRepositoryCloneHooks(
+  settings: Settings,
+  resources: ResourceRef[],
+  activeSandboxBackend: Settings["sandboxBackend"] = settings.sandboxBackend,
+): SandboxLifecycleHook[] {
   const repositories = resources.filter((resource): resource is Extract<ResourceRef, { kind: "repository" }> => (
-    resource.kind === "repository" && repositoryUsesSandboxClone(settings, resource)
+    resource.kind === "repository" && repositoryUsesSandboxClone(settings, resource, activeSandboxBackend)
   ));
   if (repositories.length === 0) {
     return [];
@@ -2243,7 +2260,32 @@ function sandboxRepositoryCloneHooks(settings: Settings, resources: ResourceRef[
   }];
 }
 
-function repositoryUsesSandboxClone(settings: Settings, resource: Extract<ResourceRef, { kind: "repository" }>): boolean {
+/**
+ * Whether the platform should seed a repository resource by `git clone` inside
+ * the sandbox before the agent starts.
+ *
+ * SAFETY GATE (selfhosted/bring-your-own machine): the clone hook writes into
+ * `posixPath.join("/workspace", mountPath)`, which a selfhosted agent rewrites
+ * to a path under its REAL launch directory — so a platform-initiated clone
+ * lands on the user's actual disk. A connected machine already owns its
+ * filesystem; the platform must NEVER clone onto it. We therefore key the
+ * decision off the EFFECTIVE/active backend, not just the session's HOME backend
+ * (`settings.sandboxBackend`): a session can run on the cloud default while its
+ * active sandbox has been swapped to a connected machine (active_sandbox_id → a
+ * selfhosted lease), in which case the agent actually executes on the user's
+ * machine even though the home backend is e.g. "modal". `activeSandboxBackend`
+ * defaults to the home backend, so a session whose HOME backend is "selfhosted"
+ * is gated with no caller change, and every cloud path is byte-for-byte
+ * unchanged.
+ */
+export function repositoryUsesSandboxClone(
+  settings: Settings,
+  resource: Extract<ResourceRef, { kind: "repository" }>,
+  activeSandboxBackend: Settings["sandboxBackend"] = settings.sandboxBackend,
+): boolean {
+  if (activeSandboxBackend === "selfhosted") {
+    return false;
+  }
   return settings.sandboxBackend === "modal" || Boolean(resource.githubInstallationId && resource.githubRepositoryId);
 }
 

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -741,6 +741,60 @@ describe("runtime event normalization", () => {
     expect(command).not.toContain("githubRepositoryId");
     expect(command).not.toContain("x-access-token");
     expect(command).not.toContain("GH_TOKEN=");
+  });
+
+  test("never clones a repository onto a selfhosted (bring-your-own) machine", () => {
+    const githubRepo = {
+      kind: "repository" as const,
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    };
+    const plainRepo = {
+      kind: "repository" as const,
+      uri: "https://github.com/acme/public.git",
+      ref: "main",
+    };
+
+    // Cloud home backend: the clone fires today (modal always clones; any
+    // backend clones a GitHub-App-connected repo). These are the unchanged
+    // cloud paths.
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "modal" }), githubRepo)).toBe(true);
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "modal" }), plainRepo)).toBe(true);
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "docker" }), githubRepo)).toBe(true);
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "docker" }), plainRepo)).toBe(false);
+
+    // Home backend IS selfhosted: gated with no caller change (active backend
+    // defaults to the home backend).
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "selfhosted" }), githubRepo)).toBe(false);
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "selfhosted" }), plainRepo)).toBe(false);
+
+    // Cloud home backend but ACTIVE sandbox swapped to a connected machine:
+    // the explicit active-backend signal suppresses the clone even though the
+    // home backend (modal/docker) would otherwise clone.
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "modal" }), githubRepo, "selfhosted")).toBe(false);
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "docker" }), githubRepo, "selfhosted")).toBe(false);
+
+    // Active backend is another cloud box (a sibling Modal swap): still clones.
+    expect(repositoryUsesSandboxClone(testSettings({ sandboxBackend: "modal" }), githubRepo, "modal")).toBe(true);
+  });
+
+  test("buildOpenGeniAgent accepts the activeSandboxBackend option for both cloud and selfhosted targets", () => {
+    const resources = [{
+      kind: "repository" as const,
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }];
+    // The gating itself is covered behaviourally by the predicate test above
+    // (the per-agent clone-hook set is held in a private WeakMap). Here we only
+    // guard that the new option is accepted on the SandboxAgent build path for a
+    // cloud home backend whether or not the active backend is swapped.
+    expect(() => buildOpenGeniAgent(testSettings({ sandboxBackend: "modal" }), resources, { activeSandboxBackend: "selfhosted" })).not.toThrow();
+    expect(() => buildOpenGeniAgent(testSettings({ sandboxBackend: "modal" }), resources, { activeSandboxBackend: "modal" })).not.toThrow();
+    expect(() => buildOpenGeniAgent(testSettings({ sandboxBackend: "modal" }), resources)).not.toThrow();
   });
 
   test("runs repository clone hook as a sandbox lifecycle hook", async () => {


### PR DESCRIPTION
Surfaced from real self-hosted use (a Mac + a Linux VM). Four safe fixes + one safety fix, plus the design spine for treating a **connected machine as a first-class compute target** rather than an overlay on a mandatory cloud box.

## Fixes (all verified)
- **macOS metrics** — fixes a cross-platform **disk unit bug** (`f_blocks` counts in `f_frsize` units, not `f_bsize`; the old `.max(block_size())` inflated macOS ≈256× — the bogus "237146 GB"). Implements macOS cpu/mem/load via subprocess + pure parsers (`sysctl`/`vm_stat`/`top`) because the workspace is `unsafe_code=forbid` (no `libc`/`mach` FFI possible). _cargo check + clippy clean, 24 tests (9 new)._
- **install.sh** — the no-token path printed a bare `opengeni-agent enroll` + a false "…honored automatically" line, but those env vars don't survive the `curl | VAR=x sh` pipe. Now prints a copy-paste-correct `OPENGENI_WORKSPACE_ID=… enroll`. _shellcheck 0._
- **Enroll dialog** — zero-click enroll-token one-liner is now the **primary** CTA (mints on open) + an **"Allow screen control"** toggle; device-flow demoted to "approve manually". _tsc 0._
- **Clone-into-your-disk guard (SAFETY)** — the platform could `git clone` a private repo onto a connected machine (clone decision keyed off the **home** backend, not where the session runs). Now gated off for a selfhosted **effective** backend; the worker resolves the **active** sandbox backend at turn start and threads it into `buildAgent` — closing both `home=selfhosted` and `home=cloud + swapped-to-machine`. _runtime 78 + worker 20 tests pass._

## Design docs — `docs/design/connected-machines/`
- **`00-primitives.md`** — `ComputeTarget` = Managed Sandbox vs Connected Machine; machine as primary compute (no home box), **no token distribution** (machine uses its own git auth), **Project/path** primitive, per-session `working_dir`, worktree-as-agent-concern.
- **`10-macos-display.md`** — macOS display feasibility: **defer the live backend** (blocked on TCC grants + a signed Mac to verify, not Rust difficulty); spike ScreenCaptureKit behind a flag.
- **`20-composer-redesign.md`** — compute-target-drives-the-form redesign + wireframes.

## Notes
- The **agent metrics** change needs an **agent release** to deploy; the rest deploys via the staging build.
- The **core refactor** (machine as primary compute / no-token auth / per-session workdir) is design-only here — awaiting sign-off on `00-primitives.md` + the open calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The repository-clone gate touches turn startup and private-repo lifecycle on BYO machines; regressions could still clone onto user disks or skip needed cloud clones, though behavior is covered by new tests.
> 
> **Overview**
> Improves **self-hosted Mac/Linux** operability and closes a **filesystem safety** hole when sessions run on enrolled machines.
> 
> **Agent metrics (`metrics.rs`)** — On macOS, CPU/mem/load now come from subprocess + pure parsers (`sysctl`, `vm_stat`, `top -l 2`) so `unsafe_code = forbid` stays intact. **Disk** math uses `f_frsize` only (fixes ~256× inflation on APFS); logic is extracted to testable `disk_used_total`.
> 
> **Install / enroll** — `install.sh` prints copy-paste `OPENGENI_WORKSPACE_ID` / `OPENGENI_API_URL` on the enroll line when set in the pipe (env does not survive `curl | sh`). **Machines** enroll dialog **mints an enroll token on open** as the primary path, adds **Allow screen control** (re-mint on toggle), and demotes device-flow to “Approve manually instead.”
> 
> **Clone-onto-real-disk guard** — `repositoryUsesSandboxClone` skips clones when the **effective** backend is `selfhosted` (including cloud home + active swap to a machine). Worker **`resolveActiveSandboxBackend`** reads `active_sandbox_id` at turn start and passes **`activeSandboxBackend`** into `buildOpenGeniAgent` / clone hooks. Tests cover runtime and worker paths.
> 
> **Design-only** — `docs/design/connected-machines/` (`00-primitives`, macOS display deferral, composer redesign wireframes); no core refactor in this PR.
> 
> **Deploy note:** agent metrics need an **agent release**; web/worker/runtime deploy with the usual build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9409528e7aa60d14e0a3b44594f03ea21a35a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->