### PR TITLE
fix(codex): sanitize codex_apps tools/list so connector tools don't fail the turn

### DIFF
--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -6,3 +6,4 @@ export * from "./normalize";
 export * from "./api-client";
 export * from "./request-context";
 export * from "./fetch";
+export * from "./mcp-sanitize";

--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -1,0 +1,93 @@
+// OpenAI's `codex_apps` connector MCP returns many tools with an empty
+// `outputSchema: {}` (no `type`) — 122 of 217 in practice. The MCP client SDK
+// (@modelcontextprotocol/sdk) validates every tool's `outputSchema` as a strict
+// `{ type: "object", ... }` and throws a ZodError ("Invalid input: expected
+// \"object\"" at tools[N].outputSchema.type) on the WHOLE tools/list response.
+// Because we register codex_apps with cacheToolsList:false, that listing runs on
+// every turn, so the error fails the entire turn (it is thrown during tool
+// enumeration, outside the best-effort *connect* wrapper).
+//
+// We can't relax the SDK's schema, so we sanitize the tools/list response on the
+// wire — before the validator sees it — by dropping any `outputSchema` that is
+// not a valid object-typed schema. Dropping it is safe: outputSchema is an
+// advisory hint for structured tool results, never required for a tool to run.
+
+import type { FetchLike } from "./fetch";
+
+/** Strip non-`{type:"object"}` outputSchemas from a JSON-RPC tools/list result, in place. */
+function sanitizeToolsInRpcMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const tools = (message as { result?: { tools?: unknown } }).result?.tools;
+  if (!Array.isArray(tools)) {
+    return;
+  }
+  for (const tool of tools) {
+    if (tool && typeof tool === "object" && "outputSchema" in tool) {
+      const outputSchema = (tool as Record<string, unknown>).outputSchema as { type?: unknown } | null | undefined;
+      if (!outputSchema || typeof outputSchema !== "object" || outputSchema.type !== "object") {
+        delete (tool as Record<string, unknown>).outputSchema;
+      }
+    }
+  }
+}
+
+/** Sanitize a single JSON body (application/json MCP response). */
+export function sanitizeMcpJsonBody(text: string): string {
+  try {
+    const parsed = JSON.parse(text);
+    sanitizeToolsInRpcMessage(parsed);
+    return JSON.stringify(parsed);
+  } catch {
+    return text; // not JSON we understand — leave untouched
+  }
+}
+
+/** Sanitize an SSE body: each JSON-RPC message rides on a `data:` line. */
+export function sanitizeMcpSseBody(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      if (!line.startsWith("data:")) {
+        return line;
+      }
+      const payload = line.slice("data:".length).trimStart();
+      try {
+        const parsed = JSON.parse(payload);
+        sanitizeToolsInRpcMessage(parsed);
+        return `data: ${JSON.stringify(parsed)}`;
+      } catch {
+        return line;
+      }
+    })
+    .join("\n");
+}
+
+/**
+ * Wrap a base fetch so the codex_apps MCP transport's tools/list response is
+ * sanitized before @modelcontextprotocol/sdk validates it. Only the POST
+ * request/response is buffered+rewritten; the long-lived GET notification SSE
+ * stream is passed through untouched (never buffered).
+ */
+export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch): FetchLike {
+  return async (input, init) => {
+    const res = await base(input, init);
+    const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+    if (method !== "POST" || !res.ok || !res.body) {
+      return res;
+    }
+    const contentType = res.headers.get("content-type") ?? "";
+    const isJson = contentType.includes("application/json");
+    const isSse = contentType.includes("text/event-stream");
+    if (!isJson && !isSse) {
+      return res;
+    }
+    const original = await res.text();
+    const sanitized = isJson ? sanitizeMcpJsonBody(original) : sanitizeMcpSseBody(original);
+    const headers = new Headers(res.headers);
+    headers.delete("content-length"); // body length changed
+    headers.delete("content-encoding");
+    return new Response(sanitized, { status: res.status, statusText: res.statusText, headers });
+  };
+}

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { codexAppsSanitizingFetch, sanitizeMcpJsonBody, sanitizeMcpSseBody } from "../src/mcp-sanitize";
+
+const toolsListMsg = (tools: unknown[]) => ({ jsonrpc: "2.0", id: 2, result: { tools } });
+
+describe("sanitizeMcpJsonBody", () => {
+  test("drops empty + non-object outputSchemas, keeps valid object ones and all tools", () => {
+    const body = JSON.stringify(toolsListMsg([
+      { name: "a", inputSchema: { type: "object" }, outputSchema: {} },                       // empty -> drop
+      { name: "b", inputSchema: { type: "object" }, outputSchema: { type: "array" } },         // non-object -> drop
+      { name: "c", inputSchema: { type: "object" }, outputSchema: { type: "object", properties: {} } }, // valid -> keep
+      { name: "d", inputSchema: { type: "object" } },                                          // none -> unchanged
+    ]));
+    const tools = JSON.parse(sanitizeMcpJsonBody(body)).result.tools;
+    expect(tools).toHaveLength(4); // no tool dropped
+    expect("outputSchema" in tools[0]).toBe(false);
+    expect("outputSchema" in tools[1]).toBe(false);
+    expect(tools[2].outputSchema).toEqual({ type: "object", properties: {} });
+    expect("outputSchema" in tools[3]).toBe(false);
+    expect(tools.map((t: { name: string }) => t.name)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("leaves non-tools-list messages untouched", () => {
+    const other = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "x", capabilities: {} } });
+    expect(sanitizeMcpJsonBody(other)).toBe(JSON.stringify(JSON.parse(other)));
+  });
+
+  test("returns non-JSON input unchanged", () => {
+    expect(sanitizeMcpJsonBody("not json")).toBe("not json");
+  });
+});
+
+describe("sanitizeMcpSseBody", () => {
+  test("rewrites the data: line and preserves event framing", () => {
+    const sse = `event: message\ndata: ${JSON.stringify(toolsListMsg([{ name: "a", outputSchema: {} }]))}\n\n`;
+    const out = sanitizeMcpSseBody(sse);
+    expect(out).toContain("event: message");
+    const dataLine = out.split("\n").find((l) => l.startsWith("data:"))!;
+    const tool = JSON.parse(dataLine.slice("data:".length).trim()).result.tools[0];
+    expect("outputSchema" in tool).toBe(false);
+  });
+});
+
+describe("codexAppsSanitizingFetch", () => {
+  test("sanitizes a POST application/json tools/list response", async () => {
+    const base = async () => new Response(JSON.stringify(toolsListMsg([{ name: "a", outputSchema: {} }])), {
+      status: 200, headers: { "content-type": "application/json" },
+    });
+    const res = await codexAppsSanitizingFetch(base)("https://x/ps/mcp", { method: "POST" });
+    const tool = (await res.json()).result.tools[0];
+    expect("outputSchema" in tool).toBe(false);
+  });
+
+  test("passes through a GET (long-lived notification SSE) untouched", async () => {
+    const body = `data: ${JSON.stringify(toolsListMsg([{ name: "a", outputSchema: {} }]))}\n\n`;
+    const base = async () => new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+    const res = await codexAppsSanitizingFetch(base)("https://x/ps/mcp", { method: "GET" });
+    expect(await res.text()).toBe(body); // not buffered/rewritten
+  });
+
+  test("passes non-OK responses through untouched", async () => {
+    const base = async () => new Response("nope", { status: 401, headers: { "content-type": "application/json" } });
+    const res = await codexAppsSanitizingFetch(base)("https://x/ps/mcp", { method: "POST" });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("nope");
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,7 @@ import {
 } from "@openai/agents/sandbox";
 import { ModalCloudBucketMountStrategy } from "@openai/agents-extensions/sandbox/modal";
 import OpenAI from "openai";
-import { CODEX_APPS_MCP_SERVER_ID, CODEX_MODEL_ID_PREFIX, CODEX_ORIGINATOR, codexRequestStorage, codexSubscriptionFetch } from "@opengeni/codex";
+import { CODEX_APPS_MCP_SERVER_ID, CODEX_MODEL_ID_PREFIX, CODEX_ORIGINATOR, codexAppsSanitizingFetch, codexRequestStorage, codexSubscriptionFetch } from "@opengeni/codex";
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -904,6 +904,10 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       url,
       name: config.name ?? config.id,
       cacheToolsList: config.cacheToolsList,
+      // codex_apps returns connector tools with empty `outputSchema: {}` that the
+      // MCP SDK's strict Tool schema rejects (fails the turn during tools/list);
+      // sanitize the response on the wire before validation.
+      ...(isCodexAppsMcpServer(config) ? { fetch: codexAppsSanitizingFetch(globalThis.fetch) } : {}),
       ...await mcpServerRequestInit(settings, config, options),
       ...(config.timeoutMs ? {
         timeout: config.timeoutMs,


### PR DESCRIPTION
A codex session with the `codex_apps` connectors enabled failed with a wall of `Invalid input: expected "object"` at `tools[N].outputSchema.type`.

**Root cause:** OpenAI's `codex_apps` connector MCP returns **122 of 217 tools with an empty `outputSchema: {}`** (no `type`). `@modelcontextprotocol/sdk` validates every tool's `outputSchema` as a strict `{type:"object"}` and ZodErrors the **whole** `tools/list` response. Because codex_apps is registered with `cacheToolsList:false`, that listing runs every turn, and the error — thrown during tool enumeration, *outside* the best-effort connect wrapper — fails the entire turn. (The backend itself accepts these tools fine; this is purely the MCP client's strict validation.)

**Fix:** inject a sanitizing `fetch` on the codex_apps transport (`MCPServerStreamableHttpOptions.fetch`) that drops any `outputSchema` which isn't a valid object schema from the `tools/list` response *before* the SDK validates it (handles `application/json` + SSE; passes the long-lived GET notification stream and non-OK responses through untouched). Dropping `outputSchema` is safe — it's an advisory hint, never required to run the tool.

**Verified live** against the real connector list: 217 tools in → 217 out (none lost), **122 bad → 0**, 93 valid object schemas preserved. Unit tests (7) + full codex suite (44) green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to codex_apps MCP transport fetch; only strips advisory outputSchema fields on successful POST JSON/SSE responses, with tests and pass-through for streams and errors.
> 
> **Overview**
> Fixes **codex_apps** turns that die during **tools/list** when the MCP SDK rejects connector tools whose `outputSchema` is `{}` or otherwise not `{ type: "object" }`.
> 
> Adds **`mcp-sanitize`** in `@opengeni/codex`: a **`codexAppsSanitizingFetch`** wrapper that rewrites successful **POST** JSON/SSE responses to strip invalid `outputSchema` fields while keeping all tools. **GET** notification streams, non-OK responses, and unrelated JSON-RPC messages are left unchanged.
> 
> **Runtime** wires that fetch into **`MCPServerStreamableHttp`** only for the codex_apps server, so listing runs cleanly before SDK validation (including when `cacheToolsList: false` lists every turn). Unit tests cover JSON, SSE, and fetch pass-through behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb180175695a489559c9831f72ba521776dcfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->