### PR TITLE
feat(machines): per-session working_dir for connected machines (Stage A)

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -84,7 +84,9 @@ export async function createAndStartSession(input: {
   // session row exists but BEFORE the first turn is enqueued/the workflow woken,
   // so the FIRST turn routes to the chosen machine. An invalid/unowned/offline
   // target fails the create (422) — never a silent fall-back to the default box.
-  seedTargetSandbox?: { sandboxId: string; settings: Settings } | null;
+  // `workingDir` (optional) is the path/cwd base the chosen machine runs under,
+  // seeded alongside the pointer through the epoch-fenced CAS.
+  seedTargetSandbox?: { sandboxId: string; settings: Settings; workingDir?: string | null } | null;
 }) {
   const sessionMetadata = {
     ...input.metadata,
@@ -159,7 +161,7 @@ async function finishStartSession(input: {
   sandboxBackend: Settings["sandboxBackend"];
   environment?: { id: string; name: string } | null;
   goal?: GoalSpec | null;
-  seedTargetSandbox?: { sandboxId: string; settings: Settings } | null;
+  seedTargetSandbox?: { sandboxId: string; settings: Settings; workingDir?: string | null } | null;
 }, session: Session): Promise<Session> {
   // The goal row is durable session state; the workflow picks it up from the
   // database once the first turn completes — no extra workflow plumbing here.
@@ -232,6 +234,9 @@ async function finishStartSession(input: {
       { db: input.db, settings: input.seedTargetSandbox.settings, bus: input.bus },
       ctx,
       input.seedTargetSandbox.sandboxId,
+      // The working dir is committed in the SAME epoch-fenced CAS that seeds the
+      // pointer, so the first turn routes to the machine AND lands in working_dir.
+      input.seedTargetSandbox.workingDir ?? null,
     );
     if (!seeded.swapped) {
       throw new HTTPException(422, {
@@ -535,6 +540,13 @@ export async function createSessionForRequest(
     inheritedBackend = member.sandboxBackend;
   }
   // else "new": leave sandboxGroupId null → own singleton group (group ≡ id).
+  // A working dir is only meaningful for a TARGETED machine (it is the chosen
+  // box's path/cwd base). Present without a targetSandboxId is a malformed request
+  // — reject it at the edge (mirrors the backend:'none' guard) rather than silently
+  // dropping it, since the default group box has no working-dir seam yet.
+  if (payload.workingDir !== undefined && !payload.targetSandboxId) {
+    throw new HTTPException(422, { message: "workingDir requires targetSandboxId (it is the targeted machine's working directory)" });
+  }
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1, model });
   const session = await createAndStartSession({
     db,
@@ -563,7 +575,7 @@ export async function createSessionForRequest(
     // (after the row exists, before the first turn dispatches). Validation
     // (ownership/liveness) lives in swapActiveSandbox; an invalid target 422s.
     seedTargetSandbox: payload.targetSandboxId
-      ? { sandboxId: payload.targetSandboxId, settings }
+      ? { sandboxId: payload.targetSandboxId, settings, workingDir: payload.workingDir ?? null }
       : null,
   });
   await recordWorkspaceUsage(deps, {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -618,7 +618,7 @@ function registerWorkspaceOrchestrationTools(
 
   if (can("sessions:create")) {
     server.registerTool("session_create", {
-      description: "Spawn a new agent session (a worker) with an initial message and optional goal, resources (e.g. repositories from github_repositories_list), tools, and workspace environment attachment. Environment attachment happens at creation only — it cannot be added to a running session — and requires the environments:use permission.",
+      description: "Spawn a new agent session (a worker) with an initial message and optional goal, resources (e.g. repositories from github_repositories_list), tools, and workspace environment attachment. Environment attachment happens at creation only — it cannot be added to a running session — and requires the environments:use permission. When targetSandboxId names a machine, workingDir sets the working directory (cwd) the spawned session runs under on that machine.",
       inputSchema: {
         initialMessage: z4.string().min(1),
         goal: z4.unknown().optional(),
@@ -634,6 +634,11 @@ function registerWorkspaceOrchestrationTools(
         // (race-free). Ownership + liveness are validated in the domain via the
         // same path as sandbox_swap; an unowned/offline/unknown target 422s.
         targetSandboxId: z4.string().uuid().optional(),
+        // The working directory (cwd) for a machine target: the path/cwd base the
+        // spawned session's agent exec, terminal, and file dock run under. A
+        // workspace_root-relative subdir or an absolute machine path. Only valid
+        // WITH targetSandboxId (workingDir alone 422s); omitted ⇒ workspace_root.
+        workingDir: z4.string().optional(),
         metadata: z4.record(z4.string(), z4.unknown()).optional(),
         // Workspace-scoped CREATE idempotency key: a retried session_create with
         // the same key returns the already-spawned worker instead of a duplicate.

--- a/apps/api/src/sandbox/fleet.ts
+++ b/apps/api/src/sandbox/fleet.ts
@@ -278,6 +278,10 @@ export async function swapActiveSandbox(
   services: FleetServices,
   ctx: FleetContext,
   target: string,
+  // The session's working directory to seed alongside the pointer (create-time
+  // machine targeting). OMITTED ⇒ the column is left unchanged (a live swap/attach
+  // never touches it); threaded straight into the epoch-fenced setActiveSandbox CAS.
+  workingDir?: string | null,
 ): Promise<FleetSwapResult> {
   const resolved = await resolveTarget(services, ctx, target);
   if (!resolved.ok) {
@@ -305,6 +309,7 @@ export async function swapActiveSandbox(
       sessionId: ctx.sessionId,
       targetSandboxId: resolved.targetSandboxId,
       expectedEpoch: pointer.activeEpoch,
+      ...(workingDir !== undefined ? { workingDir } : {}),
     });
     if (result.swapped && result.pointer) {
       return { swapped: true, activeSandboxId: result.pointer.activeSandboxId, activeEpoch: result.pointer.activeEpoch };

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -129,7 +129,7 @@ export type AppContextValue = {
   startSession: (
     workspaceId: string,
     submission: TurnSubmission,
-    options?: { targetSandboxId?: string | null },
+    options?: { targetSandboxId?: string | null; workingDir?: string | null },
   ) => Promise<Session | null>;
   resetSessionView: () => void;
   resetWorkspaceIntegrations: () => void;
@@ -443,7 +443,7 @@ export function RootRouteComponent() {
   async function startSession(
     workspaceId: string,
     submission: TurnSubmission,
-    options?: { targetSandboxId?: string | null },
+    options?: { targetSandboxId?: string | null; workingDir?: string | null },
   ): Promise<Session | null> {
     setBusy(true);
     // Reuse the in-flight key if one survives a prior failed/double-fired
@@ -469,6 +469,12 @@ export function RootRouteComponent() {
         // doesn't yet surface it, so cast the field through.
         ...(options?.targetSandboxId
           ? ({ targetSandboxId: options.targetSandboxId } as { targetSandboxId: string })
+          : {}),
+        // The targeted machine's per-session working directory — a top-level create
+        // field (only valid alongside targetSandboxId; the backend 422s it solo).
+        // The SDK request type doesn't yet surface it, so cast the field through.
+        ...(options?.workingDir
+          ? ({ workingDir: options.workingDir } as { workingDir: string })
           : {}),
       });
       // Success: release the key so the next distinct submit is independent.

--- a/apps/web/src/lib/session-create.ts
+++ b/apps/web/src/lib/session-create.ts
@@ -9,6 +9,13 @@ export type AdvancedSessionDraft = {
   // TurnSubmission extra: it's a top-level CreateSessionRequest field, threaded
   // separately into `startSession` (see `targetSandboxIdFromAdvancedSessionDraft`).
   targetSandboxId: string | null;
+  // The targeted machine's working directory — the path/cwd base its agent exec,
+  // terminal, and file dock run under. Free-form pass-through: a launch-
+  // workspace_root-relative subdir or an absolute machine path. Empty (the
+  // default) ⇒ the machine's default workspace_root (byte-identical to today).
+  // Only meaningful WITH `targetSandboxId`; like it, a top-level
+  // CreateSessionRequest field threaded into `startSession` separately.
+  workingDir: string;
   sandboxBackend: SandboxBackend | "";
   environmentId: string;
   goalText: string;
@@ -21,6 +28,7 @@ export type AdvancedSessionDraft = {
 export function emptyAdvancedSessionDraft(): AdvancedSessionDraft {
   return {
     targetSandboxId: null,
+    workingDir: "",
     sandboxBackend: "",
     environmentId: "",
     goalText: "",
@@ -36,6 +44,14 @@ export function emptyAdvancedSessionDraft(): AdvancedSessionDraft {
  *  TurnSubmission extras. */
 export function targetSandboxIdFromAdvancedSessionDraft(draft: AdvancedSessionDraft): string | null {
   return draft.targetSandboxId;
+}
+
+/** The picked machine's working directory (the top-level create field), or null
+ *  for the machine's default workspace_root. Like the target sandbox id, threaded
+ *  into `startSession` separately from the TurnSubmission extras. A blank/whitespace
+ *  value normalizes to null (omitted ⇒ no-op default). */
+export function workingDirFromAdvancedSessionDraft(draft: AdvancedSessionDraft): string | null {
+  return draft.workingDir.trim() || null;
 }
 
 /** The create-session payload extras from the advanced options card. */

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -4,7 +4,7 @@
 // in the left rail, not on this page.
 import { useEnvironments, useMachines, type ComposerState } from "@opengeni/react";
 import { useNavigate } from "@tanstack/react-router";
-import { BoxIcon, ChevronDownIcon, FlagIcon, ServerIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
+import { BoxIcon, ChevronDownIcon, FlagIcon, FolderIcon, ServerIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
@@ -25,6 +25,7 @@ import {
   emptyAdvancedSessionDraft,
   submissionExtrasFromAdvancedSessionDraft,
   targetSandboxIdFromAdvancedSessionDraft,
+  workingDirFromAdvancedSessionDraft,
   type AdvancedSessionDraft,
 } from "@/lib/session-create";
 import { cn } from "@/lib/utils";
@@ -83,7 +84,10 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
           resources: attachments.readyResources,
           ...submissionExtrasFromAdvancedSessionDraft(advanced),
         },
-        { targetSandboxId: targetSandboxIdFromAdvancedSessionDraft(advanced) },
+        {
+          targetSandboxId: targetSandboxIdFromAdvancedSessionDraft(advanced),
+          workingDir: workingDirFromAdvancedSessionDraft(advanced),
+        },
       );
       if (!created) {
         return false;
@@ -264,6 +268,27 @@ function AdvancedSessionOptions(props: {
               <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
                 Run on one of your enrolled machines, or the default cloud sandbox.
               </p>
+              {/* Per-session working directory — only meaningful for a targeted
+                  machine (it is that box's path/cwd base). Hidden for the cloud
+                  sandbox; the create 422s a workingDir without a targetSandboxId. */}
+              {draft.targetSandboxId ? (
+                <div className="mt-1 grid gap-1.5">
+                  <Label className="flex items-center gap-1.5 text-xs">
+                    <FolderIcon className="size-3" />
+                    Working directory
+                  </Label>
+                  <Input
+                    value={draft.workingDir}
+                    disabled={props.disabled}
+                    onChange={(event) => update({ workingDir: event.target.value })}
+                    placeholder="Defaults to where the agent runs (e.g. ~/repos/myproject)"
+                    className="h-9 text-sm"
+                  />
+                  <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+                    Where the agent, terminal, and file dock run. Relative paths resolve under the machine&apos;s workspace; absolute paths are used as-is.
+                  </p>
+                </div>
+              ) : null}
             </div>
             <div className="grid gap-1.5">
               <Label className="flex items-center gap-1.5 text-xs">

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2571,6 +2571,12 @@ export const CreateSessionRequest = z.object({
   // machine (race-free: the pointer is committed before the worker turn
   // workflow can read it). An invalid/unowned/offline target fails the create.
   targetSandboxId: z.string().uuid().optional(),
+  // The working directory the targeted machine runs the session under — the
+  // path/cwd base for its agent exec, terminal, and file dock. Free-form pass-
+  // through: a launch-workspace_root-relative subdir or an absolute machine path
+  // (the agent's resolve_cwd handles both). Only valid WITH targetSandboxId
+  // (workingDir alone is a 422); omitted ⇒ the machine's default workspace_root.
+  workingDir: z.string().min(1).optional(),
   // Workspace environment attachment is fixed at session creation; follow-up
   // user.message events cannot switch or add one.
   environmentId: z.string().uuid().optional(),

--- a/packages/db/drizzle/0027_session_working_dir.sql
+++ b/packages/db/drizzle/0027_session_working_dir.sql
@@ -1,0 +1,24 @@
+-- Per-session working directory (Stage A: backend slice).
+--
+-- sessions.working_dir is the path/cwd BASE the session's (selfhosted) box
+-- operates under — its agent exec, terminal pty, and structural file dock. The
+-- value is a launch-workspace_root-relative subdir (resolved under workspace_root
+-- by the agent's resolve_cwd) or an absolute machine path.
+--
+-- NULL (the default) ⇒ today's behavior EXACTLY: the agent substitutes its launch
+-- workspace_root for an empty cwd, so an unset working_dir is a byte-identical
+-- no-op (every existing + new row is NULL, no backfill). It is surfaced alongside
+-- the active-sandbox pointer (readActiveSandbox) and written through the
+-- epoch-fenced setActiveSandbox CAS, never the row INSERT — so it is seeded
+-- create-time when a machine target is named, per-session.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "working_dir" text;
+
+-- Re-grant on the new column (idempotent; mirrors the boilerplate in earlier
+-- migrations so a fresh opengeni_app role can read/write the added column).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4757,6 +4757,9 @@ export async function listSandboxes(db: Database, workspaceId: string): Promise<
 export type ActiveSandboxPointer = {
   activeSandboxId: string | null;
   activeEpoch: number;
+  // The session's working directory (the path/cwd base for a selfhosted backend),
+  // surfaced alongside the pointer. NULL ⇒ the default workspace_root behavior.
+  workingDir: string | null;
 };
 
 // Read the session's current pointer (the routing proxy re-reads this PER TOOL
@@ -4766,13 +4769,14 @@ export async function readActiveSandbox(db: Database, workspaceId: string, sessi
     const [row] = await scopedDb.select({
       activeSandboxId: schema.sessions.activeSandboxId,
       activeEpoch: schema.sessions.activeEpoch,
+      workingDir: schema.sessions.workingDir,
     }).from(schema.sessions)
       .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)))
       .limit(1);
     if (!row) {
       return null;
     }
-    return { activeSandboxId: row.activeSandboxId ?? null, activeEpoch: Number(row.activeEpoch) };
+    return { activeSandboxId: row.activeSandboxId ?? null, activeEpoch: Number(row.activeEpoch), workingDir: row.workingDir ?? null };
   });
 }
 
@@ -4789,16 +4793,22 @@ export async function setActiveSandbox(db: Database, input: {
   sessionId: string;
   targetSandboxId: string | null;
   expectedEpoch: number;
+  // The session's working directory to write alongside the pointer. OMITTED
+  // (undefined) ⇒ the column is left UNCHANGED (a plain swap/attach never touches
+  // it); a string sets it; null clears it back to the default. Per-session
+  // working dir is seeded create-time through this CAS, not the row INSERT.
+  workingDir?: string | null;
 }): Promise<{ swapped: boolean; pointer: ActiveSandboxPointer | null }> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
-    const rows = await scopedDb.execute<{ active_sandbox_id: string | null; active_epoch: number | string }>(sql`
+    const rows = await scopedDb.execute<{ active_sandbox_id: string | null; active_epoch: number | string; working_dir: string | null }>(sql`
       update sessions set
         active_sandbox_id = ${input.targetSandboxId},
         active_epoch      = active_epoch + 1,
+        working_dir       = ${input.workingDir === undefined ? sql`working_dir` : input.workingDir},
         updated_at        = now()
       where workspace_id = ${input.workspaceId} and id = ${input.sessionId}
         and active_epoch = ${input.expectedEpoch}
-      returning active_sandbox_id, active_epoch
+      returning active_sandbox_id, active_epoch, working_dir
     `);
     const row = rows[0];
     if (!row) {
@@ -4806,7 +4816,7 @@ export async function setActiveSandbox(db: Database, input: {
     }
     return {
       swapped: true,
-      pointer: { activeSandboxId: row.active_sandbox_id ?? null, activeEpoch: Number(row.active_epoch) },
+      pointer: { activeSandboxId: row.active_sandbox_id ?? null, activeEpoch: Number(row.active_epoch), workingDir: row.working_dir ?? null },
     };
   });
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -170,6 +170,14 @@ export const sessions = pgTable("sessions", {
   // sandbox. integer (NOT bigint) — the lease-epoch spike: int8 reads back as a
   // JS string and breaks the strict fence; int4 returns a number.
   activeEpoch: integer("active_epoch").notNull().default(0),
+  // The session's WORKING DIRECTORY — the path/cwd base the (selfhosted) box's
+  // agent/terminal/file-dock operate under. A launch-workspace_root-relative
+  // subdir or an absolute machine path; surfaced alongside the active-sandbox
+  // pointer (readActiveSandbox) and written through the epoch-fenced
+  // setActiveSandbox CAS, NOT the row INSERT. NULL (the default) ⇒ today's
+  // behavior exactly — the agent substitutes its workspace_root for an empty cwd,
+  // so an unset working_dir is a byte-identical no-op. Create-time only (Stage A).
+  workingDir: text("working_dir"),
   environmentId: uuid("environment_id").references(() => workspaceEnvironments.id, { onDelete: "set null" }),
   // Non-default first-party MCP token permissions (manager-style sessions);
   // null means the fixed worker default set in @opengeni/runtime.

--- a/packages/db/test/sandboxes-enrollments.test.ts
+++ b/packages/db/test/sandboxes-enrollments.test.ts
@@ -207,7 +207,7 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
     expect(reread?.activeEpoch).toBe(0);
 
     const pointer0 = await readActiveSandbox(db, workspaceId, session.id);
-    expect(pointer0).toEqual({ activeSandboxId: null, activeEpoch: 0 });
+    expect(pointer0).toEqual({ activeSandboxId: null, activeEpoch: 0, workingDir: null });
 
     const target = await createSandbox(db, { accountId, workspaceId, kind: "modal", name: "target" });
 
@@ -216,7 +216,7 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
       accountId, workspaceId, sessionId: session.id, targetSandboxId: target.id, expectedEpoch: 0,
     });
     expect(swap1.swapped).toBe(true);
-    expect(swap1.pointer).toEqual({ activeSandboxId: target.id, activeEpoch: 1 });
+    expect(swap1.pointer).toEqual({ activeSandboxId: target.id, activeEpoch: 1, workingDir: null });
 
     // A concurrent double-swap reading the OLD epoch (0) loses — the fence rejects it.
     const stale = await setActiveSandbox(db, {
@@ -226,14 +226,14 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
     expect(stale.pointer).toBeNull();
 
     // The pointer is unchanged by the losing swap.
-    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: target.id, activeEpoch: 1 });
+    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: target.id, activeEpoch: 1, workingDir: null });
 
     // Swap back to the group sandbox (NULL) at the current epoch -> wins, epoch 2.
     const swap2 = await setActiveSandbox(db, {
       accountId, workspaceId, sessionId: session.id, targetSandboxId: null, expectedEpoch: 1,
     });
     expect(swap2.swapped).toBe(true);
-    expect(swap2.pointer).toEqual({ activeSandboxId: null, activeEpoch: 2 });
+    expect(swap2.pointer).toEqual({ activeSandboxId: null, activeEpoch: 2, workingDir: null });
 
     // The full session re-read reflects the pointer (mapSession round-trip).
     const rereadAfter = await getSession(db, workspaceId, session.id);
@@ -249,6 +249,47 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
     await admin`delete from sandboxes where id = ${target.id}`;
     const afterDelete = await readActiveSandbox(db, workspaceId, session.id);
     expect(afterDelete?.activeSandboxId).toBeNull();
+  }, 60_000);
+
+  test("active-sandbox pointer carries the per-session working_dir (create-time seed / leave-unchanged / clear)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const session = await createSession(db, {
+      accountId, workspaceId, initialMessage: "hi", resources: [], metadata: {},
+      model: "gpt", sandboxBackend: "modal",
+    });
+    const target = await createSandbox(db, { accountId, workspaceId, kind: "modal", name: "wd-target" });
+
+    // A fresh pointer has a NULL working_dir (today's default — byte-identical no-op).
+    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: null, activeEpoch: 0, workingDir: null });
+
+    // Seeding the pointer WITH a working_dir writes it in the SAME epoch-fenced CAS
+    // (the create-time machine-targeting path), and readActiveSandbox surfaces it.
+    const seed = await setActiveSandbox(db, {
+      accountId, workspaceId, sessionId: session.id, targetSandboxId: target.id, expectedEpoch: 0,
+      workingDir: "/home/u/proj",
+    });
+    expect(seed.swapped).toBe(true);
+    expect(seed.pointer).toEqual({ activeSandboxId: target.id, activeEpoch: 1, workingDir: "/home/u/proj" });
+    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: target.id, activeEpoch: 1, workingDir: "/home/u/proj" });
+
+    // A plain swap with workingDir OMITTED (undefined) leaves the column UNCHANGED —
+    // a live swap/attach never touches the working dir.
+    const plainSwap = await setActiveSandbox(db, {
+      accountId, workspaceId, sessionId: session.id, targetSandboxId: null, expectedEpoch: 1,
+    });
+    expect(plainSwap.swapped).toBe(true);
+    expect(plainSwap.pointer).toEqual({ activeSandboxId: null, activeEpoch: 2, workingDir: "/home/u/proj" });
+    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: null, activeEpoch: 2, workingDir: "/home/u/proj" });
+
+    // Explicit null clears it back to the default.
+    const cleared = await setActiveSandbox(db, {
+      accountId, workspaceId, sessionId: session.id, targetSandboxId: null, expectedEpoch: 2,
+      workingDir: null,
+    });
+    expect(cleared.swapped).toBe(true);
+    expect(cleared.pointer).toEqual({ activeSandboxId: null, activeEpoch: 3, workingDir: null });
+    expect(await readActiveSandbox(db, workspaceId, session.id)).toEqual({ activeSandboxId: null, activeEpoch: 3, workingDir: null });
   }, 60_000);
 
   test("metrics: last-sample upsert (one row per enrollment) + append-only series", async () => {

--- a/packages/runtime/src/sandbox/routing/backend-resolver.ts
+++ b/packages/runtime/src/sandbox/routing/backend-resolver.ts
@@ -135,6 +135,9 @@ export function makeActiveBackendResolver(
         // the SDK's per-turn manifest-env delta is empty (no "cannot change manifest
         // environment variables" throw on a pin-to-vm turn).
         ...(deps.environment !== undefined ? { environment: deps.environment } : {}),
+        // The session's working directory (per-session pointer) → the path/cwd base
+        // for this selfhosted backend. Absent/empty ⇒ the default workspace_root.
+        ...(pointer.workingDir ? { workingDir: pointer.workingDir } : {}),
       });
       const session = (await client.resume({ agentId: sandbox.enrollmentId })) as RoutableBackendSession;
       return { session, sandboxId: sandbox.id, kind: "selfhosted" };

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -36,6 +36,13 @@ import type { ExposedPortEndpoint } from "../stream-port";
 export interface ActivePointer {
   activeSandboxId: string | null;
   activeEpoch: number;
+  /** The session's working directory — the path/cwd base for a selfhosted backend
+   *  (threaded into the SelfhostedSession via the resolver). `null`/absent ⇒ the
+   *  default workspace_root behavior. Optional so the default-pointer fallback
+   *  (`{ activeSandboxId: null, activeEpoch: 0 }`) the readPointer wiring synthesizes
+   *  when no row exists needs no extra field. Only the selfhosted branch reads it;
+   *  the modal/default branches ignore it. */
+  workingDir?: string | null;
 }
 
 /**

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -58,22 +58,46 @@ const encoder = new TextEncoder();
  * (the live-swap exec crash: `spawn hostname: No such file or directory`).
  *
  * `toMachinePath` rewrites the virtual frame onto the machine's: the root itself
- * → "" (the agent substitutes its workspace_root); a child → its
- * workspace_root-relative remainder (the agent joins it onto workspace_root). A
- * path that is NOT under the virtual root — a genuine machine-absolute path the
- * model/agent chose ("/tmp/x"), or a real path echoed back by `listDir` — passes
- * through UNTOUCHED. This is the SOLE adapter rule between the SDK's virtual
- * space and the machine's real filesystem; it is applied at every NATS path/cwd
- * boundary below (exec cwd, fs read/write/list/stat, the editor's delete).
+ * → the session `workingDir` (empty by default ⇒ "", so the agent substitutes its
+ * workspace_root); a child → `workingDir`-rooted remainder (the agent joins it onto
+ * workspace_root). A genuine machine-ABSOLUTE path the model/agent chose ("/tmp/x"),
+ * or a real path echoed back by `listDir`, passes through UNTOUCHED. This is the
+ * SOLE adapter rule between the SDK's virtual space and the machine's real
+ * filesystem; it is applied at every NATS path/cwd boundary below (exec cwd, fs
+ * read/write/list/stat, the editor's delete, the terminal's pty cwd). The
+ * per-session `workingDir` (default "" ⇒ a byte-identical no-op) is the base.
  */
 const SELFHOSTED_VIRTUAL_ROOT = "/workspace";
 
-function toMachinePath(p: string | undefined): string {
-  if (!p || p === SELFHOSTED_VIRTUAL_ROOT) return "";
+/**
+ * `workingDir` is the session's per-session working directory — the frame's BASE.
+ * It is the launch-workspace_root-relative subdir (or an absolute machine path)
+ * the agent/terminal/dock operate under. An EMPTY `workingDir` (the default) makes
+ * this byte-identical to before: `base === ""`, so every branch returns the
+ * original value (empty/virtual → "", virtual-child → its remainder, a relative or
+ * absolute path → itself). A trailing slash on `workingDir` is stripped so a join
+ * never doubles; relative stays relative and absolute stays absolute otherwise.
+ */
+function toMachinePath(p: string | undefined, workingDir: string): string {
+  const base = workingDir.replace(/\/$/, "");
+  if (!p || p === SELFHOSTED_VIRTUAL_ROOT) return base;
   if (p.startsWith(`${SELFHOSTED_VIRTUAL_ROOT}/`)) {
-    return p.slice(SELFHOSTED_VIRTUAL_ROOT.length + 1);
+    const rel = p.slice(SELFHOSTED_VIRTUAL_ROOT.length + 1);
+    return base ? `${base}/${rel}` : rel;
   }
-  return p;
+  // An ABSOLUTE machine path — a genuine path the model/agent chose ("/tmp/x") or
+  // a real path echoed back by `listDir` — points anywhere and passes through
+  // UNTOUCHED (the agent's `resolve_cwd` takes an absolute path as-is).
+  if (p.startsWith("/")) return p;
+  // A BARE-RELATIVE path is the structural Channel-A surface's frame: the file dock
+  // joins fs read/list/git sub-paths under an EMPTY workspaceRoot (yielding a bare
+  // relative), and a model-supplied relative exec workdir is bare too. Root it under
+  // the session working dir so those reads/stats stay in the SAME frame as the dock's
+  // working-dir-rooted listing/exec (which run with cwd = workingDir). The SDK agent
+  // loop never emits a bare-relative path — it anchors everything at the manifest
+  // root ("/workspace/…") — so this only re-homes the structural surface. With an
+  // empty workingDir it is a no-op (base === "" ⇒ returns the path unchanged).
+  return base ? `${base}/${p}` : p;
 }
 
 // ── The agent-turn provided-session contract (@openai/agents-core) ──────────
@@ -161,6 +185,14 @@ export interface SelfhostedSessionDeps {
    * which never applies a turn manifest, so there is no delta to validate).
    */
   environment?: Record<string, string>;
+  /**
+   * The session's working directory — the BASE every path/cwd is rooted under (see
+   * `toMachinePath` / SELFHOSTED_VIRTUAL_ROOT). A launch-workspace_root-relative
+   * subdir (resolved under workspace_root by the agent's `resolve_cwd`) or an
+   * absolute machine path. Omitted/empty (the default) ⇒ "" ⇒ today's behavior
+   * exactly (an empty cwd lets the agent substitute its workspace_root).
+   */
+  workingDir?: string;
 }
 
 /** The Channel-A `exec` result shape (a structural superset of the SDK's). */
@@ -204,6 +236,9 @@ export class SelfhostedSession {
   private readonly epoch: number;
   private readonly timeoutMs: number;
   private readonly subject: string;
+  /** The session working directory — the path/cwd base every op is rooted under
+   *  (see `toMachinePath`). "" by default ⇒ today's workspace_root behavior. */
+  private readonly workingDir: string;
 
   /**
    * The structural `state` slice consumers read. `agentId`/`instanceId` serve the
@@ -242,6 +277,7 @@ export class SelfhostedSession {
     this.epoch = deps.epoch ?? 0;
     this.timeoutMs = deps.timeoutMs ?? SELFHOSTED_DEFAULT_TIMEOUT_MS;
     this.subject = subjectFor(deps.workspaceId, deps.agentId);
+    this.workingDir = deps.workingDir ?? "";
     // A valid Manifest mirroring the Modal create-manifest shape (sandbox/index.ts
     // `createManifest`: `new Manifest({ root: "/workspace", environment })`). `root`
     // is "/workspace" to match `buildManifest`'s declared root (the root-delta guard
@@ -300,8 +336,9 @@ export class SelfhostedSession {
       shell: true,
       // Rewrite a virtual-root cwd ("/workspace[/…]") onto the machine's frame —
       // an absolute "/workspace" would ENOENT on a real machine (see
-      // SELFHOSTED_VIRTUAL_ROOT). Empty → the agent runs in its workspace_root.
-      cwd: toMachinePath(args.workdir),
+      // SELFHOSTED_VIRTUAL_ROOT). Empty → the session workingDir (itself "" by
+      // default ⇒ the agent runs in its workspace_root).
+      cwd: toMachinePath(args.workdir, this.workingDir),
       env: {},
       stdin: new Uint8Array(0),
       timeoutMs: 0,
@@ -396,12 +433,13 @@ export class SelfhostedSession {
     };
     const deletePath = async (path: string): Promise<void> => {
       // No fs-delete op in the proto; remove via the shell (the machine's own rm).
-      // The path arg is embedded in the command (not a cwd), so translate the
-      // virtual root onto the machine's frame BEFORE quoting: a "/workspace/…"
-      // path becomes its workspace_root-relative remainder, and the rm — which
-      // runs with the default (empty) cwd = workspace_root — targets the real
-      // file. A non-virtual absolute path passes through and rm uses it as-is.
-      await this.exec({ cmd: `rm -rf -- ${shellQuote(toMachinePath(path))}`, ...(runAs ? { runAs } : {}) });
+      // The path arg is embedded in the command, and this.exec runs it with the
+      // DEFAULT cwd = the session workingDir. So target the path RELATIVE to that
+      // cwd: strip the virtual root to its bare remainder (toMachinePath with an
+      // EMPTY base) — prefixing workingDir here too would DOUBLE it (the cwd is
+      // already workingDir). A non-virtual absolute path passes through and rm
+      // uses it as-is; an empty workingDir is byte-identical to before.
+      await this.exec({ cmd: `rm -rf -- ${shellQuote(toMachinePath(path, ""))}`, ...(runAs ? { runAs } : {}) });
     };
     return {
       async createFile(operation) {
@@ -433,7 +471,7 @@ export class SelfhostedSession {
     const result = await this.call({
       $case: "fsRead",
       fsRead: {
-        path: toMachinePath(args.path),
+        path: toMachinePath(args.path, this.workingDir),
         offset: "0",
         length: args.maxBytes ? String(args.maxBytes) : "0",
       },
@@ -450,7 +488,7 @@ export class SelfhostedSession {
     const result = await this.call({
       $case: "fsWrite",
       fsWrite: {
-        path: toMachinePath(args.path),
+        path: toMachinePath(args.path, this.workingDir),
         content,
         createParents: args.createParents ?? true,
         append: args.append ?? false,
@@ -467,7 +505,7 @@ export class SelfhostedSession {
   async listFiles(args: { path: string; recursive?: boolean }): Promise<NonNullable<ControlResponse["result"]> & { $case: "fsList" }> {
     const result = await this.call({
       $case: "fsList",
-      fsList: { path: toMachinePath(args.path), recursive: args.recursive ?? false },
+      fsList: { path: toMachinePath(args.path, this.workingDir), recursive: args.recursive ?? false },
     });
     if (result.$case !== "fsList") {
       throw new Error(`selfhosted listFiles: unexpected result ${result.$case}`);
@@ -477,7 +515,7 @@ export class SelfhostedSession {
 
   /** Stat a path on the machine. */
   async statFile(args: { path: string }): Promise<{ exists: boolean }> {
-    const result = await this.call({ $case: "fsStat", fsStat: { path: toMachinePath(args.path) } });
+    const result = await this.call({ $case: "fsStat", fsStat: { path: toMachinePath(args.path, this.workingDir) } });
     if (result.$case !== "fsStat") {
       throw new Error(`selfhosted statFile: unexpected result ${result.$case}`);
     }
@@ -539,7 +577,10 @@ export class SelfhostedSession {
       // the relay channel. Display-INDEPENDENT — works on a headless machine.
       const result = await this.call({
         $case: "ptyOpen",
-        ptyOpen: { command: [], cwd: "", env: {}, cols: 0, rows: 0, term: "xterm-256color" },
+        // Open the terminal in the session workingDir (default "" ⇒ the agent's
+        // workspace_root, byte-identical to before). A relative workingDir resolves
+        // under workspace_root; an absolute one is used as-is by the agent.
+        ptyOpen: { command: [], cwd: this.workingDir, env: {}, cols: 0, rows: 0, term: "xterm-256color" },
       });
       if (result.$case !== "ptyOpen") {
         throw new Error(`selfhosted resolveExposedPort(${port}): unexpected result ${result.$case}`);
@@ -596,6 +637,7 @@ export class SelfhostedSandboxClient {
   private readonly epoch: number | undefined;
   private readonly timeoutMs: number | undefined;
   private readonly environment: Record<string, string> | undefined;
+  private readonly workingDir: string | undefined;
   private controlRpcMemo: ControlRpc | undefined;
 
   constructor(opts: {
@@ -613,6 +655,10 @@ export class SelfhostedSandboxClient {
      *  empty (validateNoEnvironmentDelta). See SelfhostedSessionDeps.environment.
      *  Omitted → `{}` (the negotiation-only path; no turn manifest is applied). */
     environment?: Record<string, string>;
+    /** The session working directory threaded into every bound session (the path/
+     *  cwd base; see SelfhostedSessionDeps.workingDir). Omitted/empty ⇒ the default
+     *  workspace_root behavior. */
+    workingDir?: string;
   }) {
     this.workspaceId = opts.workspaceId;
     this.relay = opts.relay;
@@ -621,6 +667,7 @@ export class SelfhostedSandboxClient {
     this.epoch = opts.epoch;
     this.timeoutMs = opts.timeoutMs;
     this.environment = opts.environment;
+    this.workingDir = opts.workingDir;
   }
 
   private controlRpc(): ControlRpc {
@@ -639,6 +686,7 @@ export class SelfhostedSandboxClient {
       ...(this.epoch !== undefined ? { epoch: this.epoch } : {}),
       ...(this.timeoutMs !== undefined ? { timeoutMs: this.timeoutMs } : {}),
       ...(this.environment !== undefined ? { environment: this.environment } : {}),
+      ...(this.workingDir !== undefined ? { workingDir: this.workingDir } : {}),
     });
   }
 

--- a/packages/runtime/test/selfhosted-session.test.ts
+++ b/packages/runtime/test/selfhosted-session.test.ts
@@ -267,6 +267,79 @@ describe("virtual-root → machine-frame path translation (the live-swap exec EN
   });
 });
 
+describe("per-session workingDir → the toMachinePath frame BASE (create-time machine targeting)", () => {
+  // `toMachinePath` is the SOLE adapter rule between the SDK's virtual "/workspace"
+  // frame and the machine's real filesystem; the per-session `workingDir` is its
+  // BASE. The function is NOT exported, so probe it through the SAME public seam the
+  // agent observes — the wire `cwd` on an exec op (exec calls
+  // toMachinePath(workdir, workingDir)) and the wire `path` on an fs op. An EMPTY
+  // workingDir is byte-identical to today; a non-empty one roots the virtual frame
+  // under it; a trailing slash is normalized so the join never doubles.
+
+  function wireExecCwd(workingDir: string, workdir: string | undefined): Promise<string> {
+    const mock = new MockAgentResponder({ hostname: "vm" });
+    const session = new SelfhostedSession({ workspaceId: WS, agentId: AGENT, controlRpc: mock, relay: RELAY, workingDir });
+    return session
+      .exec({ cmd: "hostname", ...(workdir !== undefined ? { workdir } : {}) })
+      .then(() => {
+        const op = mock.requests[0]?.req.op;
+        if (op?.$case !== "exec") throw new Error("expected an exec op on the wire");
+        return op.exec.cwd;
+      });
+  }
+
+  test("workingDir='' is byte-identical to today: '/workspace' → '', '/workspace/sub' → 'sub'", async () => {
+    expect(await wireExecCwd("", "/workspace")).toBe("");
+    expect(await wireExecCwd("", "/workspace/sub")).toBe("sub");
+  });
+
+  test("an ABSOLUTE workingDir roots the frame under it: '/workspace' → the base, '/workspace/sub' → base/sub", async () => {
+    expect(await wireExecCwd("/home/u/proj", "/workspace")).toBe("/home/u/proj");
+    expect(await wireExecCwd("/home/u/proj", "/workspace/sub")).toBe("/home/u/proj/sub");
+  });
+
+  test("a RELATIVE workingDir stays relative: 'proj' → 'proj', '/workspace/sub' → 'proj/sub'", async () => {
+    expect(await wireExecCwd("proj", "/workspace")).toBe("proj");
+    expect(await wireExecCwd("proj", "/workspace/sub")).toBe("proj/sub");
+  });
+
+  test("a trailing slash on workingDir is normalized (the join never doubles), absolute and relative", async () => {
+    expect(await wireExecCwd("/home/u/proj/", "/workspace")).toBe("/home/u/proj");
+    expect(await wireExecCwd("/home/u/proj/", "/workspace/sub")).toBe("/home/u/proj/sub");
+    expect(await wireExecCwd("proj/", "/workspace")).toBe("proj");
+    expect(await wireExecCwd("proj/", "/workspace/sub")).toBe("proj/sub");
+  });
+
+  test("the fs path boundary shares the SAME workingDir rewrite (fsWrite path on the wire)", async () => {
+    const mock = new MockAgentResponder();
+    const session = new SelfhostedSession({ workspaceId: WS, agentId: AGENT, controlRpc: mock, relay: RELAY, workingDir: "/home/u/proj" });
+    await session.writeFile({ path: "/workspace/sub/file.txt", content: "x" });
+    const op = mock.requests[0]?.req.op;
+    if (op?.$case !== "fsWrite") throw new Error("expected an fsWrite op on the wire");
+    expect(op.fsWrite.path).toBe("/home/u/proj/sub/file.txt");
+  });
+
+  test("SelfhostedSandboxClient threads workingDir into every bound session (the resolver→client→session chain)", async () => {
+    // makeActiveBackendResolver builds a SelfhostedSandboxClient with
+    // `workingDir: pointer.workingDir` then `client.resume(...)` (backend-resolver.ts).
+    // Mirror that exactly: a client constructed with a workingDir must bind sessions
+    // that root the virtual frame under it.
+    const rpc = new MockAgentResponder();
+    const client = new SelfhostedSandboxClient({
+      workspaceId: WS,
+      relay: RELAY,
+      controlRpcFactory: () => rpc,
+      agentId: AGENT,
+      workingDir: "/home/u/proj",
+    });
+    const resumed = await client.resume({ agentId: AGENT });
+    await resumed.writeFile({ path: "/workspace/notes.md", content: "hi" });
+    const op = rpc.requests.at(-1)?.req.op;
+    if (op?.$case !== "fsWrite") throw new Error("expected an fsWrite op on the wire");
+    expect(op.fsWrite.path).toBe("/home/u/proj/notes.md");
+  });
+});
+
 describe("AgentError → runtime reason mapping (the M3 ruling)", () => {
   const err = (code: ErrorCode, retryable = false): AgentError => ({ code, message: `e${code}`, retryable, detail: {} });
 


### PR DESCRIPTION
**Stage A** of the connected-machine refactor (the approved core-refactor plan): a session targeting a connected machine can now run at a chosen **free-form host path** instead of being frozen to the agent's launch dir. The system supplies a working directory; the agent handles repos/worktrees itself — keeping arbitrary repo combinations trivial.

### Purely control-plane — no agent release
The Rust agent's `resolve_cwd` already uses an absolute cwd verbatim and substitutes its launch `workspace_root` for an empty cwd. So an **unset `working_dir` is byte-identical to today**, and non-selfhosted runs are untouched.

- **runtime** — `toMachinePath(p, workingDir)` re-anchors the virtual `/workspace` frame onto `working_dir` (absolute → as-is; relative → under the launch dir; trailing slash normalized; empty → today). Threaded through exec / fs read·write·list·stat / terminal cwd. Editor delete keeps cwd-relative to avoid double-prefixing. Manifest root stays `/workspace` so the root-delta guard is unaffected.
- **persistence** — new nullable `sessions.working_dir` (migration 0027), carried on the active-sandbox pointer, written via the epoch-fenced `setActiveSandbox` CAS (untouched on a swap that omits it).
- **api** — `session_create` + `CreateSessionRequest` gain `workingDir`; 422 if set without a machine target.
- **web** — a minimal "Working directory" input, shown only when a machine is selected.

### Verify
Typecheck clean across contracts/db/runtime/api/worker/web; **89 runtime tests** pass incl. new `toMachinePath` + resolver→client→session threading tests; file dock stays internally consistent (rooted at `working_dir`), no `toVirtualPath` needed.

Deferred to later stages (per plan): live `sandbox_swap` working-dir re-pin, UI pre-fill, the full composer redesign (Stage C), no-token (Stage B), machine-as-primary-compute (Stage D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session routing and path translation on selfhosted backends at create time; omitted/null preserves prior behavior, but wrong paths could break exec/fs on targeted machines.
> 
> **Overview**
> **Stage A** lets a session aimed at an enrolled machine start in a chosen **working directory** (relative under launch `workspace_root` or absolute on the host), instead of always using the agent’s default launch dir.
> 
> **API & contracts:** `CreateSessionRequest`, MCP `session_create`, and create-time `seedTargetSandbox` gain optional `workingDir`, valid only with `targetSandboxId` (422 otherwise). On create, `workingDir` is written in the same epoch-fenced `setActiveSandbox` CAS as the machine pointer so the first turn routes to the box **and** cwd together; live `sandbox_swap` omits it so the column stays unchanged.
> 
> **Persistence:** Migration `0027` adds nullable `sessions.working_dir`; `readActiveSandbox` / `setActiveSandbox` carry it on the pointer (NULL = today’s behavior).
> 
> **Runtime:** Selfhosted `toMachinePath` uses `workingDir` as the virtual `/workspace` frame base for exec, fs, PTY cwd, and bare-relative paths; the resolver passes `pointer.workingDir` into `SelfhostedSession` / client.
> 
> **Web:** Advanced session setup shows a working-directory field when a machine is selected; `startSession` forwards it to create (SDK types cast until updated).
> 
> Tests cover CAS semantics for `working_dir` and wire-level `workingDir` threading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849cc49ed83aea68eff1bba0b51af93aa6645f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->