### PR TITLE
fix(codex): remap codex_apps tool names to the Responses-API charset

### DIFF
--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -1,21 +1,63 @@
-// OpenAI's `codex_apps` connector MCP returns many tools with an empty
-// `outputSchema: {}` (no `type`) — 122 of 217 in practice. The MCP client SDK
-// (@modelcontextprotocol/sdk) validates every tool's `outputSchema` as a strict
-// `{ type: "object", ... }` and throws a ZodError ("Invalid input: expected
-// \"object\"" at tools[N].outputSchema.type) on the WHOLE tools/list response.
-// Because we register codex_apps with cacheToolsList:false, that listing runs on
-// every turn, so the error fails the entire turn (it is thrown during tool
-// enumeration, outside the best-effort *connect* wrapper).
+// The codex_apps connector MCP is incompatible with the Responses API tool
+// contract in two ways that each fail the whole turn:
 //
-// We can't relax the SDK's schema, so we sanitize the tools/list response on the
-// wire — before the validator sees it — by dropping any `outputSchema` that is
-// not a valid object-typed schema. Dropping it is safe: outputSchema is an
-// advisory hint for structured tool results, never required for a tool to run.
+//  1. NAMES. Connector tools are named like "vercel.deploy_to_vercel" (dots).
+//     The Responses API requires every function-tool name to match
+//     ^[A-Za-z0-9_-]+$, so the request 400s ("Invalid 'tools[0].name': string
+//     does not match pattern"). We cannot just rename them in tools/list — the
+//     model would then call a name the MCP server does not know. So we remap
+//     BIDIRECTIONALLY at the transport: sanitize the name (and remember the
+//     mapping) on the tools/list RESPONSE, and reverse it back to the original on
+//     the tools/call REQUEST.
+//
+//  2. OUTPUT SCHEMAS. 122 of 217 tools return an empty `outputSchema: {}` (no
+//     `type`). @modelcontextprotocol/sdk validates every tool's outputSchema as a
+//     strict `{ type: "object", ... }` and ZodErrors the WHOLE tools/list. Since
+//     codex_apps runs with cacheToolsList:false it re-lists per turn, so that
+//     error (thrown during tool enumeration, outside the best-effort connect
+//     wrapper) fails the turn. We drop any non-object outputSchema before the
+//     validator sees it — safe, as outputSchema is an advisory hint only.
 
 import type { FetchLike } from "./fetch";
 
-/** Strip non-`{type:"object"}` outputSchemas from a JSON-RPC tools/list result, in place. */
-function sanitizeToolsInRpcMessage(message: unknown): void {
+const VALID_TOOL_NAME = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Maps connector tool names to a Responses-API-legal charset and back. One
+ * instance per codex_apps transport (i.e. per turn): tools/list populates it,
+ * tools/call reads it. Idempotent across repeat listings.
+ */
+export class ToolNameMapper {
+  private readonly sanitizedToOriginal = new Map<string, string>();
+  private readonly used = new Set<string>();
+
+  /** Return a legal, unique name for `original`, recording the reverse mapping. */
+  sanitize(original: string): string {
+    let candidate = VALID_TOOL_NAME.test(original)
+      ? original
+      : original.replace(/[^a-zA-Z0-9_-]/g, "_") || "tool";
+    // Disambiguate a genuine collision with a DIFFERENT original (never with
+    // the same original — that keeps repeat listings stable/idempotent).
+    if (this.used.has(candidate) && this.sanitizedToOriginal.get(candidate) !== original) {
+      const base = candidate;
+      let n = 2;
+      do {
+        candidate = `${base}_${n++}`;
+      } while (this.used.has(candidate));
+    }
+    this.used.add(candidate);
+    this.sanitizedToOriginal.set(candidate, original);
+    return candidate;
+  }
+
+  /** Reverse a sanitized name back to the MCP server's original, if known. */
+  toOriginal(sanitized: string): string | undefined {
+    return this.sanitizedToOriginal.get(sanitized);
+  }
+}
+
+/** Drop bad outputSchemas + sanitize tool names on a JSON-RPC tools/list result, in place. */
+function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper): void {
   if (!message || typeof message !== "object") {
     return;
   }
@@ -24,20 +66,27 @@ function sanitizeToolsInRpcMessage(message: unknown): void {
     return;
   }
   for (const tool of tools) {
-    if (tool && typeof tool === "object" && "outputSchema" in tool) {
-      const outputSchema = (tool as Record<string, unknown>).outputSchema as { type?: unknown } | null | undefined;
+    if (!tool || typeof tool !== "object") {
+      continue;
+    }
+    const record = tool as Record<string, unknown>;
+    if ("outputSchema" in record) {
+      const outputSchema = record.outputSchema as { type?: unknown } | null | undefined;
       if (!outputSchema || typeof outputSchema !== "object" || outputSchema.type !== "object") {
-        delete (tool as Record<string, unknown>).outputSchema;
+        delete record.outputSchema;
       }
+    }
+    if (typeof record.name === "string") {
+      record.name = mapper.sanitize(record.name);
     }
   }
 }
 
 /** Sanitize a single JSON body (application/json MCP response). */
-export function sanitizeMcpJsonBody(text: string): string {
+export function sanitizeMcpJsonBody(text: string, mapper: ToolNameMapper = new ToolNameMapper()): string {
   try {
     const parsed = JSON.parse(text);
-    sanitizeToolsInRpcMessage(parsed);
+    sanitizeToolsInRpcMessage(parsed, mapper);
     return JSON.stringify(parsed);
   } catch {
     return text; // not JSON we understand — leave untouched
@@ -45,7 +94,7 @@ export function sanitizeMcpJsonBody(text: string): string {
 }
 
 /** Sanitize an SSE body: each JSON-RPC message rides on a `data:` line. */
-export function sanitizeMcpSseBody(text: string): string {
+export function sanitizeMcpSseBody(text: string, mapper: ToolNameMapper = new ToolNameMapper()): string {
   return text
     .split("\n")
     .map((line) => {
@@ -55,7 +104,7 @@ export function sanitizeMcpSseBody(text: string): string {
       const payload = line.slice("data:".length).trimStart();
       try {
         const parsed = JSON.parse(payload);
-        sanitizeToolsInRpcMessage(parsed);
+        sanitizeToolsInRpcMessage(parsed, mapper);
         return `data: ${JSON.stringify(parsed)}`;
       } catch {
         return line;
@@ -64,15 +113,47 @@ export function sanitizeMcpSseBody(text: string): string {
     .join("\n");
 }
 
+/** Reverse a sanitized tools/call name back to the original; returns null if no rewrite is needed. */
+export function remapToolCallRequestBody(body: string, mapper: ToolNameMapper): string | null {
+  try {
+    const message = JSON.parse(body) as { method?: unknown; params?: { name?: unknown } };
+    if (message.method !== "tools/call") {
+      return null;
+    }
+    const name = message.params?.name;
+    if (typeof name !== "string") {
+      return null;
+    }
+    const original = mapper.toOriginal(name);
+    if (original === undefined || original === name) {
+      return null;
+    }
+    message.params!.name = original;
+    return JSON.stringify(message);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Wrap a base fetch so the codex_apps MCP transport's tools/list response is
- * sanitized before @modelcontextprotocol/sdk validates it. Only the POST
- * request/response is buffered+rewritten; the long-lived GET notification SSE
- * stream is passed through untouched (never buffered).
+ * Wrap a base fetch so the codex_apps MCP transport is Responses-API-compatible:
+ * tools/list responses get their names sanitized + bad outputSchemas dropped (and
+ * the name mapping recorded), and tools/call requests get their name reversed back
+ * to the MCP server's original. Only the POST request/response is buffered; the
+ * long-lived GET notification SSE stream is passed through untouched.
  */
 export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch): FetchLike {
+  const mapper = new ToolNameMapper();
   return async (input, init) => {
-    const res = await base(input, init);
+    // Outgoing: reverse a sanitized tools/call name to the server's original.
+    let nextInit = init;
+    if (init && typeof init.body === "string" && (init.method ?? "GET").toUpperCase() === "POST") {
+      const remapped = remapToolCallRequestBody(init.body, mapper);
+      if (remapped !== null) {
+        nextInit = { ...init, body: remapped };
+      }
+    }
+    const res = await base(input, nextInit);
     const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
     if (method !== "POST" || !res.ok || !res.body) {
       return res;
@@ -83,8 +164,8 @@ export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch): Fe
     if (!isJson && !isSse) {
       return res;
     }
-    const original = await res.text();
-    const sanitized = isJson ? sanitizeMcpJsonBody(original) : sanitizeMcpSseBody(original);
+    const originalBody = await res.text();
+    const sanitized = isJson ? sanitizeMcpJsonBody(originalBody, mapper) : sanitizeMcpSseBody(originalBody, mapper);
     const headers = new Headers(res.headers);
     headers.delete("content-length"); // body length changed
     headers.delete("content-encoding");

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -1,7 +1,66 @@
 import { describe, expect, test } from "bun:test";
-import { codexAppsSanitizingFetch, sanitizeMcpJsonBody, sanitizeMcpSseBody } from "../src/mcp-sanitize";
+import {
+  ToolNameMapper,
+  codexAppsSanitizingFetch,
+  remapToolCallRequestBody,
+  sanitizeMcpJsonBody,
+  sanitizeMcpSseBody,
+} from "../src/mcp-sanitize";
 
 const toolsListMsg = (tools: unknown[]) => ({ jsonrpc: "2.0", id: 2, result: { tools } });
+const toolCallMsg = (name: string) => JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name, arguments: {} } });
+
+describe("ToolNameMapper", () => {
+  test("sanitizes invalid chars (dots) and reverses them", () => {
+    const m = new ToolNameMapper();
+    expect(m.sanitize("vercel.deploy_to_vercel")).toBe("vercel_deploy_to_vercel");
+    expect(m.toOriginal("vercel_deploy_to_vercel")).toBe("vercel.deploy_to_vercel");
+  });
+
+  test("leaves already-valid names untouched (identity)", () => {
+    const m = new ToolNameMapper();
+    expect(m.sanitize("github_create_issue")).toBe("github_create_issue");
+    expect(m.toOriginal("github_create_issue")).toBe("github_create_issue");
+  });
+
+  test("is idempotent for the same original across repeat listings", () => {
+    const m = new ToolNameMapper();
+    const first = m.sanitize("a.b");
+    const second = m.sanitize("a.b");
+    expect(second).toBe(first);
+    expect(m.toOriginal(first)).toBe("a.b");
+  });
+
+  test("disambiguates a collision between two distinct originals", () => {
+    const m = new ToolNameMapper();
+    const a = m.sanitize("x.y"); // -> x_y
+    const b = m.sanitize("x_y"); // already valid, but x_y is taken -> x_y_2
+    expect(a).toBe("x_y");
+    expect(b).not.toBe(a);
+    expect(m.toOriginal(a)).toBe("x.y");
+    expect(m.toOriginal(b)).toBe("x_y");
+  });
+});
+
+describe("remapToolCallRequestBody", () => {
+  test("reverses a sanitized tools/call name to the original", () => {
+    const m = new ToolNameMapper();
+    m.sanitize("vercel.deploy_to_vercel"); // record the mapping (as tools/list would)
+    const rewritten = remapToolCallRequestBody(toolCallMsg("vercel_deploy_to_vercel"), m);
+    expect(JSON.parse(rewritten!).params.name).toBe("vercel.deploy_to_vercel");
+  });
+
+  test("returns null when the name needs no rewrite", () => {
+    const m = new ToolNameMapper();
+    m.sanitize("plain_name");
+    expect(remapToolCallRequestBody(toolCallMsg("plain_name"), m)).toBeNull();
+    expect(remapToolCallRequestBody(toolCallMsg("unknown"), m)).toBeNull();
+  });
+
+  test("ignores non-tools/call messages", () => {
+    expect(remapToolCallRequestBody(JSON.stringify({ method: "tools/list" }), new ToolNameMapper())).toBeNull();
+  });
+});
 
 describe("sanitizeMcpJsonBody", () => {
   test("drops empty + non-object outputSchemas, keeps valid object ones and all tools", () => {
@@ -49,6 +108,27 @@ describe("codexAppsSanitizingFetch", () => {
     const res = await codexAppsSanitizingFetch(base)("https://x/ps/mcp", { method: "POST" });
     const tool = (await res.json()).result.tools[0];
     expect("outputSchema" in tool).toBe(false);
+  });
+
+  test("round-trip: list sanitizes the dotted name, call reverses it (same fetch instance)", async () => {
+    const sent: string[] = [];
+    const base = async (_input: unknown, init?: RequestInit) => {
+      const body = init?.body as string | undefined;
+      if (body) sent.push(body);
+      const isList = body?.includes("tools/list") ?? true;
+      const payload = isList
+        ? toolsListMsg([{ name: "vercel.deploy_to_vercel", inputSchema: { type: "object" } }])
+        : { jsonrpc: "2.0", id: 3, result: { content: [] } };
+      return new Response(JSON.stringify(payload), { status: 200, headers: { "content-type": "application/json" } });
+    };
+    const fetchImpl = codexAppsSanitizingFetch(base as never);
+    // 1. tools/list -> model sees the sanitized name
+    const listRes = await fetchImpl("https://x/ps/mcp", { method: "POST", body: JSON.stringify({ method: "tools/list" }) });
+    expect((await listRes.json()).result.tools[0].name).toBe("vercel_deploy_to_vercel");
+    // 2. tools/call with the sanitized name -> the server receives the ORIGINAL
+    await fetchImpl("https://x/ps/mcp", { method: "POST", body: toolCallMsg("vercel_deploy_to_vercel") });
+    const forwardedCall = JSON.parse(sent[sent.length - 1]!);
+    expect(forwardedCall.params.name).toBe("vercel.deploy_to_vercel");
   });
 
   test("passes through a GET (long-lived notification SSE) untouched", async () => {


### PR DESCRIPTION
Follow-up to #139. After the `outputSchema` fix, a codex session with connectors still failed — `400 Invalid 'tools[N].name': does not match '^[a-zA-Z0-9_-]+$'`. The `codex_apps` connector tools are named with **dots** (e.g. `vercel.deploy_to_vercel`), which the Responses API forbids in function-tool names, so the whole request 400s. (The SDK reports it as "400 (no body)" under the SSE accept header; the body is actually `Invalid 'tools[0].name'`.)

Reproduced against the backend: 5 dotted tool names → 400; underscored → 200; all 217 dotted → 400; all 217 underscored → 200.

**Fix:** the codex_apps sanitizing fetch now remaps tool names **bidirectionally** — renaming only in `tools/list` would break execution (the model would call a name the MCP server doesn't recognize). A per-turn `ToolNameMapper` (collision-safe, idempotent) sanitizes names to `[A-Za-z0-9_-]` + records the mapping on the `tools/list` response, and reverses the name back to the original on the `tools/call` request. Malformed `outputSchema` dropping (from #139) is preserved.

**Verified live:** 217 tools → 0 invalid names, 0 bad outputSchemas; `google_drive.batch_update_document` → `google_drive_batch_update_document` → reverses back correctly. Unit tests (15) + full codex suite green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP wire rewriting for every codex_apps turn; wrong mapping would break tool execution, but scope is isolated to the sanitizing fetch with solid unit coverage.
> 
> **Overview**
> Extends the **codex_apps** MCP sanitizing fetch so connector sessions no longer 400 when dotted tool names (e.g. `vercel.deploy_to_vercel`) are registered with the Responses API, which only allows `^[A-Za-z0-9_-]+$`.
> 
> A per-transport **`ToolNameMapper`** rewrites tool names on **`tools/list`** responses (invalid characters → underscores, collision-safe suffixes, stable on repeat listings) and **`remapToolCallRequestBody`** restores the original name on outgoing **`tools/call`** POST bodies so the MCP server still receives names it recognizes. The existing **`outputSchema`** stripping on list responses is unchanged and shares the same mapper instance.
> 
> Tests cover mapper behavior, call remapping, and a full list→call round trip through **`codexAppsSanitizingFetch`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e3a6bee58b88e11b95cbb99bce8884092441d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->