### PR TITLE
feat(composer): compute-target-gated session setup (Stage C, PR-1)

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -21,8 +21,10 @@ import { sameSessionForContext } from "./lib/session-context";
 import { groupSessionsForRail, recencyGroupFor, relativeTimeLabel } from "./lib/sessions-group";
 import { organizationsForSubject, orgLabel, workspacesInOrg } from "./lib/org";
 import {
-  emptyAdvancedSessionDraft,
-  submissionExtrasFromAdvancedSessionDraft,
+  emptySessionDraft,
+  isSessionDraftComputeReady,
+  managedBackendOptions,
+  submissionFromSessionDraft,
 } from "./lib/session-create";
 import {
   buildTools,
@@ -252,15 +254,19 @@ describe("session MCP permission groups", () => {
   });
 });
 
-describe("advanced session create draft", () => {
-  test("an untouched draft adds nothing to the create payload", () => {
-    expect(submissionExtrasFromAdvancedSessionDraft(emptyAdvancedSessionDraft())).toEqual({});
+describe("session create draft", () => {
+  test("an untouched (managed sandbox) draft adds nothing to the create payload", () => {
+    expect(submissionFromSessionDraft(emptySessionDraft())).toEqual({
+      extras: {},
+      options: { targetSandboxId: null, workingDir: null },
+      omitWorkspaceResources: false,
+    });
   });
 
-  test("maps sandbox, environment, goal, and MCP scope into the payload", () => {
+  test("maps sandbox backend, environment, goal, and MCP scope into the payload", () => {
     const draft = {
-      ...emptyAdvancedSessionDraft(),
-      sandboxBackend: "docker" as const,
+      ...emptySessionDraft(),
+      compute: { kind: "sandbox" as const, backend: "docker" as const },
       environmentId: "env-1",
       goalText: "  Keep CI green  ",
       goalSuccessCriteria: "All checks pass for 7 days",
@@ -268,27 +274,84 @@ describe("advanced session create draft", () => {
       customMcpPermissions: true,
       mcpPermissions: new Set(["sessions:read", "goals:manage"]),
     };
-    expect(submissionExtrasFromAdvancedSessionDraft(draft)).toEqual({
-      sandboxBackend: "docker",
-      environmentId: "env-1",
-      goal: {
-        text: "Keep CI green",
-        successCriteria: "All checks pass for 7 days",
-        maxAutoContinuations: 12,
+    expect(submissionFromSessionDraft(draft)).toEqual({
+      extras: {
+        sandboxBackend: "docker",
+        environmentId: "env-1",
+        goal: {
+          text: "Keep CI green",
+          successCriteria: "All checks pass for 7 days",
+          maxAutoContinuations: 12,
+        },
+        firstPartyMcpPermissions: ["sessions:read", "goals:manage"],
       },
-      firstPartyMcpPermissions: ["sessions:read", "goals:manage"],
+      options: { targetSandboxId: null, workingDir: null },
+      omitWorkspaceResources: false,
     });
   });
 
   test("ignores goal sub-fields without goal text and bad numbers", () => {
     const draft = {
-      ...emptyAdvancedSessionDraft(),
+      ...emptySessionDraft(),
       goalSuccessCriteria: "criteria without a goal",
       goalMaxAutoContinuations: "-3",
     };
-    expect(submissionExtrasFromAdvancedSessionDraft(draft)).toEqual({});
+    expect(submissionFromSessionDraft(draft).extras).toEqual({});
     const withGoal = { ...draft, goalText: "goal", goalMaxAutoContinuations: "not-a-number" };
-    expect(submissionExtrasFromAdvancedSessionDraft(withGoal)).toEqual({ goal: { text: "goal", successCriteria: "criteria without a goal" } });
+    expect(submissionFromSessionDraft(withGoal).extras).toEqual({ goal: { text: "goal", successCriteria: "criteria without a goal" } });
+  });
+
+  test("a connected machine sends targetSandboxId + workingDir, omits repos and env injection", () => {
+    const draft = {
+      ...emptySessionDraft(),
+      // Even with an environment set, a machine never injects it (D2).
+      environmentId: "env-1",
+      compute: {
+        kind: "machine" as const,
+        sandboxId: "sbx-machine-1",
+        folder: { kind: "path" as const, path: "  ~/repos/opengeni  " },
+      },
+    };
+    expect(submissionFromSessionDraft(draft)).toEqual({
+      extras: {},
+      options: { targetSandboxId: "sbx-machine-1", workingDir: "~/repos/opengeni" },
+      omitWorkspaceResources: true,
+    });
+  });
+
+  test("a connected machine at its root sends no workingDir", () => {
+    const draft = {
+      ...emptySessionDraft(),
+      compute: { kind: "machine" as const, sandboxId: "sbx-machine-2", folder: { kind: "root" as const } },
+    };
+    const submission = submissionFromSessionDraft(draft);
+    expect(submission.options).toEqual({ targetSandboxId: "sbx-machine-2", workingDir: null });
+    expect(submission.omitWorkspaceResources).toBe(true);
+  });
+
+  test("submit-gating: a managed sandbox is always ready; a connected machine needs a picked machine", () => {
+    // §3 transition rule: sandbox→machine blocks submit until a machine is chosen
+    // ("choose a machine"); machine→sandbox is immediately ready again.
+    expect(isSessionDraftComputeReady(emptySessionDraft())).toBe(true);
+    expect(isSessionDraftComputeReady({
+      ...emptySessionDraft(),
+      compute: { kind: "machine", sandboxId: null, folder: { kind: "root" } },
+    })).toBe(false);
+    expect(isSessionDraftComputeReady({
+      ...emptySessionDraft(),
+      compute: { kind: "machine", sandboxId: "sbx-1", folder: { kind: "root" } },
+    })).toBe(true);
+  });
+
+  test("managed backend options exclude selfhosted and lead with the deployment default", () => {
+    // §3 backend row: options = managed descriptors (backend !== "selfhosted");
+    // the Connected Machine kind is the selfhosted target, never a backend choice.
+    const options = managedBackendOptions();
+    expect(options[0]).toEqual({ value: "", label: "Deployment default", chips: [] });
+    const values = options.map((option) => option.value);
+    expect(values).not.toContain("selfhosted");
+    expect(values).toContain("modal");
+    expect(new Set(values).size).toBe(values.length);
   });
 });
 

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -1,4 +1,4 @@
-import { SessionStatus as SessionStatusBadge, type SessionEventsConnectionState } from "@opengeni/react";
+import { SessionStatus as SessionStatusBadge, useMachines, type SessionEventsConnectionState } from "@opengeni/react";
 import { CopyIcon, FileJsonIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -23,6 +23,13 @@ export function SessionInspector(props: {
   connectionState: SessionEventsConnectionState;
 }) {
   const terminalSession = isTerminalSessionStatus(props.session.status);
+  // The session's ACTIVE compute, not its home backend: when a connected machine
+  // is active (live-swapped or targeted at create) show the machine name, so the
+  // inspector agrees with the "Run on" header instead of reading "modal" while a
+  // selfhosted box runs the turn. Degrades to the home backend when no machine is
+  // active (or selfhosted is disabled → the fleet 404s to empty).
+  const fleet = useMachines({ sessionId: props.session.id, pollIntervalMs: 10000 });
+  const activeMachine = fleet.machines.find((machine) => machine.active && machine.kind === "selfhosted") ?? null;
   const displayEvents = props.events.map((event) => sanitizeEventForDisplay(event, props.session.status));
   const sortedEvents = [...displayEvents].sort((a, b) => b.sequence - a.sequence);
   const lifecycleEvents = [...displayEvents]
@@ -69,7 +76,10 @@ export function SessionInspector(props: {
               <InspectorSection title="Runtime">
                 <InfoRow label="Model" value={props.session.model} />
                 <InfoRow label="Effort" value={String(props.session.metadata.reasoningEffort ?? "low")} />
-                <InfoRow label="Sandbox" value={props.session.sandboxBackend} />
+                <InfoRow
+                  label={activeMachine ? "Machine" : "Sandbox"}
+                  value={activeMachine ? activeMachine.name : props.session.sandboxBackend}
+                />
                 <InfoRow label="Environment" value={props.session.environmentId ? <CopyableMono value={props.session.environmentId} /> : "none"} />
                 <InfoRow label="Stream" value={<ConnectionPill state={props.connectionState} />} />
               </InspectorSection>

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -129,7 +129,7 @@ export type AppContextValue = {
   startSession: (
     workspaceId: string,
     submission: TurnSubmission,
-    options?: { targetSandboxId?: string | null; workingDir?: string | null },
+    options?: { targetSandboxId?: string | null; workingDir?: string | null; omitWorkspaceResources?: boolean },
   ) => Promise<Session | null>;
   resetSessionView: () => void;
   resetWorkspaceIntegrations: () => void;
@@ -443,7 +443,7 @@ export function RootRouteComponent() {
   async function startSession(
     workspaceId: string,
     submission: TurnSubmission,
-    options?: { targetSandboxId?: string | null; workingDir?: string | null },
+    options?: { targetSandboxId?: string | null; workingDir?: string | null; omitWorkspaceResources?: boolean },
   ): Promise<Session | null> {
     setBusy(true);
     // Reuse the in-flight key if one survives a prior failed/double-fired
@@ -454,7 +454,10 @@ export function RootRouteComponent() {
       const selectedTools = buildTools(submission.tools, [...selectedCapabilityToolIds]);
       const created = await client.createSession(workspaceId, {
         initialMessage: submission.text,
-        resources: [...currentResources, ...(submission.resources ?? [])],
+        // Workspace repo selection is excluded when the create targets a
+        // connected machine (D3: the machine uses its own checkout & git auth);
+        // uploaded file attachments (submission.resources) still flow through.
+        resources: [...(options?.omitWorkspaceResources ? [] : currentResources), ...(submission.resources ?? [])],
         tools: selectedTools,
         model: submission.model ?? model,
         reasoningEffort: submission.reasoningEffort ?? reasoningEffort,

--- a/apps/web/src/lib/session-create.ts
+++ b/apps/web/src/lib/session-create.ts
@@ -1,22 +1,52 @@
-// Pure state + payload mapping for the rich create-session form (sandbox
-// backend, environment attach, goal, first-party MCP permission scope).
+// State + payload mapping for the rich create-session form.
+//
+// The composer is organised around ONE top-level question — "Where should this
+// run?" — modelled here as a discriminated `ComputeTarget`. That choice is the
+// parent that gates the rest of the form (repos/env on a managed sandbox; a
+// machine + working folder on a connected machine). `SessionDraft` collapses the
+// old split between the per-mount "advanced" draft and the global selection so
+// the compute target and everything it gates live in one consistent state.
+//
+// Wire fields are unchanged (PR-1, no contract change): a managed sandbox still
+// sends `sandboxBackend`/`environmentId`; a connected machine still sends the
+// top-level `targetSandboxId` (+ Stage A's `workingDir`). Only the form shape and
+// the gating change.
+import { CAPABILITY_DESCRIPTORS, type CapabilityDescriptor, type MachineView } from "@opengeni/contracts";
+
 import { sessionMcpPermissionGroups } from "@/lib/permissions";
 import type { GoalSpec, SandboxBackend, TurnSubmission } from "@/types";
 
-export type AdvancedSessionDraft = {
-  // The enrolled selfhosted machine (a sandbox id) to seed the session's active
-  // sandbox at create — `null` runs on the default cloud sandbox. This is NOT a
-  // TurnSubmission extra: it's a top-level CreateSessionRequest field, threaded
-  // separately into `startSession` (see `targetSandboxIdFromAdvancedSessionDraft`).
-  targetSandboxId: string | null;
-  // The targeted machine's working directory — the path/cwd base its agent exec,
-  // terminal, and file dock run under. Free-form pass-through: a launch-
-  // workspace_root-relative subdir or an absolute machine path. Empty (the
-  // default) ⇒ the machine's default workspace_root (byte-identical to today).
-  // Only meaningful WITH `targetSandboxId`; like it, a top-level
-  // CreateSessionRequest field threaded into `startSession` separately.
-  workingDir: string;
-  sandboxBackend: SandboxBackend | "";
+// ── Compute target — the promoted top-level "Where should this run?" choice ──
+
+/** A platform-owned ephemeral sandbox. `backend === ""` is the deployment
+ *  default; a specific managed backend is an Advanced override. */
+export type ManagedSandboxTarget = {
+  kind: "sandbox";
+  backend: SandboxBackend | "";
+};
+
+/** The working folder on a connected machine. PR-1 ships `root` (the agent's
+ *  launch dir → no `workingDir` sent) and `path` (a free-form host path → sent as
+ *  Stage A's `workingDir`). A named Project (D4) is a future third variant. */
+export type MachineFolder =
+  | { kind: "root" }
+  | { kind: "path"; path: string };
+
+/** A user-owned enrolled machine the platform attaches to (no clone, no teardown,
+ *  the machine's own env & git auth). `sandboxId` is `null` until one is picked. */
+export type ConnectedMachineTarget = {
+  kind: "machine";
+  sandboxId: string | null;
+  folder: MachineFolder;
+};
+
+export type ComputeTarget = ManagedSandboxTarget | ConnectedMachineTarget;
+
+export type SessionDraft = {
+  // PROMOTED — the parent that gates the compute-dependent band.
+  compute: ComputeTarget;
+  // Injected at start on a managed sandbox; ignored when compute.kind==="machine"
+  // (a connected machine uses its own environment & git credentials — D2).
   environmentId: string;
   goalText: string;
   goalSuccessCriteria: string;
@@ -25,11 +55,9 @@ export type AdvancedSessionDraft = {
   mcpPermissions: Set<string>;
 };
 
-export function emptyAdvancedSessionDraft(): AdvancedSessionDraft {
+export function emptySessionDraft(): SessionDraft {
   return {
-    targetSandboxId: null,
-    workingDir: "",
-    sandboxBackend: "",
+    compute: { kind: "sandbox", backend: "" },
     environmentId: "",
     goalText: "",
     goalSuccessCriteria: "",
@@ -39,40 +67,175 @@ export function emptyAdvancedSessionDraft(): AdvancedSessionDraft {
   };
 }
 
-/** The picked machine's sandbox id (the top-level create field), or null for the
- *  default cloud sandbox. Threaded into `startSession` separately from the
- *  TurnSubmission extras. */
-export function targetSandboxIdFromAdvancedSessionDraft(draft: AdvancedSessionDraft): string | null {
-  return draft.targetSandboxId;
+/** True once the draft can be submitted: a connected machine needs a picked
+ *  machine; a managed sandbox is always ready. */
+export function isSessionDraftComputeReady(draft: SessionDraft): boolean {
+  return draft.compute.kind !== "machine" || draft.compute.sandboxId !== null;
 }
 
-/** The picked machine's working directory (the top-level create field), or null
- *  for the machine's default workspace_root. Like the target sandbox id, threaded
- *  into `startSession` separately from the TurnSubmission extras. A blank/whitespace
- *  value normalizes to null (omitted ⇒ no-op default). */
-export function workingDirFromAdvancedSessionDraft(draft: AdvancedSessionDraft): string | null {
-  return draft.workingDir.trim() || null;
-}
+export type SessionDraftSubmission = {
+  /** TurnSubmission extras merged into the create payload. */
+  extras: Omit<TurnSubmission, "text">;
+  /** Top-level create fields threaded into `startSession` separately. */
+  options: { targetSandboxId: string | null; workingDir: string | null };
+  /** When true (a connected machine) the workspace's selected repos must NOT be
+   *  cloned: the machine uses its own checkout & git auth (D3). This is the UI
+   *  half of the clone-gating footgun fix — the selection is retained in context
+   *  (lossless toggle-back) but excluded from the create's `resources[]`. */
+  omitWorkspaceResources: boolean;
+};
 
-/** The create-session payload extras from the advanced options card. */
-export function submissionExtrasFromAdvancedSessionDraft(draft: AdvancedSessionDraft): Omit<TurnSubmission, "text"> {
-  const maxAutoContinuations = nonNegativeInteger(draft.goalMaxAutoContinuations);
-  const goal: GoalSpec | null = draft.goalText.trim()
-    ? {
-        text: draft.goalText.trim(),
-        ...(draft.goalSuccessCriteria.trim() ? { successCriteria: draft.goalSuccessCriteria.trim() } : {}),
-        ...(maxAutoContinuations !== null ? { maxAutoContinuations } : {}),
-      }
-    : null;
+/** The single submit mapper: turns a `SessionDraft` into the create payload,
+ *  branching on the compute kind (the one discriminant). */
+export function submissionFromSessionDraft(draft: SessionDraft): SessionDraftSubmission {
+  const goal = goalFromDraft(draft);
+  const mcp = draft.customMcpPermissions ? { firstPartyMcpPermissions: [...draft.mcpPermissions] } : {};
+
+  if (draft.compute.kind === "machine") {
+    return {
+      // No sandboxBackend (forced `selfhosted` server-side) and no environment
+      // injection — the machine's own env & git auth apply (D2).
+      extras: {
+        ...(goal ? { goal } : {}),
+        ...mcp,
+      },
+      options: {
+        targetSandboxId: draft.compute.sandboxId,
+        workingDir: workingDirFromFolder(draft.compute.folder),
+      },
+      omitWorkspaceResources: true,
+    };
+  }
+
   return {
-    ...(draft.sandboxBackend ? { sandboxBackend: draft.sandboxBackend } : {}),
-    ...(draft.environmentId ? { environmentId: draft.environmentId } : {}),
-    ...(goal ? { goal } : {}),
-    ...(draft.customMcpPermissions ? { firstPartyMcpPermissions: [...draft.mcpPermissions] } : {}),
+    extras: {
+      ...(draft.compute.backend ? { sandboxBackend: draft.compute.backend } : {}),
+      ...(draft.environmentId ? { environmentId: draft.environmentId } : {}),
+      ...(goal ? { goal } : {}),
+      ...mcp,
+    },
+    options: { targetSandboxId: null, workingDir: null },
+    omitWorkspaceResources: false,
+  };
+}
+
+/** The machine's per-session working directory, or `null` for its default
+ *  workspace_root (the agent's launch dir). A blank custom path normalizes to
+ *  `null` (omitted ⇒ byte-identical to today). */
+function workingDirFromFolder(folder: MachineFolder): string | null {
+  return folder.kind === "path" ? folder.path.trim() || null : null;
+}
+
+function goalFromDraft(draft: SessionDraft): GoalSpec | null {
+  if (!draft.goalText.trim()) {
+    return null;
+  }
+  const maxAutoContinuations = nonNegativeInteger(draft.goalMaxAutoContinuations);
+  return {
+    text: draft.goalText.trim(),
+    ...(draft.goalSuccessCriteria.trim() ? { successCriteria: draft.goalSuccessCriteria.trim() } : {}),
+    ...(maxAutoContinuations !== null ? { maxAutoContinuations } : {}),
   };
 }
 
 function nonNegativeInteger(value: string): number | null {
   const parsed = Number(value);
   return value.trim() && Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+// ── Managed sandbox backend options (descriptor-driven) ──────────────────────
+//
+// Replaces the hand-maintained literal: every managed backend is sourced from
+// `CAPABILITY_DESCRIPTORS` (the `selfhosted` row is the Connected Machine kind, so
+// it is excluded), and each option surfaces the capability metadata the table
+// already carries (Desktop/Recording/lifetime).
+
+export type ManagedBackendOption = {
+  value: SandboxBackend | "";
+  label: string;
+  /** Capability summary chips, e.g. ["Desktop", "Recording", "24h"]. */
+  chips: string[];
+};
+
+const MANAGED_BACKEND_LABELS: Partial<Record<SandboxBackend, string>> = {
+  docker: "Docker",
+  modal: "Modal",
+  local: "Local",
+  none: "None (no sandbox)",
+  daytona: "Daytona",
+  runloop: "Runloop",
+  e2b: "E2B",
+  blaxel: "Blaxel",
+  cloudflare: "Cloudflare",
+  vercel: "Vercel",
+};
+
+function backendLabel(backend: SandboxBackend): string {
+  return MANAGED_BACKEND_LABELS[backend] ?? backend.slice(0, 1).toUpperCase() + backend.slice(1);
+}
+
+function descriptorChips(descriptor: CapabilityDescriptor): string[] {
+  const chips: string[] = [];
+  if (descriptor.capabilities.DesktopStream.available) {
+    chips.push("Desktop");
+  }
+  if (descriptor.capabilities.Recording.available) {
+    chips.push("Recording");
+  }
+  const hardLifetimeMs = descriptor.lifetime.hardLifetimeMs;
+  if (hardLifetimeMs) {
+    chips.push(formatLifetime(hardLifetimeMs));
+  }
+  // Fall back to the tier so a headless/dev/none backend still reads as something.
+  if (chips.length === 0 && descriptor.tier !== "none") {
+    chips.push(descriptor.tier.slice(0, 1).toUpperCase() + descriptor.tier.slice(1));
+  }
+  return chips;
+}
+
+function formatLifetime(ms: number): string {
+  const hours = ms / (60 * 60 * 1000);
+  return Number.isInteger(hours) ? `${hours}h` : `${Math.round(hours)}h`;
+}
+
+/** The managed backend options for the Advanced override, descriptor-driven and
+ *  led by the deployment default. Excludes `selfhosted` (the Connected Machine
+ *  kind). */
+export function managedBackendOptions(): ManagedBackendOption[] {
+  const managed = (Object.entries(CAPABILITY_DESCRIPTORS) as Array<[SandboxBackend, CapabilityDescriptor]>)
+    .filter(([backend]) => backend !== "selfhosted")
+    .map(([backend, descriptor]) => ({
+      value: backend,
+      label: backendLabel(backend),
+      chips: descriptorChips(descriptor),
+    }));
+  return [{ value: "", label: "Deployment default", chips: [] }, ...managed];
+}
+
+/** The capability chips for a connected (selfhosted) machine, reflecting the
+ *  SELECTED machine's real capabilities — not the static descriptor.
+ *  FileSystem/Terminal/Git are always available, so they show even before a
+ *  machine is picked. The static descriptor *proclaims* DesktopStream, but that
+ *  is consent-gated at enrollment and absent on a headless machine — so the
+ *  "Desktop" chip is shown only when the picked machine actually has a display
+ *  (`hasDisplay`). A headless machine therefore never shows "Desktop"; the caller
+ *  surfaces a distinct "no display" indicator instead. */
+export function selfhostedCapabilityChips(machine?: MachineView | null): string[] {
+  const descriptor = CAPABILITY_DESCRIPTORS.selfhosted;
+  const chips: string[] = [];
+  if (descriptor.capabilities.FileSystem.available) {
+    chips.push("FileSystem");
+  }
+  if (descriptor.capabilities.Terminal.available) {
+    chips.push("Terminal");
+  }
+  if (descriptor.capabilities.Git.available) {
+    chips.push("Git");
+  }
+  // Per-machine truth, not the proclaimed static descriptor: only a machine that
+  // actually reports a display can offer the desktop stream.
+  if (machine?.hasDisplay) {
+    chips.push("Desktop");
+  }
+  return chips;
 }

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -1,11 +1,24 @@
-// The sessions index: the centered "Start a session" composer with the full
-// create surface (model, effort, sandbox backend, environment, repositories,
-// tools, goal, first-party MCP permissions). The session list itself now lives
-// in the left rail, not on this page.
-import { useEnvironments, useMachines, type ComposerState } from "@opengeni/react";
+// The sessions index: the centered "Start a session" composer. The form is
+// organised top-down — (A) message → (B) WHERE SHOULD THIS RUN? (the promoted
+// top-level compute target) → (C) the compute-dependent band it gates → (D) the
+// compute-independent optional band (goal, OpenGeni tool permissions).
+//
+// "Where should this run?" is a first-class segmented control with two kinds:
+// Managed Sandbox (ephemeral, platform-owned — clones repos, injects env) vs
+// Connected Machine (a user-owned enrolled machine — its own checkout & git
+// auth, a working folder, no clone, no env injection). The kind gates the band
+// below it; invalid states ("clone my repo onto a machine") are unreachable by
+// construction.
+//
+// The Connected Machine path is OPT-IN: with an empty self-hosted fleet and no
+// explicit opt-in, the segmented control is not rendered at all and the composer
+// collapses to the clean sandbox-only flow (just the managed sandbox fields). The
+// control appears once machines exist, or once the user reveals it via a
+// lightweight local opt-in.
+import { useEnvironments, useMachines, type ComposerState, type MachineView } from "@opengeni/react";
 import { useNavigate } from "@tanstack/react-router";
-import { BoxIcon, ChevronDownIcon, FlagIcon, FolderIcon, ServerIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { ArrowRightIcon, BoxIcon, CheckIcon, ChevronDownIcon, FlagIcon, FolderIcon, GitBranchIcon, MonitorOffIcon, ServerIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { PermissionGroupPicker } from "@/components/permission-picker";
@@ -22,11 +35,14 @@ import { useCodexModels } from "@/lib/use-codex-models";
 import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 import { sessionMcpPermissionGroups } from "@/lib/permissions";
 import {
-  emptyAdvancedSessionDraft,
-  submissionExtrasFromAdvancedSessionDraft,
-  targetSandboxIdFromAdvancedSessionDraft,
-  workingDirFromAdvancedSessionDraft,
-  type AdvancedSessionDraft,
+  emptySessionDraft,
+  isSessionDraftComputeReady,
+  managedBackendOptions,
+  selfhostedCapabilityChips,
+  submissionFromSessionDraft,
+  type ConnectedMachineTarget,
+  type ManagedSandboxTarget,
+  type SessionDraft,
 } from "@/lib/session-create";
 import { cn } from "@/lib/utils";
 import type { SandboxBackend } from "@/types";
@@ -37,34 +53,30 @@ const examples = [
   "Create a focused GitHub PR for the failing policy check.",
 ] as const;
 
-const sandboxBackendOptions: Array<{ value: SandboxBackend | ""; label: string }> = [
-  { value: "", label: "Deployment default" },
-  { value: "docker", label: "Docker" },
-  { value: "modal", label: "Modal" },
-  { value: "local", label: "Local" },
-  { value: "none", label: "None (no sandbox)" },
-];
+const BACKEND_OPTIONS = managedBackendOptions();
 
 export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
   const navigate = useNavigate();
   const attachments = useDraftAttachments(workspaceId);
-  const [draft, setDraft] = useState("");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [advanced, setAdvanced] = useState<AdvancedSessionDraft>(() => emptyAdvancedSessionDraft());
+  const [message, setMessage] = useState("");
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [draft, setDraft] = useState<SessionDraft>(() => emptySessionDraft());
 
   useEffect(() => {
     context.resetSessionView();
   }, [workspaceId]);
 
+  const computeReady = isSessionDraftComputeReady(draft);
+
   // The session does not exist yet, so this surface cannot use `useComposer`
   // (that hook sends to a session). It still renders the package ChatComposer
   // by implementing the same `ComposerState` contract over session creation.
   const createComposer: ComposerState = {
-    value: draft,
-    setValue: setDraft,
+    value: message,
+    setValue: setMessage,
     sending: context.busy,
-    canSend: draft.trim().length > 0 && !context.busy && !attachments.uploading,
+    canSend: message.trim().length > 0 && !context.busy && !attachments.uploading && computeReady,
     // Queue-vs-steer is meaningless before the session exists.
     mode: "queue",
     setMode: () => {},
@@ -73,26 +85,28 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
     error: null,
     clearError: () => {},
     send: async () => {
-      const text = draft.trim();
-      if (!text || context.busy || attachments.uploading) {
+      const text = message.trim();
+      if (!text || context.busy || attachments.uploading || !computeReady) {
         return false;
       }
+      const submission = submissionFromSessionDraft(draft);
       const created = await context.startSession(
         workspaceId,
         {
           text,
           resources: attachments.readyResources,
-          ...submissionExtrasFromAdvancedSessionDraft(advanced),
+          ...submission.extras,
         },
         {
-          targetSandboxId: targetSandboxIdFromAdvancedSessionDraft(advanced),
-          workingDir: workingDirFromAdvancedSessionDraft(advanced),
+          targetSandboxId: submission.options.targetSandboxId,
+          workingDir: submission.options.workingDir,
+          omitWorkspaceResources: submission.omitWorkspaceResources,
         },
       );
       if (!created) {
         return false;
       }
-      setDraft("");
+      setMessage("");
       attachments.clear();
       await navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: created.id } });
       return true;
@@ -106,7 +120,7 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
           What should the agent do?
         </h1>
         <p className="max-w-md text-sm text-[color:var(--color-fg-muted)]">
-          Start a durable sandbox session with live streams, a visible turn queue, goals, approvals, and steering.
+          It runs in a live sandbox you can watch and steer.
         </p>
       </section>
 
@@ -120,38 +134,50 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
           controls={<SessionControlStrip workspaceId={workspaceId} />}
         />
 
-        <AdvancedSessionOptions
-          open={advancedOpen}
-          onOpenChange={setAdvancedOpen}
-          draft={advanced}
-          onChange={setAdvanced}
+        {message.trim().length === 0 ? (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {examples.map((example) => (
+              <button
+                key={example}
+                type="button"
+                onClick={() => setMessage(example)}
+                disabled={context.busy}
+                className={cn(
+                  "max-w-full truncate rounded-full border px-3 py-1 text-left text-xs",
+                  "border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50",
+                  "text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]",
+                  "hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]",
+                  "transition-colors active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
+                )}
+              >
+                {example}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <ComputeTargetControl
+          workspaceId={workspaceId}
+          draft={draft}
+          onChange={setDraft}
           disabled={context.busy}
         />
 
-        <div className="mt-3 flex flex-wrap gap-1.5">
-          {examples.map((example) => (
-            <button
-              key={example}
-              type="button"
-              onClick={() => setDraft(example)}
-              disabled={context.busy}
-              className={cn(
-                "max-w-full truncate rounded-full border px-3 py-1 text-left text-xs",
-                "border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60",
-                "text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]",
-                "hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]",
-                "transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-              )}
-            >
-              {example}
-            </button>
-          ))}
-        </div>
+        <OptionalSessionOptions
+          open={optionsOpen}
+          onOpenChange={setOptionsOpen}
+          draft={draft}
+          onChange={setDraft}
+          disabled={context.busy}
+        />
       </div>
     </div>
   );
 }
 
+// The composer's inline strip: compute-INDEPENDENT controls only (model + tools).
+// Repository context now lives in the compute-dependent band below (it only makes
+// sense once a managed sandbox is the target), not as an always-visible pill.
 function SessionControlStrip({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
   const codexModels = useCodexModels(workspaceId);
@@ -166,32 +192,6 @@ function SessionControlStrip({ workspaceId }: { workspaceId: string }) {
         onModelChange={context.setModel}
         onEffortChange={context.setReasoningEffort}
       />
-      <RepositoryContextPicker
-        configured={context.githubStatus?.configured === true}
-        installUrl={context.githubStatus?.installUrl ?? null}
-        repositories={context.githubRepos}
-        groups={context.repositoryGroups}
-        selectedRepoIds={context.selectedRepoIds}
-        selectedRepoRefs={context.selectedRepoRefs}
-        selectedInstallationId={context.selectedInstallationId}
-        manualRepos={context.manualRepos}
-        manualOpen={context.manualReposOpen}
-        githubAppOpen={context.githubAppOpen}
-        org={context.githubOrg}
-        pending={context.busy}
-        repoBusy={context.repoBusy}
-        githubAppBusy={context.githubAppBusy}
-        onRefresh={() => context.refreshGitHub(workspaceId, undefined, { sync: true })}
-        onToggleRepo={context.toggleGitHubRepository}
-        onRefChange={(repoId, ref) => context.setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref }))}
-        onManualOpenChange={context.setManualReposOpen}
-        onManualAdd={context.addManualRepository}
-        onManualUpdate={(id, patch) => context.setManualRepos((current) => current.map((repo) => repo.id === id ? { ...repo, ...patch } : repo))}
-        onManualRemove={(id) => context.setManualRepos((current) => current.filter((repo) => repo.id !== id))}
-        onGitHubAppOpenChange={context.setGithubAppOpen}
-        onOrgChange={context.setGithubOrg}
-        onStartGitHubApp={() => void context.startGitHubAppManifestFlow(workspaceId)}
-      />
       <EnabledMcpToolPicker
         servers={context.toolMcpServers}
         selectedIds={context.selectedCapabilityToolIds}
@@ -202,158 +202,585 @@ function SessionControlStrip({ workspaceId }: { workspaceId: string }) {
   );
 }
 
-function AdvancedSessionOptions(props: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  draft: AdvancedSessionDraft;
-  onChange: (draft: AdvancedSessionDraft) => void;
+// The workspace repository picker, wired to the cross-route selection in context.
+// Reused in both compute kinds: the primary clone source on a managed sandbox,
+// and grayed/disabled on a connected machine (which uses its own checkout).
+function WorkspaceRepositoryPicker({ workspaceId, disabled }: { workspaceId: string; disabled: boolean }) {
+  const context = useAppContext();
+  return (
+    <RepositoryContextPicker
+      configured={context.githubStatus?.configured === true}
+      installUrl={context.githubStatus?.installUrl ?? null}
+      repositories={context.githubRepos}
+      groups={context.repositoryGroups}
+      selectedRepoIds={context.selectedRepoIds}
+      selectedRepoRefs={context.selectedRepoRefs}
+      selectedInstallationId={context.selectedInstallationId}
+      manualRepos={context.manualRepos}
+      manualOpen={context.manualReposOpen}
+      githubAppOpen={context.githubAppOpen}
+      org={context.githubOrg}
+      pending={context.busy || disabled}
+      repoBusy={context.repoBusy}
+      githubAppBusy={context.githubAppBusy}
+      onRefresh={() => context.refreshGitHub(workspaceId, undefined, { sync: true })}
+      onToggleRepo={context.toggleGitHubRepository}
+      onRefChange={(repoId, ref) => context.setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref }))}
+      onManualOpenChange={context.setManualReposOpen}
+      onManualAdd={context.addManualRepository}
+      onManualUpdate={(id, patch) => context.setManualRepos((current) => current.map((repo) => repo.id === id ? { ...repo, ...patch } : repo))}
+      onManualRemove={(id) => context.setManualRepos((current) => current.filter((repo) => repo.id !== id))}
+      onGitHubAppOpenChange={context.setGithubAppOpen}
+      onOrgChange={context.setGithubOrg}
+      onStartGitHubApp={() => void context.startGitHubAppManifestFlow(workspaceId)}
+    />
+  );
+}
+
+// Local opt-in flag for the Connected Machine path. The DEFAULT (no machines, no
+// opt-in) is the clean sandbox-only composer; this lets a user reveal the machine
+// option before/while enrolling their first machine. Mirrors the rail's
+// localStorage pattern (safe under SSR / private mode).
+// TODO(settings): promote this localStorage flag into a real persisted setting on
+// the Settings surface (workspace- or account-scoped) and surface the toggle there.
+const CONNECTED_MACHINES_OPTIN_KEY = "opengeni.composer.connectedMachines";
+
+function readConnectedMachinesOptIn(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(CONNECTED_MACHINES_OPTIN_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function persistConnectedMachinesOptIn(value: boolean): void {
+  try {
+    window.localStorage.setItem(CONNECTED_MACHINES_OPTIN_KEY, String(value));
+  } catch {
+    // localStorage may be unavailable (private mode); keep the in-memory value.
+  }
+}
+
+// ── The promoted top-level compute target (the parent that gates the band) ────
+
+function ComputeTargetControl(props: {
+  workspaceId: string;
+  draft: SessionDraft;
+  onChange: (draft: SessionDraft) => void;
   disabled: boolean;
 }) {
-  const environments = useEnvironments();
+  const { draft, onChange } = props;
   // The workspace fleet (no sessionId → no swap; just the picker source). Degrades
-  // gracefully: if selfhosted is disabled the API 404s → `machines` is empty and
-  // we render only "Cloud sandbox", never blocking session creation.
+  // gracefully: when selfhosted is disabled the API 404s → `machines` is empty and
+  // the Connected Machine kind is offered only as a disabled "enroll a machine"
+  // affordance, never blocking session creation.
   const fleet = useMachines({ pollIntervalMs: 10000 });
-  const selfhostedMachines = fleet.machines.filter((machine) => machine.kind === "selfhosted");
-  const { draft } = props;
-  const update = (patch: Partial<AdvancedSessionDraft>) => props.onChange({ ...draft, ...patch });
-  const pickedMachine = draft.targetSandboxId
-    ? selfhostedMachines.find((machine) => machine.sandboxId === draft.targetSandboxId)
+  const machines = fleet.machines.filter((machine) => machine.kind === "selfhosted");
+  const fleetEmpty = machines.length === 0;
+  // Preserve the last managed backend override across kind toggles (lossless) so
+  // toggling machine→sandbox returns to the prior choice, not a forced reset.
+  const lastBackend = useRef<SandboxBackend | "">(draft.compute.kind === "sandbox" ? draft.compute.backend : "");
+  if (draft.compute.kind === "sandbox") {
+    lastBackend.current = draft.compute.backend;
+  }
+
+  // The Connected Machine path is OPT-IN. With an EMPTY self-hosted fleet and no
+  // explicit opt-in, the segmented control is not rendered at all — the composer
+  // shows the clean sandbox-only flow (byte-identical submission to before this
+  // redesign). Once machines exist, the control is always shown. A lightweight
+  // local opt-in lets a user reveal the option before/while enrolling.
+  const [optedIn, setOptedIn] = useState<boolean>(() => readConnectedMachinesOptIn());
+  const revealConnectedMachines = () => {
+    setOptedIn(true);
+    persistConnectedMachinesOptIn(true);
+  };
+  const showComputeTarget = !fleetEmpty || optedIn;
+
+  // Defensive: if the segmented control is hidden (clean flow) while a stale draft
+  // still points at a machine (e.g. the last machine just left the fleet), fall
+  // back to the managed sandbox so a hidden machine target can never be submitted.
+  useEffect(() => {
+    if (!showComputeTarget && draft.compute.kind === "machine") {
+      onChange({ ...draft, compute: { kind: "sandbox", backend: lastBackend.current } });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showComputeTarget, draft.compute.kind]);
+
+  const selectKind = (kind: ComputeKind) => {
+    if (kind === draft.compute.kind) {
+      return;
+    }
+    if (kind === "sandbox") {
+      onChange({ ...draft, compute: { kind: "sandbox", backend: lastBackend.current } });
+      return;
+    }
+    // Auto-pick the first selectable machine so the common single-machine case is
+    // submit-ready immediately; otherwise leave it unpicked (submit stays blocked).
+    const firstSelectable = machines.find((machine) => isMachineComputeSelectable(machine.state)) ?? null;
+    onChange({ ...draft, compute: { kind: "machine", sandboxId: firstSelectable?.sandboxId ?? null, folder: { kind: "root" } } });
+  };
+
+  // Clean sandbox-only default: no "Where should this run?" header, no segmented
+  // control, no machine clutter — just the managed sandbox fields, plus a subtle
+  // opt-in link to reveal the Connected Machine path. The sandbox compute is
+  // narrowed defensively (the normalization effect keeps the draft in sync).
+  if (!showComputeTarget) {
+    const sandboxCompute: ManagedSandboxTarget =
+      draft.compute.kind === "sandbox" ? draft.compute : { kind: "sandbox", backend: lastBackend.current };
+    return (
+      <section className="mt-5 grid gap-2">
+        <ManagedSandboxFields
+          workspaceId={props.workspaceId}
+          draft={draft}
+          compute={sandboxCompute}
+          onChange={onChange}
+          disabled={props.disabled}
+        />
+        <RevealConnectedMachinesButton onClick={revealConnectedMachines} disabled={props.disabled} />
+      </section>
+    );
+  }
+
+  return (
+    <section className="mt-5 grid gap-3">
+      <p className="px-0.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[color:var(--color-fg-subtle)]">
+        Where should this run?
+      </p>
+      <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+        <ComputeKindButton
+          selected={draft.compute.kind === "sandbox"}
+          disabled={props.disabled}
+          icon={<BoxIcon className="size-4 shrink-0" />}
+          title="Managed Sandbox"
+          subtitle="A fresh box, set up for you"
+          onClick={() => selectKind("sandbox")}
+        />
+        <ComputeKindButton
+          selected={draft.compute.kind === "machine"}
+          disabled={props.disabled || fleetEmpty}
+          icon={<ServerIcon className="size-4 shrink-0" />}
+          title="Connected Machine"
+          subtitle={fleetEmpty ? "Connect one to use it" : "Run on your own machine"}
+          onClick={() => selectKind("machine")}
+        />
+      </div>
+
+      {draft.compute.kind === "sandbox" ? (
+        <ManagedSandboxFields
+          workspaceId={props.workspaceId}
+          draft={draft}
+          compute={draft.compute}
+          onChange={onChange}
+          disabled={props.disabled}
+        />
+      ) : (
+        <ConnectedMachineFields
+          workspaceId={props.workspaceId}
+          draft={draft}
+          compute={draft.compute}
+          machines={machines}
+          onChange={onChange}
+          disabled={props.disabled}
+        />
+      )}
+    </section>
+  );
+}
+
+type ComputeKind = SessionDraft["compute"]["kind"];
+
+function ComputeKindButton(props: {
+  selected: boolean;
+  disabled: boolean;
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={props.selected}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      className={cn(
+        "group flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-[color,background-color,border-color,box-shadow]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        props.selected
+          ? "border-[color:var(--color-brand)]/60 bg-[color:var(--color-brand)]/[0.08] ring-1 ring-inset ring-[color:var(--color-brand)]/20"
+          : "border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]/60",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 transition-colors",
+          props.selected ? "text-[color:var(--color-brand)]" : "text-[color:var(--color-fg-subtle)] group-hover:text-[color:var(--color-fg-muted)]",
+        )}
+      >
+        {props.icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-[color:var(--color-fg)]">{props.title}</span>
+        <span className="mt-0.5 block truncate text-[11px] text-[color:var(--color-fg-subtle)]">{props.subtitle}</span>
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full transition-all",
+          props.selected
+            ? "scale-100 bg-[color:var(--color-brand)] text-[color:var(--color-brand-fg)]"
+            : "scale-90 border border-[color:var(--color-border-strong)] opacity-0 group-hover:opacity-60",
+        )}
+      >
+        <CheckIcon className="size-2.5" strokeWidth={3} />
+      </span>
+    </button>
+  );
+}
+
+// ── Managed Sandbox kind: repo+branch (clone source), env, Advanced backend ───
+
+function ManagedSandboxFields(props: {
+  workspaceId: string;
+  draft: SessionDraft;
+  compute: ManagedSandboxTarget;
+  onChange: (draft: SessionDraft) => void;
+  disabled: boolean;
+}) {
+  const { draft, compute, onChange } = props;
+  const environments = useEnvironments();
+  const selectedBackend = BACKEND_OPTIONS.find((option) => option.value === compute.backend) ?? BACKEND_OPTIONS[0];
+  const backendSummary = [selectedBackend?.label, ...(selectedBackend?.chips ?? [])].filter(Boolean).join(" · ");
+
+  return (
+    <div className="grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
+      <div className="grid gap-2">
+        <Label className="flex items-center gap-1.5 text-xs">
+          <GitBranchIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          Repository + branch
+        </Label>
+        <div>
+          <WorkspaceRepositoryPicker workspaceId={props.workspaceId} disabled={props.disabled} />
+        </div>
+        <p className="flex items-center gap-1.5 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          <FolderIcon className="size-3 shrink-0" />
+          Cloned into <span className="font-mono text-[color:var(--color-fg-muted)]">/workspace</span>, the fixed sandbox root.
+        </p>
+      </div>
+
+      <div className="grid gap-2 border-t border-[color:var(--color-border)] pt-4">
+        <Label className="flex items-center gap-1.5 text-xs">
+          <BoxIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          Environment
+        </Label>
+        <select
+          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          value={draft.environmentId}
+          disabled={props.disabled}
+          onChange={(event) => onChange({ ...draft, environmentId: event.target.value })}
+        >
+          <option value="">No environment</option>
+          {environments.environments.map((environment) => (
+            <option key={environment.id} value={environment.id}>
+              {environment.name} ({environment.variables.length} vars)
+            </option>
+          ))}
+        </select>
+        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          Variables are set in the sandbox at start. Their values stay write-only.
+        </p>
+      </div>
+
+      {/* Low-level sandbox backend override — demoted into this kind's Advanced
+          detail, descriptor-driven from CAPABILITY_DESCRIPTORS. */}
+      <details className="group rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/30 transition-colors open:bg-[color:var(--color-surface)]/50">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-[11px] text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)]">
+          <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+          <span>Advanced</span>
+          <span className="text-[color:var(--color-fg-subtle)]/70">·</span>
+          <span className="truncate">backend {backendSummary}</span>
+        </summary>
+        <div className="grid gap-2 px-3 pb-3">
+          <select
+            className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            value={compute.backend}
+            disabled={props.disabled}
+            onChange={(event) => onChange({ ...draft, compute: { kind: "sandbox", backend: event.target.value as SandboxBackend | "" } })}
+          >
+            {BACKEND_OPTIONS.map((option) => (
+              <option key={option.value || "default"} value={option.value}>
+                {option.label}
+                {option.chips.length > 0 ? ` · ${option.chips.join(" · ")}` : ""}
+              </option>
+            ))}
+          </select>
+          <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+            Forces the underlying sandbox type. Leave on the deployment default unless you need a specific backend.
+          </p>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+// ── Connected Machine kind: machine picker, folder, grayed repos, env note ────
+
+function ConnectedMachineFields(props: {
+  workspaceId: string;
+  draft: SessionDraft;
+  compute: ConnectedMachineTarget;
+  machines: MachineView[];
+  onChange: (draft: SessionDraft) => void;
+  disabled: boolean;
+}) {
+  const { draft, compute, onChange, machines } = props;
+  const setCompute = (next: ConnectedMachineTarget) => onChange({ ...draft, compute: next });
+  const pickedMachine = compute.sandboxId
+    ? machines.find((machine) => machine.sandboxId === compute.sandboxId) ?? null
     : null;
-  const activeSummary = [
-    draft.targetSandboxId ? `machine: ${pickedMachine?.name ?? draft.targetSandboxId}` : null,
-    draft.sandboxBackend ? `sandbox: ${draft.sandboxBackend}` : null,
-    draft.environmentId ? `env: ${environments.environments.find((environment) => environment.id === draft.environmentId)?.name ?? draft.environmentId}` : null,
+  const customPath = compute.folder.kind === "path" ? compute.folder.path : "";
+  const capabilityChips = selfhostedCapabilityChips(pickedMachine);
+
+  return (
+    <div className="grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
+      <div className="grid gap-2">
+        <Label className="flex items-center gap-1.5 text-xs">
+          <ServerIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          Machine
+        </Label>
+        <select
+          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          value={compute.sandboxId ?? ""}
+          disabled={props.disabled}
+          onChange={(event) => setCompute({ ...compute, sandboxId: event.target.value || null })}
+        >
+          <option value="" disabled>
+            Choose a machine…
+          </option>
+          {machines.map((machine) => (
+            <option key={machine.sandboxId} value={machine.sandboxId} disabled={!isMachineComputeSelectable(machine.state)}>
+              {machine.name}
+              {machine.os ? ` · ${machine.os}/${machine.arch}` : ""}
+              {machine.state !== "online" ? ` (${machine.state})` : ""}
+            </option>
+          ))}
+        </select>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {capabilityChips.map((chip) => (
+            <CapabilityChip key={chip}>{chip}</CapabilityChip>
+          ))}
+          {pickedMachine && !pickedMachine.hasDisplay ? (
+            <span className="inline-flex items-center gap-1 rounded-md border border-dashed border-[color:var(--color-border-strong)] px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--color-fg-subtle)]">
+              <MonitorOffIcon className="size-3 shrink-0" />
+              No display
+            </span>
+          ) : null}
+        </div>
+        {compute.sandboxId === null ? (
+          <p className="text-[11px] leading-4 text-[color:var(--color-fg-muted)]">
+            Pick a machine to run on.
+          </p>
+        ) : null}
+      </div>
+
+      {/* Project / folder — the agent's working directory on the machine (D4/D5,
+          functional via Stage A's workingDir for root + custom path). */}
+      <div className="grid gap-2.5 border-t border-[color:var(--color-border)] pt-4">
+        <Label className="flex items-center gap-1.5 text-xs">
+          <FolderIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          Project / folder
+        </Label>
+        <div className="grid gap-2">
+          <FolderRadio
+            checked={compute.folder.kind === "root"}
+            disabled={props.disabled}
+            onSelect={() => setCompute({ ...compute, folder: { kind: "root" } })}
+            label="Machine root"
+            hint="the agent's launch directory"
+          />
+          <FolderRadio
+            checked={false}
+            disabled
+            onSelect={() => {}}
+            label="Project"
+            hint="a named path"
+            badge="Soon"
+          />
+          <FolderRadio
+            checked={compute.folder.kind === "path"}
+            disabled={props.disabled}
+            onSelect={() => setCompute({ ...compute, folder: { kind: "path", path: customPath } })}
+            label="Custom path"
+            hint="absolute, or relative to the launch root"
+          />
+          {compute.folder.kind === "path" ? (
+            <Input
+              value={customPath}
+              disabled={props.disabled}
+              onChange={(event) => setCompute({ ...compute, folder: { kind: "path", path: event.target.value } })}
+              placeholder="e.g. ~/repos/myproject or packages/runtime"
+              aria-label="Custom working directory"
+              className="ml-[1.375rem] h-9 w-[calc(100%_-_1.375rem)] text-sm"
+            />
+          ) : null}
+        </div>
+        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          Where the agent, terminal, and file dock open. Defaults to the machine&apos;s workspace root.
+        </p>
+      </div>
+
+      {/* Repositories — grayed: a connected machine uses its own checkout & git
+          auth (D3), so the workspace repo selection is never cloned onto it. */}
+      <div className="grid gap-2 border-t border-[color:var(--color-border)] pt-4">
+        <Label className="flex items-center justify-between gap-1.5 text-xs text-[color:var(--color-fg-subtle)]">
+          <span className="flex items-center gap-1.5">
+            <GitBranchIcon className="size-3 shrink-0" />
+            Repositories
+          </span>
+          <span className="rounded border border-[color:var(--color-border)] px-1.5 py-px text-[10px] font-normal text-[color:var(--color-fg-subtle)]">
+            Not cloned here
+          </span>
+        </Label>
+        <div className="pointer-events-none select-none opacity-45">
+          <WorkspaceRepositoryPicker workspaceId={props.workspaceId} disabled />
+        </div>
+        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          This machine uses its own checkout &amp; git auth, so your selected repositories aren&apos;t cloned onto it.
+        </p>
+      </div>
+
+      {/* Environment injection — hidden on a connected machine (D2). */}
+      <div className="grid gap-1 border-t border-[color:var(--color-border)] pt-4">
+        <p className="flex items-center gap-1.5 text-xs text-[color:var(--color-fg-subtle)]">
+          <BoxIcon className="size-3 shrink-0" />
+          No environment is injected here.
+        </p>
+        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          The machine&apos;s own environment &amp; git credentials apply.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CapabilityChip({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--color-fg-muted)]">
+      {children}
+    </span>
+  );
+}
+
+// The opt-in affordance that reveals the Connected Machine path from the clean
+// sandbox-only flow. A quiet secondary action, tied to the compute area, with a
+// reveal-arrow on hover.
+function RevealConnectedMachinesButton(props: { onClick: () => void; disabled: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      disabled={props.disabled}
+      className={cn(
+        "group inline-flex items-center gap-2 justify-self-start rounded-md px-1.5 py-1 text-[11px] transition-colors",
+        "text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg-muted)]",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+      )}
+    >
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50 text-[color:var(--color-fg-subtle)] transition-colors group-hover:border-[color:var(--color-border-strong)] group-hover:text-[color:var(--color-fg-muted)]">
+        <ServerIcon className="size-3" />
+      </span>
+      <span>Run on your own connected machine</span>
+      <ArrowRightIcon className="size-3 -translate-x-1 opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100" />
+    </button>
+  );
+}
+
+function FolderRadio(props: {
+  checked: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+  label: string;
+  hint: string;
+  badge?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={props.checked}
+      disabled={props.disabled}
+      onClick={props.onSelect}
+      className="group flex items-center gap-2 rounded-md text-left text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-55"
+    >
+      <span
+        className={cn(
+          "flex size-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
+          props.checked
+            ? "border-[color:var(--color-brand)]"
+            : "border-[color:var(--color-border-strong)] group-hover:border-[color:var(--color-fg-subtle)]",
+        )}
+      >
+        {props.checked ? <span className="size-1.5 rounded-full bg-[color:var(--color-brand-strong)]" /> : null}
+      </span>
+      <span className="font-medium text-[color:var(--color-fg)]">{props.label}</span>
+      {props.badge ? (
+        <span className="rounded border border-[color:var(--color-border)] px-1 py-px text-[9px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+          {props.badge}
+        </span>
+      ) : null}
+      <span className="text-[11px] text-[color:var(--color-fg-subtle)]">— {props.hint}</span>
+    </button>
+  );
+}
+
+// ── Compute-independent optional band: goal + OpenGeni tool permissions ───────
+
+function OptionalSessionOptions(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draft: SessionDraft;
+  onChange: (draft: SessionDraft) => void;
+  disabled: boolean;
+}) {
+  const { draft } = props;
+  const update = (patch: Partial<SessionDraft>) => props.onChange({ ...draft, ...patch });
+  const summary = [
     draft.goalText.trim() ? "goal set" : null,
     draft.customMcpPermissions ? `${draft.mcpPermissions.size} MCP scopes` : null,
   ].filter(Boolean);
 
   return (
-    <Collapsible open={props.open} onOpenChange={props.onOpenChange} className="mt-2">
+    <Collapsible open={props.open} onOpenChange={props.onOpenChange} className="mt-3">
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className="flex w-full items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 px-3 py-2 text-left text-xs text-[color:var(--color-fg-muted)] transition-colors hover:bg-[color:var(--color-surface-2)]/60 hover:text-[color:var(--color-fg)]"
+          className="flex w-full items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 px-3 py-2.5 text-left text-xs text-[color:var(--color-fg-muted)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]/60 hover:text-[color:var(--color-fg)]"
         >
-          <SlidersHorizontalIcon className="size-3.5 shrink-0" />
-          <span className="font-medium">Session setup</span>
+          <SlidersHorizontalIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <span className="font-medium">Goal &amp; tool permissions</span>
           <span className="min-w-0 flex-1 truncate text-[11px] text-[color:var(--color-fg-subtle)]">
-            {activeSummary.length > 0 ? activeSummary.join(" · ") : "machine, environment, goal, OpenGeni tool permissions"}
+            {summary.length > 0 ? summary.join(" · ") : "Optional — run toward a goal, limit tool access"}
           </span>
           <ChevronDownIcon className={cn("size-3.5 shrink-0 transition-transform", props.open && "rotate-180")} />
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="mt-2 grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3">
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="grid gap-1.5">
-              <Label className="flex items-center gap-1.5 text-xs">
-                <ServerIcon className="size-3" />
-                Machine
-              </Label>
-              <select
-                className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
-                value={draft.targetSandboxId ?? ""}
-                disabled={props.disabled}
-                onChange={(event) => update({ targetSandboxId: event.target.value || null })}
-              >
-                <option value="">Cloud sandbox</option>
-                {selfhostedMachines.map((machine) => (
-                  <option key={machine.sandboxId} value={machine.sandboxId} disabled={!isMachineComputeSelectable(machine.state)}>
-                    {machine.name}
-                    {machine.state !== "online" ? ` (${machine.state})` : ""}
-                  </option>
-                ))}
-              </select>
-              <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
-                Run on one of your enrolled machines, or the default cloud sandbox.
-              </p>
-              {/* Per-session working directory — only meaningful for a targeted
-                  machine (it is that box's path/cwd base). Hidden for the cloud
-                  sandbox; the create 422s a workingDir without a targetSandboxId. */}
-              {draft.targetSandboxId ? (
-                <div className="mt-1 grid gap-1.5">
-                  <Label className="flex items-center gap-1.5 text-xs">
-                    <FolderIcon className="size-3" />
-                    Working directory
-                  </Label>
-                  <Input
-                    value={draft.workingDir}
-                    disabled={props.disabled}
-                    onChange={(event) => update({ workingDir: event.target.value })}
-                    placeholder="Defaults to where the agent runs (e.g. ~/repos/myproject)"
-                    className="h-9 text-sm"
-                  />
-                  <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
-                    Where the agent, terminal, and file dock run. Relative paths resolve under the machine&apos;s workspace; absolute paths are used as-is.
-                  </p>
-                </div>
-              ) : null}
-            </div>
-            <div className="grid gap-1.5">
-              <Label className="flex items-center gap-1.5 text-xs">
-                <BoxIcon className="size-3" />
-                Environment
-              </Label>
-              <select
-                className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
-                value={draft.environmentId}
-                disabled={props.disabled}
-                onChange={(event) => update({ environmentId: event.target.value })}
-              >
-                <option value="">No environment</option>
-                {environments.environments.map((environment) => (
-                  <option key={environment.id} value={environment.id}>
-                    {environment.name} ({environment.variables.length} vars)
-                  </option>
-                ))}
-              </select>
-              <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
-                Variables are injected into the sandbox at start; values stay write-only.
-              </p>
-            </div>
-          </div>
-
-          {/* Low-level sandbox backend override — secondary to the Machine picker,
-              tucked behind a disclosure so it stays out of the primary flow. */}
-          <details className="group rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/30">
-            <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-[11px] text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg-muted)]">
-              <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-              Advanced: sandbox backend override
-              {draft.sandboxBackend ? (
-                <span className="ml-1 rounded bg-[color:var(--color-surface-2)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-muted)]">
-                  {draft.sandboxBackend}
-                </span>
-              ) : null}
-            </summary>
-            <div className="grid gap-1.5 px-3 pb-3">
-              <select
-                className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
-                value={draft.sandboxBackend}
-                disabled={props.disabled}
-                onChange={(event) => update({ sandboxBackend: event.target.value as AdvancedSessionDraft["sandboxBackend"] })}
-              >
-                {sandboxBackendOptions.map((option) => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
-              <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
-                Forces the underlying sandbox type. Leave on the deployment default unless you know you need a specific backend.
-              </p>
-            </div>
-          </details>
-
+        <div className="mt-2 grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
           <div className="grid gap-2">
             <Label className="flex items-center gap-1.5 text-xs">
-              <FlagIcon className="size-3" />
+              <FlagIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
               Goal (optional)
             </Label>
             <textarea
               value={draft.goalText}
               disabled={props.disabled}
               onChange={(event) => update({ goalText: event.target.value })}
-              placeholder="A goal keeps the session working autonomously between your messages..."
-              className="min-h-14 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm"
+              placeholder="Keep the session working on its own between your messages…"
+              className="min-h-14 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm transition-colors placeholder:text-[color:var(--color-fg-subtle)] hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             />
             <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem]">
               <Input
@@ -381,9 +808,10 @@ function AdvancedSessionOptions(props: {
                 checked={draft.customMcpPermissions}
                 disabled={props.disabled}
                 onChange={(event) => update({ customMcpPermissions: event.target.checked })}
+                className="size-3.5 accent-[color:var(--color-brand-strong)]"
               />
-              <ShieldIcon className="size-3" />
-              Restrict the session&apos;s OpenGeni tool permissions
+              <ShieldIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+              Restrict this session&apos;s OpenGeni tool permissions
             </label>
             {draft.customMcpPermissions ? (
               <PermissionGroupPicker
@@ -411,4 +839,3 @@ function AdvancedSessionOptions(props: {
     </Collapsible>
   );
 }
-


### PR DESCRIPTION
**Stage C** of the connected-machine refactor — rebuilds the new-session composer (the surface you called out as the worst part of the UX). Pure UI, no contract/backend change.

### What changed
- **Top-level `ComputeTargetControl`** (Managed Sandbox · Connected Machine) becomes the parent that **gates** the form, instead of compute being buried in a collapsed disclosure while repos sit on top.
  - **Sandbox** → repo + branch, environment, backend demoted to a descriptor-driven Advanced detail, folder = `/workspace` (info-only).
  - **Machine** → machine picker (primary), a **functional** Folder→`workingDir` control (Machine root | Custom path; named Project = "Soon"), Repositories **grayed + excluded from `resources[]`** ("Not cloned here"), environment injection hidden.
- **Surfaces only when it should:** the compute-target control appears only when the workspace has ≥1 enrolled self-hosted machine **or** the user opts in. Zero machines (the default) → clean **sandbox-only** composer, no segmented control. This also gives `@opengeni/react` embedders that only use the cloud sandbox the right default for free.
- Two split selection stores collapsed into one discriminated `SessionDraft`.
- Inspector shows the **active** self-hosted machine name when one is active.
- **Headless-aware chips:** a machine with no display shows `FileSystem · Terminal · Git` + a "No display" badge, never a contradictory "Desktop" chip.
- Copy tightened; rhythm/states polished.

### Verification
Repo-wide typecheck clean (17 packages); 82 web unit tests pass; **visually verified via headless render** (real styles, nix Chromium) of all three states — see the PR thread / session screenshots.

### Scope / deferred
PR-1 only (additive, non-breaking). Deferred: promote the opt-in to a real Settings toggle; named **Project** registry (D4); explicit SDK embedder gating; machine-as-primary-compute (D1/Stage D, which folds in the no-token cleanup D2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-create payload composition (especially omitting workspace repos on connected machines) and a large composer UX refactor; API fields are unchanged but wrong gating could surprise users.
> 
> **Overview**
> Rebuilds the **new-session composer** around a promoted **“Where should this run?”** choice (**Managed Sandbox** vs **Connected Machine**), replacing the old collapsed “advanced” panel and flat repo pill.
> 
> **`SessionDraft`** is now a discriminated **`ComputeTarget`** with **`submissionFromSessionDraft`** mapping to create extras, **`targetSandboxId`/`workingDir`**, and **`omitWorkspaceResources`**. Connected-machine creates **skip workspace repo clones** and **environment injection**; submit is gated until a machine is picked. Managed backends come from **`CAPABILITY_DESCRIPTORS`** (no `selfhosted`).
> 
> The compute UI is **opt-in** when the fleet is empty (sandbox-only default + localStorage reveal); repos move under the sandbox band and are **grayed on machines**. **`startSession`** honors **`omitWorkspaceResources`**; the **session inspector** shows the **active machine name** when self-hosted compute is live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d14cc6691865af89affa675be5761c74425bb32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->