### PR TITLE
fix(codex): harden subscription lifecycle — run-scoped model provider + RLS/refresh/429 hardening

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -11,6 +11,7 @@ import {
   getSessionGoal,
   getSessionTurn,
   isCodexBilledTurn,
+  workspaceCodexSubscriptionActive,
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
@@ -49,6 +50,7 @@ import {
   buildModelResolver,
   CODEX_CLIENT_VERSION,
   CODEX_FALLBACK_MODEL_SLUGS,
+  classifyCodexUsageLimitError,
   codexRequestStorage,
   type CodexRequestContext,
 } from "@opengeni/codex";
@@ -366,7 +368,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let triggerType: string | null = null;
     try {
       const mcpSettings = await settingsWithEnabledCapabilityMcpServers(db, input.workspaceId, settings);
-      const capabilitySettings = await settingsWithCodexCredential(db, input.workspaceId, mcpSettings);
+      // Read the active-credential flag ONCE (P2-b) and thread it through both the
+      // routing overlay (settingsWithCodexCredential) and the billed-turn predicate
+      // (isCodexBilledTurn below), so a concurrent disconnect/reconnect cannot make
+      // provider-injection and billing disagree about whether this is a codex turn.
+      const codexSubscriptionActive = await workspaceCodexSubscriptionActive(db, mcpSettings, input.workspaceId);
+      const capabilitySettings = await settingsWithCodexCredential(db, input.workspaceId, mcpSettings, codexSubscriptionActive);
       runtime.configure(capabilitySettings);
       const session = await requireSession(db, input.workspaceId, input.sessionId);
       const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
@@ -395,7 +402,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // here (before resolvedModel at the routing step) because the pre-turn gate
       // below needs it; mirrors the same active-credential read the codex provider
       // overlay uses, so billing and routing agree on what "codex" is.
-      const isCodexTurn = await isCodexBilledTurn({ db, settings, workspaceId: input.workspaceId, model: turn.model });
+      const isCodexTurn = await isCodexBilledTurn({ db, settings, workspaceId: input.workspaceId, model: turn.model, active: codexSubscriptionActive });
       await ensureRunAllowed(settings, db, input.accountId, input.workspaceId, isCodexTurn);
       const activityContext = currentActivityContext();
       // Setup (environment load, MCP connects, sandbox restore) does not
@@ -1133,6 +1140,49 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         activityStatus = "idle";
         return { status: "idle" };
       }
+      // A ChatGPT/Codex usage cap (429 usage_limit_reached) is account state,
+      // NOT an agent failure: surface the precise, actionable message (so the
+      // user sees the reset window) but idle the session — never go terminal,
+      // which would reject the user's next message after the cap lifts. The
+      // payload is retryable:false so the generic provider-backpressure auto-retry
+      // does not loop. For an active goal we hold the continuation for the reported
+      // reset window (capped) so it resumes itself when access returns, instead of
+      // hammering the capped backend.
+      const usageLimit = classifyCodexUsageLimitError(error);
+      if (usageLimit && publish && turnId && turnStartedPublished) {
+        const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
+        const goalActive = Boolean(goal && goal.status === "active");
+        await batcher?.flush().catch(() => undefined);
+        await reconcileConversationTruth();
+        const serializedRunState = agentsErrorRunState(error);
+        const runStateSaved = Boolean(serializedRunState) && settings.sessionHistorySource !== "items";
+        if (serializedRunState && settings.sessionHistorySource !== "items") {
+          await saveRunState(db, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId,
+            serializedRunState,
+            pendingApprovals: [],
+          });
+        }
+        const failurePayload = codexUsageLimitFailurePayload(usageLimit, error instanceof Error ? error.message : String(error));
+        await publish([
+          { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved } },
+          { type: "session.status.changed", payload: { status: "idle" } },
+        ], true);
+        await finishTurn(db, input.workspaceId, turnId, "failed");
+        await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+        activityStatus = "idle";
+        activityError = error;
+        if (goalActive) {
+          const resumeMs = usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
+            ? Math.min(Math.ceil(usageLimit.resetsInSeconds) * 1000, CODEX_USAGE_LIMIT_MAX_RESUME_MS)
+            : CODEX_USAGE_LIMIT_MAX_RESUME_MS;
+          return { status: "idle", continueDelayMs: resumeMs };
+        }
+        return { status: "idle" };
+      }
       // Budget/limit exhaustion between model calls is account state, not an
       // agent failure: idle the session for goal-bearing and goal-less runs
       // alike (a failed session would reject the user's next message after a
@@ -1322,6 +1372,15 @@ export function agentRunFailurePayload(error: unknown): { error: string; code?: 
   const code = typeof error === "object" && error !== null && "code" in error
     ? String((error as { code?: unknown }).code)
     : undefined;
+  // A ChatGPT/Codex usage cap is a HARD limit, not transient backpressure: it
+  // must NOT be reported as a generic, retryable rate-limit (which would loop a
+  // goal against a capped backend). Surface a precise, actionable message with
+  // the humanized reset window and code, non-retryable. Checked BEFORE the
+  // generic 429 branch below (a usage cap is also a 429).
+  const usageLimit = classifyCodexUsageLimitError(error);
+  if (usageLimit) {
+    return codexUsageLimitFailurePayload(usageLimit, message);
+  }
   if (status === 429 || code === "rate_limit_exceeded" || /(?:too many requests|rate.?limit|\b429\b)/i.test(message)) {
     return {
       error: "Model provider rate limit hit. Try again in a minute or lower the reasoning effort.",
@@ -1332,6 +1391,46 @@ export function agentRunFailurePayload(error: unknown): { error: string; code?: 
   }
   return { error: message };
 }
+
+/** Humanize a seconds duration into a short "2h 5m" / "9m" / "in under a minute" string. */
+export function humanizeResetWindow(resetsInSeconds: number | null): string {
+  if (resetsInSeconds === null || !Number.isFinite(resetsInSeconds) || resetsInSeconds <= 0) {
+    return "shortly";
+  }
+  const total = Math.ceil(resetsInSeconds);
+  if (total < 60) {
+    return "in under a minute";
+  }
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.round((total % 3600) / 60);
+  if (hours > 0) {
+    return minutes > 0 ? `in about ${hours}h ${minutes}m` : `in about ${hours}h`;
+  }
+  return `in about ${minutes}m`;
+}
+
+/**
+ * Build the turn.failed payload for a ChatGPT/Codex usage cap: a precise,
+ * actionable message naming the reset window, the stable `codex_usage_limit_reached`
+ * code, and retryable:false (an auto-retry would just re-hit the cap).
+ */
+export function codexUsageLimitFailurePayload(
+  info: { resetsInSeconds: number | null },
+  detail: string,
+): { error: string; code: string; retryable: boolean; detail?: string } {
+  return {
+    error: `Your ChatGPT/Codex subscription usage limit has been reached. Access resets ${humanizeResetWindow(info.resetsInSeconds)}. `
+      + `You can switch this session to a different model in the meantime, or wait for the limit to reset.`,
+    code: "codex_usage_limit_reached",
+    retryable: false,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+// A usage cap that won't reset for a long time should not pin a Temporal timer
+// open indefinitely for a goal-bearing session; cap the continuation hold so the
+// goal re-evaluates at most this far out (it will re-pause if still capped).
+const CODEX_USAGE_LIMIT_MAX_RESUME_MS = 60 * 60_000; // 1h
 
 /**
  * Recognize an SDK stream event that represents a COMPUTER-USE tool call actually

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -29,10 +29,14 @@ export async function settingsWithEnabledCapabilityMcpServers(db: Database, work
  * this overlay (metadata-only read); the per-request bearer is resolved later via
  * codexRequestStorage. Idempotent and a no-op when not applicable.
  */
-export async function settingsWithCodexCredential(db: Database, workspaceId: string, settings: Settings): Promise<Settings> {
+export async function settingsWithCodexCredential(db: Database, workspaceId: string, settings: Settings, activeOverride?: boolean): Promise<Settings> {
   // Same active-credential predicate the billing bypass uses, so provider
   // injection and billing can never disagree on what an "active codex" turn is.
-  if (!(await workspaceCodexSubscriptionActive(db, settings, workspaceId))) {
+  // The caller may pass `activeOverride` (a single, shared read; P2-b) so routing
+  // and billing decide from the exact same observation, immune to a concurrent
+  // disconnect/reconnect landing between two independent reads.
+  const active = activeOverride ?? await workspaceCodexSubscriptionActive(db, settings, workspaceId);
+  if (!active) {
     return settings; // disabled / not connected / needs_relogin / error -> leave settings unchanged
   }
   const withProvider = withCodexProvider(settings);

--- a/apps/worker/src/activities/codex-auth.ts
+++ b/apps/worker/src/activities/codex-auth.ts
@@ -22,9 +22,15 @@ import {
   refreshCodexToken,
 } from "@opengeni/codex";
 
-// Single-flight per workspace, process-module scope. One Temporal worker per
-// process makes this the right grain; concurrent cross-workspace turns are keyed
-// apart by workspaceId, and a refresh-token is one-time so we never double-spend it.
+// Single-flight per CREDENTIAL INSTANCE (row id + version), process-module scope.
+// One Temporal worker per process makes this the right grain. Keying by the
+// loaded credential's id+version — NOT by workspaceId alone (P1-b) — is what makes
+// a disconnect→reconnect safe: a post-reconnect getToken loads a DIFFERENT row
+// (new uuid id) and so gets a distinct key, instead of coalescing onto the OLD
+// in-flight refresh and writing stale rotated tokens over the freshly connected
+// credential (which would invalidate the new token family → 401 → needs_relogin →
+// a second, independent "no active subscription"). Concurrent calls for the SAME
+// credential still coalesce, so the one-time refresh token is never double-spent.
 const inflight = new Map<string, Promise<CodexTokenSnapshot>>();
 
 // Dependencies are injectable so the lifecycle logic (single-flight, staleness,
@@ -72,16 +78,35 @@ export function buildCodexTokenResolver(
       if (!key) {
         throw new Error("OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY is not configured");
       }
-      await deps.recordRefresh(db, {
+      // Compare-and-set on the loaded (id, version): if a disconnect→reconnect
+      // replaced the row mid-refresh, this writes 0 rows and we must NOT clobber
+      // the new credential with our now-defunct rotated tokens.
+      const persisted = await deps.recordRefresh(db, {
+        id: cred.id,
+        version: cred.version,
         workspaceId,
         credentialEncrypted: deps.encrypt(key, JSON.stringify(tokens)),
         expiresAt: accessTokenExpiry(tokens.access_token),
         lastRefreshAt: new Date(),
       });
+      if (!persisted) {
+        // The row changed under us. Our rotated tokens belong to a stale family;
+        // fall back to whatever is connected NOW (a reconnect leaves an active
+        // row). If nothing active remains, a relogin is genuinely required.
+        const current = await deps.loadCredential(db, settings, workspaceId);
+        if (current && current.status === "active") {
+          return snapshot(current);
+        }
+        throw new CodexReloginRequired("Codex credential changed during token refresh; reconnect required.");
+      }
       return { accessToken: tokens.access_token, chatgptAccountId: cred.chatgptAccountId, isFedramp: cred.isFedramp };
     } catch (error) {
       if (error instanceof CodexReloginRequired) {
-        await deps.setStatus(db, workspaceId, "needs_relogin", error.message);
+        // Stamp needs_relogin ONLY if the row we refreshed is STILL current
+        // (compare-and-set on the loaded id+version). A relogin triggered by the
+        // OLD token family must never stamp needs_relogin onto a freshly
+        // reconnected credential.
+        await deps.setStatus(db, workspaceId, "needs_relogin", error.message, { id: cred.id, version: cred.version });
       }
       throw error;
     }
@@ -92,16 +117,20 @@ export function buildCodexTokenResolver(
   // concurrent model calls in a turn can never double-spend the one-time refresh
   // token (which would trigger refresh_token_reused -> needs_relogin).
   const doRefresh = (cred: CodexCredentialForRun): Promise<CodexTokenSnapshot> => {
-    const existing = inflight.get(workspaceId);
+    // Key by the credential INSTANCE (id+version), so a reconnect's new row never
+    // coalesces onto the old row's in-flight refresh (P1-b). The row id is a uuid,
+    // globally unique across the delete+reinsert a disconnect→reconnect performs.
+    const key = `${cred.id}:${cred.version}`;
+    const existing = inflight.get(key);
     if (existing) {
       return existing;
     }
     const promise = performRefresh(cred).finally(() => {
-      if (inflight.get(workspaceId) === promise) {
-        inflight.delete(workspaceId);
+      if (inflight.get(key) === promise) {
+        inflight.delete(key);
       }
     });
-    inflight.set(workspaceId, promise);
+    inflight.set(key, promise);
     return promise;
   };
 

--- a/apps/worker/test/codex-auth.test.ts
+++ b/apps/worker/test/codex-auth.test.ts
@@ -9,6 +9,8 @@ const settings = testSettings({ codexSubscriptionEnabled: true });
 
 function makeCred(overrides: Partial<CodexCredentialForRun> = {}): CodexCredentialForRun {
   return {
+    id: "cred_1",
+    version: 1,
     workspaceId: "ws_1",
     tokens: { accessToken: "AC", refreshToken: "RF", idToken: "ID" },
     chatgptAccountId: "acct_1",
@@ -23,13 +25,21 @@ function makeCred(overrides: Partial<CodexCredentialForRun> = {}): CodexCredenti
   };
 }
 
-function deps(overrides: Partial<CodexAuthDeps> = {}): { deps: CodexAuthDeps; counts: { refresh: number; record: number; status: number } } {
-  const counts = { refresh: 0, record: 0, status: 0 };
+type Counts = {
+  refresh: number;
+  record: number;
+  status: number;
+  recordArgs: Array<{ id: string; version: number }>;
+  statusArgs: Array<{ status: string; expected?: { id: string; version: number } }>;
+};
+
+function deps(overrides: Partial<CodexAuthDeps> = {}): { deps: CodexAuthDeps; counts: Counts } {
+  const counts: Counts = { refresh: 0, record: 0, status: 0, recordArgs: [], statusArgs: [] };
   const base: CodexAuthDeps = {
     loadCredential: async () => makeCred(),
     refresh: async () => { counts.refresh += 1; return { accessToken: "AC2", refreshToken: "RF2", idToken: "ID2" }; },
-    recordRefresh: async () => { counts.record += 1; },
-    setStatus: async () => { counts.status += 1; },
+    recordRefresh: async (_db, input) => { counts.record += 1; counts.recordArgs.push({ id: input.id, version: input.version }); return true; },
+    setStatus: async (_db, _ws, status, _err, expected) => { counts.status += 1; counts.statusArgs.push({ status, expected }); return true; },
     encrypt: () => "v1:enc",
     keyBytes: () => new Uint8Array(32),
     ...overrides,
@@ -99,5 +109,73 @@ describe("buildCodexTokenResolver", () => {
     const { deps: d } = deps({ loadCredential: async () => null });
     const resolver = buildCodexTokenResolver(db, settings, "ws_missing", d);
     await expect(resolver.getToken()).rejects.toBeInstanceOf(CodexReloginRequired);
+  });
+
+  test("P1-c: the refresh write is compare-and-set on the loaded id+version", async () => {
+    const { deps: d, counts } = deps({
+      loadCredential: async () => makeCred({ id: "cred_A", version: 7, expiresAt: new Date(Date.now() - 1000) }),
+    });
+    const resolver = buildCodexTokenResolver(db, settings, "ws_cas", d);
+    await resolver.getToken();
+    expect(counts.recordArgs).toEqual([{ id: "cred_A", version: 7 }]);
+  });
+
+  test("P1-c: a CAS miss (row changed under us) falls back to the now-active credential, no relogin", async () => {
+    let load = 0;
+    const { deps: d, counts } = deps({
+      // First load: the OLD credential (stale). After the failed CAS, a reload
+      // returns the freshly RECONNECTED credential (new id, active).
+      loadCredential: async () => {
+        load += 1;
+        return load === 1
+          ? makeCred({ id: "cred_old", version: 1, expiresAt: new Date(Date.now() - 1000) })
+          : makeCred({ id: "cred_new", version: 1, tokens: { accessToken: "NEW", refreshToken: "RFn", idToken: "IDn" }, status: "active" });
+      },
+      recordRefresh: async () => { counts.record += 1; return false; }, // CAS miss
+    });
+    const resolver = buildCodexTokenResolver(db, settings, "ws_reconnect", d);
+    const token = await resolver.getToken();
+    expect(token.accessToken).toBe("NEW"); // used the reconnected credential, not the stale rotation
+    expect(counts.status).toBe(0); // never stamped needs_relogin on the new row
+  });
+
+  test("P1-c: a CAS miss with nothing active remaining surfaces relogin (CAS-guarded stamp)", async () => {
+    let load = 0;
+    const { deps: d, counts } = deps({
+      loadCredential: async () => {
+        load += 1;
+        return load === 1
+          ? makeCred({ id: "cred_old", version: 3, expiresAt: new Date(Date.now() - 1000) })
+          : null; // disconnected; nothing to fall back to
+      },
+      recordRefresh: async () => { counts.record += 1; return false; }, // CAS miss
+    });
+    const resolver = buildCodexTokenResolver(db, settings, "ws_reconnect_gone", d);
+    await expect(resolver.getToken()).rejects.toBeInstanceOf(CodexReloginRequired);
+    // The needs_relogin stamp is compare-and-set on the OLD id+version, so it
+    // can never clobber a credential that replaced it.
+    expect(counts.statusArgs).toEqual([{ status: "needs_relogin", expected: { id: "cred_old", version: 3 } }]);
+  });
+
+  test("P1-b: a reconnect's new row does NOT coalesce onto the old in-flight refresh", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let load = 0;
+    const { deps: d, counts } = deps({
+      loadCredential: async () => {
+        load += 1;
+        // first caller loads the old row; the second (post-reconnect) loads a new row id
+        return makeCred({ id: load === 1 ? "cred_old" : "cred_new", version: 1, expiresAt: new Date(Date.now() - 1000) });
+      },
+      refresh: async () => { counts.refresh += 1; await gate; return { accessToken: "AC2" }; },
+    });
+    const resolver = buildCodexTokenResolver(db, settings, "ws_reconnect_inflight", d);
+    const both = Promise.all([resolver.refresh(), resolver.refresh()]);
+    release();
+    await both;
+    // Distinct credential instances → distinct single-flight keys → two refreshes,
+    // NOT coalesced (the old behavior would have spent the new row's refresh onto
+    // the old family).
+    expect(counts.refresh).toBe(2);
   });
 });

--- a/apps/worker/test/codex-usage-limit.test.ts
+++ b/apps/worker/test/codex-usage-limit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { agentRunFailurePayload, codexUsageLimitFailurePayload, humanizeResetWindow } from "../src/activities/agent-turn";
+
+// P1-d: a ChatGPT/Codex usage cap (429 usage_limit_reached) must surface as a
+// precise, NON-retryable error with the reset window — not the generic retryable
+// "rate limit hit, try again in a minute" that would loop a goal against a hard cap.
+
+describe("humanizeResetWindow", () => {
+  test("formats hours+minutes / minutes / sub-minute / unknown", () => {
+    expect(humanizeResetWindow(3 * 3600 + 25 * 60)).toBe("in about 3h 25m");
+    expect(humanizeResetWindow(3600)).toBe("in about 1h");
+    expect(humanizeResetWindow(9 * 60)).toBe("in about 9m");
+    expect(humanizeResetWindow(30)).toBe("in under a minute");
+    expect(humanizeResetWindow(null)).toBe("shortly");
+    expect(humanizeResetWindow(0)).toBe("shortly");
+  });
+});
+
+describe("codexUsageLimitFailurePayload", () => {
+  test("names the reset window, carries the stable code, and is non-retryable", () => {
+    const payload = codexUsageLimitFailurePayload({ resetsInSeconds: 3600 }, "429 limit hit");
+    expect(payload.code).toBe("codex_usage_limit_reached");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toContain("usage limit");
+    expect(payload.error).toContain("in about 1h");
+    expect(payload.detail).toBe("429 limit hit");
+  });
+});
+
+describe("agentRunFailurePayload — codex usage limit", () => {
+  test("classifies a 429 usage_limit_reached as the non-retryable codex cap (NOT the generic rate-limit)", () => {
+    const err = Object.assign(new Error("429 You have hit your usage limit"), {
+      status: 429,
+      type: "usage_limit_reached",
+      error: { type: "usage_limit_reached", resets_in_seconds: 7200 },
+    });
+    const payload = agentRunFailurePayload(err);
+    expect(payload.code).toBe("codex_usage_limit_reached");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toContain("in about 2h");
+  });
+
+  test("a plain 429 rate-limit (no usage cap) is still the generic retryable payload", () => {
+    const err = Object.assign(new Error("429 Too Many Requests"), { status: 429, code: "rate_limit_exceeded" });
+    const payload = agentRunFailurePayload(err);
+    expect(payload.code).toBe("provider_rate_limited");
+    expect(payload.retryable).toBe(true);
+  });
+});

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -74,7 +74,16 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
       // so we must reconstruct it: collapse to one JSON Response for a non-streaming
       // caller, or repair the live stream's terminal event for a streaming caller.
       if (!res.ok) {
-        return res;
+        // Buffer the error body once and re-emit it as a concrete JSON Response.
+        // A streaming responses request whose error body is left as the raw
+        // (possibly SSE / already-streamed) Response makes the SDK throw
+        // "<status> status code (no body)" — the JSON error (type/message/
+        // resets_in_seconds) is lost, so a 429 usage cap surfaces as a generic,
+        // wrongly-retryable rate-limit. Re-emitting a clean application/json
+        // Response lets the SDK reconstruct error.error for EVERY codex error
+        // (401/400/5xx too). For a hard usage cap we also pin x-should-retry:false
+        // so the SDK does not burn its retry budget on a limit that won't lift.
+        return await bufferCodexErrorResponse(res);
       }
       return callerWantsStream ? repairCodexStream(res) : await sseToJsonResponse(res);
     };
@@ -85,6 +94,72 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
     }
     return res;
   };
+}
+
+/** The codex backend's hard-cap error type (ChatGPT/Codex usage limit reached). */
+export const CODEX_USAGE_LIMIT_ERROR_TYPE = "usage_limit_reached";
+
+export type CodexUsageLimitInfo = {
+  /** Seconds until the usage cap resets, when the backend reported it. */
+  resetsInSeconds: number | null;
+};
+
+/**
+ * Classify a thrown error as a ChatGPT/Codex usage-cap (429 usage_limit_reached)
+ * and extract the reset window. The SDK surfaces the codex backend's 429 as an
+ * OpenAI APIError whose `.type` (and `.error.type`) is `usage_limit_reached` and
+ * whose `.error.resets_in_seconds` carries the cap reset. Walks the cause chain
+ * and tolerates the message-only shape so it survives any SDK re-wrapping.
+ * Returns null for anything that is not a usage cap.
+ */
+export function classifyCodexUsageLimitError(error: unknown): CodexUsageLimitInfo | null {
+  let cur: unknown = error;
+  for (let depth = 0; depth < 6 && cur && typeof cur === "object"; depth++) {
+    const e = cur as Record<string, unknown>;
+    const body = (e.error && typeof e.error === "object" ? e.error : undefined) as Record<string, unknown> | undefined;
+    const type = (typeof e.type === "string" ? e.type : undefined) ?? (typeof body?.type === "string" ? body.type : undefined);
+    const message = typeof e.message === "string" ? e.message : "";
+    const status = Number(e.status);
+    if (
+      type === CODEX_USAGE_LIMIT_ERROR_TYPE ||
+      message.includes(CODEX_USAGE_LIMIT_ERROR_TYPE) ||
+      (status === 429 && /usage limit/i.test(message))
+    ) {
+      const resets =
+        (typeof body?.resets_in_seconds === "number" ? body.resets_in_seconds : undefined) ??
+        (typeof e.resets_in_seconds === "number" ? (e.resets_in_seconds as number) : undefined) ??
+        null;
+      return { resetsInSeconds: resets };
+    }
+    cur = e.cause;
+  }
+  return null;
+}
+
+/**
+ * Buffer a non-OK codex Response and re-emit it as a clean `application/json`
+ * Response so the SDK can reconstruct `error.error` from the body. A 429 usage
+ * cap (`error.type === "usage_limit_reached"`) is a HARD limit, not transient
+ * backpressure, so we pin `x-should-retry: false` to stop the SDK retrying it.
+ * Reading the body here also drains the socket of a discarded 401 (no leak).
+ */
+async function bufferCodexErrorResponse(res: Response): Promise<Response> {
+  const bodyText = await res.text().catch(() => "");
+  const headers = new Headers(res.headers);
+  headers.set("content-type", "application/json");
+  headers.delete("content-length"); // body re-serialized
+  headers.delete("content-encoding"); // text() already decoded any gzip
+  let errorType: string | undefined;
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: { type?: unknown } };
+    errorType = typeof parsed.error?.type === "string" ? parsed.error.type : undefined;
+  } catch {
+    /* non-JSON error body — leave as-is, no retry-header override */
+  }
+  if (errorType === CODEX_USAGE_LIMIT_ERROR_TYPE) {
+    headers.set("x-should-retry", "false");
+  }
+  return new Response(bodyText, { status: res.status, statusText: res.statusText, headers });
 }
 
 /**

--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -22,6 +22,30 @@ import type { FetchLike } from "./fetch";
 
 const VALID_TOOL_NAME = /^[a-zA-Z0-9_-]+$/;
 
+// The Responses API rejects a function-tool name longer than 64 chars (it 400s
+// the WHOLE turn). Some namespaced connector tool names exceed this, and the
+// collision-disambiguation suffix only lengthens names, so the mapper must cap
+// length too — not just charset.
+const MAX_TOOL_NAME_LEN = 64;
+
+/** Short, stable, charset-legal hash of a string (djb2 → base36). Deterministic. */
+function shortHash(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) >>> 0; // h * 33 + c, kept unsigned
+  }
+  return h.toString(36);
+}
+
+/** Truncate to <= MAX_TOOL_NAME_LEN, appending `_<hash(original)>` so the result stays unique + deterministic. */
+function capLength(candidate: string, original: string): string {
+  if (candidate.length <= MAX_TOOL_NAME_LEN) {
+    return candidate;
+  }
+  const suffix = `_${shortHash(original)}`;
+  return candidate.slice(0, Math.max(0, MAX_TOOL_NAME_LEN - suffix.length)) + suffix;
+}
+
 /**
  * Maps connector tool names to a Responses-API-legal charset and back. One
  * instance per codex_apps transport (i.e. per turn): tools/list populates it,
@@ -31,18 +55,26 @@ export class ToolNameMapper {
   private readonly sanitizedToOriginal = new Map<string, string>();
   private readonly used = new Set<string>();
 
-  /** Return a legal, unique name for `original`, recording the reverse mapping. */
+  /** Return a legal, unique name (<= 64 chars) for `original`, recording the reverse mapping. */
   sanitize(original: string): string {
     let candidate = VALID_TOOL_NAME.test(original)
       ? original
       : original.replace(/[^a-zA-Z0-9_-]/g, "_") || "tool";
+    // Enforce the Responses-API 64-char cap (stable hash suffix keyed on the
+    // ORIGINAL → deterministic across repeat listings, distinct originals don't
+    // collide after truncation).
+    candidate = capLength(candidate, original);
     // Disambiguate a genuine collision with a DIFFERENT original (never with
-    // the same original — that keeps repeat listings stable/idempotent).
+    // the same original — that keeps repeat listings stable/idempotent). Re-cap
+    // after each suffix so disambiguation never re-breaches the 64-char limit.
     if (this.used.has(candidate) && this.sanitizedToOriginal.get(candidate) !== original) {
       const base = candidate;
       let n = 2;
       do {
-        candidate = `${base}_${n++}`;
+        const suffix = `_${n++}`;
+        candidate = (base.length + suffix.length > MAX_TOOL_NAME_LEN
+          ? base.slice(0, MAX_TOOL_NAME_LEN - suffix.length)
+          : base) + suffix;
       } while (this.used.has(candidate));
     }
     this.used.add(candidate);

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -3,6 +3,7 @@ import {
   type CodexRequestContext,
   type CodexTokenSnapshot,
   type FetchLike,
+  classifyCodexUsageLimitError,
   codexRequestStorage,
   codexSubscriptionFetch,
 } from "../src";
@@ -124,5 +125,79 @@ describe("codexSubscriptionFetch", () => {
     expect(captures[0]?.url).toBe("https://api.openai.com/v1/responses"); // not rewritten
     expect(new Headers(captures[0]?.init?.headers).get("openai-beta")).toBe("x"); // not stripped
     expect(captures[0]?.init?.body).toBe('{"model":"gpt-5.5"}'); // not normalized
+  });
+
+  test("P1-d: a 429 usage_limit_reached is re-emitted as JSON with x-should-retry:false (preserving the body)", async () => {
+    const body = JSON.stringify({ error: { type: "usage_limit_reached", message: "limit hit", resets_in_seconds: 3600 } });
+    const base: FetchLike = async () => new Response(body, { status: 429, headers: { "content-type": "application/json" } });
+    const fetchImpl = codexSubscriptionFetch(base);
+    const res = await codexRequestStorage.run(ctx(), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ model: "gpt-5.5", stream: true, input: [] }) }),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("x-should-retry")).toBe("false");
+    // The JSON error body survives so the SDK can reconstruct error.error (no
+    // "429 status code (no body)").
+    const parsed = JSON.parse(await res.text()) as { error?: { type?: string; resets_in_seconds?: number } };
+    expect(parsed.error?.type).toBe("usage_limit_reached");
+    expect(parsed.error?.resets_in_seconds).toBe(3600);
+  });
+
+  test("P1-d: a generic 5xx error body is preserved WITHOUT forcing x-should-retry", async () => {
+    const base: FetchLike = async () => new Response(JSON.stringify({ error: { type: "server_error", message: "boom" } }), { status: 500, headers: { "content-type": "application/json" } });
+    const fetchImpl = codexSubscriptionFetch(base);
+    const res = await codexRequestStorage.run(ctx(), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ model: "gpt-5.5", stream: true, input: [] }) }),
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get("x-should-retry")).toBeNull(); // only usage caps are pinned non-retryable
+    expect(JSON.parse(await res.text())).toEqual({ error: { type: "server_error", message: "boom" } });
+  });
+
+  test("the 401-refresh retry still fires; the final non-OK error is buffered", async () => {
+    let call = 0;
+    const base: FetchLike = async () => {
+      call += 1;
+      return call === 1
+        ? new Response("unauth", { status: 401, headers: { "content-type": "text/plain" } })
+        : new Response(JSON.stringify({ error: { type: "usage_limit_reached" } }), { status: 429, headers: { "content-type": "application/json" } });
+    };
+    const fetchImpl = codexSubscriptionFetch(base);
+    const res = await codexRequestStorage.run(ctx(), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ model: "gpt-5.5", stream: true, input: [] }) }),
+    );
+    expect(call).toBe(2); // 401 → refresh → retry
+    expect(res.status).toBe(429);
+    expect(res.headers.get("x-should-retry")).toBe("false");
+  });
+});
+
+describe("classifyCodexUsageLimitError", () => {
+  test("detects an OpenAI-shaped 429 usage_limit_reached and extracts the reset window", () => {
+    const err = Object.assign(new Error("429 limit"), { status: 429, type: "usage_limit_reached", error: { type: "usage_limit_reached", resets_in_seconds: 1800 } });
+    expect(classifyCodexUsageLimitError(err)).toEqual({ resetsInSeconds: 1800 });
+  });
+
+  test("detects via the error body type when the top-level type is absent", () => {
+    const err = Object.assign(new Error("boom"), { status: 429, error: { type: "usage_limit_reached" } });
+    expect(classifyCodexUsageLimitError(err)).toEqual({ resetsInSeconds: null });
+  });
+
+  test("walks the cause chain (SDK re-wrap)", () => {
+    const inner = Object.assign(new Error("inner"), { status: 429, error: { type: "usage_limit_reached", resets_in_seconds: 60 } });
+    const outer = Object.assign(new Error("wrapped"), { cause: inner });
+    expect(classifyCodexUsageLimitError(outer)).toEqual({ resetsInSeconds: 60 });
+  });
+
+  test("returns null for a plain rate-limit (no usage cap)", () => {
+    const err = Object.assign(new Error("429 Too Many Requests"), { status: 429, code: "rate_limit_exceeded" });
+    expect(classifyCodexUsageLimitError(err)).toBeNull();
+  });
+
+  test("returns null for non-objects and unrelated errors", () => {
+    expect(classifyCodexUsageLimitError(new Error("nope"))).toBeNull();
+    expect(classifyCodexUsageLimitError("string")).toBeNull();
+    expect(classifyCodexUsageLimitError(null)).toBeNull();
   });
 });

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -40,6 +40,34 @@ describe("ToolNameMapper", () => {
     expect(m.toOriginal(a)).toBe("x.y");
     expect(m.toOriginal(b)).toBe("x_y");
   });
+
+  test("P2-d: caps a >64-char name to <=64 with a stable hash suffix, reverse-mappable", () => {
+    const m = new ToolNameMapper();
+    const long = `connector.${"deploy_a_very_long_namespaced_tool_name_that_blows_the_limit".repeat(2)}`;
+    expect(long.length).toBeGreaterThan(64);
+    const out = m.sanitize(long);
+    expect(out.length).toBeLessThanOrEqual(64);
+    expect(out).toMatch(/^[a-zA-Z0-9_-]+$/); // still charset-legal
+    expect(m.toOriginal(out)).toBe(long); // reverse map keyed on the EMITTED name
+  });
+
+  test("P2-d: the 64-char cap is deterministic across repeat listings (idempotent)", () => {
+    const m = new ToolNameMapper();
+    const long = "ns." + "x".repeat(80);
+    expect(m.sanitize(long)).toBe(m.sanitize(long));
+  });
+
+  test("P2-d: two distinct long names that truncate alike stay distinct + <=64", () => {
+    const m = new ToolNameMapper();
+    const base = "ns." + "y".repeat(80);
+    const a = m.sanitize(`${base}_alpha`);
+    const b = m.sanitize(`${base}_beta`);
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(64);
+    expect(b.length).toBeLessThanOrEqual(64);
+    expect(m.toOriginal(a)).toBe(`${base}_alpha`);
+    expect(m.toOriginal(b)).toBe(`${base}_beta`);
+  });
 });
 
 describe("remapToolCallRequestBody", () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -81,7 +81,22 @@ export type RlsContext = {
 };
 
 export function createDb(databaseUrl: string): DbClient {
-  const client = postgres(databaseUrl, { max: 10 });
+  // `prepare: false` is REQUIRED for Azure Database for PostgreSQL Flexible
+  // Server's transaction-pooling PgBouncer: postgres-js's default named prepared
+  // statements (`s_N`) are bound to one backend, but a transaction pooler hands
+  // each transaction a different backend, so a later `execute` intermittently
+  // throws `prepared statement "s_N" does not exist`. Every RLS read in this
+  // module (set_config + SELECT inside one db.transaction) rides on this pool, so
+  // the failure surfaces as a "worked, then didn't" credential/permission read.
+  // idle_timeout + max_lifetime recycle connections so a pooler-recycled backend
+  // is never reused indefinitely; application_name aids server-side diagnostics.
+  const client = postgres(databaseUrl, {
+    max: 10,
+    prepare: false,
+    idle_timeout: 30,
+    max_lifetime: 1800,
+    connection: { application_name: "opengeni" },
+  });
   return {
     db: drizzle(client, { schema }),
     close: async () => {
@@ -91,6 +106,13 @@ export function createDb(databaseUrl: string): DbClient {
 }
 
 export async function setRlsContext(db: Database, context: RlsContext): Promise<void> {
+  // Fail loud on an empty/blank account id: a "" account would set an RLS GUC
+  // that matches no tenant row, silently returning zero rows from every scoped
+  // read (a phantom "not found" / "no active subscription"). An RLS context with
+  // no account is always a bug at the call site, never a valid query scope.
+  if (typeof context.accountId !== "string" || context.accountId.trim() === "") {
+    throw new Error("setRlsContext: a non-empty accountId is required to establish an RLS context");
+  }
   await db.execute(sql`select set_config('opengeni.account_id', ${context.accountId}, true)`);
   await db.execute(sql`select set_config('opengeni.workspace_id', ${context.workspaceId ?? ""}, true)`);
 }
@@ -101,8 +123,27 @@ export async function withRlsContext<T>(
   fn: (db: Database) => Promise<T>,
 ): Promise<T> {
   return await db.transaction(async (tx) => {
-    await setRlsContext(tx as unknown as Database, context);
-    return await fn(tx as unknown as Database);
+    const scoped = tx as unknown as Database;
+    await setRlsContext(scoped, context);
+    // Defense-in-depth: read the LOCAL GUC back on THIS backend BEFORE running
+    // the scoped query. The set_config and this read share one db.transaction,
+    // which a transaction pooler pins to a single backend — so a mismatch here
+    // means the context was genuinely lost (a torn transaction / pooler backend
+    // swap), not normal operation. Without this guard such an event runs the
+    // scoped read with an empty account_id and returns zero RLS-visible rows,
+    // manufacturing a phantom "no active subscription" from a credential that is
+    // in fact active. Convert that silent false into a loud, root-cause-bearing
+    // error so the caller can retry rather than permanently mis-decide.
+    const applied = await tx.execute<{ account_id: string | null }>(
+      sql`select current_setting('opengeni.account_id', true) as account_id`,
+    );
+    const appliedAccountId = applied[0]?.account_id ?? "";
+    if (appliedAccountId !== context.accountId) {
+      throw new Error(
+        `RLS context not applied on the active backend: expected account ${context.accountId}, got "${appliedAccountId}"`,
+      );
+    }
+    return await fn(scoped);
   });
 }
 
@@ -2015,6 +2056,8 @@ export async function loadWorkspaceEnvironmentForRun(
 export type CodexCredentialTokens = { accessToken: string; refreshToken: string; idToken: string };
 
 export type CodexCredentialForRun = {
+  id: string;                             // row id — for compare-and-set writes (P1-c)
+  version: number;                        // optimistic-concurrency version loaded with this snapshot
   workspaceId: string;
   tokens: CodexCredentialTokens;          // decrypted — never logged, never returned by a route
   chatgptAccountId: string | null;
@@ -2056,6 +2099,13 @@ export async function upsertCodexSubscriptionCredential(db: Database, input: {
     }).onConflictDoUpdate({
       target: [schema.codexSubscriptionCredentials.workspaceId],
       set: {
+        // account_id MUST be re-asserted on conflict. Omitting it leaves a stale
+        // account_id on a row whose owning account changed (e.g. a reconnect
+        // under a different grant), which makes the row RLS-INVISIBLE to every
+        // subsequent scoped read — a permanent phantom "no active subscription".
+        // The caller derives accountId from the workspace, so this keeps the row
+        // aligned with its tenant.
+        accountId: input.accountId,
         credentialEncrypted: input.credentialEncrypted,
         chatgptAccountId: input.chatgptAccountId,
         scopes: input.scopes,
@@ -2103,6 +2153,8 @@ export async function loadCodexCredentialForRun(
       throw new Error(`failed to decrypt codex credential for workspace ${workspaceId}: ${reason}`);
     }
     return {
+      id: row.id,
+      version: row.version,
       workspaceId,
       tokens,
       chatgptAccountId: row.chatgptAccountId,
@@ -2117,15 +2169,26 @@ export async function loadCodexCredentialForRun(
   });
 }
 
-/** Persist rotated tokens after a successful refresh. Caller pre-encrypts. */
+/**
+ * Persist rotated tokens after a successful refresh. Caller pre-encrypts.
+ *
+ * COMPARE-AND-SET (P1-c): the write is guarded by the (id, version) the resolver
+ * loaded. If a disconnect→reconnect replaced/rotated the row between the load and
+ * this write, the guard matches 0 rows and we DO NOT clobber the freshly
+ * reconnected credential with tokens from the now-defunct family. Returns true
+ * iff the guarded row was updated; false means "credential changed under me —
+ * the rotation is moot, drop it."
+ */
 export async function recordCodexTokenRefresh(db: Database, input: {
+  id: string;
+  version: number;
   workspaceId: string;
   credentialEncrypted: string;
   expiresAt: Date | null;
   lastRefreshAt: Date;
-}): Promise<void> {
-  await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
-    await scopedDb.update(schema.codexSubscriptionCredentials).set({
+}): Promise<boolean> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
+    const updated = await scopedDb.update(schema.codexSubscriptionCredentials).set({
       credentialEncrypted: input.credentialEncrypted,
       expiresAt: input.expiresAt,
       lastRefreshAt: input.lastRefreshAt,
@@ -2133,21 +2196,42 @@ export async function recordCodexTokenRefresh(db: Database, input: {
       lastError: null,
       version: sql`${schema.codexSubscriptionCredentials.version} + 1`,
       updatedAt: new Date(),
-    }).where(eq(schema.codexSubscriptionCredentials.workspaceId, input.workspaceId));
+    }).where(and(
+      eq(schema.codexSubscriptionCredentials.id, input.id),
+      eq(schema.codexSubscriptionCredentials.version, input.version),
+    )).returning({ id: schema.codexSubscriptionCredentials.id });
+    return updated.length > 0;
   });
 }
 
-/** Surface a permanent or transient failure on the credential row. */
+/**
+ * Surface a permanent or transient failure on the credential row.
+ *
+ * Optionally COMPARE-AND-SET (P1-c): when `expected` is supplied, the status is
+ * stamped only if the row STILL matches the (id, version) the resolver loaded.
+ * This stops a refresh that began before a disconnect→reconnect from stamping
+ * `needs_relogin` on the brand-new, good credential. Returns true iff a row was
+ * updated. Without `expected` it falls back to the legacy workspace-scoped write.
+ */
 export async function setCodexCredentialStatus(
   db: Database,
   workspaceId: string,
   status: "active" | "needs_relogin" | "error",
   lastError: string | null,
-): Promise<void> {
-  await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
-    await scopedDb.update(schema.codexSubscriptionCredentials)
+  expected?: { id: string; version: number },
+): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const where = expected
+      ? and(
+        eq(schema.codexSubscriptionCredentials.id, expected.id),
+        eq(schema.codexSubscriptionCredentials.version, expected.version),
+      )
+      : eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId);
+    const updated = await scopedDb.update(schema.codexSubscriptionCredentials)
       .set({ status, lastError, updatedAt: new Date() })
-      .where(eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId));
+      .where(where)
+      .returning({ id: schema.codexSubscriptionCredentials.id });
+    return updated.length > 0;
   });
 }
 
@@ -2196,9 +2280,42 @@ export async function workspaceCodexSubscriptionActive(
   if (!settings.codexSubscriptionEnabled) {
     return false;
   }
-  const status = await getCodexCredentialStatus(db, workspaceId);
-  return status?.status === "active";
+  // Bounded re-read. A TRANSIENT read failure (a pooled-connection blip or a
+  // lost RLS GUC — now thrown loud by withRlsContext's read-back guard rather
+  // than silently returning zero rows) must never permanently decide a
+  // genuinely-active subscription is disconnected, which would throw the
+  // fail-loud CodexSubscriptionUnavailableError at model resolution and fail the
+  // turn. Retry only on a THROWN error (the transient signature); a cleanly
+  // returned status — a row (any status) or a confirmed absent row (null) — is
+  // authoritative and resolves immediately, so the common no-subscription turn
+  // pays no extra latency.
+  let lastError: unknown;
+  for (let attempt = 0; attempt < CODEX_ACTIVE_READ_ATTEMPTS; attempt++) {
+    try {
+      const status = await getCodexCredentialStatus(db, workspaceId);
+      return status?.status === "active";
+    } catch (error) {
+      lastError = error;
+      if (attempt < CODEX_ACTIVE_READ_ATTEMPTS - 1) {
+        await new Promise((resolve) => setTimeout(resolve, CODEX_ACTIVE_READ_RETRY_MS * (attempt + 1)));
+      }
+    }
+  }
+  // Every attempt threw: this is a real, persistent read outage, not a one-off
+  // blip. Surface the underlying error (truthful + retryable) instead of
+  // silently denying an active subscription.
+  console.error(
+    `workspaceCodexSubscriptionActive: credential read failed for workspace ${workspaceId} after ${CODEX_ACTIVE_READ_ATTEMPTS} attempts`,
+    lastError,
+  );
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
+
+// Bounded re-read tuning for the codex active-credential check. A handful of
+// attempts with a short linear backoff rides out a transient pooler/RLS blip
+// without materially delaying a genuine outage's failure.
+const CODEX_ACTIVE_READ_ATTEMPTS = 3;
+const CODEX_ACTIVE_READ_RETRY_MS = 50;
 
 /**
  * CANONICAL "is this a Codex-billed turn?" predicate.
@@ -2218,9 +2335,20 @@ export async function isCodexBilledTurn(input: {
   settings: Pick<Settings, "codexSubscriptionEnabled">;
   workspaceId: string;
   model: string | null | undefined;
+  /**
+   * Precomputed `workspaceCodexSubscriptionActive` result (P2-b). When the caller
+   * already resolved the active flag for provider injection, pass it here so the
+   * billed-turn predicate and the routing overlay read the credential ONCE and
+   * cannot disagree across a concurrent disconnect/reconnect — a drift that would
+   * either wrongly debit OpenGeni credits for a ChatGPT-paid turn or the inverse.
+   */
+  active?: boolean;
 }): Promise<boolean> {
   if (!isCodexBilledModel(input.model)) {
     return false; // cheap; no db hit on the common path
+  }
+  if (input.active !== undefined) {
+    return input.active;
   }
   return workspaceCodexSubscriptionActive(input.db, input.settings, input.workspaceId);
 }

--- a/packages/db/test/codex-credentials.test.ts
+++ b/packages/db/test/codex-credentials.test.ts
@@ -12,6 +12,7 @@ import {
   recordCodexTokenRefresh,
   setCodexCredentialStatus,
   upsertCodexSubscriptionCredential,
+  workspaceCodexSubscriptionActive,
   type Database,
   type DbClient,
 } from "../src/index";
@@ -141,15 +142,76 @@ describe("codex_subscription_credentials accessors", () => {
       chatgptAccountId: "acct_x", scopes: null, planType: "pro", isFedramp: false,
       expiresAt: null, lastRefreshAt: null,
     });
-    await recordCodexTokenRefresh(db, {
+    const before = await loadCodexCredentialForRun(db, settings, ws.workspaceId);
+    const ok = await recordCodexTokenRefresh(db, {
+      id: before!.id, version: before!.version,
       workspaceId: ws.workspaceId,
       credentialEncrypted: encTokens({ access_token: "AC2", refresh_token: "RF2", id_token: "ID2" }),
       expiresAt: new Date(Date.now() + 3_600_000), lastRefreshAt: new Date(),
     });
+    expect(ok).toBe(true);
     const loaded = await loadCodexCredentialForRun(db, settings, ws.workspaceId);
     expect(loaded?.tokens.accessToken).toBe("AC2");
     const [row] = await admin<{ version: number }[]>`select version from codex_subscription_credentials where workspace_id = ${ws.workspaceId}`;
     expect(row!.version).toBe(2);
+  });
+
+  test("P1-c: recordCodexTokenRefresh is compare-and-set — a stale (id,version) writes 0 rows", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    await upsertCodexSubscriptionCredential(db, {
+      accountId: ws.accountId, workspaceId: ws.workspaceId,
+      credentialEncrypted: encTokens({ access_token: "AC", refresh_token: "RF", id_token: "ID" }),
+      chatgptAccountId: "acct_x", scopes: null, planType: "pro", isFedramp: false,
+      expiresAt: null, lastRefreshAt: null,
+    });
+    const loaded = await loadCodexCredentialForRun(db, settings, ws.workspaceId);
+    // Wrong version → guard matches no row → false, and the blob is NOT clobbered.
+    const ok = await recordCodexTokenRefresh(db, {
+      id: loaded!.id, version: loaded!.version + 99,
+      workspaceId: ws.workspaceId,
+      credentialEncrypted: encTokens({ access_token: "STALE", refresh_token: "x", id_token: "x" }),
+      expiresAt: null, lastRefreshAt: new Date(),
+    });
+    expect(ok).toBe(false);
+    const after = await loadCodexCredentialForRun(db, settings, ws.workspaceId);
+    expect(after?.tokens.accessToken).toBe("AC"); // untouched
+  });
+
+  test("P1-c: setCodexCredentialStatus honors an (id,version) guard", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    await upsertCodexSubscriptionCredential(db, {
+      accountId: ws.accountId, workspaceId: ws.workspaceId,
+      credentialEncrypted: encTokens({ access_token: "AC", refresh_token: "RF", id_token: "ID" }),
+      chatgptAccountId: "acct_x", scopes: null, planType: "pro", isFedramp: false,
+      expiresAt: null, lastRefreshAt: null,
+    });
+    const loaded = await loadCodexCredentialForRun(db, settings, ws.workspaceId);
+    // Stale guard → no stamp.
+    expect(await setCodexCredentialStatus(db, ws.workspaceId, "needs_relogin", "x", { id: loaded!.id, version: loaded!.version + 1 })).toBe(false);
+    expect((await getCodexCredentialStatus(db, ws.workspaceId))?.status).toBe("active");
+    // Matching guard → stamps.
+    expect(await setCodexCredentialStatus(db, ws.workspaceId, "needs_relogin", "expired", { id: loaded!.id, version: loaded!.version })).toBe(true);
+    expect((await getCodexCredentialStatus(db, ws.workspaceId))?.status).toBe("needs_relogin");
+  });
+
+  test("P2-a: upsert ON CONFLICT re-asserts account_id (keeps the row RLS-visible)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const input = {
+      workspaceId: ws.workspaceId,
+      credentialEncrypted: encTokens({ access_token: "AC", refresh_token: "RF", id_token: "ID" }),
+      chatgptAccountId: "acct_x", scopes: null, planType: "pro", isFedramp: false,
+      expiresAt: null, lastRefreshAt: null,
+    };
+    await upsertCodexSubscriptionCredential(db, { ...input, accountId: ws.accountId });
+    // Conflict-update path: account_id must be present in the SET so the row
+    // stays aligned with its tenant and RLS-visible.
+    await upsertCodexSubscriptionCredential(db, { ...input, accountId: ws.accountId });
+    const [row] = await admin<{ account_id: string }[]>`select account_id from codex_subscription_credentials where workspace_id = ${ws.workspaceId}`;
+    expect(row!.account_id).toBe(ws.accountId);
+    expect(await getCodexCredentialStatus(db, ws.workspaceId)).not.toBeNull();
   });
 
   test("setCodexCredentialStatus transitions to needs_relogin", async () => {
@@ -180,6 +242,27 @@ describe("codex_subscription_credentials accessors", () => {
     expect(await deleteCodexSubscriptionCredential(db, ws.workspaceId)).toBe(true);
     expect(await getCodexCredentialStatus(db, ws.workspaceId)).toBeNull();
     expect(await deleteCodexSubscriptionCredential(db, ws.workspaceId)).toBe(false); // already gone
+  });
+
+  test("workspaceCodexSubscriptionActive: true for an active row, false when absent or non-active", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const enabled = { codexSubscriptionEnabled: true } as Parameters<typeof workspaceCodexSubscriptionActive>[1];
+    // Absent → false (authoritative, no throw).
+    expect(await workspaceCodexSubscriptionActive(db, enabled, ws.workspaceId)).toBe(false);
+    // Flag off → false regardless of row state.
+    expect(await workspaceCodexSubscriptionActive(db, { codexSubscriptionEnabled: false } as typeof enabled, ws.workspaceId)).toBe(false);
+    await upsertCodexSubscriptionCredential(db, {
+      accountId: ws.accountId, workspaceId: ws.workspaceId,
+      credentialEncrypted: encTokens({ access_token: "AC", refresh_token: "RF", id_token: "ID" }),
+      chatgptAccountId: "acct_x", scopes: null, planType: "pro", isFedramp: false,
+      expiresAt: null, lastRefreshAt: null,
+    });
+    // Active → true (the path the bounded re-read protects).
+    expect(await workspaceCodexSubscriptionActive(db, enabled, ws.workspaceId)).toBe(true);
+    // needs_relogin → false (authoritative negative).
+    await setCodexCredentialStatus(db, ws.workspaceId, "needs_relogin", "x");
+    expect(await workspaceCodexSubscriptionActive(db, enabled, ws.workspaceId)).toBe(false);
   });
 
   test("RLS: workspace B cannot read workspace A's credential", async () => {

--- a/packages/db/test/rls-context.test.ts
+++ b/packages/db/test/rls-context.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { setRlsContext, type Database } from "../src/index";
+
+// Pure (no docker): the RLS-context hardening fails LOUD on a missing account id
+// instead of letting a blank GUC silently scope every read to zero rows — the
+// phantom "no active subscription" failure mode this change set targets.
+
+describe("setRlsContext input guard", () => {
+  function dbThatMustNotExecute(): Database {
+    return {
+      execute: async () => {
+        throw new Error("db.execute must not be reached for an invalid accountId");
+      },
+    } as unknown as Database;
+  }
+
+  test("rejects an empty accountId before issuing any query", async () => {
+    await expect(setRlsContext(dbThatMustNotExecute(), { accountId: "" })).rejects.toThrow(/non-empty accountId/);
+  });
+
+  test("rejects a blank/whitespace accountId", async () => {
+    await expect(setRlsContext(dbThatMustNotExecute(), { accountId: "   " })).rejects.toThrow(/non-empty accountId/);
+  });
+
+  test("rejects a non-string accountId", async () => {
+    await expect(setRlsContext(dbThatMustNotExecute(), { accountId: undefined as unknown as string })).rejects.toThrow();
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,6 +23,7 @@ import {
   RunState,
   isOpenAIResponsesRawModelStreamEvent,
   run,
+  Runner,
   setDefaultOpenAIClient,
   setDefaultOpenAIKey,
   setOpenAIResponsesTransport,
@@ -400,10 +401,15 @@ export function resolveTurnModel(
  * `modelProvider` (or the global default). Without this router that re-resolution
  * hits the default client (e.g. Azure) and a registry model 404s
  * ("deployment does not exist"); with it the name resolves back to the right
- * provider. Installed both as the run-scoped `RunConfig.modelProvider` (see
- * runAgentStream) and as the process default (see configureOpenAI), so whichever
- * path the SDK takes, names route correctly. Falls back to the SDK default
- * provider for a model that is in no provider's allow-list.
+ * provider. Installed both as the run-scoped `Runner.config.modelProvider` (every
+ * run in runAgentStream goes through `runScopedRunner(settings)`, built from the
+ * per-turn settings) and as the process default (see configureOpenAI). The
+ * run-scoped instance is the load-bearing one: a `Runner` resolves string model
+ * names against ITS OWN modelProvider, not the lazy global default, so each
+ * concurrent turn routes codex/registry names against its own settings and a
+ * foreign turn's setDefaultModelProvider can never clobber this turn's routing.
+ * The process default remains only as a boot-time fallback. Falls back to the
+ * SDK default provider for a model that is in no provider's allow-list.
  */
 export class MultiProviderModelProvider implements ModelProvider {
   private fallback: OpenAIProvider | undefined;
@@ -1497,7 +1503,7 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       session,
       ...(sessionState ? { sessionState } : {}),
     } as SandboxRunConfig;
-    return await run(agent, prepared.input, ownedRunOptions);
+    return await runScopedRunner(settings).run(agent, prepared.input, ownedRunOptions);
   }
 
   const rawClient = overrides.sandboxClient ?? createSandboxClient(settings, environment);
@@ -1552,7 +1558,29 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       ...(sandboxSessionState ? { sessionState: sandboxSessionState } : {}),
     } as SandboxRunConfig;
   }
-  return await run(agent, prepared.input, runOptions);
+  return await runScopedRunner(settings).run(agent, prepared.input, runOptions);
+}
+
+/**
+ * A per-run `Runner` whose `modelProvider` is built from THIS turn's settings.
+ *
+ * The standalone `run()` uses a process-global default Runner whose modelProvider
+ * is the lazy global default (whatever the last `configureOpenAI` /
+ * `setDefaultModelProvider` installed). The worker runs ~100 activities
+ * concurrently in one process, so a concurrently-starting turn for a DIFFERENT
+ * workspace can overwrite that global between this turn's `configure` and a
+ * per-call `getModel()` during the stream — leaving the global router with no
+ * codex provider and throwing CodexSubscriptionUnavailableError on a
+ * `codex/<slug>` name re-resolution (the SandboxAgent/Modal path drops the Model
+ * instance and re-resolves by NAME). Pinning a run-scoped Runner makes the
+ * mutable global irrelevant to correctness: each concurrent turn resolves names
+ * against its OWN settings (which carry the codex-subscription provider via
+ * withCodexProvider for an active workspace, and the registry providers). The
+ * Runner inherits the SDK's default config for everything else, identical to the
+ * default runner. setDefaultModelProvider remains only as a boot-time fallback.
+ */
+function runScopedRunner(settings: Settings): Runner {
+  return new Runner({ modelProvider: new MultiProviderModelProvider(settings) });
 }
 
 export { MaxTurnsExceededError } from "@openai/agents";

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -230,6 +230,51 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
     expect((thrown as { code?: unknown }).code).toBeUndefined();
   });
 
+  test("P0 regression: a codex-active run provider resolves codex/* even after the GLOBAL default is clobbered by a non-codex turn", async () => {
+    // The staging incident: the worker runs ~100 activities concurrently. A codex
+    // turn injects the codex provider into ITS settings, but a concurrent
+    // non-codex turn's configureOpenAI overwrote the PROCESS-GLOBAL default
+    // provider with settings that have NO codex provider. The fix pins a
+    // run-scoped provider built from the run's OWN settings, so name resolution is
+    // immune to the global clobber. This test simulates the clobber and asserts
+    // the per-run provider still resolves codex/<slug>.
+    const { configureOpenAI } = await import("../src/index");
+    const codexProvider = {
+      kind: "codex-subscription" as const,
+      id: "codex-subscription",
+      label: "Codex (ChatGPT subscription)",
+      api: "responses" as const,
+      baseUrl: "https://chatgpt.com/backend-api",
+      models: [{ id: "codex/gpt-5.5", label: "gpt-5.5", reasoningEffort: true }],
+    };
+    // The codex turn's OWN settings (codex provider injected).
+    const codexSettings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      modelProvidersJson: JSON.stringify([codexProvider]),
+    });
+    // A foreign, concurrent non-codex turn clobbers the process-global default.
+    const nonCodexSettings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+    });
+    // Build the run-scoped provider FIRST (as runScopedRunner does at run start)…
+    const runScopedProvider = new MultiProviderModelProvider(codexSettings);
+    // …then let the foreign turn overwrite the global default provider mid-run.
+    configureOpenAI(nonCodexSettings);
+    // The run-scoped provider resolves codex/* from its own settings — no throw.
+    const model = await runScopedProvider.getModel("codex/gpt-5.5");
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+    // Proof the clobber matters: a provider built from the FOREIGN turn's
+    // (non-codex) settings — i.e. what the process-global default now points at —
+    // would throw on the very same name. The run-scoped provider's immunity is
+    // exactly what the fix buys.
+    const clobberedProvider = new MultiProviderModelProvider(nonCodexSettings);
+    await expect(clobberedProvider.getModel("codex/gpt-5.5")).rejects.toBeInstanceOf(CodexSubscriptionUnavailableError);
+  });
+
   test("falls back to the built-in default provider for a model in no provider's allow-list", async () => {
     // In production configureOpenAI sets a global default key/client; mirror that
     // so the SDK fallback OpenAIProvider can construct a model rather than erroring


### PR DESCRIPTION
## Root cause: process-global model-provider clobber (a concurrency race)

The reconnect "no active Codex subscription is connected" failure was **not** a DB/RLS/credential issue (the credential was active 51s before the turn and reads active now). The real cause, verified from `@openai/agents` 0.11.6 source:

- Turns pass the model to the agent as a **bare name string**, re-resolved at run time via a `ModelProvider`.
- `runtime.configure` installs the per-turn provider into **process-global** SDK state (`setDefaultModelProvider`).
- The worker runs ~100 activities concurrently. A sibling **non-codex** turn's `configure()` overwrites that global between this codex turn's `configure()` and its mid-turn `getModel("codex/gpt-5.5")` → the codex turn resolves against a router with no codex provider → fail-loud. (It also silently mis-routed registry models like Fireworks → Azure 404 — codex was just the loud case.)

**Fix:** route every run through a per-run `Runner({ modelProvider: new MultiProviderModelProvider(settings) })` (`runScopedRunner`), so each turn resolves names against its **own** `capabilitySettings`, immune to any concurrent global mutation. Tested: a run-scoped provider survives a global clobber.

## Proactive hardening (the "find all similar bugs" pass)
- **PgBouncer safety** — `prepare:false` + idle/lifetime on `createDb` for Azure Flexible Server.
- **RLS read-back guards** — `setRlsContext` throws on empty accountId; `withRlsContext` reads the LOCAL GUC back and throws on mismatch (torn transaction → loud, never phantom-empty); `workspaceCodexSubscriptionActive` re-reads only on a *thrown* (transient) error, authoritative on a clean null.
- **Token-refresh CAS** — `recordCodexTokenRefresh`/`setCodexCredentialStatus` are compare-and-set on `(id, version)`; single-flight keyed by credential instance; reconnect fallback. (Also covers multi-account P0.)
- **429 usage-limit UX** — buffers non-OK bodies (kills "status code (no body)"), classifies `usage_limit_reached`, surfaces a precise non-retryable message with a humanized reset window, and **idles** (not fails) the session so a goal resumes after reset. This is the auto-rotation trigger later.
- **Misc** — upsert re-asserts `account_id`; `ToolNameMapper` caps names at 64 chars with a stable hash suffix.

Security preserved: RLS still enforced (guards only tighten; cross-tenant test passes), no prefix-alone billing bypass, no token leak.

## Tests
550 pass / 0 fail across runtime (401), codex (63), worker (50), db (23, incl. FORCE-RLS integration), api (13). Typecheck clean across config/db/codex/runtime/worker/api. Adversarially verified (root cause confirmed from SDK source, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches concurrent model routing, OAuth token refresh/CAS, RLS-scoped credential reads, and turn failure/continuation behavior—core worker and billing paths—with broad test coverage but high blast radius if wrong.
> 
> **Overview**
> Fixes a **concurrency race** where concurrent worker turns overwrote the process-global SDK `modelProvider`, so a `codex/*` turn could re-resolve without the injected Codex provider and fail as “no active subscription.” Agent runs now go through a **per-turn `Runner`** whose `modelProvider` is built from that turn’s settings, so routing no longer depends on shared global state.
> 
> **Codex subscription lifecycle** is tightened end-to-end: token refresh **single-flight** keys on credential `(id, version)` instead of workspace; refresh and `needs_relogin` writes are **compare-and-set** so disconnect/reconnect cannot clobber a new row. The turn reads **active subscription once** and threads it through provider injection and billing. DB pool uses **`prepare: false`** for PgBouncer; **RLS** rejects empty account ids and verifies GUC application; credential upsert **re-asserts `account_id`**; active-credential reads **retry on transient failures**.
> 
> **ChatGPT/Codex usage caps** (`429 usage_limit_reached`): Codex fetch **buffers error bodies** (so the SDK sees JSON + reset window), classifies the cap, surfaces a **non-retryable** user message with a humanized reset time, and **idles** the session (with optional goal continuation delay) instead of terminal failure or generic retry loops. Connector **tool names** are capped at **64 characters** for the Responses API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb514005e09db0fd2329b0d1ffde63d3ec15a67d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->