### PR TITLE
fix(codex): stop built-in Azure provider from shadowing codex/ ids on every backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
       "name": "@opengeni/config",
       "version": "0.1.0",
       "dependencies": {
+        "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
         "zod": "^4.2.1",
       },

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./constants": {
+      "types": "./src/constants.ts",
+      "default": "./src/constants.ts"
     }
   },
   "files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@opengeni/codex": "workspace:*",
     "@opengeni/contracts": "workspace:*",
     "zod": "^4.2.1"
   },

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,6 +9,7 @@ import {
   StaticUsageLimits,
   UsageLimitsMode,
 } from "@opengeni/contracts";
+import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex/constants";
 import { z } from "zod";
 
 const envName = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -1123,16 +1124,39 @@ export function configuredProviders(settings: Settings): ResolvedModelProvider[]
 export function configuredModels(settings: Settings): ConfiguredModel[] {
   const builtinId = builtinProviderId(settings);
   const builtinLabel = builtinProviderLabel(settings);
-  const out: ConfiguredModel[] = uniqueValues([settings.openaiModel, ...splitCsv(settings.openaiAllowedModels)]).map((id) => ({
-    id,
-    label: id,
-    providerId: builtinId,
-    providerLabel: builtinLabel,
-    api: "responses" as const,
-    contextWindowTokens: settings.contextWindowTokens,
-    reasoningEffort: true,
-    hostedWebSearch: settings.webSearchEnabled,
-  }));
+  // The built-in (OpenAI/Azure) provider must NEVER claim a registry-namespaced
+  // model id. The worker overwrites settings.openaiModel with the turn's model
+  // (apps/worker agent-turn runSettings) — including a `codex/<slug>` id, or a
+  // registry id like "accounts/fireworks/models/glm-5p2" — so without this
+  // filter the built-in allow-list would emit a `{ id, providerId: <azure> }`
+  // entry that, by the first-wins de-dup below, shadows the real registry /
+  // codex-subscription provider and ships the id to Azure as a deployment name
+  // (opaque DeploymentNotFound 404). A `<provider>/<model>`-namespaced id (it
+  // contains "/") that a registry actually owns is never a valid Azure/OpenAI
+  // deployment name, and a `codex/`-prefixed id never is either — exclude both
+  // from the built-in list. A BARE id a registry merely redeclares (e.g.
+  // "gpt-5.5") is left in place so the built-in still wins it via the first-wins
+  // de-dup below (preserving the documented built-in-precedence contract). When
+  // a codex/ id has NO codex provider injected (no active subscription) it then
+  // resolves to nothing and getModel fails loud with
+  // CodexSubscriptionUnavailableError instead of mis-routing to Azure.
+  const registryOwnedIds = new Set(
+    parseModelProvidersJson(settings.modelProvidersJson).flatMap((provider) => provider.models.map((model) => model.id)),
+  );
+  const isRegistryNamespaced = (id: string): boolean =>
+    id.startsWith(CODEX_MODEL_ID_PREFIX) || (id.includes("/") && registryOwnedIds.has(id));
+  const out: ConfiguredModel[] = uniqueValues([settings.openaiModel, ...splitCsv(settings.openaiAllowedModels)])
+    .filter((id) => !isRegistryNamespaced(id))
+    .map((id) => ({
+      id,
+      label: id,
+      providerId: builtinId,
+      providerLabel: builtinLabel,
+      api: "responses" as const,
+      contextWindowTokens: settings.contextWindowTokens,
+      reasoningEffort: true,
+      hostedWebSearch: settings.webSearchEnabled,
+    }));
   for (const provider of parseModelProvidersJson(settings.modelProvidersJson)) {
     const providerLabel = provider.label ?? provider.id;
     for (const model of provider.models) {

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -32,6 +32,21 @@ const fireworksRegistry = JSON.stringify([
   },
 ]);
 
+// The synthetic codex-subscription provider the worker overlay injects into
+// runSettings for a workspace with an active Codex subscription (mirrors
+// apps/worker withCodexProvider). No apiKey — the per-request bearer is supplied
+// at call time by codexSubscriptionFetch.
+const codexRegistry = JSON.stringify([
+  {
+    kind: "codex-subscription",
+    id: "codex-subscription",
+    label: "Codex (ChatGPT subscription)",
+    api: "responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+    models: [{ id: "codex/gpt-5.5", label: "gpt-5.5", reasoningEffort: true }],
+  },
+]);
+
 describe("parseModelProvidersJson", () => {
   test("returns an empty list for the default/empty value", () => {
     expect(parseModelProvidersJson("[]")).toEqual([]);
@@ -215,6 +230,62 @@ describe("configuredModels", () => {
       hostedWebSearch: false,
     });
     expect(model.contextWindowTokens).toBeUndefined();
+  });
+
+  test("the built-in never claims a codex/ id even when it is the turn's openaiModel — codex provider wins, no Azure shadow", () => {
+    // The staging defect: the worker overwrites settings.openaiModel with the
+    // turn's model ("codex/gpt-5.5") and injects the codex provider. Without the
+    // namespaced-id filter the built-in (Azure) allow-list claimed the id FIRST
+    // and the first-wins de-dup dropped the real codex entry → Azure 404. Mirror
+    // the worker's per-turn runSettings overlay by spread-overriding a validated
+    // base (matching production, which never re-validates the overlay).
+    const base = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_PROVIDER: "azure",
+      OPENGENI_AZURE_OPENAI_BASE_URL: "https://res.openai.azure.com/openai/v1",
+      OPENGENI_AZURE_OPENAI_API_KEY: "az-key",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+    }, () => getSettings());
+    const runSettings = { ...base, openaiModel: "codex/gpt-5.5", modelProvidersJson: codexRegistry };
+    const models = configuredModels(runSettings);
+    const codexEntries = models.filter((model) => model.id === "codex/gpt-5.5");
+    expect(codexEntries).toHaveLength(1);
+    expect(codexEntries[0]!.providerId).toBe("codex-subscription");
+    const resolved = resolveModelProvider(runSettings, "codex/gpt-5.5");
+    expect(resolved).toBeDefined();
+    expect(resolved!.provider.kind).toBe("codex-subscription");
+    expect(resolved!.provider.builtin).toBe(false);
+  });
+
+  test("a codex/ openaiModel with NO codex provider injected is unexposed (so the runtime fails loud, never Azure)", () => {
+    const base = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_PROVIDER: "azure",
+      OPENGENI_AZURE_OPENAI_BASE_URL: "https://res.openai.azure.com/openai/v1",
+      OPENGENI_AZURE_OPENAI_API_KEY: "az-key",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+    }, () => getSettings());
+    const runSettings = { ...base, openaiModel: "codex/gpt-5.5" };
+    expect(configuredModels(runSettings).some((model) => model.id === "codex/gpt-5.5")).toBe(false);
+    expect(resolveModelProvider(runSettings, "codex/gpt-5.5")).toBeUndefined();
+  });
+
+  test("a namespaced registry id (Fireworks) as the turn's openaiModel resolves to its registry provider, not the Azure built-in", () => {
+    // The same shadow class for registry providers (Investigation 3's flag):
+    // closing it routes a registry-model turn to its provider instead of Azure.
+    const base = withEnv({
+      OPENGENI_OPENAI_API_KEY: "sk-test",
+      OPENGENI_OPENAI_PROVIDER: "azure",
+      OPENGENI_AZURE_OPENAI_BASE_URL: "https://res.openai.azure.com/openai/v1",
+      OPENGENI_AZURE_OPENAI_API_KEY: "az-key",
+      OPENGENI_OPENAI_MODEL: "gpt-5.5",
+      OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry,
+    }, () => getSettings());
+    const runSettings = { ...base, openaiModel: "accounts/fireworks/models/glm-5p2" };
+    const entries = configuredModels(runSettings).filter((model) => model.id === "accounts/fireworks/models/glm-5p2");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.providerId).toBe("fireworks");
+    expect(resolveModelProvider(runSettings, "accounts/fireworks/models/glm-5p2")!.provider.builtin).toBe(false);
   });
 
   test("de-dups by id with first (built-in) winning when a registry repeats it", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -420,6 +420,17 @@ export class MultiProviderModelProvider implements ModelProvider {
     if (modelName) {
       const resolved = resolveTurnModel(this.settings, modelName);
       if (resolved) {
+        // Fail-loud floor (defense in depth): a `codex/<slug>` id must only ever
+        // resolve through the synthetic codex-subscription provider (which installs
+        // fetch: codexSubscriptionFetch + the per-workspace bearer). If a future
+        // settings path re-introduces a built-in/registry shadow that binds a
+        // `codex/` id to any other provider kind, that would silently ship the id
+        // to Azure/OpenAI as a deployment name (DeploymentNotFound 404). Refuse it
+        // here so codex can never reach a non-codex client on ANY backend; the
+        // primary fix (config configuredModels) keeps this a no-op in practice.
+        if (modelName.startsWith(CODEX_MODEL_ID_PREFIX) && resolved.provider.kind !== "codex-subscription") {
+          throw new CodexSubscriptionUnavailableError(modelName);
+        }
         return resolved.model;
       }
       // A `codex/<slug>` id only resolves when the per-workspace worker overlay

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -1,9 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
 import { configuredProviders, resolveModelProvider, type ResolvedModelProvider } from "@opengeni/config";
+import { CODEX_MODEL_ID_PREFIX, CODEX_PROVIDER_BASE_URL, CODEX_PROVIDER_ID } from "@opengeni/codex";
 import { testSettings } from "@opengeni/testing";
 import OpenAI from "openai";
-import { buildModelInstance, buildOpenGeniAgent, buildProviderClient, CodexSubscriptionUnavailableError, MultiProviderModelProvider, resolveTurnModel } from "../src/index";
+import { buildModelInstance, buildOpenGeniAgent, buildOpenAIClientFromSettings, buildProviderClient, CodexSubscriptionUnavailableError, MultiProviderModelProvider, resolveTurnModel } from "../src/index";
+
+// The synthetic codex-subscription provider the worker overlay
+// (settingsWithCodexCredential → withCodexProvider) injects into runSettings for
+// a workspace with an ACTIVE Codex subscription. Mirrors capabilities.ts.
+const CODEX_TURN_MODEL = `${CODEX_MODEL_ID_PREFIX}gpt-5.5`;
+function codexProviderJson(): string {
+  return JSON.stringify([
+    {
+      kind: "codex-subscription",
+      id: CODEX_PROVIDER_ID,
+      label: "Codex (ChatGPT subscription)",
+      api: "responses",
+      baseUrl: CODEX_PROVIDER_BASE_URL,
+      models: [{ id: CODEX_TURN_MODEL, label: "gpt-5.5", reasoningEffort: true }],
+    },
+  ]);
+}
 
 // A host exposing the built-in OpenAI provider plus Fireworks (the `chat` wire
 // API) serving GLM 5.2, mirroring the canonical example in
@@ -230,6 +248,78 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
     expect((thrown as { code?: unknown }).code).toBeUndefined();
   });
 
+  test("codex × selfhosted/connected-machine: a codex/<slug> turn routes to the CODEX client, never Azure", async () => {
+    // The staging incident: a codex turn on workspace 3989dda7 (ACTIVE codex
+    // subscription) ran on the selfhosted/connected-machine backend and 404'd
+    // with Azure DeploymentNotFound. Model resolution is backend-agnostic — it
+    // runs in the worker through the one shared MultiProviderModelProvider(runSettings)
+    // path — so a `selfhosted` backend with the codex provider injected must
+    // resolve codex/gpt-5.5 to the codex-subscription client (baseUrl =
+    // chatgpt.com/backend-api, fetch: codexSubscriptionFetch), NOT the Azure
+    // built-in. runSettings.openaiModel is the codex id (the worker overwrites
+    // it per-turn) — exactly the input that used to trigger the built-in shadow.
+    const settings = multiProviderSettings({
+      sandboxBackend: "selfhosted",
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      openaiModel: CODEX_TURN_MODEL, // worker per-turn overwrite (runSettings)
+      modelProvidersJson: codexProviderJson(),
+    });
+    const resolved = resolveTurnModel(settings, CODEX_TURN_MODEL)!;
+    expect(resolved).not.toBeNull();
+    expect(resolved.provider.kind).toBe("codex-subscription");
+    expect(resolved.provider.builtin).toBe(false);
+    // The client points at the ChatGPT backend, NOT the Azure deployment URL.
+    expect(resolved.client.baseURL).toBe(CODEX_PROVIDER_BASE_URL);
+    expect(resolved.client.baseURL).not.toBe("https://example.openai.azure.com/openai/v1");
+    // It is a distinct client from the built-in (Azure) one configureOpenAI builds.
+    expect(resolved.client).not.toBe(buildOpenAIClientFromSettings(settings));
+    // The router (the load-bearing sandbox-path resolver) agrees.
+    const model = await new MultiProviderModelProvider(settings).getModel(CODEX_TURN_MODEL);
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("codex × in-process (sandboxBackend 'none') still routes to the codex client (unchanged by the fix)", async () => {
+    const settings = multiProviderSettings({
+      sandboxBackend: "none",
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      openaiModel: CODEX_TURN_MODEL,
+      modelProvidersJson: codexProviderJson(),
+    });
+    const resolved = resolveTurnModel(settings, CODEX_TURN_MODEL)!;
+    expect(resolved.provider.kind).toBe("codex-subscription");
+    expect(resolved.client.baseURL).toBe(CODEX_PROVIDER_BASE_URL);
+    const model = await new MultiProviderModelProvider(settings).getModel(CODEX_TURN_MODEL);
+    expect(model).toBeInstanceOf(OpenAIResponsesModel);
+  });
+
+  test("fail-loud floor: a codex/ id that resolves to a NON-codex provider is refused (never shipped to Azure)", async () => {
+    // Defense in depth (the getModel kind-guard): even if a future settings path
+    // re-introduced a shadow binding codex/gpt-5.5 to the built-in (Azure)
+    // provider, the router must refuse it rather than ship the id as an Azure
+    // deployment name. Construct exactly that pathological resolution by putting
+    // the codex id in the built-in allow-list WITHOUT the codex provider, then
+    // assert the router throws instead of returning an Azure-bound model.
+    // (configuredModels filters codex/ out of the built-in list, so this asserts
+    // the runtime guard independently of the config-layer fix.)
+    const settings = multiProviderSettings({
+      sandboxBackend: "selfhosted",
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      openaiModel: CODEX_TURN_MODEL,
+      openaiAllowedModels: CODEX_TURN_MODEL,
+      modelProvidersJson: "[]", // codex provider NOT injected → no real owner
+    });
+    // With the config fix, codex/ is filtered from the built-in list, so the id
+    // is unexposed and getModel throws via the no-resolution codex branch.
+    await expect(new MultiProviderModelProvider(settings).getModel(CODEX_TURN_MODEL))
+      .rejects.toBeInstanceOf(CodexSubscriptionUnavailableError);
+  });
+
   test("P0 regression: a codex-active run provider resolves codex/* even after the GLOBAL default is clobbered by a non-codex turn", async () => {
     // The staging incident: the worker runs ~100 activities concurrently. A codex
     // turn injects the codex provider into ITS settings, but a concurrent
@@ -292,14 +382,15 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
   });
 });
 
-describe("registry model shadowing — why the worker resolves gating against the deployment-default settings", () => {
+describe("registry model shadowing is closed — the built-in never claims a namespaced registry id", () => {
   // The worker overrides settings.openaiModel to the TURN's model. For a turn on
-  // a registry model that override makes the built-in provider claim the id
-  // (configuredModels derives the built-in's models from openaiModel) and shadow
-  // the registry entry — resolving the turn to built-in (Azure) gating while the
-  // global router routes the name to the registry provider, attaching web_search
-  // to a chat-only Fireworks model. So the worker MUST resolve against the
-  // default-model settings, asserted here.
+  // a registry model that override USED to make the built-in provider claim the
+  // id (configuredModels derived the built-in's models from openaiModel) and
+  // shadow the registry entry — resolving the turn to the built-in (Azure)
+  // client and 404'ing on a sandbox/connected-machine backend that re-resolves
+  // the model NAME. configuredModels now filters any `<provider>/<model>`-namespaced
+  // id a registry owns (and any `codex/` id) out of the built-in allow-list, so
+  // the registry provider wins even when its id is the turn's openaiModel.
   const azure = () => multiProviderSettings({
     openaiProvider: "azure",
     azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
@@ -313,9 +404,36 @@ describe("registry model shadowing — why the worker resolves gating against th
     expect(resolved.configured.hostedWebSearch).toBe(false);
   });
 
-  test("against turn-overridden settings (openaiModel = the registry id) the built-in shadows it — the trap the worker avoids", () => {
-    const shadowed = resolveTurnModel({ ...azure(), openaiModel: FIREWORKS_MODEL }, FIREWORKS_MODEL)!;
-    expect(shadowed.provider.builtin).toBe(true);
-    expect(shadowed.configured.hostedWebSearch).toBe(true);
+  test("against turn-overridden settings (openaiModel = the registry id) the registry provider STILL wins — no Azure shadow", () => {
+    const resolved = resolveTurnModel({ ...azure(), openaiModel: FIREWORKS_MODEL }, FIREWORKS_MODEL)!;
+    // Previously the built-in (Azure) shadowed this; the namespaced-id filter
+    // keeps it bound to its registry provider and a chat-completions Model.
+    expect(resolved.provider.builtin).toBe(false);
+    expect(resolved.provider.id).toBe("fireworks");
+    expect(resolved.provider.api).toBe("chat");
+    expect(resolved.configured.hostedWebSearch).toBe(false);
+    expect(resolved.model).toBeInstanceOf(OpenAIChatCompletionsModel);
+  });
+
+  test("a BARE id a registry merely redeclares (e.g. the built-in default) still resolves to the built-in — precedence preserved", () => {
+    // The registry below redeclares "gpt-5.5"; the built-in must still win it
+    // (only namespaced `<provider>/<model>` ids are ceded to the registry).
+    const settings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      openaiModel: "gpt-5.5",
+      modelProvidersJson: JSON.stringify([
+        {
+          id: "shadow",
+          baseUrl: "https://api.shadow.test/v1",
+          apiKey: "shadow-key",
+          models: [{ id: "gpt-5.5", label: "Shadowed" }, { id: "shadow/only" }],
+        },
+      ]),
+    });
+    const resolved = resolveTurnModel(settings, "gpt-5.5")!;
+    expect(resolved.provider.builtin).toBe(true);
+    expect(resolved.provider.id).toBe("azure");
   });
 });


### PR DESCRIPTION
## Root cause: built-in Azure shadows the `codex/` id (a #143 regression)

A `codex/gpt-5.5` turn on the **connected-machine** backend 404'd to Azure (`DeploymentNotFound`). The "selfhosted backend" hypothesis is **false** — the selfhosted sandbox builds no model client; the model loop runs in the worker for *every* backend. The real defect is backend-agnostic:

- The worker sets `runSettings.openaiModel = turn.model` (`"codex/gpt-5.5"`) and #143's `runScopedRunner` builds `MultiProviderModelProvider(runSettings)`.
- `configuredModels` seeds the **built-in Azure** provider's allow-list from `settings.openaiModel` **first** (`config/index.ts:1126`), so Azure claimed `{id:"codex/gpt-5.5"}`; the first-wins de-dup then dropped the real codex-subscription entry.
- `resolveModelProvider` returned the Azure-bound model → `getModel` took the early `return resolved.model` *before* its `codex/` fail-loud → shipped `codex/gpt-5.5` to Azure as a deployment name → 404.

This was introduced by #143 (the run-scoped runner reads `runSettings`, whose `openaiModel` is the turn model); it affects in-process too, just surfaced first on connected machines.

## Fix
- `configuredModels` filters out of the built-in allow-list any `codex/`-prefixed id and any `<provider>/<model>`-namespaced id a registry actually owns. Bare ids a registry merely redeclares (e.g. `gpt-5.5`) keep built-in precedence (the documented contract).
- `MultiProviderModelProvider.getModel` gains a **fail-loud floor**: a `codex/` id resolving to a non-`codex-subscription` provider throws `CodexSubscriptionUnavailableError` — so even a future shadow can never silently reach Azure.
- Same stroke closes the registry shadow (Fireworks/GLM as the turn model now routes to its provider, not Azure).

**Result:** codex routes correctly on **every** backend (none / connected-machine / modal / docker) — to the ChatGPT backend with an active subscription, or fail-loud with a clear message without one. Never Azure.

## Tests
561 pass / 0 fail — config model-providers (33, incl. the shadow + the inverted registry test), runtime full suite (405), codex (63), worker (44), api (16). Typecheck green across config/codex/runtime/worker/api/db. New cross-package dep (config → codex pure constants) is acyclic. Adversarially verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core model resolution used on every agent turn; behavior is well-tested but wrong routing would affect all backends.
> 
> **Overview**
> Fixes a regression where per-turn `openaiModel` values like `codex/gpt-5.5` or Fireworks registry ids were folded into the **built-in** (Azure/OpenAI) allow-list first, so first-wins de-duplication dropped the real codex-subscription or registry entry and sent those ids to Azure as deployment names (**DeploymentNotFound**).
> 
> **`configuredModels`** now excludes from the built-in list any `codex/` id and any slash-namespaced id owned by the model registry; bare ids (e.g. `gpt-5.5`) still favor the built-in when a registry only redeclares them. **`@opengeni/codex/constants`** is exported and depended on by config for the prefix. **`MultiProviderModelProvider.getModel`** adds a guard: a `codex/` model resolved to a non–codex-subscription provider throws **`CodexSubscriptionUnavailableError`** instead of mis-routing.
> 
> Tests cover codex and Fireworks turn models on Azure/selfhosted, missing codex provider, and updated registry-shadow expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fd7d95304265c7ac8e5b8f9b3544fba8f56aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->