### PR TITLE
feat(codex): multi-account P3 — opt-in auto-rotation (proactive + reactive 429 turn-boundary failover)

### DIFF
--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -37,8 +37,11 @@ import {
   loadCodexCredentialForRun,
   renameCodexAccount,
   setActiveCodexCredential,
+  updateCodexRotationSettings,
   upsertCodexSubscriptionCredential,
+  CODEX_ROTATION_STRATEGIES,
   type CodexAccountStatus,
+  type CodexRotationStrategy,
 } from "@opengeni/db";
 
 // The picker surfaces codex models under their own "no credits" provider group so
@@ -63,6 +66,8 @@ function codexAccountJson(row: CodexAccountStatus) {
     fiveHour: buildCodexUsageWindowFromCache(row.primaryUsedPercent, row.primaryResetAt, CODEX_FIVE_HOUR_WINDOW_SECONDS),
     weekly: buildCodexUsageWindowFromCache(row.secondaryUsedPercent, row.secondaryResetAt, CODEX_WEEKLY_WINDOW_SECONDS),
     usageCheckedAt: row.usageCheckedAt,
+    // P3 rotation cooldown: when set and in the future, this account is cooling-down.
+    exhaustedUntil: row.exhaustedUntil,
   };
 }
 
@@ -258,6 +263,37 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(404, { message: "codex account not found" });
     }
     return c.json({ activated: true, accountId });
+  });
+
+  // P3: update rotation settings (enable auto-rotation + pick the strategy). admin access.
+  // ensureCodexRotationSettings guarantees the row exists, then a one-cell patch.
+  app.patch("/v1/workspaces/:workspaceId/codex/settings", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+    const body = (await c.req.json().catch(() => ({}))) as { rotationEnabled?: unknown; rotationStrategy?: unknown };
+    const patch: { rotationEnabled?: boolean; rotationStrategy?: CodexRotationStrategy } = {};
+    if (typeof body.rotationEnabled === "boolean") {
+      patch.rotationEnabled = body.rotationEnabled;
+    }
+    if (typeof body.rotationStrategy === "string") {
+      if (!CODEX_ROTATION_STRATEGIES.includes(body.rotationStrategy as CodexRotationStrategy)) {
+        throw new HTTPException(400, { message: "invalid rotation strategy" });
+      }
+      patch.rotationStrategy = body.rotationStrategy as CodexRotationStrategy;
+    }
+    if (patch.rotationEnabled === undefined && patch.rotationStrategy === undefined) {
+      throw new HTTPException(400, { message: "no settings to update" });
+    }
+    await ensureCodexRotationSettings(db, grant.accountId, workspaceId);
+    const updated = await updateCodexRotationSettings(db, workspaceId, patch);
+    if (!updated) {
+      throw new HTTPException(404, { message: "codex rotation settings not found" });
+    }
+    return c.json({
+      rotationEnabled: updated.rotationEnabled,
+      rotationStrategy: updated.rotationStrategy,
+      activeCredentialId: updated.activeCredentialId,
+    });
   });
 
   // Rename an account (label only in P1).

--- a/apps/api/test/codex-usage-routes.test.ts
+++ b/apps/api/test/codex-usage-routes.test.ts
@@ -62,6 +62,7 @@ function account(id: string, over: Partial<opengeniDb.CodexAccountStatus> = {}):
     secondaryUsedPercent: null,
     secondaryResetAt: null,
     usageCheckedAt: null,
+    exhaustedUntil: null,
     ...over,
   };
 }
@@ -189,5 +190,67 @@ describe("GET /codex/usage — back-compat, repointed through the refreshing wra
       headers: { authorization: await bearer(["workspace:read"]) },
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// P3: PATCH /codex/settings — the rotation toggle/strategy write path. db accessors
+// are spied (poison db), so the route's validation + permission gate is what's tested.
+describe("PATCH /codex/settings — rotation settings", () => {
+  function spySettings(): { ensure: ReturnType<typeof spyOn>; update: ReturnType<typeof spyOn> } {
+    const ensure = spyOn(opengeniDb, "ensureCodexRotationSettings").mockResolvedValue(undefined);
+    const update = spyOn(opengeniDb, "updateCodexRotationSettings").mockResolvedValue({
+      activeCredentialId: ID_A,
+      rotationEnabled: true,
+      rotationStrategy: "most_remaining",
+    });
+    restores.push(() => ensure.mockRestore());
+    restores.push(() => update.mockRestore());
+    return { ensure, update };
+  }
+
+  test("enables rotation and returns the effective settings", async () => {
+    const { ensure, update } = spySettings();
+    const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
+      method: "PATCH",
+      headers: { authorization: await bearer(["workspace:admin"]), "content-type": "application/json" },
+      body: JSON.stringify({ rotationEnabled: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rotationEnabled: boolean; rotationStrategy: string };
+    expect(body.rotationEnabled).toBe(true);
+    expect(body.rotationStrategy).toBe("most_remaining");
+    expect(ensure).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(expect.anything(), WS, { rotationEnabled: true });
+  });
+
+  test("rejects an unknown strategy with 400 (never reaches the db)", async () => {
+    const { update } = spySettings();
+    const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
+      method: "PATCH",
+      headers: { authorization: await bearer(["workspace:admin"]), "content-type": "application/json" },
+      body: JSON.stringify({ rotationStrategy: "bogus" }),
+    });
+    expect(res.status).toBe(400);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("an empty patch is a 400 (no settings to update)", async () => {
+    spySettings();
+    const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
+      method: "PATCH",
+      headers: { authorization: await bearer(["workspace:admin"]), "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("requires workspace:admin (read-only token is 403/401)", async () => {
+    spySettings();
+    const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
+      method: "PATCH",
+      headers: { authorization: await bearer(["workspace:read"]), "content-type": "application/json" },
+      body: JSON.stringify({ rotationEnabled: true }),
+    });
+    expect([401, 403]).toContain(res.status);
   });
 });

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -3,7 +3,7 @@
 // unpinned sessions use), inline rename, per-account refresh/disconnect, and
 // "connect another". A connected `codex/*` model run uses the active/pinned
 // subscription instead of spending API credits.
-import type { CodexAccount, CodexAccountsResponse, CodexUsage, CodexUsageMap, CodexUsageWindow } from "@opengeni/sdk";
+import type { CodexAccount, CodexAccountsResponse, CodexRotationSettings, CodexUsage, CodexUsageMap, CodexUsageWindow } from "@opengeni/sdk";
 import { ExternalLinkIcon, Loader2Icon, PlusIcon, RefreshCwIcon, SparklesIcon, Trash2Icon, TriangleAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -261,6 +261,20 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
     }
   }, [client, workspaceId, refreshAccounts]);
 
+  // P3: enable/disable auto-rotation or change the strategy, then re-read settings.
+  const setRotation = useCallback(async (patch: { rotationEnabled?: boolean; rotationStrategy?: CodexRotationSettings["rotationStrategy"] }) => {
+    setBusy(true);
+    try {
+      await client.setCodexRotationSettings(workspaceId, patch);
+      await refreshAccounts();
+      toast.success("Rotation settings updated");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update rotation");
+    } finally {
+      setBusy(false);
+    }
+  }, [client, workspaceId, refreshAccounts]);
+
   const disconnect = useCallback(async (accountId: string) => {
     setBusy(true);
     try {
@@ -289,6 +303,13 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
 
   const accounts = data?.accounts ?? [];
   const activeAccountId = data?.activeAccountId ?? null;
+  const rotationEnabled = data?.settings?.rotationEnabled ?? false;
+  const rotationStrategy = data?.settings?.rotationStrategy ?? "most_remaining";
+  const ROTATION_STRATEGY_LABELS: Record<CodexRotationSettings["rotationStrategy"], string> = {
+    most_remaining: "most remaining quota",
+    round_robin: "round-robin",
+    drain_then_next: "drain then next",
+  };
 
   return (
     <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
@@ -309,6 +330,39 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
           </Button>
         ) : null}
       </div>
+
+      {accounts.length > 1 && canManage ? (
+        <div className="grid gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3">
+          <label className="flex cursor-pointer items-center justify-between gap-3">
+            <span className="text-xs">
+              <span className="font-medium">Auto-rotate subscriptions</span>
+              <span className="ml-1 text-[color:var(--color-fg-subtle)]">— fail over to another plan when one hits its cap, never mid-turn.</span>
+            </span>
+            <input
+              type="checkbox"
+              className="size-4 accent-[color:var(--color-brand)]"
+              checked={rotationEnabled}
+              disabled={busy}
+              onChange={(e) => void setRotation({ rotationEnabled: e.target.checked })}
+            />
+          </label>
+          {rotationEnabled ? (
+            <label className="flex items-center justify-between gap-3 text-xs">
+              <span className="text-[color:var(--color-fg-muted)]">Strategy</span>
+              <select
+                className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1 text-xs"
+                value={rotationStrategy}
+                disabled={busy}
+                onChange={(e) => void setRotation({ rotationStrategy: e.target.value as CodexRotationSettings["rotationStrategy"] })}
+              >
+                <option value="most_remaining">Most remaining quota</option>
+                <option value="round_robin">Round-robin</option>
+                <option value="drain_then_next">Drain then next</option>
+              </select>
+            </label>
+          ) : null}
+        </div>
+      ) : null}
 
       {loading ? (
         <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-subtle)]"><Loader2Icon className="size-3.5 animate-spin" /> Loading subscriptions…</div>
@@ -385,9 +439,26 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                       {account.plan} plan
                     </span>
                   ) : null}
-                  {isActive ? (
-                    <span className="shrink-0 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">Active</span>
-                  ) : null}
+                  {(() => {
+                    const coolingSecs = account.exhaustedUntil
+                      ? Math.max(0, Math.round((new Date(account.exhaustedUntil).getTime() - now) / 1000))
+                      : 0;
+                    if (coolingSecs > 0) {
+                      return (
+                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-300" title="Rotated off after hitting its cap; skipped until reset">
+                          cooling down · {resetLabel(coolingSecs)}
+                        </span>
+                      );
+                    }
+                    if (isActive) {
+                      return (
+                        <span className="shrink-0 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+                          {rotationEnabled ? "Active · default when idle" : "Active"}
+                        </span>
+                      );
+                    }
+                    return null;
+                  })()}
                 </div>
                 {needsRelogin ? (
                   <div className="flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-200">
@@ -422,7 +493,11 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
             );
           })}
           <p className="text-[11px] text-[color:var(--color-fg-subtle)]">
-            The <span className="font-medium">active</span> subscription runs every session that isn't pinned to a specific one.
+            {rotationEnabled ? (
+              <>Auto-rotating across {accounts.length} subscriptions by <span className="font-medium">{ROTATION_STRATEGY_LABELS[rotationStrategy]}</span>. Pinned sessions stay on their pin.</>
+            ) : (
+              <>The <span className="font-medium">active</span> subscription runs every session that isn't pinned to a specific one.</>
+            )}
           </p>
         </div>
       )}

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -16,6 +16,8 @@ import {
   listCodexAccountStatuses,
   getSessionCodexState,
   recordSessionActiveCodexCredential,
+  setActiveCodexCredential,
+  setCodexCredentialExhausted,
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
@@ -49,6 +51,7 @@ import {
 import { calculateModelUsageCostMicros, configuredModelPricing, configuredStaticUsageLimits, sandboxWarmRateMicrosPerSecond, type ModelUsageInput, type Settings } from "@opengeni/config";
 import { CancelledFailure } from "@temporalio/activity";
 import { settingsWithCodexCredential, settingsWithEnabledCapabilityMcpServers } from "./capabilities";
+import { chooseRotationActive, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
 import { buildCodexTokenResolver } from "./codex-auth";
 import {
   buildModelResolver,
@@ -547,18 +550,74 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           getSessionCodexState(db, input.workspaceId, input.sessionId),
         ]);
         const connectedIds = new Set(accounts.map((account) => account.id));
+        const sessionPin = sessionCodex?.pinnedCredentialId ?? null;
+        // The off-path / P1 default: today's workspace active pointer. Untouched
+        // when rotation is off or the session is pinned (byte-identical to P1).
+        let chosenActive = rotation?.activeCredentialId ?? null;
+        let rotationDecision: RotationDecision | null = null;
+
+        // P3 auto-rotation: the ONLY new branch, gated on rotation_enabled and
+        // pin-guarded (a pinned session NEVER rotates). When skipped, chosenActive
+        // stays the active pointer and selectCodexCredentialForTurn is called with
+        // byte-identical arguments to today — zero added cost on non-rotation turns.
+        if (rotation?.rotationEnabled && sessionPin == null) {
+          rotationDecision = chooseRotationActive({
+            rotationStrategy: rotation.rotationStrategy as CodexRotationStrategy,
+            activeCredentialId: rotation.activeCredentialId,
+            priorCredentialId: sessionCodex?.lastCredentialId ?? null,
+            accounts,
+            nearExhaustionPct: settings.codexRotationNearExhaustionPct,
+            now: new Date(),
+          });
+          if (rotationDecision.kind === "active") {
+            if (rotationDecision.moved) {
+              // The single authoritative pointer-move site: persist the new active.
+              await setActiveCodexCredential(db, input.workspaceId, rotationDecision.credentialId);
+            }
+            chosenActive = rotationDecision.credentialId;
+          } else if (rotationDecision.kind === "allCapped" && publish && turnId) {
+            // Every eligible account is capped/cooling: idle the turn AT THE BOUNDARY
+            // (no wasted model/sandbox build) until the EARLIEST reset across all
+            // accounts — the multi-account generalization of #143's single-account
+            // idle-until-reset. No saveRunState: no model ran, nothing to freeze.
+            const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
+            const goalActive = Boolean(goal && goal.status === "active");
+            const resumeMs = Math.min(
+              Math.max(0, rotationDecision.earliestResetAt.getTime() - Date.now()),
+              CODEX_USAGE_LIMIT_MAX_RESUME_MS,
+            );
+            const failurePayload = codexUsageLimitFailurePayload(
+              { resetsInSeconds: Math.ceil(resumeMs / 1000) },
+              "all connected Codex subscriptions are rate-limited",
+              { allAccounts: true },
+            );
+            await publish([
+              { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved: false } },
+              { type: "session.status.changed", payload: { status: "idle" } },
+            ], true);
+            await finishTurn(db, input.workspaceId, turnId, "failed");
+            await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
+            activityStatus = "idle";
+            return goalActive ? { status: "idle", continueDelayMs: resumeMs } : { status: "idle" };
+          }
+          // kind:"none" (no accounts) → chosenActive stays null → existing relogin path.
+        }
+
         effectiveCodexCredentialId = selectCodexCredentialForTurn({
-          sessionPinnedCredentialId: sessionCodex?.pinnedCredentialId ?? null,
-          activeCredentialId: rotation?.activeCredentialId ?? null,
+          sessionPinnedCredentialId: sessionPin,    // pin still wins, structurally
+          activeCredentialId: chosenActive,         // rotation-choice OR today's active
           connectedIds,
         });
         if (effectiveCodexCredentialId) {
           const priorAccountId = sessionCodex?.lastCredentialId ?? null;
           await recordSessionActiveCodexCredential(db, input.workspaceId, input.sessionId, effectiveCodexCredentialId);
           if (priorAccountId !== effectiveCodexCredentialId) {
+            // "rotation" only when the engine actually moved the pointer; otherwise the
+            // unchanged P1 "manual" literal (a manual active flip between turns).
+            const rotated = rotationDecision?.kind === "active" && rotationDecision.moved;
             await publish([{
               type: "codex.account.switched",
-              payload: { fromAccountId: priorAccountId, toAccountId: effectiveCodexCredentialId, reason: "manual" },
+              payload: { fromAccountId: priorAccountId, toAccountId: effectiveCodexCredentialId, reason: rotated ? "rotation" : "manual" },
             }]);
           }
         }
@@ -1395,9 +1454,67 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             frozenCodexCredentialId: effectiveCodexCredentialId,
           });
         }
-        const failurePayload = codexUsageLimitFailurePayload(usageLimit, error instanceof Error ? error.message : String(error));
+        // --- P3 reactive rotation (gated; re-fetch fresh state on this already-failed,
+        // already-idling path). Mark THIS account cooling until its reset, then CONSULT the
+        // engine over fresh accounts to decide continueDelayMs: a fast 0-delay re-dispatch
+        // when another account is available, or idle-until-earliest when all are capped. The
+        // catch deliberately does NOT move the active pointer — the re-dispatched turn's
+        // proactive seam (turn-start) is the single authoritative pointer-move + strip site.
+        let rotated = false;
+        let rotationResumeMs: number | null = null;     // 0 ⇒ a candidate is available; re-dispatch now
+        let allCappedResetAt: Date | null = null;       // set ⇒ every account capped; idle until this
+        if (effectiveCodexCredentialId) {
+          const [rotation, sessionCodex] = await Promise.all([
+            getCodexRotationSettings(db, input.workspaceId).catch(() => null),
+            getSessionCodexState(db, input.workspaceId, input.sessionId).catch(() => null),
+          ]);
+          const rotating = Boolean(rotation?.rotationEnabled) && (sessionCodex?.pinnedCredentialId == null);
+          if (rotating && rotation) {
+            const accounts = await listCodexAccountStatuses(db, input.workspaceId).catch(() => []);
+            const serving = accounts.find((a) => a.id === effectiveCodexCredentialId) ?? null;
+            // Cooldown end (invariant 5): authoritative resets_in_seconds from the 429; else
+            // the serving account's soonest cached window reset; else the 1h cap.
+            const cachedReset = [serving?.primaryResetAt, serving?.secondaryResetAt]
+              .filter((d): d is Date => d instanceof Date && d.getTime() > Date.now())
+              .sort((a, b) => a.getTime() - b.getTime())[0] ?? null;
+            const until = usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
+              ? new Date(Date.now() + Math.ceil(usageLimit.resetsInSeconds) * 1000)
+              : (cachedReset ?? new Date(Date.now() + CODEX_USAGE_LIMIT_MAX_RESUME_MS));
+            await setCodexCredentialExhausted(db, input.workspaceId, effectiveCodexCredentialId, until).catch(() => false);
+            // Re-rank over the fresh accounts; the in-memory list predates the cooldown
+            // write, so stamp the just-cooled account so the engine excludes it now. The
+            // serving account is thus walked AT MOST ONCE per turn (invariant 4: bounded).
+            const fresh = accounts.map((a) => (a.id === effectiveCodexCredentialId ? { ...a, exhaustedUntil: until } : a));
+            const decision = chooseRotationActive({
+              rotationStrategy: rotation.rotationStrategy as CodexRotationStrategy,
+              activeCredentialId: rotation.activeCredentialId,
+              priorCredentialId: effectiveCodexCredentialId,
+              accounts: fresh,
+              nearExhaustionPct: settings.codexRotationNearExhaustionPct,
+              now: new Date(),
+            });
+            if (decision.kind === "active") {
+              rotated = true;
+              rotationResumeMs = 0;  // re-dispatch immediately: skip BOTH the 1h hold AND the backpressure delay
+            } else if (decision.kind === "allCapped") {
+              rotated = true;
+              allCappedResetAt = decision.earliestResetAt;
+            }
+            // kind:"none" → fall through to today's single-account idle.
+          }
+        }
+
+        const failurePayload = allCappedResetAt
+          ? codexUsageLimitFailurePayload(
+              { resetsInSeconds: Math.ceil(Math.max(0, allCappedResetAt.getTime() - Date.now()) / 1000) },
+              error instanceof Error ? error.message : String(error),
+              { allAccounts: true },
+            )
+          : codexUsageLimitFailurePayload(usageLimit, error instanceof Error ? error.message : String(error));
         await publish([
-          { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved } },
+          // `rotated:true` ONLY on the reactive rotation path tells evaluateGoalContinuation to
+          // freeze autoContinuations (a rotation walk must not burn the goal's continuation budget).
+          { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved, ...(rotated ? { rotated: true } : {}) } },
           { type: "session.status.changed", payload: { status: "idle" } },
         ], true);
         await finishTurn(db, input.workspaceId, turnId, "failed");
@@ -1405,9 +1522,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         activityStatus = "idle";
         activityError = error;
         if (goalActive) {
-          const resumeMs = usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
-            ? Math.min(Math.ceil(usageLimit.resetsInSeconds) * 1000, CODEX_USAGE_LIMIT_MAX_RESUME_MS)
-            : CODEX_USAGE_LIMIT_MAX_RESUME_MS;
+          // Rotation: a candidate is available → continue NOW (0). All-capped → idle until the
+          // earliest reset across all accounts (capped at 1h). Else the unchanged single-account idle.
+          if (rotationResumeMs !== null) {
+            return { status: "idle", continueDelayMs: rotationResumeMs };
+          }
+          const resumeMs = allCappedResetAt
+            ? Math.min(Math.max(0, allCappedResetAt.getTime() - Date.now()), CODEX_USAGE_LIMIT_MAX_RESUME_MS)
+            : (usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
+                ? Math.min(Math.ceil(usageLimit.resetsInSeconds) * 1000, CODEX_USAGE_LIMIT_MAX_RESUME_MS)
+                : CODEX_USAGE_LIMIT_MAX_RESUME_MS);
           return { status: "idle", continueDelayMs: resumeMs };
         }
         return { status: "idle" };
@@ -1648,10 +1772,17 @@ export function humanizeResetWindow(resetsInSeconds: number | null): string {
 export function codexUsageLimitFailurePayload(
   info: { resetsInSeconds: number | null },
   detail: string,
+  opts?: { allAccounts?: boolean },
 ): { error: string; code: string; retryable: boolean; detail?: string } {
+  // P3: when EVERY connected subscription is rate-limited the message names the
+  // earliest reset across accounts; the single-account message is unchanged.
+  const error = opts?.allAccounts
+    ? `All connected ChatGPT/Codex subscriptions are rate-limited. Access returns ${humanizeResetWindow(info.resetsInSeconds)}. `
+      + `You can switch this session to a different model in the meantime, or wait for a subscription to reset.`
+    : `Your ChatGPT/Codex subscription usage limit has been reached. Access resets ${humanizeResetWindow(info.resetsInSeconds)}. `
+      + `You can switch this session to a different model in the meantime, or wait for the limit to reset.`;
   return {
-    error: `Your ChatGPT/Codex subscription usage limit has been reached. Access resets ${humanizeResetWindow(info.resetsInSeconds)}. `
-      + `You can switch this session to a different model in the meantime, or wait for the limit to reset.`,
+    error,
     code: "codex_usage_limit_reached",
     retryable: false,
     ...(detail ? { detail } : {}),

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -14,6 +14,7 @@ import {
   workspaceCodexSubscriptionActive,
   getCodexRotationSettings,
   listCodexAccountStatuses,
+  fetchCodexUsageForAccount,
   getSessionCodexState,
   recordSessionActiveCodexCredential,
   setActiveCodexCredential,
@@ -51,7 +52,8 @@ import {
 import { calculateModelUsageCostMicros, configuredModelPricing, configuredStaticUsageLimits, sandboxWarmRateMicrosPerSecond, type ModelUsageInput, type Settings } from "@opengeni/config";
 import { CancelledFailure } from "@temporalio/activity";
 import { settingsWithCodexCredential, settingsWithEnabledCapabilityMcpServers } from "./capabilities";
-import { chooseRotationActive, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
+import { chooseRotationActive, computeIdleDelayMs, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
+import type { CodexAccountStatus } from "@opengeni/db";
 import { buildCodexTokenResolver } from "./codex-auth";
 import {
   buildModelResolver,
@@ -319,6 +321,34 @@ export async function resolveActiveSandboxBackend(
   }
 }
 
+/**
+ * SELF-HEAL helper for the all-capped rotation idle (invariant 4: BOUNDED, no thrash).
+ * The turn hot path never refreshes Codex usage — only the usage API route does — so a
+ * window that has actually reset still reads OVER-threshold from the stale cache, which
+ * would idle-loop forever. Before idling, refresh LIVE usage for every connected account
+ * the cache marks over-threshold (bounded to the account count), which re-writes the
+ * cache columns, then return the re-read rows so the ranker can pick up a genuinely-reset
+ * window THIS turn. A refresh/read failure is swallowed (fall back to the pre-refresh rows
+ * + the bounded idle). Cooling (429'd) accounts are NOT refreshed: their exhaustedUntil
+ * cooldown is authoritative, and refreshing them would burn a provider call for nothing.
+ */
+async function refreshCappedCodexUsageRows(
+  db: ActivityServices["db"],
+  settings: Settings,
+  workspaceId: string,
+  accounts: CodexAccountStatus[],
+): Promise<CodexAccountStatus[]> {
+  const nearPct = settings.codexRotationNearExhaustionPct;
+  const stale = accounts.filter(
+    (a) => a.status === "active" && ((a.primaryUsedPercent ?? 0) >= nearPct || (a.secondaryUsedPercent ?? 0) >= nearPct),
+  );
+  if (stale.length === 0) {
+    return accounts;
+  }
+  await Promise.all(stale.map((a) => fetchCodexUsageForAccount(db, settings, workspaceId, a.id).catch(() => undefined)));
+  return listCodexAccountStatuses(db, workspaceId).catch(() => accounts);
+}
+
 export function createRunAgentTurnActivity(services: () => Promise<ActivityServices>) {
   return async function runAgentTurn(input: RunAgentTurnInput): Promise<RunAgentTurnResult> {
     const { settings, db, bus, runtime, objectStorage, observability, wakeSessionWorkflow } = await services();
@@ -561,14 +591,32 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // stays the active pointer and selectCodexCredentialForTurn is called with
         // byte-identical arguments to today — zero added cost on non-rotation turns.
         if (rotation?.rotationEnabled && sessionPin == null) {
+          let rankAccounts = accounts;
           rotationDecision = chooseRotationActive({
             rotationStrategy: rotation.rotationStrategy as CodexRotationStrategy,
             activeCredentialId: rotation.activeCredentialId,
             priorCredentialId: sessionCodex?.lastCredentialId ?? null,
-            accounts,
+            accounts: rankAccounts,
             nearExhaustionPct: settings.codexRotationNearExhaustionPct,
             now: new Date(),
           });
+          if (rotationDecision.kind === "allCapped") {
+            // SELF-HEAL (invariant 4): the turn hot path NEVER refreshes usage, so a
+            // window that has actually reset still reads capped from the stale cache —
+            // which would otherwise idle-loop forever (idle → continuation re-dispatch →
+            // same stale all-capped → idle …). Before idling, refresh usage for the
+            // over-threshold accounts (bounded to the account count) and re-rank ONCE,
+            // so a genuinely-reset window is picked up immediately and the cache heals.
+            rankAccounts = await refreshCappedCodexUsageRows(db, settings, input.workspaceId, rankAccounts);
+            rotationDecision = chooseRotationActive({
+              rotationStrategy: rotation.rotationStrategy as CodexRotationStrategy,
+              activeCredentialId: rotation.activeCredentialId,
+              priorCredentialId: sessionCodex?.lastCredentialId ?? null,
+              accounts: rankAccounts,
+              nearExhaustionPct: settings.codexRotationNearExhaustionPct,
+              now: new Date(),
+            });
+          }
           if (rotationDecision.kind === "active") {
             if (rotationDecision.moved) {
               // The single authoritative pointer-move site: persist the new active.
@@ -576,16 +624,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             }
             chosenActive = rotationDecision.credentialId;
           } else if (rotationDecision.kind === "allCapped" && publish && turnId) {
-            // Every eligible account is capped/cooling: idle the turn AT THE BOUNDARY
-            // (no wasted model/sandbox build) until the EARLIEST reset across all
-            // accounts — the multi-account generalization of #143's single-account
-            // idle-until-reset. No saveRunState: no model ran, nothing to freeze.
+            // Every eligible account is capped/cooling (and a usage refresh did NOT
+            // surface a reset): idle the turn AT THE BOUNDARY (no wasted model/sandbox
+            // build) until the EARLIEST reset across all accounts — the multi-account
+            // generalization of #143's single-account idle-until-reset. No saveRunState:
+            // no model ran, nothing to freeze.
             const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
             const goalActive = Boolean(goal && goal.status === "active");
-            const resumeMs = Math.min(
-              Math.max(0, rotationDecision.earliestResetAt.getTime() - Date.now()),
-              CODEX_USAGE_LIMIT_MAX_RESUME_MS,
-            );
+            // BOUNDED + POSITIVE: clamp to [MIN_IDLE_MS, max] so a null/elapsed/unknown
+            // reset can never yield a 0 (which session.ts would treat as "continue now",
+            // re-entering this path in a tight CPU/DB-hammering loop).
+            const resumeMs = computeIdleDelayMs(rotationDecision.earliestResetAt, new Date(), CODEX_USAGE_LIMIT_MAX_RESUME_MS);
             const failurePayload = codexUsageLimitFailurePayload(
               { resetsInSeconds: Math.ceil(resumeMs / 1000) },
               "all connected Codex subscriptions are rate-limited",
@@ -598,7 +647,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             await finishTurn(db, input.workspaceId, turnId, "failed");
             await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
             activityStatus = "idle";
-            return goalActive ? { status: "idle", continueDelayMs: resumeMs } : { status: "idle" };
+            // idleUntilReset marks this a MANDATORY hold: session.ts must wait the full
+            // resumeMs even if a future change made it 0 — never a tight re-dispatch.
+            return goalActive ? { status: "idle", continueDelayMs: resumeMs, idleUntilReset: true } : { status: "idle" };
           }
           // kind:"none" (no accounts) → chosenActive stays null → existing relogin path.
         }
@@ -1525,14 +1576,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // Rotation: a candidate is available → continue NOW (0). All-capped → idle until the
           // earliest reset across all accounts (capped at 1h). Else the unchanged single-account idle.
           if (rotationResumeMs !== null) {
+            // A candidate IS available (the just-failed account is now cooling, so the
+            // ranker cannot re-pick it — at most N rotations per N accounts, invariant 4).
+            // 0 ⇒ re-dispatch NOW; this is the legitimate skip-the-hold case.
             return { status: "idle", continueDelayMs: rotationResumeMs };
           }
+          // All-capped: clamp to [MIN_IDLE_MS, max] — a POSITIVE, BOUNDED hold (never 0,
+          // so session.ts can never tight-loop). The post-idle continuation re-dispatch
+          // hits the proactive seam, which refreshes usage and self-heals.
           const resumeMs = allCappedResetAt
-            ? Math.min(Math.max(0, allCappedResetAt.getTime() - Date.now()), CODEX_USAGE_LIMIT_MAX_RESUME_MS)
+            ? computeIdleDelayMs(allCappedResetAt, new Date(), CODEX_USAGE_LIMIT_MAX_RESUME_MS)
             : (usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
                 ? Math.min(Math.ceil(usageLimit.resetsInSeconds) * 1000, CODEX_USAGE_LIMIT_MAX_RESUME_MS)
                 : CODEX_USAGE_LIMIT_MAX_RESUME_MS);
-          return { status: "idle", continueDelayMs: resumeMs };
+          return { status: "idle", continueDelayMs: resumeMs, ...(allCappedResetAt ? { idleUntilReset: true } : {}) };
         }
         return { status: "idle" };
       }

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -1,0 +1,147 @@
+// Multi-account P3 — the PURE rotation ranker. Zero I/O: no provider calls, no
+// decrypts, no db. It consumes the already-loaded, metadata-only account list
+// (cached usage columns + the exhausted_until cooldown column) and returns the
+// account a turn should run on. The two call sites (turn-start pre-emption and
+// the reactive 429 catch in agent-turn.ts) feed its result into the unchanged
+// `selectCodexCredentialForTurn` precedence gate (pin > active). Keeping the
+// decision pure makes the whole rotation correctness story unit-testable in
+// isolation (see codex-rotation.test.ts).
+import type { CodexAccountStatus } from "@opengeni/db";
+
+export type CodexRotationStrategy = "most_remaining" | "round_robin" | "drain_then_next";
+
+export type RotationDecision =
+  // The chosen account. `moved` ⇒ it differs from the current active pointer, so
+  // the caller must persist the pointer move (and the switch is a "rotation").
+  | { kind: "active"; credentialId: string; moved: boolean }
+  // Every eligible account is capped/cooling: idle until the soonest instant ANY
+  // account clears every blocking condition (the multi-account generalization of
+  // the single-account idle-until-reset).
+  | { kind: "allCapped"; earliestResetAt: Date }
+  // No connected accounts at all (preserves today's relogin-fail path).
+  | { kind: "none" };
+
+const EPOCH0 = new Date(0);
+
+/** The worse-window used percent: weekly binds as hard as 5h, so take the max. null ⇒ 0. */
+function bindingUsedPct(acct: CodexAccountStatus): number {
+  return Math.max(acct.primaryUsedPercent ?? 0, acct.secondaryUsedPercent ?? 0);
+}
+
+/**
+ * Remaining quota across the binding window — the P3 rotation key. Mirrors
+ * buildCodexUsageWindowFromCache's `remaining = 100 - percent`, taking the MIN
+ * across both windows (the scarcer of 5h/weekly). null percent ⇒ 100 remaining.
+ */
+function bindingRemaining(acct: CodexAccountStatus): number {
+  const primaryRemaining = 100 - (acct.primaryUsedPercent ?? 0);
+  const secondaryRemaining = 100 - (acct.secondaryUsedPercent ?? 0);
+  return Math.min(primaryRemaining, secondaryRemaining);
+}
+
+function cooling(acct: CodexAccountStatus, now: Date): boolean {
+  return acct.exhaustedUntil != null && acct.exhaustedUntil.getTime() > now.getTime();
+}
+
+/**
+ * Eligible = connected/usable (status "active", excludes needs_relogin/error) AND
+ * not cooling AND under the near-exhaustion threshold on BOTH windows.
+ */
+function eligible(acct: CodexAccountStatus, nearExhaustionPct: number, now: Date): boolean {
+  return acct.status === "active" && !cooling(acct, now) && bindingUsedPct(acct) < nearExhaustionPct;
+}
+
+/**
+ * The soonest instant `acct` clears EVERY blocking condition: its cooldown end,
+ * and each window's reset (only when that window is at/over the threshold). The
+ * literal multi-account generalization of #143's single-account resetsInSeconds.
+ */
+function availableAt(acct: CodexAccountStatus, nearExhaustionPct: number): Date {
+  const candidates: Date[] = [acct.exhaustedUntil ?? EPOCH0];
+  if ((acct.primaryUsedPercent ?? 0) >= nearExhaustionPct) {
+    candidates.push(acct.primaryResetAt ?? EPOCH0);
+  }
+  if ((acct.secondaryUsedPercent ?? 0) >= nearExhaustionPct) {
+    candidates.push(acct.secondaryResetAt ?? EPOCH0);
+  }
+  return candidates.reduce((a, b) => (b.getTime() > a.getTime() ? b : a), EPOCH0);
+}
+
+/** earliestResetAt across ALL connected accounts (min of each account's availableAt). */
+function earliestReset(accounts: CodexAccountStatus[], nearExhaustionPct: number): Date {
+  return accounts
+    .map((acct) => availableAt(acct, nearExhaustionPct))
+    .reduce((a, b) => (b.getTime() < a.getTime() ? b : a));
+}
+
+/**
+ * THE pure rotation ranker. `accounts` arrives in stable created_at order
+ * (listCodexAccountStatuses), which deterministically breaks ranking ties.
+ */
+export function chooseRotationActive(args: {
+  rotationStrategy: CodexRotationStrategy;
+  activeCredentialId: string | null;
+  priorCredentialId: string | null;
+  accounts: CodexAccountStatus[];
+  nearExhaustionPct: number;
+  now: Date;
+}): RotationDecision {
+  const { rotationStrategy, activeCredentialId, priorCredentialId, accounts, nearExhaustionPct, now } = args;
+
+  if (accounts.length === 0) {
+    return { kind: "none" };
+  }
+
+  const eligibles = accounts.filter((acct) => eligible(acct, nearExhaustionPct, now));
+
+  // Healthy-active fast path (minimal churn, all strategies): a rotation-enabled
+  // session whose active account is still eligible does NOT rotate — no pointer
+  // move, no switch event. Steady-state stays as cheap as a non-rotation turn
+  // save the in-memory ranking. (Skipped for round_robin/drain which anchor on
+  // the prior account, but most_remaining is the default + correctness path.)
+  const activeRow = activeCredentialId ? accounts.find((acct) => acct.id === activeCredentialId) ?? null : null;
+
+  const decide = (chosen: CodexAccountStatus | undefined): RotationDecision => {
+    if (!chosen) {
+      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct) };
+    }
+    return { kind: "active", credentialId: chosen.id, moved: chosen.id !== activeCredentialId };
+  };
+
+  if (rotationStrategy === "round_robin") {
+    // Next eligible AFTER the prior account in list order (wrap around). When the
+    // prior account isn't found, start from the head.
+    if (eligibles.length === 0) {
+      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct) };
+    }
+    const priorIdx = priorCredentialId ? accounts.findIndex((acct) => acct.id === priorCredentialId) : -1;
+    const ordered = priorIdx >= 0
+      ? [...accounts.slice(priorIdx + 1), ...accounts.slice(0, priorIdx + 1)]
+      : accounts;
+    const chosen = ordered.find((acct) => eligible(acct, nearExhaustionPct, now));
+    return decide(chosen);
+  }
+
+  if (rotationStrategy === "drain_then_next") {
+    // Stay on the prior account while it is eligible (drain it), else first eligible.
+    const priorRow = priorCredentialId ? accounts.find((acct) => acct.id === priorCredentialId) : undefined;
+    if (priorRow && eligible(priorRow, nearExhaustionPct, now)) {
+      return decide(priorRow);
+    }
+    return decide(eligibles[0]);
+  }
+
+  // most_remaining (default + the correctness path).
+  if (activeRow && eligible(activeRow, nearExhaustionPct, now)) {
+    return { kind: "active", credentialId: activeRow.id, moved: false };
+  }
+  // Active is capped/near-cap/cooling/missing → pick max remaining, ties broken by
+  // list (created_at) order via a stable reduce.
+  const chosen = eligibles.reduce<CodexAccountStatus | undefined>((best, acct) => {
+    if (!best) {
+      return acct;
+    }
+    return bindingRemaining(acct) > bindingRemaining(best) ? acct : best;
+  }, undefined);
+  return decide(chosen);
+}

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -21,7 +21,20 @@ export type RotationDecision =
   // No connected accounts at all (preserves today's relogin-fail path).
   | { kind: "none" };
 
-const EPOCH0 = new Date(0);
+// Invariant 4 (NO THRASH / BOUNDED) safety floors. An all-capped idle MUST be a
+// positive, bounded wait — a null / elapsed / unknown reset can NEVER collapse it
+// into a 0 or a past instant (which the caller would turn into a 0 continueDelayMs
+// and a tight re-dispatch loop that hammers CPU/DB and never runs the model, so the
+// stale usage cache never self-heals).
+/** The minimum all-capped idle: continueDelayMs is clamped to at least this (never 0). */
+export const MIN_IDLE_MS = 60_000; // 60s
+/**
+ * Cooldown applied to an over-threshold account whose cached reset is null / unknown
+ * / already-elapsed (the turn hot path never refreshes usage, so a capped window's
+ * reset reads stale). Treating it as "available after a default cooldown" keeps
+ * availableAt — and therefore earliestReset — ALWAYS in the future.
+ */
+export const DEFAULT_RESET_COOLDOWN_MS = 60_000; // 60s
 
 /** The worse-window used percent: weekly binds as hard as 5h, so take the max. null ⇒ 0. */
 function bindingUsedPct(acct: CodexAccountStatus): number {
@@ -55,23 +68,58 @@ function eligible(acct: CodexAccountStatus, nearExhaustionPct: number, now: Date
  * The soonest instant `acct` clears EVERY blocking condition: its cooldown end,
  * and each window's reset (only when that window is at/over the threshold). The
  * literal multi-account generalization of #143's single-account resetsInSeconds.
+ *
+ * GUARANTEE (invariant 4): the result is ALWAYS in the future. A blocking window
+ * whose cached reset is null / unknown / already-elapsed does NOT contribute a past
+ * instant (the old EPOCH0 seed bug that made earliestReset land in 1970 → a 0
+ * continueDelayMs → a tight idle loop). Such a window is treated as clearing after a
+ * default cooldown (now + DEFAULT_RESET_COOLDOWN_MS), so the caller always idles a
+ * bounded positive time and re-checks (which refreshes usage and self-heals).
  */
-function availableAt(acct: CodexAccountStatus, nearExhaustionPct: number): Date {
-  const candidates: Date[] = [acct.exhaustedUntil ?? EPOCH0];
-  if ((acct.primaryUsedPercent ?? 0) >= nearExhaustionPct) {
-    candidates.push(acct.primaryResetAt ?? EPOCH0);
+export function availableAt(acct: CodexAccountStatus, nearExhaustionPct: number, now: Date): Date {
+  const nowMs = now.getTime();
+  // An unknown/elapsed block clears after a default cooldown, never in the past.
+  const defaultClear = new Date(nowMs + DEFAULT_RESET_COOLDOWN_MS);
+  const candidates: Date[] = [];
+  // An active cooldown only blocks while it is still in the future; a past cooldown
+  // self-clears (matches `cooling()`), so it must not pin availableAt to the past.
+  if (acct.exhaustedUntil != null && acct.exhaustedUntil.getTime() > nowMs) {
+    candidates.push(acct.exhaustedUntil);
   }
-  if ((acct.secondaryUsedPercent ?? 0) >= nearExhaustionPct) {
-    candidates.push(acct.secondaryResetAt ?? EPOCH0);
+  const windowClear = (over: boolean, resetAt: Date | null | undefined) => {
+    if (!over) return;
+    // Over-threshold window: wait for its KNOWN future reset; a null/elapsed cached
+    // reset is unknown → default cooldown (never a past instant).
+    candidates.push(resetAt != null && resetAt.getTime() > nowMs ? resetAt : defaultClear);
+  };
+  windowClear((acct.primaryUsedPercent ?? 0) >= nearExhaustionPct, acct.primaryResetAt);
+  windowClear((acct.secondaryUsedPercent ?? 0) >= nearExhaustionPct, acct.secondaryResetAt);
+  // Ineligible for a non-quota reason (needs_relogin / error) with no known block, or
+  // a cleared cooldown: still idle a bounded cooldown before re-check — never the past.
+  if (candidates.length === 0) {
+    return defaultClear;
   }
-  return candidates.reduce((a, b) => (b.getTime() > a.getTime() ? b : a), EPOCH0);
+  // Clears EVERY blocking condition ⇒ the MAX of the per-condition clear instants.
+  return candidates.reduce((a, b) => (b.getTime() > a.getTime() ? b : a));
 }
 
 /** earliestResetAt across ALL connected accounts (min of each account's availableAt). */
-function earliestReset(accounts: CodexAccountStatus[], nearExhaustionPct: number): Date {
+function earliestReset(accounts: CodexAccountStatus[], nearExhaustionPct: number, now: Date): Date {
   return accounts
-    .map((acct) => availableAt(acct, nearExhaustionPct))
+    .map((acct) => availableAt(acct, nearExhaustionPct, now))
     .reduce((a, b) => (b.getTime() < a.getTime() ? b : a));
+}
+
+/**
+ * The bounded all-capped idle delay: clamp(earliestResetAt − now) into
+ * [MIN_IDLE_MS, maxMs]. NEVER 0 and NEVER negative, so a null / elapsed / unknown
+ * reset cannot collapse the hold into a tight re-dispatch loop (invariant 4). The two
+ * agent-turn call sites (proactive turn-start + reactive 429) feed allCapped's
+ * earliestResetAt through this before returning continueDelayMs.
+ */
+export function computeIdleDelayMs(earliestResetAt: Date, now: Date, maxMs: number): number {
+  const delta = earliestResetAt.getTime() - now.getTime();
+  return Math.min(Math.max(delta, MIN_IDLE_MS), maxMs);
 }
 
 /**
@@ -103,7 +151,7 @@ export function chooseRotationActive(args: {
 
   const decide = (chosen: CodexAccountStatus | undefined): RotationDecision => {
     if (!chosen) {
-      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct) };
+      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct, now) };
     }
     return { kind: "active", credentialId: chosen.id, moved: chosen.id !== activeCredentialId };
   };
@@ -112,7 +160,7 @@ export function chooseRotationActive(args: {
     // Next eligible AFTER the prior account in list order (wrap around). When the
     // prior account isn't found, start from the head.
     if (eligibles.length === 0) {
-      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct) };
+      return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct, now) };
     }
     const priorIdx = priorCredentialId ? accounts.findIndex((acct) => acct.id === priorCredentialId) : -1;
     const ordered = priorIdx >= 0

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -126,4 +126,10 @@ export type RunAgentTurnResult = {
   // workflow holds the loop this long before admitting the next turn (an
   // active goal's continuation would otherwise immediately re-hit the limit).
   continueDelayMs?: number;
+  // Multi-account rotation all-capped idle: every connected Codex subscription is
+  // rate-limited/cooling. This is a MANDATORY hold — session.ts must wait
+  // continueDelayMs (floored to a minimum) and must NOT treat a 0/elapsed delay as
+  // "continue now" (invariant 4: NO THRASH). Distinct from a normal continueDelayMs:0
+  // which legitimately means "a rotation candidate is ready, re-dispatch immediately".
+  idleUntilReset?: boolean;
 };

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -18,6 +18,36 @@ import { activity, workflowFailureMessage } from "./activities";
 const TURNS_PER_RUN_BACKSTOP = 2_000;
 
 /**
+ * The minimum hold for a rotation all-capped idle (`idleUntilReset`). A MANDATORY
+ * floor so that even a 0/elapsed continueDelayMs (a stale/unknown reset) can never
+ * collapse the hold into a tight re-dispatch loop that hammers CPU/DB and never runs
+ * the model (invariant 4: NO THRASH). Mirrors MIN_IDLE_MS in codex-rotation.ts; kept
+ * local so the deterministic workflow bundle does not import the activities module.
+ */
+const ROTATION_IDLE_FLOOR_MS = 60_000; // 60s
+
+/**
+ * How long the continuation loop must hold before re-admitting the next turn. 0 ⇒ no
+ * hold (re-dispatch immediately — a rotation candidate is ready, or no idle delay was
+ * requested). A rotation all-capped idle (`idleUntilReset`) ALWAYS holds at least
+ * `floorMs`, so a 0/elapsed continueDelayMs can never skip the hold (invariant 4).
+ * Pure + exported so the boundedness contract is unit-testable without a workflow env.
+ */
+export function continuationHoldMs(
+  result: { status: string; continueDelayMs?: number; idleUntilReset?: boolean },
+  floorMs: number,
+): number {
+  if (result.status !== "idle") {
+    return 0;
+  }
+  const delay = result.continueDelayMs ?? 0;
+  if (result.idleUntilReset) {
+    return Math.max(delay, floorMs);
+  }
+  return Math.max(delay, 0);
+}
+
+/**
  * True when an agent-turn activity failure means "the worker hosting the
  * turn died or vanished" rather than "the turn itself failed": the server
  * closed the activity with a HEARTBEAT timeout (the worker was killed before
@@ -331,12 +361,15 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       }
     }
 
-    if (outcome.result.status === "idle" && outcome.result.continueDelayMs) {
-      // Provider backpressure: hold the loop so an active goal's continuation
-      // does not immediately re-enter the same rate-limit window. An interrupt
-      // or user signal ends the wait early and is handled by the main loop.
+    const holdMs = continuationHoldMs(outcome.result, ROTATION_IDLE_FLOOR_MS);
+    if (holdMs > 0) {
+      // Provider backpressure / rotation all-capped idle: hold the loop so an active
+      // goal's continuation does not immediately re-enter the same rate-limit window.
+      // A rotation all-capped idle is a MANDATORY hold (idleUntilReset) — a 0/elapsed
+      // delay can never skip it (invariant 4: NO THRASH). An interrupt or user signal
+      // ends the wait early and is handled by the main loop.
       const seenWakeups = wakeups;
-      await condition(() => interruptedEventId !== null || wakeups !== seenWakeups, outcome.result.continueDelayMs);
+      await condition(() => interruptedEventId !== null || wakeups !== seenWakeups, holdMs);
     }
     return true;
   }

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import type { CodexAccountStatus } from "@opengeni/db";
+import { chooseRotationActive } from "../src/activities/codex-rotation";
+
+// Multi-account P3 — the PURE rotation ranker. All rotation correctness (most_remaining
+// selection, healthy-active no-op, cooldown exclusion, all-capped earliest-reset,
+// boundedness) reduces to this function over the metadata-only account list.
+
+const NOW = new Date("2026-06-30T12:00:00.000Z");
+const HOUR = 3_600_000;
+
+function acct(id: string, over: Partial<CodexAccountStatus> = {}): CodexAccountStatus {
+  return {
+    id,
+    chatgptAccountId: `cg-${id}`,
+    label: id,
+    accountEmail: null,
+    planType: "pro",
+    status: "active",
+    isActive: false,
+    expiresAt: null,
+    lastRefreshAt: null,
+    lastError: null,
+    primaryUsedPercent: 0,
+    primaryResetAt: null,
+    secondaryUsedPercent: 0,
+    secondaryResetAt: null,
+    usageCheckedAt: null,
+    exhaustedUntil: null,
+    ...over,
+  };
+}
+
+const base = {
+  rotationStrategy: "most_remaining" as const,
+  priorCredentialId: null,
+  nearExhaustionPct: 90,
+  now: NOW,
+};
+
+describe("chooseRotationActive — most_remaining", () => {
+  test("no accounts → none (preserves the relogin-fail path)", () => {
+    expect(chooseRotationActive({ ...base, activeCredentialId: null, accounts: [] }))
+      .toEqual({ kind: "none" });
+  });
+
+  test("healthy active account → no rotation, no move (minimal churn)", () => {
+    const accounts = [acct("a", { primaryUsedPercent: 10 }), acct("b", { primaryUsedPercent: 5 })];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "a", moved: false });
+  });
+
+  test("active near-capped → rotate to the account with the most remaining quota", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 95 }),  // active, near-cap → ineligible
+      acct("b", { primaryUsedPercent: 40 }),  // 60 remaining
+      acct("c", { primaryUsedPercent: 10 }),  // 90 remaining ← winner
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("weekly window binds as hard as 5h (worst-window used pct)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),                              // active, capped
+      acct("b", { primaryUsedPercent: 10, secondaryUsedPercent: 95 }),    // weekly near-cap → ineligible
+      acct("c", { primaryUsedPercent: 50, secondaryUsedPercent: 50 }),    // eligible (50 remaining)
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("remaining = min across windows (the scarcer window wins the ranking)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),                            // active, capped
+      acct("b", { primaryUsedPercent: 10, secondaryUsedPercent: 70 }),  // remaining = min(90,30)=30
+      acct("c", { primaryUsedPercent: 20, secondaryUsedPercent: 20 }),  // remaining = min(80,80)=80 ← winner
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("a cooling account is excluded even when it has the most remaining quota", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),                                          // active, capped
+      acct("b", { primaryUsedPercent: 0, exhaustedUntil: new Date(NOW.getTime() + HOUR) }), // most remaining BUT cooling
+      acct("c", { primaryUsedPercent: 40 }),                                          // eligible
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("a cooldown in the past does NOT exclude (self-clears via now comparison)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),                                              // active, capped
+      acct("b", { primaryUsedPercent: 10, exhaustedUntil: new Date(NOW.getTime() - HOUR) }), // expired cooldown → eligible
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+
+  test("needs_relogin / error accounts are never eligible", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),                          // active, capped
+      acct("b", { status: "needs_relogin", primaryUsedPercent: 0 }),  // unusable
+      acct("c", { status: "error", primaryUsedPercent: 0 }),          // unusable
+    ];
+    const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
+    expect(decision.kind).toBe("allCapped");
+  });
+
+  test("ties broken deterministically by list (created_at) order", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99 }),   // active, capped
+      acct("b", { primaryUsedPercent: 30 }),   // 70 remaining ← first in order wins the tie
+      acct("c", { primaryUsedPercent: 30 }),   // 70 remaining
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+
+  test("all eligible accounts capped → allCapped with the EARLIEST reset across all", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }),
+      acct("b", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 1 * HOUR) }), // soonest
+      acct("c", { exhaustedUntil: new Date(NOW.getTime() + 2 * HOUR) }),
+    ];
+    const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
+    expect(decision.kind).toBe("allCapped");
+    if (decision.kind === "allCapped") {
+      expect(decision.earliestResetAt.getTime()).toBe(NOW.getTime() + 1 * HOUR);
+    }
+  });
+
+  test("boundedness: each successive capped account drains to allCapped (walk once each)", () => {
+    // Simulate the reactive walk: a, then b cooled; only b/c-style remains. After every
+    // account is cooled the engine returns allCapped — never re-picks a cooled account.
+    const cool = (until: number) => new Date(NOW.getTime() + until);
+    const accounts = [
+      acct("a", { exhaustedUntil: cool(HOUR) }),
+      acct("b", { exhaustedUntil: cool(2 * HOUR) }),
+      acct("c", { exhaustedUntil: cool(3 * HOUR) }),
+    ];
+    const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
+    expect(decision.kind).toBe("allCapped");
+    if (decision.kind === "allCapped") {
+      expect(decision.earliestResetAt.getTime()).toBe(NOW.getTime() + HOUR);
+    }
+  });
+});
+
+describe("chooseRotationActive — round_robin / drain_then_next", () => {
+  test("round_robin picks the next eligible after the prior account (wraps)", () => {
+    const accounts = [acct("a"), acct("b"), acct("c")];
+    expect(chooseRotationActive({ ...base, rotationStrategy: "round_robin", activeCredentialId: "a", priorCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+    expect(chooseRotationActive({ ...base, rotationStrategy: "round_robin", activeCredentialId: "a", priorCredentialId: "c", accounts }))
+      .toEqual({ kind: "active", credentialId: "a", moved: false });
+  });
+
+  test("round_robin skips a cooling/capped successor", () => {
+    const accounts = [acct("a"), acct("b", { primaryUsedPercent: 99 }), acct("c")];
+    expect(chooseRotationActive({ ...base, rotationStrategy: "round_robin", activeCredentialId: "a", priorCredentialId: "a", accounts }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("drain_then_next stays on the prior account while eligible, else first eligible", () => {
+    const accounts = [acct("a"), acct("b")];
+    expect(chooseRotationActive({ ...base, rotationStrategy: "drain_then_next", activeCredentialId: "a", priorCredentialId: "b", accounts }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+    const capped = [acct("a", { primaryUsedPercent: 99 }), acct("b")];
+    expect(chooseRotationActive({ ...base, rotationStrategy: "drain_then_next", activeCredentialId: "a", priorCredentialId: "a", accounts: capped }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+});

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { CodexAccountStatus } from "@opengeni/db";
-import { chooseRotationActive } from "../src/activities/codex-rotation";
+import {
+  availableAt,
+  chooseRotationActive,
+  computeIdleDelayMs,
+  DEFAULT_RESET_COOLDOWN_MS,
+  MIN_IDLE_MS,
+} from "../src/activities/codex-rotation";
 
 // Multi-account P3 — the PURE rotation ranker. All rotation correctness (most_remaining
 // selection, healthy-active no-op, cooldown exclusion, all-capped earliest-reset,
@@ -146,6 +152,127 @@ describe("chooseRotationActive — most_remaining", () => {
     if (decision.kind === "allCapped") {
       expect(decision.earliestResetAt.getTime()).toBe(NOW.getTime() + HOUR);
     }
+  });
+});
+
+// P3 all-capped infinite-loop bugfix. The original availableAt() seeded EPOCH0 (1970)
+// and used it as the fallback for a null/elapsed reset, so an over-threshold account
+// with a NULL or already-elapsed cached reset yielded a PAST instant; earliestReset MINs
+// across accounts → allCapped.earliestResetAt in the deep past → continueDelayMs =
+// max(0, past − now) = 0 → a tight CPU/DB-hammering re-dispatch loop (invariant 4 violated).
+const MAX_RESUME_MS = 60 * 60_000; // mirrors CODEX_USAGE_LIMIT_MAX_RESUME_MS (1h)
+
+describe("P3 all-capped idle — POSITIVE bounded delay, never 0 (invariant 4: NO THRASH)", () => {
+  test("(a) all-capped with a NULL resetAt → future earliestReset → positive bounded delay (>= MIN_IDLE_MS), never 0", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, primaryResetAt: null }), // over-threshold, unknown reset
+      acct("b", { primaryUsedPercent: 99, primaryResetAt: null }),
+    ];
+    const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
+    expect(decision.kind).toBe("allCapped");
+    if (decision.kind === "allCapped") {
+      // Pre-fix this was EPOCH0 (1970) — a PAST instant. It must now be in the FUTURE.
+      expect(decision.earliestResetAt.getTime()).toBeGreaterThan(NOW.getTime());
+      const delay = computeIdleDelayMs(decision.earliestResetAt, NOW, MAX_RESUME_MS);
+      expect(delay).toBeGreaterThanOrEqual(MIN_IDLE_MS);
+      expect(delay).toBeGreaterThan(0);
+    }
+  });
+
+  test("(b) all-capped with an ELAPSED resetAt → future earliestReset → positive bounded delay, never 0", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() - HOUR) }),       // 5h reset already passed
+      acct("b", { secondaryUsedPercent: 99, secondaryResetAt: new Date(NOW.getTime() - 5 * HOUR) }), // weekly reset already passed
+    ];
+    const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
+    expect(decision.kind).toBe("allCapped");
+    if (decision.kind === "allCapped") {
+      expect(decision.earliestResetAt.getTime()).toBeGreaterThan(NOW.getTime());
+      const delay = computeIdleDelayMs(decision.earliestResetAt, NOW, MAX_RESUME_MS);
+      expect(delay).toBeGreaterThanOrEqual(MIN_IDLE_MS);
+      expect(delay).toBeGreaterThan(0);
+    }
+  });
+
+  test("computeIdleDelayMs clamps into [MIN_IDLE_MS, max]: a past instant floors to MIN_IDLE_MS, never 0 or negative", () => {
+    expect(computeIdleDelayMs(new Date(NOW.getTime() - HOUR), NOW, MAX_RESUME_MS)).toBe(MIN_IDLE_MS);
+    expect(computeIdleDelayMs(NOW, NOW, MAX_RESUME_MS)).toBe(MIN_IDLE_MS);
+    expect(computeIdleDelayMs(new Date(NOW.getTime() + 5 * HOUR), NOW, MAX_RESUME_MS)).toBe(MAX_RESUME_MS); // capped
+    expect(computeIdleDelayMs(new Date(NOW.getTime() + 10 * 60_000), NOW, MAX_RESUME_MS)).toBe(10 * 60_000);
+  });
+});
+
+describe("availableAt — never a past instant for an over-threshold account (invariant 4)", () => {
+  test("(c) over-threshold account with a NULL reset → now + default cooldown, NOT the past", () => {
+    const at = availableAt(acct("a", { primaryUsedPercent: 99, primaryResetAt: null }), 90, NOW);
+    expect(at.getTime()).toBe(NOW.getTime() + DEFAULT_RESET_COOLDOWN_MS);
+    expect(at.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  test("(c) over-threshold account with an ELAPSED reset → future, not the stale past instant", () => {
+    const at = availableAt(acct("a", { secondaryUsedPercent: 99, secondaryResetAt: new Date(NOW.getTime() - HOUR) }), 90, NOW);
+    expect(at.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  test("(c) needs_relogin / error account (ineligible, no quota block) → future cooldown, not EPOCH0", () => {
+    expect(availableAt(acct("a", { status: "needs_relogin" }), 90, NOW).getTime()).toBeGreaterThan(NOW.getTime());
+    expect(availableAt(acct("b", { status: "error" }), 90, NOW).getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  test("a KNOWN future reset is honored exactly (the cooldown default only fills unknown/elapsed)", () => {
+    const at = availableAt(acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }), 90, NOW);
+    expect(at.getTime()).toBe(NOW.getTime() + 3 * HOUR);
+  });
+
+  test("clears EVERY block: a future cooldown AND a future window reset ⇒ the LATER instant", () => {
+    const at = availableAt(
+      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + HOUR), exhaustedUntil: new Date(NOW.getTime() + 2 * HOUR) }),
+      90,
+      NOW,
+    );
+    expect(at.getTime()).toBe(NOW.getTime() + 2 * HOUR);
+  });
+});
+
+describe("P3 self-heal + bounded reactive walk (invariant 4)", () => {
+  test("(d) SELF-HEAL: a refreshed (genuinely-reset) window makes the account eligible again — no permanent idle", () => {
+    // Stale cache: both over-threshold → allCapped (the would-be idle).
+    const stale = [acct("a", { primaryUsedPercent: 99 }), acct("b", { primaryUsedPercent: 99 })];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts: stale }).kind).toBe("allCapped");
+    // After the all-capped path refreshes usage, b's 5h window has ACTUALLY reset (low pct):
+    // the re-rank must now pick b instead of idling forever on the stale percent.
+    const healed = [acct("a", { primaryUsedPercent: 99 }), acct("b", { primaryUsedPercent: 5 })];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts: healed }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+
+  test("(e) BOUNDED reactive retry: N accounts ⇒ at most N rotations ⇒ fixed idle (never re-picks a cooled account, no spin)", () => {
+    // Simulate the reactive 429 walk: each turn the serving account 429s, gets cooled
+    // (exhaustedUntil future), and the engine re-ranks over the fresh list. It must never
+    // re-pick a cooled account, so it drains to allCapped in at most N steps — bounded.
+    let serving = "a";
+    let accounts = [acct("a"), acct("b"), acct("c")];
+    let rotations = 0;
+    let idled = false;
+    for (let step = 0; step < 20; step++) {
+      // the serving account just 429'd → stamp its cooldown (the reactive cooldown write).
+      accounts = accounts.map((x) => (x.id === serving ? { ...x, exhaustedUntil: new Date(NOW.getTime() + (step + 1) * HOUR) } : x));
+      const decision = chooseRotationActive({ ...base, activeCredentialId: serving, priorCredentialId: serving, accounts });
+      if (decision.kind === "allCapped") {
+        idled = true;
+        expect(decision.earliestResetAt.getTime()).toBeGreaterThan(NOW.getTime()); // a real future idle, not 1970
+        break;
+      }
+      expect(decision.kind).toBe("active");
+      if (decision.kind === "active") {
+        // boundedness guarantee: the engine NEVER re-picks an already-cooled account.
+        expect(accounts.find((x) => x.id === decision.credentialId)?.exhaustedUntil ?? null).toBeNull();
+        serving = decision.credentialId;
+        rotations++;
+      }
+    }
+    expect(idled).toBe(true);            // it terminates in a fixed idle — no infinite spin
+    expect(rotations).toBeLessThanOrEqual(3); // at most N rotations for N accounts
   });
 });
 

--- a/apps/worker/test/codex-usage-limit.test.ts
+++ b/apps/worker/test/codex-usage-limit.test.ts
@@ -25,6 +25,21 @@ describe("codexUsageLimitFailurePayload", () => {
     expect(payload.error).toContain("in about 1h");
     expect(payload.detail).toBe("429 limit hit");
   });
+
+  test("P3 all-accounts variant names the earliest reset across subscriptions", () => {
+    const payload = codexUsageLimitFailurePayload({ resetsInSeconds: 2 * 3600 }, "all capped", { allAccounts: true });
+    expect(payload.code).toBe("codex_usage_limit_reached");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toContain("All connected");
+    expect(payload.error).toContain("in about 2h");
+    expect(payload.detail).toBe("all capped");
+  });
+
+  test("the single-account message is unchanged when allAccounts is not set", () => {
+    const payload = codexUsageLimitFailurePayload({ resetsInSeconds: 3600 }, "x");
+    expect(payload.error).toContain("Your ChatGPT/Codex subscription usage limit has been reached");
+    expect(payload.error).not.toContain("All connected");
+  });
 });
 
 describe("agentRunFailurePayload — codex usage limit", () => {

--- a/apps/worker/test/session-continuation-hold.test.ts
+++ b/apps/worker/test/session-continuation-hold.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { continuationHoldMs } from "../src/workflows/session";
+
+// P3 all-capped infinite-loop bugfix (fix #6). session.ts must treat a rotation
+// all-capped idle (`idleUntilReset`) as a MANDATORY hold: a 0/elapsed continueDelayMs
+// can never skip the wait and re-enter the tight re-dispatch loop (invariant 4: NO
+// THRASH). A NORMAL continueDelayMs:0 (a rotation candidate is ready) still re-dispatches
+// immediately — the two cases must stay distinct.
+const FLOOR = 60_000; // ROTATION_IDLE_FLOOR_MS
+
+describe("continuationHoldMs — the all-capped idle is a real wait", () => {
+  test("(f) an all-capped idle with continueDelayMs:0 STILL holds the floor (a 0 cannot skip the hold)", () => {
+    expect(continuationHoldMs({ status: "idle", continueDelayMs: 0, idleUntilReset: true }, FLOOR)).toBe(FLOOR);
+  });
+
+  test("(f) an all-capped idle with an undefined delay holds the floor", () => {
+    expect(continuationHoldMs({ status: "idle", idleUntilReset: true }, FLOOR)).toBe(FLOOR);
+  });
+
+  test("(f) an all-capped idle with a positive delay holds exactly that delay", () => {
+    expect(continuationHoldMs({ status: "idle", continueDelayMs: 5 * 60_000, idleUntilReset: true }, FLOOR)).toBe(5 * 60_000);
+  });
+
+  test("a NORMAL continueDelayMs:0 (rotation candidate ready) does NOT hold — re-dispatch now", () => {
+    expect(continuationHoldMs({ status: "idle", continueDelayMs: 0 }, FLOOR)).toBe(0);
+    expect(continuationHoldMs({ status: "idle" }, FLOOR)).toBe(0);
+  });
+
+  test("a normal backpressure delay holds exactly that long", () => {
+    expect(continuationHoldMs({ status: "idle", continueDelayMs: 60_000 }, FLOOR)).toBe(60_000);
+  });
+
+  test("a non-idle result never holds (even if idleUntilReset is somehow set)", () => {
+    expect(continuationHoldMs({ status: "failed", continueDelayMs: 99, idleUntilReset: true }, FLOOR)).toBe(0);
+    expect(continuationHoldMs({ status: "requires_action" }, FLOOR)).toBe(0);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -218,6 +218,10 @@ const SettingsSchema = z.object({
   // provider whose models route through the ChatGPT backend (@opengeni/codex).
   codexSubscriptionEnabled: EnvBoolean.default(false),  // OPENGENI_CODEX_SUBSCRIPTION_ENABLED
   codexProductSku: z.string().optional(),               // OPENGENI_CODEX_PRODUCT_SKU (X-OpenAI-Product-Sku, apps only)
+  // Multi-account P3 (auto-rotation): an account is "near exhaustion" — ineligible to be
+  // rotated TO — when EITHER usage window (5h/weekly) is at/over this percent. Default 90 to
+  // match the UI danger flip (UsageBar danger at pct >= 90). OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT.
+  codexRotationNearExhaustionPct: z.coerce.number().int().min(1).max(100).default(90),
   openaiReasoningEffort: ReasoningEffort.default("low"),
   openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
@@ -863,6 +867,7 @@ export function getSettings(): Settings {
     modelProvidersJson: optional("OPENGENI_MODEL_PROVIDERS_JSON"),
     codexSubscriptionEnabled: optional("OPENGENI_CODEX_SUBSCRIPTION_ENABLED"),
     codexProductSku: optional("OPENGENI_CODEX_PRODUCT_SKU"),
+    codexRotationNearExhaustionPct: optional("OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT"),
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),
     openaiAllowedReasoningEfforts: optional("OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"),
     openaiResponsesTransport: optional("OPENGENI_OPENAI_RESPONSES_TRANSPORT"),

--- a/packages/db/drizzle/0032_codex_account_cooldown.sql
+++ b/packages/db/drizzle/0032_codex_account_cooldown.sql
@@ -1,0 +1,18 @@
+-- 0032_codex_account_cooldown.sql
+-- Multi-account P3 (auto-rotation): one cooldown column on codex_subscription_credentials.
+-- `exhausted_until` is PLAINTEXT metadata (a timestamp), NEVER a token or secret. It marks
+-- an account as cooling-down until its usage cap resets, so the rotation engine deterministically
+-- skips a just-rotated-off account until then (no immediate re-pick, no thrash). The column
+-- self-clears via the now() comparison at read time — no sweeper. RLS is row-level, so the
+-- existing workspace_isolation policy already covers it — NO policy change. Additive only
+-- (mirrors 0031's style). Runs under the runner's advisory lock.
+
+ALTER TABLE "codex_subscription_credentials" ADD COLUMN IF NOT EXISTS "exhausted_until" timestamptz;
+
+-- Re-grant (verbatim from 0031:17-22) so opengeni_app keeps DML on the altered table.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2452,6 +2452,9 @@ export type CodexAccountStatus = {
   secondaryUsedPercent: number | null;
   secondaryResetAt: Date | null;
   usageCheckedAt: Date | null;
+  // P3 rotation cooldown: when set and in the future, this account is cooling-down
+  // (rotated-off after a usage cap) and the engine skips it. null ⇒ not cooling.
+  exhaustedUntil: Date | null;
 };
 
 /**
@@ -2481,6 +2484,7 @@ export async function listCodexAccountStatuses(db: Database, workspaceId: string
       secondaryUsedPercent: schema.codexSubscriptionCredentials.secondaryUsedPercent,
       secondaryResetAt: schema.codexSubscriptionCredentials.secondaryResetAt,
       usageCheckedAt: schema.codexSubscriptionCredentials.usageCheckedAt,
+      exhaustedUntil: schema.codexSubscriptionCredentials.exhaustedUntil,
     }).from(schema.codexSubscriptionCredentials)
       .where(eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId))
       .orderBy(asc(schema.codexSubscriptionCredentials.createdAt));
@@ -2581,6 +2585,70 @@ export async function setActiveCodexCredential(db: Database, workspaceId: string
       .where(eq(schema.codexRotationSettings.workspaceId, workspaceId))
       .returning({ id: schema.codexRotationSettings.id });
     return updated.length > 0;
+  });
+}
+
+/**
+ * P3 rotation cooldown writer: stamp `exhausted_until` on a SPECIFIC credential row so the
+ * rotation engine treats it as cooling-down (capped) until `until`. Pass `until = null` to
+ * clear the cooldown. Modeled EXACTLY on recordCodexAccountUsage: RLS-scoped, guarded by
+ * (id, workspace_id), and — critically — NO `version` bump and NO `updatedAt` touch, so it can
+ * never race the (id, version) token-refresh CAS in recordCodexTokenRefresh / setCodexCredentialStatus.
+ * Returns true iff a row was updated (false ⇒ the credential was disconnected under us).
+ */
+export async function setCodexCredentialExhausted(
+  db: Database,
+  workspaceId: string,
+  credentialId: string,
+  until: Date | null,
+): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const updated = await scopedDb.update(schema.codexSubscriptionCredentials)
+      .set({ exhaustedUntil: until })
+      .where(and(
+        eq(schema.codexSubscriptionCredentials.id, credentialId),
+        eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId),
+      ))
+      .returning({ id: schema.codexSubscriptionCredentials.id });
+    return updated.length > 0;
+  });
+}
+
+/** The supported rotation strategies (P3). */
+export const CODEX_ROTATION_STRATEGIES = ["most_remaining", "round_robin", "drain_then_next"] as const;
+export type CodexRotationStrategy = (typeof CODEX_ROTATION_STRATEGIES)[number];
+
+/**
+ * P3 rotation-settings write path: one-cell UPDATE of `rotation_enabled` and/or
+ * `rotation_strategy` on the per-workspace row. Validates the strategy enum (rejects unknown).
+ * Guarded by workspaceId; ensureCodexRotationSettings guarantees the row exists. Returns the
+ * effective settings after the patch (null when no row exists yet — caller should ensure first).
+ */
+export async function updateCodexRotationSettings(
+  db: Database,
+  workspaceId: string,
+  patch: { rotationEnabled?: boolean; rotationStrategy?: CodexRotationStrategy },
+): Promise<CodexRotationSettings | null> {
+  if (patch.rotationStrategy !== undefined && !CODEX_ROTATION_STRATEGIES.includes(patch.rotationStrategy)) {
+    throw new Error(`invalid codex rotation strategy: ${patch.rotationStrategy}`);
+  }
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (patch.rotationEnabled !== undefined) {
+      set.rotationEnabled = patch.rotationEnabled;
+    }
+    if (patch.rotationStrategy !== undefined) {
+      set.rotationStrategy = patch.rotationStrategy;
+    }
+    const [row] = await scopedDb.update(schema.codexRotationSettings)
+      .set(set)
+      .where(eq(schema.codexRotationSettings.workspaceId, workspaceId))
+      .returning({
+        activeCredentialId: schema.codexRotationSettings.activeCredentialId,
+        rotationEnabled: schema.codexRotationSettings.rotationEnabled,
+        rotationStrategy: schema.codexRotationSettings.rotationStrategy,
+      });
+    return row ?? null;
   });
 }
 
@@ -6226,6 +6294,11 @@ export async function evaluateGoalContinuation(db: Database, input: {
     }
     let autoContinuations = row.autoContinuations;
     let noProgressStreak = row.noProgressStreak;
+    // P3: a 429-failover continuation (the last continuation turn carried the `rotated`
+    // marker) is a multi-account rotate, not goal progress OR a goal stall — it must not
+    // burn the auto-continuation budget while walking accounts. Freezes the increment below,
+    // mirroring the budget-pause precedent that a limits pause never consumes budget.
+    let rotatedFailover = false;
     if (row.lastContinuationTurnId) {
       const [lastFinished] = await tx.select({ id: schema.sessionTurns.id })
         .from(schema.sessionTurns)
@@ -6242,6 +6315,16 @@ export async function evaluateGoalContinuation(db: Database, input: {
         autoContinuations = 0;
         noProgressStreak = 0;
       } else if (lastFinished) {
+        const [{ rotatedFailures } = { rotatedFailures: 0 }] = await tx.select({
+          rotatedFailures: sql<number>`count(*)::int`,
+        }).from(schema.sessionEvents)
+          .where(and(
+            eq(schema.sessionEvents.workspaceId, input.workspaceId),
+            eq(schema.sessionEvents.turnId, row.lastContinuationTurnId),
+            eq(schema.sessionEvents.type, "turn.failed"),
+            sql`${schema.sessionEvents.payload} ->> 'rotated' = 'true'`,
+          ));
+        rotatedFailover = Number(rotatedFailures) > 0;
         const [{ toolCalls } = { toolCalls: 0 }] = await tx.select({
           toolCalls: sql<number>`count(*)::int`,
         }).from(schema.sessionEvents)
@@ -6315,13 +6398,16 @@ export async function evaluateGoalContinuation(db: Database, input: {
       }).where(eq(schema.sessionGoals.id, row.id)).returning();
       return { decision: "paused", reason: "limits", goal: mapSessionGoal(paused!) } as const;
     }
+    // Freeze the counter on a rotation failover (invariant: a rotation walk never
+    // consumes continuation budget); a normal continuation increments as before.
+    const nextAutoContinuations = autoContinuations + (rotatedFailover ? 0 : 1);
     const [updated] = await tx.update(schema.sessionGoals).set({
-      autoContinuations: autoContinuations + 1,
+      autoContinuations: nextAutoContinuations,
       noProgressStreak,
       versionAtLastContinuation: row.version,
       updatedAt: new Date(),
     }).where(eq(schema.sessionGoals.id, row.id)).returning();
-    return { decision: "continue", goal: mapSessionGoal(updated!), autoContinuation: autoContinuations + 1, cap } as const;
+    return { decision: "continue", goal: mapSessionGoal(updated!), autoContinuation: nextAutoContinuations, cap } as const;
   }));
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -133,6 +133,10 @@ export const codexSubscriptionCredentials = pgTable("codex_subscription_credenti
   secondaryUsedPercent: integer("secondary_used_percent"),
   secondaryResetAt: timestamp("secondary_reset_at", { withTimezone: true }),
   usageCheckedAt: timestamp("usage_checked_at", { withTimezone: true }), // snapshot freshness → cache TTL clock
+  // P3 rotation cooldown (plaintext metadata; NEVER a token). Set when this account hit its
+  // usage cap on a rotation turn; the rotation engine treats `exhausted_until > now()` as
+  // capped/skip so it isn't immediately re-picked. Self-clears via the now() comparison.
+  exhaustedUntil: timestamp("exhausted_until", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,6 +7,7 @@ import type {
   BillingEntitlementsResponse,
   CodexAccount,
   CodexAccountsResponse,
+  CodexRotationSettings,
   CodexConnectionStatus,
   CodexConnectPoll,
   CodexConnectStart,
@@ -1224,6 +1225,14 @@ export class OpenGeniClient {
   /** Switch the workspace ACTIVE Codex account (the one unpinned sessions use). */
   async activateCodexAccount(workspaceId: string, accountId: string): Promise<{ activated: boolean; accountId: string }> {
     return await this.requestJson<{ activated: boolean; accountId: string }>("POST", `/v1/workspaces/${workspaceId}/codex/accounts/${accountId}/activate`);
+  }
+
+  /** P3: enable/disable Codex auto-rotation and/or pick the strategy. Returns the effective settings. */
+  async setCodexRotationSettings(
+    workspaceId: string,
+    patch: { rotationEnabled?: boolean; rotationStrategy?: CodexRotationSettings["rotationStrategy"] },
+  ): Promise<CodexRotationSettings> {
+    return await this.requestJson<CodexRotationSettings>("PATCH", `/v1/workspaces/${workspaceId}/codex/settings`, patch);
   }
 
   /** Disconnect ONE Codex account by id (re-picks active when the removed one was active). */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -740,6 +740,9 @@ export type CodexAccount = {
   fiveHour?: CodexUsageWindow | null;
   weekly?: CodexUsageWindow | null;
   usageCheckedAt?: string | null;
+  // P3 rotation cooldown: ISO timestamp until which this account is cooling-down
+  // (rotated-off after a usage cap). null/absent ⇒ not cooling.
+  exhaustedUntil?: string | null;
 };
 
 /** Per-workspace Codex rotation/active settings. P1: rotation inert, only activeCredentialId loads. */

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -83,6 +83,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     modelProvidersJson: "[]",
     codexSubscriptionEnabled: false,
     codexProductSku: undefined,
+    codexRotationNearExhaustionPct: 90,
     openaiReasoningEffort: "high",
     openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
     openaiResponsesTransport: "http",


### PR DESCRIPTION
Multi-account Codex **Phase 3** (on P1+P2, both live): opt-in **auto-rotation** so a long-running session never stalls when the active subscription hits its 5h/weekly cap — seamless turn-boundary failover to the account with the most remaining quota.

## Behavior
- **Proactive**: at turn start, if rotation is on and the active account is at/near its cap (used_percent ≥ `OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT`, default 90), switch the active pointer to the most-remaining account (from P2's cached usage — zero extra hot-path cost).
- **Reactive**: a mid-turn `429 usage_limit_reached` (#143) cools the serving account down to its reset and re-dispatches the turn on a fresh account; once all are capped it idles until the **earliest** reset.
- **Strategy**: `most_remaining` (default), `round_robin`, `drain_then_next`.
- Reuses P1's cross-account reasoning strip on every switch.

## Safety invariants (all enforced + tested)
1. **Opt-in, default-off** — `rotation_enabled` defaults false; the off-path is byte-for-byte the P1 manual behavior (no extra db/usage calls).
2. **Manual pin always wins** over rotation.
3. **Turn-boundary only** — never mid-stream.
4. **Bounded / no-thrash** — a confirmed dangerous infinite-loop (all-capped + null/elapsed reset → `continueDelayMs:0` → tight DB-hammering spin) was caught by the adversarial pass and fixed: `availableAt()` never returns a past instant, `computeIdleDelayMs` clamps to [60s, 1h] (never 0), `session.ts` floors the idle hold, and the idle path **self-heals** via a bounded usage refresh. Reactive retry is bounded by per-account cooldown (N accounts ⇒ ≤N rotations ⇒ fixed idle).
5. **Cooldown** — a just-capped account isn't re-picked until its reset (`exhausted_until`, migration `0032`).
6. **Most-remaining** selection from P2 usage.

## Surface
`PATCH /codex/settings` (toggle + strategy), `exhausted_until` on the wire, SDK `setCodexRotationSettings`, and the rotation toggle/strategy select + cooling-down chips in workspace-settings.

## Tests
codex-rotation + session-continuation-hold + usage-limit + history-strip + agent-turn (71) + codex/db/api usage (104), full worker suite 167 pass / 0 fail, typecheck green across 7 packages, web build OK. The loop-fix tests (a)–(f) genuinely fail pre-fix. Adversarially verified: no spin/stall path remains under any null/elapsed-reset + 429-cascade + frozen-brakes combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent-turn Codex credential selection, Temporal continuation timing, and session goal continuation accounting; mistakes could cause thrashing, wrong subscription usage, or stalled sessions under rate limits.
> 
> **Overview**
> Adds **opt-in Codex subscription auto-rotation** so workspaces with multiple ChatGPT accounts can fail over at **turn boundaries** when quotas are exhausted, without changing behavior when rotation is off or a session is pinned.
> 
> **API & data:** New `PATCH /v1/workspaces/:workspaceId/codex/settings` (admin) toggles rotation and strategy (`most_remaining`, `round_robin`, `drain_then_next`). Accounts expose **`exhaustedUntil`** cooldown metadata; migration **`0032`** adds `exhausted_until` on credentials. DB helpers **`updateCodexRotationSettings`** and **`setCodexCredentialExhausted`** support settings writes and post-429 cooldowns.
> 
> **Worker:** Pure ranker **`codex-rotation.ts`** picks the next account from cached usage; **`agent-turn`** runs proactive selection at turn start and reactive handling on `429 usage_limit_reached` (cooldown stamp, immediate re-dispatch vs idle until earliest reset). **`idleUntilReset`** + **`continuationHoldMs`** in **`session.ts`** enforce a minimum hold so all-capped idles cannot tight-loop on stale/null resets; bounded usage refresh self-heals stale cache before idling. Goal auto-continuations **do not increment** on rotation failover turns marked `rotated: true`.
> 
> **UI & SDK:** Workspace settings card adds auto-rotate toggle, strategy select, and **cooling down** chips; **`setCodexRotationSettings`** on the SDK. Config **`codexRotationNearExhaustionPct`** (default 90) defines near-cap eligibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34feca3f7e8be2a9a6502b342114ba29bc639ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->