### PR TITLE
feat(codex): multi-account P4 (final) — usage-header self-update + connector-aware rotation

### DIFF
--- a/apps/api/test/codex-usage-routes.test.ts
+++ b/apps/api/test/codex-usage-routes.test.ts
@@ -63,6 +63,8 @@ function account(id: string, over: Partial<opengeniDb.CodexAccountStatus> = {}):
     secondaryResetAt: null,
     usageCheckedAt: null,
     exhaustedUntil: null,
+    connectorNamespaces: null,
+    connectorsCheckedAt: null,
     ...over,
   };
 }

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -17,6 +17,8 @@ import {
   fetchCodexUsageForAccount,
   getSessionCodexState,
   recordSessionActiveCodexCredential,
+  recordCodexAccountUsage,
+  recordCodexAccountConnectors,
   setActiveCodexCredential,
   setCodexCredentialExhausted,
   requireSession,
@@ -62,6 +64,7 @@ import {
   classifyCodexUsageLimitError,
   codexRequestStorage,
   type CodexRequestContext,
+  type CodexUsageHeaderSnapshot,
 } from "@opengeni/codex";
 import {
   mergeResourceRefs,
@@ -470,6 +473,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // The Codex account this turn runs on (pin > workspace active), resolved once
     // a codex-billed turn is confirmed and threaded into the token resolver below.
     let effectiveCodexCredentialId: string | null = null;
+    // Multi-account P4 (Part A): the latest usage-header snapshot scraped FOR FREE
+    // off this turn's `/codex/responses` responses (a turn issues many model calls;
+    // latest wins). Flushed ONCE into the P2 usage cache for the serving account in
+    // the `finally` — cheaper than a /wham/usage poll AND it self-heals P3 rotation
+    // (the proactive + 429 rankers read these exact columns). null ⇒ nothing scraped.
+    // Hoisted to activity scope so the finally flush (below) sees it. The sink is
+    // wired into codexContext.onUsageHeaders inside the try.
+    let latestCodexUsage: CodexUsageHeaderSnapshot | null = null;
     // Hoisted for the preemption path: an approval-decision rerun must
     // re-enter through the approval resume path (its frozen mid-flight state
     // only exists in the RunState blob), never through a swapped trigger.
@@ -599,6 +610,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             accounts: rankAccounts,
             nearExhaustionPct: settings.codexRotationNearExhaustionPct,
             now: new Date(),
+            // P4: the leaving (active) account's cached connector set is the proxy
+            // for "what this session has access to" — prefer a covering target.
+            usedConnectors: rankAccounts.find((a) => a.id === rotation.activeCredentialId)?.connectorNamespaces ?? [],
           });
           if (rotationDecision.kind === "allCapped") {
             // SELF-HEAL (invariant 4): the turn hot path NEVER refreshes usage, so a
@@ -615,6 +629,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               accounts: rankAccounts,
               nearExhaustionPct: settings.codexRotationNearExhaustionPct,
               now: new Date(),
+              // P4: leaving (active) account's connector set (refreshCappedCodexUsageRows
+              // only touches usage columns, so connectorNamespaces is preserved here).
+              usedConnectors: rankAccounts.find((a) => a.id === rotation.activeCredentialId)?.connectorNamespaces ?? [],
             });
           }
           if (rotationDecision.kind === "active") {
@@ -666,9 +683,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // "rotation" only when the engine actually moved the pointer; otherwise the
             // unchanged P1 "manual" literal (a manual active flip between turns).
             const rotated = rotationDecision?.kind === "active" && rotationDecision.moved;
+            // P4: surface the dropped-connector note when this rotation pick couldn't
+            // cover the session's used connectors (a Tier-2/unknown failover); the pill
+            // renders the badge. Omitted when the switch covered everything (the norm).
+            const droppedConnectors = rotationDecision?.kind === "active" ? rotationDecision.droppedConnectors : undefined;
             await publish([{
               type: "codex.account.switched",
-              payload: { fromAccountId: priorAccountId, toAccountId: effectiveCodexCredentialId, reason: rotated ? "rotation" : "manual" },
+              payload: {
+                fromAccountId: priorAccountId,
+                toAccountId: effectiveCodexCredentialId,
+                reason: rotated ? "rotation" : "manual",
+                ...(droppedConnectors && droppedConnectors.length > 0 ? { droppedConnectors } : {}),
+              },
             }]);
           }
         }
@@ -724,6 +750,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               getToken: resolver.getToken,
               refresh: resolver.refresh,
               resolveModel: buildModelResolver(CODEX_FALLBACK_MODEL_SLUGS, CODEX_FALLBACK_MODEL_SLUGS[0]),
+              onUsageHeaders: (snapshot) => { latestCodexUsage = snapshot; }, // latest wins; flushed once in finally
             };
           })()
         : null;
@@ -1543,6 +1570,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               accounts: fresh,
               nearExhaustionPct: settings.codexRotationNearExhaustionPct,
               now: new Date(),
+              // P4: the just-capped serving account's connector set is the proxy for
+              // "what this session has access to" — prefer a covering failover target.
+              usedConnectors: serving?.connectorNamespaces ?? [],
             });
             if (decision.kind === "active") {
               rotated = true;
@@ -1709,6 +1739,27 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         },
         error: activityError,
       });
+      // Multi-account P4: flush the serving account's free per-turn caches ONCE,
+      // best-effort (same discipline as today's usage write). Both writers skip
+      // version/updatedAt, so neither can race the token-refresh CAS.
+      if (effectiveCodexCredentialId) {
+        // Part A: the latest scraped usage-header snapshot → the P2 usage cache. A
+        // full both-windows snapshot (parseCodexUsageHeaders gates on both), so this
+        // is byte-identical to the /wham/usage write — no partial-window clobber.
+        if (latestCodexUsage) {
+          await recordCodexAccountUsage(db, input.workspaceId, effectiveCodexCredentialId, latestCodexUsage)
+            .catch(() => undefined);
+        }
+        // Part B.1: the connector namespaces codex_apps listed this turn → the
+        // connector-set cache. NON-EMPTY-only: a flaky/empty tools/list must never
+        // overwrite a known set with [] (false coverage drop). Read by reference
+        // AFTER the run, so every tools/list this turn has accumulated.
+        const connectorNamespaces = preparedTools?.codexConnectorNamespaces;
+        if (connectorNamespaces && connectorNamespaces.size > 0) {
+          await recordCodexAccountConnectors(db, input.workspaceId, effectiveCodexCredentialId, [...connectorNamespaces])
+            .catch(() => undefined);
+        }
+      }
       await preparedTools?.close().catch(() => undefined);
       if (heartbeatTimer) {
         clearInterval(heartbeatTimer);

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -13,7 +13,10 @@ export type CodexRotationStrategy = "most_remaining" | "round_robin" | "drain_th
 export type RotationDecision =
   // The chosen account. `moved` ⇒ it differs from the current active pointer, so
   // the caller must persist the pointer move (and the switch is a "rotation").
-  | { kind: "active"; credentialId: string; moved: boolean }
+  // `droppedConnectors` (P4 Part B): the leaving session's used connectors that the
+  // chosen account does NOT cover — populated ONLY on a Tier-2/unknown pick that
+  // can't cover (prefer-not-require: failover still happens, but the pill warns).
+  | { kind: "active"; credentialId: string; moved: boolean; droppedConnectors?: string[] }
   // Every eligible account is capped/cooling: idle until the soonest instant ANY
   // account clears every blocking condition (the multi-account generalization of
   // the single-account idle-until-reset).
@@ -54,6 +57,42 @@ function bindingRemaining(acct: CodexAccountStatus): number {
 
 function cooling(acct: CodexAccountStatus, now: Date): boolean {
   return acct.exhaustedUntil != null && acct.exhaustedUntil.getTime() > now.getTime();
+}
+
+/**
+ * P4 connector coverage (prefer-not-require). `acct` COVERS `usedConnectors` iff its
+ * cached connector set is a SUPERSET of the session's used set. An empty used set is
+ * trivially covered by everyone (→ Tier 1 == all eligibles == byte-identical to P3).
+ * A null (never-probed) set is UNKNOWN: never credited as covering (Tier 2 only),
+ * but — critically — never excluded, so failover is fully preserved.
+ */
+function covers(acct: CodexAccountStatus, usedConnectors: string[]): boolean {
+  if (usedConnectors.length === 0) {
+    return true;
+  }
+  const owned = acct.connectorNamespaces;
+  if (owned === null) {
+    return false; // unprobed ⇒ unknown ⇒ never Tier 1 (but still a Tier-2 candidate)
+  }
+  const ownedSet = new Set(owned);
+  return usedConnectors.every((connector) => ownedSet.has(connector));
+}
+
+/**
+ * The used connectors the chosen account does NOT cover (the "switch dropped a
+ * connector" note). Empty when the account covers (superset) or nothing was used.
+ * A null (unknown) set surfaces ALL used connectors — we can't prove it covers them.
+ */
+function droppedConnectorsFor(acct: CodexAccountStatus, usedConnectors: string[]): string[] {
+  if (usedConnectors.length === 0) {
+    return [];
+  }
+  const owned = acct.connectorNamespaces;
+  if (owned === null) {
+    return [...usedConnectors];
+  }
+  const ownedSet = new Set(owned);
+  return usedConnectors.filter((connector) => !ownedSet.has(connector));
 }
 
 /**
@@ -133,8 +172,14 @@ export function chooseRotationActive(args: {
   accounts: CodexAccountStatus[];
   nearExhaustionPct: number;
   now: Date;
+  // P4 (Part B): the connectors the leaving session has access to (the leaving
+  // account's cached connector set, used as the "session needs these" proxy).
+  // Optional + defaults to [] ⇒ when absent/empty the ranker is BYTE-IDENTICAL to
+  // P3 (every account trivially covers → Tier 1 == all eligibles). Self-gating.
+  usedConnectors?: string[];
 }): RotationDecision {
   const { rotationStrategy, activeCredentialId, priorCredentialId, accounts, nearExhaustionPct, now } = args;
+  const usedConnectors = args.usedConnectors ?? [];
 
   if (accounts.length === 0) {
     return { kind: "none" };
@@ -153,7 +198,15 @@ export function chooseRotationActive(args: {
     if (!chosen) {
       return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct, now) };
     }
-    return { kind: "active", credentialId: chosen.id, moved: chosen.id !== activeCredentialId };
+    // P4: surface the dropped-connector note when the chosen account doesn't cover
+    // the session's used connectors (a Tier-2/unknown failover pick). Empty ⇒ omit.
+    const dropped = droppedConnectorsFor(chosen, usedConnectors);
+    return {
+      kind: "active",
+      credentialId: chosen.id,
+      moved: chosen.id !== activeCredentialId,
+      ...(dropped.length > 0 ? { droppedConnectors: dropped } : {}),
+    };
   };
 
   if (rotationStrategy === "round_robin") {
@@ -180,12 +233,22 @@ export function chooseRotationActive(args: {
   }
 
   // most_remaining (default + the correctness path).
+  // Healthy-active fast path UNCHANGED (no-thrash): a session whose active account
+  // is still eligible never switches — not even for connector coverage. Coverage
+  // matters ONLY on the must-move branch below.
   if (activeRow && eligible(activeRow, nearExhaustionPct, now)) {
     return { kind: "active", credentialId: activeRow.id, moved: false };
   }
-  // Active is capped/near-cap/cooling/missing → pick max remaining, ties broken by
-  // list (created_at) order via a stable reduce.
-  const chosen = eligibles.reduce<CodexAccountStatus | undefined>((best, acct) => {
+  // Active is capped/near-cap/cooling/missing → must move. Two-tier coverage pick
+  // over the SAME eligible set (prefer-not-require):
+  //   Tier 1 — eligibles whose connector set COVERS the session's used set.
+  //   Tier 2 — ALL eligibles, only if Tier 1 is empty (failover fully preserved).
+  // Within the chosen tier, max bindingRemaining, ties broken by list (created_at)
+  // order via a stable reduce — byte-identical to P3 when usedConnectors is empty
+  // (Tier 1 == all eligibles).
+  const covering = eligibles.filter((acct) => covers(acct, usedConnectors));
+  const pool = covering.length > 0 ? covering : eligibles;
+  const chosen = pool.reduce<CodexAccountStatus | undefined>((best, acct) => {
     if (!best) {
       return acct;
     }

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -33,6 +33,8 @@ function acct(id: string, over: Partial<CodexAccountStatus> = {}): CodexAccountS
     secondaryResetAt: null,
     usageCheckedAt: null,
     exhaustedUntil: null,
+    connectorNamespaces: null,
+    connectorsCheckedAt: null,
     ...over,
   };
 }
@@ -297,6 +299,78 @@ describe("chooseRotationActive — round_robin / drain_then_next", () => {
       .toEqual({ kind: "active", credentialId: "b", moved: true });
     const capped = [acct("a", { primaryUsedPercent: 99 }), acct("b")];
     expect(chooseRotationActive({ ...base, rotationStrategy: "drain_then_next", activeCredentialId: "a", priorCredentialId: "a", accounts: capped }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+});
+
+// P4 — connector-aware rotation (prefer-not-require). The ranker PREFERS a failover
+// target whose connector set COVERS the leaving session's used connectors, but still
+// fails over to a lesser-coverage account when that is the only one with quota. When
+// usedConnectors is empty the ranker is byte-identical to P3.
+describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => {
+  test("empty usedConnectors → byte-identical to P3 (max remaining wins, no dropped note)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 95 }),                                    // active, near-cap
+      acct("b", { primaryUsedPercent: 40, connectorNamespaces: ["github"] }),   // 60 remaining
+      acct("c", { primaryUsedPercent: 10, connectorNamespaces: [] }),           // 90 remaining ← winner
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: [] }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true });
+  });
+
+  test("PREFERS a covering target even when a non-covering one has MORE remaining quota", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 95, connectorNamespaces: ["github"] }),                 // active, near-cap (leaving)
+      acct("b", { primaryUsedPercent: 50, connectorNamespaces: ["github", "gmail"] }),        // covers github, 50 remaining ← winner
+      acct("c", { primaryUsedPercent: 5, connectorNamespaces: ["gmail"] }),                   // 95 remaining BUT lacks github
+    ];
+    // Session used github (the leaving account's set). c has the most quota but can't
+    // cover github → Tier 1 = {b}; b is chosen despite less remaining. No dropped note.
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github"] }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+
+  test("FAILS OVER to a non-covering account when it is the ONLY one with quota (+ dropped note)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github"] }),                 // active, capped (leaving)
+      acct("b", { primaryUsedPercent: 99, connectorNamespaces: ["github", "gmail"] }),        // covers BUT also capped
+      acct("c", { primaryUsedPercent: 10, connectorNamespaces: ["gmail"] }),                  // eligible BUT lacks github
+    ];
+    // Tier 1 (covering) is empty among eligibles → Tier 2 = {c}: failover preserved,
+    // and the dropped-connector note surfaces github so the pill can warn.
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github"] }))
+      .toEqual({ kind: "active", credentialId: "c", moved: true, droppedConnectors: ["github"] });
+  });
+
+  test("null (never-probed) connector set is UNKNOWN: never Tier 1, never excluded, dropped note lists the used set", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github"] }), // active, capped (leaving)
+      acct("b", { primaryUsedPercent: 10, connectorNamespaces: null }),       // unprobed → Tier 2 only, but eligible
+    ];
+    // No covering eligible (b is unknown) → Tier 2 picks b (failover), and since we
+    // can't prove b covers github, the note surfaces it.
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github"] }))
+      .toEqual({ kind: "active", credentialId: "b", moved: true, droppedConnectors: ["github"] });
+  });
+
+  test("healthy-active fast path is UNCHANGED by coverage (no switch for connectors)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 10, connectorNamespaces: [] }),                  // active, healthy, lacks github
+      acct("b", { primaryUsedPercent: 5, connectorNamespaces: ["github"] }),           // covers github, more remaining
+    ];
+    // Even though b covers github and a does not, the still-eligible active account
+    // never switches for coverage — no-thrash. No move, no dropped note.
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github"] }))
+      .toEqual({ kind: "active", credentialId: "a", moved: false });
+  });
+
+  test("a covering target that is a strict SUPERSET covers (multi-connector session)", () => {
+    const accounts = [
+      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github", "linear"] }),                 // capped (leaving)
+      acct("b", { primaryUsedPercent: 50, connectorNamespaces: ["github", "linear", "gmail"] }),        // superset ← covers
+      acct("c", { primaryUsedPercent: 5, connectorNamespaces: ["github"] }),                            // most quota but missing linear
+    ];
+    expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github", "linear"] }))
       .toEqual({ kind: "active", credentialId: "b", moved: true });
   });
 });

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -12,9 +12,65 @@
 
 import { CODEX_ORIGINATOR } from "./constants";
 import { normalizeCodexRequestBody } from "./normalize";
-import { codexRequestStorage, type CodexTokenSnapshot } from "./request-context";
+import { codexRequestStorage, type CodexTokenSnapshot, type CodexUsageHeaderSnapshot } from "./request-context";
 
 export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/** Parse an integer header value; null when absent or not a finite integer. */
+function parseIntHeader(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const n = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve a window reset instant from the response headers: prefer the absolute
+ * `*-reset-at` (epoch SECONDS → ms, mirroring codex-token-resolver's usage parse),
+ * else the relative `*-reset-after-seconds` from now, else now (a missing reset
+ * reads as "already cleared" — availableAt treats an elapsed reset as a bounded
+ * default cooldown, so the ranker never strands on it).
+ */
+function resolveResetAt(headers: Headers, atKey: string, afterKey: string, nowMs: number): Date {
+  const at = parseIntHeader(headers.get(atKey));
+  if (at !== null) {
+    return new Date(at * 1000);
+  }
+  const after = parseIntHeader(headers.get(afterKey));
+  if (after !== null) {
+    return new Date(nowMs + after * 1000);
+  }
+  return new Date(nowMs);
+}
+
+/**
+ * Multi-account P4 (Part A): scrape the full usage snapshot the codex backend
+ * stamps on every `/codex/responses` response in `x-codex-primary-*` /
+ * `x-codex-secondary-*` headers (integer-identical to GET /wham/usage, for free).
+ *
+ * CRITICAL clobber-fix: return null unless BOTH windows expose a valid used-percent
+ * integer. recordCodexAccountUsage writes all five columns unconditionally, so a
+ * primary-only snapshot would null the weekly column. Both windows are always
+ * emitted together on `/codex/responses`; gating on both makes every write a full
+ * 5-column snapshot byte-identical to the poll path, and a malformed/absent header
+ * set simply no-ops (the /wham/usage poll fallback still covers it).
+ */
+export function parseCodexUsageHeaders(headers: Headers): CodexUsageHeaderSnapshot | null {
+  const primaryUsedPercent = parseIntHeader(headers.get("x-codex-primary-used-percent"));
+  const secondaryUsedPercent = parseIntHeader(headers.get("x-codex-secondary-used-percent"));
+  if (primaryUsedPercent === null || secondaryUsedPercent === null) {
+    return null; // not a full both-windows snapshot — no-op (never a partial clobber)
+  }
+  const nowMs = Date.now();
+  return {
+    primaryUsedPercent,
+    primaryResetAt: resolveResetAt(headers, "x-codex-primary-reset-at", "x-codex-primary-reset-after-seconds", nowMs),
+    secondaryUsedPercent,
+    secondaryResetAt: resolveResetAt(headers, "x-codex-secondary-reset-at", "x-codex-secondary-reset-after-seconds", nowMs),
+    checkedAt: new Date(nowMs),
+  };
+}
 
 export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): FetchLike {
   return async (input, init) => {
@@ -65,6 +121,16 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
         console.error(`[codex-debug] POST ${rewritten} stream=${callerWantsStream} bodyKeys=[${keys.join(",")}]`);
       }
       const res = await base(rewritten, nextInit);
+      // Multi-account P4 (Part A): scrape the usage headers ONCE, before the
+      // OK/!res.ok branch, so the same fire-and-forget read also covers the 429
+      // hard-cap path (an exhausted serving account stamps its own fresh
+      // used_percent with no extra fetch). Sync + non-throwing + never awaited;
+      // `if (usage)` makes an absent/malformed header set a safe no-op. We read
+      // res.headers only — the SSE body is never touched here.
+      const usage = parseCodexUsageHeaders(res.headers);
+      if (usage) {
+        ctx.onUsageHeaders?.(usage);
+      }
       if (process.env.CODEX_DEBUG && !res.ok) {
         console.error(`[codex-debug] <- ${res.status} ${await res.clone().text()}`);
       }

--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -88,8 +88,16 @@ export class ToolNameMapper {
   }
 }
 
-/** Drop bad outputSchemas + sanitize tool names on a JSON-RPC tools/list result, in place. */
-function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper): void {
+/**
+ * Drop bad outputSchemas + sanitize tool names on a JSON-RPC tools/list result, in place.
+ *
+ * P4 (Part B.1): when `namespaceSink` is provided, accumulate each tool's ORIGINAL
+ * connector namespace (the segment BEFORE the first dot, e.g. `github` from
+ * `github.create_issue`) into it — captured HERE because this pass sees the original
+ * dotted name BEFORE mapper.sanitize rewrites the dot away. Only dotted names carry a
+ * connector namespace; un-dotted (already-legal) names are not connectors and are skipped.
+ */
+function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper, namespaceSink?: Set<string>): void {
   if (!message || typeof message !== "object") {
     return;
   }
@@ -109,16 +117,22 @@ function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper): vo
       }
     }
     if (typeof record.name === "string") {
+      if (namespaceSink && record.name.includes(".")) {
+        const namespace = record.name.slice(0, record.name.indexOf("."));
+        if (namespace) {
+          namespaceSink.add(namespace);
+        }
+      }
       record.name = mapper.sanitize(record.name);
     }
   }
 }
 
 /** Sanitize a single JSON body (application/json MCP response). */
-export function sanitizeMcpJsonBody(text: string, mapper: ToolNameMapper = new ToolNameMapper()): string {
+export function sanitizeMcpJsonBody(text: string, mapper: ToolNameMapper = new ToolNameMapper(), namespaceSink?: Set<string>): string {
   try {
     const parsed = JSON.parse(text);
-    sanitizeToolsInRpcMessage(parsed, mapper);
+    sanitizeToolsInRpcMessage(parsed, mapper, namespaceSink);
     return JSON.stringify(parsed);
   } catch {
     return text; // not JSON we understand — leave untouched
@@ -126,7 +140,7 @@ export function sanitizeMcpJsonBody(text: string, mapper: ToolNameMapper = new T
 }
 
 /** Sanitize an SSE body: each JSON-RPC message rides on a `data:` line. */
-export function sanitizeMcpSseBody(text: string, mapper: ToolNameMapper = new ToolNameMapper()): string {
+export function sanitizeMcpSseBody(text: string, mapper: ToolNameMapper = new ToolNameMapper(), namespaceSink?: Set<string>): string {
   return text
     .split("\n")
     .map((line) => {
@@ -136,7 +150,7 @@ export function sanitizeMcpSseBody(text: string, mapper: ToolNameMapper = new To
       const payload = line.slice("data:".length).trimStart();
       try {
         const parsed = JSON.parse(payload);
-        sanitizeToolsInRpcMessage(parsed, mapper);
+        sanitizeToolsInRpcMessage(parsed, mapper, namespaceSink);
         return `data: ${JSON.stringify(parsed)}`;
       } catch {
         return line;
@@ -173,8 +187,13 @@ export function remapToolCallRequestBody(body: string, mapper: ToolNameMapper): 
  * the name mapping recorded), and tools/call requests get their name reversed back
  * to the MCP server's original. Only the POST request/response is buffered; the
  * long-lived GET notification SSE stream is passed through untouched.
+ *
+ * P4 (Part B.1): an optional `namespaceSink` Set accumulates the ORIGINAL-dotted
+ * connector namespaces seen across every tools/list this turn (captured before the
+ * dot is sanitized away). The worker reads the (live, by-reference) Set after the
+ * turn to cache the serving account's connector set — packages/codex stays db-free.
  */
-export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch): FetchLike {
+export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch, namespaceSink?: Set<string>): FetchLike {
   const mapper = new ToolNameMapper();
   return async (input, init) => {
     // Outgoing: reverse a sanitized tools/call name to the server's original.
@@ -197,7 +216,9 @@ export function codexAppsSanitizingFetch(base: FetchLike = globalThis.fetch): Fe
       return res;
     }
     const originalBody = await res.text();
-    const sanitized = isJson ? sanitizeMcpJsonBody(originalBody, mapper) : sanitizeMcpSseBody(originalBody, mapper);
+    const sanitized = isJson
+      ? sanitizeMcpJsonBody(originalBody, mapper, namespaceSink)
+      : sanitizeMcpSseBody(originalBody, mapper, namespaceSink);
     const headers = new Headers(res.headers);
     headers.delete("content-length"); // body length changed
     headers.delete("content-encoding");

--- a/packages/codex/src/request-context.ts
+++ b/packages/codex/src/request-context.ts
@@ -13,6 +13,23 @@ export type CodexTokenSnapshot = {
   isFedramp: boolean;
 };
 
+/**
+ * Multi-account P4 (Part A): a full usage snapshot scraped FOR FREE from the
+ * `x-codex-primary-*` / `x-codex-secondary-*` response headers the codex backend
+ * stamps on every `/codex/responses` turn (success AND 429 hard-cap). Integer-
+ * identical to GET /wham/usage but with zero extra round-trip. parseCodexUsageHeaders
+ * returns this only when BOTH windows parse, so a write is always a full 5-column
+ * snapshot (no partial-window clobber). Shape mirrors db's CodexAccountUsageSnapshot
+ * (non-null here: a partial read is filtered to null upstream, never half-written).
+ */
+export type CodexUsageHeaderSnapshot = {
+  primaryUsedPercent: number;
+  primaryResetAt: Date;
+  secondaryUsedPercent: number;
+  secondaryResetAt: Date;
+  checkedAt: Date;
+};
+
 export type CodexRequestContext = {
   clientVersion: string;
   /** Worker-supplied: proactive refresh + single-flight + db persist. */
@@ -21,6 +38,13 @@ export type CodexRequestContext = {
   refresh: () => Promise<CodexTokenSnapshot>;
   /** Model-slug resolver (longest-prefix against the live catalog). */
   resolveModel: (slug: string) => string;
+  /**
+   * Multi-account P4 (Part A): fire-and-forget usage-header sink. Called by
+   * codexSubscriptionFetch on EVERY response (sync, non-throwing, never awaited)
+   * with the parsed full-window snapshot. The worker records the latest into the
+   * P2 usage cache once per turn in its `finally` — packages/codex stays db-free.
+   */
+  onUsageHeaders?: (snapshot: CodexUsageHeaderSnapshot) => void;
 };
 
 export const codexRequestStorage = new AsyncLocalStorage<CodexRequestContext>();

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import {
   type CodexRequestContext,
   type CodexTokenSnapshot,
+  type CodexUsageHeaderSnapshot,
   type FetchLike,
   classifyCodexUsageLimitError,
   codexRequestStorage,
   codexSubscriptionFetch,
+  parseCodexUsageHeaders,
 } from "../src";
 
 type Capture = { url: string; init?: RequestInit | undefined };
@@ -199,5 +201,97 @@ describe("classifyCodexUsageLimitError", () => {
     expect(classifyCodexUsageLimitError(new Error("nope"))).toBeNull();
     expect(classifyCodexUsageLimitError("string")).toBeNull();
     expect(classifyCodexUsageLimitError(null)).toBeNull();
+  });
+});
+
+// Multi-account P4 (Part A): the free per-turn usage scrape.
+describe("parseCodexUsageHeaders", () => {
+  test("both windows present → full 5-column snapshot (epoch seconds → ms)", () => {
+    const resetPrimary = 1782700000;
+    const resetSecondary = 1783200000;
+    const snap = parseCodexUsageHeaders(new Headers({
+      "x-codex-primary-used-percent": "42",
+      "x-codex-primary-reset-at": String(resetPrimary),
+      "x-codex-secondary-used-percent": "7",
+      "x-codex-secondary-reset-at": String(resetSecondary),
+    }));
+    expect(snap).not.toBeNull();
+    expect(snap!.primaryUsedPercent).toBe(42);
+    expect(snap!.secondaryUsedPercent).toBe(7);
+    expect(snap!.primaryResetAt.getTime()).toBe(resetPrimary * 1000);
+    expect(snap!.secondaryResetAt.getTime()).toBe(resetSecondary * 1000);
+    expect(snap!.checkedAt).toBeInstanceOf(Date);
+  });
+
+  test("primary-only (missing secondary) → null (NO partial-window clobber)", () => {
+    expect(parseCodexUsageHeaders(new Headers({
+      "x-codex-primary-used-percent": "42",
+      "x-codex-primary-reset-at": "1782700000",
+    }))).toBeNull();
+  });
+
+  test("absent / non-integer used-percent → null (safe no-op)", () => {
+    expect(parseCodexUsageHeaders(new Headers({}))).toBeNull();
+    expect(parseCodexUsageHeaders(new Headers({
+      "x-codex-primary-used-percent": "n/a",
+      "x-codex-secondary-used-percent": "3",
+    }))).toBeNull();
+  });
+
+  test("reset-after-seconds fallback when no absolute reset-at", () => {
+    const before = Date.now();
+    const snap = parseCodexUsageHeaders(new Headers({
+      "x-codex-primary-used-percent": "10",
+      "x-codex-primary-reset-after-seconds": "3600",
+      "x-codex-secondary-used-percent": "20",
+      "x-codex-secondary-reset-after-seconds": "7200",
+    }));
+    expect(snap).not.toBeNull();
+    expect(snap!.primaryResetAt.getTime()).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(snap!.secondaryResetAt.getTime()).toBeGreaterThanOrEqual(before + 7200 * 1000);
+  });
+});
+
+describe("codexSubscriptionFetch — usage-header sink (P4 Part A)", () => {
+  function usageBase(status: number, headers: Record<string, string>): FetchLike {
+    return async () => new Response("data: {}\n\n", {
+      status,
+      headers: { "content-type": "text/event-stream", ...headers },
+    });
+  }
+
+  test("fires onUsageHeaders on the OK path with the parsed snapshot", async () => {
+    const seen: CodexUsageHeaderSnapshot[] = [];
+    const fetchImpl = codexSubscriptionFetch(usageBase(200, {
+      "x-codex-primary-used-percent": "55",
+      "x-codex-primary-reset-at": "1782700000",
+      "x-codex-secondary-used-percent": "12",
+      "x-codex-secondary-reset-at": "1783200000",
+    }));
+    await codexRequestStorage.run(ctx({ onUsageHeaders: (s) => seen.push(s) }), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ stream: true }) }));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.primaryUsedPercent).toBe(55);
+    expect(seen[0]!.secondaryUsedPercent).toBe(12);
+  });
+
+  test("fires on the 429 hard-cap path too (an exhausted account stamps its own usage)", async () => {
+    const seen: CodexUsageHeaderSnapshot[] = [];
+    const fetchImpl = codexSubscriptionFetch(usageBase(429, {
+      "x-codex-primary-used-percent": "100",
+      "x-codex-secondary-used-percent": "100",
+    }));
+    await codexRequestStorage.run(ctx({ onUsageHeaders: (s) => seen.push(s) }), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ stream: true }) }));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.primaryUsedPercent).toBe(100);
+  });
+
+  test("does NOT fire when headers are absent/partial (safe no-op)", async () => {
+    const seen: CodexUsageHeaderSnapshot[] = [];
+    const fetchImpl = codexSubscriptionFetch(usageBase(200, { "x-codex-primary-used-percent": "55" }));
+    await codexRequestStorage.run(ctx({ onUsageHeaders: (s) => seen.push(s) }), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: JSON.stringify({ stream: true }) }));
+    expect(seen).toHaveLength(0);
   });
 });

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -115,6 +115,23 @@ describe("sanitizeMcpJsonBody", () => {
   test("returns non-JSON input unchanged", () => {
     expect(sanitizeMcpJsonBody("not json")).toBe("not json");
   });
+
+  // P4 (Part B.1): the connector-namespace sink captures the ORIGINAL dotted
+  // namespace before the dot is sanitized away.
+  test("namespace sink accumulates the original connector namespace (before dot rewrite)", () => {
+    const sink = new Set<string>();
+    const body = JSON.stringify(toolsListMsg([
+      { name: "github.create_issue", inputSchema: { type: "object" } },
+      { name: "github.list_repos", inputSchema: { type: "object" } },   // dedup → still one "github"
+      { name: "gmail.send", inputSchema: { type: "object" } },
+      { name: "set_session_title", inputSchema: { type: "object" } },   // un-dotted → not a connector namespace
+    ]));
+    const tools = JSON.parse(sanitizeMcpJsonBody(body, new ToolNameMapper(), sink)).result.tools;
+    // The wire names were sanitized (dot → underscore) for the model.
+    expect(tools[0].name).toBe("github_create_issue");
+    // The sink kept the ORIGINAL namespaces, deduped, excluding the un-dotted tool.
+    expect([...sink].sort()).toEqual(["github", "gmail"]);
+  });
 });
 
 describe("sanitizeMcpSseBody", () => {

--- a/packages/db/drizzle/0033_codex_connector_cache.sql
+++ b/packages/db/drizzle/0033_codex_connector_cache.sql
@@ -1,0 +1,20 @@
+-- 0033_codex_connector_cache.sql
+-- Multi-account P4 (Part B): per-account connector-set cache on codex_subscription_credentials.
+-- Both columns are PLAINTEXT metadata (the ORIGINAL-dotted connector namespaces the account
+-- exposes via codex_apps, e.g. {github,gmail,linear}, plus a freshness clock); they NEVER hold a
+-- token or any secret. The rotation ranker PREFERS (never requires) a target whose connector set
+-- covers the leaving account's set, so a switch doesn't strand a session mid-connector. RLS is
+-- row-level, so the existing workspace_isolation policy already covers them — NO policy change.
+-- Both nullable (null ⇒ never probed = unknown to the ranker). Additive only (mirrors 0031/0032's
+-- style). Runs under the runner's advisory lock.
+
+ALTER TABLE "codex_subscription_credentials" ADD COLUMN IF NOT EXISTS "connector_namespaces" text[];
+ALTER TABLE "codex_subscription_credentials" ADD COLUMN IF NOT EXISTS "connectors_checked_at" timestamptz;
+
+-- Re-grant (verbatim from 0031/0032) so opengeni_app keeps DML on the altered table.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2455,6 +2455,11 @@ export type CodexAccountStatus = {
   // P3 rotation cooldown: when set and in the future, this account is cooling-down
   // (rotated-off after a usage cap) and the engine skips it. null ⇒ not cooling.
   exhaustedUntil: Date | null;
+  // P4 connector-aware rotation: the ORIGINAL-dotted connector namespaces this
+  // account exposes via codex_apps (github/gmail/linear/…). null ⇒ never probed
+  // (the ranker treats it as unknown: never credited as covering, never excluded).
+  connectorNamespaces: string[] | null;
+  connectorsCheckedAt: Date | null;
 };
 
 /**
@@ -2485,6 +2490,9 @@ export async function listCodexAccountStatuses(db: Database, workspaceId: string
       secondaryResetAt: schema.codexSubscriptionCredentials.secondaryResetAt,
       usageCheckedAt: schema.codexSubscriptionCredentials.usageCheckedAt,
       exhaustedUntil: schema.codexSubscriptionCredentials.exhaustedUntil,
+      // P4 connector-set cache — metadata-only, rides along on this read.
+      connectorNamespaces: schema.codexSubscriptionCredentials.connectorNamespaces,
+      connectorsCheckedAt: schema.codexSubscriptionCredentials.connectorsCheckedAt,
     }).from(schema.codexSubscriptionCredentials)
       .where(eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId))
       .orderBy(asc(schema.codexSubscriptionCredentials.createdAt));
@@ -2605,6 +2613,43 @@ export async function setCodexCredentialExhausted(
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const updated = await scopedDb.update(schema.codexSubscriptionCredentials)
       .set({ exhaustedUntil: until })
+      .where(and(
+        eq(schema.codexSubscriptionCredentials.id, credentialId),
+        eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId),
+      ))
+      .returning({ id: schema.codexSubscriptionCredentials.id });
+    return updated.length > 0;
+  });
+}
+
+/**
+ * P4 connector-set cache writer: persist the set of ORIGINAL-dotted connector
+ * namespaces a SPECIFIC credential exposes via codex_apps (+ the freshness clock).
+ * Modeled byte-for-byte on recordCodexAccountUsage / setCodexCredentialExhausted:
+ * RLS-scoped, guarded by (id, workspace_id), and — critically — NO `version` bump and
+ * NO `updatedAt` touch, so it can never race the (id, version) token-refresh CAS.
+ *
+ * The CALLER must only invoke this with a NON-EMPTY set: codex_apps connects
+ * best-effort (a transient failure yields an empty tools/list), and overwriting a
+ * known non-empty set with [] would falsely "drop" coverage on a flaky turn. A
+ * genuinely connector-less account stays null (the ranker treats null as unknown).
+ * Returns true iff a row was updated (false ⇒ the credential was disconnected under us).
+ */
+export async function recordCodexAccountConnectors(
+  db: Database,
+  workspaceId: string,
+  credentialId: string,
+  namespaces: string[],
+): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const updated = await scopedDb.update(schema.codexSubscriptionCredentials)
+      .set({
+        connectorNamespaces: namespaces,
+        connectorsCheckedAt: new Date(),
+        // NB: no `version` bump and no `updatedAt` touch — connector set is non-credential
+        // metadata and must NOT race the (id, version) refresh CAS (same discipline as
+        // recordCodexAccountUsage / setCodexCredentialExhausted).
+      })
       .where(and(
         eq(schema.codexSubscriptionCredentials.id, credentialId),
         eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -137,6 +137,14 @@ export const codexSubscriptionCredentials = pgTable("codex_subscription_credenti
   // usage cap on a rotation turn; the rotation engine treats `exhausted_until > now()` as
   // capped/skip so it isn't immediately re-picked. Self-clears via the now() comparison.
   exhaustedUntil: timestamp("exhausted_until", { withTimezone: true }),
+  // P4 connector-aware rotation cache (plaintext metadata; NEVER a token). The set
+  // of ORIGINAL-dotted connector namespaces (github/gmail/linear/…) this account
+  // exposes via codex_apps, captured from the per-turn tools/list. null ⇒ never
+  // probed (the ranker treats it as unknown: never credited as covering, never
+  // excluded). The writer only ever sets a NON-empty set, so a flaky empty turn
+  // can't false-drop coverage. connectorsCheckedAt is the freshness clock.
+  connectorNamespaces: text("connector_namespaces").array(),
+  connectorsCheckedAt: timestamp("connectors_checked_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({

--- a/packages/db/test/codex-usage.test.ts
+++ b/packages/db/test/codex-usage.test.ts
@@ -12,6 +12,7 @@ import {
   getCodexCredentialStatus,
   listCodexAccountStatuses,
   recordCodexAccountUsage,
+  recordCodexAccountConnectors,
   setActiveCodexCredential,
   upsertCodexSubscriptionCredential,
   type Database,
@@ -170,6 +171,29 @@ describe("recordCodexAccountUsage + the cached read", () => {
     expect(await recordCodexAccountUsage(db, ws.workspaceId, crypto.randomUUID(), {
       primaryUsedPercent: 99, primaryResetAt: null, secondaryUsedPercent: 99, secondaryResetAt: null, checkedAt: new Date(),
     })).toBe(false);
+  });
+});
+
+describe("recordCodexAccountConnectors + the cached read (P4 Part B.1)", () => {
+  test("writes the connector set and listCodexAccountStatuses reads it back; null until first write", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const id = await connect(ws, "acct_x", { access_token: "AC", refresh_token: "RF", id_token: "ID" }, new Date(Date.now() + 3_600_000));
+    // Never-probed → null (the ranker treats it as unknown).
+    const [before] = await listCodexAccountStatuses(db, ws.workspaceId);
+    expect(before!.connectorNamespaces).toBeNull();
+    expect(before!.connectorsCheckedAt).toBeNull();
+    expect(await recordCodexAccountConnectors(db, ws.workspaceId, id, ["github", "gmail"])).toBe(true);
+    const [after] = await listCodexAccountStatuses(db, ws.workspaceId);
+    expect([...(after!.connectorNamespaces ?? [])].sort()).toEqual(["github", "gmail"]);
+    expect(after!.connectorsCheckedAt).not.toBeNull();
+  });
+
+  test("an unknown id writes 0 rows (false)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    await connect(ws, "acct_x", { access_token: "AC", refresh_token: "RF", id_token: "ID" }, new Date(Date.now() + 3_600_000));
+    expect(await recordCodexAccountConnectors(db, ws.workspaceId, crypto.randomUUID(), ["github"])).toBe(false);
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -890,6 +890,13 @@ export function sandboxRunAs(_settings: Settings): string | undefined {
 export type PreparedAgentTools = {
   mcpServers: MCPServer[];
   close: () => Promise<void>;
+  // P4 (Part B.1): the live, by-reference Set of ORIGINAL-dotted connector
+  // namespaces the codex_apps transport saw across this turn's tools/list calls.
+  // Accumulates as the agent lists tools during the run, so the worker reads it
+  // AFTER the turn (in its finally) to cache the serving account's connector set.
+  // Empty when this turn has no codex_apps server (or it never listed any
+  // namespaced tool) — the worker only persists a non-empty set.
+  codexConnectorNamespaces: Set<string>;
 };
 
 export type PrepareToolsOptions = {
@@ -907,8 +914,12 @@ export type PrepareToolsOptions = {
 };
 
 export async function prepareAgentTools(settings: Settings, tools: ToolRef[], options: PrepareToolsOptions = {}): Promise<PreparedAgentTools> {
+  // P4 (Part B.1): one Set per prepareTools call, shared by reference into the
+  // codex_apps sanitizing fetch so every tools/list this turn accumulates the
+  // account's connector namespaces. Surfaced on PreparedAgentTools for the worker.
+  const codexConnectorNamespaces = new Set<string>();
   if (tools.length === 0) {
-    return { mcpServers: [], close: async () => {} };
+    return { mcpServers: [], close: async () => {}, codexConnectorNamespaces };
   }
   const registry = new Map(settings.mcpServers.map((server) => [server.id, server]));
   const servers = await Promise.all(tools.map(async (tool) => {
@@ -923,8 +934,9 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       cacheToolsList: config.cacheToolsList,
       // codex_apps returns connector tools with empty `outputSchema: {}` that the
       // MCP SDK's strict Tool schema rejects (fails the turn during tools/list);
-      // sanitize the response on the wire before validation.
-      ...(isCodexAppsMcpServer(config) ? { fetch: codexAppsSanitizingFetch(globalThis.fetch) } : {}),
+      // sanitize the response on the wire before validation. The namespace Set
+      // also captures each tool's original connector namespace (P4 Part B.1).
+      ...(isCodexAppsMcpServer(config) ? { fetch: codexAppsSanitizingFetch(globalThis.fetch, codexConnectorNamespaces) } : {}),
       ...await mcpServerRequestInit(settings, config, options),
       ...(config.timeoutMs ? {
         timeout: config.timeoutMs,
@@ -957,6 +969,7 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
         await connectedBestEffort.close();
       }
     },
+    codexConnectorNamespaces,
   };
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -764,6 +764,10 @@ export type CodexAccountSwitchedPayload = {
   fromAccountId: string | null;
   toAccountId: string;
   reason: "manual" | "exhausted" | "rotation";
+  // P4 connector-aware rotation: the session's used connectors that the new account
+  // does NOT cover (a prefer-not-require failover that dropped a connector). Present
+  // only on such a switch; the UI renders a "dropped <connector>" badge on the pill.
+  droppedConnectors?: string[];
 };
 
 /** Device-code start: show `userCode` at `verificationUri`, then poll with `state`. */


### PR DESCRIPTION
Multi-account Codex **Phase 4 (final)** — completes the feature on P1/P2/P3 (all live).

## Part A — Usage-header self-update (the high-value win)
Live-probed and confirmed: `POST /codex/responses` stamps the **complete** usage snapshot in `x-codex-{primary,secondary}-{used-percent,reset-after-seconds,reset-at}` headers on **every turn** — byte-identical to `/wham/usage` (verified to the integer, ~free). So we scrape them off the existing model response (no extra request, no body double-consume; covers the 429 path) and refresh the P2 usage cache for the serving account. This **self-heals P3 rotation**: the proactive ranker and the all-capped idle re-check now read live usage for the just-served account with zero polling. (Non-serving accounts still poll `/wham/usage`.) Both-windows-or-null gate avoids partial-window clobber; flush is best-effort in the turn `finally`, doesn't touch `exhausted_until`.

## Part B — Connector-aware rotation (prefer, never block)
Connectors differ per account. Cache each account's connector namespaces (migration `0033`, captured from the dotted names in `mcp-sanitize` before sanitization). `chooseRotationActive` gains a two-tier pick: Tier 1 = accounts that **cover** the leaving account's connectors; Tier 2 = the full eligible set if no covering account has quota — so **failover is never blocked** to keep a connector, and a dropped-connector note rides the `codex.account.switched` event. `null` set = unknown (never preferred, never excluded). Off-path (no `usedConnectors`) is byte-identical to P3.

## Cleanly deferred (not half-shipped)
Per-`/ps/mcp` scrape (no usage headers there), exact per-session connector tracking (the leaving-account set is the proxy), and coverage in `round_robin`/`drain_then_next`.

## Tests
codex 82, runtime 415, worker 173 (+1 skip), db 8, api 11, sdk 90, react 351 — all pass. Typecheck green across 7 packages; web build OK. Adversarially verified: serving-account-only scrape, no extra round-trip, no corruption on missing/garbled headers; rotation prefers coverage but always fails over. **No defects found.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-account rotation, per-turn usage cache writes, and new DB columns on credentials; mistakes could mis-rank accounts or stale usage, but both-window gating and non-empty-only connector writes limit corruption.
> 
> **Overview**
> **Multi-account Codex P4** adds two behaviors on top of existing rotation and usage caching.
> 
> **Part A — usage from `/codex/responses` headers:** `codexSubscriptionFetch` parses `x-codex-primary-*` / `x-codex-secondary-*` (including on **429**) via `parseCodexUsageHeaders`, which returns **null unless both windows** parse so partial writes cannot clobber the DB cache. The worker keeps the latest snapshot through `onUsageHeaders` and **best-effort flushes** it with `recordCodexAccountUsage` in the turn `finally`, refreshing P2 usage for the serving account without extra `/wham/usage` polls.
> 
> **Part B — connector-aware rotation:** Migration **0033** adds `connector_namespaces` / `connectors_checked_at` on credentials. `codex_apps` `tools/list` sanitization accumulates dotted connector namespaces into a shared `Set` on `PreparedAgentTools`; the turn end persists non-empty sets via `recordCodexAccountConnectors`. For **`most_remaining`**, `chooseRotationActive` takes optional `usedConnectors` (leaving account’s cached set): **Tier 1** eligible accounts that cover that set, else **Tier 2** all eligibles (failover never blocked). `droppedConnectors` is attached to `codex.account.switched` when a failover cannot cover. Healthy-active accounts still do not switch for coverage alone.
> 
> SDK types and tests cover header parsing, rotation tiers, and DB connector writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3719d75cb4caa100beeee107e24e5752f9d70d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->