### PR TITLE
docs(embedder): Connected Machines across the SDK docs + client skills

### DIFF
--- a/.agents/skills/opengeni-client/SKILL.md
+++ b/.agents/skills/opengeni-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opengeni-client
-description: Use when integrating a customer product, coding agent, generic automation agent, CLI, SDK, or backend service with the OpenGeni API. Covers managed API-key auth, configured/self-host bearer auth, workspace discovery, workspace-scoped sessions, SSE/event replay, files, documents/search, schedules, GitHub repository resources, billing/limits handling, safe retries, and keeping client guidance aligned with the live OpenGeni service rather than stale docs.
+description: Use when integrating a customer product, coding agent, generic automation agent, CLI, SDK, or backend service with the OpenGeni API. Covers managed API-key auth, configured/self-host bearer auth, workspace discovery, workspace-scoped sessions, choosing a session's compute target (a managed sandbox or an enrolled Connected Machine), machine enrollment (device-flow consent + headless enroll tokens), SSE/event replay, files, documents/search, schedules, GitHub repository resources, billing/limits handling, safe retries, and keeping client guidance aligned with the live OpenGeni service rather than stale docs.
 ---
 
 # OpenGeni Client
@@ -18,19 +18,25 @@ Code and live service behavior are the source of truth. Prefer `/v1/config/clien
 - Old unscoped operational routes are intentionally removed, not soft-deprecated.
 - Resource ids never authorize by themselves; use the URL workspace plus credential grant.
 - Sessions and scheduled tasks are the current run primitives. Do not assume a first-class agent-definition API exists until the live service exposes one.
+- Every session picks a compute target at creation. Two co-equal kinds: a **Managed Sandbox** (a platform-owned ephemeral box, selected via the `sandboxBackend` enum and the `sandbox` placement union) or a **Connected Machine** (a user-owned machine enrolled into the workspace, addressed by `targetSandboxId` plus an optional per-session `workingDir`).
+- A Connected Machine is first-class *primary* compute, not a backend overlay: there is no phantom cloud box behind it, no OpenGeni credential is distributed to it (it uses its own git auth), repos are not cloned onto it, and the session runs directly under the chosen `workingDir` on the machine. `selfhosted` is the internal `sandboxBackend` enum value for such a machine — prefer the product term "Connected Machine" in client-facing copy.
+- Enrolling a machine is a client capability: an interactive device flow with a loud whole-machine consent step, or a headless enroll token for fleet/non-interactive enrollment. Gated by `enrollments:read` (list a workspace's machines) and `enrollments:manage` (approve/mint/revoke); `workspace:admin` is the super-wildcard over both.
 
 ## Integration Workflow
 
 1. Determine the API base URL and credential type.
 2. Fetch `/v1/config/client` to learn auth mode, model options, MCP providers, and upload capability.
 3. Call `/v1/access/me`; use `defaultWorkspaceId` or list/create workspaces if permissions allow.
-4. Create sessions under `/v1/workspaces/:workspaceId/sessions`.
+4. Create sessions under `/v1/workspaces/:workspaceId/sessions`, choosing the compute target: omit the sandbox fields for a managed sandbox (optionally pin `sandboxBackend` or the `sandbox` placement union), or set `targetSandboxId` (plus an optional `workingDir`) to run the session on an enrolled Connected Machine.
 5. Stream events from `/v1/workspaces/:workspaceId/sessions/:sessionId/events/stream` and replay from the event list after reconnects.
 6. Upload files through the workspace file upload flow before attaching file resources.
 7. Select MCP tools by configured id, such as OpenGeni, Files, or Document Search.
 8. Use workspace GitHub repository listings before attaching private GitHub App repositories.
-9. For recurring work, create scheduled tasks under the workspace and inspect run history.
-10. Treat 401/403/404/402/429 as product signals: re-authenticate, switch workspace, stop on missing permissions, top up credits, or back off.
+9. For Connected Machines: list a workspace's machines (and their metrics) before targeting one, swap a session's active machine after create when needed, and enroll new machines through the device-flow (with consent) or a headless enroll token.
+10. For recurring work, create scheduled tasks under the workspace and inspect run history.
+11. Treat 401/403/404/402/429 as product signals: re-authenticate, switch workspace, stop on missing permissions, top up credits, or back off.
+
+If you build a React client with `@opengeni/react`, the root entrypoint is the clean sandbox-only default. The Connected-Machine UI — the machines dashboard, the enrollment device-flow/consent screens, and the machine status pills — lives under the `@opengeni/react/machines` subpath (the root still re-exports it for back-compat, deprecated per #144). Separately, the root-exported sandbox-surfacing components (`WorkspaceDock`, `SandboxTerminal`, `FileBrowser`, `DiffView`, `DesktopViewer`) pull heavy client deps (`@xterm/*`, `@novnc/novnc`, `@pierre/diffs`, `@uiw/react-codemirror`, `@codemirror/lang-*`) as optional peer dependencies you install only for the surfaces you mount.
 
 Read `references/api-workflows.md` for request shapes, retry guidance, and common client patterns.
 

--- a/.agents/skills/opengeni-client/references/api-workflows.md
+++ b/.agents/skills/opengeni-client/references/api-workflows.md
@@ -44,12 +44,24 @@ events.addEventListener("agent.message.delta", (event) => {
 
 If the runtime cannot attach `Authorization` headers to `EventSource`, use `fetch` streaming or a server-side proxy that injects the credential.
 
+## Session Creation Options
+
+Beyond `initialMessage`/`tools`/`resources`, the create body (`POST /v1/workspaces/:workspaceId/sessions`, the SDK's `createSession(workspaceId, request)`) chooses where the session runs:
+
+- `sandboxBackend` — pick the managed sandbox execution backend; omit for the deployment default.
+- `targetSandboxId` (uuid) — run the session on an enrolled **Connected Machine** (a user-owned machine) instead of a managed sandbox. It seeds the session's active-sandbox pointer at creation so the first turn routes to that machine; an invalid/unowned/offline target fails the create.
+- `workingDir` — the host path the machine runs the session under (the base for its agent cwd, terminal, and file dock). **Only valid together with `targetSandboxId`** — sending `workingDir` alone is a 422. Omit it to use the machine's default working directory.
+- `sandbox` — shared-sandbox placement for managed sandboxes, a three-way union: `"shared"` (join the creating session's box; a top-level `"shared"` is a 422), `"new"` (mint a fresh box), or `{ groupId }` (join a specific sibling group in the same workspace). Omitted resolves a context-dependent default server-side.
+- `idempotencyKey` (1–200 chars) — a workspace-scoped CREATE idempotency key (see below).
+
+`targetSandboxId`/`workingDir` are the managed-sandbox-vs-Connected-Machine choice; `sandboxBackend` and the `sandbox` placement union only apply to managed sandboxes. To move a session onto a different machine *after* creation, use the active-sandbox swap (below) — not `updateSession`, whose only field is the session `title`.
+
 ## Replay And Retry
 
 - Persist the latest event sequence seen by the client.
 - On reconnect, list events after the last known sequence before reopening the stream.
 - Retry idempotent reads and stream reconnects with bounded backoff.
-- Do not blindly retry session creation unless the API exposes an idempotency key for the operation in the current contract.
+- Session creation exposes a workspace-scoped `idempotencyKey` (distinct from the per-call `clientEventId`): forward a stable value so concurrent/retried creates of the same logical session collapse to a single session. Without it every create is independent, so a blind retry can double-create — keep sending a stable key when you retry.
 - Treat unknown event types as extensible timeline entries, not client crashes.
 
 ## Files
@@ -72,6 +84,25 @@ Use document bases when the product needs indexed/searchable knowledge rather th
 For private repos, use the workspace GitHub repository list before attaching a resource. A valid repository resource normally includes clone URL, ref, mount path, GitHub installation id, and GitHub repository id from OpenGeni's listing response. The worker mints short-lived GitHub App tokens for selected repositories and should not persist clone credentials in session manifests.
 
 Do not ask customers to paste GitHub App private keys into their client integration. Managed SaaS uses the OpenGeni-owned app; self-hosted operators configure their own app server-side.
+
+## Connected Machines And Enrollment
+
+A Connected Machine is a user-owned machine enrolled into a workspace and used as first-class primary compute (no cloud box behind it; it uses its own git auth; repos are not cloned onto it). `selfhosted` is the internal `sandboxBackend` enum value for such a machine.
+
+Discover and target machines:
+
+- `GET /v1/workspaces/:workspaceId/machines` — list the workspace's machines (each with its derived state, latest metrics, and shared-session count) plus the active-sandbox pointer. Pass `?sessionId=` for an in-session view that also includes the session's own group box. SDK: `listMachines(workspaceId, { sessionId })`.
+- `GET /v1/workspaces/:workspaceId/machines/:enrollmentId/metrics/series?window=15m|1h|6h|24h` — the downsampled (~1/min) metrics history. SDK: `machineMetricsSeries(workspaceId, enrollmentId, { window })`.
+- Create a session with `targetSandboxId` (a machine's `sandboxId` from the list) plus an optional `workingDir` to run on it.
+- `POST /v1/workspaces/:workspaceId/sessions/:sessionId/active-sandbox` with `{ target }` — swap the session's active sandbox mid-conversation; `target` is a machine's `sandboxId`, or `"session"`/`"default"` to return to the session's own group box. The response echoes `swapped`, `activeSandboxId`, `activeEpoch`, and a `reason` when a target is refused. SDK: `swapActiveSandbox(workspaceId, sessionId, { target })`.
+
+Enroll a machine (the client-driven parts):
+
+- Interactive device flow: the machine's own agent starts and polls the flow agent-side (unauthenticated). A workspace operator resolves the pending request by user code with `POST /v1/enrollments/device/lookup` (no workspace in the path — the server resolves it from the code, then authorizes `enrollments:read`), then `POST /v1/workspaces/:workspaceId/enrollments/device/approve` (the loud consent step; `allowScreenControl` opts into screen control) or `.../device/deny`. SDK: `lookupDeviceEnrollment(userCode)`, `approveDeviceEnrollment(workspaceId, { userCode, allowScreenControl })`, `denyDeviceEnrollment(workspaceId, { userCode })`.
+- Headless / fleet: `POST /v1/workspaces/:workspaceId/enrollments/token` mints a short-TTL SECRET enroll token (surface it once with a copy-now warning); the machine's agent redeems it agent-side at `POST /v1/enrollments/token/exchange`. SDK: `mintEnrollToken(workspaceId, { allowScreenControl })`.
+- `POST /v1/workspaces/:workspaceId/enrollments/:enrollmentId/revoke` removes a machine. Approving, minting, and revoking all require `enrollments:manage`; listing needs `enrollments:read`.
+
+Never distribute an OpenGeni credential to a Connected Machine or try to inject git tokens into it — the machine authenticates to git with its own credentials. Device start/poll and token exchange are agent-side calls, not client SDK methods.
 
 ## Billing And Limits
 

--- a/.agents/skills/opengeni/references/client-integration.md
+++ b/.agents/skills/opengeni/references/client-integration.md
@@ -59,7 +59,7 @@ Prefer this shape, adjusted to the current contracts:
 2. **Fetch config**: get product access mode, default model, allowed models, reasoning efforts, MCP providers, and whether file uploads are enabled.
 3. **Resolve workspace**: call `/v1/access/me` and use `defaultWorkspaceId`, or list/create workspaces through `/v1/workspaces` if the grant allows it.
 4. **Prepare resources**: upload files under the workspace first; select repository resources from available repo/source picker; select MCP tool providers by id.
-5. **Create session**: send initial message plus selected resources/tools/model/sandbox options to `/v1/workspaces/:workspaceId/sessions`.
+5. **Create session**: send initial message plus selected resources/tools/model and the compute-target choice to `/v1/workspaces/:workspaceId/sessions`. The compute target is either a managed sandbox (optional `sandboxBackend`, plus the `sandbox` placement union `"shared" | "new" | { groupId }`) or an enrolled **Connected Machine** via `targetSandboxId` — plus an optional per-session `workingDir`, which is valid only alongside `targetSandboxId` (`workingDir` alone is a 422). Optionally pass a workspace-scoped `idempotencyKey` so a retried create collapses to one session.
 6. **Connect SSE**: stream events from `/v1/workspaces/:workspaceId/sessions/:sessionId/events/stream`. Use the last event sequence as the reconnect cursor.
 7. **Render timeline**: display user messages, agent deltas/completions, reasoning, tool calls, sandbox operations, approvals, status changes, failures, and final output according to current event types.
 8. **Send follow-ups**: post a user message into the existing workspace-scoped session; the API queues another turn.
@@ -96,7 +96,7 @@ Client UX should distinguish:
 - **File attachments**: upload, then attach by file id.
 - **Repository attachments**: select repo URL/ref/mount information; GitHub App metadata may be needed for scoped token minting.
 - **Tool providers**: select configured MCP server ids, such as document search or custom enterprise search.
-- **Sandbox backend**: expose only if the product wants users to choose execution backend; otherwise use deployment defaults.
+- **Compute target**: expose only if the product wants users to choose where a session runs; otherwise use deployment defaults. Two distinct axes: a managed **sandbox backend** (a platform-owned ephemeral box; the `sandboxBackend` enum) versus an enrolled **Connected Machine** (user-owned compute addressed by `targetSandboxId` + an optional `workingDir`, run as first-class primary compute — no cloud box behind it, its own git auth, repos not cloned onto it). Do not conflate a **self-hosted deployment** (an operator running the whole OpenGeni service themselves — the `configured` product access mode) with a **Connected Machine** (an end user attaching their own machine as a session's compute, possible inside any deployment, managed or self-hosted). `selfhosted` is only the internal `sandboxBackend` enum value for a Connected Machine; prefer the product term in UI copy.
 
 ## Approvals And Interrupts
 
@@ -131,7 +131,7 @@ Use client-centered language:
 - "Attach files, repositories, and MCP tool providers to a run."
 - "Replay the event log after reloads or network drops."
 - "Handle approvals and interrupts as normal API events."
-- "Self-hosted configured deployments can use delegated bearer tokens or the deployment shared-key boundary without Better Auth."
+- "Self-hosted (operator-run) configured deployments can use delegated bearer tokens or the deployment shared-key boundary without Better Auth. This is the deployment topology, not the same thing as a Connected Machine (a user attaching their own compute to a session)."
 - "Managed deployments use Better Auth for browser sign-up and OpenGeni API keys for headless product integration."
 
 Avoid implying clients call Temporal, NATS, Postgres, the worker, or the sandbox directly.
@@ -146,4 +146,5 @@ Update this file when:
 - Auth/tenancy is added to the base API.
 - Client config capabilities change.
 - File upload or repository selection flow changes.
+- Compute-target selection (managed sandbox vs Connected Machine), the `targetSandboxId`/`workingDir`/`sandbox`/`idempotencyKey` create fields, active-sandbox swap, machine metrics, or the enrollment flow change.
 - New first-class client SDKs are added.

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -1,0 +1,241 @@
+# Connected Machines (bring-your-own-compute)
+
+A **Connected Machine** is one of a session's compute targets — your own
+computer (a laptop, a workstation, a CI box, even a macOS machine) enrolled into
+a workspace and driven by the agent directly. It is a **first-class, co-equal
+primary compute target**, not a backend variant layered on top of a managed
+box.
+
+This guide is embedder-facing: it shows how to create a session on a machine,
+discover the enrolled machines and their metrics, swap a session's active
+sandbox, enroll a machine (zero-click token or the interactive device flow), and
+revoke/detach — all through the typed [`@opengeni/sdk`](../packages/sdk/README.md)
+client. The matching UI ships in
+[`@opengeni/react/machines`](../packages/react/README.md).
+
+> Terminology: **Connected Machine** is the product term used throughout. The
+> internal `SandboxBackend` enum value for one is `"selfhosted"` — you will see
+> it in `MachineView.kind` (`"selfhosted"` vs `"modal"`) and in negotiated
+> capability reasons.
+
+## The two compute targets
+
+| | Managed Sandbox | Connected Machine |
+| --- | --- | --- |
+| Ownership | platform-owned, ephemeral | user-owned, persistent |
+| Provisioning | platform provisions + tears down | platform **attaches** to what's already there |
+| Repos | cloned into `/workspace` | **not cloned** — the machine uses its own git auth |
+| Working dir | `/workspace` (virtual root) | a real host path you pass per session |
+| Backend enum | `docker`/`modal`/`local`/… | `selfhosted` |
+
+The model that follows from this: a machine-bound session has **no phantom Modal
+"home box"**, **no OpenGeni git token is distributed to the machine** (it uses
+its own ssh / `gh` / credential helper), repos are **not cloned onto it**, and
+the agent runs under a **per-session working directory** (making its own
+worktrees under that path as it needs them).
+
+## Create a session on a machine
+
+`createSession` grows two fields for a Connected-Machine target:
+
+- **`targetSandboxId`** (uuid) — the enrolled machine to run the session on (a
+  `MachineView.sandboxId` from `listMachines`). It **seeds the active-sandbox
+  pointer at creation**, so the very first turn lands on that machine.
+- **`workingDir`** (host path) — the directory the agent runs the session under
+  (its cwd base for exec, terminal, and the file dock). A launch-root-relative
+  subdir or an absolute machine path both work.
+
+```ts
+import { OpenGeniClient } from "@opengeni/sdk";
+
+const client = new OpenGeniClient({ baseUrl, apiKey });
+
+// Pick a machine from the workspace fleet…
+const { machines } = await client.listMachines(workspaceId);
+const box = machines.find((m) => m.kind === "selfhosted" && m.state === "online");
+
+// …and run the session on it.
+const session = await client.createSession(workspaceId, {
+  initialMessage: "Run the test suite and fix what's red",
+  targetSandboxId: box!.sandboxId, // seeds the active-sandbox pointer at create
+  workingDir: "/home/me/projects/app", // the agent's cwd on the machine
+});
+```
+
+Rules to keep in mind:
+
+- **`workingDir` requires `targetSandboxId`.** Sending `workingDir` alone (with
+  no machine target) is a **422** — a bare working directory has no machine to
+  resolve it against.
+- Omit `workingDir` and the session runs under the machine's **default workspace
+  root** (the agent's launch dir).
+- **Repos are not cloned** onto a machine target. `resources` you attach are
+  available for context, but the platform never `git clone`s onto the user's
+  real filesystem — the machine uses its own git auth.
+- `sandboxBackend` selects the backend for a **managed** sandbox; for a machine
+  target the backend is the machine itself, so leave it off (or `"none"`) and
+  point at the machine with `targetSandboxId`.
+
+## Discover machines + metrics
+
+`listMachines` returns the workspace fleet plus the active-sandbox pointer. Pass
+`sessionId` for an in-session view, which also folds in that session's synthetic
+Modal group box and the session's active-sandbox pointer.
+
+```ts
+const res = await client.listMachines(workspaceId, { sessionId });
+// res.activeSandboxId — the session's currently-active sandbox (null ⇒ the
+//                       session's own group box is active)
+// res.activeEpoch     — monotonic fence for the pointer (see "swap" below)
+// res.machines        — MachineView[]
+```
+
+Each `MachineView` carries the fields a dashboard needs:
+
+```ts
+type MachineView = {
+  sandboxId: string;            // the id you pass as targetSandboxId / swap target
+  enrollmentId: string | null;  // the enrollment id for metrics + revoke
+  name: string;
+  kind: "modal" | "selfhosted";
+  state:                        // derived liveness + consent/display/enrollment state
+    | "online" | "reconnecting" | "offline"
+    | "consent_required" | "display_unavailable" | "enrolling";
+  active: boolean;              // is this the session's active sandbox?
+  isSessionGroup: boolean;      // the synthetic Modal group box (not a real machine)
+  os: string;
+  arch: string;
+  hasDisplay: boolean;
+  allowScreenControl: boolean;
+  sharedSessionCount: number;   // live sessions sharing this whole-machine lease
+  lastSeenAt: string | null;
+  metrics: MetricSample | null; // latest point-in-time sample
+};
+```
+
+For a time series (the dashboard's charts), read the downsampled (~1/min)
+per-machine history over a window. Samples are oldest-first (left-to-right):
+
+```ts
+const samples = await client.machineMetricsSeries(workspaceId, enrollmentId, {
+  window: "1h", // "15m" | "1h" (default) | "6h" | "24h"
+});
+// MetricSample: cpuPct, load1/5/15, memUsedBytes/memTotalBytes,
+//   diskUsedBytes/diskTotalBytes, gpuUtilPct|null, gpuMemBytes|null,
+//   runQueue, sampledAt (ISO-8601). GPU fields are null when no GPU is present.
+```
+
+## Swap the active sandbox
+
+A session points at one active sandbox at a time. `swapActiveSandbox` re-points
+it — the user-authenticated equivalent of the agent's `sandbox_swap` MCP tool.
+
+```ts
+// Point the session at a machine…
+const swap = await client.swapActiveSandbox(workspaceId, sessionId, {
+  target: box.sandboxId, // a MachineView.sandboxId
+});
+// …or swap back to the session's own managed group box:
+await client.swapActiveSandbox(workspaceId, sessionId, { target: "session" });
+// ("session" and "default" both mean "the session's own group box".)
+
+// swap.swapped        — true on a successful repoint OR a no-op (already there)
+// swap.activeSandboxId — the resulting pointer
+// swap.activeEpoch    — the new fence value
+// swap.reason         — set when swapped:false (unowned/offline target, or a
+//                       lost epoch fence)
+```
+
+Validation (ownership, liveness, epoch fence) is server-side; a rejected target
+comes back as `swapped: false` with a `reason` rather than throwing. The next
+turn runs on whatever the pointer resolves to.
+
+## Enroll a machine
+
+Enrollment turns a user's machine into a `selfhosted` sandbox in the workspace.
+There are two paths. Both require the caller to hold `enrollments:manage`.
+
+### Zero-click token (fleet / headless)
+
+Mint a short-TTL enroll token and hand it to the machine's installer. The token
+is **secret** — surface it once with a copy-now warning; it cannot be re-read.
+
+```ts
+const { token, expiresAt, expiresInSeconds } =
+  await client.mintEnrollToken(workspaceId, {
+    allowScreenControl: false, // bake screen-control consent into the token
+  });
+// Run on the machine (the installer dials OpenGeni and exchanges the token for
+// its own long-lived agent credentials — the token exchange happens on the
+// machine, not through this client):
+//   curl -fsSL https://…/install.sh | sh -s -- --token <token>
+```
+
+`allowScreenControl` bakes the (optional) screen-control consent into the token;
+whole-machine access — exec, files, terminal — is implicit and mandatory for any
+enrollment.
+
+### Device flow (interactive, in-session)
+
+When a user runs the installer with no token, the machine's agent starts a
+device flow and prints a short **`userCode`** plus a **`verificationUri`** (the
+device-flow start/poll is done by the machine's agent, not this client). Your
+app renders an approve page. Resolve the pending flow by its code — note there is
+**no workspace in the path**; the server resolves the workspace from the
+(globally-unique-among-pending) code and authorizes the caller against it
+(`enrollments:read`):
+
+```ts
+const pending = await client.lookupDeviceEnrollment(userCode);
+// pending.workspaceId, pending.userCode, pending.expiresAt
+// pending.machine: { machineName, os, arch, canOfferDisplay, requestsScreenControl }
+```
+
+Then approve (the loud whole-machine consent) or deny:
+
+```ts
+const approved = await client.approveDeviceEnrollment(pending.workspaceId, {
+  userCode,
+  allowScreenControl: true, // the authoritative screen-control consent
+});
+// approved.enrollmentId, approved.sandboxId, approved.allowScreenControl
+
+// or, the explicit "no":
+await client.denyDeviceEnrollment(pending.workspaceId, { userCode });
+```
+
+Approving lands an enrollment plus a `selfhosted` sandbox and unblocks the
+agent's poll; `sandboxId` is immediately usable as a `targetSandboxId` or a swap
+target.
+
+## Revoke / detach
+
+- **Reject a pending enrollment** at the approve page:
+  `client.denyDeviceEnrollment(workspaceId, { userCode })`.
+- **Detach a machine from a session** without un-enrolling it: swap the active
+  sandbox back to the session's own box —
+  `client.swapActiveSandbox(workspaceId, sessionId, { target: "session" })`.
+  Subsequent turns run on the managed box; the machine stays enrolled for other
+  sessions.
+- **Permanently un-enroll** a machine (so it can never be attached again) is a
+  workspace administration action; it is not wrapped as a typed method on the
+  `@opengeni/sdk` client as of 0.5.0.
+
+## React components
+
+`@opengeni/react/machines` renders all of the above:
+
+- **`useMachines`** — the fleet hook: polls `listMachines`, exposes
+  `attach(sandboxId)` (wired to `swapActiveSandbox` when a `sessionId` is in
+  scope), `fetchSeries`, and `activeSandboxId`/`activeEpoch`.
+- **`MachinesDashboard`** / **`MachineCard`** / **`MachineMetrics`** — the fleet
+  grid with per-machine meters and an attach/swap affordance.
+- **`MachineDockBar`** — a slim bar over the Files/Terminal/Desktop dock that
+  names which machine those surfaces are bound to and its connection status.
+- **`EnrollmentDeviceFlow`** — the in-session panel that shows the `userCode` +
+  `verificationUri` and the pending → authorized/denied/expired progression.
+- **`EnrollmentConsent`** — the loud whole-machine approve page for the device
+  flow.
+- **`MachineStatusPill`** / **`ConnectionStatusPill`** — the status chips.
+
+See the [`@opengeni/react` README](../packages/react/README.md) for wiring.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,7 +3,17 @@
 React hooks and styled components for OpenGeni, built on
 [`@opengeni/sdk`](../sdk): live session streaming, a chat composer, a message
 timeline that renders streaming deltas / tool calls / spawned-worker status,
-session status badges, and fleet tiles for workspace overviews.
+session status badges, and fleet tiles for workspace overviews. Two opt-in
+surfaces layer on top: a **sandbox-surfacing** workbench (files, terminal, diff,
+and an optional desktop stream) and, at the
+[`@opengeni/react/machines`](#connected-machines-opengenireactmachines) subpath,
+the **Connected Machines** dashboard + enrollment flow.
+
+The default root import (`@opengeni/react`) is the clean sandbox-agnostic
+surface — the chat/timeline hooks and components plus the sandbox-surfacing
+suite. Connected-Machine UI lives under the `@opengeni/react/machines` subpath so
+consumers that never surface machines don't pull it in. (The root barrel still
+re-exports the machines island for back-compat, deprecated per #144.)
 
 Design-system-first: every visual decision routes through CSS-variable tokens
 (`styles/tokens.css`) — color, typography, radius, shadow, motion. Dark mode is
@@ -90,7 +100,16 @@ export function App() {
   events.
 - `useSessionControl(sessionId)` — `interrupt(reason?)` and
   `approve`/`reject(approvalId, message?)` for `requires_action` approvals.
-- `useSession(sessionId)` — fetch one session (optional polling).
+- `useSession(sessionId)` — fetch one session (optional polling) with
+  `updateTitle(title)` (rename) and live title-patching on `session.title_set`.
+- `useFileAttachments()` — the composer's attach flow: stages files, drives the
+  SDK's direct-to-blob upload, and yields the `resources` to send with a message.
+- `useAvailableModels()` — the deployment's provider-grouped selectable `models`
+  plus the `defaultModel` to preselect (from the client config) for a picker.
+- `useCodexAccounts()` — connected Codex (ChatGPT) accounts, the active/next-run
+  pointer, and per-session account pinning for multi-account subscriptions.
+- `useSlashCommands(...)` — the slash-command palette state (registry + parsing +
+  handlers) behind `CommandPalette`.
 - `useWorkspaceSessions()` / `useScheduledTasks()` — workspace lists for
   fleet/manager views (optional polling).
 - `useEnvironments()` — workspace environments with create/update/remove and
@@ -132,6 +151,94 @@ with the same semantics.
   `renderMessageText` to plug a markdown renderer.
 - `SessionStatus` / `StatusDot` — status badges; live states breathe.
 - `FleetTile` — one session in a fleet grid: title, status, model, recency.
+- `ModelPicker` — a compact model dropdown for a composer slot, grouping the
+  host-exposed models by provider.
+- `Markdown` — the timeline's markdown renderer (GFM), also usable standalone.
+- `CommandPalette` — the slash-command palette UI over `useSlashCommands`.
+
+The timeline is extensible: `createToolRegistry` / `defaultToolRegistry` plug
+per-tool renderers, and the rendering primitives (`ActivityDisclosure`,
+`ScreenshotFigure`, `TermBlock`, `LightboxProvider`, …) compose custom rows with
+the same semantics.
+
+## Sandbox surfacing
+
+An opt-in workbench that surfaces a session's live sandbox — files, terminal,
+diff, and (when available) a desktop pixel stream — driven by a negotiated
+capability document so every surface degrades to a reason instead of crashing.
+
+- `useSessionCapabilities(sessionId, { attachDesktop?, attachTerminal?, attachFiles? })`
+  — negotiates the per-session capability doc, tracks lease liveness
+  (`cold`/`warming`/`warm`), and acquires the viewer holder(s) that keep the box
+  warm. Desktop attach is gated behind the un-redacted-pixel acknowledgment.
+- `useSandboxFiles` / `useSandboxGit` — the Pierre file tree + git status/diff
+  feeds (the synchronous `fs*`/`git*` SDK point queries plus `fs.changed` /
+  `git.changed` live notifications).
+- `useSandboxTerminal` / `useTerminalStream` — the read-only command-output
+  firehose and the real interactive PTY over the minted `pty-ws` cell.
+- `useDesktopStream` — the noVNC socket, hot-swapped on box rollover via
+  `stream.url.rotated`.
+- Components: `WorkspaceDock` (the resizable/collapsible right-hand dock),
+  `FileBrowser` / `SandboxFiles`, `DiffView` / `PierreDiff` / `PierreFile`,
+  `CodeEditor`, `SandboxTerminal`, and `DesktopViewer`.
+
+These surfaces pull in [optional peer dependencies](#optional-peer-dependencies)
+— install only the ones for surfaces you actually mount.
+
+## Connected Machines (`@opengeni/react/machines`)
+
+Bring-your-own-compute UI: the Machines dashboard, per-machine metrics, the
+active-sandbox swap, and the enrollment flow. Imported from the
+`@opengeni/react/machines` subpath so consumers that never surface machines
+never pull it in.
+
+- `useMachines({ sessionId? })` — polls the fleet, exposes `attach(sandboxId)`
+  (wired to the SDK's active-sandbox swap when a `sessionId` is in scope),
+  `fetchSeries`, and the `activeSandboxId` / `activeEpoch` pointer.
+- `MachinesDashboard` / `MachineCard` / `MachineMetrics` — the fleet grid with
+  per-machine meters and an attach/swap affordance.
+- `MachineDockBar` / `SharedMachineDisclosure` — the backend-aware bar over the
+  sandbox dock naming which machine (Modal box or your machine) it is bound to.
+- `EnrollmentDeviceFlow` — the in-session device-flow panel (`userCode` +
+  `verificationUri`, pending → authorized/denied/expired).
+- `EnrollmentConsent` — the loud whole-machine approve page.
+- `MachineStatusPill` / `ConnectionStatusPill` / `ConnectionDot` — status chips,
+  plus the `MachineView` / `MachineState` / `MetricSample` view-model types.
+
+```tsx
+import { MachinesDashboard, useMachines } from "@opengeni/react/machines";
+
+function Fleet({ sessionId }: { sessionId: string }) {
+  const { machines, activeSandboxId, attach, attachingSandboxId, refresh } =
+    useMachines({ sessionId, pollIntervalMs: 5000 });
+  return (
+    <MachinesDashboard
+      machines={machines}
+      activeSandboxId={activeSandboxId}
+      attachingSandboxId={attachingSandboxId}
+      onAttach={(m) => attach(m.sandboxId)}
+      onRefresh={refresh}
+    />
+  );
+}
+```
+
+See the [Connected Machines guide](../../docs/connected-machines.md) for the
+end-to-end embedder story (create-on-machine, discover, swap, enroll, revoke).
+
+## Optional peer dependencies
+
+The chat/timeline surface has none. The sandbox-surfacing and diff surfaces pull
+their heavy libraries from **optional** `peerDependencies`, so you install only
+what the surfaces you mount need:
+
+- Terminal (`SandboxTerminal`): `@xterm/xterm`, `@xterm/addon-fit`,
+  `@xterm/addon-web-links`.
+- Desktop (`DesktopViewer`): `@novnc/novnc`.
+- Diff (`DiffView` / `PierreDiff` / `PierreFile`): `@pierre/diffs`.
+- Code editor (`CodeEditor`): `@uiw/react-codemirror` + the `@codemirror/lang-*`
+  language packs you need (`css`, `html`, `javascript`, `json`, `markdown`,
+  `python`).
 
 ## Demo harness
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -101,6 +101,40 @@ const file = await client.uploadFile(workspaceId, {
 const { url } = await client.createFileDownloadUrl(workspaceId, file.id);
 ```
 
+## Connected Machines (bring-your-own-compute)
+
+A session can run on an enrolled **Connected Machine** — a user's own computer —
+instead of a platform-managed sandbox. Two `createSession` fields target one:
+
+- **`targetSandboxId`** (uuid) — the machine to run on (a `MachineView.sandboxId`
+  from `listMachines`). It seeds the session's active-sandbox pointer at
+  creation, so the first turn lands on that machine.
+- **`workingDir`** (host path) — the directory the agent runs under on that
+  machine. **Only valid together with `targetSandboxId`** — `workingDir` alone is
+  a **422**. Omit it and the session runs under the machine's default workspace
+  root. Repos attached to a machine session are **not cloned** (the machine uses
+  its own git auth).
+
+```ts
+const { machines } = await client.listMachines(workspaceId);
+const box = machines.find((m) => m.kind === "selfhosted" && m.state === "online");
+
+const session = await client.createSession(workspaceId, {
+  initialMessage: "Run the test suite and fix what's red",
+  targetSandboxId: box!.sandboxId, // seeds the active-sandbox pointer at create
+  workingDir: "/home/me/projects/app", // requires targetSandboxId, else 422
+});
+
+// Re-point a running session's active sandbox (or "session"/"default" to swap
+// back to its own managed box):
+await client.swapActiveSandbox(workspaceId, session.id, { target: box!.sandboxId });
+```
+
+Discovery (`listMachines`, `machineMetricsSeries`), the active-sandbox swap, and
+the enrollment methods (`mintEnrollToken`, `lookupDeviceEnrollment`,
+`approveDeviceEnrollment`, `denyDeviceEnrollment`) are covered in the
+[Connected Machines guide](../../docs/connected-machines.md).
+
 ## Full API coverage
 
 Every public endpoint group has typed methods:
@@ -108,7 +142,8 @@ Every public endpoint group has typed methods:
 | Group | Methods |
 | --- | --- |
 | Access + workspaces | `getAccessContext`, `listWorkspaces`, `createWorkspace`, `getWorkspace`, `updateWorkspace` |
-| Sessions + events | `createSession`, `listSessions`, `getSession`, `listEvents`, `sendEvent`, `sendMessage`, `steerMessage`, `interrupt`, `sendApprovalDecision`, `streamEvents`, `openEventStream` |
+| Sessions + events | `createSession`, `listSessions`, `getSession`, `updateSession`, `listEvents`, `sendEvent`, `sendMessage`, `steerMessage`, `interrupt`, `sendApprovalDecision`, `streamEvents`, `openEventStream` |
+| Machines (bring-your-own-compute) | `listMachines`, `machineMetricsSeries`, `swapActiveSandbox`, `mintEnrollToken`, `lookupDeviceEnrollment`, `approveDeviceEnrollment`, `denyDeviceEnrollment` |
 | Turn queue | `listTurns`, `updateQueuedTurn`, `reorderQueuedTurns`, `deleteQueuedTurn` |
 | Goal | `getGoal`, `updateGoal`, `pauseGoal`, `resumeGoal` |
 | Scheduled tasks | `createScheduledTask`, `listScheduledTasks`, `getScheduledTask`, `updateScheduledTask`, `pauseScheduledTask`, `resumeScheduledTask`, `triggerScheduledTask`, `deleteScheduledTask`, `listScheduledTaskRuns` |


### PR DESCRIPTION
**Embedder tier** of the docs/skills rework (first of four: embedder → maintainer → operator → product). The docs mentioned "selfhosted backend #11" but predated **Connected Machine** becoming a first-class, co-equal **primary** compute target — and never covered `workingDir`, no-token/own-git-auth, or the SDK `/machines` split.

- **`packages/react/README.md`** — updated from a pre-0.4 description to the real **0.5.0** surface: the `@opengeni/react/machines` subpath (root import = clean sandbox-only default), the sandbox-surfacing suite + its optional peer deps, current hooks/components.
- **`packages/sdk/README.md`** — `createSession` now documents `targetSandboxId` + `workingDir` (with the 422 rule) + a `swapActiveSandbox` example; added a Machines/BYO-compute row + `updateSession` to the coverage table.
- **`docs/connected-machines.md`** (new) — embedder guide: create-on-machine, discover + metrics, active-sandbox swap, enroll (zero-click token / device flow), detach.
- **`.agents/skills/*`** (opengeni-client + opengeni client-integration) — compute-target choice at create, `targetSandboxId`/`workingDir`, the `/machines` subpath; fixed the stale idempotency-key note.

### Semantic verification
Every asserted API name/field cross-checked against the shipped code (`client.ts`, contracts `CreateSessionRequest`, the react barrels + `package.json`, and the worker/runtime git-auth behavior). **Verdict: accurate** — no corrections needed.

Follow-up (non-blocking): the SDK's hand-written `CreateSessionRequest` type omits the `sandbox` placement union that exists in `@opengeni/contracts`; add for strict-typed parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and skill reference changes only; no runtime, API, or auth code paths are modified.
> 
> **Overview**
> **Embedder-facing documentation** now treats **Connected Machine** as a first-class compute target alongside managed sandboxes, replacing stale “selfhosted backend” framing.
> 
> Adds **`docs/connected-machines.md`** — SDK walkthrough for `targetSandboxId`/`workingDir`, fleet discovery and metrics, `swapActiveSandbox`, enrollment (token + device flow), and detach.
> 
> Updates **`packages/sdk/README.md`** and **`packages/react/README.md`** for 0.5.0: Machines API table row, `createSession` BYO fields, `@opengeni/react/machines` subpath, sandbox-surfacing suite, and optional peer deps.
> 
> Refreshes **`.agents/skills/opengeni-client`** and **`client-integration.md`**: compute-target choice at session create, enrollment permissions, session `idempotencyKey` retry guidance (replacing the old “no idempotency” note), and terminology separating operator self-hosted deployments from user Connected Machines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40bef119a67c908f530639a94a6ccc01e318fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->