### PR TITLE
fix(codex): bound the reactive 429 rotate+retry + align the all-capped continuation freeze

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -21,6 +21,7 @@ import {
   recordCodexAccountConnectors,
   setActiveCodexCredential,
   setCodexCredentialExhausted,
+  countConsecutiveReactiveRotations,
   requireSession,
   recordUsageEvent,
   appendSessionHistoryItems,
@@ -54,7 +55,7 @@ import {
 import { calculateModelUsageCostMicros, configuredModelPricing, configuredStaticUsageLimits, sandboxWarmRateMicrosPerSecond, type ModelUsageInput, type Settings } from "@opengeni/config";
 import { CancelledFailure } from "@temporalio/activity";
 import { settingsWithCodexCredential, settingsWithEnabledCapabilityMcpServers } from "./capabilities";
-import { chooseRotationActive, computeIdleDelayMs, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
+import { chooseRotationActive, computeIdleDelayMs, computeReactiveRotationResume, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
 import type { CodexAccountStatus } from "@opengeni/db";
 import { buildCodexTokenResolver } from "./codex-auth";
 import {
@@ -658,7 +659,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               { allAccounts: true },
             );
             await publish([
-              { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved: false } },
+              // `rotated:true` (Finding 2): the proactive all-capped wait is the SAME
+              // rotation-wait state as the reactive all-capped path, so it must freeze
+              // autoContinuations identically (evaluateGoalContinuation reads this marker)
+              // — a goal waiting out a long reset must not burn its continuation budget on
+              // the proactive path while the reactive path spares it.
+              { type: "turn.failed", payload: { ...failurePayload, recovery: goalActive ? "goal_continuation" : "user_message", runStateSaved: false, rotated: true } },
               { type: "session.status.changed", payload: { status: "idle" } },
             ], true);
             await finishTurn(db, input.workspaceId, turnId, "failed");
@@ -1540,6 +1546,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // proactive seam (turn-start) is the single authoritative pointer-move + strip site.
         let rotated = false;
         let rotationResumeMs: number | null = null;     // 0 ⇒ a candidate is available; re-dispatch now
+        let rotationResumeIdleUntilReset = false;       // circuit-breaker fall (Finding 1b) ⇒ MANDATORY hold
         let allCappedResetAt: Date | null = null;       // set ⇒ every account capped; idle until this
         if (effectiveCodexCredentialId) {
           const [rotation, sessionCodex] = await Promise.all([
@@ -1558,7 +1565,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             const until = usageLimit.resetsInSeconds !== null && Number.isFinite(usageLimit.resetsInSeconds) && usageLimit.resetsInSeconds > 0
               ? new Date(Date.now() + Math.ceil(usageLimit.resetsInSeconds) * 1000)
               : (cachedReset ?? new Date(Date.now() + CODEX_USAGE_LIMIT_MAX_RESUME_MS));
-            await setCodexCredentialExhausted(db, input.workspaceId, effectiveCodexCredentialId, until).catch(() => false);
+            // Finding 1a: INSPECT the cooldown-write result. A swallowed best-effort
+            // write whose failure went unnoticed is exactly what lets the next proactive
+            // rank re-pick this just-capped account (stale-low cached usedPercent, not
+            // cooling) — so capture whether it PERSISTED and feed it into the resume floor.
+            const cooldownPersisted = await setCodexCredentialExhausted(db, input.workspaceId, effectiveCodexCredentialId, until).catch(() => false);
             // Re-rank over the fresh accounts; the in-memory list predates the cooldown
             // write, so stamp the just-cooled account so the engine excludes it now. The
             // serving account is thus walked AT MOST ONCE per turn (invariant 4: bounded).
@@ -1576,7 +1587,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             });
             if (decision.kind === "active") {
               rotated = true;
-              rotationResumeMs = 0;  // re-dispatch immediately: skip BOTH the 1h hold AND the backpressure delay
+              // Finding 1: a live candidate normally re-dispatches NOW (0). Two second-order
+              // faults would turn that 0 into a hot loop, so bound it. Count the consecutive
+              // reactive failovers since the last successful turn (this one is not yet
+              // published) and combine with the cooldown-persistence result.
+              const priorConsecutiveRotations = await countConsecutiveReactiveRotations(db, input.workspaceId, input.sessionId).catch(() => 0);
+              const resume = computeReactiveRotationResume({
+                cooldownPersisted,
+                priorConsecutiveRotations,
+                connectedAccountCount: accounts.length,
+              });
+              rotationResumeMs = resume.continueDelayMs;               // 0 (happy path), a slow-retry floor, or the circuit-breaker idle
+              rotationResumeIdleUntilReset = resume.idleUntilReset;    // true only on the circuit-breaker fall (MANDATORY hold)
             } else if (decision.kind === "allCapped") {
               rotated = true;
               allCappedResetAt = decision.earliestResetAt;
@@ -1606,10 +1628,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // Rotation: a candidate is available → continue NOW (0). All-capped → idle until the
           // earliest reset across all accounts (capped at 1h). Else the unchanged single-account idle.
           if (rotationResumeMs !== null) {
-            // A candidate IS available (the just-failed account is now cooling, so the
-            // ranker cannot re-pick it — at most N rotations per N accounts, invariant 4).
-            // 0 ⇒ re-dispatch NOW; this is the legitimate skip-the-hold case.
-            return { status: "idle", continueDelayMs: rotationResumeMs };
+            // A candidate IS available. Normally the just-failed account is now cooling so
+            // the ranker cannot re-pick it → 0 (re-dispatch NOW, the legitimate skip-the-hold
+            // case). Finding 1 bounds the two exceptions: a persistence fault yields a positive
+            // slow-retry floor, and once consecutive failovers exceed the account count + margin
+            // the circuit breaker returns a fixed MANDATORY idle (idleUntilReset) — never a 0-delay
+            // hot loop against a capped backend + DB.
+            return { status: "idle", continueDelayMs: rotationResumeMs, ...(rotationResumeIdleUntilReset ? { idleUntilReset: true } : {}) };
           }
           // All-capped: clamp to [MIN_IDLE_MS, max] — a POSITIVE, BOUNDED hold (never 0,
           // so session.ts can never tight-loop). The post-idle continuation re-dispatch

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -161,6 +161,74 @@ export function computeIdleDelayMs(earliestResetAt: Date, now: Date, maxMs: numb
   return Math.min(Math.max(delta, MIN_IDLE_MS), maxMs);
 }
 
+// --- P3 reactive-rotation boundedness (Finding 1). The reactive 429 catch, on a
+// LIVE failover candidate, normally returns continueDelayMs:0 (skip the hold and
+// re-dispatch NOW — the just-served account is cooling so the next rank cannot
+// re-pick it). Two independent second-order faults can break that "cannot
+// re-pick it" premise and turn the 0-delay re-dispatch into a hot loop, so this
+// pure decision applies two backstops before allowing the 0.
+
+/**
+ * Slow-retry floor (Finding 1a) for the double-fault where the just-served
+ * account's cooldown write could NOT be confirmed persisted: the next proactive
+ * rank might re-select the same capped account (stale-low cached usedPercent, not
+ * cooling). A positive floor degrades that to a SLOW retry instead of a
+ * model-paced hot loop. A few seconds — long enough to break the loop, short
+ * enough to stay responsive once the transient write fault clears.
+ */
+export const REACTIVE_PERSISTENCE_FAULT_FLOOR_MS = 5_000; // 5s
+/**
+ * Circuit-breaker slack (Finding 1b) added to the connected-account count to bound
+ * consecutive reactive failovers. Each legitimate failover cools one account, so
+ * after at most N failovers every account is capped and the reactive path takes the
+ * all-capped idle instead; the +margin absorbs benign re-ranks (a connector-covering
+ * pick order) without tripping the breaker in normal use.
+ */
+export const REACTIVE_ROTATION_MARGIN = 2;
+/**
+ * The FIXED positive idle the reactive path falls to once consecutive reactive
+ * failovers exceed the bound (a double-fault where cooldown writes are not sticking
+ * AND the 429s carry no usage headers, so the same account keeps getting re-picked).
+ * Mirrors the all-capped floor — a mandatory, bounded hold, never another 0-delay
+ * re-dispatch — so the loop can never hammer the capped backend + DB (invariant 4).
+ */
+export const REACTIVE_CIRCUIT_BREAKER_IDLE_MS = MIN_IDLE_MS; // 60s
+
+/** The reactive-resume shape returned to the goal-continuation caller. */
+export type ReactiveRotationResume = { continueDelayMs: number; idleUntilReset: boolean };
+
+/**
+ * Decide the continueDelayMs for a reactive 429 failover onto a LIVE candidate,
+ * bounding the (otherwise 0-delay) re-dispatch against two second-order faults:
+ *
+ *  1. Circuit breaker (1b): if the consecutive reactive-failover streak (prior
+ *     rotated 429 failovers since the last successful turn, PLUS this one) exceeds
+ *     `connectedAccountCount + REACTIVE_ROTATION_MARGIN`, fall to a FIXED positive,
+ *     MANDATORY idle. Covers the double-fault (cooldown write not persisted + a
+ *     header-less cap 429) where the same capped account is re-picked every turn.
+ *  2. Persistence-fault floor (1a): if the just-served account's cooldown could NOT
+ *     be confirmed persisted, use a positive floor (slow retry) instead of 0.
+ *
+ * Otherwise (a confirmed cooldown + an in-bounds streak) returns the unchanged
+ * 0-delay fast re-dispatch — the happy single-rotation path is byte-identical.
+ * Pure so the boundedness contract is unit-testable without a worker/db env.
+ */
+export function computeReactiveRotationResume(args: {
+  cooldownPersisted: boolean;
+  priorConsecutiveRotations: number; // reactive rotated failovers since last success (excludes this one)
+  connectedAccountCount: number;
+}): ReactiveRotationResume {
+  const streak = args.priorConsecutiveRotations + 1; // include the failover about to be published
+  const bound = args.connectedAccountCount + REACTIVE_ROTATION_MARGIN;
+  if (streak > bound) {
+    return { continueDelayMs: REACTIVE_CIRCUIT_BREAKER_IDLE_MS, idleUntilReset: true };
+  }
+  if (!args.cooldownPersisted) {
+    return { continueDelayMs: REACTIVE_PERSISTENCE_FAULT_FLOOR_MS, idleUntilReset: false };
+  }
+  return { continueDelayMs: 0, idleUntilReset: false };
+}
+
 /**
  * THE pure rotation ranker. `accounts` arrives in stable created_at order
  * (listCodexAccountStatuses), which deterministically breaks ranking ties.

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -4,8 +4,12 @@ import {
   availableAt,
   chooseRotationActive,
   computeIdleDelayMs,
+  computeReactiveRotationResume,
   DEFAULT_RESET_COOLDOWN_MS,
   MIN_IDLE_MS,
+  REACTIVE_CIRCUIT_BREAKER_IDLE_MS,
+  REACTIVE_PERSISTENCE_FAULT_FLOOR_MS,
+  REACTIVE_ROTATION_MARGIN,
 } from "../src/activities/codex-rotation";
 
 // Multi-account P3 — the PURE rotation ranker. All rotation correctness (most_remaining
@@ -372,5 +376,70 @@ describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => 
     ];
     expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts, usedConnectors: ["github", "linear"] }))
       .toEqual({ kind: "active", credentialId: "b", moved: true });
+  });
+});
+
+// Finding 1 (reactive-rotation boundedness). computeReactiveRotationResume bounds the
+// reactive 429 failover's otherwise-0-delay re-dispatch against two second-order faults
+// so a double-fault (cooldown write not persisted + a header-less cap 429 that re-picks
+// the SAME account every proactive rank) degrades to a positive, bounded retry instead
+// of a model-paced hot loop that hammers the capped backend + DB (invariant 4: NO THRASH).
+describe("computeReactiveRotationResume — the reactive failover is bounded", () => {
+  test("(4) happy path: a confirmed cooldown + first failover → 0-delay fast re-dispatch (byte-identical to P3)", () => {
+    // A single rotation onto a live candidate: the just-served account IS cooling, so
+    // the next rank cannot re-pick it. Re-dispatch NOW, no hold, no idleUntilReset.
+    expect(computeReactiveRotationResume({ cooldownPersisted: true, priorConsecutiveRotations: 0, connectedAccountCount: 3 }))
+      .toEqual({ continueDelayMs: 0, idleUntilReset: false });
+  });
+
+  test("(1a) persistence fault: cooldown NOT confirmed persisted → POSITIVE slow-retry floor, never 0", () => {
+    const resume = computeReactiveRotationResume({ cooldownPersisted: false, priorConsecutiveRotations: 0, connectedAccountCount: 3 });
+    expect(resume.continueDelayMs).toBe(REACTIVE_PERSISTENCE_FAULT_FLOOR_MS);
+    expect(resume.continueDelayMs).toBeGreaterThan(0);   // the crux: a persistence fault never yields a 0-delay hot loop
+    expect(resume.idleUntilReset).toBe(false);           // a slow retry, not a mandatory long hold
+  });
+
+  test("(1b) double-fault below the bound still floors positive (persistence fault dominates the 0)", () => {
+    // 2 prior + this = streak 3, bound = 2 accounts + margin(2) = 4 → in bounds, but the
+    // unpersisted cooldown still forces the positive floor rather than a 0.
+    const resume = computeReactiveRotationResume({ cooldownPersisted: false, priorConsecutiveRotations: 2, connectedAccountCount: 2 });
+    expect(resume.continueDelayMs).toBe(REACTIVE_PERSISTENCE_FAULT_FLOOR_MS);
+    expect(resume.continueDelayMs).toBeGreaterThan(0);
+  });
+
+  test("(1b) once consecutive failovers EXCEED accounts + margin → FIXED mandatory idle (circuit breaker), never another 0", () => {
+    const accounts = 2;
+    const bound = accounts + REACTIVE_ROTATION_MARGIN; // 4
+    // Walk the streak up to and past the bound; the double-fault keeps cooldown unpersisted.
+    const at = (prior: number) => computeReactiveRotationResume({ cooldownPersisted: false, priorConsecutiveRotations: prior, connectedAccountCount: accounts });
+    // streak = prior+1. In bounds (streak ≤ 4): positive slow-retry floor, not the breaker.
+    expect(at(bound - 1)).toEqual({ continueDelayMs: REACTIVE_PERSISTENCE_FAULT_FLOOR_MS, idleUntilReset: false }); // streak 4 == bound
+    // Over the bound (streak 5): the circuit breaker fires — a FIXED positive MANDATORY idle.
+    const broken = at(bound); // streak 5 > 4
+    expect(broken.continueDelayMs).toBe(REACTIVE_CIRCUIT_BREAKER_IDLE_MS);
+    expect(broken.continueDelayMs).toBeGreaterThan(0);
+    expect(broken.idleUntilReset).toBe(true);   // MANDATORY hold — session.ts can never collapse it to a 0-delay re-dispatch
+  });
+
+  test("(1b) the circuit breaker fires even when the cooldown DID persist (header-less caps can still re-pick)", () => {
+    // Boundedness must not depend on the persistence result: an unbounded streak trips the breaker regardless.
+    const broken = computeReactiveRotationResume({ cooldownPersisted: true, priorConsecutiveRotations: 10, connectedAccountCount: 2 });
+    expect(broken.idleUntilReset).toBe(true);
+    expect(broken.continueDelayMs).toBe(REACTIVE_CIRCUIT_BREAKER_IDLE_MS);
+  });
+
+  test("(2) a RESET streak (priorConsecutiveRotations back to 0 after a successful turn) returns to the 0-delay happy path", () => {
+    // The DB counter resets to 0 on a successful turn (turn.completed anchor); the pure
+    // decision must then behave exactly like a fresh first failover — no lingering hold.
+    expect(computeReactiveRotationResume({ cooldownPersisted: true, priorConsecutiveRotations: 0, connectedAccountCount: 1 }))
+      .toEqual({ continueDelayMs: 0, idleUntilReset: false });
+  });
+
+  test("more connected accounts raise the bound proportionally (a legit N-account walk never trips the breaker)", () => {
+    // With N accounts a legitimate walk cools one per failover; the bound N+margin absorbs it.
+    const accounts = 5;
+    // streak N (== accounts) with cooldowns persisting stays on the fast path.
+    expect(computeReactiveRotationResume({ cooldownPersisted: true, priorConsecutiveRotations: accounts - 1, connectedAccountCount: accounts }))
+      .toEqual({ continueDelayMs: 0, idleUntilReset: false });
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2623,6 +2623,50 @@ export async function setCodexCredentialExhausted(
 }
 
 /**
+ * P3 reactive-rotation boundedness (Finding 1b): the number of CONSECUTIVE rotated
+ * 429-failover turns since the session last had a SUCCESSFUL turn. Counts
+ * `turn.failed` events carrying the `rotated` marker that occurred AFTER the most
+ * recent `turn.completed` event (the natural reset anchor — any successful turn
+ * moves the anchor past every prior failover, so the streak resets to 0). The
+ * reactive 429 catch consults this to bound its otherwise-0-delay re-dispatch:
+ * once the streak exceeds ~(connected accounts + margin) the path degrades to a
+ * fixed positive idle instead of another hot re-dispatch (invariant 4: NO THRASH),
+ * covering the double-fault where a cooldown write did not persist AND the 429
+ * carried no usage headers. Derived from persisted events so it is correct across
+ * the Temporal re-dispatch (each failover is a NEW turn, but its event survives).
+ */
+export async function countConsecutiveReactiveRotations(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<number> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [lastOk] = await scopedDb.select({ sequence: schema.sessionEvents.sequence })
+      .from(schema.sessionEvents)
+      .where(and(
+        eq(schema.sessionEvents.workspaceId, workspaceId),
+        eq(schema.sessionEvents.sessionId, sessionId),
+        eq(schema.sessionEvents.type, "turn.completed"),
+      ))
+      .orderBy(desc(schema.sessionEvents.sequence))
+      .limit(1);
+    const conditions = [
+      eq(schema.sessionEvents.workspaceId, workspaceId),
+      eq(schema.sessionEvents.sessionId, sessionId),
+      eq(schema.sessionEvents.type, "turn.failed"),
+      sql`${schema.sessionEvents.payload} ->> 'rotated' = 'true'`,
+    ];
+    if (lastOk) {
+      conditions.push(sql`${schema.sessionEvents.sequence} > ${lastOk.sequence}`);
+    }
+    const [{ rotated } = { rotated: 0 }] = await scopedDb.select({
+      rotated: sql<number>`count(*)::int`,
+    }).from(schema.sessionEvents).where(and(...conditions));
+    return Number(rotated);
+  });
+}
+
+/**
  * P4 connector-set cache writer: persist the set of ORIGINAL-dotted connector
  * namespaces a SPECIFIC credential exposes via codex_apps (+ the freshness clock).
  * Modeled byte-for-byte on recordCodexAccountUsage / setCodexCredentialExhausted:

--- a/packages/db/test/reactive-rotation-boundedness.test.ts
+++ b/packages/db/test/reactive-rotation-boundedness.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import {
+  countConsecutiveReactiveRotations,
+  createDb,
+  evaluateGoalContinuation,
+  type Database,
+  type DbClient,
+} from "../src/index";
+
+// Finding 1b + Finding 2 — the persisted-event backstops for the codex
+// auto-rotation boundedness, driven through the REAL packages/db query fns against
+// a throwaway postgres under the NON-superuser opengeni_app role (so FORCE RLS
+// actually applies). Seeding is done as the superuser (bypasses RLS).
+//
+//   Finding 1b — countConsecutiveReactiveRotations: the number of CONSECUTIVE
+//     rotated 429-failover turns since the last SUCCESSFUL turn (turn.completed
+//     anchor). The reactive path consults it to bound its 0-delay re-dispatch, and
+//     it RESETS to 0 the moment a turn.completed lands.
+//   Finding 2 — evaluateGoalContinuation must FREEZE autoContinuations for the
+//     rotation-wait state on BOTH the reactive AND the (now `rotated:true`)
+//     proactive all-capped path, while a NORMAL non-rotation goal continuation
+//     still increments. A goal waiting out a reset must not burn its budget.
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+  const [a] = await admin<{ id: string }[]>`insert into managed_accounts (name) values ('acct') returning id`;
+  const [w] = await admin<{ id: string }[]>`insert into workspaces (account_id, name) values (${a!.id}, 'ws') returning id`;
+  return { accountId: a!.id, workspaceId: w!.id };
+}
+
+async function seedSession(ws: { accountId: string; workspaceId: string }): Promise<string> {
+  const id = crypto.randomUUID();
+  await admin`
+    insert into sessions (id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id)
+    values (${id}, ${ws.accountId}, ${ws.workspaceId}, 'go', 'gpt', 'modal', ${id})`;
+  return id;
+}
+
+// Append a session_event as the superuser at the next per-session sequence.
+async function appendEvent(
+  ws: { accountId: string; workspaceId: string },
+  sessionId: string,
+  type: string,
+  payload: Record<string, unknown>,
+  turnId: string | null = null,
+): Promise<void> {
+  const [{ next } = { next: 0 }] = await admin<{ next: number }[]>`
+    select coalesce(max(sequence), -1) + 1 as next from session_events
+    where workspace_id = ${ws.workspaceId} and session_id = ${sessionId}`;
+  await admin`
+    insert into session_events (account_id, workspace_id, session_id, turn_id, sequence, type, payload)
+    values (${ws.accountId}, ${ws.workspaceId}, ${sessionId}, ${turnId}, ${next}, ${type}, ${admin.json(payload as Parameters<typeof admin.json>[0])})`;
+}
+
+// A finished turn + an active goal whose lastContinuationTurnId points at it, so
+// evaluateGoalContinuation reads THIS turn's events to decide the freeze.
+async function seedGoalOnFinishedTurn(
+  ws: { accountId: string; workspaceId: string },
+  sessionId: string,
+): Promise<string> {
+  const turnId = crypto.randomUUID();
+  const triggerEventId = crypto.randomUUID();
+  await admin`
+    insert into session_turns (id, account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+                               status, position, prompt, model, reasoning_effort, sandbox_backend, finished_at)
+    values (${turnId}, ${ws.accountId}, ${ws.workspaceId}, ${sessionId}, ${triggerEventId}, 'wf',
+            'failed', 1, 'go', 'gpt', 'medium', 'modal', now())`;
+  await admin`
+    insert into session_goals (account_id, workspace_id, session_id, status, text,
+                               version, auto_continuations, no_progress_streak,
+                               last_continuation_turn_id, version_at_last_continuation)
+    values (${ws.accountId}, ${ws.workspaceId}, ${sessionId}, 'active', 'ship it',
+            1, 0, 0, ${turnId}, 1)`;
+  return turnId;
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("reactive-rotation-boundedness");
+  if (!shared) {
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[reactive-rotation-boundedness] docker unavailable, skipping");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  try { await client?.close(); } catch { /* noop */ }
+  await shared?.release();
+});
+
+describe("Finding 1b — countConsecutiveReactiveRotations", () => {
+  test("no events → 0 (a fresh session is never mid-loop)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(0);
+  });
+
+  test("counts every rotated turn.failed when there is no successful turn yet (the runaway-walk case)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true, recovery: "goal_continuation" });
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true, recovery: "goal_continuation" });
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true, recovery: "goal_continuation" });
+    expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(3);
+  });
+
+  test("a non-rotated turn.failed is NOT counted (only rotation failovers)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    await appendEvent(ws, sessionId, "turn.failed", { recovery: "provider_backpressure" }); // no rotated marker
+    expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(1);
+  });
+
+  test("(2) the streak RESETS after a successful turn (turn.completed moves the anchor past prior failovers)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    // Two failovers, then a SUCCESS, then one more failover.
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    await appendEvent(ws, sessionId, "turn.completed", { output: "done" }); // real progress → resets the anchor
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    // Only the failover AFTER the success counts — the pre-success streak is forgotten.
+    expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(1);
+  });
+
+  test("(2) a success with NO subsequent failover returns 0 (fully reset)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
+    await appendEvent(ws, sessionId, "turn.completed", { output: "done" });
+    expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(0);
+  });
+});
+
+describe("Finding 2 — evaluateGoalContinuation freezes the rotation-wait on BOTH paths", () => {
+  const CONFIG = { noProgressLimit: 3, defaultMaxAutoContinuations: 100 } as const;
+
+  test("(3) a rotated:true continuation FREEZES autoContinuations (reactive AND proactive all-capped, post-fix)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    const turnId = await seedGoalOnFinishedTurn(ws, sessionId);
+    // The turn.failed shape BOTH all-capped paths now emit: recovery=goal_continuation + rotated:true.
+    await appendEvent(ws, sessionId, "turn.failed", { rotated: true, recovery: "goal_continuation", code: "codex_usage_limit_reached" }, turnId);
+    const decision = await evaluateGoalContinuation(db, { workspaceId: ws.workspaceId, sessionId, ...CONFIG });
+    expect(decision.decision).toBe("continue");
+    // FROZEN: the rotation-wait did not consume the goal's continuation budget.
+    expect(decision.decision === "continue" ? decision.autoContinuation : -1).toBe(0);
+  });
+
+  test("(3) a NORMAL non-rotation goal continuation still INCREMENTS (the pre-fix proactive shape / normal backpressure)", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    const turnId = await seedGoalOnFinishedTurn(ws, sessionId);
+    // recovery=goal_continuation but NO rotated marker — exactly the proactive all-capped
+    // payload BEFORE Finding 2, and a normal (non-rotation) continuation in general.
+    await appendEvent(ws, sessionId, "turn.failed", { recovery: "goal_continuation", code: "codex_usage_limit_reached" }, turnId);
+    const decision = await evaluateGoalContinuation(db, { workspaceId: ws.workspaceId, sessionId, ...CONFIG });
+    expect(decision.decision).toBe("continue");
+    // Not a rotation wait → the budget advances as before (proves the freeze is scoped to rotation).
+    expect(decision.decision === "continue" ? decision.autoContinuation : -1).toBe(1);
+  });
+});


### PR DESCRIPTION
## What & why

Closes the **two residual findings** from the rotation robustness audit (the "Is it 100% robust?" follow-up). Rotation was already safe under all normal conditions and its one dangerous mode (all-capped tight-loop) was fixed in P3 — but the audit surfaced a **double-fault** path with no backstop.

### Finding 1 — reactive-429 hot-loop under a double-fault
Reactive failover returned a **0-delay** re-dispatch. Under a *double-fault* — the `setCodexCredentialExhausted` cooldown-write silently failing (its result was swallowed via `.catch(()=>false)`) **AND** a header-less cap 429 (so the capped account isn't excluded on the next rank) — the next proactive rank could re-select the same capped account → 429 again → a **zero-backoff, model-paced loop** with the goal guards frozen (`rotated:true`).

**Fix (defense-in-depth, both a + b):**
- **(a) positive floor** — new pure `computeReactiveRotationResume(...)`: when the cooldown write is **not confirmed persisted**, return a positive `REACTIVE_PERSISTENCE_FAULT_FLOOR_MS` (5s) instead of 0.
- **(b) bounded circuit breaker** — `countConsecutiveReactiveRotations(...)` counts `rotated` `turn.failed` events **since the last `turn.completed`** (RLS-scoped, derived from persisted events so it survives the Temporal re-dispatch and **resets on any successful turn**). Once the streak exceeds `connectedAccounts + REACTIVE_ROTATION_MARGIN` (2), the resume becomes a **fixed 60s MANDATORY idle** (`idleUntilReset`) — never another 0-delay re-dispatch.

Confirmed-cooldown + in-bounds streak still returns **0** (byte-identical to P3's happy path). The double-fault now degrades to a **5s → 60s slow retry** that self-heals when the real reset lands.

### Finding 2 — proactive vs reactive all-capped inconsistency
The proactive all-capped `turn.failed` carried `recovery:goal_continuation` but **no `rotated` field**, so it *incremented* `autoContinuations` while the reactive path *froze* it — inconsistent goal-budget burn if `goalMaxAutoContinuations` is finite. Now the proactive all-capped payload also stamps `rotated:true`, so both paths freeze the budget identically. A normal (non-rotation) continuation still increments.

## Invariants preserved
All new logic sits inside the `rotationEnabled && pin==null` gates → rotation-off / pinned turns are **byte-identical**. The all-capped idle floor, cooldown, `most_remaining`, token isolation, and RLS are untouched. `countConsecutiveReactiveRotations` runs under `withWorkspaceRls`.

## Tests
- `apps/worker/test/codex-rotation.test.ts` — 7 new pure cases (double-fault → positive floor never 0; streak>bound → fixed 60s idle; streak-reset → 0-delay happy path; breaker independent of persistence result; bound scales with account count).
- `packages/db/test/reactive-rotation-boundedness.test.ts` (new, real Postgres + RLS) — `countConsecutiveReactiveRotations` counts/ignores/resets correctly; `evaluateGoalContinuation` freezes on a `rotated:true` continuation (both all-capped paths) and still increments on a normal one.

**Verification:** typecheck green (worker, db, runtime, config, codex); worker 180 pass / 1 skip / 0 fail; db 112 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches goal continuation and Temporal re-dispatch timing on Codex rate-limit paths; gated to rotation-enabled, unpinned sessions, with happy-path behavior unchanged when cooldowns persist and streaks stay in bounds.
> 
> **Overview**
> Hardens **Codex multi-account rotation** when a turn hits a usage cap (429) and fails over to another account, closing two audit gaps without changing normal rotation behavior.
> 
> **Reactive failover boundedness (Finding 1):** Failover used to return **immediate** re-dispatch (`continueDelayMs: 0`). If the cooldown write for the capped account failed silently and the next rank could pick the same account again, that could spin in a tight loop. The worker now checks whether `setCodexCredentialExhausted` actually persisted, counts consecutive `turn.failed` events with `rotated: true` since the last `turn.completed` via new `countConsecutiveReactiveRotations`, and feeds both into pure `computeReactiveRotationResume`: **5s slow retry** when cooldown isn’t confirmed, **60s mandatory idle** (`idleUntilReset`) when the streak exceeds connected accounts + margin, otherwise still **0** on the happy path.
> 
> **Goal budget alignment (Finding 2):** Proactive turn-start **all-capped** failures now emit `rotated: true` on `turn.failed`, matching the reactive path so `evaluateGoalContinuation` **freezes** `autoContinuations` while waiting on rotation instead of burning the cap on one path only.
> 
> Coverage: unit tests for `computeReactiveRotationResume` and integration tests for the DB counter + continuation freeze.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc51b800531a3892e0c163101339ecb8dc6e92ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->