### PR TITLE
docs(operator+product): Connected Machines deployment, trust model, and pitch

### DIFF
--- a/.agents/skills/opengeni/references/deployment-infrastructure.md
+++ b/.agents/skills/opengeni/references/deployment-infrastructure.md
@@ -10,6 +10,7 @@ Use this reference to orient source discovery for OpenGeni deployment work. It i
 - Provider substrate examples: `deploy/terraform/azure`, `deploy/terraform/aws`, and `deploy/terraform/gcp`.
 - Optional stack wrappers for upstream platform charts: `deploy/stacks`.
 - Validation scripts: `scripts/deployment-preflight.ts`, `scripts/deployment-stack.ts`, `scripts/deployment-runtime-artifacts.ts`, `scripts/deployment-temporal-values.ts`, and `scripts/deployment-conformance.ts`.
+- Connected Machine (`selfhosted` backend) surfaces: the stream relay edge `agent/crates/opengeni-relay`; the enrollment routes `apps/api/src/routes/enrollments.ts` over `apps/api/src/sandbox/enrollment.ts`; the agent install/binary routes `apps/api/src/routes/install.ts` plus the committed `agent/install`; the relay/NATS chart templates under `deploy/helm/opengeni/templates` (`relay-*.yaml`, `nats-*.yaml`) and the `relay`/`nats`/`selfhosted` blocks in `deploy/helm/opengeni/values.yaml`; the `@opengeni/react/machines` client subpath.
 
 If paths move, rediscover by searching for deployment profile names, `DeploymentContract`, `stackPlanFor`, `deployment:preflight`, `deployment:stack`, Helm values files, and Terraform roots.
 
@@ -74,6 +75,45 @@ When planning a deployment, make these choices explicitly from current source:
 - Execution: real model provider credentials and a real sandbox backend unless the goal is smoke only.
 - Edge: ingress, TLS, auth boundary, metrics exposure, tracing/logging, and secret delivery.
 - Product posture: `access.mode` (`local`, `configured`, `managed`), `billing.mode`, `entitlements.mode`, and `usageLimits.mode`. Keep this orthogonal to cloud profile names such as `azure-managed`.
+
+## Connected Machines Versus Self-Hosted Deployment
+
+"Self-hosted" is overloaded in this repo — keep the two meanings distinct:
+
+- **Self-hosted DEPLOYMENT**: an operator runs the whole OpenGeni product
+  (API/web/worker + Postgres/NATS/Temporal/object storage) on their own
+  infrastructure. This is what every profile above and `docs/deployment.md`
+  describe.
+- **Connected Machine (user-owned compute)**: the `selfhosted` sandbox backend
+  (`OPENGENI_SANDBOX_BACKEND=selfhosted`; also the 11th entry in the
+  `SandboxBackend` enum and the `selfhosted` `MachineKind`). A user enrolls their
+  own computer as a first-class primary compute target. A machine-targeted turn
+  establishes the machine session directly and routes tool execution to the
+  agent on that machine over NATS request/reply; the platform creates no cloud
+  box, distributes no platform-minted git token (the machine uses its own git
+  credentials), and does not clone repos onto it. Optional and OFF by default.
+
+Operator surfaces the Connected Machine feature adds, all gated by
+`OPENGENI_SANDBOX_SELFHOSTED_ENABLED` (default off → enrollment routes 404, the
+backend is inert):
+
+- **The stream relay** (`opengeni-relay` image, `relay.enabled=true`): the wss
+  channel a machine's agent dials OUT to. It splices the agent's producer stream
+  and the viewer's consumer stream in a per-replica in-memory registry, so a
+  multi-replica relay behind an L7 ingress needs channel affinity (both dials for
+  a channel must reach the same replica). It holds no cluster state and makes no
+  cluster egress.
+- **NATS with auth-callout** (`nats.authCallout` or an external NATS running the
+  same `deploy/nats/auth-callout.conf`): the per-workspace-scoped control plane
+  the agent authenticates to.
+- **Agent-binary hosting from the control plane**: the API serves the install
+  script and the per-deploy agent binary at auth-exempt paths (`/install.sh`,
+  `/install.ps1`, `/agent/*`; `apps/api/src/routes/install.ts`), so the install
+  one-liner pulls the exact agent build matching the running control plane, with a
+  public release archive as fallback/self-update.
+- **Runtime-secret + non-secret wiring**: the relay/enrollment/NATS token secrets
+  and the `OPENGENI_SELFHOSTED_*` URLs/names (see the `values.yaml` `secret:`
+  comment and `packages/config`).
 
 ## Verification Meaning
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ OpenGeni is a self-hostable managed agent service for long-running workspace and
 
 It provides a session-based API for creating, steering, observing, interrupting, and replaying agent runs. The included React app is one client for that API; other products can call the same API directly and let OpenGeni own durable session state, event history, approvals, and final outputs.
 
+Every session picks where it runs. A **managed sandbox** (a fresh cloud box OpenGeni provisions and tears down) and a **Connected Machine** (a computer you enroll — your laptop, a build server, a GPU box) are co-equal, first-class compute targets. A machine-targeted session runs directly on your hardware, under your own files and your own git credentials, with no cloud box in the loop.
+
 If you want to try the managed version, go to [app.opengeni.ai](https://app.opengeni.ai).
 
 ## What It Does
@@ -11,7 +13,8 @@ If you want to try the managed version, go to [app.opengeni.ai](https://app.open
 - Runs OpenAI Agents SDK agents behind a durable API.
 - Streams live session events over SSE while storing the replayable event log in Postgres.
 - Coordinates long-running work with Temporal signals for follow-ups, approvals, and interrupts.
-- Executes agent tools in sandbox backends such as Docker, Modal, local, or none.
+- Runs each session on a chosen compute target: a managed sandbox (Docker, Modal, local, cloud provider, or none) or a **Connected Machine** you enroll — with a per-session working folder on that machine.
+- Establishes a machine-targeted turn directly on the enrolled machine, using the machine's own git credentials — no cloud box is created and no OpenGeni-minted token is pushed to it.
 - Attaches repositories, uploaded files, and document-search tools to sessions.
 - Uses a GitHub App integration for scoped repository access.
 - Supports document upload, indexing, retry, and semantic search with pgvector.
@@ -59,8 +62,12 @@ flowchart LR
     Temporal["Temporal<br/>orchestration and signals"]
     Worker["Worker<br/>OpenAI Agents SDK harness"]
     NATS["NATS Core<br/>live fanout"]
-    Sandbox["Sandbox backend<br/>Docker, Modal, cloud, or self-hosted"]
+    Control["NATS control plane<br/>machine exec/RPC"]
+    Relay["Stream relay<br/>pty/desktop frames"]
+    Sandbox["Managed sandbox<br/>Docker, Modal, cloud, or none"]
   end
+
+  Machine["Connected Machine<br/>your enrolled computer"]
 
   Web --> API
   Service --> API
@@ -73,7 +80,12 @@ flowchart LR
   Worker <--> DB
   Worker --> NATS
   Worker <--> Sandbox
+  Worker <--> Control
+  Machine -. dials out .-> Control
+  Machine -. dials out .-> Relay
 ```
+
+Managed sandboxes are provisioned inside the deployment. A Connected Machine is a computer you own: its agent dials **out** to the NATS control plane (for exec and control RPC) and to the stream relay (for terminal and desktop frames), so nothing has to be routable to the machine. Machine-target support is off by default and gated by an operator flag; see [Connected Machines](#connected-machines).
 
 Postgres is the durable source of truth. NATS is only the realtime fanout bus. If an API instance or SSE client misses live events, the API backfills from Postgres by event sequence.
 
@@ -91,7 +103,8 @@ For a map of every app and package and how they fit together, see [docs/architec
 - NATS Core realtime bus
 - MinIO for local S3-compatible file storage and Azure Blob, AWS S3, or GCS for production object storage
 - OpenAI Agents SDK
-- Pluggable sandbox backends: Docker, Modal, local, and cloud providers, plus self-hosted bring-your-own-compute (see [docs/architecture.md](docs/architecture.md) for the full list)
+- Two co-equal compute targets: managed sandboxes (Docker, Modal, local, cloud providers, or none) and Connected Machines — computers you enroll and run sessions on directly (see [Connected Machines](#connected-machines) and [docs/architecture.md](docs/architecture.md) for the full list)
+- A Rust agent + stream relay for Connected Machines (`agent/crates`), served to hosts by the control plane
 
 ## Agent Guides
 
@@ -208,12 +221,57 @@ Production operators should use managed services, existing endpoints, or officia
 1. Start the stack with `bun run dev`.
 2. Open `http://127.0.0.1:3000`.
 3. Choose model and reasoning settings.
-4. Optionally attach repositories, files, or document search.
-5. Send the first task.
-6. Watch messages, tool calls, approvals, sandbox output, and final status.
-7. Send follow-ups, approve or reject tool requests, or interrupt the session.
+4. Answer **Where should this run?** — pick **Managed Sandbox** (a fresh box, set up for you) or **Connected Machine** (run on your own computer). Machine is offered only when the feature is enabled and you have at least one enrolled machine.
+5. For a Connected Machine, pick the machine and its **Project / folder** — the per-session working directory the agent runs under (the machine root / its launch directory, or a subdirectory). A managed sandbox needs no folder choice.
+6. Optionally attach repositories, files, or document search.
+7. Send the first task.
+8. Watch messages, tool calls, approvals, sandbox output, and final status. The session header's **Run on** control shows the active target and, when machines are enabled, lets you swap targets mid-session.
+9. Send follow-ups, approve or reject tool requests, or interrupt the session.
 
 Sessions are durable. Reloading the browser or opening the session URL later replays event history from Postgres and reconnects to live events.
+
+### Enrolling a Connected Machine
+
+When Connected Machines are enabled, enroll one from the workspace **Machines** dashboard (or from the composer's machine picker):
+
+1. Click **Enroll a machine** and run the printed install one-liner on the computer you want to connect. It pulls the OpenGeni agent binary from the control plane and starts it.
+2. Approve the machine. Two paths exist:
+   - **Device flow (consent):** the agent prints a short code and a verification link; you open it and click **Grant** in the workspace to approve that specific machine. Approval is the loud, explicit consent step, and it records who approved.
+   - **Zero-click enroll token:** mint a short-lived enroll token in the workspace ahead of time; the agent redeems it headlessly (the token is the grant, no per-machine click) — the path for scripted or fleet enrollment.
+3. The machine appears in the dashboard with its status, OS/arch, and whether it offers a screen. You can revoke it at any time. Screen control is a separate opt-in granted at approval.
+
+The agent dials **out** to the control plane, so the machine needs no inbound network exposure. See [Connected Machines](#connected-machines) for how an operator turns the feature on.
+
+## Connected Machines
+
+A Connected Machine is a first-class, co-equal alternative to the managed sandbox: instead of a cloud box OpenGeni provisions, a session runs on a computer you enroll and own.
+
+How a machine session differs from a managed sandbox:
+
+- **Runs directly on your machine.** A machine-targeted turn establishes the session on the enrolled machine directly — no cloud box is created or billed for that turn.
+- **Your own git auth.** OpenGeni does not mint or distribute a repository token to the machine. Commands run under the machine's own local environment and its own git credentials. (For a managed sandbox, OpenGeni injects a short-lived, run-scoped GitHub App token; for a machine that injection is skipped.)
+- **Your files, not a clone.** OpenGeni does not clone selected repositories onto the machine's real disk; the machine already owns its filesystem. The agent works in the per-session working folder you chose.
+- **Per-session working folder.** Each session names a working directory on the machine (the machine root, or a subdirectory); it is the cwd base for the agent's exec, terminal, and file dock.
+
+### Targeting machines from a custom client
+
+Any client that speaks the OpenGeni API can target a machine:
+
+- `POST /v1/workspaces/:workspaceId/sessions` (and the `session_create` MCP tool) accept `targetSandboxId` (the enrolled machine to run on) and `workingDir` (the per-session folder; only valid alongside `targetSandboxId`, and omitted means the machine's default working root).
+- The React SDK ships a `@opengeni/react/machines` subpath with the machines dashboard, enrollment device-flow and consent components, status surfacing, and a `useMachines` hook.
+- Enrollment is a small REST surface: agent-side device `start`/`poll` and headless token `exchange`, plus user-authenticated `approve`/`deny`, enroll-token mint, list, and revoke. All of it returns `404` while the feature is disabled.
+
+### Enabling Connected Machines (operators)
+
+The feature is **off by default**. While off, every enrollment and machine route returns `404` and the machine backend is inert — the surface does not exist for that deployment. Turning it on is provider-neutral:
+
+- **The enable flag.** Set `OPENGENI_SANDBOX_SELFHOSTED_ENABLED=true`. This is the keystone that reveals the enrollment routes and activates the machine backend.
+- **The relay component.** Deploy the stream relay (`opengeni-relay`, in `agent/crates`) as its own workload. A machine's agent dials out to it for terminal and desktop frames. Configure its listen address (`OPENGENI_RELAY_BIND`) and token secret (`OPENGENI_RELAY_TOKEN_SECRET`).
+- **Control-plane endpoints handed to the agent.** Point the control plane at the NATS control plane the agent dials (`OPENGENI_SELFHOSTED_NATS_URL`) and the relay's base URL (`OPENGENI_SELFHOSTED_RELAY_URL`); these are returned to the agent as connect info at enrollment.
+- **Signing secrets.** `OPENGENI_ENROLLMENT_SIGNING_SECRET` signs the enrollment credential the agent presents back; `OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET` signs the agent's relay producer token (the relay verifies it with the same secret, and it falls back to the stream-token secret when unset). Without these the credential and stream planes degrade gracefully rather than failing boot. Keep them in the deployment secret store; never log them.
+- **Agent binary hosting.** The control plane serves the agent binary and install script under `/agent/*`; the install one-liner pulls from there. Nothing else needs to host it.
+
+Provision NATS and the relay with your own managed services or upstream charts, as the rest of the stack recommends. Do not expose the machine feature without the relay-token and enrollment-signing secrets in place and rate limits on the enrollment routes.
 
 ## GitHub App Setup
 
@@ -287,6 +345,18 @@ Document endpoints:
 - `POST /v1/workspaces/:workspaceId/document-bases/:baseId/documents`
 - `POST /v1/workspaces/:workspaceId/document-bases/:baseId/search`
 - `POST /v1/workspaces/:workspaceId/document-bases/:baseId/documents/:documentId/reindex`
+
+Connected Machine endpoints (all return `404` unless `OPENGENI_SANDBOX_SELFHOSTED_ENABLED=true`):
+
+- `POST /v1/enrollments/device/start` (agent-side, unauthenticated)
+- `POST /v1/enrollments/device/poll` (agent-side, unauthenticated)
+- `POST /v1/enrollments/device/lookup`
+- `POST /v1/enrollments/token/exchange` (agent-side headless enroll-token redemption)
+- `POST /v1/workspaces/:workspaceId/enrollments/device/approve`
+- `POST /v1/workspaces/:workspaceId/enrollments/device/deny`
+- `POST /v1/workspaces/:workspaceId/enrollments/token` (mint a headless enroll token)
+- `GET /v1/workspaces/:workspaceId/enrollments`
+- `POST /v1/workspaces/:workspaceId/enrollments/:enrollmentId/revoke`
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,31 @@ Do not include API keys, tokens, private keys, cloud credentials, customer data,
 
 ## Local Development
 
-OpenGeni runs agents that can execute tools in configured sandboxes. Review `.env` carefully before running live sessions, especially sandbox preparation profiles and `OPENGENI_SANDBOX_ENV_ALLOWLIST`.
+OpenGeni runs agents that can execute tools in configured sandboxes. Review `.env` carefully before running live sessions, especially sandbox preparation profiles and `OPENGENI_SANDBOX_ENV_ALLOWLIST`. These preparation and env-injection controls describe what reaches a **managed sandbox** — a box OpenGeni provisions. A [Connected Machine](#connected-machines) is a different trust boundary; see below.
 
 The base API is workspace-scoped and resolves protected requests through an access grant. `managed` mode uses Better Auth for browser human auth and OpenGeni-owned API keys for product/API access. `configured` mode lets a self-hosted or embedded deployment use delegated bearer tokens or a deployment shared-key boundary. The deployment shared key uses `x-opengeni-access-key`; product API keys use `Authorization: Bearer`.
 
 Before exposing OpenGeni beyond local development, choose the access mode intentionally, run the workspace-isolation/RLS checks, use a non-owner application DB role in production where possible, and put appropriate gateway rate limits and request size limits in front of public routes.
 
-No model provider credentials are automatically exposed inside agent sandboxes. Only expose host credentials through explicit preparation profiles or allowlists, and prefer short-lived credentials.
+No model provider credentials are automatically exposed inside agent sandboxes. Only expose host credentials to a managed sandbox through explicit preparation profiles or allowlists, and prefer short-lived credentials.
+
+## Connected Machines
+
+A Connected Machine is a computer a user enrolls and runs sessions on directly — a first-class, co-equal compute target alongside the managed sandbox. Because a machine session runs on hardware OpenGeni does not own, its trust boundary differs from a managed sandbox in specific, deliberate ways.
+
+**The feature is off by default.** It is gated by `OPENGENI_SANDBOX_SELFHOSTED_ENABLED`; while off, the enrollment and machine routes return `404` and the machine backend is inert, so no deployment exposes this surface without an operator deliberately enabling it.
+
+**No OpenGeni-minted token is distributed to the machine.** For a managed sandbox, OpenGeni mints a short-lived, run-scoped GitHub App installation token and injects it (plus git identity and any workspace-environment values) into the box. A machine-targeted turn skips that mint entirely: the machine uses its **own** local git credentials. The agent's command RPC to the machine carries an empty environment on the wire — the run's env block is used only for an internal manifest-parity check in the worker and is never transmitted to the machine. In practice, the workspace-environment / allowlist / preparation-profile injection that reaches a managed sandbox does **not** push secrets into a machine's commands.
+
+**What that means for the operator's own machine.** Running on your own hardware means the agent operates with whatever that machine's environment already holds — its logged-in git credentials, its shell environment, its files. That access is the point, and it is also the risk: enroll a machine only where you accept an agent acting with that machine's own credentials and reachable data. OpenGeni does not clone selected repositories onto the machine's real disk; the machine already owns its filesystem, and the agent works in the per-session working folder chosen at session creation.
+
+**Enrollment and consent.** A machine joins a workspace one of two ways, both requiring the `enrollments:manage` permission on the approving side:
+
+- **Device flow (explicit consent):** the machine's agent starts an enrollment (unauthenticated, presenting only the deployment access key, IP-rate-limited) and prints a short user code. A workspace member with `enrollments:manage` then approves that specific code. Approval is the loud consent step and records who approved. An unauthenticated start can never grant access to a workspace no authorized user later approves in — the approve is workspace-scoped to the code.
+- **Zero-click enroll token:** a member with `enrollments:manage` mints a short-TTL enroll token; the agent redeems it headlessly (the token is the grant). This is for scripted or fleet enrollment and carries the same authorization the human approve would.
+
+Screen control is a separate opt-in granted at approval, not implied by enrollment. Machines can be listed and revoked at any time (`enrollments:read` / `enrollments:manage`).
+
+**Relay isolation.** A machine's agent dials **out** to the control plane; nothing routes inbound to the machine. Terminal and desktop frames flow through a separate stream relay that pairs an agent (producer) with a viewer (consumer) by channel key. The relay is a byte-pump with bounded buffers and per-token rate limits: the agent authenticates to it with a signed, short-lived producer token, and a viewer with its own token, so the relay never grants ambient access to a machine.
+
+Operators enabling this feature must provision the relay and the enrollment/relay signing secrets and keep rate limits on the enrollment routes. See the README's Connected Machines section for the provider-neutral deployment shape.

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -5,6 +5,16 @@ This root creates a cleanup-friendly AWS substrate for the Helm chart:
 - EKS cluster and managed node group.
 - ECR repositories scoped under `name_prefix` for API, worker, and web images.
 - S3 bucket for `OPENGENI_OBJECT_STORAGE_BACKEND=aws-s3`.
+
+Connected Machines (`OPENGENI_SANDBOX_BACKEND=selfhosted`) add one more deployed
+component, the `opengeni-relay` stream relay. It is a separate image, so an
+operator enabling Connected Machines must also provision a container repository
+for it (this root creates the API/worker/web repositories only). The relay pairs
+each channel's producer and consumer in a per-replica in-memory registry, so its
+public wss ingress must route both dials for a channel to the same replica
+(consistent-hash / session affinity keyed on the channel) whenever more than one
+relay replica runs. See `docs/deployment.md` (Connected Machines) for the full
+relay/NATS/secret wiring.
 - AWS Secrets Manager runtime secret placeholder.
 - Optional RDS PostgreSQL when `postgres.mode = "managed"`.
 - `temporal.mode = "officialChart"` output wiring for the stack-wrapper managed upstream Temporal chart, or `external` for Temporal Cloud/customer endpoints.

--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -15,6 +15,15 @@ This Terraform root module is the Azure reference substrate for OpenGeni. It is 
 - ACR pull role assignment for AKS kubelet identity.
 - Optional AKS Microsoft Defender attachment to an existing Log Analytics workspace.
 
+Connected Machines (`OPENGENI_SANDBOX_BACKEND=selfhosted`) add one more deployed
+component, the `opengeni-relay` stream relay. Its image is pushed to the same
+Azure Container Registry as the API/worker/web images (no extra registry
+resource is required). The relay pairs each channel's producer and consumer in a
+per-replica in-memory registry, so its public wss ingress must route both dials
+for a channel to the same replica (consistent-hash / session affinity keyed on
+the channel) whenever more than one relay replica runs. See `docs/deployment.md`
+(Connected Machines) for the full relay/NATS/secret wiring.
+
 ## Phases
 
 Use `deployment_phase = "bootstrap"` to create cloud substrate before runtime dependencies are known. Bootstrap mode does not require Temporal, object storage, or external Postgres endpoints unless those resources are being created by Terraform.

--- a/deploy/terraform/gcp/README.md
+++ b/deploy/terraform/gcp/README.md
@@ -11,6 +11,15 @@ This root creates a cleanup-friendly GCP substrate for the Helm chart:
 - Private Service Connect / service networking for managed Cloud SQL when `postgres.private_ip_enabled = true`.
 - `temporal.mode = "officialChart"` output wiring for the stack-wrapper managed upstream Temporal chart, or `external` for Temporal Cloud/customer endpoints.
 
+Connected Machines (`OPENGENI_SANDBOX_BACKEND=selfhosted`) add one more deployed
+component, the `opengeni-relay` stream relay. Its image is pushed to the same
+Artifact Registry repository as the API/worker/web images (no extra registry
+resource is required). The relay pairs each channel's producer and consumer in a
+per-replica in-memory registry, so its public wss ingress must route both dials
+for a channel to the same replica (consistent-hash / session affinity keyed on
+the channel) whenever more than one relay replica runs. See `docs/deployment.md`
+(Connected Machines) for the full relay/NATS/secret wiring.
+
 Keep OpenGeni workloads in the provider-neutral Helm chart. This root should only create cloud substrate and emit non-secret Helm values.
 
 Managed Postgres defaults to `edition = "ENTERPRISE"` and `availability_type = "REGIONAL"` for production resilience. Short-lived evaluation stacks can set `postgres.availability_type = "ZONAL"` with `deletion_protection = false` to reduce cost.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -158,6 +158,18 @@ The sandbox image remains separate:
 docker build -f docker/sandbox.Dockerfile -t opengeni-sandbox:local .
 ```
 
+The Connected Machine stream relay is a separate deployed component built from
+the `agent/` Cargo workspace. It is only needed when Connected Machines are
+enabled (see [Connected Machines](#connected-machines)):
+
+```bash
+docker build -f agent/crates/opengeni-relay/Dockerfile -t opengeni-relay agent
+```
+
+For production Helm releases that enable Connected Machines, pin the
+`opengeni-relay` image by digest as well as tag, the same way API, worker, web,
+and migration images are pinned.
+
 ## Helm
 
 Render the chart with an existing secret:
@@ -335,6 +347,117 @@ Sandbox file mount support is also backend-specific:
 | --- | --- | --- | --- | --- |
 | Docker/local in-container sandboxes | rclone mount | rclone mount | signed download materialization | signed download materialization |
 | Modal | SDK cloud bucket mount | signed download materialization | signed download materialization | signed download materialization |
+
+## Connected Machines
+
+A Connected Machine is a user-owned computer (a laptop, workstation, or server,
+including macOS) enrolled as a first-class primary compute backend
+(`OPENGENI_SANDBOX_BACKEND=selfhosted`). When a session turn targets a Connected
+Machine, the platform establishes the machine session directly and routes tool
+execution to the agent running on that machine over a NATS request/reply control
+plane. No cloud sandbox box is created for that turn, no platform-minted GitHub
+token is distributed to the machine (it uses its own local git credentials), and
+repositories are not cloned onto it by the platform; the working directory is
+chosen per session.
+
+This is a separate, optional deployment surface. It is gated OFF by default;
+existing deployments are completely unaffected unless an operator enables it.
+
+### Enable flag
+
+The whole feature is gated by `OPENGENI_SANDBOX_SELFHOSTED_ENABLED` (default
+`false`). While it is off, the enrollment routes return `404` — the surface does
+not exist for the deployment — and the `selfhosted` backend is inert.
+
+### Components to deploy
+
+Enabling Connected Machines adds two net-new deployed components plus their
+ingress and secret wiring:
+
+- **Stream relay** (`opengeni-relay` image): a stateless wss byte-pump that
+  splices the agent's producer stream and the viewer's consumer stream for a
+  channel (pty/desktop). Enable with `relay.enabled=true`; the chart then renders
+  the relay Deployment, Service, HPA, PodDisruptionBudget, NetworkPolicy, and —
+  when observability is on — a ServiceMonitor. The relay holds no cluster state
+  and makes no cluster egress; both the agent and the viewer dial IN through the
+  ingress.
+- **NATS with auth-callout**: the machine's agent dials a NATS websocket to reach
+  the request/reply control plane, authenticated per workspace by a NATS
+  auth-callout responder. Use the chart-managed NATS fixture with
+  `nats.authCallout.enabled=true` for preview/smoke, or fold the same
+  `deploy/nats/auth-callout.conf` config into an external/production NATS
+  deployment (`nats.enabled=false`).
+
+Both the relay and the NATS websocket need public wss ingress hosts (for example
+`relay.<domain>` and `nats.<domain>`) with the long-lived-stream ingress
+annotations (read/send timeouts of at least `3600` seconds, buffering off). Flip
+`selfhosted.enabled=true` together with `relay.enabled=true` and the NATS
+callout.
+
+### Ingress channel affinity
+
+The relay pairs a channel's producer and consumer in a per-replica in-memory
+registry, so both dials for a given channel must reach the SAME relay replica.
+When running more than one relay replica behind an L7 ingress, configure the
+ingress to route both dials for a channel to the same backend (consistent-hash or
+session affinity keyed on the channel); otherwise a producer and consumer can
+land on different replicas and never pair.
+
+### Runtime-secret keys
+
+Set these in the runtime secret (never a committed values file) when enabling
+Connected Machines:
+
+- `OPENGENI_STREAM_TOKEN_SECRET` — HMAC the relay verifies the viewer (`ogs_`)
+  stream token with.
+- `OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET` — HMAC the relay verifies the agent
+  (`ogr_`) producer token with; may be omitted to reuse
+  `OPENGENI_STREAM_TOKEN_SECRET` for both planes.
+- `OPENGENI_ENROLLMENT_SIGNING_SECRET` — HMAC the control plane signs the
+  enrollment bearer with (falls back to `OPENGENI_DELEGATION_SECRET`).
+- `OPENGENI_SELFHOSTED_NATS_CALLOUT_ACCOUNT_SEED`,
+  `OPENGENI_SELFHOSTED_NATS_CALLOUT_PUBLIC_KEY`,
+  `OPENGENI_SELFHOSTED_NATS_CONTROL_PASSWORD`, and
+  `OPENGENI_SELFHOSTED_NATS_CALLOUT_PASSWORD` — the NATS auth-callout account
+  seed/public key and the control/callout logins.
+
+Non-secret wiring goes in config/values: `OPENGENI_SELFHOSTED_NATS_URL` and
+`OPENGENI_SELFHOSTED_RELAY_URL` (the public wss URLs the agent dials, matching the
+ingress hosts) plus the callout account/user names. The relay's non-secret tuning
+knobs are `OPENGENI_RELAY_RING_FRAMES`, `OPENGENI_RELAY_SPLICE_BUFFER`,
+`OPENGENI_RELAY_RATE_BURST_BYTES`, `OPENGENI_RELAY_RATE_BYTES_PER_SEC`, and
+`OPENGENI_RELAY_PAIR_TIMEOUT_SECS`. A missing token secret makes the relay reject
+every connection (fail-closed).
+
+### Agent binary distribution
+
+The machine agent is served from the control plane itself. The API exposes the
+install script and the per-deploy agent binary at auth-exempt paths
+(`/install.sh`, `/install.ps1`, `/uninstall.sh`, and `/agent/*`), so
+`curl -fsSL https://<host>/install.sh | sh` installs the exact agent build that
+matches the running control plane (the per-SHA binary baked into the API image),
+with no dependency on an external CDN. A public release archive is the fallback
+for other OS/arch assets and the self-update channel. Route these paths (and an
+optional `get.<domain>` host) to the `api` service in the ingress.
+
+### Enrolling a machine
+
+Enrollment binds a machine to a workspace and requires the enable flag. Two paths
+are supported:
+
+- **Device flow**: the agent starts an enrollment
+  (`/v1/enrollments/device/start`) and a workspace member holding
+  `enrollments:manage` approves it at the consent page
+  (`/v1/workspaces/:workspaceId/enrollments/device/approve`).
+- **Zero-click enroll token**: a workspace member holding `enrollments:manage`
+  mints a short-TTL enroll token
+  (`/v1/workspaces/:workspaceId/enrollments/token`) that the agent redeems
+  headlessly (`/v1/enrollments/token/exchange`) with no human approval — suited
+  to fleet or headless provisioning.
+
+Client SDKs surface the machine dashboard and enrollment flow through the
+`@opengeni/react/machines` subpath, and target a session at a specific machine
+with `CreateSessionRequest.targetSandboxId` (plus an optional `workingDir`).
 
 ## Security Boundary
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -5,7 +5,7 @@ A workspace owns named **environments**: sets of environment variables whose val
 ## Invariants
 
 1. **Write-only values.** No API response, session event, log, span, or audit record ever contains a variable value. Reads return names and metadata (version, timestamps) only; there is no read-back even at create time. Rotation is `PUT` with a new value.
-2. **No attachment, no injection.** A run whose session has `environmentId = null` gets exactly the pre-existing behavior: the deployment env allowlist, git identity, and run-scoped GitHub auth. Nothing more.
+2. **No attachment, no injection.** A run whose session has `environmentId = null` gets exactly the pre-existing behavior: the deployment env allowlist, git identity, and run-scoped GitHub auth. Nothing more. (This injection describes a **managed sandbox**; a Connected Machine session is not injected this way — see [Env injection is a managed-sandbox concept](#env-injection-is-a-managed-sandbox-concept).)
 3. **Agents cannot self-attach.** The worker's **default** first-party MCP delegated token never carries `environments:use`, and the MCP scheduled-task tools reject attachment changes (set **or** detach) and instruction edits to environment-attached tasks for grants without it. A session only holds a stronger first-party token when its creator explicitly granted one at creation (`firstPartyMcpPermissions`, capped by the creating grant) — agents can never escalate themselves.
 4. **Workspace isolation.** Both tables are protected by the same forced row-level-security policy as every other workspace table.
 5. **Encryption at rest.** Values are AES-256-GCM encrypted with an operator key (`OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY`) held outside Postgres. A database dump alone does not reveal values.
@@ -70,6 +70,15 @@ deployment allowlist < git identity < workspace environment < run-scoped GitHub 
 ```
 
 Later wins. Reserved-name validation prevents collisions with the platform-managed git/GitHub entries, so the run-scoped GitHub token block always applies last untouched. Note that sandbox lifecycle hooks are profile-driven: workspace-provided `AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`/`AZURE_TENANT_ID` only trigger the `azure-cli-login` hook on deployments that enable the `azure` preparation profile; on profile-less deployments the values are injected but no login hook runs.
+
+### Env injection is a managed-sandbox concept
+
+This whole layering — the deployment allowlist, git identity, workspace environment, and the run-scoped GitHub-auth block that always applies last — describes a **managed sandbox**: a box OpenGeni provisions and injects environment into. A session that runs on a [Connected Machine](../SECURITY.md#connected-machines) is a different backend and is **not** injected this way:
+
+- **The GitHub-token injection is skipped.** A machine-targeted turn does not mint or distribute a run-scoped GitHub App token; the machine uses its **own** git credentials. The "last, untouched" GitHub block above simply does not exist for a machine turn.
+- **No env reaches the machine over the wire.** The run's declared environment is still assembled server-side (and threaded into the session manifest so the SDK's per-turn manifest-env delta stays empty — the internal parity guard), but the command RPC to the machine carries an empty environment. Workspace-environment values are therefore not delivered to a machine's commands.
+
+Practically: attaching an environment shapes what a managed sandbox sees; it does not push secrets onto a Connected Machine. If a machine run needs a secret, it must already be present in that machine's own local environment.
 
 ## Deletion semantics
 


### PR DESCRIPTION
**Final tier** (4/4: embedder ✅ · maintainer ✅ · **operator + product**). Covers the two remaining audiences.

**Operator**
- `docs/deployment.md` — a Connected Machines section: the `opengeni-relay` stream component (build/deploy/pin-by-digest), the `OPENGENI_SANDBOX_SELFHOSTED_ENABLED` gate (default off; existing deploys unaffected), the NATS auth-callout + relay token secret env, the wss ingress + channel-affinity requirement, the control-plane agent-binary hosting. Cloud-generic.
- `deploy/terraform/{aws,azure,gcp}/README.md` — add the `opengeni-relay` component.
- `deployment-infrastructure.md` skill — relay + agent-binary as operator surfaces; disambiguate self-hosted *deployment* from *Connected Machine*.

**Product**
- `README.md` — reframe the pitch: Connected Machines are a first-class, co-equal compute target; add enroll + the composer "Where should this run?" + the working folder to the Web-App walkthrough.
- `SECURITY.md` — the Connected-Machine trust boundary (no token distributed / own git auth, enrollment consent, relay isolation).
- `docs/environments.md` — reconcile "run-scoped GitHub auth injected last" (managed sandbox) with "a Connected Machine uses its own git auth".

### Verification
Cited env/flag names (`OPENGENI_SANDBOX_SELFHOSTED_ENABLED`, `OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET`, NATS auth-callout) match `packages/config`; the relay component (`agent/crates/opengeni-relay`) exists; **no internal Azure/ops/staging specifics leaked** (cloud-generic); terminology consistent. (The workflow's structured-verify step failed to emit its schema, so I verified the highest-risk operator claims directly against source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or infrastructure code modified; misdocumented env names could mislead operators but cited flags match `packages/config`.
> 
> **Overview**
> Documentation-only PR that introduces **Connected Machines** as a first-class compute target alongside managed sandboxes, and spells out how operators enable it and how it differs from self-hosted *deployment*.
> 
> **Product-facing:** `README.md` reframes the pitch (managed sandbox vs enrolled machine), updates the architecture diagram (NATS control plane, stream relay, outbound agent dials), extends the web-app flow (“Where should this run?”, working folder, enrollment), and documents API enrollment routes and operator enablement. `SECURITY.md` adds a Connected Machine trust boundary (feature off by default, no platform git token / empty env on RPC, consent paths, relay isolation). `docs/environments.md` clarifies that workspace env injection and run-scoped GitHub auth apply to **managed sandboxes only**, not machine runs.
> 
> **Operator-facing:** `docs/deployment.md` gains a Connected Machines section (`OPENGENI_SANDBOX_SELFHOSTED_ENABLED`, `opengeni-relay` build/pin, NATS auth-callout, wss ingress + channel affinity, runtime secrets, control-plane `/install.sh` and `/agent/*`). AWS/Azure/GCP Terraform READMEs note the extra relay image (ECR on AWS) and affinity requirement. The OpenGeni deployment skill reference maps relay, enrollment, install routes, Helm blocks, and disambiguates terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e1fe40004f02a36990f28418c1ece7031e96f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->