### PR TITLE
feat(machines): honest "selfhosted" home label + SDK sandbox-field parity (Stage-D closure)

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -20,6 +20,7 @@ import {
   createSessionWithIdempotencyKey,
   enqueueSessionTurn,
   getAnySessionInGroup,
+  getSandbox,
   getSession,
   getSessionByCreateIdempotencyKey,
   getSessionTurn,
@@ -547,6 +548,35 @@ export async function createSessionForRequest(
   if (payload.workingDir !== undefined && !payload.targetSandboxId) {
     throw new HTTPException(422, { message: "workingDir requires targetSandboxId (it is the targeted machine's working directory)" });
   }
+  // Honest-label (Stage-D closure): a top-level session TARGETED at a Connected
+  // Machine (a selfhosted sandbox) runs machine-primary every turn, so its HOME
+  // sandbox_backend must read "selfhosted" — not the deployment cloud default —
+  // so the session row + first turn honestly reflect where the agent runs (the
+  // Machines dashboard, the turn's warm-metering, and the file-download plane all
+  // key off this). GUARDS: (1) only at a TOP-LEVEL create (inheritedBackend
+  // undefined) — a shared/{groupId} spawn is literally the creator's box and must
+  // NOT be relabeled; (2) only when the target's kind is actually "selfhosted" —
+  // targetSandboxId also accepts a first-class MODAL sandbox id (resolveTarget),
+  // which must never be mislabeled. A not-found / non-selfhosted / modal target
+  // falls through to the default; the seed swap in createAndStartSession still
+  // validates ownership/liveness and 422s a bad target. (3) only when the feature
+  // flags that make the worker actually take the machine-primary path are ON
+  // (sandboxOwnershipEnabled + sandboxSelfhostedEnabled/routing) — otherwise the
+  // worker ignores the active pointer and a home="selfhosted" turn would fall to
+  // the registry client with no bound agentId and throw; with the flags off we
+  // keep the cloud default and the machine layers as a (pre-honest-label) overlay.
+  let machineHomeBackend: Session["sandboxBackend"] | undefined;
+  if (
+    payload.targetSandboxId
+    && inheritedBackend === undefined
+    && settings.sandboxOwnershipEnabled
+    && settings.sandboxSelfhostedEnabled
+  ) {
+    const targetSandbox = await getSandbox(db, workspaceId, payload.targetSandboxId);
+    if (targetSandbox?.kind === "selfhosted") {
+      machineHomeBackend = "selfhosted";
+    }
+  }
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1, model });
   const session = await createAndStartSession({
     db,
@@ -561,8 +591,11 @@ export async function createSessionForRequest(
     model,
     reasoningEffort,
     // A shared spawn inherits the box's backend; a caller-supplied
-    // sandboxBackend on a shared spawn is ignored (it is the same box).
-    sandboxBackend: inheritedBackend ?? payload.sandboxBackend ?? settings.sandboxBackend,
+    // sandboxBackend on a shared spawn is ignored (it is the same box). A
+    // machine-targeted top-level create labels the home "selfhosted"
+    // (machineHomeBackend), overriding the caller/deployment default so the row
+    // matches where the session actually runs.
+    sandboxBackend: inheritedBackend ?? machineHomeBackend ?? payload.sandboxBackend ?? settings.sandboxBackend,
     sandboxGroupId,
     metadata: payload.metadata,
     environment: environment ? { id: environment.id, name: environment.name } : null,

--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -1,0 +1,186 @@
+// Stage-D honest label — a session TARGETED at a Connected Machine (a selfhosted
+// sandbox) must carry a HOME sandbox_backend of "selfhosted", not the deployment
+// cloud default, so the session row + its first turn honestly reflect where the
+// agent runs (the Machines dashboard, warm-metering, and the file-download plane
+// all key off it). Driven through the REAL createSessionForRequest resolution +
+// the REAL seedTargetSandbox swap against a THROWAWAY postgres, with an in-memory
+// MemoryEventBus responder answering the liveness ping so the target reads online.
+//
+// Proves:
+//   - a machine-targeted top-level create ⇒ home + first turn sandbox_backend
+//     "selfhosted" (the honest label), overriding the "modal" deployment default.
+//   - a normal top-level create ⇒ unchanged (the "modal" deployment default).
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+import { testSettings, MemoryEventBus, acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { ControlRequest, ControlResponse, ErrorCode } from "@opengeni/agent-proto";
+import {
+  createDb,
+  createEnrollment,
+  createSandbox,
+  type Database,
+  type DbClient,
+} from "@opengeni/db";
+import { subjectFor } from "@opengeni/runtime";
+import type { AccessGrant } from "@opengeni/contracts";
+import { createSessionForRequest } from "../src/domain/sessions";
+import type { ApiRouteDeps, SessionWorkflowClient } from "../src/dependencies";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+// The deployment default is a REAL cloud backend ("modal"), so the "normal create
+// is unchanged" assertion is meaningful (the machine override is the ONLY thing
+// that flips the home to "selfhosted"). selfhosted routing on + a relay url so the
+// liveness probe path resolves.
+const settings = testSettings({
+  productAccessMode: "managed",
+  sandboxBackend: "modal",
+  sandboxOwnershipEnabled: true,
+  sandboxSelfhostedEnabled: true,
+  selfhostedRelayUrl: "wss://relay.example",
+  publicBaseUrl: "https://app.example",
+});
+
+/** A MemoryEventBus whose responder answers ping → online for the agent subject
+ *  (a stand-in for a real enrolled agent over NATS), so the seed swap's liveness
+ *  gate passes without a broker. */
+function busWithAgent(opts: { workspaceId: string; agentId: string }): MemoryEventBus {
+  const bus = new MemoryEventBus();
+  bus.subscribeRequests(subjectFor(opts.workspaceId, opts.agentId), (payload) => {
+    const req = ControlRequest.decode(payload);
+    const op = req.op;
+    const res: ControlResponse = op?.$case === "ping"
+      ? { requestId: req.requestId, result: { $case: "ping", ping: { nonce: op.ping.nonce, agentMonotonicMs: "0" } } }
+      : { requestId: req.requestId, error: { code: ErrorCode.ERROR_CODE_UNSUPPORTED, message: "unsupported", retryable: false, detail: {} } };
+    return ControlResponse.encode(res).finish();
+  });
+  return bus;
+}
+
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+  const [a] = await admin<{ id: string }[]>`insert into managed_accounts (name) values ('acct') returning id`;
+  const [w] = await admin<{ id: string }[]>`insert into workspaces (account_id, name) values (${a!.id}, 'ws') returning id`;
+  return { accountId: a!.id, workspaceId: w!.id };
+}
+
+/** Seed an enrolled, online selfhosted machine (+ its sandbox record) in a fresh
+ *  workspace, and return the id + a bus whose responder makes it probe online. */
+async function seedMachine(): Promise<{ accountId: string; workspaceId: string; sandboxId: string; bus: MemoryEventBus }> {
+  const { accountId, workspaceId } = await freshWorkspace();
+  const enrollment = await createEnrollment(db, {
+    accountId,
+    workspaceId,
+    pubkey: `ed25519:${crypto.randomUUID()}`,
+    exposure: "whole-machine",
+    hasDisplay: true,
+    allowScreenControl: true,
+    os: "linux",
+    arch: "x86_64",
+  });
+  // Recent lastSeenAt so a probe-miss would be "reconnecting"; the online responder
+  // makes the probe succeed → "online" (the seed swap's attach gate).
+  await admin`update enrollments set last_seen_at = now() where id = ${enrollment.id}`;
+  const sandbox = await createSandbox(db, {
+    accountId,
+    workspaceId,
+    kind: "selfhosted",
+    name: "my-laptop",
+    enrollmentId: enrollment.id,
+  });
+  return { accountId, workspaceId, sandboxId: sandbox.id, bus: busWithAgent({ workspaceId, agentId: enrollment.id }) };
+}
+
+// A stub workflowClient — the create path only calls wakeSessionWorkflow.
+function stubWorkflowClient(): SessionWorkflowClient {
+  const noop = async () => {};
+  return {
+    signalUserMessage: noop,
+    wakeSessionWorkflow: noop,
+    signalApprovalDecision: noop,
+    signalInterrupt: noop,
+    syncScheduledTask: noop,
+    deleteScheduledTaskSchedule: noop,
+    triggerScheduledTask: noop,
+  } as unknown as SessionWorkflowClient;
+}
+
+function deps(bus: MemoryEventBus): ApiRouteDeps {
+  return {
+    settings,
+    db,
+    bus,
+    workflowClient: stubWorkflowClient(),
+    githubStateSecret: "x",
+    objectStorage: null,
+    documentIndexer: { indexDocument: async () => {} },
+    getDocumentServices: () => ({} as never),
+    resumeBoxById: async () => {
+      throw new Error("resumeBoxById should not be called in these tests (no box establish on the create path)");
+    },
+  } as unknown as ApiRouteDeps;
+}
+
+function grant(accountId: string, workspaceId: string): AccessGrant {
+  return {
+    accountId,
+    workspaceId,
+    subjectId: "subject",
+    permissions: ["sessions:create", "sessions:read"],
+  };
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("machine-home-backend");
+  if (!shared) {
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[machine-home-backend] docker unavailable, skipping");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  try {
+    await client?.close();
+  } catch { /* noop */ }
+  await shared?.release();
+});
+
+describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
+  test("a machine-targeted top-level create ⇒ home + first turn 'selfhosted'", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, sandboxId, bus } = await seedMachine();
+    const session = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "run this on my laptop",
+      targetSandboxId: sandboxId,
+    });
+    // The home is labeled honestly — the machine, not the "modal" deployment default.
+    expect(session.sandboxBackend).toBe("selfhosted");
+    // The first turn inherits the same home backend (label is consistent end-to-end).
+    const [turnRow] = await admin<{ sandbox_backend: string }[]>`
+      select sandbox_backend from session_turns where session_id = ${session.id} limit 1`;
+    expect(turnRow?.sandbox_backend).toBe("selfhosted");
+  }, 60_000);
+
+  test("a normal top-level create (no machine target) ⇒ unchanged deployment default", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, bus } = await seedMachine();
+    const session = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "just a normal session",
+    });
+    // No target ⇒ the "modal" deployment default is untouched (only a machine
+    // target flips the home to "selfhosted").
+    expect(session.sandboxBackend).toBe("modal");
+    const [turnRow] = await admin<{ sandbox_backend: string }[]>`
+      select sandbox_backend from session_turns where session_id = ${session.id} limit 1`;
+    expect(turnRow?.sandbox_backend).toBe("modal");
+  }, 60_000);
+});

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -840,6 +840,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       if (settings.sandboxOwnershipEnabled && turn.sandboxBackend !== "none") {
         sandboxHolderId = dispatchId ?? `turn:${turnId}`;
         sandboxGroupId = session.sandboxGroupId;
+        // STAGE D honest-label guard: a machine-home session carries
+        // turn.sandboxBackend "selfhosted", but a turn is only machine-PRIMARY
+        // when a live machine pointer resolves (activeSandboxBackend==='selfhosted'
+        // + enrollmentId). When it is NOT primary — the agent swapped back to the
+        // group box (sandbox_swap 'session'/'default'/groupId clears the pointer) or
+        // selfhosted routing is flag-OFF (the pointer is ignored) — the else-branch
+        // must resume a REAL cloud group box, not a "selfhosted" one: the registry
+        // SelfhostedSandboxClient has no bound agentId and throws. Fall the group-box
+        // backend back to the deployment default cloud backend so swap-away / flag-off
+        // degrade to a genuine cloud box exactly like today (home=modal did).
+        const groupBoxBackend: Settings["sandboxBackend"] =
+          turn.sandboxBackend === "selfhosted" && !machinePrimary
+            ? settings.sandboxBackend
+            : turn.sandboxBackend;
         if (machinePrimary) {
           // STAGE D D1-lite: the active sandbox is a connected machine, so DO NOT
           // establish or lease a phantom Modal home box (today's path leased + BILLED
@@ -900,7 +914,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               workspaceId: input.workspaceId,
               sandboxGroupId: session.sandboxGroupId,
               sessionId: input.sessionId,
-              backend: turn.sandboxBackend,
+              // groupBoxBackend, not turn.sandboxBackend: a machine-home turn that
+              // is not machine-primary resumes a real cloud group box (the
+              // deployment default), never a "selfhosted" box (which would throw
+              // for lack of a bound agentId).
+              backend: groupBoxBackend,
               os: session.sandboxOs,
               environment: sandboxEnvironment,
             },
@@ -949,8 +967,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // Modal box, so it must accrue ZERO cloud warm-seconds — `selfhosted` has no
         // configured warm rate (0). Keying off turn.sandboxBackend (modal) would bill
         // cloud seconds for a box that does not exist (a real money bug). Non-machine
-        // turns fall back to turn.sandboxBackend (byte-for-byte today).
-        const warmRate = sandboxWarmRateMicrosPerSecond(settings, activeSandboxBackend ?? turn.sandboxBackend);
+        // turns fall back to groupBoxBackend (the REAL box that ran): for a machine-
+        // home turn that degraded to the cloud group box (swap-away / flag-off), that
+        // is the deployment default (modal), so the fallback box is warm-metered at
+        // the cloud rate instead of selfhosted's rate-0 (which would under-bill).
+        const warmRate = sandboxWarmRateMicrosPerSecond(settings, activeSandboxBackend ?? groupBoxBackend);
         leaseHeartbeatTimer = setInterval(() => {
           void heartbeatLeaseHolder(db, {
             accountId: input.accountId,
@@ -2139,6 +2160,16 @@ async function sandboxFileDownloadsForRun(
 }
 
 function requiresSignedFileResourceDownloads(settings: Settings): boolean {
+  // A selfhosted machine (bring-your-own-compute) can NEVER mount ANY object store
+  // — it is a remote user machine reached only over NATS, so file resources are
+  // ALWAYS delivered by exec-curling a pre-signed URL onto it. Without this a
+  // machine-home turn (sandbox_backend "selfhosted") would silently drop file
+  // resources on an azure-blob / s3-compatible store (nativeBucketMount=false),
+  // a regression from the pre-honest-label path where the same turn ran home=modal
+  // and modal's descriptor forced signed downloads.
+  if (settings.sandboxBackend === "selfhosted") {
+    return true;
+  }
   // A nativeBucketMount backend (modal) cannot mount Azure Blob entries, so it
   // needs pre-signed downloads for that store. Keying on the descriptor (not the
   // "modal" literal) keeps this correct as bucket-mount backends are added.

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -605,6 +605,13 @@ export type CreateSessionRequest = {
   // Distinct from the per-call clientEventId.
   idempotencyKey?: string | undefined;
   firstPartyMcpPermissions?: string[] | undefined;
+  // Shared-sandbox placement (mirror of `@opengeni/contracts` CreateSessionRequest.sandbox,
+  // addendum 05 §D.1). Three-way union; OMITTED ⇒ the context-dependent server default
+  // (from inside a session → "shared" with the creator's box, top-level → "new").
+  //   - "shared":  join the CREATOR's box (requires a parent session; top-level → 422).
+  //   - "new":     mint a fresh singleton box (group ≡ the new session's id).
+  //   - {groupId}: join a SPECIFIC sibling group in THIS workspace (manager fan-out).
+  sandbox?: "shared" | "new" | { groupId: string } | undefined;
 };
 
 // --- Access, workspaces, API keys -------------------------------------------


### PR DESCRIPTION
Closes out Stage D. A machine-targeted session now **honestly labels its home backend `"selfhosted"`** instead of the vestigial `"modal"`, and the SDK create type regains the `sandbox` field.

### Honest label (chosen over the risky no-home-box `"none"`)
When a top-level create targets a Connected Machine, the session row + first turn read `sandbox_backend="selfhosted"` so the Machines dashboard, warm-metering, and the file-download plane key off where the agent actually runs. **Not a pure relabel** — 4 guarded edits:
- **create-path** — set `"selfhosted"` only at a top-level create, only when the target kind is actually selfhosted (never a first-class modal target), and only when the machine-primary flags are on (`sandboxOwnershipEnabled` + `sandboxSelfhostedEnabled`) so the worker will take the machine-primary path.
- **worker no-pointer guard** — when `turn.sandboxBackend==="selfhosted"` but the turn is *not* machine-primary (pointer cleared by a swap-away, or routing/flag off), fall the group-box backend back to the deployment cloud default → degrades to a real cloud box instead of throwing "no agentId".
- **warm-rate** keyed off `(activeSandboxBackend ?? groupBoxBackend)` so a degraded cloud box bills at the cloud rate, not selfhosted rate-0.
- **file-delivery fix** — `requiresSignedFileResourceDownloads` now returns true for selfhosted, else file resources silently wouldn't reach a machine on blob/s3 stores (a machine exec-curls signed URLs; it can't mount the bucket).

### SDK parity
`CreateSessionRequest` gains the `sandbox` union (`shared | new | {groupId}`), matching `@opengeni/contracts`.

### Deferred (not a leak, pre-existing)
The cloud→machine *mid-session* swap-drain — moderate effort; the lingering Modal box drains on idle today.

### Verify
Typecheck clean (sdk/api/worker); sdk 90 + new machine-home-backend 2 + worker agent-turn/routing/resume suites pass; adversarial verify **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session labeling, sandbox resume backend selection, warm billing, and file delivery for machine-targeted sessions; guarded by feature flags and fallbacks, with new integration coverage.
> 
> **Overview**
> **Stage D** makes machine-targeted sessions **honestly record `sandbox_backend: "selfhosted"`** on the session and first turn instead of inheriting the deployment cloud default (e.g. modal), so dashboards, metering, and file delivery align with where the agent actually runs.
> 
> On **create** (`createSessionForRequest`), `"selfhosted"` is applied only for a **top-level** create with `targetSandboxId` pointing at a **selfhosted** sandbox, and only when **ownership + selfhosted routing** flags are on; shared/group spawns and modal targets are unchanged.
> 
> The **worker** adds a **`groupBoxBackend` fallback**: when the turn is labeled selfhosted but the turn is **not** machine-primary (swap back to group box or routing off), group-box resume and **warm metering** use the deployment cloud backend so the turn does not try to resume a phantom selfhosted box or under-bill. **`requiresSignedFileResourceDownloads`** treats deployment `sandboxBackend === "selfhosted"` as always requiring signed URLs so file resources reach machines on blob/S3 stores.
> 
> **SDK** `CreateSessionRequest` gains optional **`sandbox`** (`shared` | `new` | `{ groupId }`) to match contracts. New integration tests cover machine-targeted vs normal create home backend labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da69a1edb64bf331975d49ed992e760d461f8fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->