### PR TITLE
feat(sandbox): token-broker (B1) + image-is-shared-state (B3) + share-safe tool desc (B2)

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -35,6 +35,7 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents } from "@opengeni/events";
 import {
+  createGitHubAppInstallationToken,
   createSignedState,
   GitHubAppConfigurationError,
   githubAppMissingSettings,
@@ -134,6 +135,12 @@ export function buildOpenGeniMcpServer(deps: ApiRouteDeps, grant: AccessGrant, o
   registerEnvironmentTools(server, deps, grant, can, json);
   if (can("github:use")) {
     registerGitHubConnectTool(server, deps, grant, options, json);
+    // TOKEN-BROKER (B1): the agent-refreshable git token. Session-scoped (keys off the
+    // worker-signed sessionId claim so it mints for THIS session's repos), gated on
+    // the same github:use capability as github_connect_link.
+    if (sessionId !== null) {
+      registerGitHubTokenTool(server, deps, grant, sessionId, json);
+    }
   }
 
   server.registerTool("files_get_download_url", {
@@ -810,6 +817,55 @@ function registerGitHubConnectTool(
       installUrl: `${base}/v1/workspaces/${grant.workspaceId}/github/connect?state=${encodeURIComponent(state)}`,
       expiresInSeconds: stateMaxAgeSeconds,
       missing: [],
+    });
+  });
+}
+
+// TOKEN-BROKER (B1): mint a FRESH short-lived GitHub App installation token for the
+// session's repository resources. The agent calls this to refresh git auth before
+// the current token expires. The MCP server CANNOT write the box, so the tool RETURNS
+// the token as JSON; the agent writes it to the token file (via exec) to refresh
+// GIT_ASKPASS. Same github:use capability gate as github_connect_link.
+function registerGitHubTokenTool(
+  server: McpServer,
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  sessionId: string,
+  json: JsonResult,
+): void {
+  server.registerTool("github_token", {
+    description: "Mint a fresh short-lived GitHub token for this session's repositories. Write it to $OPENGENI_GIT_TOKEN_FILE (default $HOME/.opengeni/git-token) to refresh git auth before the current token expires.",
+    inputSchema: {},
+  }, async () => {
+    const session = await requireSession(deps.db, grant.workspaceId, sessionId);
+    // Resolve the run-scoped installation + repository ids from THIS session's
+    // repository resources (same shape sandboxEnvironmentForRun mints against). Only
+    // private GitHub-App repos carry the installation/repository ids.
+    const selected = (session.resources ?? []).flatMap((resource) => {
+      if (resource.kind !== "repository") {
+        return [];
+      }
+      const installationId = resource.githubInstallationId;
+      const repositoryId = resource.githubRepositoryId;
+      return typeof installationId === "number" && installationId > 0
+        && typeof repositoryId === "number" && repositoryId > 0
+        ? [{ installationId, repositoryId }]
+        : [];
+    });
+    if (selected.length === 0) {
+      throw new Error("this session has no GitHub App repository resources to mint a token for");
+    }
+    const installationId = selected[0]!.installationId;
+    if (selected.some((item) => item.installationId !== installationId)) {
+      throw new Error("GitHub App repository resources must belong to one installation");
+    }
+    const token = await createGitHubAppInstallationToken(deps.settings, {
+      installationId,
+      repositoryIds: selected.map((item) => item.repositoryId),
+    });
+    return json({
+      token,
+      tokenFile: "$OPENGENI_GIT_TOKEN_FILE (default $HOME/.opengeni/git-token)",
     });
   });
 }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -653,17 +653,23 @@ function registerWorkspaceOrchestrationTools(
         // First-party MCP token permissions for the spawned session; every
         // permission must be held by this grant (validated in the domain).
         firstPartyMcpPermissions: z4.array(z4.string()).optional(),
-        // Shared-sandbox placement (addendum 05 §D). OMIT to share THIS box by
-        // default (a session-spawned session shares its creator's box); pass
-        // "new" for a fresh private box, or {groupId} (a sibling session's
-        // `sandboxGroupId` from a prior session_create response) to fan two
-        // workers into one box. A shared box means one filesystem/repo/desktop,
-        // N independent conversations. The group is workspace-scoped.
+        // Shared-sandbox placement (addendum 05 §D). OMIT (default) to SHARE the
+        // creator's box — one filesystem/repo/desktop, N independent conversations;
+        // this is the SAFE DEFAULT and env vars are per-exec, NOT a reason to split.
+        // Pass "new" for a fresh isolated box (a different repo set or a genuinely
+        // separate filesystem), or {groupId} (a sibling session's `sandboxGroupId`
+        // from a prior session_create response) to join that specific sibling's box.
+        // A shared box requires the SAME image; a conflicting image is rejected (B3).
+        // The description below is what the AGENT sees (this comment is invisible to
+        // it); keep the two in sync. Grouping stays env-blind (correct) — the only
+        // shared-state hard-fail is the image conflict at the lease layer.
         sandbox: z4.union([
           z4.literal("shared"),
           z4.literal("new"),
           z4.object({ groupId: z4.string().uuid() }),
-        ]).optional(),
+        ]).describe(
+          "Sandbox placement. OMIT (default) to SHARE the creator's box — one filesystem/repo/desktop, N independent conversations; this is the safe default and env vars are per-exec, not a reason to split. Pass 'new' for a fresh isolated box (different repo set or a genuinely separate filesystem). Pass {groupId} to join a specific sibling's box. A shared box requires the same image; a conflicting image is rejected.",
+        ).optional(),
         // The parent (manager) session is auto-inferred from the caller's
         // worker-signed sessionId claim, so a spawned worker's completion wakes
         // its manager automatically. There is deliberately no caller-supplied

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -910,6 +910,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               backend: turn.sandboxBackend,
               os: session.sandboxOs,
               environment: sandboxEnvironment,
+              // IMAGE IS SHARED STATE (B3, Modal warm-box path only): the container image
+              // this run resolves. The lease stamps it + conflicts on a live shared box
+              // running a DIFFERENT image (solo → recreate on the new image; N-holders →
+              // SandboxImageConflictError surfaced as an actionable turn error). Prefer the
+              // explicit Modal image ref, else the docker image. The selfhosted branch
+              // (establishSelfhostedTurnSession/acquireSelfhostedLeaseForTurn) NEVER passes
+              // an image — B3 lives only on this Modal else-branch.
+              ...((runSettings.modalImageRef ?? runSettings.dockerImage)
+                ? { image: runSettings.modalImageRef ?? runSettings.dockerImage }
+                : {}),
             },
             "turn",
             sandboxHolderId,

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -818,7 +818,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // this same object. A machine-primary turn skips the (inert) token mint entirely
       // (the machine uses its own git creds); the SAME base env still feeds the box +
       // the agent, so env-parity holds.
-      const sandboxEnvironment = await sandboxEnvironmentForRun(
+      // TOKEN-BROKER (B1): sandboxEnvironmentForRun now returns the STABLE manifest
+      // env (no rotating GH_TOKEN/GITHUB_TOKEN/GIT_CONFIG_* extraheader) PLUS the
+      // run-scoped GitHub token minted ONCE per turn as `gitToken`. The env feeds BOTH
+      // the box manifest AND the agent (env-parity, as before); the token is threaded
+      // OFF-MANIFEST as the clone-seed `gitTokenSeed` to buildAgent (below) so the box
+      // never carries a rotating value on its manifest. gitToken is undefined on the
+      // selfhosted skip path (the machine uses its own git creds).
+      const { environment: sandboxEnvironment, gitToken: sandboxGitToken } = await sandboxEnvironmentForRun(
         runSettings,
         turnResources,
         workspaceEnvironment?.values ?? {},
@@ -1049,6 +1056,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         reasoningEffort: turn.reasoningEffort,
         genesisTitleHint: isGenesisTurn,
         sandboxEnvironment,
+        // TOKEN-BROKER (B1): forward the per-turn git token OFF-MANIFEST as the clone
+        // seed. ONLY when the effective backend is NOT selfhosted (the connected
+        // machine uses its own git creds — mirrors the skipGitHubToken gate above)
+        // AND the mint actually produced a token (repo resources present). The runtime
+        // seeds it to the box's token file before the repository-clone runs; it never
+        // touches the box/agent manifest env.
+        ...(activeSandboxBackend !== "selfhosted" && sandboxGitToken ? { gitTokenSeed: sandboxGitToken } : {}),
         ...(activeSandboxBackend ? { activeSandboxBackend } : {}),
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -62,7 +62,15 @@ export async function sandboxEnvironmentForRun(
     repositoryIds: selection.repositoryIds,
   });
   const identity = githubAppBotIdentity(settings);
-  environment.GIT_ASKPASS = "/usr/local/bin/opengeni-git-askpass";
+  // TOKEN-BROKER (B2): the askpass helper is PROVISIONED AT SETUP (runtime) into a
+  // per-box, user-writable path in the SAME dir as the token file, instead of a
+  // baked image script at /usr/local/bin/opengeni-git-askpass. The clone-hook seed
+  // block writes both the token file AND this askpass script before the fetch, so
+  // git auth becomes correct on ANY box image (including pre-existing warm boxes on
+  // their next turn's clone hook) — no product image needs to carry the askpass.
+  // HOME is already resolved in the STABLE base above; keep the /workspace fallback
+  // in lockstep with stableSandboxEnvironmentForRun's OPENGENI_GIT_TOKEN_FILE.
+  environment.GIT_ASKPASS = `${environment.HOME ?? "/workspace"}/.opengeni/askpass`;
   environment.GIT_TERMINAL_PROMPT = "0";
   if (identity) {
     environment.GIT_AUTHOR_NAME = environment.GIT_AUTHOR_NAME || identity.name;

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -23,39 +23,46 @@ export async function sandboxEnvironmentForRun(
   resources: ResourceRef[],
   workspaceEnvironment: Record<string, string> = {},
   options: { skipGitHubToken?: boolean } = {},
-): Promise<Record<string, string>> {
+): Promise<{ environment: Record<string, string>; gitToken?: string }> {
   // Precedence: deployment allowlist < git identity < workspace environment
   // < backend-aware HOME (the STABLE base, shared with the API-direct attach
   // paths via stableSandboxEnvironmentForRun) < platform run-scoped GitHub auth
   // (applied below, always last). Reserved name validation at write time prevents
   // workspace values from colliding with the platform-managed entries.
+  //
+  // TOKEN-BROKER (B1): the run-scoped GitHub App installation token is NO LONGER
+  // layered into the box/agent MANIFEST env (no GH_TOKEN/GITHUB_TOKEN/GIT_CONFIG_*
+  // extraheader). It is minted ONCE per turn and returned as `gitToken`; the caller
+  // threads it OFF-MANIFEST as a clone-seed exec env (OPENGENI_GIT_TOKEN_SEED) so the
+  // clone hook writes it to a stable FILE ($OPENGENI_GIT_TOKEN_FILE), and git auth
+  // flows through GIT_ASKPASS -> that file. The manifest carries only the stable
+  // pointers (GIT_ASKPASS, GIT_TERMINAL_PROMPT, identity, and — via the shared base —
+  // OPENGENI_GIT_TOKEN_FILE), so the token VALUE never rides the manifest and the
+  // SDK's per-turn provided-session env delta stays empty even though the token
+  // rotates. The agent can refresh the token mid-turn via the `github_token` MCP tool.
   const environment = stableSandboxEnvironmentForRun(settings, workspaceEnvironment);
   const selection = githubRepositorySelection(resources);
   // NO-TOKEN SKIP (Stage D, change B): when the turn's EFFECTIVE compute backend is
   // a connected machine (selfhosted), the platform GitHub App installation token is
   // INERT — exec routes over NATS to the user's machine, which uses ITS OWN git
   // credentials, and the box that the token would auth is never created. So skip the
-  // (network) token mint entirely and return the STABLE base env. Env-parity holds:
-  // the SAME base object still feeds buildManifest + the SelfhostedSession manifest,
-  // so the SDK's per-turn provided-session env delta stays empty
+  // (network) token mint entirely and return the STABLE base env (no gitToken). Env-
+  // parity holds: the SAME base object still feeds buildManifest + the SelfhostedSession
+  // manifest, so the SDK's per-turn provided-session env delta stays empty
   // (validateNoEnvironmentDelta). The API-direct viewer attach path already drops the
   // token under this exact contract — proof a box runs fine without it.
   if (!selection || options.skipGitHubToken) {
-    return environment;
+    return { environment };
   }
-  // Run-scoped sandbox preparation for GitHub App repository resources.
+  // Run-scoped sandbox preparation for GitHub App repository resources. A SINGLE mint
+  // per turn: the value is returned as `gitToken` (seeded to the box's token file by
+  // the caller's clone hook) — NOT layered into the manifest env.
   const token = await createGitHubAppInstallationToken(settings, {
     installationId: selection.installationId,
     repositoryIds: selection.repositoryIds,
   });
   const identity = githubAppBotIdentity(settings);
-  const authHeader = Buffer.from(`x-access-token:${token}`, "utf8").toString("base64");
-  environment.GH_TOKEN = token;
-  environment.GITHUB_TOKEN = token;
   environment.GIT_ASKPASS = "/usr/local/bin/opengeni-git-askpass";
-  environment.GIT_CONFIG_COUNT = "1";
-  environment.GIT_CONFIG_KEY_0 = "http.https://github.com/.extraheader";
-  environment.GIT_CONFIG_VALUE_0 = `AUTHORIZATION: basic ${authHeader}`;
   environment.GIT_TERMINAL_PROMPT = "0";
   if (identity) {
     environment.GIT_AUTHOR_NAME = environment.GIT_AUTHOR_NAME || identity.name;
@@ -63,7 +70,7 @@ export async function sandboxEnvironmentForRun(
     environment.GIT_COMMITTER_NAME = environment.GIT_COMMITTER_NAME || identity.name;
     environment.GIT_COMMITTER_EMAIL = environment.GIT_COMMITTER_EMAIL || identity.email;
   }
-  return environment;
+  return { environment, gitToken: token };
 }
 
 function githubRepositorySelection(resources: ResourceRef[]): { installationId: number; repositoryIds: number[] } | null {

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -81,6 +81,14 @@ export type ResumeBoxIds = {
    * (the legacy default; only the resume/spawn-without-an-agent callers rely on it).
    */
   environment?: Record<string, string>;
+  /**
+   * IMAGE IS SHARED STATE (B3): the container image this run resolves (Modal image ref
+   * / docker image). Threaded to acquireLease, which stamps it on the cold-create and
+   * conflicts on a live box already running a DIFFERENT image (solo holder recreates;
+   * N-holders throw SandboxImageConflictError). Omitted -> image is not enforced (the
+   * selfhosted path never passes it; a legacy/null-image box never conflicts).
+   */
+  image?: string;
 };
 
 /** What resumeBoxForTurn returns: the live NON-OWNED session to inject, the
@@ -150,6 +158,11 @@ export async function resumeBoxForTurn(
     subjectId: ids.sessionId,
     backend: ids.backend,
     os,
+    // IMAGE IS SHARED STATE (B3): thread the resolved image so the lease stamps it +
+    // conflicts on a live box already running a different image. A SandboxImageConflictError
+    // propagates to the turn activity (an actionable error); a solo image change is handled
+    // by acquireLease recreating the box cold on the new image.
+    ...(ids.image ? { image: ids.image } : {}),
     leaseTtlMs,
   });
 

--- a/apps/worker/test/git-askpass.test.ts
+++ b/apps/worker/test/git-askpass.test.ts
@@ -1,0 +1,68 @@
+// TOKEN-BROKER (B1): the askpass helper (docker/opengeni-git-askpass) now reads the
+// git token from a FILE ($OPENGENI_GIT_TOKEN_FILE, default $HOME/.opengeni/git-token)
+// rather than from the GITHUB_TOKEN/GH_TOKEN manifest env vars. This lets the agent
+// refresh the token mid-turn (github_token MCP tool -> write the file) without any
+// manifest-env change (validateNoEnvironmentDelta stays happy). Baked into the sandbox
+// + desktop images by CONTENT (sandbox.Dockerfile / desktop.Dockerfile), so this test
+// exercises the shipped script directly with /bin/sh.
+
+import { describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+const SCRIPT = join(import.meta.dir, "..", "..", "..", "docker", "opengeni-git-askpass");
+
+async function askpass(prompt: string, env: Record<string, string>): Promise<string> {
+  const { stdout } = await exec("/bin/sh", [SCRIPT, prompt], { env: { ...process.env, ...env } });
+  return stdout;
+}
+
+describe("opengeni-git-askpass reads the token FILE (B1)", () => {
+  test("Password prompt -> the file contents at $OPENGENI_GIT_TOKEN_FILE", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "askpass-"));
+    try {
+      const tokenFile = join(dir, "git-token");
+      writeFileSync(tokenFile, "ghs_fileToken999");
+      const out = await askpass("Password for 'https://github.com':", {
+        OPENGENI_GIT_TOKEN_FILE: tokenFile,
+      });
+      expect(out.trim()).toBe("ghs_fileToken999");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("Password prompt -> the $HOME/.opengeni/git-token fallback when no explicit file var", async () => {
+    const home = mkdtempSync(join(tmpdir(), "askpass-home-"));
+    try {
+      mkdirSync(join(home, ".opengeni"), { recursive: true });
+      writeFileSync(join(home, ".opengeni", "git-token"), "ghs_homeToken777");
+      const out = await askpass("Password:", { HOME: home, OPENGENI_GIT_TOKEN_FILE: "" });
+      expect(out.trim()).toBe("ghs_homeToken777");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("Password prompt with NO token file -> a blank line (never crashes the fetch)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "askpass-empty-"));
+    try {
+      const out = await askpass("Password:", {
+        OPENGENI_GIT_TOKEN_FILE: join(dir, "does-not-exist"),
+      });
+      // `cat ... || printf '\n'` -> an empty/blank line, exit 0 (no error).
+      expect(out).toBe("\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("Username prompt still answers x-access-token", async () => {
+    const out = await askpass("Username for 'https://github.com':", {});
+    expect(out.trim()).toBe("x-access-token");
+  });
+});

--- a/apps/worker/test/machine-primary.test.ts
+++ b/apps/worker/test/machine-primary.test.ts
@@ -39,7 +39,9 @@ describe("change B — sandboxEnvironmentForRun no-token skip for a machine turn
     // skipGitHubToken (the effective backend is a connected machine) the mint is
     // skipped entirely — no network, no GH_TOKEN — and the STABLE base env is
     // returned. The machine uses its own git creds; exec routes over NATS.
-    const env = await sandboxEnvironmentForRun(settings, [repoResource()], {}, { skipGitHubToken: true });
+    // TOKEN-BROKER (B1): sandboxEnvironmentForRun returns { environment, gitToken }.
+    const { environment: env, gitToken } = await sandboxEnvironmentForRun(settings, [repoResource()], {}, { skipGitHubToken: true });
+    expect(gitToken).toBeUndefined();
     expect(env.GH_TOKEN).toBeUndefined();
     expect(env.GITHUB_TOKEN).toBeUndefined();
     expect(env.GIT_ASKPASS).toBeUndefined();
@@ -65,7 +67,8 @@ describe("change B — sandboxEnvironmentForRun no-token skip for a machine turn
     const withSkip = await sandboxEnvironmentForRun(settings, [], {}, { skipGitHubToken: true });
     const withoutSkip = await sandboxEnvironmentForRun(settings, [], {}, { skipGitHubToken: false });
     expect(withSkip).toEqual(withoutSkip);
-    expect(withSkip.GH_TOKEN).toBeUndefined();
+    expect(withSkip.environment.GH_TOKEN).toBeUndefined();
+    expect(withSkip.gitToken).toBeUndefined();
   });
 });
 

--- a/apps/worker/test/sandbox-attach-env-parity.test.ts
+++ b/apps/worker/test/sandbox-attach-env-parity.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, test } from "bun:test";
 import { stableSandboxEnvironmentForRun } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
+import type { ResourceRef } from "@opengeni/contracts";
 import { sandboxEnvironmentForRun } from "../src/activities/environment";
 
 // The exact SDK delta predicate (validateNoEnvironmentDelta): true iff every key
@@ -46,7 +47,8 @@ describe("attach-vs-turn manifest-environment parity (no repo attached)", () => 
     const settings = baseSettings();
 
     // The worker TURN's declared agent-manifest environment, no repo resources.
-    const turnEnv = await sandboxEnvironmentForRun(settings, [], {});
+    // TOKEN-BROKER (B1): sandboxEnvironmentForRun returns { environment, gitToken }.
+    const { environment: turnEnv } = await sandboxEnvironmentForRun(settings, [], {});
     // The env the API-direct ATTACH paths now create a cold box with.
     const attachEnv = stableSandboxEnvironmentForRun(settings, {});
 
@@ -59,6 +61,10 @@ describe("attach-vs-turn manifest-environment parity (no repo attached)", () => 
     expect(attachEnv.GIT_AUTHOR_NAME).toBe("OpenGeni Bot");
     expect(attachEnv.GIT_AUTHOR_EMAIL).toBe("bot@opengeni.dev");
     expect(attachEnv.HOME).toBe("/workspace");
+    // TOKEN-BROKER (B1): the STABLE token FILE PATH rides the shared base, so it is
+    // present + IDENTICAL on both manifests (the token VALUE never does).
+    expect(attachEnv.OPENGENI_GIT_TOKEN_FILE).toBe("/workspace/.opengeni/git-token");
+    expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBe("/workspace/.opengeni/git-token");
   });
 
   test("the turn env (workspace environment attached) has NO delta against the attach env", async () => {
@@ -69,7 +75,7 @@ describe("attach-vs-turn manifest-environment parity (no repo attached)", () => 
     // attach path loads the SAME workspace environment (loadWorkspaceEnvironmentForRun)
     // and threads it through the same stable helper. Here we feed both the same
     // decrypted values (the load+decrypt is exercised by the DB-backed paths).
-    const turnEnv = await sandboxEnvironmentForRun(settings, [], workspaceEnv);
+    const { environment: turnEnv } = await sandboxEnvironmentForRun(settings, [], workspaceEnv);
     const attachEnv = stableSandboxEnvironmentForRun(settings, workspaceEnv);
 
     expect(attachEnv).toEqual(turnEnv);
@@ -87,12 +93,60 @@ describe("attach-vs-turn manifest-environment parity (no repo attached)", () => 
     // the git-identity + HOME keys the turn declares, so the SDK sees a delta and
     // throws. The assertion proves the parity test above is not vacuously green.
     const settings = baseSettings();
-    const turnEnv = await sandboxEnvironmentForRun(settings, [], {});
+    const { environment: turnEnv } = await sandboxEnvironmentForRun(settings, [], {});
 
     // The pre-fix attach env: NO git identity, NO HOME (just whatever the base
     // allowlist yields — empty in a clean test env).
     const oldAttachEnv: Record<string, string> = {};
 
     expect(hasNoEnvironmentDelta(oldAttachEnv, turnEnv)).toBe(false);
+  });
+});
+
+// TOKEN-BROKER (B1): a repo-attached turn no longer layers the rotating GitHub token
+// (or the extraheader) onto the manifest env — the token is returned as `gitToken`
+// (seeded off-manifest to the box token file). The manifest carries ONLY the stable
+// pointers (GIT_ASKPASS, GIT_TERMINAL_PROMPT, identity, and — from the shared base —
+// OPENGENI_GIT_TOKEN_FILE), so it stays attach-reproducible and the SDK sees no delta.
+describe("repo-attached turn: token VALUE is OFF the manifest, only the FILE PATH is on it", () => {
+  // A repo-attached turn mints a REAL GitHub App token via the network; the clean
+  // test env has no app configured, so we exercise the SKIP path (which returns the
+  // stable base with no gitToken) to assert the manifest shape without a live mint.
+  // The env shape a repo-attached turn declares is the SAME stable base + GIT_ASKPASS
+  // pointers; the rotating value is the only thing gated behind the live mint.
+  test("the stable base carries the token FILE PATH and NEVER the rotating token keys", async () => {
+    const settings = baseSettings();
+    const repoResource: ResourceRef = {
+      kind: "repository",
+      uri: "github.com/acme/repo",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    };
+    // Skip the (network) mint: returns the stable base env + no gitToken. This is the
+    // exact manifest a machine-effective repo turn declares; a cloud repo turn adds
+    // GIT_ASKPASS/GIT_TERMINAL_PROMPT on top but STILL no GH_TOKEN/GITHUB_TOKEN/
+    // GIT_CONFIG_* (those keys were removed by the token broker).
+    const { environment: turnEnv, gitToken } = await sandboxEnvironmentForRun(
+      settings,
+      [repoResource],
+      {},
+      { skipGitHubToken: true },
+    );
+
+    // The rotating token keys are ABSENT from the manifest env (the broker removed them).
+    expect(turnEnv.GH_TOKEN).toBeUndefined();
+    expect(turnEnv.GITHUB_TOKEN).toBeUndefined();
+    expect(turnEnv.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(turnEnv.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(turnEnv.GIT_CONFIG_VALUE_0).toBeUndefined();
+    // No token was minted on the skip path.
+    expect(gitToken).toBeUndefined();
+
+    // The STABLE token FILE PATH matches the attach base (parity-safe pointer).
+    const attachEnv = stableSandboxEnvironmentForRun(settings, {});
+    expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBe("/workspace/.opengeni/git-token");
+    expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBe(attachEnv.OPENGENI_GIT_TOKEN_FILE);
+    expect(hasNoEnvironmentDelta(attachEnv, turnEnv)).toBe(true);
   });
 });

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -28,6 +28,7 @@ import {
   createDb,
   heartbeatLeaseHolder,
   readLease,
+  SandboxImageConflictError,
   type Database,
   type DbClient,
 } from "@opengeni/db";
@@ -64,12 +65,12 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 
 async function readRow(workspaceId: string, groupId: string) {
   const [r] = await admin`
-    select liveness, refcount, turn_holders, viewer_holders, lease_epoch, instance_id, resume_backend_id
+    select liveness, refcount, turn_holders, viewer_holders, lease_epoch, instance_id, resume_backend_id, image
     from sandbox_leases
     where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
   return r as {
     liveness: string; refcount: number; turn_holders: number; viewer_holders: number;
-    lease_epoch: number; instance_id: string | null; resume_backend_id: string | null;
+    lease_epoch: number; instance_id: string | null; resume_backend_id: string | null; image: string | null;
   } | undefined;
 }
 
@@ -366,5 +367,59 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
     // Independent proof: nothing materialized a lease for this fresh group.
     const lease = await readLease(db, workspaceId, groupId);
     expect(lease).toBeNull();
+  }, 60_000);
+
+  // IMAGE IS SHARED STATE (B3): resumeBoxForTurn threads `image` into acquireLease.
+  test("(B3-a) resumeBoxForTurn stamps the resolved image on the box it spawns", async () => {
+    if (!available) return;
+    const settings = settingsFor(true);
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const resumed = await resumeBoxForTurn(
+      { db, settings },
+      { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local", os: "linux", environment: { HOME: "/workspace" }, image: "img-A" },
+      "turn",
+      "activity-1",
+    );
+    try {
+      const warm = await readRow(workspaceId, groupId);
+      expect(warm?.liveness).toBe("warm");
+      expect(warm?.image).toBe("img-A");
+    } finally {
+      await resumed.release();
+      await dropSession(resumed.established);
+    }
+  }, 60_000);
+
+  test("(B3-b) resumeBoxForTurn PROPAGATES SandboxImageConflictError when another holder runs a different image", async () => {
+    if (!available) return;
+    const settings = settingsFor(true);
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    // A first turn warms the box on img-A and STAYS holding it (do not release).
+    const keeper = await resumeBoxForTurn(
+      { db, settings },
+      { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local", os: "linux", environment: { HOME: "/workspace" }, image: "img-A" },
+      "turn",
+      "keeper",
+    );
+    try {
+      // A second holder resolving a DIFFERENT image while keeper holds -> conflict
+      // propagates out of resumeBoxForTurn (the turn activity surfaces it as an
+      // actionable error).
+      await expect(
+        resumeBoxForTurn(
+          { db, settings },
+          { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local", os: "linux", environment: { HOME: "/workspace" }, image: "img-B" },
+          "turn",
+          "newcomer",
+        ),
+      ).rejects.toThrow(SandboxImageConflictError);
+      // The box is untouched — keeper's session keeps running.
+      const warm = await readRow(workspaceId, groupId);
+      expect(warm?.liveness).toBe("warm");
+      expect(warm?.image).toBe("img-A");
+    } finally {
+      await keeper.release();
+      await dropSession(keeper.established);
+    }
   }, 60_000);
 });

--- a/docker/opengeni-git-askpass
+++ b/docker/opengeni-git-askpass
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 case "$1" in
   *Username*) printf '%s\n' "x-access-token" ;;
-  *Password*) printf '%s\n' "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ;;
+  *Password*) cat "${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}" 2>/dev/null || printf '\n' ;;
   *) printf '\n' ;;
 esac

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1366,14 +1366,19 @@ export function collectGitIdentityEnvironment(settings: Settings): Record<string
  * at write time keeps workspace values from colliding with platform entries.
  *
  * DELIBERATELY EXCLUDES the per-run, ROTATING GitHub App installation token
- * (GH_TOKEN/GITHUB_TOKEN/GIT_ASKPASS/GIT_CONFIG_*) that `sandboxEnvironmentForRun`
- * layers on top when a repository resource is attached: that token is minted FRESH
- * per call, so it is not a stable, attach-reproducible value and must not be part
- * of the shared base. The attach surfaces have only the `Session` (no repo
- * resources) and so cannot reproduce it anyway; the BLOCKING attach-vs-turn error
- * this helper fixes is for the common (no-repo) and workspace-environment-attached
- * cases. (A repo-attached turn re-attaching to an attach-warmed box is a separate,
- * pre-existing rotating-secret concern — see sandboxEnvironmentForRun.)
+ * VALUE that `sandboxEnvironmentForRun` mints when a repository resource is
+ * attached: that token is minted FRESH per call, so it is not a stable, attach-
+ * reproducible value and must not be part of the shared base. Under the token-
+ * broker (B1) the token VALUE never rides the manifest at all — it is seeded to a
+ * FILE inside the box (agent-managed, refreshable mid-turn via the `github_token`
+ * MCP tool) and git auth flows through GIT_ASKPASS -> that file. What IS stable and
+ * lives here is the token FILE PATH (`OPENGENI_GIT_TOKEN_FILE`): a constant derived
+ * from HOME, so it appears IDENTICALLY on BOTH the turn AND every attach manifest
+ * (the SDK's per-turn provided-session env delta stays empty even as the token
+ * rotates). The attach surfaces have only the `Session` (no repo resources) and so
+ * never seed a token, but the file-path pointer is harmless (an unwritten file
+ * simply yields no auth); the BLOCKING attach-vs-turn error this helper fixes is
+ * for the common (no-repo) and workspace-environment-attached cases.
  */
 export function stableSandboxEnvironmentForRun(
   settings: Settings,
@@ -1391,6 +1396,14 @@ export function stableSandboxEnvironmentForRun(
   if (settings.sandboxBackend !== "none" && settings.sandboxBackend !== "local") {
     environment.HOME ??= descriptor.workspaceRoot;
   }
+  // TOKEN-BROKER (B1): the STABLE token FILE PATH. A constant derived from the
+  // resolved HOME (falling back to the descriptor workspaceRoot), so it is
+  // parity-safe — it joins the shared base and therefore appears IDENTICALLY on
+  // BOTH the worker-turn manifest AND every API-direct attach manifest, keeping
+  // the SDK's provided-session env delta empty. Only the PATH is stable; the token
+  // VALUE lives exclusively in the file (agent-managed, refreshable mid-turn), never
+  // the manifest env.
+  environment.OPENGENI_GIT_TOKEN_FILE ??= `${environment.HOME ?? descriptor.workspaceRoot}/.opengeni/git-token`;
   return environment;
 }
 

--- a/packages/db/drizzle/0034_sandbox_lease_image.sql
+++ b/packages/db/drizzle/0034_sandbox_lease_image.sql
@@ -1,0 +1,21 @@
+-- 0034_sandbox_lease_image.sql
+-- IMAGE IS SHARED STATE (B3): stamp the container image the group box runs on the lease.
+-- A shared box (sandbox:{groupId} / the default SHARE placement) is ONE filesystem across
+-- N sessions, so every session that attaches must run the SAME image. This column records
+-- the image the live box was created with; a resume whose resolved image DIFFERS is a
+-- conflict — a SOLO holder recreates the box on the new image (force cold + re-stamp),
+-- N-holders are rejected at the lease layer (SandboxImageConflictError). Nullable (a
+-- legacy/cold row reads NULL = "image unknown", which never conflicts) — additive only,
+-- forward-only, no backfill. Mirrors 0022's re-grant boilerplate. Runs under the runner's
+-- advisory lock.
+
+ALTER TABLE "sandbox_leases" ADD COLUMN IF NOT EXISTS "image" text;
+
+-- Re-grant on the new column (idempotent; mirrors the boilerplate in 0018/0022 so a
+-- fresh opengeni_app role can read/write the added column).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4007,6 +4007,7 @@ type LeaseRow = {
   instance_id: string | null;
   backend: string;
   os: string;
+  image: string | null;
   data_plane_url: string | null;
   terminal_data_plane_url: string | null;
   lease_epoch: number | string;
@@ -4027,6 +4028,10 @@ export interface LeaseSnapshot {
   instanceId: string | null;
   backend: string;
   os: string;
+  // The container image the group box runs (Modal image ref / docker image). Null
+  // for a legacy/cold row (image unknown). Shared state: all the box's sessions run
+  // this image; a resume resolving a different image conflicts (B3).
+  image: string | null;
   dataPlaneUrl: string | null;
   // The cached ttyd pty-ws tunnel URL (7681), separate from dataPlaneUrl (the
   // 6080 desktop tunnel). Null until mintTerminalStream resolves + records it.
@@ -4048,6 +4053,12 @@ export interface AcquireLeaseInput {
   subjectId?: string | null;   // the attributing session within the group
   backend: string;             // sessions.sandbox_backend
   os?: string;                 // default 'linux'
+  // The container image this run resolves (Modal image ref / docker image). Stamped on
+  // the cold-create + folded onto a warming/CAS; a warm/draining/warming box already
+  // running a DIFFERENT image is a shared-state conflict (B3): a SOLO holder forces the
+  // box to recreate on this image, N-holders throw SandboxImageConflictError. Omitted
+  // (null/undefined) -> image is not enforced (legacy/cold rows, selfhosted).
+  image?: string | null;
   leaseTtlMs: number;          // refresh window for expires_at (turn-heartbeat cadence)
   // Optional epoch fence for a re-establishing turn holder: when set, the
   // turn-arrival increment is gated on lease_epoch == expectedEpoch (split-brain).
@@ -4076,6 +4087,26 @@ export class SandboxLeaseSupersededError extends Error {
   }
 }
 
+// IMAGE IS SHARED STATE (B3): thrown when a resume resolves an image DIFFERENT from
+// the one the live shared box was created with AND other holders are still on the box.
+// A shared box is ONE filesystem; recreating it on a new image would yank the running
+// filesystem out from under the OTHER sessions, so we refuse. The turn activity surfaces
+// this as an actionable error: spawn with sandbox:'new' or align the pack image. A SOLO
+// holder never hits this — acquireLease recreates the box on the new image instead.
+export class SandboxImageConflictError extends Error {
+  constructor(
+    public readonly sandboxGroupId: string,
+    public readonly currentImage: string,
+    public readonly requestedImage: string,
+  ) {
+    super(
+      `Sandbox group ${sandboxGroupId} runs image ${currentImage}; this run resolves image ${requestedImage}. `
+      + `A shared box requires one image — spawn with sandbox:'new' for an isolated box or align the pack image.`,
+    );
+    this.name = "SandboxImageConflictError";
+  }
+}
+
 function mapLeaseRow(row: LeaseRow): LeaseSnapshot {
   return {
     id: row.id,
@@ -4087,6 +4118,7 @@ function mapLeaseRow(row: LeaseRow): LeaseSnapshot {
     instanceId: row.instance_id,
     backend: row.backend,
     os: row.os,
+    image: row.image ?? null,
     dataPlaneUrl: row.data_plane_url,
     terminalDataPlaneUrl: row.terminal_data_plane_url ?? null,
     // Defensive coercion: integer returns a number, but coerce regardless so the
@@ -4152,14 +4184,17 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
   return await withRlsContext(db, { accountId, workspaceId }, async (scopedDb) =>
     await scopedDb.transaction(async (txRaw) => {
       const tx = txRaw as unknown as Database;
+      const image = input.image ?? null;
       // (1) Materialize the singleton row if absent. ON CONFLICT DO NOTHING + the
       // unique index = idempotent under a race; concurrent inserts collapse to
-      // one row. expires_at seeded so a never-warmed cold row has a valid TTL.
+      // one row. expires_at seeded so a never-warmed cold row has a valid TTL. The
+      // image (B3) is stamped on the cold-create so a fresh box records the image it
+      // will be built on; a conflict on an EXISTING live box is handled below.
       await tx.execute(sql`
         insert into sandbox_leases
-          (account_id, workspace_id, sandbox_group_id, liveness, backend, os, expires_at)
+          (account_id, workspace_id, sandbox_group_id, liveness, backend, os, image, expires_at)
         values
-          (${accountId}, ${workspaceId}, ${sandboxGroupId}, 'cold', ${backend}, ${os},
+          (${accountId}, ${workspaceId}, ${sandboxGroupId}, 'cold', ${backend}, ${os}, ${image},
            now() + (${String(input.leaseTtlMs)} || ' milliseconds')::interval)
         on conflict (workspace_id, sandbox_group_id) do nothing
       `);
@@ -4175,7 +4210,45 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
       const row = rows[0];
       if (!row) throw new Error(`Lease row vanished post-insert: ${sandboxGroupId}`);
 
-      const liveness = row.liveness;
+      let liveness = row.liveness;
+
+      // -- IMAGE IS SHARED STATE (B3): a LIVE box (warm/draining/warming) already runs
+      // a specific image. If this run resolves a DIFFERENT image (both sides known),
+      // the shared filesystem cannot serve both. Under the held row lock we count the
+      // OTHER holders (holders that are not this exact (kind, holderId) — an idempotent
+      // retry of our own holder does not count as a rival):
+      //   - SOLO (no other holders): RECREATE. Reset the box to cold and re-stamp the
+      //     NEW image, then fall through to the cold branch below, which CASes us in as
+      //     the spawner. The spawner cold-creates a fresh box on the new image (the
+      //     archive replay in establishSandboxSessionFromEnvelope hydrates /workspace).
+      //   - OTHER holders present: REFUSE. Throw SandboxImageConflictError — recreating
+      //     would yank the running filesystem out from under the other sessions.
+      // Only enforced when BOTH images are known; a cold row / a legacy null-image box /
+      // an unset input image never conflicts (the selfhosted path passes no image).
+      if (liveness !== "cold" && image !== null && row.image !== null && row.image !== image) {
+        const others = await tx.execute<{ n: number }>(sql`
+          select count(*)::int as n from sandbox_lease_holders
+          where lease_id = ${row.id} and not (kind = ${kind} and holder_id = ${holderId})
+        `);
+        const otherHolders = Number(others[0]?.n ?? 0);
+        if (otherHolders > 0) {
+          throw new SandboxImageConflictError(sandboxGroupId, row.image, image);
+        }
+        // SOLO recreate: reset to cold + re-stamp the new image. Clear the live-box
+        // fields so no stale instance/tunnel survives the image roll (symmetric with
+        // failWarmingToCold). resume_state is nulled — a solo image change is an
+        // intentional fresh box (a divergent image cannot replay the old box's live
+        // state); the session envelope/archive still drives /workspace hydration on the
+        // cold re-create. Fall through to the cold branch, which CASes us in as spawner.
+        await tx.execute(sql`
+          update sandbox_leases set
+            liveness = 'cold', image = ${image}, instance_id = null,
+            data_plane_url = null, terminal_data_plane_url = null,
+            resume_backend_id = null, resume_state = null, updated_at = now()
+          where id = ${row.id}
+        `);
+        liveness = "cold";
+      }
 
       // -- draining: late arrival re-arms (D1). Box still alive (grace open).
       if (liveness === "draining") {
@@ -4186,9 +4259,14 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
 
       // -- cold: WIN the cold->warming CAS (C1). Exactly one winner under the
       // held row lock; concurrent arrivals serialize behind us and see warming.
+      // The image (B3) is (re-)stamped on the CAS so the box the spawner cold-creates
+      // records the image it runs — for a fresh cold row or a solo-recreate above.
       if (liveness === "cold") {
         const casRows = await tx.execute<{ id: string }>(sql`
-          update sandbox_leases set liveness = 'warming', updated_at = now()
+          update sandbox_leases set
+            liveness = 'warming',
+            ${image !== null ? sql`image = ${image},` : sql``}
+            updated_at = now()
           where id = ${row.id} and liveness = 'cold'
           returning id
         `);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -550,6 +550,13 @@ export const sandboxLeases = pgTable("sandbox_leases", {
   instanceId: text("instance_id"),
   backend: text("backend").notNull(),
   os: text("os").notNull().default("linux"),
+  // The container IMAGE the group box runs (Modal image ref / docker image). A shared
+  // box is SHARED STATE: all its sessions run the SAME filesystem, so they must run the
+  // same image. This column stamps the image the live box was created with; a resume
+  // whose resolved image DIFFERS is a conflict (B3): a solo holder recreates the box on
+  // the new image, N-holders are rejected (SandboxImageConflictError). Nullable — a
+  // legacy/cold row reads NULL = "image unknown", which never conflicts.
+  image: text("image"),
   dataPlaneUrl: text("data_plane_url"),
   // The REAL PTY terminal (ttyd pty-ws) rides a SEPARATE provider tunnel (7681)
   // from the desktop noVNC (6080), so its resolved URL is cached independently.

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -11,6 +11,7 @@ import {
   reapStaleLeaseHolders,
   reapStaleLeaseHoldersGlobal,
   releaseLeaseHolder,
+  SandboxImageConflictError,
   type Database,
   type DbClient,
 } from "../src/index";
@@ -392,4 +393,85 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     expect(row?.resume_state).toBeNull();
     expect(row?.resume_backend_id).toBeNull();
   }, 60_000);
+
+  // IMAGE IS SHARED STATE (B3): the lease stamps the image the box runs; a resume with
+  // a DIFFERENT image is a conflict (solo → recreate; N-holders → hard fail).
+  test("(9) image B3: cold-create stamps the image on the warming row", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const res = await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "t", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    expect(res.role).toBe("spawner");
+    const [row] = await admin<{ image: string | null; liveness: string }[]>`
+      select image, liveness from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    expect(row?.image).toBe("img-A");
+    expect(row?.liveness).toBe("warming");
+  });
+
+  test("(10) image B3: warm box + SAME image = plain attach (no recreate)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "spawner", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    await commitWarmingToWarm(db, { accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: 0, instanceId: "sb-live", resumeBackendId: "modal", resumeState: { backendId: "modal" }, leaseTtlMs: 45_000 });
+    // A SECOND holder arrives on the warm box with the SAME image -> attach, box intact.
+    const res = await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "viewer", holderId: "v2", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    expect(res.role).toBe("attached");
+    const [row] = await admin<{ liveness: string; image: string | null; instance_id: string | null; refcount: number }[]>`
+      select liveness, image, instance_id, refcount from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    expect(row?.liveness).toBe("warm");        // never recreated
+    expect(row?.image).toBe("img-A");
+    expect(row?.instance_id).toBe("sb-live");   // live box untouched
+    expect(row?.refcount).toBe(2);
+  });
+
+  test("(11) image B3: warm box + SOLO holder + DIFFERENT image -> recreate (cold, re-stamped, spawner)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    // Warm on img-A, held by exactly ONE holder ("solo").
+    await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "solo", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    await commitWarmingToWarm(db, { accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: 0, instanceId: "sb-live", resumeBackendId: "modal", resumeState: { backendId: "modal", sessionState: { providerState: { sandboxId: "sb-live" } } }, leaseTtlMs: 45_000 });
+    // The SAME solo holder re-arrives resolving a DIFFERENT image -> recreate. acquireLease
+    // resets to cold, re-stamps img-B, and CASes the holder back in as spawner.
+    const res = await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "solo", backend: "modal", image: "img-B", leaseTtlMs: 45_000 });
+    expect(res.role).toBe("spawner");
+    const [row] = await admin<{ liveness: string; image: string | null; instance_id: string | null; resume_state: unknown }[]>`
+      select liveness, image, instance_id, resume_state from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    // Warming (spawner will cold-create on the NEW image), image re-stamped, live-box
+    // fields cleared (a divergent image cannot replay the old box's live state).
+    expect(row?.liveness).toBe("warming");
+    expect(row?.image).toBe("img-B");
+    expect(row?.instance_id).toBeNull();
+    expect(row?.resume_state).toBeNull();
+  });
+
+  test("(12) image B3: warm box + OTHER holders + DIFFERENT image -> SandboxImageConflictError (box untouched)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    // Warm on img-A with a holder that STAYS on the box.
+    await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "viewer", holderId: "keeper", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    await commitWarmingToWarm(db, { accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: 0, instanceId: "sb-live", resumeBackendId: "modal", resumeState: { backendId: "modal" }, leaseTtlMs: 45_000 });
+    // A DIFFERENT holder resolves a DIFFERENT image while "keeper" still holds -> refuse.
+    await expect(
+      acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "newcomer", backend: "modal", image: "img-B", leaseTtlMs: 45_000 }),
+    ).rejects.toThrow(SandboxImageConflictError);
+    // The box is UNTOUCHED — the other session keeps running its filesystem.
+    const [row] = await admin<{ liveness: string; image: string | null; instance_id: string | null }[]>`
+      select liveness, image, instance_id from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    expect(row?.liveness).toBe("warm");
+    expect(row?.image).toBe("img-A");
+    expect(row?.instance_id).toBe("sb-live");
+  });
+
+  test("(13) image B3: a null input image (e.g. selfhosted) NEVER conflicts + never stamps", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "viewer", holderId: "keeper", backend: "modal", image: "img-A", leaseTtlMs: 45_000 });
+    await commitWarmingToWarm(db, { accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: 0, instanceId: "sb-live", resumeBackendId: "modal", resumeState: { backendId: "modal" }, leaseTtlMs: 45_000 });
+    // No image on this acquire -> attach, no conflict, image column unchanged.
+    const res = await acquireLease(db, { accountId, workspaceId, sandboxGroupId: groupId, kind: "turn", holderId: "no-image", backend: "modal", leaseTtlMs: 45_000 });
+    expect(res.role).toBe("attached");
+    const [row] = await admin<{ image: string | null; liveness: string }[]>`
+      select image, liveness from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    expect(row?.image).toBe("img-A");
+    expect(row?.liveness).toBe("warm");
+  });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -646,6 +646,15 @@ export type BuildAgentOptions = {
   fileResourceDownloads?: SandboxFileDownload[];
   mcpServers?: MCPServer[];
   workspaceEnvironment?: WorkspaceEnvironmentContext;
+  // TOKEN-BROKER (B1): the run-scoped GitHub App installation token, minted ONCE
+  // per turn by the worker (sandboxEnvironmentForRun's `gitToken`). Threaded here
+  // OFF-MANIFEST — it is NOT part of sandboxEnvironment (the manifest env), so the
+  // token VALUE never triggers the SDK's provided-session env-delta guard even
+  // though it rotates every turn. buildAgent stashes it alongside the agent's
+  // repository-clone hooks; runStream forwards it into the clone hook context, which
+  // seeds it to the box's token FILE before the clone runs. Omitted on the
+  // selfhosted path (the machine uses its own git creds) — a NO-OP there.
+  gitTokenSeed?: string;
   // Genesis turn only: append a one-shot instruction to the agent's system
   // prompt telling it to title the session via opengeni__set_session_title
   // before responding. Delivered through the instructions channel (where the
@@ -744,6 +753,12 @@ export function composeAgentInstructions(template: string, workspaceEnvironment?
 
 const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
+// TOKEN-BROKER (B1): the per-turn git token seed, stashed alongside the agent's
+// repository-clone hooks (a parallel map keyed by the agent). Kept OFF the
+// manifest/defaultManifest so the rotating value never rides the SDK's provided-
+// session env; runStream reads it to build the clone hook context. Absent when
+// no repo is attached / on the selfhosted path.
+const agentGitTokenSeed = new WeakMap<object, string>();
 
 export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[], options: BuildAgentOptions = {}): Agent<any, any> {
   // Resolved per-turn gating. Each override defaults to today's settings-derived
@@ -823,6 +838,11 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
   agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources, options.activeSandboxBackend));
+  // TOKEN-BROKER (B1): stash the per-turn seed off-manifest so runStream can seed the
+  // clone hook without the token ever touching defaultManifest / sandboxEnvironment.
+  if (options.gitTokenSeed) {
+    agentGitTokenSeed.set(agent, options.gitTokenSeed);
+  }
   return agent;
 }
 
@@ -1504,6 +1524,9 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
         ...(runAs ? { runAs } : {}),
       })
       : (ownedClient as SandboxClient);
+    // TOKEN-BROKER (B1): the per-turn git token seed, forwarded OFF-MANIFEST so the
+    // repository-clone hook seeds it to the box's token file before the clone.
+    const ownedGitTokenSeed = gitTokenSeedForAgent(agent);
     const decoratedClient = withSandboxLifecycleHooks(resourceClient, [
       ...sandboxLifecycleHooksForIds(sandboxLifecycleHookIds(settings)),
       ...sandboxRepositoryCloneHooksForAgent(agent),
@@ -1511,6 +1534,7 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       environment,
       ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
       ...(runAs ? { runAs } : {}),
+      ...(ownedGitTokenSeed ? { gitTokenSeed: ownedGitTokenSeed } : {}),
     });
     const ownedFilter = composeCallModelInputFilters(
       [callModelInputFilterForSettings(settings), overrides.callModelInputFilter].filter(
@@ -1542,6 +1566,9 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       ...(runAs ? { runAs } : {}),
     })
     : refreshedClient;
+  // TOKEN-BROKER (B1): the per-turn git token seed, forwarded OFF-MANIFEST so the
+  // repository-clone hook seeds it to the box's token file before the clone.
+  const gitTokenSeed = gitTokenSeedForAgent(agent);
   const client = resourceClient
     ? withSandboxLifecycleHooks(resourceClient, [
       ...sandboxLifecycleHooksForIds(sandboxLifecycleHookIds(settings)),
@@ -1550,6 +1577,7 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       environment,
       ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
       ...(runAs ? { runAs } : {}),
+      ...(gitTokenSeed ? { gitTokenSeed } : {}),
     })
     : undefined;
   const sandboxSessionState = prepared.sandboxSessionState
@@ -2231,6 +2259,11 @@ export type SandboxLifecycleHookContext = {
   environment: Record<string, string>;
   onRuntimeEvent?: (event: NormalizedRuntimeEvent) => Promise<void> | void;
   runAs?: string;
+  // TOKEN-BROKER (B1): the run-scoped GitHub token to seed into the box's token
+  // FILE before the repository clone runs. Threaded OFF-MANIFEST — it rides ONLY
+  // the clone exec's per-call env (OPENGENI_GIT_TOKEN_SEED), NEVER the box/agent
+  // manifest env (validateNoEnvironmentDelta must never see a rotating value).
+  gitTokenSeed?: string;
 };
 
 export type SandboxLifecycleHook = {
@@ -2296,6 +2329,13 @@ function sandboxRepositoryCloneHooksForAgent(agent: Agent<any, any>): SandboxLif
   return agentRepositoryCloneHooks.get(agent) ?? [];
 }
 
+// TOKEN-BROKER (B1): the per-turn git token seed stashed for this agent (undefined
+// when no repo is attached / on the selfhosted path). Read into the clone hook
+// context at runStream so the token is seeded off-manifest.
+function gitTokenSeedForAgent(agent: Agent<any, any>): string | undefined {
+  return agentGitTokenSeed.get(agent);
+}
+
 function sandboxRepositoryCloneHooks(
   settings: Settings,
   resources: ResourceRef[],
@@ -2350,6 +2390,19 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     "set -eu",
     "export HOME=\"${HOME:-/workspace}\"",
     "export GIT_TERMINAL_PROMPT=\"${GIT_TERMINAL_PROMPT:-0}\"",
+    // TOKEN-BROKER (B1): seed the run-scoped GitHub token into the STABLE token FILE
+    // BEFORE any clone runs, so GIT_ASKPASS reads it for the fetch below. The seed
+    // rides the per-exec env (OPENGENI_GIT_TOKEN_SEED) — NEVER the box/agent manifest
+    // (validateNoEnvironmentDelta must not see a rotating value), so this block is a
+    // no-op when the seed is absent (e.g. the selfhosted path, which uses its own git
+    // creds). The file lives at $OPENGENI_GIT_TOKEN_FILE (stable, from the shared base)
+    // with a $HOME/.opengeni/git-token fallback; chmod 600 keeps the token private.
+    "if [ -n \"${OPENGENI_GIT_TOKEN_SEED:-}\" ]; then",
+    "  git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"",
+    "  mkdir -p \"$(dirname \"$git_token_file\")\"",
+    "  printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"",
+    "  chmod 600 \"$git_token_file\"",
+    "fi",
     "ensure_git() {",
     "  if command -v git >/dev/null 2>&1; then",
     "    return 0",
@@ -2430,7 +2483,18 @@ export async function runRepositoryCloneHook(
   const payload = { name: "repository-clone", repositoryCount: resources.length };
   await context.onRuntimeEvent?.({ type: "sandbox.operation.started", payload });
   try {
-    const command = repositoryCloneCommand(resources);
+    // TOKEN-BROKER (B1): thread the run-scoped GitHub token PER-EXEC, never on the
+    // manifest. The SDK's ExecCommandArgs has no `environment` field (exec inherits
+    // the box's manifest env), so we can't hand the seed through an exec option — and
+    // we MUST NOT put it on the manifest (validateNoEnvironmentDelta would see a
+    // rotating value). We therefore inline it as an ephemeral `export` prefix on THIS
+    // exec's command text only: it lives in the command, not the box/agent manifest,
+    // and never persists. The clone command's gated seed block then writes it to the
+    // token FILE before the fetch, so GIT_ASKPASS reads it. Absent seed (e.g. the
+    // selfhosted path) -> no prefix, the clone runs byte-for-byte as before.
+    const command = context.gitTokenSeed
+      ? `export OPENGENI_GIT_TOKEN_SEED=${shellQuote(context.gitTokenSeed)}\n${repositoryCloneCommand(resources)}`
+      : repositoryCloneCommand(resources);
     if (session.exec) {
       const result = await session.exec({
         cmd: command,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2390,18 +2390,40 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     "set -eu",
     "export HOME=\"${HOME:-/workspace}\"",
     "export GIT_TERMINAL_PROMPT=\"${GIT_TERMINAL_PROMPT:-0}\"",
-    // TOKEN-BROKER (B1): seed the run-scoped GitHub token into the STABLE token FILE
-    // BEFORE any clone runs, so GIT_ASKPASS reads it for the fetch below. The seed
-    // rides the per-exec env (OPENGENI_GIT_TOKEN_SEED) — NEVER the box/agent manifest
-    // (validateNoEnvironmentDelta must not see a rotating value), so this block is a
-    // no-op when the seed is absent (e.g. the selfhosted path, which uses its own git
-    // creds). The file lives at $OPENGENI_GIT_TOKEN_FILE (stable, from the shared base)
-    // with a $HOME/.opengeni/git-token fallback; chmod 600 keeps the token private.
+    // TOKEN-BROKER (B1/B2): seed the run-scoped GitHub token into the STABLE token FILE
+    // AND provision the git-askpass helper into the box AT SETUP (runtime) BEFORE any
+    // clone runs, so GIT_ASKPASS points at a per-box, user-writable script that reads
+    // that file for the fetch below. Provisioning the askpass here (rather than relying
+    // on a baked image script at /usr/local/bin/opengeni-git-askpass) removes the
+    // image-rebuild rollout gate: the askpass is correct on ANY box image, including
+    // pre-existing warm boxes on their next turn's clone hook, and no product image has
+    // to carry it. The seed rides the per-exec env (OPENGENI_GIT_TOKEN_SEED) — NEVER the
+    // box/agent manifest (validateNoEnvironmentDelta must not see a rotating value), so
+    // this whole block is a no-op when the seed is absent (e.g. the selfhosted path,
+    // which uses its own git creds). The token file lives at $OPENGENI_GIT_TOKEN_FILE
+    // (stable, from the shared base) with a $HOME/.opengeni/git-token fallback; chmod 600
+    // keeps the token private. $GIT_ASKPASS is on the box manifest env (set by
+    // sandboxEnvironmentForRun to $HOME/.opengeni/askpass), so it is available to this
+    // exec; the askpass script we write is byte-identical to docker/opengeni-git-askpass
+    // and is written via a QUOTED heredoc (<<'ASKPASS_EOF') so NOTHING inside it expands
+    // ($1, $HOME, ${OPENGENI_GIT_TOKEN_FILE:-...}, and the literal \n in printf all land
+    // verbatim), then chmod 0755 so git can exec it.
     "if [ -n \"${OPENGENI_GIT_TOKEN_SEED:-}\" ]; then",
     "  git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"",
     "  mkdir -p \"$(dirname \"$git_token_file\")\"",
     "  printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"",
     "  chmod 600 \"$git_token_file\"",
+    "  git_askpass=\"${GIT_ASKPASS:-$HOME/.opengeni/askpass}\"",
+    "  mkdir -p \"$(dirname \"$git_askpass\")\"",
+    "  cat > \"$git_askpass\" <<'ASKPASS_EOF'",
+    "#!/usr/bin/env sh",
+    "case \"$1\" in",
+    "  *Username*) printf '%s\\n' \"x-access-token\" ;;",
+    "  *Password*) cat \"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\" 2>/dev/null || printf '\\n' ;;",
+    "  *) printf '\\n' ;;",
+    "esac",
+    "ASKPASS_EOF",
+    "  chmod 0755 \"$git_askpass\"",
     "fi",
     "ensure_git() {",
     "  if command -v git >/dev/null 2>&1; then",

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -743,6 +743,30 @@ describe("runtime event normalization", () => {
     expect(command).not.toContain("GH_TOKEN=");
   });
 
+  test("TOKEN-BROKER (B1): the clone command emits the gated token-seed block that writes the token FILE before the clone", () => {
+    const command = repositoryCloneCommand([{
+      kind: "repository",
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }]);
+
+    // The seed block is GATED on the per-exec OPENGENI_GIT_TOKEN_SEED (never on the
+    // manifest), writes the STABLE token file, and chmod 600s it.
+    expect(command).toContain("if [ -n \"${OPENGENI_GIT_TOKEN_SEED:-}\" ]; then");
+    expect(command).toContain("git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"");
+    expect(command).toContain("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"");
+    expect(command).toContain("chmod 600 \"$git_token_file\"");
+    // The seed write MUST come BEFORE the fetch that consumes it (order matters:
+    // GIT_ASKPASS reads the file during the fetch).
+    expect(command.indexOf("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\"")).toBeLessThan(
+      command.indexOf("git -C \"$tmp\" fetch"),
+    );
+    // The token VALUE is never literally in the command (only the env-var reference).
+    expect(command).not.toContain("x-access-token");
+  });
+
   test("never clones a repository onto a selfhosted (bring-your-own) machine", () => {
     const githubRepo = {
       kind: "repository" as const,
@@ -825,6 +849,59 @@ describe("runtime event normalization", () => {
     expect(String(calls[0]?.cmd)).toContain("git init");
     expect(String(calls[0]?.cmd)).not.toContain("secret-token");
     expect(events).toEqual(["sandbox.operation.started", "sandbox.operation.completed"]);
+  });
+
+  test("TOKEN-BROKER (B1): the clone hook seeds the git token PER-EXEC (command prefix), never on the exec env/manifest", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    await runRepositoryCloneHook({
+      exec: async (args: Record<string, unknown>) => {
+        calls.push(args);
+        return { output: "", stdout: "", stderr: "", wallTimeSeconds: 0, exitCode: 0 };
+      },
+    } as any, [{
+      kind: "repository",
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }], {
+      environment: { HOME: "/workspace" },
+      runAs: "sandbox",
+      gitTokenSeed: "ghs_liveToken123",
+    });
+
+    expect(calls).toHaveLength(1);
+    // The seed is inlined as an ephemeral export PREFIX on the command text — it is
+    // NOT passed as an exec `environment` option (ExecCommandArgs has no such field)
+    // and NEVER lands on the box/agent manifest.
+    expect(calls[0]?.environment).toBeUndefined();
+    expect(String(calls[0]?.cmd)).toContain("export OPENGENI_GIT_TOKEN_SEED='ghs_liveToken123'");
+    // The prefix precedes the gated seed block that writes the file.
+    expect(String(calls[0]?.cmd).indexOf("export OPENGENI_GIT_TOKEN_SEED=")).toBeLessThan(
+      String(calls[0]?.cmd).indexOf("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\""),
+    );
+  });
+
+  test("TOKEN-BROKER (B1): with NO seed the clone hook command is byte-for-byte the un-prefixed clone (no-op on selfhosted)", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    await runRepositoryCloneHook({
+      exec: async (args: Record<string, unknown>) => {
+        calls.push(args);
+        return { output: "", stdout: "", stderr: "", wallTimeSeconds: 0, exitCode: 0 };
+      },
+    } as any, [{
+      kind: "repository",
+      uri: "https://github.com/acme/private.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }], {
+      environment: { HOME: "/workspace" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]?.cmd)).not.toContain("export OPENGENI_GIT_TOKEN_SEED=");
+    expect(String(calls[0]?.cmd).startsWith("set -eu")).toBe(true);
   });
 
   test("fails repository clone hook when sandbox command is still running", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -739,11 +739,15 @@ describe("runtime event normalization", () => {
     expect(command).toContain("clone_repository '/workspace/repos/acme/private' 'https://github.com/acme/private.git' 'main' 'packages/api'");
     expect(command).not.toContain("githubInstallationId");
     expect(command).not.toContain("githubRepositoryId");
-    expect(command).not.toContain("x-access-token");
+    // TOKEN-BROKER (B2): the provisioned askpass script legitimately references the
+    // "x-access-token" USERNAME constant (git's basic-auth username for an App token)
+    // — that is not a credential. The credential guard is that no token VALUE and no
+    // token-carrying env assignment ever rides the command text.
     expect(command).not.toContain("GH_TOKEN=");
+    expect(command).not.toContain("GITHUB_TOKEN=");
   });
 
-  test("TOKEN-BROKER (B1): the clone command emits the gated token-seed block that writes the token FILE before the clone", () => {
+  test("TOKEN-BROKER (B1/B2): the clone command emits the gated seed block that writes the token FILE and PROVISIONS the askpass before the clone", () => {
     const command = repositoryCloneCommand([{
       kind: "repository",
       uri: "https://github.com/acme/private.git",
@@ -758,13 +762,32 @@ describe("runtime event normalization", () => {
     expect(command).toContain("git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"");
     expect(command).toContain("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"");
     expect(command).toContain("chmod 600 \"$git_token_file\"");
-    // The seed write MUST come BEFORE the fetch that consumes it (order matters:
-    // GIT_ASKPASS reads the file during the fetch).
+
+    // TOKEN-BROKER (B2): the SAME gated block PROVISIONS the git-askpass helper at
+    // SETUP (runtime) into the per-box, user-writable $GIT_ASKPASS (a manifest env
+    // pointer, default $HOME/.opengeni/askpass), so auth is correct on ANY box image
+    // without a baked script. It mkdir -p's the dir, writes the helper via a QUOTED
+    // heredoc, and chmod 0755s it so git can exec it.
+    expect(command).toContain("git_askpass=\"${GIT_ASKPASS:-$HOME/.opengeni/askpass}\"");
+    expect(command).toContain("cat > \"$git_askpass\" <<'ASKPASS_EOF'");
+    expect(command).toContain("chmod 0755 \"$git_askpass\"");
+    // The provisioned askpass' Password branch reads the token FILE (this is the
+    // load-bearing wiring: GIT_ASKPASS -> askpass -> token file).
+    expect(command).toContain("*Password*) cat \"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\" 2>/dev/null || printf '\\n' ;;");
+    expect(command).toContain("*Username*) printf '%s\\n' \"x-access-token\" ;;");
+
+    // Both writes MUST come BEFORE the fetch that consumes them (order matters:
+    // GIT_ASKPASS execs the provisioned script, which reads the token file, during
+    // the fetch).
     expect(command.indexOf("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\"")).toBeLessThan(
       command.indexOf("git -C \"$tmp\" fetch"),
     );
-    // The token VALUE is never literally in the command (only the env-var reference).
-    expect(command).not.toContain("x-access-token");
+    expect(command.indexOf("cat > \"$git_askpass\"")).toBeLessThan(
+      command.indexOf("git -C \"$tmp\" fetch"),
+    );
+    // The token VALUE is never literally in the command (only the env-var reference);
+    // the "x-access-token" USERNAME constant is not a credential.
+    expect(command).not.toContain("OPENGENI_GIT_TOKEN_SEED=");
   });
 
   test("never clones a repository onto a selfhosted (bring-your-own) machine", () => {
@@ -880,6 +903,13 @@ describe("runtime event normalization", () => {
     expect(String(calls[0]?.cmd).indexOf("export OPENGENI_GIT_TOKEN_SEED=")).toBeLessThan(
       String(calls[0]?.cmd).indexOf("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\""),
     );
+    // TOKEN-BROKER (B2): the SAME per-exec command also provisions an EXECUTABLE git
+    // askpass into $GIT_ASKPASS whose Password branch reads the token file — so a warm
+    // box on ANY image gets a correct askpass at setup, no baked script required.
+    const cmd = String(calls[0]?.cmd);
+    expect(cmd).toContain("cat > \"$git_askpass\" <<'ASKPASS_EOF'");
+    expect(cmd).toContain("chmod 0755 \"$git_askpass\"");
+    expect(cmd).toContain("*Password*) cat \"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\" 2>/dev/null || printf '\\n' ;;");
   });
 
   test("TOKEN-BROKER (B1): with NO seed the clone hook command is byte-for-byte the un-prefixed clone (no-op on selfhosted)", async () => {


### PR DESCRIPTION
Fixes the sandbox manifest-immutability failure class (three stacked bugs behind "the geni agent broke"). Verified: `bun run typecheck` clean (all packages); **117 tests pass / 0 fail** (parity, askpass, machine-primary, resume, runtime, db-lease incl. 5 new B3 cases). **Not Modal/e2e-verified — see the merge gate below.**

## B1 — token-broker (Modal-only; no-op on connected machines)
The run-scoped ~1h GitHub token was baked into the immutable sandbox **manifest env** (`GH_TOKEN`/`GITHUB_TOKEN`/`GIT_CONFIG_*` extraheader). On a warm-box **crash-resume** the token is re-minted ≠ the baked one → `validateNoEnvironmentDelta` throws → the session is **permanently wedged** (and any turn > ~1h hits token expiry). Fix: evict the token value from the manifest; git auth flows through `GIT_ASKPASS` → a **file** (`$OPENGENI_GIT_TOKEN_FILE`, default `$HOME/.opengeni/git-token`); the token is minted once/turn and **seeded to the file at clone** (off-manifest, via the clone exec's command text); a new **`github_token` MCP tool** lets the agent re-mint + overwrite the file when it expires. The manifest carries only stable pointers (path + `GIT_ASKPASS` + identity), so the per-turn env delta stays empty even as the token rotates.

## B3 — image is shared state (Modal warm-box only)
A pack-image bump left a warm box on the old image (silent skew; no guard). Add nullable `image` to `sandbox_leases`; stamp on cold-create; on warm re-attach with a different image → **recreate** (solo box) or **`SandboxImageConflictError`** 422 (other holders). No-op on selfhosted.

## B2 — share-safe `session_create` tool description
The `sandbox` param had **no `.describe()`** (the framing was a code comment the model never sees). Add one: SHARE is the safe default, **env vars are per-exec — not a reason to split**, use `new` for a genuinely different filesystem, "a shared box requires the same image; a conflicting image is rejected." **Grouping logic unchanged** (env-blind is correct).

## ⚠ MERGE GATE — do NOT merge without these
1. **Real-Modal-box e2e:** B1 removes the `GIT_CONFIG` extraheader (today's *primary* auth vector); git now depends entirely on `GIT_ASKPASS`→file. Confirm on a live Modal box that clone/fetch/push actually authenticate via the seeded file (I could not exercise a live box here).
2. **Sandbox-image rebuild + rollout ordering:** `docker/opengeni-git-askpass` changed (now reads the file, not env). It's baked into `sandbox.Dockerfile`/`desktop.Dockerfile`. The rebuilt sandbox image MUST ship with/before the worker change — if the worker drops the token while boxes still run the old (env-reading) askpass, git breaks. Rebuild + roll the box image together.

## Deviation from spec
Seed passed via an ephemeral `export OPENGENI_GIT_TOKEN_SEED=...` prefix on the clone exec's **command text** (not an exec `environment` option — `@openai/agents-core` 0.11.6 `ExecCommandArgs` has no such field). Same intent: per-exec, off-manifest, `validateNoEnvironmentDelta`-safe.

Part of the sandbox/manifest plan (A1 pack fleet-upgrade already merged+deployed in geni #58). Order was B1→B3→B2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes critical git auth path (extraheader removed) and shared-sandbox lease behavior; requires coordinated sandbox image rollout and Modal e2e verification per the PR merge gate.
> 
> **Overview**
> Fixes warm-box **manifest env delta** failures and long-turn git expiry by **moving the rotating GitHub App token off the sandbox manifest** and into a stable **token file** read via `GIT_ASKPASS`.
> 
> **B1 — token-broker:** `sandboxEnvironmentForRun` now returns stable manifest env plus a once-per-turn `gitToken` (no `GH_TOKEN` / `GIT_CONFIG` extraheader). The worker passes `gitTokenSeed` into `buildAgent`; the clone hook seeds `OPENGENI_GIT_TOKEN_FILE` and provisions a per-box askpass script before fetch. `stableSandboxEnvironmentForRun` adds `OPENGENI_GIT_TOKEN_FILE` for attach/turn parity. `docker/opengeni-git-askpass` reads the file. New MCP **`github_token`** (session-scoped, `github:use`) re-mints for mid-turn refresh.
> 
> **B3 — image on shared boxes:** Nullable `sandbox_leases.image`, stamped on cold-create; `acquireLease` conflicts on mismatched image when other holders exist (`SandboxImageConflictError`), or solo-recreates on a new image. Worker threads resolved Modal/docker image through `resumeBoxForTurn`.
> 
> **B2:** `session_create` **`sandbox`** param gets a `.describe()` visible to agents (share default, per-exec env, image conflict).
> 
> Tests cover askpass, env parity, lease B3 cases, and clone seed wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0fc4131b1bb2bfd17dec6aeb841a2b0b0b073b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->