### PR TITLE
fix(codex): emit function apply_patch on the ChatGPT backend (hosted tool rejected)

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1092,6 +1092,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             hostedWebSearch: resolvedModel.configured.hostedWebSearch,
             encryptedReasoning: resolvedModel.provider.api === "responses" && runSettings.openaiReasoningEncryptedContent,
             contextWindowTokens: resolvedModel.configured.contextWindowTokens ?? runSettings.contextWindowTokens,
+            // The ChatGPT/Codex backend rejects the SDK's HOSTED sandbox tools —
+            // the `apply_patch` tool type ("Unsupported tool type: apply_patch")
+            // and structured tool output — which the OpenAIResponsesModel the SDK
+            // binds would otherwise select. Tell buildAgent to emit the function
+            // `apply_patch` + text `view_image` variants the backend accepts. Only
+            // the codex-subscription provider needs this; every other backend
+            // (built-in OpenAI/Azure = real hosted support; registry "chat"
+            // providers = the SDK's own ChatCompletions detection) keeps the SDK
+            // default.
+            structuredToolTransport: resolvedModel.provider.kind !== "codex-subscription",
           }
           : {}),
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -625,10 +625,23 @@ export type BuildAgentOptions = {
   // - contextWindowTokens: the model's effective window, used to derive the
   //   server-path compaction threshold. A registry model can declare its own
   //   (e.g. GLM 5.2's 1,048,576). Default: settings.contextWindowTokens.
+  // - structuredToolTransport: whether the backend supports the Responses
+  //   STRUCTURED/HOSTED sandbox-tool transport — the hosted `apply_patch` tool
+  //   type and structured `view_image` output. The SDK's sandbox capabilities
+  //   pick hosted-vs-function purely from the bound model instance's constructor
+  //   name (supportsApplyPatchTransport / supportsStructuredToolOutputTransport).
+  //   Our codex turns run the OpenAIResponsesModel — which the SDK reads as
+  //   hosted-capable — but route it to the ChatGPT/Codex backend, which REJECTS
+  //   the hosted `apply_patch` type ("Unsupported tool type: apply_patch",
+  //   verified live). Set false for that backend so filesystem emits the
+  //   function `apply_patch` + text `view_image` variants it accepts. Default
+  //   true (let the SDK decide from the model instance) — non-codex paths are
+  //   byte-for-byte unchanged.
   compactionMode?: ContextCompactionMode;
   hostedWebSearch?: boolean;
   encryptedReasoning?: boolean;
   contextWindowTokens?: number;
+  structuredToolTransport?: boolean;
   sandboxEnvironment?: Record<string, string>;
   // The EFFECTIVE/active compute backend for this turn. `settings.sandboxBackend`
   // is the session's HOME backend (the default cloud group box it was created
@@ -819,11 +832,33 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     ...baseConfig,
     defaultManifest: buildManifest(settings, resources, options.sandboxEnvironment, options.fileResourceDownloads),
     ...(runAs ? { runAs } : {}),
-    capabilities: buildAgentCapabilities(settings, options.packSkills ?? [], { compactionMode, contextWindowTokens }),
+    capabilities: buildAgentCapabilities(settings, options.packSkills ?? [], {
+      compactionMode,
+      contextWindowTokens,
+      ...(options.structuredToolTransport !== undefined ? { structuredToolTransport: options.structuredToolTransport } : {}),
+    }),
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
   agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources, options.activeSandboxBackend));
   return agent;
+}
+
+/**
+ * Force a sandbox capability to emit its FUNCTION-transport tool variants instead
+ * of the hosted ones, by dropping the model instance the SDK's transport
+ * detection keys off. See {@link buildAgentCapabilities} for why (codex routes the
+ * OpenAIResponsesModel to the ChatGPT backend, which rejects the hosted
+ * `apply_patch` tool type). The SDK reads hosted-vs-function ONLY from
+ * `_modelInstance` (set via `bindModel`); overriding `bindModel` to discard the
+ * instance leaves `_modelInstance` undefined, so `supportsApplyPatchTransport` /
+ * `supportsStructuredToolOutputTransport` return false and `tools()` emits the
+ * function `apply_patch` + text `view_image`. `bindModel` still returns the
+ * capability so the SDK's bind chain (`.bind().bindRunAs().bindModel()`) is
+ * preserved.
+ */
+function neutralizeStructuredToolTransport(capability: ReturnType<typeof filesystem>): void {
+  const bindModel = capability.bindModel.bind(capability);
+  capability.bindModel = (model: string) => bindModel(model, undefined);
 }
 
 /**
@@ -853,11 +888,24 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
 export function buildAgentCapabilities(
   settings: Settings,
   packSkills: PackSkill[],
-  options: { compactionMode?: ContextCompactionMode; contextWindowTokens?: number } = {},
+  options: { compactionMode?: ContextCompactionMode; contextWindowTokens?: number; structuredToolTransport?: boolean } = {},
 ): ReturnType<typeof Capabilities.default> {
   const mode = options.compactionMode ?? resolveContextCompactionMode(settings);
   const contextWindowTokens = options.contextWindowTokens ?? settings.contextWindowTokens;
-  const caps: ReturnType<typeof Capabilities.default> = [filesystem(), shell()];
+  // The `filesystem()` capability picks hosted-vs-function tool variants from the
+  // bound model instance (supportsApplyPatchTransport / structured tool output).
+  // When the caller declares the backend does NOT support that structured/hosted
+  // transport (codex → the ChatGPT backend rejects the hosted `apply_patch` type),
+  // neutralize this capability's model binding so tools() falls to the function
+  // `apply_patch` + text `view_image` variants the backend accepts — the SDK
+  // handles their function_call round-trip natively, so no reimplementation.
+  // Scoped to filesystem: shell() (always function tools) and compaction() (a
+  // sampling param, dropped by the codex normalizer) are untouched.
+  const filesystemCapability = filesystem();
+  if (options.structuredToolTransport === false) {
+    neutralizeStructuredToolTransport(filesystemCapability);
+  }
+  const caps: ReturnType<typeof Capabilities.default> = [filesystemCapability, shell()];
   if (mode === "server") {
     caps.push(compaction({ policy: new StaticCompactionPolicy(contextServerCompactThreshold({ ...settings, contextWindowTokens })) }));
   }

--- a/packages/runtime/test/codex-hosted-apply-patch.test.ts
+++ b/packages/runtime/test/codex-hosted-apply-patch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import { buildAgentCapabilities } from "../src/index";
+
+// The ChatGPT/Codex backend rejects the SDK's HOSTED `apply_patch` tool type
+// ("Unsupported tool type: apply_patch", verified live) — but our codex turns run
+// the OpenAIResponsesModel, which the SDK's transport detection
+// (supportsApplyPatchTransport, keyed off the bound model instance's constructor
+// name) reads as hosted-capable. buildAgent threads `structuredToolTransport:
+// false` on the codex path so the filesystem capability falls to the FUNCTION
+// `apply_patch` the backend accepts. These tests lock that behaviour in AND
+// guard that every other backend keeps the SDK default (hosted), by inspecting
+// the exact tool the filesystem capability emits once a Responses-style model is
+// bound.
+
+// A model instance the SDK reads as hosted-transport-capable: its constructor
+// name does NOT contain "ChatCompletions" (so supportsApplyPatchTransport → true,
+// exactly like the real OpenAIResponsesModel our codex turns bind).
+class OpenAIResponsesModel {}
+
+/** Bind a stub sandbox session + a Responses-style model and return the emitted apply_patch tool's `type`. */
+function filesystemApplyPatchToolType(options: Parameters<typeof buildAgentCapabilities>[2]): string | undefined {
+  const caps = buildAgentCapabilities(testSettings({ sandboxBackend: "docker" }), [], options);
+  const filesystemCap = caps.find((cap) => (cap as { type?: unknown }).type === "filesystem") as {
+    bind: (session: unknown) => { bindRunAs: (r?: unknown) => { bindModel: (m: string, i?: unknown) => unknown } };
+    tools: () => Array<{ type?: string; name?: string }>;
+  };
+  // filesystem.tools() only needs createEditor() (truthy) at build time; viewImage
+  // is referenced lazily by the view_image tool's execute, never invoked here.
+  const stubSession = { createEditor: () => ({}), viewImage: async () => "img" };
+  filesystemCap.bind(stubSession).bindRunAs(undefined).bindModel("gpt-5.5", new OpenAIResponsesModel());
+  return filesystemCap.tools().find((tool) => tool.name === "apply_patch")?.type;
+}
+
+describe("codex hosted-tool transport: apply_patch", () => {
+  test("default (structuredToolTransport unset): a Responses model gets the HOSTED apply_patch — non-codex byte-for-byte unchanged", () => {
+    expect(filesystemApplyPatchToolType({})).toBe("apply_patch");
+  });
+
+  test("structuredToolTransport:true is the same as the default (explicit opt-in to the SDK default)", () => {
+    expect(filesystemApplyPatchToolType({ structuredToolTransport: true })).toBe("apply_patch");
+  });
+
+  test("structuredToolTransport:false (codex path): filesystem emits the FUNCTION apply_patch the ChatGPT backend accepts", () => {
+    // Was "apply_patch" (hosted) → now "function": the SDK handles its
+    // function_call round-trip natively via the same editor, so execution is
+    // preserved while the wire tool becomes one the codex backend accepts.
+    expect(filesystemApplyPatchToolType({ structuredToolTransport: false })).toBe("function");
+  });
+});


### PR DESCRIPTION
## Symptom

Every Codex **sandbox** turn (e.g. modal) fails with **`400 status code (no body)`**. Retrying the same session on the platform `gpt-5.5` model succeeds. (Reported live on staging: session `220c33d0…` — turns 1 & 2 on `codex/gpt-5.5` failed, turn 3 on `gpt-5.5` completed.)

## Root cause (verified live against the ChatGPT backend)

The SDK's `filesystem()` sandbox capability emits the **hosted `apply_patch` tool** (`{type:'apply_patch'}`) whenever the bound model instance reports structured-tool transport — which `@openai/agents-core/sandbox/capabilities/transport` decides **purely from the model's constructor name** (`supportsApplyPatchTransport`/`supportsStructuredToolOutputTransport` → true unless the name contains `ChatCompletions`).

Our codex turns run the **`OpenAIResponsesModel`** (so the SDK reads "hosted-capable") but route it through `codexSubscriptionFetch` to the **ChatGPT/Codex backend**, which rejects that tool:

```
{"detail":"Unsupported tool type: apply_patch"}
```

The real OpenAI platform (Azure `gpt-5.5`) *does* accept it — which is exactly why the platform retry worked and only the Codex path is affected. Bisected live with a connected pro account:

| request | result |
|---|---|
| minimal, no tools | **200** |
| `+ {type:'apply_patch'}` (hosted) | **400 Unsupported tool type: apply_patch** |
| `+ function apply_patch` | **200** |
| `+ {type:'local_shell'}` (hosted) | 400 "no longer supported" — but `shell()` actually emits **function** `exec_command`/`write_stdin`, so not sent |
| full post-fix codex modal tool set (function apply_patch + exec_command + write_stdin + view_image + load_skill + set_session_title + web_search) | **200** |

## Fix

Thread a `structuredToolTransport` flag through `buildAgent` → `buildAgentCapabilities`. On the **codex-subscription provider** it is `false`, which neutralizes **only** the `filesystem()` capability's model binding (overriding `bindModel` to drop the model instance). With no model instance, the SDK's own detection returns false and `tools()` falls to the **function `apply_patch`** (+ text `view_image`) variants the backend accepts — and the SDK handles their `function_call` round-trip natively, so there's **no reimplementation** of the patch parser/applier.

- **Non-codex byte-for-byte unchanged:** every other backend keeps the SDK default — built-in OpenAI/Azure keep real hosted support; registry "chat" providers keep the SDK's own `ChatCompletions` detection. The flag defaults to "let the SDK decide".
- **Scoped to filesystem:** `shell()` (already function tools) and `compaction()` (a sampling param the codex normalizer drops) are untouched.

## Tests

`packages/runtime/test/codex-hosted-apply-patch.test.ts` — binds a Responses-style model to the **real SDK filesystem capability** and asserts: default/`true` → **hosted** `apply_patch` (non-codex unchanged); `structuredToolTransport:false` → **function** `apply_patch`.

Runtime suite green (133 pass incl. capabilities/sandbox-computer/runtime/model-providers); typecheck green (runtime, worker, config, codex, db).

## Known follow-up (separate, desktop-gated)

The hosted **computer-use** tool has no function fallback and would also be rejected by this backend; computer-use should be disabled on codex turns. Not addressed here (it's gated off by default and orthogonal to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool wiring on every codex-subscription turn; scope is narrow (filesystem capability only) and non-codex paths are intended to be byte-identical, with tests guarding regressions.
> 
> **Overview**
> **Fixes Codex sandbox turns failing with `400`** when the SDK registers hosted `apply_patch` tools that the ChatGPT/Codex API rejects (`Unsupported tool type: apply_patch`), while platform OpenAI/Azure paths still accept them.
> 
> Adds a **`structuredToolTransport`** option through `buildAgent` / `buildAgentCapabilities`. For **`codex-subscription`** turns the worker sets it to **`false`**, which only tweaks the **`filesystem()`** capability: `bindModel` no longer passes the model instance, so SDK transport detection falls back to **function `apply_patch`** and text **`view_image`** instead of hosted variants. **Other providers are unchanged** (flag omitted or `true`).
> 
> New tests in `codex-hosted-apply-patch.test.ts` lock default hosted vs codex function tool types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5b5652c64cd75b234d79e7dd6e1384b4fafd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->