### PR TITLE
feat(mcp): session_interrupt tool — agent-driven stop/steer of workspace sessions

### DIFF
--- a/.changeset/session-interrupt-timeline.md
+++ b/.changeset/session-interrupt-timeline.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Render `session_interrupt` as a distinct worker action in the timeline. When a manager agent stops or steers a session it spawned (the new first-party `session_interrupt` MCP tool), the projection now emits a dedicated `interrupt` worker item carrying the target `workerSessionId` and the `mode` (`"stop"` | `"steer"`), and the activity rail titles it accordingly ("Stopping worker" / "Steering worker" / "Worker stopped" / "Worker steered") instead of a generic tool-call row — matching the existing `spawn` / `message` worker rendering.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -683,7 +683,7 @@ function registerWorkspaceOrchestrationTools(
 
     server.registerTool("session_interrupt", {
       description:
-        "Interrupt a session in this workspace. mode='stop' (default) cancels the current turn AND pauses the session's active goal so it halts. mode='steer' cancels the current turn WITHOUT pausing the goal, so the session picks up its next queued turn — pair it with a preceding session_send_message to redirect a running session. Works whether the target is mid-turn or idle.",
+        "Interrupt a session in this workspace. mode='stop' (default) cancels the current turn AND pauses the session's active goal so it halts. mode='steer' cancels the current turn WITHOUT pausing the goal, so the session picks up its next queued turn (or, if nothing is queued, continues toward its active goal) — pair it with a preceding session_send_message to redirect a running session. Works whether the target is mid-turn or idle.",
       inputSchema: {
         sessionId: z4.string().uuid(),
         mode: z4.enum(["stop", "steer"]).optional(),

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -63,7 +63,7 @@ import {
   syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
 } from "../domain/scheduled-tasks";
-import { acceptSessionUserMessage, createSessionForRequest, updateSessionTitle } from "../domain/sessions";
+import { acceptSessionUserMessage, createSessionForRequest, updateSessionTitle, workflowIdForSession } from "../domain/sessions";
 import {
   buildFleetContextForSession,
   listFleet,
@@ -679,6 +679,33 @@ function registerWorkspaceOrchestrationTools(
         toolsProvided: false,
       });
       return json({ event: accepted, turnId: turn.id });
+    });
+
+    server.registerTool("session_interrupt", {
+      description:
+        "Interrupt a session in this workspace. mode='stop' (default) cancels the current turn AND pauses the session's active goal so it halts. mode='steer' cancels the current turn WITHOUT pausing the goal, so the session picks up its next queued turn — pair it with a preceding session_send_message to redirect a running session. Works whether the target is mid-turn or idle.",
+      inputSchema: {
+        sessionId: z4.string().uuid(),
+        mode: z4.enum(["stop", "steer"]).optional(),
+      },
+    }, async ({ sessionId, mode }) => {
+      await requireSession(deps.db, grant.workspaceId, sessionId);
+      const appended = await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [{
+        type: "user.interrupt",
+        payload: mode === "steer" ? { reason: "steer" } : {},
+      }]);
+      const accepted = appended[0];
+      if (!accepted) {
+        throw new Error("failed to append interrupt event");
+      }
+      await deps.workflowClient.signalInterrupt({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId,
+        eventId: accepted.id,
+        workflowId: workflowIdForSession(sessionId),
+      });
+      return json({ event: accepted });
     });
 
     server.registerTool("set_other_session_title", {

--- a/apps/api/test/session-interrupt-tool.test.ts
+++ b/apps/api/test/session-interrupt-tool.test.ts
@@ -3,10 +3,13 @@
 // keep goal → next queued turn runs) a workspace session it spawned.
 //
 // A mock-deps UNIT test (no live DB / Temporal): `@opengeni/db.requireSession`
-// and `@opengeni/events.appendAndPublishEvents` are module-mocked (spreading
-// the REAL module so every other export keeps working), and the workflow
-// client's `signalInterrupt` is a spy. That lets us build the real
-// `buildOpenGeniMcpServer` and drive the actual tool handler.
+// and `@opengeni/events.appendAndPublishEvents` are replaced with RESTORABLE
+// spies (spyOn + `mock.restore()` in afterAll), NOT a `mock.module` — the latter
+// is process-global and sticky in bun, so with no teardown it would leak these
+// mocked seams into every later test file in the suite. The workflow client's
+// `signalInterrupt` is a spy too. That lets us build the real
+// `buildOpenGeniMcpServer` and drive the actual tool handler, then tear the
+// spies back down before any other file runs.
 //
 // Proves:
 //   - REGISTRATION GATING: `session_interrupt` is registered iff the grant
@@ -15,12 +18,11 @@
 //     for mode:"steer" and {} otherwise, then signals the interrupt with the
 //     APPENDED event's id (mirroring the REST /events route).
 
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { testSettings } from "@opengeni/testing";
 import type { AccessGrant, Permission } from "@opengeni/contracts";
-import * as realDb from "@opengeni/db";
-import * as realEvents from "@opengeni/events";
+import * as dbMod from "@opengeni/db";
+import * as eventsMod from "@opengeni/events";
 import type { ApiRouteDeps } from "../src/dependencies";
 
 // ── recorded interactions of the mocked seams ────────────────────────────────
@@ -38,30 +40,31 @@ const APPENDED_EVENT_ID = "11111111-2222-4333-8444-555555555555";
 let buildOpenGeniMcpServer: (typeof import("../src/mcp/server"))["buildOpenGeniMcpServer"];
 
 beforeAll(async () => {
-  // Spread the REAL modules so only the two DB-touching seams are replaced;
-  // every other export server.ts (and its transitive deps) rely on is untouched.
-  mock.module("@opengeni/db", () => ({
-    ...realDb,
-    requireSession: async (_db: unknown, workspaceId: string, sessionId: string) => {
-      requireSessionCalls.push({ workspaceId, sessionId });
-      return { id: sessionId, workspaceId, status: "running" } as unknown as ReturnType<typeof realDb.requireSession>;
-    },
-  }));
-  mock.module("@opengeni/events", () => ({
-    ...realEvents,
-    appendAndPublishEvents: async (
-      _db: unknown,
-      _bus: unknown,
-      workspaceId: string,
-      sessionId: string,
-      events: Array<{ type: string; payload?: unknown }>,
-    ) => {
-      appendCalls.push({ workspaceId, sessionId, events });
-      // Return a persisted-event shape carrying the id the handler must reuse.
-      return [{ id: APPENDED_EVENT_ID, workspaceId, sessionId, sequence: 1, type: events[0]?.type, payload: events[0]?.payload ?? {}, occurredAt: new Date().toISOString() }] as unknown as Awaited<ReturnType<typeof realEvents.appendAndPublishEvents>>;
-    },
-  }));
+  // Replace ONLY the two DB-touching seams with restorable spies. spyOn patches
+  // the named export in place, so server.ts's `import { requireSession } from
+  // "@opengeni/db"` (a live binding) calls through the spy — every other export
+  // it and its transitive deps rely on is the real thing, untouched. Crucially,
+  // spyOn is fully reverted by `mock.restore()` (see afterAll), unlike the
+  // process-global, non-restoring `mock.module`.
+  spyOn(dbMod, "requireSession").mockImplementation(async (_db, workspaceId, sessionId) => {
+    requireSessionCalls.push({ workspaceId, sessionId });
+    return { id: sessionId, workspaceId, status: "running" } as unknown as Awaited<ReturnType<typeof dbMod.requireSession>>;
+  });
+  spyOn(eventsMod, "appendAndPublishEvents").mockImplementation(async (_db, _bus, workspaceId, sessionId, events) => {
+    appendCalls.push({ workspaceId, sessionId, events: events as AppendCall["events"] });
+    // Return a persisted-event shape carrying the id the handler must reuse.
+    return [{ id: APPENDED_EVENT_ID, workspaceId, sessionId, sequence: 1, type: events[0]?.type, payload: events[0]?.payload ?? {}, occurredAt: new Date().toISOString() }] as unknown as Awaited<ReturnType<typeof eventsMod.appendAndPublishEvents>>;
+  });
   ({ buildOpenGeniMcpServer } = await import("../src/mcp/server"));
+});
+
+afterAll(() => {
+  // Restore the real requireSession / appendAndPublishEvents BEFORE any other
+  // test file in the suite runs. This is the whole point of the fix: without it
+  // the mocked seams leak (a mocked appendAndPublishEvents that returns a single
+  // fake event breaks the real-DB sandbox integration tests with a 500 "failed
+  // to append initial user event").
+  mock.restore();
 });
 
 beforeEach(() => {

--- a/apps/api/test/session-interrupt-tool.test.ts
+++ b/apps/api/test/session-interrupt-tool.test.ts
@@ -1,0 +1,155 @@
+// session_interrupt — the first-party MCP tool that lets a manager holding
+// `sessions:control` STOP (cancel turn + pause goal) or STEER (cancel turn,
+// keep goal → next queued turn runs) a workspace session it spawned.
+//
+// A mock-deps UNIT test (no live DB / Temporal): `@opengeni/db.requireSession`
+// and `@opengeni/events.appendAndPublishEvents` are module-mocked (spreading
+// the REAL module so every other export keeps working), and the workflow
+// client's `signalInterrupt` is a spy. That lets us build the real
+// `buildOpenGeniMcpServer` and drive the actual tool handler.
+//
+// Proves:
+//   - REGISTRATION GATING: `session_interrupt` is registered iff the grant
+//     carries `sessions:control` (a `sessions:read`-only grant does not see it).
+//   - HANDLER: appends a `user.interrupt` event with payload {reason:"steer"}
+//     for mode:"steer" and {} otherwise, then signals the interrupt with the
+//     APPENDED event's id (mirroring the REST /events route).
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import type { AccessGrant, Permission } from "@opengeni/contracts";
+import * as realDb from "@opengeni/db";
+import * as realEvents from "@opengeni/events";
+import type { ApiRouteDeps } from "../src/dependencies";
+
+// ── recorded interactions of the mocked seams ────────────────────────────────
+type AppendCall = { workspaceId: string; sessionId: string; events: Array<{ type: string; payload?: unknown }> };
+type SignalCall = { accountId: string; workspaceId: string; sessionId: string; eventId: string; workflowId: string };
+
+const appendCalls: AppendCall[] = [];
+const requireSessionCalls: Array<{ workspaceId: string; sessionId: string }> = [];
+const signalCalls: SignalCall[] = [];
+
+// The id the mocked append hands back; the handler MUST thread exactly this into
+// signalInterrupt (never the incoming sessionId or a fresh id).
+const APPENDED_EVENT_ID = "11111111-2222-4333-8444-555555555555";
+
+let buildOpenGeniMcpServer: (typeof import("../src/mcp/server"))["buildOpenGeniMcpServer"];
+
+beforeAll(async () => {
+  // Spread the REAL modules so only the two DB-touching seams are replaced;
+  // every other export server.ts (and its transitive deps) rely on is untouched.
+  mock.module("@opengeni/db", () => ({
+    ...realDb,
+    requireSession: async (_db: unknown, workspaceId: string, sessionId: string) => {
+      requireSessionCalls.push({ workspaceId, sessionId });
+      return { id: sessionId, workspaceId, status: "running" } as unknown as ReturnType<typeof realDb.requireSession>;
+    },
+  }));
+  mock.module("@opengeni/events", () => ({
+    ...realEvents,
+    appendAndPublishEvents: async (
+      _db: unknown,
+      _bus: unknown,
+      workspaceId: string,
+      sessionId: string,
+      events: Array<{ type: string; payload?: unknown }>,
+    ) => {
+      appendCalls.push({ workspaceId, sessionId, events });
+      // Return a persisted-event shape carrying the id the handler must reuse.
+      return [{ id: APPENDED_EVENT_ID, workspaceId, sessionId, sequence: 1, type: events[0]?.type, payload: events[0]?.payload ?? {}, occurredAt: new Date().toISOString() }] as unknown as Awaited<ReturnType<typeof realEvents.appendAndPublishEvents>>;
+    },
+  }));
+  ({ buildOpenGeniMcpServer } = await import("../src/mcp/server"));
+});
+
+beforeEach(() => {
+  appendCalls.length = 0;
+  requireSessionCalls.length = 0;
+  signalCalls.length = 0;
+});
+
+const WORKSPACE_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const ACCOUNT_ID = "99999999-8888-4777-8666-555555555555";
+const TARGET_SESSION_ID = "12121212-3434-4565-8787-909090909090";
+
+function grantWith(permissions: Permission[]): AccessGrant {
+  return {
+    workspaceId: WORKSPACE_ID,
+    accountId: ACCOUNT_ID,
+    subjectId: "manager-session",
+    permissions,
+    // No sessionId claim → set_session_title / goal / fleet tools stay off; we
+    // exercise the workspace-orchestration surface only.
+    metadata: {},
+  };
+}
+
+function depsWithSignalSpy(): ApiRouteDeps {
+  const workflowClient = {
+    signalInterrupt: async (input: SignalCall) => {
+      signalCalls.push(input);
+    },
+  };
+  return {
+    settings: testSettings({ productAccessMode: "managed" }),
+    db: {} as unknown,
+    bus: {} as unknown,
+    workflowClient,
+    objectStorage: undefined,
+  } as unknown as ApiRouteDeps;
+}
+
+/** The SDK stores tools in a private `_registeredTools` map keyed by name. */
+function registeredTools(server: unknown): Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }> {
+  return (server as { _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }> })._registeredTools;
+}
+
+describe("session_interrupt registration gating", () => {
+  test("is registered when the grant carries sessions:control", () => {
+    const server = buildOpenGeniMcpServer(depsWithSignalSpy(), grantWith(["sessions:control"]));
+    expect(registeredTools(server)["session_interrupt"]).toBeDefined();
+    // Sanity: its sibling under the same gate is present too.
+    expect(registeredTools(server)["session_send_message"]).toBeDefined();
+  });
+
+  test("is NOT registered when the grant lacks sessions:control", () => {
+    const server = buildOpenGeniMcpServer(depsWithSignalSpy(), grantWith(["sessions:read"]));
+    expect(registeredTools(server)["session_interrupt"]).toBeUndefined();
+    // The read-only grant still sees its own tools — proving the gap is
+    // specifically the sessions:control gate, not an empty server.
+    expect(registeredTools(server)["sessions_list"]).toBeDefined();
+  });
+});
+
+describe("session_interrupt handler", () => {
+  test("mode:'steer' appends {reason:'steer'} and signals with the appended event id", async () => {
+    const server = buildOpenGeniMcpServer(depsWithSignalSpy(), grantWith(["sessions:control"]));
+    await registeredTools(server)["session_interrupt"]!.handler({ sessionId: TARGET_SESSION_ID, mode: "steer" }, {});
+
+    expect(requireSessionCalls).toEqual([{ workspaceId: WORKSPACE_ID, sessionId: TARGET_SESSION_ID }]);
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.sessionId).toBe(TARGET_SESSION_ID);
+    expect(appendCalls[0]!.events).toEqual([{ type: "user.interrupt", payload: { reason: "steer" } }]);
+
+    expect(signalCalls).toHaveLength(1);
+    expect(signalCalls[0]).toMatchObject({
+      accountId: ACCOUNT_ID,
+      workspaceId: WORKSPACE_ID,
+      sessionId: TARGET_SESSION_ID,
+      eventId: APPENDED_EVENT_ID,
+    });
+    expect(typeof signalCalls[0]!.workflowId).toBe("string");
+    expect(signalCalls[0]!.workflowId.length).toBeGreaterThan(0);
+  });
+
+  test("default mode (stop) appends an empty payload and still signals the interrupt", async () => {
+    const server = buildOpenGeniMcpServer(depsWithSignalSpy(), grantWith(["sessions:control"]));
+    await registeredTools(server)["session_interrupt"]!.handler({ sessionId: TARGET_SESSION_ID }, {});
+
+    expect(appendCalls[0]!.events).toEqual([{ type: "user.interrupt", payload: {} }]);
+    expect(signalCalls).toHaveLength(1);
+    expect(signalCalls[0]!.eventId).toBe(APPENDED_EVENT_ID);
+  });
+});

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -145,13 +145,19 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
           : cancelled
             ? "Worker interrupted"
             : "Worker spawned"
-      : running
-        ? "Messaging worker"
-        : failed
-          ? "Worker message failed"
-          : cancelled
-            ? "Worker interrupted"
-            : "Worker messaged";
+      : item.action === "interrupt"
+        ? (() => {
+            const verb = item.mode === "steer" ? "Steering" : "Stopping";
+            const done = item.mode === "steer" ? "Worker steered" : "Worker stopped";
+            return running ? `${verb} worker` : failed ? "Worker interrupt failed" : cancelled ? "Worker interrupted" : done;
+          })()
+        : running
+          ? "Messaging worker"
+          : failed
+            ? "Worker message failed"
+            : cancelled
+              ? "Worker interrupted"
+              : "Worker messaged";
   return (
     <div
       className={cn(

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -29,6 +29,7 @@ import type {
 /** Tool names on the first-party OpenGeni MCP server that operate on sessions. */
 const WORKER_SPAWN_TOOL = "session_create";
 const WORKER_MESSAGE_TOOL = "session_send_message";
+const WORKER_INTERRUPT_TOOL = "session_interrupt";
 
 export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   const items: TimelineItem[] = [];
@@ -159,6 +160,23 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         const callId = typeof payload.id === "string" ? payload.id : null;
         const args = payload.arguments ?? null;
         closeStreamingTail();
+        if (name === WORKER_INTERRUPT_TOOL) {
+          // stop (default) vs steer — the target keeps its goal on steer and
+          // picks up its next queued turn (pair with session_send_message).
+          items.push({
+            kind: "worker",
+            id: event.id,
+            turnId,
+            callId,
+            action: "interrupt",
+            prompt: null,
+            workerSessionId: extractSessionRef(args),
+            mode: workerInterruptMode(args),
+            status: "running",
+            occurredAt: event.occurredAt,
+          });
+          break;
+        }
         if (name === WORKER_SPAWN_TOOL || name === WORKER_MESSAGE_TOOL) {
           items.push({
             kind: "worker",
@@ -500,6 +518,12 @@ function workerPrompt(args: unknown): string | null {
     }
   }
   return null;
+}
+
+/** The interrupt mode from `session_interrupt` args; defaults to "stop". */
+function workerInterruptMode(args: unknown): "stop" | "steer" {
+  const record = asRecord(typeof args === "string" ? tryParseJson(args) : args);
+  return record.mode === "steer" ? "steer" : "stop";
 }
 
 /**

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -69,11 +69,16 @@ export type WorkerItem = {
   id: string;
   turnId: string | null;
   callId: string | null;
-  action: "spawn" | "message";
+  action: "spawn" | "message" | "interrupt";
   /** The worker's initial message / the message sent to it, when parseable. */
   prompt: string | null;
   /** The target/spawned worker session id, when parseable from args/output. */
   workerSessionId: string | null;
+  /**
+   * For an `interrupt` action, whether it stops the target (default) or steers
+   * it (cancel the current turn, keep the goal). Absent on spawn/message.
+   */
+  mode?: "stop" | "steer";
   status: "running" | "complete" | "failed" | "cancelled";
   occurredAt: string;
 };

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -208,6 +208,40 @@ describe("buildTimeline", () => {
     expect(item.prompt).toBe("Status?");
   });
 
+  test("session_interrupt becomes a distinct interrupt worker item (default stop mode)", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "session_interrupt",
+        arguments: { sessionId: "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d" },
+      }),
+    ]);
+    const item = items[0] as WorkerItem;
+    expect(item.kind).toBe("worker");
+    expect(item.action).toBe("interrupt");
+    expect(item.mode).toBe("stop");
+    expect(item.workerSessionId).toBe("7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d");
+    expect(item.status).toBe("running");
+  });
+
+  test("session_interrupt with mode 'steer' carries the steer mode and settles on its output", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "session_interrupt",
+        arguments: JSON.stringify({ sessionId: "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d", mode: "steer" }),
+      }),
+      event("agent.toolCall.output", { id: "call-1", output: { content: [{ type: "text", text: "{}" }] } }),
+    ]);
+    const item = items[0] as WorkerItem;
+    expect(item.action).toBe("interrupt");
+    expect(item.mode).toBe("steer");
+    expect(item.workerSessionId).toBe("7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d");
+    expect(item.status).toBe("complete");
+  });
+
   test("groups sandbox operations by name and appends command output deltas", () => {
     reset();
     const items = buildTimeline([


### PR DESCRIPTION
## What & why

A manager agent could already **spawn** (`session_create`) and **message** (`session_send_message`) another session in its workspace, but it had **no way to stop or steer** one it started. This adds the first-party MCP tool `session_interrupt` that closes that gap.

## Design — one tool, two modes, no plumbing changes

- **`mode='stop'` (default)** — appends a plain `user.interrupt` event and signals the workflow. The worker cancels the current turn **and pauses the session's active goal**, so it halts.
- **`mode='steer'`** — appends `user.interrupt` tagged `{reason:"steer"}`. The worker cancels the current turn but **keeps the goal**, so the session picks up its next queued turn. Paired with a preceding `session_send_message`, this redirects a running session — the same composition as the SDK's `OpenGeniClient.steerMessage`.

The interrupt machinery already existed (REST-only, on the `/events` route); this tool reuses that **exact** path — `appendAndPublishEvents` → `workflowClient.signalInterrupt({ accountId, workspaceId, sessionId, eventId, workflowId })` with `workflowIdForSession`. The stop-vs-steer distinction is read by the worker off `payload.reason` (`activities/goals.ts` `isSteerInterrupt`), so only the appended payload matters; the signal just carries the event id. **No workflow change, no contracts change.**

## Security

- Gated on the existing **`sessions:control`** permission (registered in the same block as `session_send_message` / `set_other_session_title`) — no new escalation surface.
- `requireSession` is **RLS-scoped** to the caller's workspace: a grant cannot interrupt a session outside its workspace.
- There is **no `parentSessionId` parameter** — nothing lets a caller target an arbitrary session's wake channel beyond what `sessions:control` already permits.

## UI projection parity (`@opengeni/react`)

A `session_interrupt` tool-call now projects to a **distinct `interrupt` worker item** (carrying `workerSessionId` + `mode`) rather than a generic tool row, and the activity rail titles it (Stopping/Steering worker, Worker stopped/steered) — mirroring the `spawn` / `message` branches. Covered by a changeset (minor `@opengeni/react`).

## Tests

- **`apps/api/test/session-interrupt-tool.test.ts`** (mock-deps unit, no live DB/Temporal): registration gating on `sessions:control`, and the handler appends `{reason:"steer"}` vs `{}` and signals with the **appended** event's id.
- **`packages/react/test/timeline.test.ts`**: two new projection cases (default stop + steer settle).
- Typecheck clean for `@opengeni/api` and `@opengeni/react`; full `@opengeni/react` suite green (353 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces agent-driven session control (cancel turns, pause goals on stop) on an existing permission gate; behavior depends on correct interrupt event payloads and workflow signaling, but no new auth surface beyond `sessions:control`.
> 
> **Overview**
> Adds first-party MCP tool **`session_interrupt`** so manager agents with **`sessions:control`** can stop or steer another workspace session. **`mode='stop'`** (default) appends `user.interrupt` with an empty payload; **`mode='steer'`** uses `{ reason: "steer" }`. The handler reuses the existing REST interrupt path: **`appendAndPublishEvents`** then **`workflowClient.signalInterrupt`** with the persisted event id and **`workflowIdForSession`**.
> 
> In **`@opengeni/react`**, **`session_interrupt`** tool calls project to a dedicated **`interrupt`** worker item (target **`workerSessionId`** + **`mode`**) instead of a generic tool row. The activity rail shows **Stopping/Steering worker** and **Worker stopped/steered**, aligned with spawn/message worker cards. Minor changeset for the package.
> 
> Unit tests cover MCP registration gating, steer vs stop payloads and signaling, and timeline projection for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526b15d762516c03429a5772b1224a524026b04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->