### PR TITLE
fix(codex): close two more ChatGPT-backend tool-surface incompatibilities (computer-use + connector name length)

### DIFF
--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -18,6 +18,7 @@
 //     wrapper) fails the turn. We drop any non-object outputSchema before the
 //     validator sees it — safe, as outputSchema is an advisory hint only.
 
+import { CODEX_APPS_MCP_SERVER_ID } from "./constants";
 import type { FetchLike } from "./fetch";
 
 const VALID_TOOL_NAME = /^[a-zA-Z0-9_-]+$/;
@@ -28,6 +29,18 @@ const VALID_TOOL_NAME = /^[a-zA-Z0-9_-]+$/;
 // length too — not just charset.
 const MAX_TOOL_NAME_LEN = 64;
 
+// CRITICAL: this sanitizer runs on the codex_apps tools/list wire BEFORE OpenGeni's
+// PrefixedMcpServer (packages/runtime) prepends `<serverId>__` to every tool name
+// (prefixedMcpToolName). The 64-char limit applies to that FINAL prefixed name the
+// model sees, so a name we cap at 64 here becomes 64 + 12 = 76 after prefixing and
+// 400s the whole turn. Reserve the runtime prefix so `codex_apps__<sanitized>` is
+// always <= 64. The sanitizer owns the server id, so the reservation is exact and
+// stays self-contained (no runtime import). The reverse mapping is unaffected: the
+// mapper is keyed on the pre-prefix sanitized name, which is what tools/call carries
+// back after PrefixedMcpServer strips its prefix.
+const RUNTIME_TOOL_NAME_PREFIX_LEN = CODEX_APPS_MCP_SERVER_ID.length + "__".length; // `codex_apps__` = 12
+const EFFECTIVE_MAX_TOOL_NAME_LEN = MAX_TOOL_NAME_LEN - RUNTIME_TOOL_NAME_PREFIX_LEN; // 52
+
 /** Short, stable, charset-legal hash of a string (djb2 → base36). Deterministic. */
 function shortHash(input: string): string {
   let h = 5381;
@@ -37,13 +50,13 @@ function shortHash(input: string): string {
   return h.toString(36);
 }
 
-/** Truncate to <= MAX_TOOL_NAME_LEN, appending `_<hash(original)>` so the result stays unique + deterministic. */
+/** Truncate to <= EFFECTIVE_MAX_TOOL_NAME_LEN (reserving the runtime prefix), appending `_<hash(original)>` so the result stays unique + deterministic. */
 function capLength(candidate: string, original: string): string {
-  if (candidate.length <= MAX_TOOL_NAME_LEN) {
+  if (candidate.length <= EFFECTIVE_MAX_TOOL_NAME_LEN) {
     return candidate;
   }
   const suffix = `_${shortHash(original)}`;
-  return candidate.slice(0, Math.max(0, MAX_TOOL_NAME_LEN - suffix.length)) + suffix;
+  return candidate.slice(0, Math.max(0, EFFECTIVE_MAX_TOOL_NAME_LEN - suffix.length)) + suffix;
 }
 
 /**
@@ -55,7 +68,7 @@ export class ToolNameMapper {
   private readonly sanitizedToOriginal = new Map<string, string>();
   private readonly used = new Set<string>();
 
-  /** Return a legal, unique name (<= 64 chars) for `original`, recording the reverse mapping. */
+  /** Return a legal, unique name (<= EFFECTIVE_MAX_TOOL_NAME_LEN, so `<prefix>__name` <= 64) for `original`, recording the reverse mapping. */
   sanitize(original: string): string {
     let candidate = VALID_TOOL_NAME.test(original)
       ? original
@@ -66,14 +79,14 @@ export class ToolNameMapper {
     candidate = capLength(candidate, original);
     // Disambiguate a genuine collision with a DIFFERENT original (never with
     // the same original — that keeps repeat listings stable/idempotent). Re-cap
-    // after each suffix so disambiguation never re-breaches the 64-char limit.
+    // after each suffix so disambiguation never re-breaches the effective limit.
     if (this.used.has(candidate) && this.sanitizedToOriginal.get(candidate) !== original) {
       const base = candidate;
       let n = 2;
       do {
         const suffix = `_${n++}`;
-        candidate = (base.length + suffix.length > MAX_TOOL_NAME_LEN
-          ? base.slice(0, MAX_TOOL_NAME_LEN - suffix.length)
+        candidate = (base.length + suffix.length > EFFECTIVE_MAX_TOOL_NAME_LEN
+          ? base.slice(0, EFFECTIVE_MAX_TOOL_NAME_LEN - suffix.length)
           : base) + suffix;
       } while (this.used.has(candidate));
     }

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -41,32 +41,51 @@ describe("ToolNameMapper", () => {
     expect(m.toOriginal(b)).toBe("x_y");
   });
 
-  test("P2-d: caps a >64-char name to <=64 with a stable hash suffix, reverse-mappable", () => {
+  // The runtime PrefixedMcpServer prepends `codex_apps__` (12) to the sanitized
+  // name; the Responses-API 64-char limit applies to THAT final name. So the real
+  // invariant is `("codex_apps__" + out).length <= 64`, i.e. out <= 52.
+  const CODEX_APPS_PREFIX = "codex_apps__";
+  const prefixed = (name: string) => `${CODEX_APPS_PREFIX}${name}`;
+
+  test("P2-d: caps a >64-char name so the PREFIXED name stays <=64, with a stable hash suffix, reverse-mappable", () => {
     const m = new ToolNameMapper();
     const long = `connector.${"deploy_a_very_long_namespaced_tool_name_that_blows_the_limit".repeat(2)}`;
     expect(long.length).toBeGreaterThan(64);
     const out = m.sanitize(long);
-    expect(out.length).toBeLessThanOrEqual(64);
+    expect(prefixed(out).length).toBeLessThanOrEqual(64); // the FINAL name the model sees
     expect(out).toMatch(/^[a-zA-Z0-9_-]+$/); // still charset-legal
     expect(m.toOriginal(out)).toBe(long); // reverse map keyed on the EMITTED name
   });
 
-  test("P2-d: the 64-char cap is deterministic across repeat listings (idempotent)", () => {
+  test("P2-d: the length cap is deterministic across repeat listings (idempotent)", () => {
     const m = new ToolNameMapper();
     const long = "ns." + "x".repeat(80);
     expect(m.sanitize(long)).toBe(m.sanitize(long));
   });
 
-  test("P2-d: two distinct long names that truncate alike stay distinct + <=64", () => {
+  test("P2-d: two distinct long names that truncate alike stay distinct + prefixed <=64", () => {
     const m = new ToolNameMapper();
     const base = "ns." + "y".repeat(80);
     const a = m.sanitize(`${base}_alpha`);
     const b = m.sanitize(`${base}_beta`);
     expect(a).not.toBe(b);
-    expect(a.length).toBeLessThanOrEqual(64);
-    expect(b.length).toBeLessThanOrEqual(64);
+    expect(prefixed(a).length).toBeLessThanOrEqual(64);
+    expect(prefixed(b).length).toBeLessThanOrEqual(64);
     expect(m.toOriginal(a)).toBe(`${base}_alpha`);
     expect(m.toOriginal(b)).toBe(`${base}_beta`);
+  });
+
+  test("reserves the runtime prefix: a 53–64 char name (passes the raw 64 cap) is capped so codex_apps__<name> <= 64", () => {
+    const m = new ToolNameMapper();
+    // 60 chars, already charset-legal — under the raw 64 cap, but 60 + 12 = 72 > 64
+    // would 400 the whole turn once PrefixedMcpServer prepends the namespace.
+    const name60 = "a".repeat(60);
+    expect(name60.length).toBeGreaterThan(52);
+    expect(name60.length).toBeLessThanOrEqual(64);
+    const out = m.sanitize(name60);
+    expect(prefixed(out).length).toBeLessThanOrEqual(64); // the regression: was 72
+    expect(out).toMatch(/^[a-zA-Z0-9_-]+$/);
+    expect(m.toOriginal(out)).toBe(name60); // reverse mapping intact after the cap
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -922,6 +922,13 @@ export function buildAgentCapabilities(
     settings.computerUseEnabled
     && settings.sandboxDesktopEnabled
     && desktopCapableBackend(settings.sandboxBackend)
+    // computer-use emits a HOSTED `computer`/`computer_use_preview` tool with NO
+    // function-transport fallback. The ChatGPT/Codex backend rejects hosted tool
+    // types (only function/custom/web_search are accepted), so on the codex path
+    // (structuredToolTransport === false) attaching it would 400 the ENTIRE turn.
+    // Suppress it there — driving the desktop via the agent is simply unavailable
+    // on that backend; every other backend keeps the desktop tier.
+    && options.structuredToolTransport !== false
   ) {
     caps.push(computerUse({
       dimensions: [settings.streamResolutionWidth, settings.streamResolutionHeight],

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -276,4 +276,16 @@ describe("buildAgentCapabilities computer-use gating (P4.3)", () => {
     const t = types(testSettings({ sandboxBackend: "none", sandboxDesktopEnabled: true, computerUseEnabled: true }));
     expect(t).not.toContain("computer-use");
   });
+
+  test("codex path (structuredToolTransport:false): NO computer-use even with desktop fully on — the hosted computer tool has no function fallback and would 400 the whole turn", () => {
+    const desktopOn = testSettings({ sandboxBackend: "modal", sandboxDesktopEnabled: true, computerUseEnabled: true });
+    // Same settings that DO attach computer-use on every other backend...
+    expect(buildAgentCapabilities(desktopOn, []).map((c) => (c as { type?: string }).type)).toContain("computer-use");
+    // ...are suppressed on the codex backend, which rejects the hosted computer tool.
+    const onCodex = buildAgentCapabilities(desktopOn, [], { structuredToolTransport: false }).map((c) => (c as { type?: string }).type);
+    expect(onCodex).not.toContain("computer-use");
+    // filesystem/shell/skills still present — only the unsupported hosted tool is dropped.
+    expect(onCodex).toContain("filesystem");
+    expect(onCodex).toContain("shell");
+  });
 });


### PR DESCRIPTION
Follow-up to #159 (hosted `apply_patch`), from an **adversarial audit** of the full codex-turn tool surface against the live backend accept/reject matrix. Two real latent 400s — both fail the **whole turn** — neither converted/dropped before:

### 1. computer-use hosted tool (gated, but a total-turn 400 when enabled)
`computerUse()` emits a hosted `computer`/`computer_use_preview` tool with **no function fallback**. It's gated behind the desktop tier (`sandboxDesktopEnabled`, default **off**), so it doesn't hit a default turn — but the moment an operator enables desktop on a codex workspace, **every** codex turn 400s "Unsupported tool type". The #159 fix only rebinds the *filesystem* capability; the computer-use branch is independent.

**Fix:** gate the `computerUse()` push on `structuredToolTransport !== false`, so codex never emits it (driving the desktop via the agent is simply unavailable on that backend). Every other backend keeps the desktop tier.

### 2. codex_apps connector tool names > 64 chars
`mcp-sanitize` capped connector tool names at 64 — but OpenGeni's `PrefixedMcpServer` then prepends `codex_apps__` (12 chars) **after** the cap → up to **76 chars** → exceeds the Responses-API 64-char limit → **400s the whole turn**. Reachable for any connected account whose connector exposes a ≥53-char sanitized tool name (codex_apps is injected for every active codex credential — no flag).

**Fix:** reserve the runtime prefix in the sanitizer — `EFFECTIVE_MAX_TOOL_NAME_LEN = 64 − len("codex_apps__") = 52` — computed from the server id the sanitizer already owns (self-contained, no runtime import). The reverse (`tools/call`) mapping is unaffected: it's keyed on the pre-prefix sanitized name.

### Tests
- `sandbox-computer` — the codex path drops computer-use while every other backend keeps it (same desktop-on settings).
- `mcp-sanitize` — the **prefixed** name (`codex_apps__<name>`) stays ≤ 64, incl. a 53–64-char name that passed the old raw cap but would 400 after prefixing.
- Typecheck green (runtime, codex, worker); codex 83 pass, runtime 172 pass.

The audit also **verified the #159 fix's execution round-trip is clean** — `view_image` text-transport and encrypted-reasoning round-trip both refuted as breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes codex turn tool registration and MCP name sanitization on a critical path; mistakes could drop tools or break connector calls, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes two ChatGPT/Codex backend incompatibilities that **400 the entire turn** when triggered.
> 
> **Connector tool names:** `mcp-sanitize` now caps sanitized `codex_apps` names at **52** characters (not 64), reserving space for runtime `PrefixedMcpServer`’s `codex_apps__` prefix so the **final** tool name the model sees stays within the Responses API 64-character limit. Reverse `tools/call` mapping is unchanged.
> 
> **Computer-use:** When `structuredToolTransport === false` (codex path), `buildAgentCapabilities` no longer attaches **computer-use**—the hosted `computer` tool has no function fallback and the backend rejects it, same pattern as the prior `apply_patch` fix. Other backends and capabilities (filesystem, shell, skills) are unchanged on codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e25f7da01867dc974d528542852d0489fd7f77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->