### PR TITLE
fix(codex): make the filesystem transport override clone-safe (regression from #159)

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -857,8 +857,20 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
  * preserved.
  */
 function neutralizeStructuredToolTransport(capability: ReturnType<typeof filesystem>): void {
-  const bindModel = capability.bindModel.bind(capability);
-  capability.bindModel = (model: string) => bindModel(model, undefined);
+  // Use `this` (NOT a captured reference to `capability`): the SandboxAgent binds
+  // via `cap.clone().bind(session).bindRunAs(runAs).bindModel(model, instance)` and
+  // runs tools() on the object the CHAIN returns. Capability.clone() copies this
+  // override onto the fresh per-run instance, so bindModel must operate on and
+  // RETURN `this` (the clone) — a version that mutated/returned the ORIGINAL
+  // capability leaves the clone (which .bind() set `_session` on) out of the chain,
+  // so tools() runs on the unbound original and throws "Filesystem capability is
+  // not bound to a SandboxSession". Dropping the model instance is all we need:
+  // supportsApplyPatchTransport(undefined) is false → the function apply_patch.
+  const forceFunctionTransport = function (this: Record<string, unknown>): unknown {
+    this._modelInstance = undefined;
+    return this;
+  };
+  (capability as unknown as { bindModel: typeof forceFunctionTransport }).bindModel = forceFunctionTransport;
 }
 
 /**

--- a/packages/runtime/test/codex-hosted-apply-patch.test.ts
+++ b/packages/runtime/test/codex-hosted-apply-patch.test.ts
@@ -18,18 +18,30 @@ import { buildAgentCapabilities } from "../src/index";
 // exactly like the real OpenAIResponsesModel our codex turns bind).
 class OpenAIResponsesModel {}
 
-/** Bind a stub sandbox session + a Responses-style model and return the emitted apply_patch tool's `type`. */
+// The exact bind chain the SandboxAgent runs: clone() a fresh per-run instance,
+// then bind → bindRunAs → bindModel, and call tools() on the object the CHAIN
+// RETURNS (not the original). Exercising clone() + the chain return is essential:
+// a bindModel override that returns the wrong `this` leaves the cloned+bound
+// instance out of the chain and makes tools() throw "not bound to a SandboxSession"
+// (the live regression this test now guards).
+type BindableCap = {
+  clone: () => BindableCap;
+  bind: (session: unknown) => BindableCap;
+  bindRunAs: (r?: unknown) => BindableCap;
+  bindModel: (m: string, i?: unknown) => BindableCap;
+  tools: () => Array<{ type?: string; name?: string }>;
+};
+
+/** Bind a stub sandbox session + a Responses-style model the way SandboxAgent does, return the emitted apply_patch tool's `type`. */
 function filesystemApplyPatchToolType(options: Parameters<typeof buildAgentCapabilities>[2]): string | undefined {
   const caps = buildAgentCapabilities(testSettings({ sandboxBackend: "docker" }), [], options);
-  const filesystemCap = caps.find((cap) => (cap as { type?: unknown }).type === "filesystem") as {
-    bind: (session: unknown) => { bindRunAs: (r?: unknown) => { bindModel: (m: string, i?: unknown) => unknown } };
-    tools: () => Array<{ type?: string; name?: string }>;
-  };
+  const filesystemCap = caps.find((cap) => (cap as { type?: unknown }).type === "filesystem") as unknown as BindableCap;
   // filesystem.tools() only needs createEditor() (truthy) at build time; viewImage
   // is referenced lazily by the view_image tool's execute, never invoked here.
   const stubSession = { createEditor: () => ({}), viewImage: async () => "img" };
-  filesystemCap.bind(stubSession).bindRunAs(undefined).bindModel("gpt-5.5", new OpenAIResponsesModel());
-  return filesystemCap.tools().find((tool) => tool.name === "apply_patch")?.type;
+  // MUST use the chain's return value (the cloned+bound instance), exactly as the SDK does.
+  const bound = filesystemCap.clone().bind(stubSession).bindRunAs(undefined).bindModel("gpt-5.5", new OpenAIResponsesModel());
+  return bound.tools().find((tool) => tool.name === "apply_patch")?.type;
 }
 
 describe("codex hosted-tool transport: apply_patch", () => {


### PR DESCRIPTION
## Live regression (breaks every codex sandbox turn)

#159's `neutralizeStructuredToolTransport` broke **every** codex sandbox turn with **`Filesystem capability is not bound to a SandboxSession`** (observed live: session `4478525d…`).

## Cause

The SDK binds capabilities in `agentPreparation.js`:

```js
cloneSandboxCapabilities(caps).map((c) =>
  c.bind(session).bindRunAs(runAs).bindModel(model, instance))
```

It **clones** each capability, then uses the value the **bind chain returns**. The old override captured a reference to the *original* capability and returned it from `bindModel`, so `.map(...)` produced the unbound original instead of the cloned+bound instance → `tools()` ran on an object whose `_session` was never set → throw.

## Fix

The override now uses `this` — `this._modelInstance = undefined; return this` — a faithful drop-in for the real `bindModel` contract that differs only in dropping the model instance. It operates on and returns whatever instance the SDK binds (the clone), so `_session` (set by `.bind()`) stays on the object `tools()` runs on. `supportsApplyPatchTransport(undefined)` is still false → the function `apply_patch`.

## Why the test missed it (now fixed)

The unit test bound the capability **directly** (no `clone()`, and ignored the chain's return value). It now `clone()`s + uses the chain return exactly like the SandboxAgent — **verified to FAIL with the old override** (identical `not bound to a SandboxSession` error) and pass with the fix. Runtime suite 114 pass; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox capability binding on every Codex turn with `structuredToolTransport: false`; scope is narrow but failure mode previously broke all such turns.
> 
> **Overview**
> Fixes a regression where **every Codex sandbox turn** failed with **`Filesystem capability is not bound to a SandboxSession`**.
> 
> `neutralizeStructuredToolTransport` still forces function-style `apply_patch` by clearing `_modelInstance`, but **`bindModel` now uses `this` and returns `this`** instead of mutating/returning the original capability. SandboxAgent binds with **`clone().bind().bindRunAs().bindModel()`** and runs `tools()` on the chain’s return value; returning the uncloned object dropped the instance that actually had `_session` set.
> 
> The **`codex-hosted-apply-patch`** test now **`clone()`s**, follows the full bind chain, and calls **`tools()` on the bound clone**—matching production so the old wrong-`this` behavior fails the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f89f2040460a5810be565bcefb37bbea3c0435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->