### PR TITLE
fix(mcp): auto-attached capability MCP failure no longer kills the turn

### DIFF
--- a/apps/api/src/domain/resources.ts
+++ b/apps/api/src/domain/resources.ts
@@ -30,7 +30,11 @@ export function validateToolRefs(tools: ToolRef[], settings: Settings): ToolRef[
       continue;
     }
     selected.add(tool.id);
-    out.push(tool);
+    // Normalize to a bare, STRICT ref: a client-supplied `optional` flag is
+    // dropped so an EXPLICITLY-requested tool always fails the turn when its
+    // server is unavailable. `optional: true` is set only server-side, at the
+    // default-capability auto-attach seam (enabledCapabilityMcpToolRefs).
+    out.push({ kind: "mcp", id: tool.id });
   }
   return out;
 }
@@ -41,7 +45,11 @@ export function enabledCapabilityMcpToolRefs(settings: McpSettings, runtimeSetti
   const configuredIds = new Set(settings.mcpServers.map((server) => server.id));
   return runtimeSettings.mcpServers
     .filter((server) => !configuredIds.has(server.id))
-    .map((server) => ({ kind: "mcp", id: server.id }));
+    // AUTO-ATTACHED (workspace-default) capability servers are marked optional:
+    // one of them having a broken/expired credential must SKIP that server, not
+    // fail the whole turn before the model runs. The caller only reaches here
+    // when the request omitted `tools`; an explicit list is never defaulted.
+    .map((server) => ({ kind: "mcp", id: server.id, optional: true }));
 }
 
 export function withDefaultEnabledCapabilityMcpTools(tools: ToolRef[], settings: McpSettings, runtimeSettings: McpSettings): ToolRef[] {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -10,6 +10,7 @@ import {
   replaySessionEvents,
   routeLabel,
   validateGitHubRepositorySelectionShape,
+  validateToolRefs,
   withDefaultEnabledCapabilityMcpTools,
   workflowIdForSession,
 } from "../src/app";
@@ -66,8 +67,26 @@ describe("API helpers", () => {
       },
     )).toEqual([
       { kind: "mcp", id: "opengeni" },
-      { kind: "mcp", id: "cap-4fetch" },
+      // AUTO-ATTACHED capability MCPs carry optional:true so a broken/expired
+      // credential is non-fatal (skipped, turn proceeds) instead of failing the
+      // whole turn before the model runs.
+      { kind: "mcp", id: "cap-4fetch", optional: true },
     ]);
+  });
+
+  test("validateToolRefs strips a client-supplied optional flag (explicit tools stay strict)", () => {
+    const runtimeSettings = {
+      mcpServers: [
+        { id: "opengeni", url: "https://example.com/mcp", cacheToolsList: false },
+        { id: "cap-notebook", url: "https://example.com/notebook", cacheToolsList: false },
+      ],
+    };
+    // A client cannot smuggle optional:true onto an explicitly-requested tool to
+    // make it non-fatal; the normalized ref is a bare strict ref.
+    expect(validateToolRefs(
+      [{ kind: "mcp", id: "cap-notebook", optional: true }] as never,
+      runtimeSettings as never,
+    )).toEqual([{ kind: "mcp", id: "cap-notebook" }]);
   });
 
   test("maps scheduled task schedules into Temporal specs", () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1202,6 +1202,16 @@ export type DocumentSearchRequest = z.infer<typeof DocumentSearchRequest>;
 export const ToolRef = z.object({
   kind: z.literal("mcp"),
   id: z.string().min(1),
+  // Non-fatal-on-connect marker for an AUTO-ATTACHED (workspace-default)
+  // capability MCP server: when true, a connect / tools-list failure (e.g. an
+  // expired capability credential returning 401) must SKIP that server with a
+  // logged warning and let the turn proceed, rather than failing the whole
+  // turn before the model runs. Absent/false ⇒ STRICT: an unavailable server
+  // fails the turn (the contract for EXPLICITLY-requested tools). This flag is
+  // set server-side only, at the default-capability auto-attach seam; it is
+  // stripped from client-supplied tool refs so an explicit request always
+  // stays strict.
+  optional: z.boolean().optional(),
 });
 export type ToolRef = z.infer<typeof ToolRef>;
 
@@ -1213,17 +1223,26 @@ export class ResourceRefConflictError extends Error {
 }
 
 export function mergeToolRefs(existing: ToolRef[], additions: ToolRef[]): ToolRef[] {
-  const seen = new Set<string>();
-  const out: ToolRef[] = [];
+  const byKey = new Map<string, ToolRef>();
+  const order: string[] = [];
   for (const tool of [...existing, ...additions]) {
     const key = `${tool.kind}:${tool.id}`;
-    if (seen.has(key)) {
+    const prior = byKey.get(key);
+    if (!prior) {
+      byKey.set(key, tool);
+      order.push(key);
       continue;
     }
-    seen.add(key);
-    out.push(tool);
+    // Strict wins: if the same server appears both auto-attached (optional) and
+    // explicitly requested (non-optional), the explicit occurrence upgrades the
+    // merged ref to strict — a later explicit request of an already-defaulted
+    // capability MCP must still fail the turn when the server is unavailable.
+    if (prior.optional === true && tool.optional !== true) {
+      const { optional: _dropped, ...strict } = prior;
+      byKey.set(key, strict);
+    }
   }
-  return out;
+  return order.map((key) => byKey.get(key)!);
 }
 
 export function mergeResourceRefs(

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -16,6 +16,7 @@ import {
   DocumentSearchRequest,
   EnablePackRequest,
   MarketingDailyAnalysisTaskRequest,
+  mergeToolRefs,
   ResourceRef,
   SessionBusMessage,
   CLEARED_RUN_STATE_BLOB,
@@ -297,6 +298,26 @@ describe("contracts", () => {
     expect(() => CreateDocumentBaseRequest.parse({ name: "" })).toThrow();
     expect(() => AddDocumentRequest.parse({ fileId: "not-a-uuid" })).toThrow();
     expect(() => DocumentSearchRequest.parse({ query: "" })).toThrow();
+  });
+
+  test("mergeToolRefs: explicit (strict) beats auto-attached (optional) for the same server", () => {
+    // A capability that is both auto-attached (optional) at create AND later
+    // explicitly requested must end up STRICT — the explicit request wins so an
+    // unavailable server fails the turn, preserving the fail-loud contract.
+    expect(mergeToolRefs(
+      [{ kind: "mcp", id: "cap-notebook", optional: true }],
+      [{ kind: "mcp", id: "cap-notebook" }],
+    )).toEqual([{ kind: "mcp", id: "cap-notebook" }]);
+    // Order-independent: explicit first, optional second → still strict.
+    expect(mergeToolRefs(
+      [{ kind: "mcp", id: "cap-notebook" }],
+      [{ kind: "mcp", id: "cap-notebook", optional: true }],
+    )).toEqual([{ kind: "mcp", id: "cap-notebook" }]);
+    // Both optional → stays optional (non-fatal on connect).
+    expect(mergeToolRefs(
+      [{ kind: "mcp", id: "cap-notebook", optional: true }],
+      [{ kind: "mcp", id: "cap-notebook", optional: true }],
+    )).toEqual([{ kind: "mcp", id: "cap-notebook", optional: true }]);
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -998,14 +998,28 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
         clientSessionTimeoutSeconds: Math.ceil(config.timeoutMs / 1000),
       } : {}),
     }), config.id, config.allowedTools);
-    // codex_apps connector availability is RUNTIME-DISCOVERED: the device-code
-    // login may lack the connector scopes, and the backend can reject the bearer
-    // at the initialize/tools-list handshake. Connect it best-effort so a 401/403
-    // (or a missing/failed token) drops the server rather than failing the turn.
-    return { server, bestEffort: isCodexAppsMcpServer(config) };
+    // A server is connected BEST-EFFORT (a connect / tools-list failure drops
+    // it instead of failing the turn) in two cases:
+    //  - codex_apps: connector availability is RUNTIME-DISCOVERED — the
+    //    device-code login may lack the connector scopes, and the backend can
+    //    reject the bearer at the initialize/tools-list handshake, so a 401/403
+    //    (or a missing/failed token) drops the server.
+    //  - an AUTO-ATTACHED workspace-default capability MCP (ToolRef.optional):
+    //    the caller never explicitly requested it, so a broken/expired
+    //    capability credential must SKIP the server with a warning, never kill
+    //    the turn before the model runs. An EXPLICITLY-requested tool omits
+    //    `optional` and stays strict (below), preserving the fail-loud contract.
+    const optional = tool.optional === true;
+    return { server, bestEffort: isCodexAppsMcpServer(config) || optional, optional };
   }));
   const requiredServers = servers.filter((entry) => !entry.bestEffort).map((entry) => entry.server);
   const bestEffortServers = servers.filter((entry) => entry.bestEffort).map((entry) => entry.server);
+  // Names of the OPTIONAL capability servers (not codex_apps) so a drop is
+  // surfaced as a warning; codex_apps keeps its historically-quiet drop (a
+  // not-logged-in ChatGPT plan is a normal, non-noteworthy state).
+  const optionalServerNames = new Set(
+    servers.filter((entry) => entry.optional).map((entry) => entry.server.name),
+  );
   const connectedRequired = await connectMcpServers(requiredServers, {
     connectInParallel: true,
     strict: true,
@@ -1016,6 +1030,18 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
         strict: false,
       })
     : null;
+  if (connectedBestEffort) {
+    for (const failed of connectedBestEffort.failed) {
+      if (!optionalServerNames.has(failed.name)) {
+        continue;
+      }
+      const error = connectedBestEffort.errors.get(failed);
+      console.warn(
+        `[mcp] optional capability server "${failed.name}" failed to connect/list tools; skipping it for this turn`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
   return {
     mcpServers: [...connectedRequired.active, ...(connectedBestEffort?.active ?? [])],
     close: async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1198,6 +1198,89 @@ describe("runtime event normalization", () => {
     }
   });
 
+  test("optional (auto-attached) capability MCP whose connect fails is skipped, not fatal", async () => {
+    // The geni-notebook class of bug: a workspace-default capability MCP whose
+    // credential expired returns 401 at connect. Because it was AUTO-ATTACHED
+    // (ToolRef.optional), the failure must drop the server with a warning and
+    // let the turn proceed — not fail the whole turn before the model runs. The
+    // config carries NO credential header, so the required-header server 401s.
+    const broken = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+    try {
+      const prepared = await prepareAgentTools(testSettings({
+        mcpServers: [{
+          id: "geni-notebook",
+          name: "Geni Notebook",
+          url: broken.url,
+          cacheToolsList: false,
+        }],
+      }), [{ kind: "mcp", id: "geni-notebook", optional: true }]);
+      try {
+        expect(prepared.mcpServers).toHaveLength(0); // 401 at connect => dropped, no throw
+      } finally {
+        await prepared.close();
+      }
+      // A warning names the skipped server so the drop is observable.
+      const warned = warnings.some((args) => args.some((arg) => typeof arg === "string" && arg.includes("geni-notebook")));
+      expect(warned).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      broken.close();
+    }
+  });
+
+  test("optional capability MCP drop does NOT take down a healthy sibling in the same turn", async () => {
+    // A broken optional capability server rides alongside a working required
+    // server: the required one must still connect and remain available while the
+    // optional one is skipped.
+    const broken = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    const healthy = startTestMcpServer();
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const prepared = await prepareAgentTools(testSettings({
+        mcpServers: [
+          { id: "geni-notebook", name: "Geni Notebook", url: broken.url, cacheToolsList: false },
+          { id: "docs", name: "Document Search", url: healthy.url, cacheToolsList: false },
+        ],
+      }), [
+        { kind: "mcp", id: "geni-notebook", optional: true },
+        { kind: "mcp", id: "docs" },
+      ]);
+      try {
+        expect(prepared.mcpServers.map((server) => server.name)).toEqual(["docs"]);
+        const tools = await prepared.mcpServers[0]!.listTools();
+        expect(tools.map((tool) => tool.name)).toContain("docs__search_documents");
+      } finally {
+        await prepared.close();
+      }
+    } finally {
+      console.warn = originalWarn;
+      broken.close();
+      healthy.close();
+    }
+  });
+
+  test("explicitly-requested (non-optional) capability MCP whose connect fails still fails the turn", async () => {
+    // The strict contract is unchanged: a tool the caller explicitly requested
+    // (no `optional` flag) that cannot connect must fail the turn.
+    const broken = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
+    try {
+      await expect(prepareAgentTools(testSettings({
+        mcpServers: [{
+          id: "geni-notebook",
+          name: "Geni Notebook",
+          url: broken.url,
+          cacheToolsList: false,
+        }],
+      }), [{ kind: "mcp", id: "geni-notebook" }])).rejects.toThrow();
+    } finally {
+      broken.close();
+    }
+  });
+
   test("does not bleed the permission-scoped first-party tools-list across sessions", async () => {
     // The Agents SDK caches tools/list in a process-global map keyed by MCP
     // server name. The built-in `opengeni` server has the same name for every


### PR DESCRIPTION
A live machine-primary session died **before the model ran** with `unauthorized: send a per-workspace Geni MCP token` (caught by the gold-standard verification on the real Mac).

**Root cause:** a session created without an explicit `tools` list auto-attaches *every* DB-enabled capability MCP server (`sessions.ts` gates auto-attach on the `tools` key). One — `geni-notebook` — had an **expired credential**; its 401 during `tools/list` threw inside `connectMcpServers(strict:true)` (`runtime/index.ts:~1009`), **failing the entire turn**. So any session without an explicit `tools` list broke in that workspace.

**Fix (class-level, durable):** an *auto-attached* (workspace-default) capability MCP is now **optional** — a connect/list failure drops just that server with a warning and the turn proceeds; **explicitly-requested tools stay strict** (unchanged).
- `contracts`: `ToolRef.optional` (back-compat); `mergeToolRefs` strict-wins.
- `resources`: auto-attached defaults marked `optional:true`; `validateToolRefs` strips a client-supplied `optional` from explicit refs.
- `runtime`: optional servers connect best-effort (`strict:false`, dropped on failure) + a `[mcp] optional capability server … skipping` warning.

Covers create + send-message + scheduled-task (same helper).

> Separate, Geni-side: `geni-onboarding` persisted a short-lived `ogd_` token as the permanent `geni-notebook` Authorization header, which expired — **re-onboard geni-notebook** to refresh the credential.

**Verify:** typecheck clean (contracts/runtime/api/worker); runtime 422 + contracts 47 + api-tools 26 tests pass, incl. 3 new (optional 401 skipped+warns; a broken optional doesn't take down a healthy sibling; explicit still throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-start MCP connection semantics for sessions without an explicit `tools` list; behavior is well-tested but affects a core agent-turn path before the model runs.
> 
> **Overview**
> **Auto-attached workspace-default capability MCP servers no longer fail the whole turn** when connect or `tools/list` fails (e.g. expired credentials returning 401). Those servers are now marked **`optional: true`** server-side only; the runtime connects them best-effort, drops failures with a **`[mcp] optional capability server … skipping`** warning, and continues with healthy siblings.
> 
> **Explicitly requested tools stay strict:** `ToolRef` gains an optional `optional` flag in contracts; **`validateToolRefs` strips client-supplied `optional`** so callers cannot weaken required tools. **`mergeToolRefs`** upgrades duplicates so an explicit (non-optional) ref wins over an auto-attached optional one for the same server.
> 
> **Runtime** extends the existing codex_apps best-effort path to honor `ToolRef.optional`, with targeted warnings for optional capability drops (codex_apps remains quiet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e96f119eb190ff35a386e7d6cfba1e3e7f89390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->