### PR TITLE
feat(agent): ship the macOS display feature + wire the TCC consent flow

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -128,8 +128,14 @@ jobs:
         run: |
           set -euo pipefail
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
-          cargo build --release --target x86_64-apple-darwin -p opengeni-agent
-          cargo build --release --target aarch64-apple-darwin -p opengeni-agent
+          # `--features macos-desktop` ships the real macOS display backend
+          # (ScreenCaptureKit capture + CGEvent input + the TCC consent flow). It
+          # forwards to opengeni-agent-platform/macos-desktop and is macOS-ONLY —
+          # the Linux/Windows legs above build default features so their binaries
+          # stay byte-identical. The feature-on path compiles only on this macOS
+          # runner (the objc2 Apple FFI has no Linux/Windows target).
+          cargo build --release --target x86_64-apple-darwin -p opengeni-agent --features macos-desktop
+          cargo build --release --target aarch64-apple-darwin -p opengeni-agent --features macos-desktop
           lipo -create \
             "target/x86_64-apple-darwin/release/opengeni-agent" \
             "target/aarch64-apple-darwin/release/opengeni-agent" \

--- a/agent/crates/opengeni-agent-platform/src/lib.rs
+++ b/agent/crates/opengeni-agent-platform/src/lib.rs
@@ -58,6 +58,14 @@ pub use error::{PlatformError, PlatformResult};
 pub use native::NativePlatform;
 pub use pty::{spawn_pty, PtyProcess};
 
+/// macOS TCC-grant helpers (feature `macos-desktop`, macOS-only): read the Screen
+/// Recording + Accessibility grant state without prompting ([`desktop_grants`])
+/// and fire the OS consent prompts once ([`request_desktop_grants`]). The agent's
+/// startup/enroll seam uses these to request display capability on a real Mac; a
+/// denied grant degrades cleanly to `display_unavailable`.
+#[cfg(all(target_os = "macos", feature = "macos-desktop"))]
+pub use macos::{desktop_grants, request_desktop_grants, DesktopGrants};
+
 /// Reported OS/arch identity of the host the agent runs on, folded into the
 /// connect [`Hello`](opengeni_agent_proto::v1::Hello).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/agent/crates/opengeni-agent-platform/src/macos.rs
+++ b/agent/crates/opengeni-agent-platform/src/macos.rs
@@ -72,6 +72,55 @@ impl MacosDesktop {
 #[cfg(feature = "macos-desktop")]
 use opengeni_agent_macos_ffi as macffi;
 
+// --- TCC grant status + consent request (feature `macos-desktop`) -----------
+//
+// `MacosDesktop::probe`/`capture`/`inject` all fail closed until the two macOS
+// TCC grants are in place: Screen Recording (probe + capture) and Accessibility
+// (CGEvent input delivery). These small helpers let the agent's lifecycle code
+// (`opengeni-agent`'s startup/enroll seam) READ the current grant state without
+// prompting and fire the OS consent prompts ONCE, so a display-capable Mac can
+// actually advertise its display. They are macOS + feature gated, so the default
+// and non-macOS builds compile nothing here (byte-identical).
+
+/// A non-prompting snapshot of the two macOS TCC grants the desktop backend needs.
+#[cfg(feature = "macos-desktop")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DesktopGrants {
+    /// Screen Recording (`kTCCServiceScreenCapture`) — required for probe + capture.
+    pub screen_recording: bool,
+    /// Accessibility (`AXIsProcessTrusted`) — required for CGEvent input delivery.
+    pub accessibility: bool,
+}
+
+#[cfg(feature = "macos-desktop")]
+impl DesktopGrants {
+    /// Both grants are in place, so the backend can fully probe/capture/inject.
+    #[must_use]
+    pub fn all_granted(self) -> bool {
+        self.screen_recording && self.accessibility
+    }
+}
+
+/// Reads the current macOS TCC grant status WITHOUT prompting (the leaf crate's
+/// non-prompting `CGPreflightScreenCaptureAccess` + `AXIsProcessTrusted`).
+#[cfg(feature = "macos-desktop")]
+#[must_use]
+pub fn desktop_grants() -> DesktopGrants {
+    DesktopGrants {
+        screen_recording: macffi::screen_capture_granted(),
+        accessibility: macffi::accessibility_trusted(),
+    }
+}
+
+/// Fires the two macOS TCC consent prompts once (Screen Recording via
+/// `CGRequestScreenCaptureAccess`, Accessibility via the prompting
+/// `AXIsProcessTrustedWithOptions`) and deep-links to the Settings panes. Only the
+/// on-machine process can trigger the prompts; the user still flips the toggles.
+#[cfg(feature = "macos-desktop")]
+pub fn request_desktop_grants() {
+    macffi::request_grants();
+}
+
 #[cfg(feature = "macos-desktop")]
 #[async_trait]
 impl DesktopBackend for MacosDesktop {

--- a/agent/crates/opengeni-agent/Cargo.toml
+++ b/agent/crates/opengeni-agent/Cargo.toml
@@ -15,6 +15,16 @@ workspace = true
 name = "opengeni-agent"
 path = "src/main.rs"
 
+[features]
+# Ship the real macOS display backend + its TCC consent flow. OFF by default; the
+# agent-release workflow enables it ONLY on the macOS build leg
+# (.github/workflows/agent-release.yml). Forwards to the platform crate's feature
+# of the same name so `-p opengeni-agent --features macos-desktop` lights up the
+# ScreenCaptureKit/CGEvent backend and the startup grant request. The feature-on
+# path compiles only on macOS (the objc2 Apple FFI has no Linux/Windows target),
+# so it is gated by the macos-26 CI leg; the default/non-macOS build is unchanged.
+macos-desktop = ["opengeni-agent-platform/macos-desktop"]
+
 [dependencies]
 opengeni-agent-proto = { path = "../opengeni-agent-proto" }
 opengeni-agent-platform = { path = "../opengeni-agent-platform" }

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -127,6 +127,13 @@ fn string_err(message: String) -> anyhow_lite::BoxError {
 /// The FOREGROUND `run` command: enroll-if-needed, then dial + serve until a
 /// clean SIGINT/SIGTERM stops it.
 async fn run(args: RunArgs, api_url: &str) -> anyhow_lite::Result {
+    // macOS: request the Screen Recording + Accessibility grants ONCE so a
+    // display-capable Mac can probe + advertise its display (the supervisor's
+    // per-connect `capabilities()` re-probe then reflects a freshly-granted
+    // display). A denied/pending grant degrades cleanly to `display_unavailable`
+    // and never blocks the serve loop. No-op on every non-macOS / feature-off build.
+    ensure_macos_desktop_grants();
+
     // Enroll if we have no persisted credentials yet ("enroll-if-needed").
     let creds = if let Some(creds) = config::load_credentials().map_err(to_boxed)? {
         info!(agent_id = %creds.agent_id, "loaded existing enrollment");
@@ -224,11 +231,67 @@ fn parse_geometry(geometry: &str) -> (u32, u32) {
 /// `desktop` capability: `probe()` does a synchronous x11rb connect, so run it on
 /// the blocking pool — a wedged X server must not stall this async enroll task.
 async fn probe_offers_display() -> bool {
+    // On macOS, make sure the desktop grants have been requested before we probe,
+    // so a freshly-granted Mac reports its display in the enroll offer. No-op on
+    // every non-macOS / feature-off build.
+    ensure_macos_desktop_grants();
     let desktop = opengeni_agent_platform::resolve_desktop();
     tokio::task::spawn_blocking(move || desktop.probe().is_some())
         .await
         .unwrap_or(false)
 }
+
+/// macOS consent flow (feature `macos-desktop`): ensure the OS TCC grants the
+/// desktop backend needs — Screen Recording (probe + capture) and Accessibility
+/// (CGEvent input) — have been requested, so a display-capable Mac can actually
+/// probe and advertise its display.
+///
+/// If either grant is missing it logs a clear human message and fires the OS
+/// prompts ONCE per process (a [`std::sync::Once`] guard), then re-reads the state
+/// for an informative log. A still-denied grant degrades cleanly: `probe()` keeps
+/// returning `None`, so the capability stays `display_unavailable` — this NEVER
+/// blocks enroll or the serve loop, and exec/fs/git remain fully available.
+///
+/// The grant reads + request are non-blocking, non-prompting-preflight + a single
+/// prompt fire (the OS shows the dialog / the user toggles System Settings).
+#[cfg(all(target_os = "macos", feature = "macos-desktop"))]
+fn ensure_macos_desktop_grants() {
+    use std::sync::Once;
+    static REQUESTED: Once = Once::new();
+
+    let grants = opengeni_agent_platform::desktop_grants();
+    if grants.all_granted() {
+        return;
+    }
+    REQUESTED.call_once(|| {
+        warn!(
+            screen_recording = grants.screen_recording,
+            accessibility = grants.accessibility,
+            "this Mac needs OS permission to expose its display to OpenGeni — requesting \
+             Screen Recording + Accessibility. Approve the system prompt(s), or open \
+             System Settings > Privacy & Security and enable BOTH 'Screen Recording' and \
+             'Accessibility' for opengeni-agent, then let it reconnect. Until then the \
+             machine runs headless (exec/fs/git still work); the display appears once both \
+             grants are in place."
+        );
+        opengeni_agent_platform::request_desktop_grants();
+    });
+    let after = opengeni_agent_platform::desktop_grants();
+    if !after.all_granted() {
+        info!(
+            screen_recording = after.screen_recording,
+            accessibility = after.accessibility,
+            "macOS desktop grants still pending; display stays unavailable until both are \
+             enabled in System Settings (does not block exec/fs/git or enroll)"
+        );
+    }
+}
+
+/// No-op on every build except macOS-with-`macos-desktop`, keeping the default and
+/// non-macOS binaries byte-identical (mirrors the [`maybe_spawn_virtual_desktop`]
+/// cfg-stub pattern).
+#[cfg(not(all(target_os = "macos", feature = "macos-desktop")))]
+fn ensure_macos_desktop_grants() {}
 
 /// The `enroll` command: drive the device flow, persist the credentials, and
 /// return them (so `run` can chain straight into serving).


### PR DESCRIPTION
Turns the (already-merged, default-off) macOS display backend into something that **lights up** on a Connected Mac.

**A1 — release build:** `agent-release.yml` "Build (macOS universal)" now builds both macOS targets with `--features macos-desktop`, so the shipped universal binary includes ScreenCaptureKit/CGEvent. Linux + Windows stay default (byte-identical); codesign/notarize/lipo untouched. (agent crate gains a passthrough feature so `--features macos-desktop` is valid on it.)

**A2 — TCC consent (macOS):** the agent asks for the OS grants so `probe()` can succeed.
- platform crate: safe-Rust wrappers over the existing leaf FFI (`DesktopGrants`, `desktop_grants()`, `request_desktop_grants()`) — **no new `objc2`/`unsafe`**.
- agent `main.rs`: `ensure_macos_desktop_grants()` reads grants; if missing, logs a clear "grant Screen Recording + Accessibility" message and fires the prompts **once per process**, then re-reads. Denied/pending degrades cleanly (`probe None → display_unavailable`), never blocks enroll/run. Called at `run()` top + the enroll display-offer probe. Non-macOS/feature-off build is a byte-identical no-op stub.

**Verify (Linux, feature-off default):** `cargo check` (platform + agent) PASS; `--workspace --all-features` PASS; `clippy --all-features -D warnings` PASS; fmt clean; YAML validated. The feature-ON Apple path compiles on the **macOS-26 CI leg** (the gate).

**Remaining to a live display (operator):** add the Apple Developer-ID release secrets (`APPLE_CERT_P12`/`PASSWORD`/`APPLE_ASC_KEY`/`APPLE_DEVELOPER_ID` — Team `L5D4TC8H8W`) so the signed+notarized binary keeps a stable cdhash across self-updates; then grant Screen Recording + Accessibility once on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS release artifacts and privacy-sensitive TCC consent timing, but behavior is feature- and OS-gated and denied grants degrade without blocking enroll or the serve loop.
> 
> **Overview**
> **Release macOS binaries with the real desktop backend.** The agent-release workflow now builds the universal macOS artifact with `--features macos-desktop` (ScreenCaptureKit, CGEvent, TCC helpers). Linux and Windows legs stay on default features so those binaries are unchanged.
> 
> **Opt-in feature on the agent crate.** `opengeni-agent` gains a `macos-desktop` feature that forwards to `opengeni-agent-platform/macos-desktop`, so release and local macOS builds can enable the backend from the binary crate.
> 
> **TCC consent wired into agent lifecycle.** The platform crate exposes `DesktopGrants`, non-prompting `desktop_grants()`, and `request_desktop_grants()` over the existing macOS FFI. At `run` startup and before the enroll `offers_display` probe, `ensure_macos_desktop_grants()` logs when Screen Recording or Accessibility is missing, triggers OS prompts **once per process**, and leaves enroll/serve running if grants are still denied (`display_unavailable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e812c1c46f2de16ef8f09968006ef0da36557986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->