### PR TITLE
fix(codex): drop all codex_apps outputSchemas so connector tool calls stop -32602ing

### DIFF
--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -124,10 +124,18 @@ function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper, nam
     }
     const record = tool as Record<string, unknown>;
     if ("outputSchema" in record) {
-      const outputSchema = record.outputSchema as { type?: unknown } | null | undefined;
-      if (!outputSchema || typeof outputSchema !== "object" || outputSchema.type !== "object") {
-        delete record.outputSchema;
-      }
+      // Drop EVERY outputSchema, not just malformed/empty ones. The MCP SDK client
+      // caches a validator for any tool that declares an outputSchema and validates
+      // each tool CALL's `structuredContent` against it — and the codex_apps
+      // connectors return results that do NOT match their own declared schemas
+      // (e.g. the schema requires a `result` property the response omits), so the
+      // SDK throws `McpError -32602: Structured content does not match the tool's
+      // output schema` and EVERY such connector tool call fails (observed live:
+      // gmail_search_emails / gmail_get_profile / gmail_list_labels all -32602ed).
+      // outputSchema is advisory — the agent reads the text `content` regardless —
+      // so dropping it makes the connector tools usable. This also subsumes the
+      // empty-`{}` case the strict Tool schema rejected at tools/list time.
+      delete record.outputSchema;
     }
     if (typeof record.name === "string") {
       if (namespaceSink && record.name.includes(".")) {

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -110,20 +110,25 @@ describe("remapToolCallRequestBody", () => {
 });
 
 describe("sanitizeMcpJsonBody", () => {
-  test("drops empty + non-object outputSchemas, keeps valid object ones and all tools", () => {
+  test("drops EVERY outputSchema (incl. valid object ones) but keeps all tools", () => {
+    // Dropping every outputSchema stops the MCP SDK from validating each tool
+    // CALL's structuredContent against it — the connectors return results that
+    // don't match their own declared schemas, which otherwise -32602s the call.
     const body = JSON.stringify(toolsListMsg([
       { name: "a", inputSchema: { type: "object" }, outputSchema: {} },                       // empty -> drop
       { name: "b", inputSchema: { type: "object" }, outputSchema: { type: "array" } },         // non-object -> drop
-      { name: "c", inputSchema: { type: "object" }, outputSchema: { type: "object", properties: {} } }, // valid -> keep
-      { name: "d", inputSchema: { type: "object" } },                                          // none -> unchanged
+      { name: "c", inputSchema: { type: "object" }, outputSchema: { type: "object", properties: {} } }, // valid -> drop too
+      { name: "d", inputSchema: { type: "object" }, outputSchema: { type: "object", required: ["result"] } }, // the live failure shape -> drop
+      { name: "e", inputSchema: { type: "object" } },                                          // none -> unchanged
     ]));
     const tools = JSON.parse(sanitizeMcpJsonBody(body)).result.tools;
-    expect(tools).toHaveLength(4); // no tool dropped
-    expect("outputSchema" in tools[0]).toBe(false);
-    expect("outputSchema" in tools[1]).toBe(false);
-    expect(tools[2].outputSchema).toEqual({ type: "object", properties: {} });
-    expect("outputSchema" in tools[3]).toBe(false);
-    expect(tools.map((t: { name: string }) => t.name)).toEqual(["a", "b", "c", "d"]);
+    expect(tools).toHaveLength(5); // no tool dropped
+    for (const tool of tools) {
+      expect("outputSchema" in tool).toBe(false); // every outputSchema gone
+    }
+    // inputSchema (needed by the model) and the tool itself are untouched.
+    expect(tools[0].inputSchema).toEqual({ type: "object" });
+    expect(tools.map((t: { name: string }) => t.name)).toEqual(["a", "b", "c", "d", "e"]);
   });
 
   test("leaves non-tools-list messages untouched", () => {


### PR DESCRIPTION
## Symptom (found after the sandbox turn finally ran end-to-end)

A codex turn now completes, connects the codex_apps connectors, and calls them — but **every** connector tool call fails with:

```
McpError -32602: Structured content does not match the tool's output schema: data must have required property 'result'
```

Observed live: `gmail_search_emails`, `gmail_search_email_ids`, `gmail_get_profile`, `gmail_list_labels` — all -32602. The agent gracefully reported it couldn't read the mail, so the turn *completed*, but the connectors are unusable.

## Cause

The MCP SDK client caches a validator for any tool that declares an `outputSchema` (`client/index.js:545`) and validates each tool **call**'s `structuredContent` against it (`index.js:504-509`). The codex_apps connectors return results that **don't match their own declared schemas** (the schema requires a `result` property the response omits) → the SDK throws.

The sanitizer already dropped **empty/non-object** outputSchemas (to get past the strict `Tool` schema at tools/list). It kept valid-object ones — which are exactly the ones that then fail **result** validation.

## Fix

Drop **every** `outputSchema` in the codex_apps tools/list. With no cached validator, the SDK skips result validation and passes the tool result through. `outputSchema` is advisory — the agent reads the text `content` regardless — so nothing is lost. This also subsumes the empty-`{}` case.

Test updated: every outputSchema (empty, non-object, valid object, and the live `required:["result"]` shape) is dropped while the tools and their `inputSchema` are untouched. Codex suite 83 pass; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transport-layer sanitization for codex_apps only; no auth or data-path changes, and agents still use text `content` from tool results.
> 
> **Overview**
> **codex_apps MCP sanitizer** now strips **every** `outputSchema` from `tools/list` responses, not only empty or malformed ones.
> 
> Previously, valid object schemas were left in place; the MCP SDK then validated each tool call’s `structuredContent` against them and threw **-32602** because connector responses often omit required fields (e.g. `result`). With no `outputSchema`, the SDK skips that validation and connector tools (Gmail, etc.) can return results; `inputSchema` and tool names are unchanged.
> 
> Tests assert all `outputSchema` variants are removed while tools and `inputSchema` stay intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661752ec15dea8c32c59ccd171b1a35ef839569c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->