### PR TITLE
fix(selfhosted): live-refresh has_display from connect Hello + decouple screen view from control consent

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { Connection, Client as TemporalClient, ScheduleNotFoundError, ScheduleOv
 import type { ScheduleOptions, ScheduleSpec, ScheduleUpdateOptions } from "@temporalio/client";
 import { createApp, type DocumentIndexClient, type SessionWorkflowClient } from "./app";
 import { startAuthCalloutResponder } from "./sandbox/auth-callout";
-import { startMetricsIngestion } from "./sandbox/metrics-ingestion";
+import { startHelloIngestion, startMetricsIngestion } from "./sandbox/metrics-ingestion";
 
 /**
  * A REJECT_DUPLICATE start collides on the deterministic workflowId when the
@@ -198,6 +198,10 @@ export async function startApi() {
   // M10 — start the metrics-ingestion consumer (agent heartbeats → DB last-sample
   // + downsampled series), gated on the selfhosted flag. A no-op when disabled.
   let stopMetricsIngestion: (() => void) | undefined;
+  // Reconcile enrollments.has_display to the LIVE capability the agent reports in
+  // its connect Hello (has_display was frozen at the enroll-time snapshot). Gated
+  // on the same selfhosted flag.
+  let stopHelloIngestion: (() => void) | undefined;
   // M-AUTH — start the NATS auth-callout responder (the tenancy boundary): it
   // validates an agent's enrollment bearer presented at NATS connect and mints a
   // workspace-scoped user JWT. Gated on the selfhosted flag + a resolvable callout
@@ -207,7 +211,8 @@ export async function startApi() {
   let authCalloutResponder: ResponderConnection | undefined;
   if (settings.sandboxSelfhostedEnabled) {
     stopMetricsIngestion = startMetricsIngestion({ db: dbClient.db, bus, observability });
-    observability.info("OpenGeni machine-metrics ingestion consumer started", {});
+    stopHelloIngestion = startHelloIngestion({ db: dbClient.db, bus, observability });
+    observability.info("OpenGeni machine-metrics + hello ingestion consumers started", {});
 
     const callout = resolveNatsCalloutConfig(settings);
     if (callout) {
@@ -239,6 +244,7 @@ export async function startApi() {
     close: async () => {
       server.stop(true);
       stopMetricsIngestion?.();
+      stopHelloIngestion?.();
       await Promise.allSettled([
         authCalloutResponder?.close(),
         bus.close(),

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -1,44 +1,71 @@
 // apps/api/src/sandbox/metrics-ingestion.ts — the M10 metrics INGESTION consumer
-// (dossier §10.7 + §10.6). The enrolled agent piggybacks a `MetricsSample` on its
-// ~5s heartbeat (an `AgentEvent` published one-way on `agent.<ws>.<id>.events`).
-// This consumer subscribes the wildcard `agent.*.*.events`, decodes the
-// AgentEvent, and on each HEARTBEAT:
-//   1. touchEnrollmentLastSeen  — the liveness cursor (online/reconnecting/offline
-//      derivation + the M3 probe disambiguation).
-//   2. ingestMachineMetricsSample — UPSERT machine_metrics_latest (the "now" row)
-//      + APPEND a machine_metrics_series row downsampled to ~1/min.
-// A GOING-OFFLINE event is not a metrics point — liveness flips via the lease/
-// probe path; we simply skip it here (no-op).
+// (dossier §10.7 + §10.6) + the connect-Hello DISPLAY-REFRESH consumer. The
+// enrolled agent piggybacks a `MetricsSample` on its ~5s heartbeat (an
+// `AgentEvent` published one-way on `agent.<ws>.<id>.events`) and publishes a
+// `Hello` (its live self-description) on `agent.<ws>.<id>.hello` on every connect
+// /reconnect. This module owns the two agent→control-plane inbound consumers:
 //
-// Ingestion is BEST-EFFORT and fail-soft: a decode/DB error for one event is
-// logged + swallowed (the bus subscription already swallows handler throws) so a
-// metrics blip never tears down the consumer or back-pressures the agent.
+//   `agent.*.*.events` (heartbeat) →
+//     1. touchEnrollmentLastSeen  — the liveness cursor (online/reconnecting/offline
+//        derivation + the M3 probe disambiguation).
+//     2. ingestMachineMetricsSample — UPSERT machine_metrics_latest (the "now" row)
+//        + APPEND a machine_metrics_series row downsampled to ~1/min.
+//     A GOING-OFFLINE event is not a metrics point — liveness flips via the lease/
+//     probe path; we skip it here (no-op).
+//
+//   `agent.*.*.hello` (connect) →
+//     refreshEnrollmentDisplay — reconcile `enrollments.has_display` to the LIVE
+//     capability the Hello reports. `has_display` was previously FROZEN at the
+//     enroll-time offer snapshot; a machine that GAINS a display later (a Mac that
+//     grants Screen Recording, a box whose Xvfb starts) or LOSES one never
+//     re-surfaced. Consuming the Hello's `capabilities.desktop` / `display` makes
+//     `has_display` track reality (both directions), which the desktop-capability
+//     gate (packages/runtime capabilities.ts) keys off.
+//
+// Both consumers are BEST-EFFORT and fail-soft: a decode/DB error for one message
+// is logged + swallowed (the bus subscription already swallows handler throws) so
+// a metrics blip / a display-refresh write failure never tears down the consumer,
+// back-pressures the agent, or breaks its connect.
 
 import {
   getEnrollment,
   ingestMachineMetricsSample,
+  setEnrollmentHasDisplay,
   touchEnrollmentLastSeen,
   type Database,
   type MachineMetricsSample,
 } from "@opengeni/db";
 import type { EventBus } from "@opengeni/events";
 import type { Observability } from "@opengeni/observability";
-import { AgentEvent, type MetricsSample } from "@opengeni/agent-proto";
+import { AgentEvent, Hello, type MetricsSample } from "@opengeni/agent-proto";
 
 /** The wildcard subject the agent event plane publishes heartbeats on. */
 export const AGENT_EVENTS_SUBJECT = "agent.*.*.events";
 
+/** The wildcard subject the agent publishes its connect Hello on. */
+export const AGENT_HELLO_SUBJECT = "agent.*.*.hello";
+
 /**
- * Parse `agent.<ws>.<id>.events` → `{ workspaceId, agentId }`. Returns null for a
- * subject that does not match the shape (defensive — the subscription pattern
- * already constrains it).
+ * Parse `agent.<ws>.<id>.<tail>` → `{ workspaceId, agentId }`, requiring the
+ * expected tail token. Returns null for a subject that does not match the shape
+ * (defensive — the subscription pattern already constrains it).
  */
-export function parseAgentEventSubject(subject: string): { workspaceId: string; agentId: string } | null {
+function parseAgentSubject(subject: string, tail: "events" | "hello"): { workspaceId: string; agentId: string } | null {
   const parts = subject.split(".");
-  if (parts.length !== 4 || parts[0] !== "agent" || parts[3] !== "events") {
+  if (parts.length !== 4 || parts[0] !== "agent" || parts[3] !== tail) {
     return null;
   }
   return { workspaceId: parts[1]!, agentId: parts[2]! };
+}
+
+/** Parse `agent.<ws>.<id>.events` → `{ workspaceId, agentId }` (heartbeat plane). */
+export function parseAgentEventSubject(subject: string): { workspaceId: string; agentId: string } | null {
+  return parseAgentSubject(subject, "events");
+}
+
+/** Parse `agent.<ws>.<id>.hello` → `{ workspaceId, agentId }` (connect plane). */
+export function parseAgentHelloSubject(subject: string): { workspaceId: string; agentId: string } | null {
+  return parseAgentSubject(subject, "hello");
 }
 
 /**
@@ -159,5 +186,104 @@ export function startMetricsIngestion(deps: {
 }): () => void {
   return deps.bus.subscribeAgentEvents(AGENT_EVENTS_SUBJECT, (payload, subject) =>
     handleAgentEventPayload(deps.db, deps.observability, payload, subject),
+  );
+}
+
+// ── Connect-Hello display refresh ─────────────────────────────────────────────
+
+/**
+ * The LIVE display presence the agent's Hello reports: a desktop framebuffer is
+ * available (`capabilities.desktop`, which the agent sets true only when a display
+ * probes AND it can stream it) OR a `Display` detail is present. An unset
+ * Capabilities (or a headless machine) → false. This is what `has_display` should
+ * track, replacing the enroll-time snapshot.
+ */
+export function helloReportsDisplay(hello: Hello): boolean {
+  const caps = hello.capabilities;
+  if (!caps) {
+    return false;
+  }
+  return caps.desktop === true || caps.display != null;
+}
+
+/**
+ * Reconcile `enrollments.has_display` to the display presence a Hello reports.
+ * Resolves the enrollment (the accountId is the RLS principal + the existence
+ * check + the current value). A no-change Hello short-circuits BEFORE issuing any
+ * write (and the DB writer is itself change-guarded as a backstop), so a steady
+ * state never churns. An unknown/cross-workspace agentId is a no-op.
+ */
+export async function refreshEnrollmentDisplay(
+  db: Database,
+  input: { workspaceId: string; agentId: string; hasDisplay: boolean },
+): Promise<{ updated: boolean }> {
+  const enrollment = await getEnrollment(db, input.workspaceId, input.agentId);
+  if (!enrollment) {
+    return { updated: false };
+  }
+  if (enrollment.hasDisplay === input.hasDisplay) {
+    // Unchanged — do not even issue the UPDATE (no churn on a steady-state Hello).
+    return { updated: false };
+  }
+  return await setEnrollmentHasDisplay(db, {
+    accountId: enrollment.accountId,
+    workspaceId: input.workspaceId,
+    enrollmentId: input.agentId,
+    hasDisplay: input.hasDisplay,
+  });
+}
+
+/**
+ * Decode a raw `Hello` payload + refresh the enrollment's display cursor (the
+ * per-message handler for the hello plane). Decode failures + write failures are
+ * reported + swallowed — a display refresh must NEVER break the agent's connect.
+ */
+export async function handleHelloPayload(
+  db: Database,
+  observability: Observability | undefined,
+  payload: Uint8Array,
+  subject: string,
+): Promise<void> {
+  const ids = parseAgentHelloSubject(subject);
+  if (!ids) {
+    return;
+  }
+  let hello: Hello;
+  try {
+    hello = Hello.decode(payload);
+  } catch (error) {
+    observability?.warn?.("Failed to decode an agent Hello for display refresh", {
+      subject,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  try {
+    await refreshEnrollmentDisplay(db, {
+      workspaceId: ids.workspaceId,
+      agentId: ids.agentId,
+      hasDisplay: helloReportsDisplay(hello),
+    });
+  } catch (error) {
+    observability?.warn?.("Failed to refresh an enrollment's display from a Hello", {
+      subject,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Start the Hello display-refresh consumer: subscribe `agent.*.*.hello` and
+ * reconcile `has_display` to the live capability the agent reports on every
+ * connect. Gated by sandboxSelfhostedEnabled (the caller checks the flag). Returns
+ * the unsubscribe fn.
+ */
+export function startHelloIngestion(deps: {
+  db: Database;
+  bus: EventBus;
+  observability?: Observability;
+}): () => void {
+  return deps.bus.subscribeAgentEvents(AGENT_HELLO_SUBJECT, (payload, subject) =>
+    handleHelloPayload(deps.db, deps.observability, payload, subject),
   );
 }

--- a/apps/api/test/hello-ingestion.test.ts
+++ b/apps/api/test/hello-ingestion.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+import { acquireSharedTestDatabase, MemoryEventBus, type SharedTestDatabase } from "@opengeni/testing";
+import { Hello } from "@opengeni/agent-proto";
+import {
+  createDb,
+  createEnrollment,
+  getEnrollment,
+  type Database,
+  type DbClient,
+} from "@opengeni/db";
+import {
+  AGENT_HELLO_SUBJECT,
+  handleHelloPayload,
+  helloReportsDisplay,
+  parseAgentHelloSubject,
+  refreshEnrollmentDisplay,
+  startHelloIngestion,
+} from "../src/sandbox/metrics-ingestion";
+
+// The connect-Hello DISPLAY-REFRESH consumer: an agent's Hello carries its LIVE
+// capabilities, and consuming it reconciles `enrollments.has_display` to reality
+// (both directions) instead of the frozen enroll-time snapshot. Pure helpers run
+// always; the DB round-trip (through the REAL packages/db on a throwaway postgres,
+// mirroring machines-routes.test.ts) is gated on docker.
+
+// ── Pure helpers (no DB / broker) ─────────────────────────────────────────────
+
+describe("parseAgentHelloSubject", () => {
+  test("extracts workspaceId + agentId from agent.<ws>.<id>.hello", () => {
+    expect(parseAgentHelloSubject("agent.ws-1.ag-2.hello")).toEqual({ workspaceId: "ws-1", agentId: "ag-2" });
+  });
+  test("the wildcard subscription subject is agent.*.*.hello", () => {
+    expect(AGENT_HELLO_SUBJECT).toBe("agent.*.*.hello");
+  });
+  test("rejects a non-hello subject (the heartbeat plane is not the hello plane)", () => {
+    expect(parseAgentHelloSubject("agent.ws.ag.events")).toBeNull();
+    expect(parseAgentHelloSubject("agent.ws.hello")).toBeNull();
+  });
+});
+
+describe("helloReportsDisplay", () => {
+  test("desktop=true → has display", () => {
+    expect(helloReportsDisplay(Hello.fromPartial({ capabilities: { desktop: true } }))).toBe(true);
+  });
+  test("a present Display detail (even if desktop=false) → has display", () => {
+    expect(
+      helloReportsDisplay(Hello.fromPartial({ capabilities: { desktop: false, display: { id: ":99", width: 1920, height: 1080, virtual: true } } })),
+    ).toBe(true);
+  });
+  test("headless (desktop=false, no display) → no display", () => {
+    expect(helloReportsDisplay(Hello.fromPartial({ capabilities: { desktop: false } }))).toBe(false);
+  });
+  test("absent Capabilities → no display", () => {
+    expect(helloReportsDisplay(Hello.fromPartial({}))).toBe(false);
+  });
+});
+
+// ── DB round-trip: the Hello refreshes has_display (both directions, no churn) ──
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+  const [a] = await admin<{ id: string }[]>`insert into managed_accounts (name) values ('acct') returning id`;
+  const [w] = await admin<{ id: string }[]>`insert into workspaces (account_id, name) values (${a!.id}, 'ws') returning id`;
+  return { accountId: a!.id, workspaceId: w!.id };
+}
+
+async function seedEnrollment(hasDisplay: boolean) {
+  const { accountId, workspaceId } = await freshWorkspace();
+  const enrollment = await createEnrollment(db, {
+    accountId, workspaceId, pubkey: `ed25519:${crypto.randomUUID()}`,
+    exposure: "whole-machine", hasDisplay, allowScreenControl: true, os: "linux", arch: "x86_64",
+  });
+  return { accountId, workspaceId, enrollment };
+}
+
+function helloPayload(agentId: string, workspaceId: string, opts: { desktop: boolean }): Uint8Array {
+  return Hello.encode(
+    Hello.fromPartial({ agentId, workspaceId, capabilities: { desktop: opts.desktop } }),
+  ).finish();
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("hello-ingestion");
+  if (!shared) {
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[hello-ingestion] docker unavailable, skipping DB round-trip");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  try {
+    await client?.close();
+  } catch { /* noop */ }
+  await shared?.release();
+});
+
+describe("refreshEnrollmentDisplay — the Hello reconciles has_display", () => {
+  test("desktop=true flips a HEADLESS enrollment's has_display false → true", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(false);
+
+    await handleHelloPayload(db, undefined, helloPayload(enrollment.id, workspaceId, { desktop: true }), `agent.${workspaceId}.${enrollment.id}.hello`);
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.hasDisplay).toBe(true);
+  });
+
+  test("desktop=false flips a DISPLAYED enrollment's has_display true → false", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(true);
+
+    await handleHelloPayload(db, undefined, helloPayload(enrollment.id, workspaceId, { desktop: false }), `agent.${workspaceId}.${enrollment.id}.hello`);
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.hasDisplay).toBe(false);
+  });
+
+  test("an UNCHANGED Hello writes nothing (no churn — updatedAt untouched, updated:false)", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(true);
+    const before = await getEnrollment(db, workspaceId, enrollment.id);
+
+    // refreshEnrollmentDisplay short-circuits before issuing any UPDATE.
+    const result = await refreshEnrollmentDisplay(db, { workspaceId, agentId: enrollment.id, hasDisplay: true });
+    expect(result.updated).toBe(false);
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.hasDisplay).toBe(true);
+    expect(after?.updatedAt).toBe(before!.updatedAt); // no write ⇒ updatedAt unchanged
+  });
+
+  test("an unknown agentId is a no-op (no row → no write)", async () => {
+    if (!available) return;
+    const { workspaceId } = await seedEnrollment(false);
+    const result = await refreshEnrollmentDisplay(db, { workspaceId, agentId: crypto.randomUUID(), hasDisplay: true });
+    expect(result.updated).toBe(false);
+  });
+
+  test("the live consumer wiring: a Hello on agent.*.*.hello flips has_display via startHelloIngestion", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(false);
+    const bus = new MemoryEventBus();
+    const stop = startHelloIngestion({ db, bus, observability: undefined });
+    try {
+      await bus.emitAgentEvent(
+        `agent.${workspaceId}.${enrollment.id}.hello`,
+        helloPayload(enrollment.id, workspaceId, { desktop: true }),
+      );
+      const after = await getEnrollment(db, workspaceId, enrollment.id);
+      expect(after?.hasDisplay).toBe(true);
+    } finally {
+      stop();
+    }
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -57,7 +57,7 @@ import { isCodexBilledModel } from "@opengeni/codex";
 // Re-exported so consumers get the whole codex-billed detection surface (the pure
 // prefix test + the credential-aware predicates below) from a single import.
 export { isCodexBilledModel } from "@opengeni/codex";
-import { and, asc, desc, eq, gt, gte, inArray, lt, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, ne, sql, type SQL } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { decryptEnvironmentValue } from "./environment-crypto";
@@ -4932,6 +4932,34 @@ export async function touchEnrollmentLastSeen(db: Database, input: {
         eq(schema.enrollments.workspaceId, input.workspaceId),
         eq(schema.enrollments.id, input.enrollmentId),
       ));
+  });
+}
+
+// Live display cursor: the agent's connect Hello reports whether a display is
+// present RIGHT NOW (a desktop framebuffer probes). Unlike `has_display` set once
+// at enroll time from the enroll-offer snapshot, this tracks REALITY across the
+// machine's life — a Mac that later grants Screen Recording, or a Linux box whose
+// Xvfb starts after enrollment, flips false→true on its next Hello (and a display
+// that goes away flips true→false). CHANGE-GUARDED at the SQL layer (the `ne`
+// predicate): a Hello that reports the same value the row already holds updates
+// zero rows, so a steady state never churns a write. Returns whether a row was
+// actually changed. Best-effort — the caller swallows failures so a display
+// refresh never breaks the agent's connect.
+export async function setEnrollmentHasDisplay(db: Database, input: {
+  accountId: string; workspaceId: string; enrollmentId: string; hasDisplay: boolean;
+}): Promise<{ updated: boolean }> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
+    const rows = await scopedDb.update(schema.enrollments)
+      .set({ hasDisplay: input.hasDisplay, updatedAt: new Date() })
+      .where(and(
+        eq(schema.enrollments.workspaceId, input.workspaceId),
+        eq(schema.enrollments.id, input.enrollmentId),
+        // Only write on a CHANGE — an unchanged display must not churn a write on
+        // every reconnect Hello.
+        ne(schema.enrollments.hasDisplay, input.hasDisplay),
+      ))
+      .returning({ id: schema.enrollments.id });
+    return { updated: rows.length > 0 };
   });
 }
 

--- a/packages/runtime/src/sandbox/selfhosted/capabilities.ts
+++ b/packages/runtime/src/sandbox/selfhosted/capabilities.ts
@@ -192,21 +192,21 @@ export async function negotiateSelfhostedCapabilities(input: SelfhostedNegotiati
   }
 
   // Online: FS/Terminal/Git stay as the base negotiated them (the machine is
-  // reachable). The desktop/computer-use plane carries the consent + display
-  // gates. Precedence on the desktop cell: a missing display (the machine is
-  // headless, no Xvfb) > missing consent. A headless online machine reports
-  // display_unavailable; a displayed-but-unconsented machine reports
-  // consent_required. (If the base already degraded the desktop for a policy
-  // reason — desktop disabled / no stream-token secret — that base reason wins
-  // and we leave it; we only stamp a selfhosted reason on a cell the base left
-  // AVAILABLE.)
-  const desktopGate: CapabilityUnavailableReason | null = !liveness.hasDisplay
-    ? "display_unavailable"
-    : !liveness.consented
-      ? "consent_required"
-      : null;
-
-  if (desktopGate) {
+  // reachable). The desktop plane splits VIEW from CONTROL:
+  //  - VIEW (a read-only DesktopStream, Recording) requires a DISPLAY only. The
+  //    agent already holds whole-machine shell exec (it can `screencapture` the
+  //    screen itself), so passive viewing is within the exposure the user already
+  //    consented to; a missing display (headless, no Xvfb / no macOS Screen
+  //    Recording grant) is the only blocker.
+  //  - CONTROL — driving input (ComputerUse) or an INTERACTIVE stream —
+  //    additionally requires the explicit allowScreenControl consent (`consented`).
+  // Precedence: a headless machine blocks everything (display_unavailable); a
+  // displayed-but-unconsented machine can be VIEWED (read-only) + RECORDED but not
+  // CONTROLLED (consent_required). (If the base already degraded a cell for a
+  // policy reason — desktop disabled / no stream-token secret — that base reason
+  // wins; we only stamp a selfhosted reason on a cell the base left AVAILABLE.)
+  if (!liveness.hasDisplay) {
+    const reason: CapabilityUnavailableReason = "display_unavailable";
     return {
       ...caps,
       DesktopStream: caps.DesktopStream.transport !== null
@@ -222,14 +222,29 @@ export async function negotiateSelfhostedCapabilities(input: SelfhostedNegotiati
           acknowledged: false,
           shared: false,
           sharedSessionIds: [],
-          reason: desktopGate,
+          reason,
         }
         : caps.DesktopStream,
       Recording: caps.Recording.available
-        ? { ...caps.Recording, available: false, modes: [], codecs: [], reason: desktopGate }
+        ? { ...caps.Recording, available: false, modes: [], codecs: [], reason }
         : caps.Recording,
       ComputerUse: caps.ComputerUse.available
-        ? { ...caps.ComputerUse, available: false, reason: desktopGate }
+        ? { ...caps.ComputerUse, available: false, reason }
+        : caps.ComputerUse,
+    };
+  }
+
+  if (!liveness.consented) {
+    // Displayed but no screen-CONTROL consent: VIEW (read-only) + Recording stay
+    // available; only CONTROL (input) is withheld. Force the stream to read-only
+    // so no input is forwarded even if the base offered an interactive mode.
+    return {
+      ...caps,
+      DesktopStream: caps.DesktopStream.transport !== null
+        ? { ...caps.DesktopStream, mode: "read-only" }
+        : caps.DesktopStream,
+      ComputerUse: caps.ComputerUse.available
+        ? { ...caps.ComputerUse, available: false, reason: "consent_required" }
         : caps.ComputerUse,
     };
   }

--- a/packages/runtime/src/sandbox/selfhosted/testing.ts
+++ b/packages/runtime/src/sandbox/selfhosted/testing.ts
@@ -161,9 +161,12 @@ export class MockAgentResponder implements ControlRpc {
         return ok(req.requestId, { $case: "fsStat", fsStat: res });
       }
       case "desktopEnsure": {
-        if (!this.consented) {
-          return errorResponse(req.requestId, ErrorCode.ERROR_CODE_CONSENT_REQUIRED, "screen control not consented", false);
-        }
+        // The desktop STREAM (view) is DISPLAY-gated, not consent-gated: the real
+        // agent registers the channel + captures frames regardless of screen-control
+        // consent (`register_desktop` in hub.rs sets `allow_input` from consent and
+        // the pump captures anyway) — only INPUT injection is gated. This stub has a
+        // (mock) display and does not model input injection, so desktopEnsure always
+        // succeeds; `consented` only affects the computer-use INPUT plane.
         return ok(req.requestId, {
           $case: "desktopEnsure",
           desktopEnsure: {

--- a/packages/runtime/test/selfhosted-capabilities.test.ts
+++ b/packages/runtime/test/selfhosted-capabilities.test.ts
@@ -137,7 +137,7 @@ describe("negotiateSelfhostedCapabilities — every cell decided correctly", () 
     expect(caps.ComputerUse.reason).toBe("agent_reconnecting");
   });
 
-  test("CONSENT_REQUIRED (online + displayed but not consented): desktop/computer-use gated, Channel-A stays available", async () => {
+  test("CONSENT_REQUIRED (online + displayed but not consented): VIEW (read-only) + Recording stay available, only CONTROL is gated", async () => {
     const caps = await negotiateSelfhostedCapabilities({
       sessionId: SESSION_ID,
       leaseEpoch: 1,
@@ -149,12 +149,17 @@ describe("negotiateSelfhostedCapabilities — every cell decided correctly", () 
     expect(caps.FileSystem.available).toBe(true);
     expect(caps.Terminal.transport).toBe("pty-ws");
     expect(caps.Git.available).toBe(true);
-    // The desktop plane is consent-gated.
-    expect(caps.DesktopStream.transport).toBeNull();
-    expect(caps.DesktopStream.reason).toBe("consent_required");
+    // VIEW decouples from CONTROL: with a display alone the screen can be VIEWED
+    // (read-only stream) + RECORDED — the agent already has whole-machine exec, so
+    // passive viewing adds no capability. Only INPUT (ComputerUse / an interactive
+    // stream) requires the explicit allowScreenControl consent.
+    expect(caps.DesktopStream.transport).toBe("vnc-ws");
+    expect(caps.DesktopStream.mode).toBe("read-only");
+    expect(caps.DesktopStream.reason).toBeNull();
+    expect(caps.Recording.available).toBe(true);
+    expect(caps.Recording.reason).toBeNull();
     expect(caps.ComputerUse.available).toBe(false);
     expect(caps.ComputerUse.reason).toBe("consent_required");
-    expect(caps.Recording.reason).toBe("consent_required");
   });
 
   test("DISPLAY_UNAVAILABLE (online but headless, no display): desktop degraded, Channel-A available", async () => {


### PR DESCRIPTION
## Why the Mac's screen stays unviewable

Two coupled gaps kept an enrolled, displayed machine's screen stuck at `display_unavailable` / `consent_required` in the UI, even when the machine can be viewed.

### 1. `has_display` was frozen at enroll time
`enrollments.has_display` was written once at enroll from the enroll-offer snapshot (`enrollment.ts` `canOfferDisplay`) and never updated. A Mac that **later grants Screen Recording**, or a Linux box whose Xvfb starts after enrollment, never re-surfaced a display.

**Fix:** consume the agent's connect `Hello` on `agent.*.*.hello` (a new `startHelloIngestion` consumer alongside metrics) and reconcile `has_display` to the **live** `capabilities.desktop` / `display` the agent probes and reports on every connect/reconnect — both directions (gains *and* loses a display).
- The DB write (`setEnrollmentHasDisplay`) is **change-guarded** at the SQL layer (`ne` predicate) — an unchanged value updates zero rows, so a steady-state reconnect never churns a write.
- The whole path is **best-effort / fail-soft**: a decode or write failure is logged + swallowed so a display refresh can never break the agent's connect.

### 2. Screen VIEW was coupled to screen-CONTROL consent
The desktop capability gate degraded `DesktopStream` + `Recording` + `ComputerUse` together on the single `allowScreenControl` consent — so a machine enrolled **without** screen-control couldn't even be **viewed**.

But the **real Rust agent already decouples them**: `register_desktop` (`hub.rs`) registers the desktop channel and the pump captures frames *regardless* of consent, gating only **input injection** (`allow_input = allow_screen_control`, dropped in `framebuffer_pump.rs`). `desktop_ensure` errors only on no-display / no-relay, and `capabilities()` advertises `desktop` on display presence alone.

**Fix:** split the negotiation to match the agent:
- **VIEW** — a read-only `DesktopStream` + `Recording` — needs a **display alone**. The agent already holds whole-machine shell exec (it can `screencapture` the screen itself), so passive viewing adds no capability beyond what enroll already granted.
- **CONTROL** — `ComputerUse` (driving input) or an interactive stream — still requires the explicit `allowScreenControl` consent (`consent_required`).
- A headless machine still blocks everything (`display_unavailable`); a displayed-but-unconsented machine is now **viewable (read-only) + recordable** but not controllable.

Also fixes the `MockAgentResponder` test double to match the real agent (`desktopEnsure` is display-gated, not consent-gated).

## Verification
- `packages/runtime` typecheck clean; `selfhosted-capabilities` (15) + `selfhosted-session` (48) pass — the `CONSENT_REQUIRED` case now asserts view+record available, only input gated.
- `packages/db` + `apps/api` typecheck clean; `hello-ingestion` (12, incl. a real-postgres round-trip) pass.
- Traced the full chain against the agent source: `send_hello` → `agent.<ws>.<id>.hello` carries probed `capabilities` → consumer → change-guarded `has_display` write → view gate unblocks → mint (agent registers channel, captures, drops input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop capability and consent gating (who can view vs control a machine) and mutates enrollment state from agent-reported Hello data; behavior is aligned with the Rust agent but expands view access for enrollments without screen-control consent.
> 
> **Overview**
> Fixes selfhosted machines staying stuck at **display_unavailable** / **consent_required** when the screen could actually be viewed.
> 
> **Live `has_display`:** Adds a **`startHelloIngestion`** consumer (with metrics ingestion, gated on `sandboxSelfhostedEnabled`) on `agent.*.*.hello` that decodes connect **`Hello`** messages and reconciles **`enrollments.has_display`** from **`capabilities.desktop`** / **`display`**, so enroll-time snapshots can flip when a display appears or disappears. **`setEnrollmentHasDisplay`** is change-guarded in SQL (`ne` on `has_display`); the handler short-circuits unchanged values and **fail-soft** logging so connect is never broken.
> 
> **View vs control:** **`negotiateSelfhostedCapabilities`** now gates **read-only `DesktopStream` + `Recording`** on **display only**; **`ComputerUse`** and interactive control still require **`allowScreenControl`**. Displayed-but-unconsented machines get **read-only** stream mode instead of blocking the whole desktop plane. The selfhosted test mock’s **`desktopEnsure`** matches the real agent (display-gated, not consent-gated).
> 
> Adds **`hello-ingestion`** tests (helpers + Postgres round-trips) and updates **`selfhosted-capabilities`** expectations for the consent case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052f29ccd55492f854c10b553d98b662aab2ec02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->