### PR TITLE
fix(codex): inline connector structuredContent into content so tool results carry data

### DIFF
--- a/packages/codex/src/mcp-sanitize.ts
+++ b/packages/codex/src/mcp-sanitize.ts
@@ -149,11 +149,52 @@ function sanitizeToolsInRpcMessage(message: unknown, mapper: ToolNameMapper, nam
   }
 }
 
+/**
+ * Surface a tool CALL's `structuredContent` to the model by inlining it as a text
+ * `content` block, in place.
+ *
+ * WHY. The @openai/agents MCP bridge forwards ONLY `result.content` to the model
+ * (agents-core shims/mcp-server: `const result = parsed.content`) and DISCARDS
+ * `result.structuredContent`. The codex_apps connectors return the real payload in
+ * `structuredContent` and a bare `"Action completed."` placeholder in `content`
+ * (verified live: `gmail.get_profile` → content=[{text:"Action completed."}],
+ * structuredContent={id,name,email,…}). Without this the agent's tool call
+ * "succeeds" but carries NO data — the model sees only the placeholder. Appending
+ * the structured payload as a text block makes the data reach the model while
+ * leaving the original content untouched.
+ *
+ * No-op when there is no `structuredContent` — so a tools/list response (or any
+ * result without it) passes through unchanged. Runs alongside (after) the empty
+ * outputSchema drop, which is what stops the MCP SDK -32602ing this same result.
+ */
+function inlineStructuredContentInRpcMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const result = (message as { result?: unknown }).result;
+  if (!result || typeof result !== "object") {
+    return;
+  }
+  const record = result as Record<string, unknown>;
+  if (!("structuredContent" in record)) {
+    return;
+  }
+  const structured = record.structuredContent;
+  if (structured === undefined || structured === null) {
+    return;
+  }
+  const text = typeof structured === "string" ? structured : JSON.stringify(structured);
+  const content = Array.isArray(record.content) ? [...record.content] : [];
+  content.push({ type: "text", text });
+  record.content = content;
+}
+
 /** Sanitize a single JSON body (application/json MCP response). */
 export function sanitizeMcpJsonBody(text: string, mapper: ToolNameMapper = new ToolNameMapper(), namespaceSink?: Set<string>): string {
   try {
     const parsed = JSON.parse(text);
     sanitizeToolsInRpcMessage(parsed, mapper, namespaceSink);
+    inlineStructuredContentInRpcMessage(parsed);
     return JSON.stringify(parsed);
   } catch {
     return text; // not JSON we understand — leave untouched
@@ -172,6 +213,7 @@ export function sanitizeMcpSseBody(text: string, mapper: ToolNameMapper = new To
       try {
         const parsed = JSON.parse(payload);
         sanitizeToolsInRpcMessage(parsed, mapper, namespaceSink);
+        inlineStructuredContentInRpcMessage(parsed);
         return `data: ${JSON.stringify(parsed)}`;
       } catch {
         return line;

--- a/packages/codex/test/mcp-sanitize.test.ts
+++ b/packages/codex/test/mcp-sanitize.test.ts
@@ -131,6 +131,28 @@ describe("sanitizeMcpJsonBody", () => {
     expect(tools.map((t: { name: string }) => t.name)).toEqual(["a", "b", "c", "d", "e"]);
   });
 
+  test("inlines a tool CALL's structuredContent into content so it reaches the model", () => {
+    // The live connector shape: real data in structuredContent, bare placeholder in content.
+    const call = JSON.stringify({
+      jsonrpc: "2.0", id: 7,
+      result: {
+        content: [{ type: "text", text: "Action completed." }],
+        structuredContent: { email: "jorgen.sandhaug@gmail.com", name: "Jørgen" },
+      },
+    });
+    const out = JSON.parse(sanitizeMcpJsonBody(call)).result;
+    // original content preserved + the structured payload appended as a text block
+    expect(out.content).toHaveLength(2);
+    expect(out.content[0]).toEqual({ type: "text", text: "Action completed." });
+    expect(out.content[1].type).toBe("text");
+    expect(JSON.parse(out.content[1].text)).toEqual({ email: "jorgen.sandhaug@gmail.com", name: "Jørgen" });
+  });
+
+  test("a call result with no structuredContent is untouched", () => {
+    const call = JSON.stringify({ jsonrpc: "2.0", id: 8, result: { content: [{ type: "text", text: "hi" }] } });
+    expect(sanitizeMcpJsonBody(call)).toBe(JSON.stringify(JSON.parse(call)));
+  });
+
   test("leaves non-tools-list messages untouched", () => {
     const other = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "x", capabilities: {} } });
     expect(sanitizeMcpJsonBody(other)).toBe(JSON.stringify(JSON.parse(other)));


### PR DESCRIPTION
## Symptom (found by actually running a connector turn)

After #166 killed the `-32602`, codex_apps connector tool calls **succeed but return no data** — the agent sees only `"Action completed."` and reports it can't read the mail.

## Cause

The `@openai/agents` MCP bridge forwards **only `result.content`** to the model (`agents-core` shims/mcp-server: `const result = parsed.content`) and **discards `result.structuredContent`**. The codex_apps connectors put the real payload in `structuredContent` and a bare `"Action completed."` placeholder in `content`.

**Verified live** against the connected account:
- `gmail.get_profile` → `content=[{text:"Action completed."}]`, `structuredContent={id,name,email:"redacted@example.invalid",…}`
- `gmail.search_emails` → placeholder content, `structuredContent={emails:[…]}`

## Fix

On a tools/call response, inline `structuredContent` as a text `content` block so it reaches the model (original content preserved; no-op when there's no `structuredContent`, e.g. tools/list). Runs *after* the outputSchema drop from #166 — that drop is what stops the MCP SDK from `-32602`ing this same result, and this makes the result actually useful.

**Verified live end-to-end at the transport:** feeding the real `gmail.search_emails` response through the actual sanitizer, the model now receives the real inbox JSON (subjects/senders/snippets) instead of `"Action completed."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live MCP transport shaping for all codex_apps tool-call responses; behavior is narrow (append-only, no-op without structuredContent) but affects what the model sees for every connector call.
> 
> **Overview**
> Fixes **codex_apps connector tool calls that succeed but return no usable data** to the model: the agents MCP bridge only forwards `result.content`, while connectors put real payloads in `structuredContent` and a placeholder like `"Action completed."` in `content`.
> 
> Adds **`inlineStructuredContentInRpcMessage`** in `mcp-sanitize.ts`, invoked from both **`sanitizeMcpJsonBody`** and **`sanitizeMcpSseBody`** after existing tool-list sanitization. When a JSON-RPC result includes `structuredContent`, it **appends** a `{ type: "text", text }` block (JSON-stringified object or raw string) to `content` while leaving existing blocks unchanged; messages without `structuredContent` are unchanged.
> 
> Tests assert preserved placeholder + inlined JSON for a representative call shape, and unchanged output when `structuredContent` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190f84d0314d6489ecc3d1120a8ebf42339c5654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->