### PR TITLE
fix(machines): displayed machine without screen-control consent stays online + selectable (view/control decoupling pt 2)

### DIFF
--- a/apps/api/src/sandbox/machines.ts
+++ b/apps/api/src/sandbox/machines.ts
@@ -126,16 +126,21 @@ async function probeEnrollment(
 }
 
 /**
- * Resolve the dashboard STATE of an online machine. A machine that is online but
- * (a) has no display → `display_unavailable`; (b) is displayed but whole-machine
- * /screen-control consent is not acked → `consent_required`. Otherwise the
- * liveness state (online/reconnecting/offline) is the state. This mirrors the
- * desktop/computer-use degradation reasons in the selfhosted capability
- * negotiation so the dashboard pill and the dock agree.
+ * Resolve the dashboard STATE of a machine. State reflects REACHABILITY + the
+ * VIEW plane only: an online machine with no display → `display_unavailable` (no
+ * desktop stream, but compute — exec/fs/git/terminal — still works); otherwise
+ * the liveness state (online/reconnecting/offline). It deliberately does NOT fold
+ * in screen-control consent: a displayed machine can be VIEWED (read-only) and
+ * used for compute regardless of `allowScreenControl` — only INPUT (ComputerUse /
+ * an interactive stream) needs that consent, which is a per-capability concern
+ * carried by the separate `allowScreenControl` field (surfaced in the viewer's
+ * Take-control affordance), NOT a blocking machine state. This mirrors the
+ * view/control split in the selfhosted capability negotiation so the dashboard
+ * pill, the dock, and the "Run on" picker agree (a machine is never wrongly
+ * un-selectable just because its input isn't consented).
  */
 function machineStateFor(
   liveness: "online" | "reconnecting" | "offline",
-  consented: boolean,
   hasDisplay: boolean,
 ): MachinesResponse["machines"][number]["state"] {
   if (liveness !== "online") {
@@ -143,9 +148,6 @@ function machineStateFor(
   }
   if (!hasDisplay) {
     return "display_unavailable";
-  }
-  if (!consented) {
-    return "consent_required";
   }
   return "online";
 }
@@ -222,7 +224,7 @@ export async function listMachines(
       continue;
     }
     const probe = await probeEnrollment(services, workspaceId, enrollment);
-    const state = machineStateFor(probe.state, probe.consented, probe.hasDisplay);
+    const state = machineStateFor(probe.state, probe.hasDisplay);
 
     // sharedSessionCount = the lease refcount for this machine's group. The
     // selfhosted sandbox id IS the lease group key (maxSandboxes:1, N sessions

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -229,15 +229,18 @@ describe("M10 GET /machines — dashboard list + states + metrics", () => {
     expect(sessBody.machines.length).toBe(2);
   }, 90_000);
 
-  test("state matrix: consent_required when display present but screen-control not acked; offline when no responder", async () => {
+  test("state matrix: displayed-but-unconsented is ONLINE (view/control decoupled); offline when no responder", async () => {
     if (!available) return;
-    // consent_required: has a display but allowScreenControl=false (consent not acked).
+    // A displayed machine whose SCREEN CONTROL isn't consented is still ONLINE:
+    // compute + read-only viewing work; only INPUT is withheld (surfaced via the
+    // separate allowScreenControl field, not by degrading the machine state).
     {
       const { accountId, workspaceId, bus } = await seed({ allowScreenControl: false, hasDisplay: true });
       const app = appFor(bus);
       const auth = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
-      const body = await (await app.request(`/v1/workspaces/${workspaceId}/machines`, { headers: { authorization: auth } })).json() as { machines: Array<{ state: string }> };
-      expect(body.machines[0]!.state).toBe("consent_required");
+      const body = await (await app.request(`/v1/workspaces/${workspaceId}/machines`, { headers: { authorization: auth } })).json() as { machines: Array<{ state: string; allowScreenControl: boolean }> };
+      expect(body.machines[0]!.state).toBe("online");
+      expect(body.machines[0]!.allowScreenControl).toBe(false);
     }
     // offline: online=false → no responder → the probe misses; lastSeenAt is recent
     // BUT we clear it so it is hard-offline.

--- a/apps/web/src/lib/machine-selectability.test.ts
+++ b/apps/web/src/lib/machine-selectability.test.ts
@@ -4,9 +4,10 @@ import { isMachineComputeSelectable } from "./machine-selectability";
 
 // The session "Run on" pickers (sessions-index machine <select> + the in-session
 // sandbox-switcher) gate selectability through this helper. The backend attach
-// gate is liveness-only, so an online-but-headless machine (display_unavailable)
-// must be selectable for compute-only sessions, while consent/offline/reconnecting
-// must stay gated.
+// gate is liveness-only, so any REACHABLE machine — online, headless
+// (display_unavailable), or one whose screen control isn't consented
+// (consent_required) — must be selectable for compute-only sessions, while
+// offline / reconnecting / enrolling genuinely can't attach.
 describe("isMachineComputeSelectable", () => {
   test("a headless online machine (display_unavailable) is selectable", () => {
     expect(isMachineComputeSelectable("display_unavailable")).toBe(true);
@@ -16,12 +17,15 @@ describe("isMachineComputeSelectable", () => {
     expect(isMachineComputeSelectable("online")).toBe(true);
   });
 
+  test("a displayed machine without screen-control consent (consent_required) is still selectable for compute + view", () => {
+    expect(isMachineComputeSelectable("consent_required")).toBe(true);
+  });
+
   test("an offline machine is not selectable", () => {
     expect(isMachineComputeSelectable("offline")).toBe(false);
   });
 
-  test("consent_required / reconnecting / enrolling stay gated", () => {
-    expect(isMachineComputeSelectable("consent_required")).toBe(false);
+  test("reconnecting / enrolling stay gated", () => {
     expect(isMachineComputeSelectable("reconnecting")).toBe(false);
     expect(isMachineComputeSelectable("enrolling")).toBe(false);
   });

--- a/apps/web/src/lib/machine-selectability.ts
+++ b/apps/web/src/lib/machine-selectability.ts
@@ -1,11 +1,14 @@
 // Compute-selectability for an enrolled machine in the session "Run on" pickers.
 //
 // The backend create-time attach gate checks LIVENESS only — compute-only
-// sessions (terminal/files/git/exec) are fully supported, so `display_unavailable`
-// means "no desktop stream", NOT "can't attach". A machine is selectable iff its
-// liveness is online: `online` or `display_unavailable`. `consent_required` must
-// still gate (consent), and `offline` / `reconnecting` / `enrolling` genuinely
-// can't attach.
+// sessions (terminal/files/git/exec) are fully supported. A machine is selectable
+// iff the control plane can REACH it: `online` or `display_unavailable` (headless
+// — no desktop stream, but compute works). `consent_required` is also selectable
+// — a machine whose SCREEN CONTROL isn't consented is still fully usable for
+// compute and read-only viewing; only INPUT is withheld (so it must never be
+// un-selectable on that basis). Only `offline` / `reconnecting` / `enrolling`
+// genuinely can't attach. (Since the machines deriver no longer folds consent
+// into the state, `consent_required` is a defensive inclusion.)
 export function isMachineComputeSelectable(state: string): boolean {
-  return state === "online" || state === "display_unavailable";
+  return state === "online" || state === "display_unavailable" || state === "consent_required";
 }


### PR DESCRIPTION
## The regression this closes

Follow-up to #167 (view/control decoupling in the capability negotiation). The moment a Mac's `has_display` flipped true — its agent reconnected and reported a display via the new hello consumer — it became **un-selectable** in the "Run on" picker and its dock showed **"consent required"**, even though compute and read-only viewing are fully available.

Root cause: the machines **dashboard** deriver (`machineStateFor`) was never decoupled. It still returned `consent_required` for an online+displayed machine whose `allowScreenControl=false`, and `isMachineComputeSelectable` treated `consent_required` as non-selectable. (Before the flip the Mac was `display_unavailable`/headless → selectable; flipping `has_display` true walked it straight into the consent branch.)

## Fix (mirrors the negotiation split from #167)

- **`machineStateFor`** no longer folds screen-control consent into the state. State reflects **reachability + the VIEW plane only** (`online` / `display_unavailable` / liveness). Screen-control consent is a per-capability concern carried by the separate `allowScreenControl` field — surfaced in the viewer's Take-control affordance — not a blocking machine state.
- **`isMachineComputeSelectable`** treats `consent_required` as selectable too (defensive: a reachable machine is always compute-selectable; only `offline`/`reconnecting`/`enrolling` gate).

Net: a displayed-but-unconsented machine is now `online`, selectable for new sessions, and viewable read-only. Taking **input** control still requires the explicit consent (unchanged).

## Verification
- `apps/api` + `apps/web` typecheck clean.
- `machine-selectability` (5) — consent_required now asserts selectable.
- `machines-routes` state-matrix (4, real PG) — displayed+unconsented now asserts `state==="online"` with `allowScreenControl===false`.
- `machines-components` (22) — pill enum unchanged, still renders.

Verified live against staging: the user's Mac's `has_display` flipped false→true via the #167 consumer at 15:04Z; this un-breaks the picker that flip exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible machine state and picker behavior for selfhosted enrollments; input control is still expected to be gated elsewhere via `allowScreenControl`, but any UI still keyed on `consent_required` state would behave differently.
> 
> **Overview**
> Fixes a regression where a Mac that reported a display (`has_display`) flipped to **`consent_required`** in the machines dashboard and became **un-selectable** in **Run on**, even though compute and read-only viewing should still work.
> 
> **API:** `machineStateFor` no longer maps `allowScreenControl === false` to `consent_required`. Dashboard **state** is now **reachability + view only** (`online`, `display_unavailable`, or liveness). Screen-control consent stays on the separate **`allowScreenControl`** field (Take-control), matching the selfhosted view/control split from capability negotiation.
> 
> **Web:** `isMachineComputeSelectable` treats **`consent_required`** as selectable (defensive), so only `offline` / `reconnecting` / `enrolling` block attach.
> 
> Tests updated: machines route state matrix expects **online** + `allowScreenControl: false` for displayed-but-unconsented machines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd642a4601e4730ea89607b2f464477c52d501f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->