### PR TITLE
feat(desktop): render the self-hosted desktop stream (PNG-frame canvas client)

### DIFF
--- a/.changeset/selfhosted-desktop-frame-renderer.md
+++ b/.changeset/selfhosted-desktop-frame-renderer.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/react": minor
+"@opengeni/sdk": minor
+---
+
+Render the self-hosted desktop stream: a PNG-frame canvas client for `transport: "relay-frames"`.
+
+Self-hosted machines stream their desktop as PNG-per-frame protobuf datagrams over the relay (not RFB), so the noVNC/RFB viewer could never render them — the desktop went "warm" but the live stream never came up. This adds `useRelayFrameStream`, a view-only canvas renderer that opens the relay channel, decodes each PNG frame, and paints it (latest-wins backpressure so a slow decode never queues). `useDesktopStream` now dispatches on `DesktopStream.transport`: `"vnc-ws"` → noVNC (Modal boxes), `"relay-frames"` → the frame renderer (self-hosted machines). The `DesktopStream.transport` / `client` unions gain `"relay-frames"` / `"frames"`. View-only in v1 (matches the machine's read-only mode); interactive input is a follow-up.

--- a/bun.lock
+++ b/bun.lock
@@ -257,6 +257,7 @@
       "name": "@opengeni/react",
       "version": "0.5.0",
       "dependencies": {
+        "@opengeni/agent-proto": "workspace:*",
         "@opengeni/sdk": "workspace:*",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",

--- a/bun.lock
+++ b/bun.lock
@@ -257,7 +257,7 @@
       "name": "@opengeni/react",
       "version": "0.5.0",
       "dependencies": {
-        "@opengeni/agent-proto": "workspace:*",
+        "@bufbuild/protobuf": "^2.2.0",
         "@opengeni/sdk": "workspace:*",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -279,6 +279,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@happy-dom/global-registrator": "^20.10.2",
         "@novnc/novnc": "^1.7.0",
+        "@opengeni/agent-proto": "workspace:*",
         "@pierre/diffs": "^1.2.11",
         "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^19.2.14",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2778,8 +2778,11 @@ export const SessionCapabilities = z.object({
     reason: CapabilityUnavailableReason.nullable(),
   }),
   DesktopStream: z.object({
-    transport: z.enum(["vnc-ws", "rdp-ws", "webrtc"]).nullable(),
-    client: z.enum(["novnc", "web-rdp"]).nullable(),
+    // "relay-frames" is the selfhosted framebuffer stream: PNG-per-frame protobuf
+    // datagrams spliced over the relay (NOT RFB). The viewer renders it with the
+    // "frames" client (a canvas painter), distinct from Modal's "vnc-ws"/"novnc".
+    transport: z.enum(["vnc-ws", "rdp-ws", "webrtc", "relay-frames"]).nullable(),
+    client: z.enum(["novnc", "web-rdp", "frames"]).nullable(),
     mode: z.enum(["read-only", "interactive"]).default("read-only"),
     url: z.string().url().nullable(),
     token: z.string().nullable(),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,7 @@
     "demo:build": "vite build demo"
   },
   "dependencies": {
-    "@opengeni/agent-proto": "workspace:*",
+    "@bufbuild/protobuf": "^2.2.0",
     "@opengeni/sdk": "workspace:*",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
@@ -111,6 +111,7 @@
   },
   "devDependencies": {
     "@codemirror/lang-css": "^6.3.1",
+    "@opengeni/agent-proto": "workspace:*",
     "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,6 +44,7 @@
     "demo:build": "vite build demo"
   },
   "dependencies": {
+    "@opengeni/agent-proto": "workspace:*",
     "@opengeni/sdk": "workspace:*",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/packages/react/src/components/desktop-viewer.tsx
+++ b/packages/react/src/components/desktop-viewer.tsx
@@ -3,6 +3,7 @@ import { LoaderCircleIcon, MonitorIcon, MousePointerClickIcon, WifiOffIcon } fro
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import { useDesktopStream } from "../hooks/use-desktop-stream";
+import type { DesktopWebSocketFactory } from "../hooks/use-relay-frame-stream";
 
 export type DesktopViewerProps = {
   /** The desktop cell of the negotiated capabilities (`capabilities.DesktopStream`). */
@@ -19,6 +20,9 @@ export type DesktopViewerProps = {
   scaleViewport?: boolean | undefined;
   /** Custom RFB factory (tests / a WebRTC swap). Defaults to lazy @novnc/novnc. */
   rfbFactory?: DesktopRfbFactory | undefined;
+  /** Custom socket factory for the self-hosted `relay-frames` transport (tests).
+   *  Defaults to `new WebSocket(url)`. Mirrors `rfbFactory`. */
+  webSocketFactory?: DesktopWebSocketFactory | undefined;
   /**
    * Consent gate for the un-redacted (and possibly shared) pixel plane. Rendered
    * BEFORE connecting whenever the desktop requires acknowledgment that hasn't
@@ -121,6 +125,7 @@ export function DesktopViewer({
   showControlToggle = true,
   scaleViewport,
   rfbFactory,
+  webSocketFactory,
   renderConsentGate,
   onAcknowledge,
   watching,
@@ -213,6 +218,7 @@ export function DesktopViewer({
     interactive: inControl,
     ...(scaleViewport !== undefined ? { scaleViewport } : {}),
     ...(rfbFactory ? { rfbFactory } : {}),
+    ...(webSocketFactory ? { webSocketFactory } : {}),
   });
 
   const connected = stream.state === "connected";
@@ -429,7 +435,11 @@ export function DesktopViewer({
         <TakeControlCallToAction
           disabled={!serverAllowsControl}
           disabledReason={
-            !serverAllowsControl ? "This deployment streams the desktop read-only" : undefined
+            !serverAllowsControl
+              ? capability?.client === "frames"
+                ? "View-only — live control isn't available for this machine yet."
+                : "This deployment streams the desktop read-only"
+              : undefined
           }
           onTakeControl={() => setTakeControl(true)}
         />

--- a/packages/react/src/hooks/use-desktop-stream.ts
+++ b/packages/react/src/hooks/use-desktop-stream.ts
@@ -7,17 +7,21 @@ import {
   type DesktopStreamCapability,
 } from "@opengeni/sdk";
 import { type RefObject, useEffect, useRef, useState } from "react";
+import { type DesktopWebSocketFactory, useRelayFrameStream } from "./use-relay-frame-stream";
 
 export type UseDesktopStreamOptions = {
   /** The desktop cell of the negotiated capabilities (`capabilities.DesktopStream`). */
   capability: DesktopStreamCapability | null;
-  /** The mount target. RFB attaches here on connect. */
+  /** The mount target. RFB (or the frame canvas) attaches here on connect. */
   containerRef: RefObject<HTMLDivElement | null>;
   /** Read-only by default (v1 ruling H). interactive only when cap.mode allows. */
   interactive?: boolean | undefined;
   scaleViewport?: boolean | undefined;
   /** Custom RFB factory (tests / a WebRTC swap). Defaults to a lazy @novnc/novnc. */
   rfbFactory?: DesktopRfbFactory | undefined;
+  /** Custom socket factory for the `relay-frames` transport (tests). Defaults to
+   *  `new WebSocket(url)`. Mirrors `rfbFactory` for the frame renderer. */
+  webSocketFactory?: DesktopWebSocketFactory | undefined;
 };
 
 export type UseDesktopStreamResult = {
@@ -57,9 +61,26 @@ async function defaultRfbFactory(): Promise<DesktopRfbFactory> {
  * `interactive` prop → `RFB.viewOnly`. v1 always resolves to read-only. On a
  * capability `url` change (a rotation), the old RFB disconnects and a fresh one
  * connects to the new URL — a brief "desktop blink", acceptable on rollover.
+ *
+ * Transport dispatch: a Modal box negotiates `transport: "vnc-ws"` and drives the
+ * noVNC RFB below. A SELF-HOSTED machine negotiates `transport: "relay-frames"`
+ * (PNG-per-frame over the relay, view-only) — that path is delegated to
+ * `useRelayFrameStream`, which paints a `<canvas>`. Both hooks are ALWAYS called
+ * (rules of hooks); each is dormant for the other's transport, and we return the
+ * result of whichever owns the surface. The public interface is identical either
+ * way, so `DesktopViewer` is transport-agnostic.
  */
 export function useDesktopStream(options: UseDesktopStreamOptions): UseDesktopStreamResult {
-  const { capability, containerRef, interactive, scaleViewport, rfbFactory } = options;
+  const { capability, containerRef, interactive, scaleViewport, rfbFactory, webSocketFactory } =
+    options;
+
+  // The self-hosted PNG-frame path. Always invoked (rules of hooks); dormant
+  // unless `transport === "relay-frames"`, in which case it owns the surface.
+  const frameStream = useRelayFrameStream({
+    capability,
+    containerRef,
+    ...(webSocketFactory ? { webSocketFactory } : {}),
+  });
   const [state, setState] = useState<DesktopConnectionState>("idle");
   const [error, setError] = useState<Error | null>(null);
   const [nonce, setNonce] = useState(0);
@@ -210,5 +231,10 @@ export function useDesktopStream(options: UseDesktopStreamOptions): UseDesktopSt
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scaleViewport, state]);
 
+  // Delegate to whichever transport owns the surface. For `relay-frames` the
+  // noVNC effect above is dormant (it bailed to idle) and the frame renderer
+  // drives; for `vnc-ws` (and everything else) the noVNC path drives while the
+  // frame renderer stays idle. Same public shape either way.
+  if (transport === "relay-frames") return frameStream;
   return { state, error, reconnect };
 }

--- a/packages/react/src/hooks/use-relay-frame-stream.ts
+++ b/packages/react/src/hooks/use-relay-frame-stream.ts
@@ -1,0 +1,335 @@
+import {
+  StreamFrame,
+  StreamKind,
+  StreamOpen,
+  StreamOpenAck,
+  StreamRole,
+} from "@opengeni/agent-proto";
+import type { DesktopConnectionState, DesktopStreamCapability } from "@opengeni/sdk";
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+/**
+ * The minimal WebSocket surface the frame renderer drives. Lets tests (and a
+ * future transport swap) inject a fake without a live socket — the exact
+ * analogue of `DesktopRfbFactory` for the noVNC path. Structurally a subset of
+ * the browser `WebSocket`.
+ */
+export interface DesktopWebSocketLike {
+  binaryType: string;
+  send(data: ArrayBuffer): void;
+  close(): void;
+  addEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (ev: { data?: unknown } & Record<string, unknown>) => void,
+  ): void;
+  removeEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (ev: { data?: unknown } & Record<string, unknown>) => void,
+  ): void;
+}
+
+export type DesktopWebSocketFactory = (url: string) => DesktopWebSocketLike;
+
+export type UseRelayFrameStreamOptions = {
+  /** The desktop cell of the negotiated capabilities (`capabilities.DesktopStream`). */
+  capability: DesktopStreamCapability | null;
+  /** The mount target. A `<canvas>` is appended here on connect. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** Custom socket factory (tests / a transport swap). Defaults to `new WebSocket(url)`. */
+  webSocketFactory?: DesktopWebSocketFactory | undefined;
+};
+
+export type UseRelayFrameStreamResult = {
+  state: DesktopConnectionState;
+  error: Error | null;
+  /** Tear down + reopen the socket (e.g. after a drop, once a fresh url arrives). */
+  reconnect: () => void;
+};
+
+// Relay datagram tags: byte[0] of every binary message. Mirrors the proven wire
+// protocol in `apps/api/scripts/diagnose-mac-desktop-stream.ts`.
+const TAG_OPEN = 1;
+const TAG_OPENACK = 2;
+const TAG_FRAME = 3;
+
+/** Build a relay datagram: a fresh Uint8Array of `body.length + 1` with the tag
+ *  at [0] and the protobuf body copied at offset 1 (so `.buffer` is exact). */
+function datagram(tag: number, body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(body.length + 1);
+  out[0] = tag;
+  out.set(body, 1);
+  return out;
+}
+
+function defaultWebSocketFactory(url: string): DesktopWebSocketLike {
+  // The browser `WebSocket` is structurally a superset of `DesktopWebSocketLike`
+  // (its event maps are stricter); cast so the seam stays loosely typed for fakes.
+  return new WebSocket(url) as unknown as DesktopWebSocketLike;
+}
+
+/**
+ * VIEW-ONLY PNG-frame renderer for a SELF-HOSTED desktop stream — the relay
+ * transport (`transport: "relay-frames"`, `client: "frames"`). The self-hosted
+ * agent produces one PNG per frame as a protobuf datagram over the relay; there
+ * is no RFB/noVNC here. This hook opens the relay DESKTOP channel as a CLIENT
+ * (mirroring the proven diagnostic wire protocol), decodes each PNG onto a
+ * `<canvas>` mounted into `containerRef`, and drives the connection state
+ * machine: idle → connecting (ws opening) → connected (first painted frame) →
+ * error (ws error/close/ack rejection).
+ *
+ * It is DORMANT for any other transport (or no url): it stays idle and touches
+ * nothing, so the noVNC path owns the surface. SSR-safe: the socket + DOM attach
+ * live inside `useEffect`.
+ *
+ * Backpressure (critical — frames are ~1.8MB at ~10fps): at most one frame is
+ * decoded at a time; a frame arriving mid-decode replaces the pending one
+ * (latest-wins), so a slow decode can never build an unbounded queue.
+ */
+export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRelayFrameStreamResult {
+  const { capability, containerRef, webSocketFactory } = options;
+  const [state, setState] = useState<DesktopConnectionState>("idle");
+  const [error, setError] = useState<Error | null>(null);
+  const [nonce, setNonce] = useState(0);
+  const stateRef = useRef<DesktopConnectionState>("idle");
+  const setBoth = (next: DesktopConnectionState) => {
+    stateRef.current = next;
+    setState(next);
+  };
+
+  const reconnect = () => setNonce((n) => n + 1);
+
+  const transport = capability?.transport ?? null;
+  const url = capability?.url ?? null;
+  const token = capability?.token ?? null;
+
+  // The factory is read via a ref so swapping it never re-opens the socket (it is
+  // not a connect-effect dependency), symmetric with the noVNC `rfbFactory`.
+  const factoryRef = useRef(webSocketFactory);
+  factoryRef.current = webSocketFactory;
+
+  useEffect(() => {
+    // SSR / no DOM: stay idle and show the placeholder.
+    if (typeof window === "undefined") return;
+    // This hook OWNS the surface ONLY for the frame transport; anything else (or
+    // no live url) → dormant idle so the noVNC path can drive.
+    if (transport !== "relay-frames" || !url) {
+      setBoth("idle");
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      // Mount target not in the DOM yet (tab hidden) — stay idle so a re-attach
+      // nudge can re-run this effect once the container exists.
+      setBoth("idle");
+      return;
+    }
+
+    // Parse the 4 relay query params the channel is keyed on.
+    let channel: {
+      channelId: string;
+      workspaceId: string;
+      agentId: string;
+      kind: StreamKind;
+      port: number;
+    };
+    try {
+      const u = new URL(url);
+      channel = {
+        channelId: u.searchParams.get("channel") ?? "",
+        workspaceId: u.searchParams.get("ws") ?? "",
+        agentId: u.searchParams.get("agent") ?? "",
+        kind: StreamKind.STREAM_KIND_DESKTOP,
+        port: Number(u.searchParams.get("port") ?? "0"),
+      };
+    } catch (cause) {
+      setError(cause instanceof Error ? cause : new Error(String(cause)));
+      setBoth("error");
+      return;
+    }
+
+    setError(null);
+    setBoth("connecting");
+
+    // Canvas mount — mirror the noVNC surface conventions: absolute-fill the
+    // panel and CONTAIN the framebuffer (aspect-preserved, centered, letterboxed)
+    // — never distorted, never overflowing. `max-*: 100%` + `margin: auto` +
+    // intrinsic size gives fit-to-panel without a resize observer.
+    const canvas = document.createElement("canvas");
+    canvas.setAttribute("data-opengeni-desktop-frames", "");
+    const style = canvas.style;
+    style.position = "absolute";
+    style.top = "0";
+    style.left = "0";
+    style.right = "0";
+    style.bottom = "0";
+    style.margin = "auto";
+    style.maxWidth = "100%";
+    style.maxHeight = "100%";
+    style.width = "auto";
+    style.height = "auto";
+    style.display = "block";
+    style.imageRendering = "auto";
+    container.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+
+    let disposed = false;
+    let acked = false;
+    // Backpressure: decode at most ONE frame at a time; a frame arriving mid-
+    // decode replaces `pending` (keep only the LATEST) — never a queue.
+    let decoding = false;
+    let pending: Uint8Array | null = null;
+
+    const drainLatest = async () => {
+      if (decoding) return;
+      decoding = true;
+      try {
+        while (!disposed && pending) {
+          const data = pending;
+          pending = null;
+          let bmp: ImageBitmap;
+          try {
+            // Copy the exact frame bytes into a fresh ArrayBuffer-backed view:
+            // ts-proto's `bytes()` hands back a subarray VIEW into the larger
+            // message buffer, so slicing isolates just this PNG (and satisfies the
+            // `BlobPart` typing, which rejects the generic `ArrayBufferLike`).
+            bmp = await createImageBitmap(new Blob([new Uint8Array(data)], { type: "image/png" }));
+          } catch {
+            // A corrupt/partial frame is skipped; latest-wins keeps us live.
+            continue;
+          }
+          if (disposed) {
+            bmp.close();
+            break;
+          }
+          // Size the backing store to the frame's natural WxH on the first frame
+          // (or when the resolution changes); CSS then scales the element to fit.
+          if (canvas.width !== bmp.width || canvas.height !== bmp.height) {
+            canvas.width = bmp.width;
+            canvas.height = bmp.height;
+          }
+          ctx?.drawImage(bmp, 0, 0, canvas.width, canvas.height);
+          bmp.close();
+          // First painted frame → connected.
+          if (!disposed && stateRef.current !== "connected") setBoth("connected");
+        }
+      } finally {
+        decoding = false;
+      }
+    };
+
+    let ws: DesktopWebSocketLike;
+    try {
+      ws = (factoryRef.current ?? defaultWebSocketFactory)(url);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause : new Error(String(cause)));
+      setBoth("error");
+      canvas.remove();
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+
+    const onOpen = () => {
+      if (disposed) return;
+      const body = StreamOpen.encode({
+        channel,
+        token: token ?? "",
+        role: StreamRole.STREAM_ROLE_CLIENT,
+        resumeFromSeq: "0",
+      }).finish();
+      try {
+        ws.send(datagram(TAG_OPEN, body).buffer as ArrayBuffer);
+      } catch {
+        // Socket already closing; the close/error handler surfaces it.
+      }
+    };
+
+    const onMessage = (ev: { data?: unknown }) => {
+      if (disposed) return;
+      const data = ev.data;
+      if (!(data instanceof ArrayBuffer)) return;
+      const buf = new Uint8Array(data);
+      if (buf.length === 0) return;
+      const tag = buf[0];
+      const rest = buf.subarray(1);
+      if (tag === TAG_OPENACK) {
+        let ack: ReturnType<typeof StreamOpenAck.decode>;
+        try {
+          ack = StreamOpenAck.decode(rest);
+        } catch {
+          return;
+        }
+        if (!ack.accepted) {
+          setError(
+            new Error(
+              ack.error?.message
+                ? `desktop stream rejected: ${ack.error.message}`
+                : "desktop stream rejected by the relay",
+            ),
+          );
+          setBoth("error");
+          try {
+            ws.close();
+          } catch {
+            // already closed
+          }
+          return;
+        }
+        // Accepted — stay "connecting" until the first frame paints.
+        acked = true;
+      } else if (tag === TAG_FRAME) {
+        let fr: ReturnType<typeof StreamFrame.decode>;
+        try {
+          fr = StreamFrame.decode(rest);
+        } catch {
+          return;
+        }
+        if (fr.data && fr.data.length > 0) {
+          pending = fr.data; // latest-wins backpressure
+          void drainLatest();
+        }
+      }
+    };
+
+    const onError = () => {
+      if (disposed) return;
+      setError((prev) => prev ?? new Error("desktop stream connection error"));
+      setBoth("error");
+    };
+
+    const onClose = () => {
+      if (disposed) return;
+      setError(
+        (prev) =>
+          prev ??
+          new Error(acked ? "desktop stream closed" : "desktop stream closed before it opened"),
+      );
+      setBoth("error");
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("error", onError);
+    ws.addEventListener("close", onClose);
+
+    return () => {
+      disposed = true;
+      pending = null;
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("message", onMessage);
+      ws.removeEventListener("error", onError);
+      ws.removeEventListener("close", onClose);
+      try {
+        ws.close();
+      } catch {
+        // ignore teardown errors
+      }
+      canvas.remove();
+    };
+    // ONLY a real transport change reopens: a fresh url (rotation), a new token,
+    // the transport flipping, or a manual reconnect (`nonce`). The factory is read
+    // via a ref and must never re-open the socket.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, token, transport, nonce]);
+
+  return { state, error, reconnect };
+}

--- a/packages/react/src/hooks/use-relay-frame-stream.ts
+++ b/packages/react/src/hooks/use-relay-frame-stream.ts
@@ -1,10 +1,10 @@
 import {
-  StreamFrame,
-  StreamKind,
-  StreamOpen,
-  StreamOpenAck,
-  StreamRole,
-} from "@opengeni/agent-proto";
+  decodeStreamFrame,
+  decodeStreamOpenAck,
+  encodeStreamOpen,
+  STREAM_KIND_DESKTOP,
+  STREAM_ROLE_CLIENT,
+} from "../lib/relay-wire";
 import type { DesktopConnectionState, DesktopStreamCapability } from "@opengeni/sdk";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
@@ -129,7 +129,7 @@ export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRel
       channelId: string;
       workspaceId: string;
       agentId: string;
-      kind: StreamKind;
+      kind: number;
       port: number;
     };
     try {
@@ -138,7 +138,7 @@ export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRel
         channelId: u.searchParams.get("channel") ?? "",
         workspaceId: u.searchParams.get("ws") ?? "",
         agentId: u.searchParams.get("agent") ?? "",
-        kind: StreamKind.STREAM_KIND_DESKTOP,
+        kind: STREAM_KIND_DESKTOP,
         port: Number(u.searchParams.get("port") ?? "0"),
       };
     } catch (cause) {
@@ -230,12 +230,12 @@ export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRel
 
     const onOpen = () => {
       if (disposed) return;
-      const body = StreamOpen.encode({
+      const body = encodeStreamOpen({
         channel,
         token: token ?? "",
-        role: StreamRole.STREAM_ROLE_CLIENT,
+        role: STREAM_ROLE_CLIENT,
         resumeFromSeq: "0",
-      }).finish();
+      });
       try {
         ws.send(datagram(TAG_OPEN, body).buffer as ArrayBuffer);
       } catch {
@@ -252,9 +252,9 @@ export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRel
       const tag = buf[0];
       const rest = buf.subarray(1);
       if (tag === TAG_OPENACK) {
-        let ack: ReturnType<typeof StreamOpenAck.decode>;
+        let ack: ReturnType<typeof decodeStreamOpenAck>;
         try {
-          ack = StreamOpenAck.decode(rest);
+          ack = decodeStreamOpenAck(rest);
         } catch {
           return;
         }
@@ -277,9 +277,9 @@ export function useRelayFrameStream(options: UseRelayFrameStreamOptions): UseRel
         // Accepted — stay "connecting" until the first frame paints.
         acked = true;
       } else if (tag === TAG_FRAME) {
-        let fr: ReturnType<typeof StreamFrame.decode>;
+        let fr: ReturnType<typeof decodeStreamFrame>;
         try {
-          fr = StreamFrame.decode(rest);
+          fr = decodeStreamFrame(rest);
         } catch {
           return;
         }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -55,6 +55,13 @@ export type {
 } from "./hooks/use-session-capabilities";
 export { useDesktopStream } from "./hooks/use-desktop-stream";
 export type { UseDesktopStreamOptions, UseDesktopStreamResult } from "./hooks/use-desktop-stream";
+export { useRelayFrameStream } from "./hooks/use-relay-frame-stream";
+export type {
+  DesktopWebSocketFactory,
+  DesktopWebSocketLike,
+  UseRelayFrameStreamOptions,
+  UseRelayFrameStreamResult,
+} from "./hooks/use-relay-frame-stream";
 export { useTerminalStream } from "./hooks/use-terminal-stream";
 export type {
   TerminalStreamStatus,

--- a/packages/react/src/lib/relay-wire.ts
+++ b/packages/react/src/lib/relay-wire.ts
@@ -1,0 +1,116 @@
+// Minimal HAND-MIRROR of the relay stream wire messages the desktop frame client
+// needs (`StreamOpen` encode; `StreamOpenAck` + `StreamFrame` decode). It exists
+// because the publish-closure guard (scripts/publish-closure-guard.ts) forbids
+// `@opengeni/react` from depending on `@opengeni/agent-proto` — the published SDK
+// closure may only reach `@opengeni/sdk` among `@opengeni/*` packages. So, exactly
+// as the guard prescribes ("hand-mirror it"), we re-encode just these three
+// messages against the third-party `@bufbuild/protobuf/wire` runtime (the same
+// runtime `@opengeni/agent-proto` generates against), byte-compatible with the
+// generated code. Field numbers copied verbatim from
+// `packages/agent-proto/src/gen/opengeni_agent.ts`:
+//   StreamChannel: channelId=1, workspaceId=2, agentId=3, kind=4(int32), port=5(uint32)
+//   StreamOpen:    channel=1(msg), token=2, role=3(int32), resumeFromSeq=4(uint64, omitted when "0")
+//   StreamOpenAck: accepted=1(bool), error=2(AgentError msg), resumeFromSeq=3
+//   AgentError:    code=1, message=2, retryable=3, detail=4  (we read only message)
+//   StreamFrame:   channelId=1, seq=2, data=3(bytes), producedAtMs=4  (we read only data)
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+/** `StreamKind.STREAM_KIND_DESKTOP` (agent-proto enum value). */
+export const STREAM_KIND_DESKTOP = 2;
+/** `StreamRole.STREAM_ROLE_CLIENT` (agent-proto enum value). */
+export const STREAM_ROLE_CLIENT = 2;
+
+export interface RelayChannel {
+  channelId: string;
+  workspaceId: string;
+  agentId: string;
+  kind: number;
+  port: number;
+}
+
+export interface RelayStreamOpen {
+  channel: RelayChannel;
+  token: string;
+  role: number;
+  resumeFromSeq: string;
+}
+
+function encodeChannel(message: RelayChannel, writer: BinaryWriter): BinaryWriter {
+  if (message.channelId !== "") writer.uint32(10).string(message.channelId);
+  if (message.workspaceId !== "") writer.uint32(18).string(message.workspaceId);
+  if (message.agentId !== "") writer.uint32(26).string(message.agentId);
+  if (message.kind !== 0) writer.uint32(32).int32(message.kind);
+  if (message.port !== 0) writer.uint32(40).uint32(message.port);
+  return writer;
+}
+
+/** Encode a `StreamOpen`, byte-compatible with `StreamOpen.encode(...).finish()`. */
+export function encodeStreamOpen(message: RelayStreamOpen): Uint8Array {
+  const writer = new BinaryWriter();
+  encodeChannel(message.channel, writer.uint32(10).fork()).join();
+  if (message.token !== "") writer.uint32(18).string(message.token);
+  if (message.role !== 0) writer.uint32(24).int32(message.role);
+  if (message.resumeFromSeq !== "0") writer.uint32(32).uint64(message.resumeFromSeq);
+  return writer.finish();
+}
+
+/** The only `AgentError` field we surface from a rejected ack. */
+function decodeAgentErrorMessage(reader: BinaryReader, length: number): { message?: string } {
+  const end = reader.pos + length;
+  let message: string | undefined;
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    if (tag >>> 3 === 2 && tag === 18) {
+      message = reader.string();
+      continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) break;
+    reader.skip(tag & 7);
+  }
+  return message !== undefined ? { message } : {};
+}
+
+/** Decode a `StreamOpenAck` (we need `accepted` + the error message). */
+export function decodeStreamOpenAck(bytes: Uint8Array): {
+  accepted: boolean;
+  error?: { message?: string };
+} {
+  const reader = new BinaryReader(bytes);
+  const end = reader.len;
+  let accepted = false;
+  let error: { message?: string } | undefined;
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    if (tag >>> 3 === 1 && tag === 8) {
+      accepted = reader.bool();
+      continue;
+    }
+    if (tag >>> 3 === 2 && tag === 18) {
+      error = decodeAgentErrorMessage(reader, reader.uint32());
+      continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) break;
+    reader.skip(tag & 7);
+  }
+  return error !== undefined ? { accepted, error } : { accepted };
+}
+
+/** Decode a `StreamFrame`, extracting only the `data` (framebuffer PNG) bytes. */
+export function decodeStreamFrame(bytes: Uint8Array): { data: Uint8Array } {
+  const reader = new BinaryReader(bytes);
+  const end = reader.len;
+  let data = new Uint8Array(0);
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    if (tag >>> 3 === 3 && tag === 26) {
+      // Copy into a fresh ArrayBuffer-backed view: BinaryReader.bytes() returns
+      // `Uint8Array<ArrayBufferLike>` (a view into the message buffer), which both
+      // narrows the type to `Uint8Array<ArrayBuffer>` and isolates just this frame.
+      data = new Uint8Array(reader.bytes());
+      continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) break;
+    reader.skip(tag & 7);
+  }
+  return { data };
+}

--- a/packages/react/test/desktop-frames.test.tsx
+++ b/packages/react/test/desktop-frames.test.tsx
@@ -1,0 +1,215 @@
+/* ----------------------------------------------------------------------------
+   Self-hosted desktop: the `relay-frames` transport paints PNG-per-frame onto a
+   <canvas> (no RFB). These tests inject a fake WebSocket that speaks the proven
+   relay wire protocol (Open → OpenAck → StreamFrame) and assert the viewer
+   reaches `connected` after decoding+painting the first frame, plus graceful
+   error on an ack rejection.
+   -------------------------------------------------------------------------- */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  StreamFrame,
+  StreamKind,
+  StreamOpen,
+  StreamOpenAck,
+  StreamRole,
+} from "@opengeni/agent-proto";
+import { act } from "react";
+import { registerDom, renderComponent, flush } from "./render-hook";
+import { fakeCapabilities } from "./sandbox-fixtures";
+import { DesktopViewer } from "../src/components/desktop-viewer";
+import type {
+  DesktopWebSocketFactory,
+  DesktopWebSocketLike,
+} from "../src/hooks/use-relay-frame-stream";
+
+registerDom();
+
+// Relay datagram tags (byte[0]).
+const TAG_OPEN = 1;
+const TAG_OPENACK = 2;
+const TAG_FRAME = 3;
+function datagram(tag: number, body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(body.length + 1);
+  out[0] = tag;
+  out.set(body, 1);
+  return out;
+}
+
+// A tiny, valid 1x1 transparent PNG (decoded from base64 so the byte array stays
+// readable). `createImageBitmap` is stubbed, so the exact pixels don't matter —
+// only that it is a non-empty PNG the frame carries end-to-end.
+const PNG_1x1 = Uint8Array.from(
+  atob(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  ),
+  (c) => c.charCodeAt(0),
+);
+
+/** A fake WebSocket that records what the hook sends and lets the test dispatch
+ *  relay datagrams back to it. Matches `DesktopWebSocketLike`. */
+class FakeWebSocket implements DesktopWebSocketLike {
+  binaryType = "blob";
+  readonly sent: ArrayBuffer[] = [];
+  closed = false;
+  private readonly listeners = new Map<string, Set<(ev: { data?: unknown }) => void>>();
+
+  constructor(readonly url: string) {}
+
+  addEventListener(type: string, cb: (ev: { data?: unknown }) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(cb);
+  }
+  removeEventListener(type: string, cb: (ev: { data?: unknown }) => void): void {
+    this.listeners.get(type)?.delete(cb);
+  }
+  send(data: ArrayBuffer): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  emit(type: string, ev: { data?: unknown } = {}): void {
+    for (const cb of [...(this.listeners.get(type) ?? [])]) cb(ev);
+  }
+}
+
+/** Dispatch a relay event to the socket inside `act` so the synchronous React
+ *  state updates it triggers are flushed without a warning. */
+async function dispatch(socket: FakeWebSocket, type: string, ev: { data?: unknown } = {}) {
+  await act(async () => {
+    socket.emit(type, ev);
+  });
+}
+
+function relayCapability() {
+  return {
+    ...fakeCapabilities().DesktopStream,
+    transport: "relay-frames" as const,
+    client: "frames" as const,
+    mode: "read-only" as const,
+    url: "wss://relay.example/stream?ws=W1&agent=A1&port=6080&channel=C1",
+    token: "stream-token",
+    // Already acknowledged so the consent gate does not block connection.
+    requiresAcknowledgment: false,
+    acknowledged: true,
+  };
+}
+
+describe("DesktopViewer — relay-frames (self-hosted PNG stream)", () => {
+  const realCreateImageBitmap = (globalThis as { createImageBitmap?: unknown }).createImageBitmap;
+  let decoded: number;
+
+  beforeEach(() => {
+    decoded = 0;
+    // jsdom/happy-dom lacks createImageBitmap; stub it so a "decode+paint" is
+    // observable and deterministic (1x1 bitmap with a close()).
+    (globalThis as { createImageBitmap: unknown }).createImageBitmap = mock(async (_blob: Blob) => {
+      decoded += 1;
+      return { width: 1, height: 1, close: () => {} } as unknown as ImageBitmap;
+    });
+  });
+  afterEach(() => {
+    (globalThis as { createImageBitmap?: unknown }).createImageBitmap = realCreateImageBitmap;
+  });
+
+  test("Open → OpenAck(accepted) → StreamFrame reaches connected and paints a PNG", async () => {
+    let socket: FakeWebSocket | undefined;
+    const factory: DesktopWebSocketFactory = (url) => {
+      socket = new FakeWebSocket(url);
+      return socket;
+    };
+
+    const r = await renderComponent(
+      <DesktopViewer capability={relayCapability()} webSocketFactory={factory} />,
+    );
+    await flush(5);
+
+    // The canvas mount was appended into the viewer's container.
+    expect(r.container.querySelector("[data-opengeni-desktop-frames]")).not.toBeNull();
+    expect(socket).toBeDefined();
+    expect(socket!.binaryType).toBe("arraybuffer");
+
+    // WS opens → the hook sends exactly the Open datagram for a CLIENT desktop
+    // channel, keyed off the url's query params.
+    await dispatch(socket!, "open");
+    expect(socket!.sent.length).toBe(1);
+    const openBuf = new Uint8Array(socket!.sent[0]!);
+    expect(openBuf[0]).toBe(TAG_OPEN);
+    const open = StreamOpen.decode(openBuf.subarray(1));
+    expect(open.channel?.channelId).toBe("C1");
+    expect(open.channel?.workspaceId).toBe("W1");
+    expect(open.channel?.agentId).toBe("A1");
+    expect(open.channel?.port).toBe(6080);
+    expect(open.channel?.kind).toBe(StreamKind.STREAM_KIND_DESKTOP);
+    expect(open.role).toBe(StreamRole.STREAM_ROLE_CLIENT);
+    expect(open.token).toBe("stream-token");
+
+    // Still connecting until the first frame paints.
+    const surface = r.container.querySelector("[data-opengeni-desktop]");
+    expect(surface?.getAttribute("data-state")).not.toBe("connected");
+
+    // Relay accepts the channel.
+    const ack = datagram(
+      TAG_OPENACK,
+      StreamOpenAck.encode({ accepted: true, error: undefined, resumeFromSeq: "0" }).finish(),
+    );
+    await dispatch(socket!, "message", { data: ack.buffer });
+
+    // A frame carrying the 1x1 PNG → decode + paint → connected.
+    const frame = datagram(
+      TAG_FRAME,
+      StreamFrame.encode({
+        channelId: "C1",
+        seq: "1",
+        data: PNG_1x1,
+        producedAtMs: "0",
+      }).finish(),
+    );
+    await dispatch(socket!, "message", { data: frame.buffer });
+    await flush(5);
+
+    expect(decoded).toBeGreaterThan(0);
+    expect(surface?.getAttribute("data-state")).toBe("connected");
+
+    await r.unmount();
+    // Teardown closes the socket.
+    expect(socket!.closed).toBe(true);
+  });
+
+  test("an ack rejection surfaces a graceful error overlay (no crash)", async () => {
+    let socket: FakeWebSocket | undefined;
+    const factory: DesktopWebSocketFactory = (url) => {
+      socket = new FakeWebSocket(url);
+      return socket;
+    };
+
+    const r = await renderComponent(
+      <DesktopViewer capability={relayCapability()} webSocketFactory={factory} />,
+    );
+    await flush(5);
+    await dispatch(socket!, "open");
+
+    const ack = datagram(
+      TAG_OPENACK,
+      StreamOpenAck.encode({
+        accepted: false,
+        error: { code: 0, message: "lease fenced", retryable: false, detail: {} },
+        resumeFromSeq: "0",
+      }).finish(),
+    );
+    await dispatch(socket!, "message", { data: ack.buffer });
+    await flush(5);
+
+    const surface = r.container.querySelector("[data-opengeni-desktop]");
+    expect(surface?.getAttribute("data-state")).toBe("error");
+    // The disconnected overlay shows the relay's reason + a Reconnect affordance.
+    expect(r.container.textContent).toContain("lease fenced");
+    expect(r.container.textContent).toContain("Reconnect");
+
+    await r.unmount();
+  });
+});

--- a/packages/runtime/src/sandbox/select.ts
+++ b/packages/runtime/src/sandbox/select.ts
@@ -283,11 +283,17 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
     // deployment that wants a genuinely read-only desktop sets
     // sandboxDesktopInteractive=false → mode "read-only" and the client disables
     // take-control. An unavailable cell is always "read-only" (nothing to drive).
-    const interactive = available && ctx.desktopInteractive !== false;
+    // Selfhosted desktop is the RELAY framebuffer: PNG-per-frame protobuf datagrams
+    // spliced over the relay, rendered by the "frames" canvas client — NOT noVNC/RFB
+    // (that x11vnc path exists only for Modal boxes). It is VIEW-ONLY in v1 (the
+    // frame client does not forward input yet), so its mode is always read-only
+    // regardless of the take-control policy.
+    const selfhostedFrames = ctx.backend === "selfhosted";
+    const interactive = available && !selfhostedFrames && ctx.desktopInteractive !== false;
     const mode = interactive ? ("interactive" as const) : ("read-only" as const);
     return {
-      transport: available ? cap.transport : null,
-      client: available ? ("novnc" as const) : null,
+      transport: available ? (selfhostedFrames ? ("relay-frames" as const) : cap.transport) : null,
+      client: available ? (selfhostedFrames ? ("frames" as const) : ("novnc" as const)) : null,
       mode,
       url: minted?.url ?? null,
       token: minted?.token ?? null,

--- a/packages/runtime/test/selfhosted-capabilities.test.ts
+++ b/packages/runtime/test/selfhosted-capabilities.test.ts
@@ -85,7 +85,9 @@ describe("negotiateSelfhostedCapabilities — every cell decided correctly", () 
     expect(caps.FileSystem.reason).toBeNull();
     expect(caps.Git.available).toBe(true);
     expect(caps.Terminal.transport).toBe("pty-ws");
-    expect(caps.DesktopStream.transport).toBe("vnc-ws");
+    // Selfhosted desktop is the RELAY framebuffer (PNG-per-frame), rendered by the
+    // "frames" canvas client — never noVNC (that's Modal's x11vnc path).
+    expect(caps.DesktopStream.transport).toBe("relay-frames");
     expect(caps.DesktopStream.reason).toBeNull();
     expect(caps.ComputerUse.available).toBe(true);
     expect(caps.Recording.available).toBe(true);
@@ -153,7 +155,7 @@ describe("negotiateSelfhostedCapabilities — every cell decided correctly", () 
     // (read-only stream) + RECORDED — the agent already has whole-machine exec, so
     // passive viewing adds no capability. Only INPUT (ComputerUse / an interactive
     // stream) requires the explicit allowScreenControl consent.
-    expect(caps.DesktopStream.transport).toBe("vnc-ws");
+    expect(caps.DesktopStream.transport).toBe("relay-frames");
     expect(caps.DesktopStream.mode).toBe("read-only");
     expect(caps.DesktopStream.reason).toBeNull();
     expect(caps.Recording.available).toBe(true);

--- a/packages/runtime/test/selfhosted-nats.integration.test.ts
+++ b/packages/runtime/test/selfhosted-nats.integration.test.ts
@@ -105,7 +105,9 @@ describe("selfhosted mocked-NATS integration — exec + fs round-trip through a 
       session,
     });
     expect(caps.FileSystem.available).toBe(true);
-    expect(caps.DesktopStream.transport).toBe("vnc-ws");
+    // Selfhosted desktop is the RELAY framebuffer (PNG-per-frame), rendered by the
+    // "frames" canvas client — never noVNC/vnc-ws (that's Modal's x11vnc path).
+    expect(caps.DesktopStream.transport).toBe("relay-frames");
 
     // Flip offline → the surface degrades to agent_offline on the same session.
     mock.setOnline(false);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -84,8 +84,10 @@ export type SessionCapabilities = {
     reason: CapabilityUnavailableReason | null;
   };
   DesktopStream: {
-    transport: "vnc-ws" | "rdp-ws" | "webrtc" | null;
-    client: "novnc" | "web-rdp" | null;
+    // "relay-frames" + "frames": the selfhosted framebuffer stream — PNG-per-frame
+    // protobuf datagrams over the relay, painted by a canvas client (NOT RFB).
+    transport: "vnc-ws" | "rdp-ws" | "webrtc" | "relay-frames" | null;
+    client: "novnc" | "web-rdp" | "frames" | null;
     mode: "read-only" | "interactive";
     url: string | null;
     token: string | null;


### PR DESCRIPTION
## The bug

Self-hosted machines stream their desktop as **PNG-per-frame** protobuf datagrams over the relay — **not RFB**. But the viewer only ever loaded **noVNC/RFB** (the Xvfb→x11vnc→websockify stack that satisfies noVNC exists *only* for Modal boxes). So noVNC dialed the relay, received raw PNG bytes, failed the RFB handshake, and hit the 13s watchdog: **"the desktop is warm but the live stream didn't come up."**

The pixel path itself is fine — verified live against a real Mac: **14 frames / ~25 MB** of the actual screen pulled over the relay, first frame a valid PNG. Only the render contract was mismatched.

## The fix

A frame renderer, plus a transport signal to select it:

- **Negotiation** (`packages/runtime/src/sandbox/select.ts`) now advertises, for self-hosted desktop cells, `transport: "relay-frames"`, `client: "frames"`, `mode: "read-only"` (Modal keeps `"vnc-ws"`/`"novnc"`). Added those values to the contracts zod schema + the SDK type unions.
- **`useRelayFrameStream`** (new, `packages/react`): opens the relay DESKTOP channel as a CLIENT using the proven wire protocol (tag-1 `StreamOpen` datagram → tag-2 `OpenAck` → tag-3 `StreamFrame`), decodes each PNG via `createImageBitmap` onto a `<canvas>` mounted in the viewer container, CONTAIN-fit + centered. **Latest-wins backpressure** (frames are ~1.8 MB at ~10 fps): at most one decode in flight; a frame arriving mid-decode replaces the pending one — never a queue.
- **`useDesktopStream`** dispatches on `transport`: `"relay-frames"` → the frame renderer, else noVNC. Same public interface, so `DesktopViewer` stays transport-agnostic; both hooks are always called (rules of hooks) and each is dormant for the other's transport.

**View-only in v1** — matches the self-hosted read-only mode and the declined screen-control consent. Interactive input (relay `DesktopInput`) is a follow-up.

## Verification
- Typecheck clean: contracts, sdk, runtime, react.
- react suite green (355 pass); new `desktop-frames.test.tsx` injects a fake WebSocket, drives Open→OpenAck→StreamFrame(real 1×1 PNG), asserts `connected` + a decode, and asserts ack-rejection → graceful error.
- runtime `selfhosted-capabilities` updated to assert `transport: "relay-frames"`.
- `@opengeni/agent-proto` confirmed frontend-safe (`@bufbuild/protobuf/wire` only; no node builtins).
- **Visually verified in a real headless browser** painting a real captured Mac frame: correct contain-fit, centered, letterboxed on the black backdrop, no distortion.

## Follow-ups (not in scope)
- Interactive input (relay `DesktopInput` tag-5).
- Bandwidth: PNG is ~1.8 MB/frame; JPEG/WebP or delta encoding would cut wire cost (an agent-side pump change).
- `stream.url.rotated` folding for `relay-frames` (auto-reconnect on epoch rotation, as noVNC has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New live streaming path and capability contract changes affect how self-hosted desktops connect and display; scope is bounded to view-only relay frames with existing consent/ack flows unchanged for Modal.
> 
> **Overview**
> Fixes self-hosted desktop viewing where the relay sends **PNG-per-frame** protobuf datagrams, not RFB — noVNC could never complete a handshake, so streams stayed “warm” but never connected.
> 
> **Negotiation** now advertises `transport: "relay-frames"` and `client: "frames"` for self-hosted desktop (Modal keeps `vnc-ws` / `novnc`), with contracts, SDK types, and runtime `select.ts` updated; self-hosted desktop stays **read-only** in v1.
> 
> **`useRelayFrameStream`** opens the relay DESKTOP channel (Open → OpenAck → StreamFrame), decodes PNGs with `createImageBitmap`, and paints a contain-fit `<canvas>` with **latest-wins** decode backpressure. **`useDesktopStream`** branches on `transport` and returns the frame hook for `relay-frames` while keeping the same API for **`DesktopViewer`** (optional `webSocketFactory` for tests). A hand-mirrored **`relay-wire`** module encodes/decodes protobuf without a runtime `@opengeni/agent-proto` dependency in the published React package.
> 
> Tests cover the Open→Ack→Frame happy path and ack rejection; capability tests expect `relay-frames` for self-hosted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3caddc76debc0f41855c77cafb783ee4a1ed00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->