### PR TITLE
fix(desktop): swap-case sessions advertise relay-frames for a selfhosted active sandbox

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -578,7 +578,31 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
           }
         : {}),
     });
-    return c.json(capabilities);
+
+    // SWAP-CASE desktop transport: the negotiation keyed on the HOME backend, but
+    // the desktop/terminal plane actually runs on the ACTIVE sandbox when one is
+    // pinned. If that active sandbox is a SELFHOSTED machine, its desktop is the
+    // RELAY framebuffer (PNG-per-frame) — the "relay-frames"/"frames" client, NOT
+    // the home box's noVNC. Override the cell so the viewer selects the frame
+    // renderer (the mint already served the machine's relay url). Machine-PRIMARY
+    // sessions (home backend already selfhosted) negotiate relay-frames directly,
+    // so the `=== "vnc-ws"` guard skips the extra lookup for them.
+    let responseCapabilities = capabilities;
+    if (session.activeSandboxId && capabilities.DesktopStream.transport === "vnc-ws") {
+      const activeSandbox = await getSandbox(db, workspaceId, session.activeSandboxId);
+      if (activeSandbox?.kind === "selfhosted") {
+        responseCapabilities = {
+          ...capabilities,
+          DesktopStream: {
+            ...capabilities.DesktopStream,
+            transport: "relay-frames",
+            client: "frames",
+            mode: "read-only",
+          },
+        };
+      }
+    }
+    return c.json(responseCapabilities);
   });
 
   // POST .../stream-capabilities/acknowledge — record the calling principal's


### PR DESCRIPTION
## The gap

Follow-up to #170 (self-hosted desktop frame renderer). The stream-capabilities negotiation keys `DesktopStream.transport`/`client` on the **home** session backend (`sessions.ts` → `negotiateCapabilities({ backend: session.sandboxBackend })`). But the desktop plane actually runs on the **active** sandbox when one is pinned.

So a session that started on a cloud box (home `modal`) and then **swapped** its active sandbox to a self-hosted machine got a relay framebuffer url from the mint but a `"vnc-ws"`/`"novnc"` label from the negotiation → the viewer loaded noVNC against a PNG-frame stream and never came up. (Machine-**primary** sessions — home backend already `selfhosted`, the Stage-D honest label — negotiate `relay-frames` directly and were already correct; verified live.)

## Fix

When a pinned active sandbox is self-hosted, override the desktop cell to `relay-frames`/`frames`/`read-only` so the viewer selects the frame renderer (the mint already served the machine's relay url). Guarded on `transport === "vnc-ws"` so machine-primary sessions skip the extra sandbox lookup entirely.

## Verification
- `apps/api` typecheck clean.
- **Live integration** (post-deploy): a `modal`-home session swapped to the user's Mac now returns `DesktopStream.transport: "relay-frames"` and the real `useRelayFrameStream` hook paints its live screen in a headless browser (same harness that verified the machine-primary path end-to-end). The positive machine-primary path already has unit (`selfhosted-capabilities`) + live coverage; this guarded override is the symmetric swap-path case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow response-shape fix on stream-capabilities with one conditional DB lookup; no auth or minting changes.
> 
> **Overview**
> **Fixes desktop viewer transport after swapping the active sandbox to a self-hosted machine** when the session still has a cloud “home” backend.
> 
> `GET .../stream-capabilities` still derives `DesktopStream` from `session.sandboxBackend`, so a modal-home session with a pinned self-hosted active sandbox could return `vnc-ws` / `novnc` while minting already pointed at the relay PNG stream—breaking the viewer. The handler now, when `activeSandboxId` is set and negotiation says `vnc-ws`, loads that sandbox and **overrides** the desktop cell to `relay-frames` / `frames` / `read-only` for `kind === "selfhosted"`. Sessions whose home backend is already self-hosted skip this path because they never advertise `vnc-ws`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e0aedadad8c3c5580a072c569649409bf6fcb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->