### PR TITLE
feat(codex): progressive connector disclosure via native tool_search (flag-off)

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -218,6 +218,12 @@ const SettingsSchema = z.object({
   // provider whose models route through the ChatGPT backend (@opengeni/codex).
   codexSubscriptionEnabled: EnvBoolean.default(false),  // OPENGENI_CODEX_SUBSCRIPTION_ENABLED
   codexProductSku: z.string().optional(),               // OPENGENI_CODEX_PRODUCT_SKU (X-OpenAI-Product-Sku, apps only)
+  // Progressive connector disclosure (Codex-CLI-style tool_search): on a codex
+  // turn, flag the ~217 codex_apps connector tools `defer_loading:true` (dropping
+  // their schemas from model context) and add one client-executed tool_search
+  // tool that BM25-discloses only the matching connectors. Default OFF — a codex
+  // turn is byte-for-byte unchanged until enabled. OPENGENI_CODEX_TOOL_SEARCH_ENABLED
+  codexToolSearchEnabled: EnvBoolean.default(false),
   // Multi-account P3 (auto-rotation): an account is "near exhaustion" — ineligible to be
   // rotated TO — when EITHER usage window (5h/weekly) is at/over this percent. Default 90 to
   // match the UI danger flip (UsageBar danger at pct >= 90). OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT.
@@ -866,6 +872,7 @@ export function getSettings(): Settings {
     modelPricingJson: optional("OPENGENI_MODEL_PRICING_JSON"),
     modelProvidersJson: optional("OPENGENI_MODEL_PROVIDERS_JSON"),
     codexSubscriptionEnabled: optional("OPENGENI_CODEX_SUBSCRIPTION_ENABLED"),
+    codexToolSearchEnabled: optional("OPENGENI_CODEX_TOOL_SEARCH_ENABLED"),
     codexProductSku: optional("OPENGENI_CODEX_PRODUCT_SKU"),
     codexRotationNearExhaustionPct: optional("OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT"),
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),

--- a/packages/runtime/src/codex-tool-search.ts
+++ b/packages/runtime/src/codex-tool-search.ts
@@ -1,0 +1,196 @@
+// Progressive connector disclosure for the ChatGPT/Codex backend — parity with
+// how the Codex CLI surfaces its ~217 `codex_apps` connector tools WITHOUT paying
+// their schemas in every turn's context.
+//
+// WHY. OpenGeni connects the codex_apps MCP server as a CLIENT and the SDK
+// materializes EVERY connector tool as a `function` tool in request.tools[] on
+// every codex turn (~217 tools ≈ tens of thousands of context tokens). The Codex
+// CLI instead uses the backend's NATIVE tool-search: the model gets one compact
+// search tool + all connector tools flagged `defer_loading:true` (schemas dropped
+// from model context), searches by capability, and only the matched tools are
+// disclosed back and become callable.
+//
+// PROVEN LIVE (Phase 0 probe against /codex/responses on gpt-5.5): the backend
+// HONORS `defer_loading:true` on function tools — 50 fat tools dropped input_tokens
+// 6766 → 108 — AND makes a tool callable purely because a prior `tool_search_output`
+// disclosed it (V3). The model emits `tool_search_call` on our slug.
+//
+// HOW. We wrap the agent's `getAllTools` (codex turns only, flag-gated): tag every
+// `codex_apps__*` function tool `deferLoading = true` (converTool then serializes
+// `defer_loading:true`, dropping the schema from context) and append one
+// client-executed `toolSearchTool`. The SDK routes a `tool_search_call` to our
+// executor (ClientToolSearchExecutor), which BM25-ranks the deferred pool and
+// returns the matched tools BY REFERENCE — the SDK emits the `tool_search_output`
+// that discloses them; the subsequent `function_call` resolves through the normal
+// PrefixedMcpServer.callTool path (auth + name-sanitize + structuredContent inline
+// all unchanged). Invocation is untouched; only the wire tool-set shrinks.
+
+import { toolSearchTool, type Tool } from "@openai/agents";
+
+/** The prefix OpenGeni's PrefixedMcpServer stamps on codex_apps connector tools. */
+export const CODEX_APPS_TOOL_PREFIX = "codex_apps__";
+const DEFAULT_SEARCH_LIMIT = 8;
+const MAX_SEARCH_LIMIT = 20;
+
+/** True for a materialized codex_apps connector function tool. */
+export function isCodexAppsFunctionTool(tool: unknown): tool is Tool & { name: string; deferLoading?: boolean } {
+  return (
+    !!tool
+    && typeof tool === "object"
+    && (tool as { type?: unknown }).type === "function"
+    && typeof (tool as { name?: unknown }).name === "string"
+    && (tool as { name: string }).name.startsWith(CODEX_APPS_TOOL_PREFIX)
+  );
+}
+
+/** Split snake_case/camelCase/dotted text into lowercase word tokens (len ≥ 2). */
+function tokenize(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1);
+}
+
+/** The searchable text of a connector tool: name (weighted ×2) + description + param names. */
+function toolSearchText(tool: Tool): string {
+  const raw = (tool as { name?: string }).name ?? "";
+  const name = raw.startsWith(CODEX_APPS_TOOL_PREFIX) ? raw.slice(CODEX_APPS_TOOL_PREFIX.length) : raw;
+  const description = typeof (tool as { description?: unknown }).description === "string" ? (tool as { description: string }).description : "";
+  const params = (tool as { parameters?: { properties?: Record<string, unknown> } }).parameters?.properties;
+  const paramNames = params && typeof params === "object" ? Object.keys(params).join(" ") : "";
+  return `${name} ${name} ${description} ${paramNames}`;
+}
+
+/**
+ * Rank connector tools against a plain-language query with BM25 (Okapi, k1=1.5,
+ * b=0.75) over tokenized name+description+params. Returns the top `limit` tools
+ * with a positive score, most-relevant first. An empty/no-match query returns
+ * the first `limit` tools (never empty when tools exist) so a search always
+ * discloses SOMETHING the model can act on or reject.
+ */
+export function bm25RankTools(tools: Tool[], query: string, limit: number): Tool[] {
+  const qTokens = Array.from(new Set(tokenize(query)));
+  if (tools.length === 0) return [];
+  if (qTokens.length === 0) return tools.slice(0, limit);
+
+  const docs = tools.map((tool) => {
+    const tokens = tokenize(toolSearchText(tool));
+    const tf = new Map<string, number>();
+    for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+    return { tool, len: tokens.length, tf };
+  });
+  const N = docs.length;
+  const avgdl = Math.max(1, docs.reduce((s, d) => s + d.len, 0) / N);
+  const df = new Map<string, number>();
+  for (const d of docs) for (const t of d.tf.keys()) df.set(t, (df.get(t) ?? 0) + 1);
+
+  const k1 = 1.5;
+  const b = 0.75;
+  const scored = docs.map((d) => {
+    let score = 0;
+    for (const qt of qTokens) {
+      const n = df.get(qt);
+      const f = d.tf.get(qt);
+      if (!n || !f) continue;
+      const idf = Math.log(1 + (N - n + 0.5) / (n + 0.5));
+      score += idf * ((f * (k1 + 1)) / (f + k1 * (1 - b + (b * d.len) / avgdl)));
+    }
+    return { tool: d.tool, score };
+  });
+  const hits = scored.filter((s) => s.score > 0).sort((a, b2) => b2.score - a.score);
+  if (hits.length === 0) return tools.slice(0, limit); // never strand the model with nothing
+  return hits.slice(0, limit).map((s) => s.tool);
+}
+
+/** Parse `{query, limit}` from a tool_search_call's arguments (string or object). */
+function parseSearchArgs(raw: unknown): { query: string; limit: number } {
+  let obj: Record<string, unknown> = {};
+  try {
+    obj = typeof raw === "string" ? (raw.length ? JSON.parse(raw) : {}) : (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {});
+  } catch {
+    obj = {};
+  }
+  const query = typeof obj.query === "string" ? obj.query : "";
+  const limitRaw = typeof obj.limit === "number" && Number.isFinite(obj.limit) ? obj.limit : DEFAULT_SEARCH_LIMIT;
+  return { query, limit: Math.max(1, Math.min(MAX_SEARCH_LIMIT, Math.round(limitRaw))) };
+}
+
+const SEARCH_TOOL_DESCRIPTION =
+  "Search the user's connected app tools (Gmail, GitHub, Google Calendar, Slack, and more) by capability. "
+  + "Describe in plain language WHAT you need to do (for example: \"send an email\", \"create a calendar event\", "
+  + "\"list GitHub issues\") rather than guessing exact tool names. Returns the matching connector tools, which then become callable.";
+
+const SEARCH_TOOL_PARAMETERS = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Plain-language description of the capability you need." },
+    limit: { type: "number", description: "Maximum number of tools to return (default 8)." },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} as const;
+
+/**
+ * The client tool-search executor: BM25 over the deferred codex_apps pool from the
+ * turn's live `availableTools`, returning matched tools BY REFERENCE (the only legal
+ * return — the SDK emits the disclosing `tool_search_output` and flips the loaded
+ * gate; returning copies would throw). Stateless — reads the pool per call.
+ */
+function codexToolSearchExecutor(args: { availableTools?: Tool[]; toolCall?: { arguments?: unknown } }): Tool[] {
+  const deferred = (args.availableTools ?? []).filter(isCodexAppsFunctionTool);
+  if (deferred.length === 0) return [];
+  const { query, limit } = parseSearchArgs(args.toolCall?.arguments);
+  return bm25RankTools(deferred, query, limit);
+}
+
+/** Build the client-executed tool_search tool that discloses codex_apps connectors on demand. */
+export function buildCodexToolSearchTool(): Tool {
+  return toolSearchTool({
+    execution: "client",
+    description: SEARCH_TOOL_DESCRIPTION,
+    parameters: SEARCH_TOOL_PARAMETERS as unknown as Record<string, unknown>,
+    execute: codexToolSearchExecutor as never,
+  }) as unknown as Tool;
+}
+
+/** True for the built-in tool_search tool (so we never add a second one). */
+function isToolSearchTool(tool: unknown): boolean {
+  const t = tool as { name?: unknown; providerData?: { type?: unknown } } | null;
+  return !!t && (t.name === "tool_search" || t.providerData?.type === "tool_search");
+}
+
+/**
+ * The transform applied to a turn's resolved tool list: tag every codex_apps
+ * connector function tool `deferLoading = true`, and — only if we tagged at least
+ * one and no tool_search tool is already present — append the client tool_search
+ * tool. Pure (mutates the passed tools + returns the possibly-extended array); the
+ * SDK's `getTools` gate requires a tool_search whenever a deferred tool is present,
+ * which appending here satisfies in the same request. No-op (same array, untouched)
+ * when the turn has no codex_apps tools.
+ */
+export function applyCodexToolSearch(tools: Tool[]): Tool[] {
+  let tagged = 0;
+  for (const tool of tools) {
+    if (isCodexAppsFunctionTool(tool) && (tool as { deferLoading?: boolean }).deferLoading !== true) {
+      (tool as { deferLoading?: boolean }).deferLoading = true;
+      tagged++;
+    }
+  }
+  if (tagged === 0 || tools.some(isToolSearchTool)) {
+    return tools;
+  }
+  return [...tools, buildCodexToolSearchTool()];
+}
+
+/**
+ * Install progressive connector disclosure on a codex-path agent by wrapping
+ * `getAllTools` so every per-model-call tool resolution runs {@link applyCodexToolSearch}.
+ * Idempotent-per-call (re-tags each freshly-materialized MCP tool under
+ * cacheToolsList:false). Gated by the caller (flag + codex path); does nothing on a
+ * turn with no codex_apps tools.
+ */
+export function installCodexToolSearch(agent: { getAllTools: (runContext: unknown) => Promise<Tool[]> }): void {
+  const original = agent.getAllTools.bind(agent);
+  agent.getAllTools = (async (runContext: unknown) => applyCodexToolSearch(await original(runContext))) as typeof agent.getAllTools;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -82,6 +82,7 @@ import { dirname, isAbsolute, join, posix as posixPath, relative } from "node:pa
 import { fileURLToPath } from "node:url";
 
 import { computerCallNormalizingFetch, normalizeComputerCallActions, sanitizeHistoryItemsForModel } from "./history-sanitizer";
+import { installCodexToolSearch } from "./codex-tool-search";
 import { enforceInputBudget, estimateItemTokens } from "./context-compaction";
 import {
   createSandboxClient,
@@ -839,7 +840,9 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   } as const;
 
   if (settings.sandboxBackend === "none") {
-    return new Agent(baseConfig);
+    const agent = new Agent(baseConfig);
+    maybeInstallCodexToolSearch(agent, settings, options);
+    return agent;
   }
 
   const runAs = sandboxRunAs(settings);
@@ -860,7 +863,22 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   if (options.gitTokenSeed) {
     agentGitTokenSeed.set(agent, options.gitTokenSeed);
   }
+  maybeInstallCodexToolSearch(agent, settings, options);
   return agent;
+}
+
+/**
+ * Enable Codex-CLI-style progressive connector disclosure on a codex turn when the
+ * flag is on. Gated on `structuredToolTransport === false` — the same signal that
+ * identifies a codex-subscription turn (the ChatGPT backend that rejects hosted
+ * tools) — so no non-codex turn is ever touched. On qualifying turns it wraps
+ * `getAllTools` to defer codex_apps schemas + add the client tool_search tool; a
+ * turn with no codex_apps tools is a no-op (see {@link applyCodexToolSearch}).
+ */
+function maybeInstallCodexToolSearch(agent: Agent<any, any>, settings: Settings, options: BuildAgentOptions): void {
+  if (settings.codexToolSearchEnabled && options.structuredToolTransport === false) {
+    installCodexToolSearch(agent as unknown as { getAllTools: (runContext: unknown) => Promise<any[]> });
+  }
 }
 
 /**

--- a/packages/runtime/test/codex-tool-search.test.ts
+++ b/packages/runtime/test/codex-tool-search.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { getClientToolSearchExecutor, type Tool } from "@openai/agents";
+import {
+  applyCodexToolSearch,
+  bm25RankTools,
+  buildCodexToolSearchTool,
+  isCodexAppsFunctionTool,
+} from "../src/codex-tool-search";
+
+// Minimal function-tool doubles (only the fields the search + transform read).
+function connectorTool(name: string, description: string, props: string[] = []): Tool {
+  return {
+    type: "function",
+    name: `codex_apps__${name}`,
+    description,
+    parameters: { type: "object", properties: Object.fromEntries(props.map((p) => [p, { type: "string" }])) },
+  } as unknown as Tool;
+}
+function plainTool(name: string): Tool {
+  return { type: "function", name, description: name, parameters: { type: "object", properties: {} } } as unknown as Tool;
+}
+
+const POOL: Tool[] = [
+  connectorTool("gmail_send_email", "Send an email message via Gmail to one or more recipients", ["to", "subject", "body"]),
+  connectorTool("gmail_search_emails", "Search the Gmail inbox for messages matching a query", ["query", "label_ids"]),
+  connectorTool("calendar_create_event", "Create a Google Calendar event with a title, start and end time", ["title", "start_time", "end_time"]),
+  connectorTool("github_create_issue", "Open a new issue on a GitHub repository", ["repo", "title", "body"]),
+  connectorTool("slack_post_message", "Post a message to a Slack channel", ["channel", "text"]),
+  connectorTool("drive_upload_file", "Upload a file to Google Drive", ["path", "folder"]),
+];
+
+describe("bm25RankTools", () => {
+  test("ranks the capability-relevant tool first", () => {
+    const top = bm25RankTools(POOL, "send an email to someone", 3)[0] as { name: string };
+    expect(top.name).toBe("codex_apps__gmail_send_email");
+  });
+
+  test("matches on capability words, not just exact names", () => {
+    const top = bm25RankTools(POOL, "schedule a meeting on my calendar", 3)[0] as { name: string };
+    expect(top.name).toBe("codex_apps__calendar_create_event");
+  });
+
+  test("respects the limit", () => {
+    expect(bm25RankTools(POOL, "email message", 2)).toHaveLength(2);
+  });
+
+  test("a no-match query still returns something (never strands the model)", () => {
+    const out = bm25RankTools(POOL, "zzzz totally unrelated qqqq", 3);
+    expect(out.length).toBeGreaterThan(0);
+    expect(out.length).toBeLessThanOrEqual(3);
+  });
+
+  test("empty pool → empty result", () => {
+    expect(bm25RankTools([], "anything", 5)).toEqual([]);
+  });
+});
+
+describe("applyCodexToolSearch", () => {
+  test("tags codex_apps tools deferLoading + appends exactly one tool_search tool", () => {
+    const tools: Tool[] = [...POOL.map((t) => ({ ...t })) as Tool[], plainTool("opengeni__set_session_title")];
+    const out = applyCodexToolSearch(tools);
+    const connectors = out.filter(isCodexAppsFunctionTool);
+    expect(connectors.length).toBe(POOL.length);
+    for (const c of connectors) expect((c as { deferLoading?: boolean }).deferLoading).toBe(true);
+    const searchTools = out.filter((t) => (t as { name?: string }).name === "tool_search");
+    expect(searchTools).toHaveLength(1);
+    // the non-connector tool is untouched (not deferred)
+    const title = out.find((t) => (t as { name?: string }).name === "opengeni__set_session_title");
+    expect((title as { deferLoading?: boolean }).deferLoading).toBeUndefined();
+  });
+
+  test("no codex_apps tools → no-op (same array, no tool_search added)", () => {
+    const tools: Tool[] = [plainTool("opengeni__set_session_title"), plainTool("web_search")];
+    const out = applyCodexToolSearch(tools);
+    expect(out).toBe(tools); // same reference — untouched
+    expect(out.some((t) => (t as { name?: string }).name === "tool_search")).toBe(false);
+  });
+
+  test("idempotent — re-applying does not double-add the search tool", () => {
+    const tools: Tool[] = POOL.map((t) => ({ ...t })) as Tool[];
+    const once = applyCodexToolSearch(tools);
+    const twice = applyCodexToolSearch(once);
+    expect(twice.filter((t) => (t as { name?: string }).name === "tool_search")).toHaveLength(1);
+  });
+});
+
+describe("tool_search tool wiring", () => {
+  test("buildCodexToolSearchTool is a hosted tool_search with an attached client executor that BM25s the deferred pool", async () => {
+    const searchTool = buildCodexToolSearchTool();
+    expect((searchTool as { name?: string }).name).toBe("tool_search");
+    const executor = getClientToolSearchExecutor(searchTool as never);
+    expect(typeof executor).toBe("function");
+    // drive it exactly as the SDK would: availableTools = the resolved set, toolCall.arguments = the model's query
+    const result = await executor!({
+      agent: {} as never,
+      availableTools: [...POOL, plainTool("web_search")] as never,
+      loadDefault: (() => []) as never,
+      runContext: {} as never,
+      toolCall: { type: "tool_search_call", arguments: JSON.stringify({ query: "open a github issue", limit: 2 }) } as never,
+    });
+    const matched = (Array.isArray(result) ? result : result ? [result] : []) as Array<{ name: string }>;
+    expect(matched.length).toBeGreaterThan(0);
+    expect(matched.length).toBeLessThanOrEqual(2);
+    expect(matched[0]!.name).toBe("codex_apps__github_create_issue");
+    // returns tools BY REFERENCE from availableTools (required for correct disclosure)
+    expect(POOL).toContain(matched[0] as unknown as Tool);
+  });
+});

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -82,6 +82,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     }),
     modelProvidersJson: "[]",
     codexSubscriptionEnabled: false,
+    codexToolSearchEnabled: false,
     codexProductSku: undefined,
     codexRotationNearExhaustionPct: 90,
     openaiReasoningEffort: "high",


### PR DESCRIPTION
## What

Codex-CLI-style **progressive connector disclosure** behind `OPENGENI_CODEX_TOOL_SEARCH_ENABLED` (**default OFF** — codex turns are byte-for-byte unchanged until enabled). Today every codex turn materializes **all ~217 `codex_apps` connector tools** as function tools in the request (tens of thousands of context tokens/turn); this lets the model **search** and disclose only the matching connectors.

## Proven first (Phase 0 live probe, `/codex/responses`, gpt-5.5)

| Variant | `input_tokens` |
|---|---|
| 50 tools active (baseline) | **6,766** |
| 50 tools `defer_loading:true` + `tool_search` | **108** |
| disclose 1 via `tool_search_output` → model called it | **322** |

→ the backend **honors `defer_loading`** (drops schemas from model context, 98.4% cut) and makes a tool **callable purely from a prior `tool_search_output` disclosure**. Model emits `tool_search_call` on our slug. So the context win needs **no transport strip** — `defer_loading` alone delivers it.

## Mechanism

On a codex turn (`structuredToolTransport === false`) with the flag on, wrap `agent.getAllTools`:
1. tag every `codex_apps__*` function tool `deferLoading = true` (`converTool` serializes `defer_loading:true` → schema off the model context),
2. append one **client-executed** `toolSearchTool`.

The SDK routes a `tool_search_call` to our `ClientToolSearchExecutor`, which **BM25**-ranks the deferred pool from the live `availableTools` and returns matches **by reference** (the only legal return — the SDK emits the disclosing `tool_search_output` and flips the loaded gate). The subsequent `function_call` resolves through the **unchanged** `PrefixedMcpServer.callTool` path (auth + name-sanitize + `structuredContent` inline intact).

## Tests
`packages/runtime/test/codex-tool-search.test.ts` — BM25 relevance/limit/no-strand; the transform (tags + exactly one search tool + no-op without codex_apps + idempotent); the executor via the SDK's `getClientToolSearchExecutor` (parses the query, BM25s, returns by reference). Typecheck green (config/runtime/codex/worker); runtime **109 pass**, no regression.

## ⚠️ Required before flipping the flag (NOT in this PR)
1. **History hardening** — `history-sanitizer` must pair `tool_search_call → tool_search_output` and `applyCodexHistoryStrip` must drop foreign-account `tool_search` items, else `store:false` multi-turn replay 400s.
2. **Canary** — deploy flag-on on one workspace; verify the search→disclose→call round-trip end-to-end, measure token savings + BM25 recall + cross-turn re-search rate.

Full design in `CODEX-NATIVE-TOOLSEARCH-PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes codex turn tool payloads and model tool-selection behavior when the flag is on; default off limits blast radius, but enabling it without follow-up history hardening (called out in the PR) can break multi-turn replay.
> 
> **Overview**
> Adds **Codex-CLI-style progressive connector disclosure** behind `OPENGENI_CODEX_TOOL_SEARCH_ENABLED` (**default off**). When enabled on codex subscription turns (`structuredToolTransport === false`), the runtime wraps `agent.getAllTools` so ~217 `codex_apps__*` connector tools get `defer_loading` (schemas omitted from model context) and a single client-executed `tool_search` tool is appended.
> 
> `tool_search` runs a **BM25** ranker over the deferred pool and returns matches by reference so the SDK can emit `tool_search_output` and disclose only the connectors the model needs. Actual MCP invocation stays on the existing path.
> 
> New module `packages/runtime/src/codex-tool-search.ts`, wiring in `buildOpenGeniAgent` for both plain `Agent` and `SandboxAgent`, plus unit tests for ranking, transform behavior, and executor wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 865b44ffb5f1cfe9f332cda6b1d33c97bd6cb286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->