### PR TITLE
feat(computer-use): native desktop control for self-hosted machines (macOS/Linux)

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "image",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "hex",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"

--- a/agent/crates/opengeni-agent/src/dispatch.rs
+++ b/agent/crates/opengeni-agent/src/dispatch.rs
@@ -43,6 +43,11 @@ pub struct DispatchContext {
     pub epoch: u32,
     /// Process start instant, for the ping/heartbeat monotonic clock.
     pub started: std::time::Instant,
+    /// Whether the operator consented to SCREEN CONTROL at enrollment (the same
+    /// grant the relay framebuffer pump's `allow_input` gates on). The
+    /// [`Op::DesktopInput`] arm refuses synthetic input with
+    /// [`ErrorCode::ConsentRequired`] when this is `false`, BEFORE touching the OS.
+    pub consented_screen_control: bool,
 }
 
 impl DispatchContext {
@@ -189,6 +194,11 @@ async fn dispatch_future<P: Platform>(
             platform.desktop_ensure(&req).await,
             RespResult::DesktopEnsure,
         ),
+
+        // --- computer-use control ops: the AGENT drives its own desktop --------
+        // Extracted to helpers so this dispatch match stays compact + readable.
+        Op::DesktopInput(req) => desktop_input(request_id, req, platform, ctx).await,
+        Op::DesktopScreenshot(_req) => desktop_screenshot(request_id, platform).await,
         Op::PtyWrite(req) => result(
             request_id,
             platform.pty_write(&req).await,
@@ -205,6 +215,68 @@ async fn dispatch_future<P: Platform>(
             RespResult::PtyClose,
         ),
     }
+}
+
+/// Handles [`Op::DesktopInput`] — the computer-use INJECT op the agent runs
+/// against its own desktop.
+///
+/// SECURITY: synthetic input REQUIRES the operator to have consented to screen
+/// control at enrollment. When consent was not granted, this returns
+/// [`ErrorCode::ConsentRequired`] and DOES NOT inject — the platform is never
+/// touched.
+async fn desktop_input<P: Platform>(
+    request_id: String,
+    req: v1::DesktopInputRequest,
+    platform: &Arc<P>,
+    ctx: &DispatchContext,
+) -> ControlResponse {
+    if ctx.consented_screen_control {
+        // The event oneof types (Pointer/Key/Scroll) are SHARED with the relay
+        // `DesktopInput`, so the map is a 1:1 rename of the wrapper. A control-plane
+        // input has no relay channel, so `channel_id` is empty (it goes straight to
+        // the display).
+        let input = v1::DesktopInput {
+            channel_id: String::new(),
+            event: req.event.map(|event| match event {
+                v1::desktop_input_request::Event::Pointer(p) => {
+                    v1::desktop_input::Event::Pointer(p)
+                }
+                v1::desktop_input_request::Event::Key(k) => v1::desktop_input::Event::Key(k),
+                v1::desktop_input_request::Event::Scroll(s) => v1::desktop_input::Event::Scroll(s),
+            }),
+        };
+        result(
+            request_id,
+            platform
+                .desktop_input(&input)
+                .await
+                .map(|()| v1::DesktopInputResponse {}),
+            RespResult::DesktopInput,
+        )
+    } else {
+        consent_required_error(request_id, "screen control not consented")
+    }
+}
+
+/// Handles [`Op::DesktopScreenshot`] — a one-shot desktop capture.
+///
+/// NO consent gate: a screenshot is a VIEW op — it needs a DISPLAY, not
+/// screen-control consent (the view/control decoupling). A headless host surfaces
+/// `Unsupported` from the backend, mapped like any other error.
+async fn desktop_screenshot<P: Platform>(request_id: String, platform: &Arc<P>) -> ControlResponse {
+    result(
+        request_id,
+        platform
+            .desktop()
+            .capture()
+            .await
+            .map(|frame| v1::DesktopScreenshotResponse {
+                png: frame.png.into(),
+                width: frame.width,
+                height: frame.height,
+            }),
+        RespResult::DesktopScreenshot,
+    )
 }
 
 /// Wraps a successful typed result into a `ControlResponse`.
@@ -258,6 +330,22 @@ fn fenced_error(op_epoch: u32, held_epoch: u32) -> AgentError {
     }
 }
 
+/// A `ERROR_CODE_CONSENT_REQUIRED` response for a screen-control op the operator
+/// did not consent to at enrollment. Built here (not via the platform) because the
+/// gate is enforced BEFORE the platform is reached — no input is injected.
+fn consent_required_error(request_id: String, message: &str) -> ControlResponse {
+    ControlResponse {
+        request_id,
+        error: Some(AgentError {
+            code: ErrorCode::ConsentRequired as i32,
+            message: message.to_string(),
+            retryable: false,
+            detail: std::collections::HashMap::new(),
+        }),
+        result: None,
+    }
+}
+
 /// A `ERROR_CODE_PROTOCOL` error response for a malformed/misused request.
 fn protocol_error(request_id: String, message: &str) -> ControlResponse {
     ControlResponse {
@@ -279,11 +367,50 @@ mod tests {
     use opengeni_agent_platform::{HostIdentity, PlatformResult};
     use prost::Message as _;
 
+    /// A fake desktop backend that records every injected input and hands back a
+    /// canned screenshot, so the computer-use control ops can be exercised without
+    /// a real display.
+    #[derive(Default)]
+    struct FakeDesktop {
+        injected: std::sync::Mutex<Vec<v1::DesktopInput>>,
+    }
+
+    impl FakeDesktop {
+        /// The canned screenshot bytes/geometry the `capture()` fake returns.
+        const PNG: &'static [u8] = b"fake-png-bytes";
+        const WIDTH: u32 = 320;
+        const HEIGHT: u32 = 240;
+    }
+
+    #[async_trait]
+    impl opengeni_agent_platform::DesktopBackend for FakeDesktop {
+        fn probe(&self) -> Option<v1::Display> {
+            Some(v1::Display {
+                id: ":0".to_string(),
+                width: Self::WIDTH,
+                height: Self::HEIGHT,
+                r#virtual: false,
+            })
+        }
+        async fn capture(&self) -> PlatformResult<opengeni_agent_platform::CapturedFrame> {
+            Ok(opengeni_agent_platform::CapturedFrame {
+                png: Self::PNG.to_vec(),
+                width: Self::WIDTH,
+                height: Self::HEIGHT,
+            })
+        }
+        async fn inject(&self, input: &v1::DesktopInput) -> PlatformResult<()> {
+            self.injected.lock().unwrap().push(input.clone());
+            Ok(())
+        }
+    }
+
     /// A fake platform recording the last op it saw and returning canned results,
     /// so the dispatch table can be exercised without touching the real host.
     #[derive(Default)]
     struct FakePlatform {
         fail_exec: bool,
+        desktop: Arc<FakeDesktop>,
     }
 
     #[async_trait]
@@ -298,7 +425,7 @@ mod tests {
             "/work".to_string()
         }
         fn desktop(&self) -> std::sync::Arc<dyn opengeni_agent_platform::DesktopBackend> {
-            std::sync::Arc::new(opengeni_agent_platform::NoDesktop)
+            self.desktop.clone()
         }
         fn default_shell(&self) -> Vec<String> {
             vec!["/bin/sh".to_string()]
@@ -366,10 +493,15 @@ mod tests {
     }
 
     fn ctx() -> DispatchContext {
+        ctx_with_consent(false)
+    }
+
+    fn ctx_with_consent(consented_screen_control: bool) -> DispatchContext {
         DispatchContext {
             agent_id: "a1".to_string(),
             epoch: 5,
             started: std::time::Instant::now(),
+            consented_screen_control,
         }
     }
 
@@ -405,7 +537,10 @@ mod tests {
 
     #[tokio::test]
     async fn handler_error_maps_to_agent_error_not_panic() {
-        let platform = Arc::new(FakePlatform { fail_exec: true });
+        let platform = Arc::new(FakePlatform {
+            fail_exec: true,
+            ..Default::default()
+        });
         let req = request(
             5,
             Op::Exec(v1::ExecRequest {
@@ -493,6 +628,82 @@ mod tests {
         match resp.result {
             Some(RespResult::FsRead(r)) => assert_eq!(&r.content[..], b"file-bytes"),
             other => panic!("expected FsRead, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn desktop_input_without_consent_is_refused_and_never_injects() {
+        let platform = Arc::new(FakePlatform::default());
+        let req = request(
+            5,
+            Op::DesktopInput(v1::DesktopInputRequest {
+                event: Some(v1::desktop_input_request::Event::Pointer(
+                    v1::PointerEvent {
+                        x: 10,
+                        y: 20,
+                        action: v1::PointerAction::Click as i32,
+                        button: v1::PointerButton::Left as i32,
+                    },
+                )),
+            }),
+        );
+        // ctx() defaults consented_screen_control = false.
+        let resp = dispatch(req, &platform, &ctx()).await;
+        assert!(resp.result.is_none(), "no result on a refused input");
+        let err = resp.error.expect("consent error present");
+        assert_eq!(err.code, ErrorCode::ConsentRequired as i32);
+        // The security-critical assertion: the platform was NEVER touched.
+        assert!(
+            platform.desktop.injected.lock().unwrap().is_empty(),
+            "an unconsented input must NOT reach inject"
+        );
+    }
+
+    #[tokio::test]
+    async fn desktop_input_with_consent_injects_the_event() {
+        let platform = Arc::new(FakePlatform::default());
+        let pointer = v1::PointerEvent {
+            x: 42,
+            y: 99,
+            action: v1::PointerAction::Down as i32,
+            button: v1::PointerButton::Right as i32,
+        };
+        let req = request(
+            5,
+            Op::DesktopInput(v1::DesktopInputRequest {
+                // `PointerEvent` is `Copy`, so this does not move `pointer`.
+                event: Some(v1::desktop_input_request::Event::Pointer(pointer)),
+            }),
+        );
+        let resp = dispatch(req, &platform, &ctx_with_consent(true)).await;
+        assert!(resp.error.is_none(), "a consented input has no error");
+        assert!(matches!(resp.result, Some(RespResult::DesktopInput(_))));
+        let seen = platform.desktop.injected.lock().unwrap();
+        assert_eq!(seen.len(), 1, "exactly one inject reached the backend");
+        // The control-plane input maps to a relay DesktopInput with an EMPTY
+        // channel_id (it goes straight to the display) and the same event.
+        assert_eq!(seen[0].channel_id, "");
+        assert_eq!(
+            seen[0].event,
+            Some(v1::desktop_input::Event::Pointer(pointer)),
+            "the event must reach inject unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn desktop_screenshot_returns_the_captured_frame_without_consent() {
+        let platform = Arc::new(FakePlatform::default());
+        // No consent needed: a screenshot is a VIEW op; ctx() is UNCONSENTED.
+        let req = request(5, Op::DesktopScreenshot(v1::DesktopScreenshotRequest {}));
+        let resp = dispatch(req, &platform, &ctx()).await;
+        assert!(resp.error.is_none(), "a screenshot needs no consent");
+        match resp.result {
+            Some(RespResult::DesktopScreenshot(s)) => {
+                assert_eq!(&s.png[..], FakeDesktop::PNG);
+                assert_eq!(s.width, FakeDesktop::WIDTH);
+                assert_eq!(s.height, FakeDesktop::HEIGHT);
+            }
+            other => panic!("expected DesktopScreenshot, got {other:?}"),
         }
     }
 }

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -432,6 +432,9 @@ impl<P: Platform + 'static> Supervisor<P> {
             agent_id: self.creds.agent_id.clone(),
             epoch: self.epoch.load(),
             started: self.started,
+            // The computer-use input consent gate reads the SAME enrollment grant
+            // the relay pump's `allow_input` uses.
+            consented_screen_control: self.creds.consented_screen_control,
         }
     }
 
@@ -515,6 +518,8 @@ fn op_label(req: &ControlRequest) -> &'static str {
         Some(Op::PtyResize(_)) => "pty_resize",
         Some(Op::PtyClose(_)) => "pty_close",
         Some(Op::DesktopEnsure(_)) => "desktop_ensure",
+        Some(Op::DesktopInput(_)) => "desktop_input",
+        Some(Op::DesktopScreenshot(_)) => "desktop_screenshot",
         Some(Op::Metrics(_)) => "metrics",
         Some(Op::UpdateMayProceed(_)) => "update_may_proceed",
         None => "none",

--- a/agent/proto/opengeni_agent.proto
+++ b/agent/proto/opengeni_agent.proto
@@ -507,6 +507,32 @@ message DesktopEnsureResponse {
   Display display = 2;
 }
 
+// Inject one synthetic computer-use input event on the machine's desktop — the
+// CONTROL-PLANE twin of the relay DesktopInput (the agent drives its OWN screen
+// for computer-use; there is no human viewer channel). Reuses the relay
+// DesktopInput event shapes; there is no channel_id (this goes straight to the
+// display, not a relay channel). Injection is gated on consented_screen_control:
+// an ungated call fails with ERROR_CODE_CONSENT_REQUIRED and never touches the OS.
+message DesktopInputRequest {
+  oneof event {
+    PointerEvent pointer = 1;
+    KeyEvent key = 2;
+    ScrollEvent scroll = 3;
+  }
+}
+message DesktopInputResponse {}
+
+// Capture a single screenshot of the machine's desktop as a PNG. A VIEW op: it
+// needs a display, NOT screen-control consent (the view/control decoupling), so
+// it is not consent-gated. Returns the encoded image plus its geometry so the
+// caller can size a canvas without decoding.
+message DesktopScreenshotRequest {}
+message DesktopScreenshotResponse {
+  bytes png = 1;
+  uint32 width = 2;
+  uint32 height = 3;
+}
+
 // =============================================================================
 // Heartbeat + metrics
 // =============================================================================
@@ -708,6 +734,8 @@ message ControlRequest {
     DesktopEnsureRequest desktop_ensure = 26;
     MetricsRequest metrics = 27;
     UpdateMayProceedRequest update_may_proceed = 28;
+    DesktopInputRequest desktop_input = 29;
+    DesktopScreenshotRequest desktop_screenshot = 30;
   }
 }
 
@@ -736,6 +764,8 @@ message ControlResponse {
     DesktopEnsureResponse desktop_ensure = 26;
     MetricsSample metrics = 27;
     UpdateMayProceedResponse update_may_proceed = 28;
+    DesktopInputResponse desktop_input = 29;
+    DesktopScreenshotResponse desktop_screenshot = 30;
   }
 }
 

--- a/packages/agent-proto/src/gen/opengeni_agent.ts
+++ b/packages/agent-proto/src/gen/opengeni_agent.ts
@@ -807,11 +807,21 @@ export interface EnrollmentCredentials {
   agentId: string;
   workspaceId: string;
   /**
-   * NATS Account credentials (creds-file body) for the control plane connection.
-   * Account isolation is the tenancy boundary.
+   * The NATS CONNECT AUTH-TOKEN the agent presents (the signed `oge_` enrollment
+   * bearer). The server runs with AUTH CALLOUT (dossier §10.1 / M-AUTH): on connect
+   * the agent passes this as the auth-token; nats-server issues an authorization
+   * request to the control-plane's callout responder, which validates the bearer
+   * and returns a SIGNED user JWT scoping the connection to pub/sub ONLY
+   * `agent.<ws>.>` (+ `_INBOX.>`). That per-subject scope IS the per-workspace
+   * tenancy boundary — there is NO per-machine creds file to ship. (Field name kept
+   * for proto stability; it now carries the bearer, not an operator creds-file body.)
    */
   natsCredentials: string;
-  /** The NATS server URL(s) to dial. */
+  /**
+   * The NATS server URL(s) to dial. For the control plane these are `wss://` URLs
+   * (the relay-symmetric TLS ingress) so the agent rides the same TLS endpoint as
+   * the stream relay — no separate public TCP load balancer (dossier M-AUTH).
+   */
   natsUrls: string[];
   /** The relay edge base URL for opening stream channels. */
   relayUrl: string;
@@ -1067,6 +1077,39 @@ export interface DesktopEnsureResponse {
 }
 
 /**
+ * Inject one synthetic computer-use input event on the machine's desktop — the
+ * CONTROL-PLANE twin of the relay DesktopInput (the agent drives its OWN screen
+ * for computer-use; there is no human viewer channel). Reuses the relay
+ * DesktopInput event shapes; there is no channel_id (this goes straight to the
+ * display, not a relay channel). Injection is gated on consented_screen_control:
+ * an ungated call fails with ERROR_CODE_CONSENT_REQUIRED and never touches the OS.
+ */
+export interface DesktopInputRequest {
+  event: { $case: "pointer"; pointer: PointerEvent } | { $case: "key"; key: KeyEvent } | {
+    $case: "scroll";
+    scroll: ScrollEvent;
+  } | undefined;
+}
+
+export interface DesktopInputResponse {
+}
+
+/**
+ * Capture a single screenshot of the machine's desktop as a PNG. A VIEW op: it
+ * needs a display, NOT screen-control consent (the view/control decoupling), so
+ * it is not consent-gated. Returns the encoded image plus its geometry so the
+ * caller can size a canvas without decoding.
+ */
+export interface DesktopScreenshotRequest {
+}
+
+export interface DesktopScreenshotResponse {
+  png: Uint8Array;
+  width: number;
+  height: number;
+}
+
+/**
  * The agent's periodic liveness ping. Carries a metrics sample so the control
  * plane can upsert the machine's last-sample without a separate RPC. The
  * `seq` increments per heartbeat so the control plane can detect a gap.
@@ -1263,6 +1306,8 @@ export interface ControlRequest {
     | { $case: "desktopEnsure"; desktopEnsure: DesktopEnsureRequest }
     | { $case: "metrics"; metrics: MetricsRequest }
     | { $case: "updateMayProceed"; updateMayProceed: UpdateMayProceedRequest }
+    | { $case: "desktopInput"; desktopInput: DesktopInputRequest }
+    | { $case: "desktopScreenshot"; desktopScreenshot: DesktopScreenshotRequest }
     | undefined;
 }
 
@@ -1291,6 +1336,8 @@ export interface ControlResponse {
     | { $case: "desktopEnsure"; desktopEnsure: DesktopEnsureResponse }
     | { $case: "metrics"; metrics: MetricsSample }
     | { $case: "updateMayProceed"; updateMayProceed: UpdateMayProceedResponse }
+    | { $case: "desktopInput"; desktopInput: DesktopInputResponse }
+    | { $case: "desktopScreenshot"; desktopScreenshot: DesktopScreenshotResponse }
     | undefined;
 }
 
@@ -5743,6 +5790,297 @@ export const DesktopEnsureResponse: MessageFns<DesktopEnsureResponse> = {
   },
 };
 
+function createBaseDesktopInputRequest(): DesktopInputRequest {
+  return { event: undefined };
+}
+
+export const DesktopInputRequest: MessageFns<DesktopInputRequest> = {
+  encode(message: DesktopInputRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    switch (message.event?.$case) {
+      case "pointer":
+        PointerEvent.encode(message.event.pointer, writer.uint32(10).fork()).join();
+        break;
+      case "key":
+        KeyEvent.encode(message.event.key, writer.uint32(18).fork()).join();
+        break;
+      case "scroll":
+        ScrollEvent.encode(message.event.scroll, writer.uint32(26).fork()).join();
+        break;
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DesktopInputRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDesktopInputRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.event = { $case: "pointer", pointer: PointerEvent.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.event = { $case: "key", key: KeyEvent.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.event = { $case: "scroll", scroll: ScrollEvent.decode(reader, reader.uint32()) };
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DesktopInputRequest {
+    return {
+      event: isSet(object.pointer)
+        ? { $case: "pointer", pointer: PointerEvent.fromJSON(object.pointer) }
+        : isSet(object.key)
+        ? { $case: "key", key: KeyEvent.fromJSON(object.key) }
+        : isSet(object.scroll)
+        ? { $case: "scroll", scroll: ScrollEvent.fromJSON(object.scroll) }
+        : undefined,
+    };
+  },
+
+  toJSON(message: DesktopInputRequest): unknown {
+    const obj: any = {};
+    if (message.event?.$case === "pointer") {
+      obj.pointer = PointerEvent.toJSON(message.event.pointer);
+    } else if (message.event?.$case === "key") {
+      obj.key = KeyEvent.toJSON(message.event.key);
+    } else if (message.event?.$case === "scroll") {
+      obj.scroll = ScrollEvent.toJSON(message.event.scroll);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DesktopInputRequest>, I>>(base?: I): DesktopInputRequest {
+    return DesktopInputRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DesktopInputRequest>, I>>(object: I): DesktopInputRequest {
+    const message = createBaseDesktopInputRequest();
+    switch (object.event?.$case) {
+      case "pointer": {
+        if (object.event?.pointer !== undefined && object.event?.pointer !== null) {
+          message.event = { $case: "pointer", pointer: PointerEvent.fromPartial(object.event.pointer) };
+        }
+        break;
+      }
+      case "key": {
+        if (object.event?.key !== undefined && object.event?.key !== null) {
+          message.event = { $case: "key", key: KeyEvent.fromPartial(object.event.key) };
+        }
+        break;
+      }
+      case "scroll": {
+        if (object.event?.scroll !== undefined && object.event?.scroll !== null) {
+          message.event = { $case: "scroll", scroll: ScrollEvent.fromPartial(object.event.scroll) };
+        }
+        break;
+      }
+    }
+    return message;
+  },
+};
+
+function createBaseDesktopInputResponse(): DesktopInputResponse {
+  return {};
+}
+
+export const DesktopInputResponse: MessageFns<DesktopInputResponse> = {
+  encode(_: DesktopInputResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DesktopInputResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDesktopInputResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): DesktopInputResponse {
+    return {};
+  },
+
+  toJSON(_: DesktopInputResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DesktopInputResponse>, I>>(base?: I): DesktopInputResponse {
+    return DesktopInputResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DesktopInputResponse>, I>>(_: I): DesktopInputResponse {
+    const message = createBaseDesktopInputResponse();
+    return message;
+  },
+};
+
+function createBaseDesktopScreenshotRequest(): DesktopScreenshotRequest {
+  return {};
+}
+
+export const DesktopScreenshotRequest: MessageFns<DesktopScreenshotRequest> = {
+  encode(_: DesktopScreenshotRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DesktopScreenshotRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDesktopScreenshotRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): DesktopScreenshotRequest {
+    return {};
+  },
+
+  toJSON(_: DesktopScreenshotRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DesktopScreenshotRequest>, I>>(base?: I): DesktopScreenshotRequest {
+    return DesktopScreenshotRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DesktopScreenshotRequest>, I>>(_: I): DesktopScreenshotRequest {
+    const message = createBaseDesktopScreenshotRequest();
+    return message;
+  },
+};
+
+function createBaseDesktopScreenshotResponse(): DesktopScreenshotResponse {
+  return { png: new Uint8Array(0), width: 0, height: 0 };
+}
+
+export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = {
+  encode(message: DesktopScreenshotResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.png.length !== 0) {
+      writer.uint32(10).bytes(message.png);
+    }
+    if (message.width !== 0) {
+      writer.uint32(16).uint32(message.width);
+    }
+    if (message.height !== 0) {
+      writer.uint32(24).uint32(message.height);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DesktopScreenshotResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDesktopScreenshotResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.png = reader.bytes();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.width = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.height = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DesktopScreenshotResponse {
+    return {
+      png: isSet(object.png) ? bytesFromBase64(object.png) : new Uint8Array(0),
+      width: isSet(object.width) ? globalThis.Number(object.width) : 0,
+      height: isSet(object.height) ? globalThis.Number(object.height) : 0,
+    };
+  },
+
+  toJSON(message: DesktopScreenshotResponse): unknown {
+    const obj: any = {};
+    if (message.png.length !== 0) {
+      obj.png = base64FromBytes(message.png);
+    }
+    if (message.width !== 0) {
+      obj.width = Math.round(message.width);
+    }
+    if (message.height !== 0) {
+      obj.height = Math.round(message.height);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DesktopScreenshotResponse>, I>>(base?: I): DesktopScreenshotResponse {
+    return DesktopScreenshotResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DesktopScreenshotResponse>, I>>(object: I): DesktopScreenshotResponse {
+    const message = createBaseDesktopScreenshotResponse();
+    message.png = object.png ?? new Uint8Array(0);
+    message.width = object.width ?? 0;
+    message.height = object.height ?? 0;
+    return message;
+  },
+};
+
 function createBaseHeartbeat(): Heartbeat {
   return { seq: "0", uptimeMs: "0", activeSessions: 0, metrics: undefined, draining: false };
 }
@@ -7580,6 +7918,12 @@ export const ControlRequest: MessageFns<ControlRequest> = {
       case "updateMayProceed":
         UpdateMayProceedRequest.encode(message.op.updateMayProceed, writer.uint32(226).fork()).join();
         break;
+      case "desktopInput":
+        DesktopInputRequest.encode(message.op.desktopInput, writer.uint32(234).fork()).join();
+        break;
+      case "desktopScreenshot":
+        DesktopScreenshotRequest.encode(message.op.desktopScreenshot, writer.uint32(242).fork()).join();
+        break;
     }
     return writer;
   },
@@ -7762,6 +8106,25 @@ export const ControlRequest: MessageFns<ControlRequest> = {
           };
           continue;
         }
+        case 29: {
+          if (tag !== 234) {
+            break;
+          }
+
+          message.op = { $case: "desktopInput", desktopInput: DesktopInputRequest.decode(reader, reader.uint32()) };
+          continue;
+        }
+        case 30: {
+          if (tag !== 242) {
+            break;
+          }
+
+          message.op = {
+            $case: "desktopScreenshot",
+            desktopScreenshot: DesktopScreenshotRequest.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -7843,6 +8206,17 @@ export const ControlRequest: MessageFns<ControlRequest> = {
         ? { $case: "updateMayProceed", updateMayProceed: UpdateMayProceedRequest.fromJSON(object.updateMayProceed) }
         : isSet(object.update_may_proceed)
         ? { $case: "updateMayProceed", updateMayProceed: UpdateMayProceedRequest.fromJSON(object.update_may_proceed) }
+        : isSet(object.desktopInput)
+        ? { $case: "desktopInput", desktopInput: DesktopInputRequest.fromJSON(object.desktopInput) }
+        : isSet(object.desktop_input)
+        ? { $case: "desktopInput", desktopInput: DesktopInputRequest.fromJSON(object.desktop_input) }
+        : isSet(object.desktopScreenshot)
+        ? { $case: "desktopScreenshot", desktopScreenshot: DesktopScreenshotRequest.fromJSON(object.desktopScreenshot) }
+        : isSet(object.desktop_screenshot)
+        ? {
+          $case: "desktopScreenshot",
+          desktopScreenshot: DesktopScreenshotRequest.fromJSON(object.desktop_screenshot),
+        }
         : undefined,
     };
   },
@@ -7893,6 +8267,10 @@ export const ControlRequest: MessageFns<ControlRequest> = {
       obj.metrics = MetricsRequest.toJSON(message.op.metrics);
     } else if (message.op?.$case === "updateMayProceed") {
       obj.updateMayProceed = UpdateMayProceedRequest.toJSON(message.op.updateMayProceed);
+    } else if (message.op?.$case === "desktopInput") {
+      obj.desktopInput = DesktopInputRequest.toJSON(message.op.desktopInput);
+    } else if (message.op?.$case === "desktopScreenshot") {
+      obj.desktopScreenshot = DesktopScreenshotRequest.toJSON(message.op.desktopScreenshot);
     }
     return obj;
   },
@@ -8025,6 +8403,21 @@ export const ControlRequest: MessageFns<ControlRequest> = {
         }
         break;
       }
+      case "desktopInput": {
+        if (object.op?.desktopInput !== undefined && object.op?.desktopInput !== null) {
+          message.op = { $case: "desktopInput", desktopInput: DesktopInputRequest.fromPartial(object.op.desktopInput) };
+        }
+        break;
+      }
+      case "desktopScreenshot": {
+        if (object.op?.desktopScreenshot !== undefined && object.op?.desktopScreenshot !== null) {
+          message.op = {
+            $case: "desktopScreenshot",
+            desktopScreenshot: DesktopScreenshotRequest.fromPartial(object.op.desktopScreenshot),
+          };
+        }
+        break;
+      }
     }
     return message;
   },
@@ -8099,6 +8492,12 @@ export const ControlResponse: MessageFns<ControlResponse> = {
         break;
       case "updateMayProceed":
         UpdateMayProceedResponse.encode(message.result.updateMayProceed, writer.uint32(226).fork()).join();
+        break;
+      case "desktopInput":
+        DesktopInputResponse.encode(message.result.desktopInput, writer.uint32(234).fork()).join();
+        break;
+      case "desktopScreenshot":
+        DesktopScreenshotResponse.encode(message.result.desktopScreenshot, writer.uint32(242).fork()).join();
         break;
     }
     return writer;
@@ -8285,6 +8684,28 @@ export const ControlResponse: MessageFns<ControlResponse> = {
           };
           continue;
         }
+        case 29: {
+          if (tag !== 234) {
+            break;
+          }
+
+          message.result = {
+            $case: "desktopInput",
+            desktopInput: DesktopInputResponse.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
+        case 30: {
+          if (tag !== 242) {
+            break;
+          }
+
+          message.result = {
+            $case: "desktopScreenshot",
+            desktopScreenshot: DesktopScreenshotResponse.decode(reader, reader.uint32()),
+          };
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -8366,6 +8787,20 @@ export const ControlResponse: MessageFns<ControlResponse> = {
         ? { $case: "updateMayProceed", updateMayProceed: UpdateMayProceedResponse.fromJSON(object.updateMayProceed) }
         : isSet(object.update_may_proceed)
         ? { $case: "updateMayProceed", updateMayProceed: UpdateMayProceedResponse.fromJSON(object.update_may_proceed) }
+        : isSet(object.desktopInput)
+        ? { $case: "desktopInput", desktopInput: DesktopInputResponse.fromJSON(object.desktopInput) }
+        : isSet(object.desktop_input)
+        ? { $case: "desktopInput", desktopInput: DesktopInputResponse.fromJSON(object.desktop_input) }
+        : isSet(object.desktopScreenshot)
+        ? {
+          $case: "desktopScreenshot",
+          desktopScreenshot: DesktopScreenshotResponse.fromJSON(object.desktopScreenshot),
+        }
+        : isSet(object.desktop_screenshot)
+        ? {
+          $case: "desktopScreenshot",
+          desktopScreenshot: DesktopScreenshotResponse.fromJSON(object.desktop_screenshot),
+        }
         : undefined,
     };
   },
@@ -8416,6 +8851,10 @@ export const ControlResponse: MessageFns<ControlResponse> = {
       obj.metrics = MetricsSample.toJSON(message.result.metrics);
     } else if (message.result?.$case === "updateMayProceed") {
       obj.updateMayProceed = UpdateMayProceedResponse.toJSON(message.result.updateMayProceed);
+    } else if (message.result?.$case === "desktopInput") {
+      obj.desktopInput = DesktopInputResponse.toJSON(message.result.desktopInput);
+    } else if (message.result?.$case === "desktopScreenshot") {
+      obj.desktopScreenshot = DesktopScreenshotResponse.toJSON(message.result.desktopScreenshot);
     }
     return obj;
   },
@@ -8546,6 +8985,24 @@ export const ControlResponse: MessageFns<ControlResponse> = {
           message.result = {
             $case: "updateMayProceed",
             updateMayProceed: UpdateMayProceedResponse.fromPartial(object.result.updateMayProceed),
+          };
+        }
+        break;
+      }
+      case "desktopInput": {
+        if (object.result?.desktopInput !== undefined && object.result?.desktopInput !== null) {
+          message.result = {
+            $case: "desktopInput",
+            desktopInput: DesktopInputResponse.fromPartial(object.result.desktopInput),
+          };
+        }
+        break;
+      }
+      case "desktopScreenshot": {
+        if (object.result?.desktopScreenshot !== undefined && object.result?.desktopScreenshot !== null) {
+          message.result = {
+            $case: "desktopScreenshot",
+            desktopScreenshot: DesktopScreenshotResponse.fromPartial(object.result.desktopScreenshot),
           };
         }
         break;

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -33,6 +33,7 @@
 
 import { computerTool, type Computer, type Tool } from "@openai/agents";
 import { Capability, type SandboxSessionLike } from "@openai/agents/sandbox";
+import { KeyAction, PointerAction, PointerButton, type DesktopInputRequest } from "@opengeni/agent-proto";
 
 import { sandboxCommandExitCode, sandboxCommandOutput, sandboxCommandStillRunning } from "./index";
 // `stripExecBanner` is the SAME pure helper recording.ts uses to recover the raw
@@ -341,6 +342,171 @@ export class SandboxComputer implements Computer {
   }
 }
 
+// ── The native-desktop computer (self-hosted / macOS) ────────────────────────
+//
+// `SandboxComputer` drives the desktop by shelling out to xdotool/scrot over the
+// session's `exec` — which needs those X utilities installed in the box image and
+// only works under X11. A SELF-HOSTED machine (macOS OR bring-your-own Linux) has
+// neither guarantee, so it drives the desktop NATIVELY over the control plane: the
+// Rust agent injects input via CGEvent (macOS) / XTEST (Linux) and captures via
+// ScreenCaptureKit / x11, exposed as the two `SelfhostedSession` ops below. No
+// xdotool/scrot dependency; works on macOS.
+
+/** The structural slice of a self-hosted session the native computer drives — the
+ *  two control-plane ops added in session.ts. Kept structural (NOT an import of
+ *  `SelfhostedSession`) so this agent-loop file never hard-couples to the sandbox
+ *  leaf; the duck-typed `isNativeDesktopSession` probe (below) selects on it. */
+export type NativeDesktopSession = {
+  desktopInput(event: DesktopInputRequest["event"]): Promise<void>;
+  screenshot(): Promise<{ png: Uint8Array; width: number; height: number }>;
+};
+
+/** Model `Button` → wire `PointerButton`. The proto has no back/forward button, so
+ *  those degrade to UNSPECIFIED (the agent ignores an unmapped button rather than
+ *  mis-clicking). A total record so indexing is exhaustive. */
+const POINTER_BUTTON: Record<ComputerButton, PointerButton> = {
+  left: PointerButton.POINTER_BUTTON_LEFT,
+  right: PointerButton.POINTER_BUTTON_RIGHT,
+  wheel: PointerButton.POINTER_BUTTON_MIDDLE,
+  back: PointerButton.POINTER_BUTTON_UNSPECIFIED,
+  forward: PointerButton.POINTER_BUTTON_UNSPECIFIED,
+};
+
+export type NativeDesktopComputerOptions = {
+  dimensions?: [number, number]; // the display geometry (must match the capture size)
+  environment?: NonNullable<Computer["environment"]>; // "ubuntu" (default) | "mac" | ...; model uses it for OS key conventions
+  readOnly?: boolean; // when true, every WRITE action throws ComputerReadOnlyError
+};
+
+/**
+ * A `Computer` that drives a SELF-HOSTED machine's OWN desktop NATIVELY over the
+ * control plane (`desktopInput` inject + `screenshot` capture on the bound
+ * `SelfhostedSession`) instead of xdotool/scrot over `exec`. Consent + epoch are
+ * enforced AGENT-side, so an unconsented inject surfaces the session's mapped
+ * control error.
+ *
+ * screenshot() returns raw base64 with NO data-URL prefix — the EXACT contract of
+ * `SandboxComputer.screenshot`: the Agents SDK wraps it as
+ * `data:image/png;base64,${output}`, so an empty string would become
+ * `image_url: ''` and 400 the model turn. An empty PNG therefore THROWS
+ * `ComputerUnavailableError` (mirroring SandboxComputer's empty-guard) — the model
+ * never receives an empty image_url.
+ */
+export class NativeDesktopComputer implements Computer {
+  readonly environment: NonNullable<Computer["environment"]>;
+  readonly dimensions: [number, number];
+  private session: NativeDesktopSession;
+  private readonly readOnly: boolean;
+
+  constructor(session: NativeDesktopSession, opts: NativeDesktopComputerOptions = {}) {
+    this.session = session;
+    this.dimensions = opts.dimensions ?? DEFAULT_DIMENSIONS;
+    // Default "ubuntu" (self-hosted Linux is the near-term target); a macOS session
+    // should pass "mac" so the model uses ⌘-based shortcuts — see the coordinate TODO.
+    this.environment = opts.environment ?? "ubuntu";
+    this.readOnly = opts.readOnly ?? false;
+  }
+
+  /** Rebind to a freshly resumed-by-id session after a box rollover / re-establish. */
+  rebind(session: NativeDesktopSession) { this.session = session; }
+
+  private guardWrite() {
+    if (this.readOnly) throw new ComputerReadOnlyError();
+  }
+
+  private async pointer(x: number, y: number, action: PointerAction, button: PointerButton): Promise<void> {
+    // COORDINATE SEAM — TODO(verify e2e on macOS): the model computes x/y against the
+    // pixels of the screenshot it just saw, and the agent's macOS CGEvent inject
+    // treats x/y as raw screen coordinates. On a Retina Mac, ScreenCaptureKit may
+    // capture at 2× the logical POINT space while CGEvent expects logical points — a
+    // potential 2× mismatch between the coords the model derives and the coords the
+    // inject applies. This MUST be measured on a real Retina Mac (compare the
+    // screenshot's reported width/height against the logical display bounds) before
+    // any DPR scaling is added. Do NOT add scaling speculatively. Self-hosted Linux
+    // (XTEST/x11) is 1:1 and unaffected.
+    await this.session.desktopInput({ $case: "pointer", pointer: { x, y, action, button } });
+  }
+
+  async screenshot(): Promise<string> {
+    // CRITICAL CONTRACT (mirrors SandboxComputer.screenshot): NEVER return "". The
+    // Agents SDK builds the model image as `data:image/png;base64,${output}`; an
+    // empty output → `image_url: ''` → the model API 400s and kills the turn. A
+    // missing/empty frame is therefore a THROW, never a silent "". Native capture
+    // (ScreenCaptureKit / x11) does not have the cold-scrot warm-up the xdotool path
+    // retries around, so a single capture + a hard empty-guard is sufficient.
+    const { png } = await this.session.screenshot();
+    if (png.length === 0) {
+      throw new ComputerUnavailableError("native desktop screenshot returned an empty frame (display not up?)");
+    }
+    return Buffer.from(png).toString("base64");
+  }
+
+  async click(x: number, y: number, button: ComputerButton) {
+    this.guardWrite();
+    await this.pointer(x, y, PointerAction.POINTER_ACTION_CLICK, POINTER_BUTTON[button] ?? PointerButton.POINTER_BUTTON_LEFT);
+  }
+  async doubleClick(x: number, y: number) {
+    this.guardWrite();
+    await this.pointer(x, y, PointerAction.POINTER_ACTION_DOUBLE_CLICK, PointerButton.POINTER_BUTTON_LEFT);
+  }
+  async move(x: number, y: number) {
+    this.guardWrite();
+    await this.pointer(x, y, PointerAction.POINTER_ACTION_MOVE, PointerButton.POINTER_BUTTON_UNSPECIFIED);
+  }
+  async scroll(x: number, y: number, sx: number, sy: number) {
+    this.guardWrite();
+    // The model's scroll deltas are PIXELS — forward them straight to the agent as a
+    // ScrollEvent{x,y,deltaX,deltaY} and let the native inject translate to wheel
+    // events per platform. No xdotool "notch" quantization here (that is an
+    // xdotool-specific artifact); the agent owns the platform-appropriate scaling.
+    await this.session.desktopInput({ $case: "scroll", scroll: { x, y, deltaX: sx, deltaY: sy } });
+  }
+  async type(text: string) {
+    this.guardWrite();
+    // A literal text burst: isText:true tells the agent to type the string verbatim
+    // (Unicode-aware) rather than interpret it as a key name.
+    await this.session.desktopInput({ $case: "key", key: { key: text, isText: true, action: KeyAction.KEY_ACTION_PRESS } });
+  }
+  async keypress(keys: string[]) {
+    this.guardWrite();
+    // A chord ("ctrl+c") as ONE non-text KeyEvent (isText:false ⇒ interpret as key
+    // names). We send the model's PLATFORM-INDEPENDENT key names joined with "+" —
+    // NOT xdotool X keysyms (SandboxComputer's toKeysym maps to "Return"/"super"/
+    // "Prior", which are X-specific and wrong for the macOS CGEvent path). The agent
+    // owns the per-platform key-name → keycode mapping (the KeyEvent.key contract).
+    await this.session.desktopInput({ $case: "key", key: { key: keys.join("+"), isText: false, action: KeyAction.KEY_ACTION_PRESS } });
+  }
+  async drag(path: [number, number][]) {
+    this.guardWrite();
+    if (path.length === 0) return;
+    // Press at the start, move through each waypoint with the button held, release at
+    // the last point. The agent tracks button state across the DOWN → MOVE… → UP.
+    const [sx, sy] = path[0]!;
+    await this.pointer(sx, sy, PointerAction.POINTER_ACTION_DOWN, PointerButton.POINTER_BUTTON_LEFT);
+    for (const [px, py] of path.slice(1)) {
+      await this.pointer(px, py, PointerAction.POINTER_ACTION_MOVE, PointerButton.POINTER_BUTTON_LEFT);
+    }
+    const [ex, ey] = path[path.length - 1]!;
+    await this.pointer(ex, ey, PointerAction.POINTER_ACTION_UP, PointerButton.POINTER_BUTTON_LEFT);
+  }
+  async wait() {
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+/**
+ * Backend-aware SELECTION discriminator: a SELF-HOSTED session exposes the two
+ * native control-plane ops (`desktopInput` + `screenshot`); a MODAL session does
+ * not (it drives the desktop via xdotool/scrot over `exec`). Duck-typing on those
+ * two methods keeps this file from hard-importing `SelfhostedSession` (avoiding an
+ * agent-loop ↔ sandbox-leaf import coupling) and is future-proof: any backend that
+ * grows native inject/capture is picked up automatically.
+ */
+export function isNativeDesktopSession(session: SandboxSessionLike): session is SandboxSessionLike & NativeDesktopSession {
+  const s = session as Partial<NativeDesktopSession>;
+  return typeof s.desktopInput === "function" && typeof s.screenshot === "function";
+}
+
 // ── The capability (the SDK seam) ────────────────────────────────────────────
 
 export type ComputerUseArgs = {
@@ -367,13 +533,23 @@ export class ComputerUseCapability extends Capability {
 
   override tools(): Tool<unknown>[] {
     const session = requireBoundSession("computer-use", this._session);
-    const computer = new SandboxComputer(session, {
-      ...(this.args.dimensions ? { dimensions: this.args.dimensions } : {}),
-      ...(this.args.readOnly !== undefined ? { readOnly: this.args.readOnly } : {}),
-      ...(this.args.display ? { display: this.args.display } : {}),
-      // The SDK base exposes the bound runAs as a protected field.
-      ...(typeof this._runAs === "string" ? { runAs: this._runAs } : {}),
-    });
+    // Backend-aware: a SELF-HOSTED session (macOS OR bring-your-own Linux) drives the
+    // desktop NATIVELY (CGEvent/XTEST inject + ScreenCaptureKit/x11 capture over the
+    // control plane) — no xdotool/scrot on the user's machine required. Everything
+    // else (Modal) keeps the xdotool/scrot-over-exec SandboxComputer. See
+    // `isNativeDesktopSession` for the duck-typed discriminator.
+    const computer: Computer = isNativeDesktopSession(session)
+      ? new NativeDesktopComputer(session, {
+          ...(this.args.dimensions ? { dimensions: this.args.dimensions } : {}),
+          ...(this.args.readOnly !== undefined ? { readOnly: this.args.readOnly } : {}),
+        })
+      : new SandboxComputer(session, {
+          ...(this.args.dimensions ? { dimensions: this.args.dimensions } : {}),
+          ...(this.args.readOnly !== undefined ? { readOnly: this.args.readOnly } : {}),
+          ...(this.args.display ? { display: this.args.display } : {}),
+          // The SDK base exposes the bound runAs as a protected field.
+          ...(typeof this._runAs === "string" ? { runAs: this._runAs } : {}),
+        });
     return [
       computerTool({
         computer,

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -20,6 +20,7 @@ import {
   ControlResponse,
   FsEntryKind,
   StreamKind,
+  type DesktopInputRequest,
   type ExecRequest,
   type ExecResponse,
   type StreamChannel,
@@ -520,6 +521,41 @@ export class SelfhostedSession {
       throw new Error(`selfhosted statFile: unexpected result ${result.$case}`);
     }
     return { exists: result.fsStat.exists };
+  }
+
+  // ── Computer-use control plane (the agent drives its OWN screen) ──────────────
+  // The CONTROL-PLANE twin of the relay DesktopInput/desktop stream: instead of a
+  // human viewer channel, the agent injects synthetic input into — and captures —
+  // its own display for the model's computer-use loop. Both route over the SAME
+  // `call()` primitive, so a consent/epoch rejection surfaces as the mapped
+  // `SelfhostedControlError` exactly like every other op. `NativeDesktopComputer`
+  // (sandbox-computer.ts) is the sole consumer.
+
+  /** Computer-use WRITE op: inject one synthetic desktop input event (pointer/key/
+   *  scroll) on the machine's OWN display. The agent injects via CGEvent (macOS) /
+   *  XTEST (Linux) and CONSENT-GATES it — an unconsented call never touches the OS
+   *  and surfaces the mapped control error (ERROR_CODE_CONSENT_REQUIRED) via `call()`. */
+  async desktopInput(event: DesktopInputRequest["event"]): Promise<void> {
+    const result = await this.call({ $case: "desktopInput", desktopInput: { event } });
+    if (result.$case !== "desktopInput") {
+      throw new Error(`selfhosted desktopInput: unexpected result ${result.$case}`);
+    }
+  }
+
+  /** Computer-use VIEW op: capture a single PNG screenshot of the machine's desktop
+   *  plus its geometry (via ScreenCaptureKit / x11). NOT consent-gated (a view op —
+   *  the view/control decoupling), so it works with a display but no screen-control
+   *  consent. Returns the raw encoded bytes + width/height. */
+  async screenshot(): Promise<{ png: Uint8Array; width: number; height: number }> {
+    const result = await this.call({ $case: "desktopScreenshot", desktopScreenshot: {} });
+    if (result.$case !== "desktopScreenshot") {
+      throw new Error(`selfhosted screenshot: unexpected result ${result.$case}`);
+    }
+    return {
+      png: result.desktopScreenshot.png,
+      width: result.desktopScreenshot.width,
+      height: result.desktopScreenshot.height,
+    };
   }
 
   /** A cheap liveness probe — request a Ping on the subject; returns true iff a

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -3,12 +3,16 @@ import { testSettings } from "@opengeni/testing";
 import { buildAgentCapabilities } from "../src/index";
 import {
   SandboxComputer,
+  NativeDesktopComputer,
+  isNativeDesktopSession,
   ComputerUseCapability,
   computerUse,
   ComputerReadOnlyError,
   ComputerUnavailableError,
   ComputerActionError,
+  type NativeDesktopSession,
 } from "../src/sandbox-computer";
+import { KeyAction, PointerAction, PointerButton, type DesktopInputRequest } from "@opengeni/agent-proto";
 
 // A mock provider session that records every command. By default it mimics
 // MODAL: it implements execCommand (the formatted-string contract) and does NOT
@@ -234,6 +238,188 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
     const c = new SandboxComputer(session as never, { dimensions: [1024, 768] });
     expect(c.environment).toBe("ubuntu");
     expect(c.dimensions).toEqual([1024, 768]);
+  });
+});
+
+// A FAKE self-hosted session presenting the `{ desktopInput, screenshot }` native
+// surface. Records every injected DesktopInput event so tests can assert the exact
+// protos (event $case + fields + enum values), and returns a configurable PNG.
+function makeNativeSession(opts: { png?: Uint8Array; width?: number; height?: number } = {}) {
+  const inputs: NonNullable<DesktopInputRequest["event"]>[] = [];
+  const session: NativeDesktopSession = {
+    desktopInput: async (event) => {
+      if (event) inputs.push(event);
+    },
+    screenshot: async () => ({
+      png: opts.png ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]),
+      width: opts.width ?? 1280,
+      height: opts.height ?? 800,
+    }),
+  };
+  return { session, inputs };
+}
+
+describe("NativeDesktopComputer (self-hosted / macOS native inject+capture)", () => {
+  test("click emits a POINTER CLICK event with the coords + LEFT button", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.click(100, 200, "left");
+    expect(inputs.length).toBe(1);
+    const ev = inputs[0]!;
+    expect(ev.$case).toBe("pointer");
+    if (ev.$case !== "pointer") throw new Error("expected pointer");
+    expect(ev.pointer).toEqual({
+      x: 100,
+      y: 200,
+      action: PointerAction.POINTER_ACTION_CLICK,
+      button: PointerButton.POINTER_BUTTON_LEFT,
+    });
+  });
+
+  test("right/wheel clicks map to the RIGHT/MIDDLE pointer buttons", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.click(1, 1, "right");
+    await c.click(2, 2, "wheel");
+    expect((inputs[0] as { pointer: { button: PointerButton } }).pointer.button).toBe(PointerButton.POINTER_BUTTON_RIGHT);
+    expect((inputs[1] as { pointer: { button: PointerButton } }).pointer.button).toBe(PointerButton.POINTER_BUTTON_MIDDLE);
+  });
+
+  test("doubleClick emits a DOUBLE_CLICK pointer event (LEFT)", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.doubleClick(5, 6);
+    const ev = inputs[0]!;
+    if (ev.$case !== "pointer") throw new Error("expected pointer");
+    expect(ev.pointer.action).toBe(PointerAction.POINTER_ACTION_DOUBLE_CLICK);
+    expect(ev.pointer.button).toBe(PointerButton.POINTER_BUTTON_LEFT);
+  });
+
+  test("type emits a TEXT key event (isText:true, PRESS) with the verbatim string", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.type("it's a test");
+    const ev = inputs[0]!;
+    expect(ev.$case).toBe("key");
+    if (ev.$case !== "key") throw new Error("expected key");
+    expect(ev.key).toEqual({ key: "it's a test", isText: true, action: KeyAction.KEY_ACTION_PRESS });
+  });
+
+  test("keypress emits ONE non-text chord KeyEvent (platform-independent names, PRESS)", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.keypress(["ctrl", "c"]);
+    expect(inputs.length).toBe(1);
+    const ev = inputs[0]!;
+    if (ev.$case !== "key") throw new Error("expected key");
+    // Joined with "+", isText:false (interpret as key names — NOT xdotool keysyms).
+    expect(ev.key).toEqual({ key: "ctrl+c", isText: false, action: KeyAction.KEY_ACTION_PRESS });
+  });
+
+  test("scroll forwards the raw pixel deltas as a ScrollEvent (no notch quantization)", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.scroll(10, 20, -3, 300);
+    const ev = inputs[0]!;
+    expect(ev.$case).toBe("scroll");
+    if (ev.$case !== "scroll") throw new Error("expected scroll");
+    expect(ev.scroll).toEqual({ x: 10, y: 20, deltaX: -3, deltaY: 300 });
+  });
+
+  test("drag emits DOWN → MOVE(s) → UP pointer events along the path", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session);
+    await c.drag([[0, 0], [10, 10], [20, 20]]);
+    const actions = inputs.map((ev) => (ev.$case === "pointer" ? ev.pointer.action : -1));
+    // DOWN at the start, a MOVE through EACH subsequent waypoint, UP at the last.
+    expect(actions).toEqual([
+      PointerAction.POINTER_ACTION_DOWN,
+      PointerAction.POINTER_ACTION_MOVE,
+      PointerAction.POINTER_ACTION_MOVE,
+      PointerAction.POINTER_ACTION_UP,
+    ]);
+    // Down at the start, up at the last waypoint.
+    const first = inputs[0]!;
+    const last = inputs[inputs.length - 1]!;
+    if (first.$case !== "pointer" || last.$case !== "pointer") throw new Error("expected pointers");
+    expect([first.pointer.x, first.pointer.y]).toEqual([0, 0]);
+    expect([last.pointer.x, last.pointer.y]).toEqual([20, 20]);
+  });
+
+  test("screenshot returns the base64 of the fake PNG (non-empty, no data-URL prefix)", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { session } = makeNativeSession({ png });
+    const c = new NativeDesktopComputer(session);
+    const shot = await c.screenshot();
+    expect(shot).toBe(Buffer.from(png).toString("base64"));
+    // Raw base64 — the SDK adds the `data:image/png;base64,` prefix itself.
+    expect(shot.startsWith("data:")).toBe(false);
+  });
+
+  test("REGRESSION: an empty PNG THROWS (never an empty image_url that would 400 the turn)", async () => {
+    const { session } = makeNativeSession({ png: new Uint8Array() });
+    const c = new NativeDesktopComputer(session);
+    const result = await c.screenshot().then((s) => ({ ok: true as const, s }), (e) => ({ ok: false as const, e }));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error(`screenshot() resolved to ${JSON.stringify(result.s)} — an empty image_url would 400 the model turn`);
+    expect(result.e).toBeInstanceOf(ComputerUnavailableError);
+  });
+
+  test("readOnly blocks every write but screenshot is always allowed", async () => {
+    const { session, inputs } = makeNativeSession();
+    const c = new NativeDesktopComputer(session, { readOnly: true });
+    await expect(c.click(1, 1, "left")).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.doubleClick(1, 1)).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.move(1, 1)).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.scroll(1, 1, 0, 10)).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.type("x")).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.keypress(["a"])).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    await expect(c.drag([[0, 0], [1, 1]])).rejects.toBeInstanceOf(ComputerReadOnlyError);
+    // No write ever reached the session.
+    expect(inputs.length).toBe(0);
+    // screenshot is a READ — never gated.
+    await expect(c.screenshot()).resolves.toBeString();
+  });
+
+  test("environment defaults to 'ubuntu' and dimensions default to the stream geometry", () => {
+    const { session } = makeNativeSession();
+    const c = new NativeDesktopComputer(session, { dimensions: [1024, 768] });
+    expect(c.environment).toBe("ubuntu");
+    expect(c.dimensions).toEqual([1024, 768]);
+  });
+});
+
+describe("computer backend selection (native vs xdotool)", () => {
+  test("isNativeDesktopSession: true for a {desktopInput,screenshot} session, false for a Modal session", () => {
+    const { session: native } = makeNativeSession();
+    expect(isNativeDesktopSession(native as never)).toBe(true);
+    // The Modal-shaped mock (execCommand only) is NOT native.
+    const { session: modal } = makeMockSession();
+    expect(isNativeDesktopSession(modal as never)).toBe(false);
+  });
+
+  test("ComputerUseCapability bound to a native session drives desktopInput (NOT exec)", async () => {
+    const { session, inputs } = makeNativeSession();
+    const cap = computerUse({ readOnly: false });
+    cap.bind(session as never);
+    const tools = cap.tools();
+    expect(tools.length).toBe(1);
+    // Reach through the tool to the selected computer and drive a click — it must
+    // land on the native desktopInput seam, proving NativeDesktopComputer was chosen.
+    const computer = (tools[0] as unknown as { computer: NativeDesktopComputer }).computer;
+    expect(computer).toBeInstanceOf(NativeDesktopComputer);
+    await computer.click(3, 4, "left");
+    expect(inputs.length).toBe(1);
+    expect(inputs[0]!.$case).toBe("pointer");
+  });
+
+  test("ComputerUseCapability bound to a Modal session selects the xdotool SandboxComputer", () => {
+    const { session } = makeMockSession();
+    const cap = computerUse({ readOnly: false });
+    cap.bind(session as never);
+    const tools = cap.tools();
+    const computer = (tools[0] as unknown as { computer: unknown }).computer;
+    expect(computer).toBeInstanceOf(SandboxComputer);
   });
 });
 


### PR DESCRIPTION
## The gap

The agent's **computer-use** tool couldn't drive a self-hosted machine. The only `Computer` implementation (`SandboxComputer`) shells `xdotool`/`scrot` on an X11 `:0` display over exec — which don't exist on macOS, so every click/type/screenshot threw. The macOS agent *can* inject (CGEvent) and capture (ScreenCaptureKit), but those were wired only to the human viewer's relay stream, never the agent's control channel.

## The fix — a native control-plane path

### Agent (proto + Rust) — agent **v0.1.1**
Two new ControlRpc ops (`ControlRequest`/`ControlResponse` oneof fields 29/30), regenerated in both proto stacks:
- **`desktop_input`** — inject one synthetic event (pointer/key/scroll) → the existing `Platform::desktop_input`. **Consent-gated:** refuses with `ERROR_CODE_CONSENT_REQUIRED` unless `consented_screen_control` (threaded from the agent creds into the dispatch context). Epoch-fenced like every op.
- **`desktop_screenshot`** — one-shot `DesktopBackend::capture` → PNG. **Not** consent-gated — capture is a *view* op (needs a display, not screen control), consistent with the view/control split already shipped.

3 dispatch tests assert: input without consent is refused and never injects; input with consent injects the mapped event; screenshot returns the frame without consent.

### Runtime (TS)
- `SelfhostedSession.desktopInput()` / `screenshot()` over the same NATS ControlRpc.
- `NativeDesktopComputer implements Computer` — maps click/doubleClick/move/drag/scroll/type/keypress → `DesktopInput` protos, screenshot → the capture op, platform-independent key names for CGEvent.
- `ComputerUseCapability.tools()` selects it for self-hosted sessions (duck-typed on `desktopInput`/`screenshot`); Modal keeps `SandboxComputer`.

## Verification
- Agent: `cargo fmt`/`clippy -D warnings`/`test`/`check` (incl. `--features macos-desktop`) all clean; 3 new consent tests.
- Runtime: typecheck clean; `sandbox-computer` 34 pass; full suite 439 pass. `apps/api` typecheck clean.
- **Deferred to e2e on the Mac (this PR + a live drive):** the CGEvent inject of a real KeyEvent chord + the Retina coordinate mapping (ScreenCaptureKit capture space vs CGEvent logical points) — flagged with a TODO at the pointer seam.

## Rollout (post-merge)
1. **Agent Release** v0.1.1 (macOS universal, `--features macos-desktop`) → the user re-installs.
2. Deploy the control-plane (runtime + regenerated proto) to staging.
3. Re-enroll with `allowScreenControl=true` (computer use controls the whole machine) + restart the agent to pick up consent.
4. Drive a session → verify the agent clicks/types on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent-gated synthetic input and a new control RPC surface; mistakes could allow unconsented injection or break computer-use on self-hosted vs Modal paths.
> 
> **Overview**
> Adds **control-plane computer-use** for self-hosted agents so the model can drive the machine’s own desktop without xdotool/scrot over exec.
> 
> **Wire + agent (v0.1.1):** New `desktop_input` and `desktop_screenshot` `ControlRequest`/`ControlResponse` ops (proto + regenerated TS). Dispatch handles them via `desktop_input` / `DesktopBackend::capture`; **`consented_screen_control`** on `DispatchContext` (from enrollment creds) gates synthetic input with `ConsentRequired` before the platform runs—screenshots are not consent-gated. Supervisor passes consent and logs the new op names.
> 
> **Runtime:** `SelfhostedSession` exposes `desktopInput` / `screenshot` over NATS. **`NativeDesktopComputer`** maps Agents SDK `Computer` actions to proto events; **`ComputerUseCapability`** picks native vs `SandboxComputer` when the session duck-types `desktopInput` + `screenshot`.
> 
> Tests cover consent refusal without inject, consented inject mapping, screenshot without consent, and native computer mapping/selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c1487b77effb11f15073a8f5a5cd46dd58173a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->