### PR TITLE
fix(sandbox): run beforeAgentStart lifecycle hooks on the owned-box path

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -371,6 +371,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // run. null when the flag is off (byte-for-byte the legacy build-and-discard
     // path) OR when the backend is "none". Released + dropped in `finally`.
     let resolvedSandbox: ResumedTurnSandbox | null = null;
+    // The UN-PROXIED established box session, captured BEFORE wrapTurnBoxWithRouting.
+    // Platform setup (beforeAgentStart hooks + file materialization) execs against
+    // THIS handle so a mid-turn sandbox_swap can never re-route those execs onto a
+    // connected machine (the user's real computer).
+    let setupBoxSession: unknown = null;
     // The lease holder id (Temporal activityId, unique per scheduled execution)
     // + the group id, captured so the lease heartbeat can refresh the lease TTL
     // epoch-fenced (a superseded owner self-evicts) and finally can release.
@@ -891,6 +896,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             "turn",
             sandboxHolderId,
           );
+          setupBoxSession = established.session;
           resolvedSandbox = {
             // Wrap in the SAME routing proxy so a mid-turn swap (to another machine
             // or back to the group box) still re-routes per op. PIN this established
@@ -942,6 +948,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             "turn",
             sandboxHolderId,
           );
+          setupBoxSession = resolvedSandbox.established.session;
           // M7 hot-swap: when the selfhosted feature is on, wrap the established
           // group box in the STABLE routing proxy before it is injected NON-OWNED
           // into the run. The SDK binds to this ONE object once and calls its
@@ -1253,6 +1260,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               client: resolvedSandbox.established.client,
               session: resolvedSandbox.established.session,
               sessionState: resolvedSandbox.established.sessionState,
+              // Pin platform setup (hooks + file materialization) to the un-proxied
+              // established box — never through the routing proxy, which would
+              // re-route those execs onto a machine swapped in mid-turn.
+              ...(setupBoxSession ? { setupSession: setupBoxSession } : {}),
             },
           }
           : {}),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1638,15 +1638,31 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     // TOKEN-BROKER (B1): the per-turn git token seed, forwarded OFF-MANIFEST so the
     // repository-clone hook seeds it to the box's token file before the clone.
     const ownedGitTokenSeed = gitTokenSeedForAgent(agent);
-    const decoratedClient = withSandboxLifecycleHooks(resourceClient, [
+    const ownedHooks = [
       ...sandboxLifecycleHooksForIds(sandboxLifecycleHookIds(settings)),
       ...sandboxRepositoryCloneHooksForAgent(agent),
-    ], {
+    ];
+    const ownedHookContext: SandboxLifecycleHookContext = {
       environment,
       ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
       ...(runAs ? { runAs } : {}),
       ...(ownedGitTokenSeed ? { gitTokenSeed: ownedGitTokenSeed } : {}),
-    });
+    };
+    // OWNED-PATH HOOKS: the SDK NEVER calls client.create/resume when handed a live
+    // provided session (SandboxRuntimeManager uses `sandboxConfig.session` directly),
+    // so the withSandboxLifecycleHooks decoration below can never fire on this branch —
+    // it only wraps create/resume. Run the beforeAgentStart hooks directly against the
+    // provided box, once per turn, BEFORE the run starts: this is what executes the
+    // repository-clone hook (which also seeds the B1 askpass + token file) and the
+    // azure-cli-login hook on lease-owned boxes. Re-running on a warm box is safe by
+    // construction: clone skips when the target is already materialized, the token
+    // seed OVERWRITES the file (the desired per-turn refresh), and az login is
+    // idempotent. A turn resumed after preemption re-enters here and re-seeds the
+    // freshly minted token — which is exactly what a >1h-old warm box needs.
+    await runBeforeAgentStartHooks(session as SandboxSessionLike, ownedHooks, ownedHookContext);
+    // Keep the decoration as a safety net for any session the SDK does create/resume
+    // through the client during this run (it is inert for the provided session).
+    const decoratedClient = withSandboxLifecycleHooks(resourceClient, ownedHooks, ownedHookContext);
     const ownedFilter = composeCallModelInputFilters(
       [callModelInputFilterForSettings(settings), overrides.callModelInputFilter].filter(
         (f): f is CallModelInputFilter => Boolean(f),
@@ -2403,12 +2419,40 @@ export function sandboxLifecycleHooksForIds(ids: string[]): SandboxLifecycleHook
   });
 }
 
+function applicableBeforeAgentStartHooks(
+  hooks: SandboxLifecycleHook[],
+  context: SandboxLifecycleHookContext,
+): SandboxLifecycleHook[] {
+  return hooks.filter((hook) => hook.phase === "beforeAgentStart" && (hook.shouldRun?.(context) ?? true));
+}
+
+/**
+ * Run the beforeAgentStart lifecycle hooks directly against an already-live box.
+ *
+ * The create/resume decoration (withSandboxLifecycleHooks) is structurally blind to
+ * the PROVIDED-session path: when runStream hands the SDK a live `session`
+ * (runOptions.sandbox.session — the lease-owned box resolved by the turn activity),
+ * SandboxRuntimeManager uses it as-is and never calls client.create/resume, so a
+ * wrapper around those methods never fires. Callers on that path invoke this
+ * before starting the run so the box still gets its beforeAgentStart preparation
+ * (repository clone + B1 askpass/token-file seed, azure-cli-login).
+ */
+export async function runBeforeAgentStartHooks(
+  session: SandboxSessionLike,
+  hooks: SandboxLifecycleHook[],
+  context: SandboxLifecycleHookContext,
+): Promise<void> {
+  for (const hook of applicableBeforeAgentStartHooks(hooks, context)) {
+    await hook.run(session, context);
+  }
+}
+
 export function withSandboxLifecycleHooks(
   client: SandboxClient,
   hooks: SandboxLifecycleHook[],
   context: SandboxLifecycleHookContext,
 ): SandboxClient {
-  const beforeAgentStartHooks = hooks.filter((hook) => hook.phase === "beforeAgentStart" && (hook.shouldRun?.(context) ?? true));
+  const beforeAgentStartHooks = applicableBeforeAgentStartHooks(hooks, context);
   if (beforeAgentStartHooks.length === 0) {
     return client;
   }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1533,6 +1533,12 @@ export type RunAgentStreamOptions = {
     client: unknown;          // built by the per-turn resume path (the raw provider client)
     session: unknown;         // SandboxSessionLike — the live, NON-OWNED handle (never reaped)
     sessionState?: unknown;   // SandboxSessionState the box was resumed from
+    // The UN-PROXIED established box for platform setup (lifecycle hooks + file
+    // resource materialization). `session` may be the mid-turn routing proxy whose
+    // every exec re-reads the active pointer — platform-initiated setup must NOT
+    // follow a swap onto a connected machine (the user's real computer), so it
+    // runs against this pinned handle instead. Absent -> falls back to `session`.
+    setupSession?: unknown;
   };
   // A per-turn model-input filter chained AFTER the provider-item-id strip.
   // Used by the genesis-title injection to prepend a hidden, NON-PERSISTED
@@ -1639,6 +1645,11 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
   // block is skipped (byte-for-byte the legacy path).
   if (overrides.ownedSandbox) {
     const { client: ownedClient, session, sessionState } = overrides.ownedSandbox;
+    // Platform setup (hooks + file materialization) execs against the UN-PROXIED
+    // established box when the caller pinned one — never through the routing proxy,
+    // whose per-op pointer re-read could land these execs on a machine swapped in
+    // mid-turn.
+    const setupSession = (overrides.ownedSandbox.setupSession ?? session) as SandboxSessionLike;
     const runAs = sandboxRunAs(settings);
     const fileDownloads = sandboxFileDownloadsForAgent(agent);
     const resourceClient = fileDownloads.length > 0
@@ -1675,7 +1686,19 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     // user's REAL computer — the platform must not run setup against it (the clone
     // hooks are already empty there; this keeps az login off it too).
     if (agentActiveSandboxBackend.get(agent) !== "selfhosted") {
-      await runBeforeAgentStartHooks(session as SandboxSessionLike, ownedHooks, ownedHookContext);
+      await runBeforeAgentStartHooks(setupSession, ownedHooks, ownedHookContext);
+      // FILE RESOURCES: withSandboxFileDownloads below has the IDENTICAL provided-
+      // session blind spot (it too wraps only create/resume), so signed-URL file
+      // materialization must also run directly against the pinned box. The download
+      // command is idempotent (skips an existing file) and atomic (tmp + rename),
+      // so the per-turn re-run is safe; the turn re-signs URLs each run, so a
+      // re-warmed box always gets fresh links.
+      if (fileDownloads.length > 0) {
+        await materializeSandboxFileDownloads(setupSession, fileDownloads, {
+          ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
+          ...(runAs ? { runAs } : {}),
+        });
+      }
     }
     // Keep the decoration as a safety net for any session the SDK does create/resume
     // through the client during this run (it is inert for the provided session).
@@ -2573,21 +2596,30 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     // box/agent manifest (validateNoEnvironmentDelta must not see a rotating value), so
     // this whole block is a no-op when the seed is absent (e.g. the selfhosted path,
     // which uses its own git creds). The token file lives at $OPENGENI_GIT_TOKEN_FILE
-    // (stable, from the shared base) with a $HOME/.opengeni/git-token fallback; chmod 600
-    // keeps the token private. $GIT_ASKPASS is on the box manifest env (set by
+    // (stable, from the shared base) with a $HOME/.opengeni/git-token fallback.
+    // $GIT_ASKPASS is on the box manifest env (set by
     // sandboxEnvironmentForRun to $HOME/.opengeni/askpass), so it is available to this
     // exec; the askpass script we write is byte-identical to docker/opengeni-git-askpass
     // and is written via a QUOTED heredoc (<<'ASKPASS_EOF') so NOTHING inside it expands
     // ($1, $HOME, ${OPENGENI_GIT_TOKEN_FILE:-...}, and the literal \n in printf all land
     // verbatim), then chmod 0755 so git can exec it.
+    //
+    // ATOMIC REWRITE: this block now re-runs at the start of EVERY turn on a warm box
+    // that other turn holders may be actively using — an in-flight `git fetch` from a
+    // concurrent turn can invoke the askpass (which cats the token file) at any moment.
+    // Both files are therefore written to a pid-suffixed temp under umask 077 and
+    // renamed into place: rename is atomic, concurrent readers keep the old inode, and
+    // the token is never observable world-readable (no post-hoc chmod window).
     "if [ -n \"${OPENGENI_GIT_TOKEN_SEED:-}\" ]; then",
+    "  seed_umask=\"$(umask)\"",
+    "  umask 077",
     "  git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"",
     "  mkdir -p \"$(dirname \"$git_token_file\")\"",
-    "  printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"",
-    "  chmod 600 \"$git_token_file\"",
+    "  printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file.tmp.$$\"",
+    "  mv -f \"$git_token_file.tmp.$$\" \"$git_token_file\"",
     "  git_askpass=\"${GIT_ASKPASS:-$HOME/.opengeni/askpass}\"",
     "  mkdir -p \"$(dirname \"$git_askpass\")\"",
-    "  cat > \"$git_askpass\" <<'ASKPASS_EOF'",
+    "  cat > \"$git_askpass.tmp.$$\" <<'ASKPASS_EOF'",
     "#!/usr/bin/env sh",
     "case \"$1\" in",
     "  *Username*) printf '%s\\n' \"x-access-token\" ;;",
@@ -2595,7 +2627,9 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     "  *) printf '\\n' ;;",
     "esac",
     "ASKPASS_EOF",
-    "  chmod 0755 \"$git_askpass\"",
+    "  chmod 0755 \"$git_askpass.tmp.$$\"",
+    "  mv -f \"$git_askpass.tmp.$$\" \"$git_askpass\"",
+    "  umask \"$seed_umask\"",
     "fi",
     "ensure_git() {",
     "  if command -v git >/dev/null 2>&1; then",
@@ -2618,16 +2652,30 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     "  ref=\"$3\"",
     "  subpath=\"$4\"",
     "  if [ -e \"$target\" ] && { [ -f \"$target\" ] || [ -n \"$(find \"$target\" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\" ]; }; then",
-    "    echo \"Repository resource already present at $target\"",
-    "    return 0",
+    // This hook re-runs every turn on a long-lived box, so \"non-empty\" alone is not
+    // proof of a completed materialization: an interrupted clone (worker crash /
+    // lifecycle timeout mid-mv/cp) leaves a partial tree that would otherwise pass
+    // this check forever. A full-repo target must actually BE a work tree to be
+    // skipped; a partial one is wiped and rebuilt (nothing legitimate writes under
+    // the mount path before the repo exists). Subpath extracts are not git repos —
+    // for those the plain non-empty check stands (no stronger signal available).
+    "    if [ -n \"$subpath\" ] || git -C \"$target\" rev-parse --is-inside-work-tree >/dev/null 2>&1; then",
+    "      echo \"Repository resource already present at $target\"",
+    "      return 0",
+    "    fi",
+    "    echo \"Re-materializing partial repository resource at $target\" >&2",
+    "    find \"$target\" -mindepth 1 -maxdepth 1 -exec rm -rf {} +",
     "  fi",
     "  mkdir -p \"$(dirname \"$target\")\"",
     "  tmp=\"${target}.tmp.$$\"",
     "  rm -rf \"$tmp\"",
-    "  git init \"$tmp\" >/dev/null",
-    "  git -C \"$tmp\" remote add origin \"$uri\"",
-    "  git -C \"$tmp\" fetch --depth 1 --no-tags --filter=blob:none origin \"$ref\"",
-    "  git -C \"$tmp\" checkout --detach FETCH_HEAD >/dev/null",
+    // Fetch failures must not leak the pid-suffixed tmp clone beside the mount
+    // (set -eu would exit before any cleanup).
+    "  if ! { git init \"$tmp\" >/dev/null && git -C \"$tmp\" remote add origin \"$uri\" && git -C \"$tmp\" fetch --depth 1 --no-tags --filter=blob:none origin \"$ref\" && git -C \"$tmp\" checkout --detach FETCH_HEAD >/dev/null; }; then",
+    "    rm -rf \"$tmp\"",
+    "    echo \"Repository resource fetch failed for $target\" >&2",
+    "    exit 1",
+    "  fi",
     "  if [ -n \"$subpath\" ]; then",
     "    if [ ! -e \"$tmp/$subpath\" ]; then",
     "      echo \"Repository subpath not found: $subpath\" >&2",
@@ -2644,7 +2692,22 @@ export function repositoryCloneCommand(resources: Extract<ResourceRef, { kind: "
     "    rm -rf \"$tmp\"",
     "  else",
     "    rmdir \"$target\" 2>/dev/null || true",
-    "    mv \"$tmp\" \"$target\"",
+    // Two concurrent turn holders can race this install: without the existence
+    // re-check the loser's un-flagged `mv` would nest its tmp clone INSIDE the
+    // winner's tree as <name>.tmp.<pid>. If the winner produced a valid work tree,
+    // accept it; a non-empty non-repo survivor here is a mount point the manifest
+    // re-filled — install into it by content copy instead of rename.
+    "    if [ -e \"$target\" ]; then",
+    "      if git -C \"$target\" rev-parse --is-inside-work-tree >/dev/null 2>&1; then",
+    "        rm -rf \"$tmp\"",
+    "        echo \"Repository resource already present at $target\"",
+    "        return 0",
+    "      fi",
+    "      cp -a \"$tmp/.\" \"$target/\"",
+    "      rm -rf \"$tmp\"",
+    "    else",
+    "      mv \"$tmp\" \"$target\"",
+    "    fi",
     "    git -C \"$target\" rev-parse --is-inside-work-tree >/dev/null",
     "  fi",
     "  if [ ! -e \"$target\" ]; then",
@@ -2734,7 +2797,11 @@ export function azureCliLoginCommand(): string {
     "if [ -n \"$CLIENT_ID\" ] && [ -n \"$CLIENT_SECRET\" ] && [ -n \"$TENANT_ID\" ]; then",
     "  command -v az >/dev/null 2>&1 || { echo \"Azure CLI is not installed in the sandbox\" >&2; exit 127; }",
     "  az account show --only-show-errors >/dev/null 2>&1 || az login --service-principal --username \"$CLIENT_ID\" --password \"$CLIENT_SECRET\" --tenant \"$TENANT_ID\" --allow-no-subscriptions --only-show-errors --output none",
-    "  [ -n \"$SUBSCRIPTION_ID\" ] && az account set --subscription \"$SUBSCRIPTION_ID\" --only-show-errors",
+    // if/fi, NOT `[ -n ] && az`: this line ends the credentialed if-body, so with a
+    // no-subscription SP (an explicitly supported config — the login above passes
+    // --allow-no-subscriptions) the bare `[ -n ]` would exit the whole script 1 and
+    // fail the turn.
+    "  if [ -n \"$SUBSCRIPTION_ID\" ]; then az account set --subscription \"$SUBSCRIPTION_ID\" --only-show-errors; fi",
     "fi",
   ].join("\n");
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -773,6 +773,10 @@ const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
 // session env; runStream reads it to build the clone hook context. Absent when
 // no repo is attached / on the selfhosted path.
 const agentGitTokenSeed = new WeakMap<object, string>();
+// The EFFECTIVE backend the turn resolved for this agent (undefined -> the home
+// backend). Read by runStream's owned branch to keep platform box-setup hooks off
+// connected machines (a user's real computer).
+const agentActiveSandboxBackend = new WeakMap<object, Settings["sandboxBackend"]>();
 
 export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[], options: BuildAgentOptions = {}): Agent<any, any> {
   // Resolved per-turn gating. Each override defaults to today's settings-derived
@@ -858,6 +862,14 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
   agentRepositoryCloneHooks.set(agent, sandboxRepositoryCloneHooks(settings, resources, options.activeSandboxBackend));
+  // Stash the EFFECTIVE backend so runStream's owned branch can skip the direct
+  // beforeAgentStart hook run on a connected machine: the box there is the user's
+  // REAL computer — the platform must not run setup (az login) against it. The
+  // clone hooks are already excluded for selfhosted at construction (above); this
+  // keeps the built-in hooks equally out.
+  if (options.activeSandboxBackend) {
+    agentActiveSandboxBackend.set(agent, options.activeSandboxBackend);
+  }
   // TOKEN-BROKER (B1): stash the per-turn seed off-manifest so runStream can seed the
   // clone hook without the token ever touching defaultManifest / sandboxEnvironment.
   if (options.gitTokenSeed) {
@@ -1659,7 +1671,12 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     // seed OVERWRITES the file (the desired per-turn refresh), and az login is
     // idempotent. A turn resumed after preemption re-enters here and re-seeds the
     // freshly minted token — which is exactly what a >1h-old warm box needs.
-    await runBeforeAgentStartHooks(session as SandboxSessionLike, ownedHooks, ownedHookContext);
+    // EXCEPT on a connected machine (effective backend "selfhosted"): the box is the
+    // user's REAL computer — the platform must not run setup against it (the clone
+    // hooks are already empty there; this keeps az login off it too).
+    if (agentActiveSandboxBackend.get(agent) !== "selfhosted") {
+      await runBeforeAgentStartHooks(session as SandboxSessionLike, ownedHooks, ownedHookContext);
+    }
     // Keep the decoration as a safety net for any session the SDK does create/resume
     // through the client during this run (it is inert for the provided session).
     const decoratedClient = withSandboxLifecycleHooks(resourceClient, ownedHooks, ownedHookContext);

--- a/packages/runtime/test/ownership-inversion.test.ts
+++ b/packages/runtime/test/ownership-inversion.test.ts
@@ -309,4 +309,53 @@ describe("owned-path beforeAgentStart hooks — the provided-session blind spot"
     expect(cloneExecs[0]!.cmd).toContain("seed-token-e2e");
     expect(cloneExecs[0]!.cmd).toContain("repos/example/repo");
   });
+
+  test("connected machine (effective backend selfhosted): NO platform setup exec touches the user's box", async () => {
+    // A connected machine is the user's real computer. The clone hooks are already
+    // excluded at construction for selfhosted; the direct owned-path hook run must
+    // skip the built-in hooks (az login) there too — even when the session carries
+    // an azure-credentialed workspace Environment.
+    const settings = testSettings({ sandboxBackend: "local", webSearchEnabled: false });
+    const environment = {
+      HOME: "/workspace",
+      ARM_CLIENT_ID: "cid",
+      ARM_CLIENT_SECRET: "secret",
+      ARM_TENANT_ID: "tid",
+    };
+    const model = new ScriptedModel([{ output: [assistantMessage("done, no tools")] }]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      sandboxEnvironment: environment,
+      activeSandboxBackend: "selfhosted",
+    });
+
+    const execCalls: Array<{ cmd: string }> = [];
+    const providedSession = {
+      state: { manifest: buildManifest(settings, [], environment) },
+      exec: async (args: { cmd: string }) => {
+        execCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      createEditor: () => ({}),
+      execCommand: async (args: { cmd: string }) => {
+        execCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      pathExists: async () => false,
+      materializeEntry: async () => undefined,
+    };
+
+    const result = await runAgentStream(agent, "just answer", settings, {
+      ownedSandbox: {
+        client: { backendId: "unix_local", serializeSessionState: async () => ({}) } as never,
+        session: providedSession as never,
+      },
+    });
+    for await (const _ of result.toStream()) {
+      void _;
+    }
+    await result.completed;
+
+    expect(execCalls.length).toBe(0);
+  });
 });

--- a/packages/runtime/test/ownership-inversion.test.ts
+++ b/packages/runtime/test/ownership-inversion.test.ts
@@ -236,3 +236,77 @@ describe("P1.2 isProviderSandboxNotFoundError (per-backend NotFound discriminato
     expect(isProviderSandboxNotFoundError("modal", undefined)).toBe(false);
   });
 });
+
+describe("owned-path beforeAgentStart hooks — the provided-session blind spot", () => {
+  // The SDK NEVER calls client.create/resume when runOptions.sandbox carries a live
+  // `session` (SandboxRuntimeManager.prepareAgent uses sandboxConfig.session as-is),
+  // so the create/resume decoration alone can never run lifecycle hooks on the
+  // lease-owned box. runAgentStream's owned branch must therefore run them DIRECTLY
+  // against the provided session — this is what executes the repository-clone hook
+  // (which also seeds the B1 askpass + token file) on production turns. Regression:
+  // hooks silently stopped running when sandbox ownership was enabled, which left
+  // boxes with an empty repo mount dir and no git auth at all.
+  test("repository-clone hook (with B1 token seed) runs against the provided session before the turn", async () => {
+    const settings = testSettings({ sandboxBackend: "local", webSearchEnabled: false });
+    const repoResource = {
+      kind: "repository" as const,
+      uri: "https://github.com/example/repo.git",
+      ref: "main",
+      mountPath: "repos/example/repo",
+      // installation+repository ids make repositoryUsesSandboxClone() true on the
+      // local backend, mirroring the GitHub-App resources production sessions carry.
+      githubInstallationId: 1,
+      githubRepositoryId: 2,
+    };
+    const environment = { HOME: "/workspace", GIT_ASKPASS: "/workspace/.opengeni/askpass" };
+    const model = new ScriptedModel([{ output: [assistantMessage("done, no tools")] }]);
+    const agent = buildOpenGeniAgent(settings, [repoResource], {
+      model,
+      sandboxEnvironment: environment,
+      gitTokenSeed: "seed-token-e2e",
+    });
+
+    // Stub live box: records execs; its manifest mirrors the agent's default manifest
+    // so applyManifestToProvidedSession sees no delta to apply.
+    const execCalls: Array<{ cmd: string }> = [];
+    const providedSession = {
+      state: { manifest: buildManifest(settings, [repoResource], environment) },
+      exec: async (args: { cmd: string }) => {
+        execCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      // The SDK's filesystem/shell/skills capabilities require these at prepare
+      // time even when the scripted turn never touches a tool.
+      createEditor: () => ({}),
+      execCommand: async (args: { cmd: string }) => {
+        execCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      pathExists: async () => false,
+      materializeEntry: async () => undefined,
+    };
+    const stubClient = {
+      backendId: "unix_local",
+      serializeSessionState: async () => ({}),
+    };
+
+    const result = await runAgentStream(agent, "just answer", settings, {
+      ownedSandbox: {
+        client: stubClient as never,
+        session: providedSession as never,
+      },
+    });
+    for await (const _ of result.toStream()) {
+      void _;
+    }
+    await result.completed;
+
+    // The clone/seed command hit the PROVIDED box exactly once, before the turn —
+    // carrying both the off-manifest token seed and the clone script.
+    const cloneExecs = execCalls.filter((c) => c.cmd.includes("clone_repository"));
+    expect(cloneExecs.length).toBe(1);
+    expect(cloneExecs[0]!.cmd).toContain("OPENGENI_GIT_TOKEN_SEED");
+    expect(cloneExecs[0]!.cmd).toContain("seed-token-e2e");
+    expect(cloneExecs[0]!.cmd).toContain("repos/example/repo");
+  });
+});

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -757,20 +757,25 @@ describe("runtime event normalization", () => {
     }]);
 
     // The seed block is GATED on the per-exec OPENGENI_GIT_TOKEN_SEED (never on the
-    // manifest), writes the STABLE token file, and chmod 600s it.
+    // manifest) and writes the STABLE token file ATOMICALLY: pid-suffixed temp under
+    // umask 077, renamed into place — concurrent readers (another turn's in-flight
+    // git fetch invoking the askpass) keep the old inode, and the token is never
+    // observable world-readable.
     expect(command).toContain("if [ -n \"${OPENGENI_GIT_TOKEN_SEED:-}\" ]; then");
+    expect(command).toContain("umask 077");
     expect(command).toContain("git_token_file=\"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\"");
-    expect(command).toContain("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file\"");
-    expect(command).toContain("chmod 600 \"$git_token_file\"");
+    expect(command).toContain("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\" > \"$git_token_file.tmp.$$\"");
+    expect(command).toContain("mv -f \"$git_token_file.tmp.$$\" \"$git_token_file\"");
 
     // TOKEN-BROKER (B2): the SAME gated block PROVISIONS the git-askpass helper at
     // SETUP (runtime) into the per-box, user-writable $GIT_ASKPASS (a manifest env
     // pointer, default $HOME/.opengeni/askpass), so auth is correct on ANY box image
-    // without a baked script. It mkdir -p's the dir, writes the helper via a QUOTED
-    // heredoc, and chmod 0755s it so git can exec it.
+    // without a baked script. Written via a QUOTED heredoc to a temp, chmod 0755,
+    // then renamed into place (same atomicity as the token file).
     expect(command).toContain("git_askpass=\"${GIT_ASKPASS:-$HOME/.opengeni/askpass}\"");
-    expect(command).toContain("cat > \"$git_askpass\" <<'ASKPASS_EOF'");
-    expect(command).toContain("chmod 0755 \"$git_askpass\"");
+    expect(command).toContain("cat > \"$git_askpass.tmp.$$\" <<'ASKPASS_EOF'");
+    expect(command).toContain("chmod 0755 \"$git_askpass.tmp.$$\"");
+    expect(command).toContain("mv -f \"$git_askpass.tmp.$$\" \"$git_askpass\"");
     // The provisioned askpass' Password branch reads the token FILE (this is the
     // load-bearing wiring: GIT_ASKPASS -> askpass -> token file).
     expect(command).toContain("*Password*) cat \"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\" 2>/dev/null || printf '\\n' ;;");
@@ -782,7 +787,7 @@ describe("runtime event normalization", () => {
     expect(command.indexOf("printf '%s' \"$OPENGENI_GIT_TOKEN_SEED\"")).toBeLessThan(
       command.indexOf("git -C \"$tmp\" fetch"),
     );
-    expect(command.indexOf("cat > \"$git_askpass\"")).toBeLessThan(
+    expect(command.indexOf("cat > \"$git_askpass.tmp.$$\"")).toBeLessThan(
       command.indexOf("git -C \"$tmp\" fetch"),
     );
     // The token VALUE is never literally in the command (only the env-var reference);
@@ -907,8 +912,9 @@ describe("runtime event normalization", () => {
     // askpass into $GIT_ASKPASS whose Password branch reads the token file — so a warm
     // box on ANY image gets a correct askpass at setup, no baked script required.
     const cmd = String(calls[0]?.cmd);
-    expect(cmd).toContain("cat > \"$git_askpass\" <<'ASKPASS_EOF'");
-    expect(cmd).toContain("chmod 0755 \"$git_askpass\"");
+    expect(cmd).toContain("cat > \"$git_askpass.tmp.$$\" <<'ASKPASS_EOF'");
+    expect(cmd).toContain("chmod 0755 \"$git_askpass.tmp.$$\"");
+    expect(cmd).toContain("mv -f \"$git_askpass.tmp.$$\" \"$git_askpass\"");
     expect(cmd).toContain("*Password*) cat \"${OPENGENI_GIT_TOKEN_FILE:-$HOME/.opengeni/git-token}\" 2>/dev/null || printf '\\n' ;;");
   });
 
@@ -1635,5 +1641,173 @@ describe("provider item id stripping", () => {
     expect((agent as any).modelSettings.providerData).toEqual({ include: ["reasoning.encrypted_content"] });
     const disabled = buildOpenGeniAgent(testSettings({ sandboxBackend: "none", openaiReasoningEncryptedContent: false }), []);
     expect((disabled as any).modelSettings.providerData).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Functional shell-semantics tests: the clone/seed and az-login scripts now run
+// at the start of EVERY turn against long-lived, possibly-shared boxes, so their
+// idempotency and exit-status semantics are load-bearing. These execute the REAL
+// generated scripts under sh in a temp sandbox (local git origin over file://).
+// ---------------------------------------------------------------------------
+describe("lifecycle scripts — real sh execution semantics", () => {
+  const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
+  const { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, statSync, readFileSync, readdirSync } = require("node:fs") as typeof import("node:fs");
+  const { tmpdir } = require("node:os") as typeof import("node:os");
+  const { join } = require("node:path") as typeof import("node:path");
+
+  /** The generated clone script minus the /workspace-hardcoded invocations, plus a
+   *  test-controlled `clone_repository` call. */
+  function cloneScriptWithTarget(target: string, uri: string): string {
+    const generated = repositoryCloneCommand([{
+      kind: "repository",
+      uri,
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }]);
+    const withoutInvocations = generated.split("\n").filter((line) => !line.startsWith("clone_repository '")).join("\n");
+    return `${withoutInvocations}\nclone_repository '${target}' '${uri}' 'main' ''`;
+  }
+
+  function makeOrigin(root: string): string {
+    const origin = join(root, "origin");
+    mkdirSync(origin, { recursive: true });
+    execFileSync("git", ["init", "-b", "main", origin]);
+    writeFileSync(join(origin, "README.md"), "hello\n");
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+    };
+    execFileSync("git", ["-C", origin, "add", "."], { env: gitEnv });
+    execFileSync("git", ["-C", origin, "commit", "-m", "init"], { env: gitEnv });
+    // file:// partial clone (--filter=blob:none) needs the origin to allow it.
+    execFileSync("git", ["-C", origin, "config", "uploadpack.allowfilter", "true"]);
+    return origin;
+  }
+
+  function runScript(script: string, env: Record<string, string>): { status: number; output: string } {
+    try {
+      // merge stderr into stdout so diagnostics like "Re-materializing..." are visible
+      const output = execFileSync("sh", ["-c", `{\n${script}\n} 2>&1`], {
+        env: { ...process.env, ...env },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return { status: 0, output };
+    } catch (error) {
+      const e = error as { status?: number; stdout?: string; stderr?: string };
+      return { status: e.status ?? 1, output: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    }
+  }
+
+  test("seed block: token file 600 + askpass 755, atomic (no temp leftovers), askpass reads the token", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-clone-"));
+    try {
+      const origin = makeOrigin(root);
+      const home = join(root, "home");
+      mkdirSync(home, { recursive: true });
+      const target = join(root, "ws", "repos", "acme", "private");
+      const env = { HOME: home, OPENGENI_GIT_TOKEN_SEED: "tok-atomic-123" };
+      const run = runScript(cloneScriptWithTarget(target, `file://${origin}`), env);
+      expect(run.status).toBe(0);
+      const tokenFile = join(home, ".opengeni", "git-token");
+      const askpass = join(home, ".opengeni", "askpass");
+      expect(readFileSync(tokenFile, "utf8")).toBe("tok-atomic-123");
+      expect(statSync(tokenFile).mode & 0o777).toBe(0o600);
+      expect(statSync(askpass).mode & 0o777).toBe(0o755);
+      // atomic install: no pid temp files left behind
+      expect(readdirSync(join(home, ".opengeni")).filter((f) => f.includes(".tmp."))).toEqual([]);
+      // the askpass Password branch reads the token file
+      const askOut = execFileSync("sh", [askpass, "Password for host"], { env: { ...process.env, HOME: home }, encoding: "utf8" });
+      expect(askOut).toBe("tok-atomic-123");
+      // and the clone landed as a real work tree
+      expect(existsSync(join(target, "README.md"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("clone is idempotent on a valid work tree and RE-MATERIALIZES a partial (interrupted) tree", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-clone-"));
+    try {
+      const origin = makeOrigin(root);
+      const home = join(root, "home");
+      mkdirSync(home, { recursive: true });
+      const target = join(root, "ws", "repos", "acme", "private");
+      const script = cloneScriptWithTarget(target, `file://${origin}`);
+      const env = { HOME: home, OPENGENI_GIT_TOKEN_SEED: "tok" };
+
+      // fresh clone into a pre-created EMPTY dir (the manifest dir() mount skeleton)
+      mkdirSync(target, { recursive: true });
+      expect(runScript(script, env).status).toBe(0);
+      expect(existsSync(join(target, ".git"))).toBe(true);
+
+      // second run: skip, agent work preserved
+      writeFileSync(join(target, "WORK.md"), "agent work\n");
+      const second = runScript(script, env);
+      expect(second.status).toBe(0);
+      expect(second.output).toContain("already present");
+      expect(readFileSync(join(target, "WORK.md"), "utf8")).toBe("agent work\n");
+
+      // partial tree (interrupted materialization: files but no .git) -> rebuilt
+      rmSync(join(target, ".git"), { recursive: true, force: true });
+      const third = runScript(script, env);
+      expect(third.status).toBe(0);
+      expect(third.output).toContain("Re-materializing partial repository resource");
+      expect(existsSync(join(target, ".git"))).toBe(true);
+      expect(existsSync(join(target, "README.md"))).toBe(true);
+      // no tmp clone leaked beside the target
+      expect(readdirSync(join(root, "ws", "repos", "acme")).filter((f) => f.includes(".tmp."))).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("clone failure (bad ref/uri) exits non-zero and leaks no tmp clone", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-clone-"));
+    try {
+      const home = join(root, "home");
+      mkdirSync(home, { recursive: true });
+      const target = join(root, "ws", "repos", "acme", "private");
+      const run = runScript(cloneScriptWithTarget(target, `file://${join(root, "nonexistent")}`), { HOME: home });
+      expect(run.status).not.toBe(0);
+      expect(existsSync(target)).toBe(false);
+      expect(existsSync(`${target}.tmp.`)).toBe(false);
+      const parent = join(root, "ws", "repos", "acme");
+      expect(existsSync(parent) ? readdirSync(parent).filter((f) => f.includes(".tmp.")) : []).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("az-login script exits 0 for a no-subscription service principal (previously exit 1 -> failed the turn)", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-az-"));
+    try {
+      // stub az that always succeeds
+      const bin = join(root, "bin");
+      mkdirSync(bin, { recursive: true });
+      writeFileSync(join(bin, "az"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      const home = join(root, "home");
+      mkdirSync(home, { recursive: true });
+      const base = { HOME: home, PATH: `${bin}:${process.env.PATH}` };
+
+      // SP creds, NO subscription id: must exit 0 (az login passes --allow-no-subscriptions)
+      const noSub = runScript(azureCliLoginCommand(), {
+        ...base, ARM_CLIENT_ID: "cid", ARM_CLIENT_SECRET: "sec", ARM_TENANT_ID: "tid",
+      });
+      expect(noSub.status).toBe(0);
+
+      // with subscription id: still 0
+      const withSub = runScript(azureCliLoginCommand(), {
+        ...base, ARM_CLIENT_ID: "cid", ARM_CLIENT_SECRET: "sec", ARM_TENANT_ID: "tid", ARM_SUBSCRIPTION_ID: "sub",
+      });
+      expect(withSub.status).toBe(0);
+
+      // no creds at all: no-op, exit 0
+      expect(runScript(azureCliLoginCommand(), base).status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## P0: lifecycle hooks (repo clone, B1 askpass/token seed, az login) never run on lease-owned boxes

**Found by live staging e2e** of #158's token-broker: a fresh modal session with a GitHub-App repo resource came up with an **empty repo mount dir, no `~/.opengeni/` (no askpass, no token file), and no az login** — session `735798cb` (lumen ws), events show zero `sandbox.operation.*` entries, vs. pre-ownership sessions (e.g. `def12777`, 06-15) which show `repository-clone` started/completed.

### Root cause
`withSandboxLifecycleHooks` wraps only `client.create`/`client.resume`. On the sandbox-ownership path (enabled on staging 06-25) the turn activity resolves the box itself (`resumeBoxForTurn`) and hands the SDK a live `session`; `SandboxRuntimeManager.prepareAgent` uses `sandboxConfig.session` **as-is and never calls create/resume** — so the decoration never fires and every `beforeAgentStart` hook is dead on owned boxes.

Pre-B1 this was masked: the manifest env still carried `GH_TOKEN`/`GIT_CONFIG_*`, so agents cloned manually. After #158 evicted the token from the manifest (correctly), the hook was the only auth provisioning path → git-auth fully broken on owned boxes.

### Fix
Run the `beforeAgentStart` hooks **directly against the provided session** in `runAgentStream`'s owned branch, once per turn, before the run starts — same hook list, same context (incl. the off-manifest `gitTokenSeed`). Safe on warm boxes by construction:
- clone skips an already-materialized target,
- the token seed **overwrites** the file — the desired per-turn refresh; a preemption **resume re-seeds the freshly-minted token** (fixes the >1h-stale-token-on-resume window too),
- az login is idempotent.

The create/resume decoration stays as a safety net for any session the SDK does create through the client.

### Verification
- Regression test drives the real owned branch (`runAgentStream` + stub provided session) and asserts the clone/seed exec hits the box — **fails without the fix, passes with it**.
- Full suite: 1882 pass / 0 fail; typecheck clean (17 pkgs).
- Staging live-verify plan: deploy → rerun the git-auth e2e (clone+push via askpass→token-file, env scan clean) → crash-resume e2e → warm-box re-seed e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gRe8QSUk7nBoPxsDLfLUm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the per-turn sandbox setup path (git auth, repo materialization, Azure login) on lease-owned and possibly shared boxes, plus safety rules for connected machines; regressions could break clones or touch user hardware.
> 
> **Overview**
> **Lease-owned sandboxes** now run `beforeAgentStart` setup (repo clone, B1 git token/askpass seed, Azure CLI login, signed file materialization) **once per turn** by calling hooks directly against the provided session, because the SDK never hits `create`/`resume` when a live box is injected.
> 
> The turn activity pins an **un-proxied `setupSession`** for that setup so it does not go through the mid-turn routing proxy and cannot land on a swapped-in **connected machine**; when the effective backend is **selfhosted**, platform setup is skipped entirely.
> 
> Generated clone/login shell scripts are tightened for **shared warm boxes**: atomic token/askpass writes, re-materialize partial clones, safer concurrent install races, and Azure login no longer fails turns when subscription ID is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff58c3b6b061c52295397a45df128f3a50c46f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->