### PR TITLE
feat(computer-use): function-transport computer tool for codex/ChatGPT models (gpt-5.5)

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -886,15 +886,16 @@ function maybeInstallCodexToolSearch(agent: Agent<any, any>, settings: Settings,
  * of the hosted ones, by dropping the model instance the SDK's transport
  * detection keys off. See {@link buildAgentCapabilities} for why (codex routes the
  * OpenAIResponsesModel to the ChatGPT backend, which rejects the hosted
- * `apply_patch` tool type). The SDK reads hosted-vs-function ONLY from
- * `_modelInstance` (set via `bindModel`); overriding `bindModel` to discard the
- * instance leaves `_modelInstance` undefined, so `supportsApplyPatchTransport` /
- * `supportsStructuredToolOutputTransport` return false and `tools()` emits the
- * function `apply_patch` + text `view_image`. `bindModel` still returns the
- * capability so the SDK's bind chain (`.bind().bindRunAs().bindModel()`) is
- * preserved.
+ * `apply_patch` AND `computer_use_preview` tool types). The SDK reads
+ * hosted-vs-function ONLY from `_modelInstance` (set via `bindModel`); overriding
+ * `bindModel` to discard the instance leaves `_modelInstance` undefined, so
+ * `supportsApplyPatchTransport` / `supportsStructuredToolOutputTransport` return
+ * false and `tools()` emits the function variants — `apply_patch` + text
+ * `view_image` for filesystem, and the `computer_*` function tools + text
+ * `computer_screenshot` for computer-use. `bindModel` still returns the capability
+ * so the SDK's bind chain (`.bind().bindRunAs().bindModel()`) is preserved.
  */
-function neutralizeStructuredToolTransport(capability: ReturnType<typeof filesystem>): void {
+function neutralizeStructuredToolTransport(capability: ReturnType<typeof filesystem> | ReturnType<typeof computerUse>): void {
   // Use `this` (NOT a captured reference to `capability`): the SandboxAgent binds
   // via `cap.clone().bind(session).bindRunAs(runAs).bindModel(model, instance)` and
   // runs tools() on the object the CHAIN returns. Capability.clone() copies this
@@ -972,18 +973,23 @@ export function buildAgentCapabilities(
     settings.computerUseEnabled
     && settings.sandboxDesktopEnabled
     && desktopCapableBackend(settings.sandboxBackend)
-    // computer-use emits a HOSTED `computer`/`computer_use_preview` tool with NO
-    // function-transport fallback. The ChatGPT/Codex backend rejects hosted tool
-    // types (only function/custom/web_search are accepted), so on the codex path
-    // (structuredToolTransport === false) attaching it would 400 the ENTIRE turn.
-    // Suppress it there — driving the desktop via the agent is simply unavailable
-    // on that backend; every other backend keeps the desktop tier.
-    && options.structuredToolTransport !== false
   ) {
-    caps.push(computerUse({
+    // computer-use is now transport-aware, exactly like filesystem: its `tools()`
+    // emits the HOSTED `computer_use_preview` tool on the structured transport and a
+    // set of FUNCTION `computer_*` tools on the text transport. The ChatGPT/Codex
+    // backend rejects hosted tool types (only function/custom/web_search accepted),
+    // so on the codex path (structuredToolTransport === false) we neutralize the
+    // capability's model binding — the SAME trick used for filesystem above — so
+    // `tools()` sees no model instance and emits the function tools the backend can
+    // call, instead of suppressing the desktop tier entirely.
+    const computerCapability = computerUse({
       dimensions: [settings.streamResolutionWidth, settings.streamResolutionHeight],
       readOnly: settings.computerUseReadOnly,
-    }) as unknown as ReturnType<typeof Capabilities.default>[number]);
+    });
+    if (options.structuredToolTransport === false) {
+      neutralizeStructuredToolTransport(computerCapability);
+    }
+    caps.push(computerCapability as unknown as ReturnType<typeof Capabilities.default>[number]);
   }
   return caps;
 }

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -31,7 +31,7 @@
 //   F5  scroll deltas are model PIXELS (often hundreds) — divided by a notch step
 //       and clamped, NOT used as literal wheel-click `--repeat` counts.
 
-import { computerTool, type Computer, type Tool } from "@openai/agents";
+import { computerTool, tool, type Computer, type Tool } from "@openai/agents";
 import { Capability, type SandboxSessionLike } from "@openai/agents/sandbox";
 import { KeyAction, PointerAction, PointerButton, type DesktopInputRequest } from "@opengeni/agent-proto";
 
@@ -507,6 +507,244 @@ export function isNativeDesktopSession(session: SandboxSessionLike): session is 
   return typeof s.desktopInput === "function" && typeof s.screenshot === "function";
 }
 
+// ── Function-transport (codex / text backend) computer tools ─────────────────
+//
+// The SDK emits computer-use ONLY as the HOSTED `computer_use_preview` tool, which
+// the codex / ChatGPT backend rejects (it accepts only function/custom/web_search
+// tool types) — so on codex the hosted tool is unusable and the agent has nothing
+// to drive the desktop with. We mirror EXACTLY how the SDK's filesystem capability
+// degrades `view_image` for the text transport: when the bound model does NOT
+// support the structured tool-output transport, emit a set of FUNCTION tools that
+// route to the SAME bound `Computer`, and hand the model the screen by rendering
+// the screenshot image-output as a text-transport data URL — the identical two-step
+// `imageOutputFromBytes` → `renderImageForTextTransport` the SDK's text `view_image`
+// uses. Those three helpers are NOT public exports of `@openai/agents` /
+// `@openai/agents/sandbox` (they live in the SDK's private capabilities/transport +
+// shared/media modules, unreachable via the package `exports` map), so — mirroring
+// selfhosted/session.ts's local `sniffImageMediaType` — the three tiny pure helpers
+// are reimplemented here in lockstep with the SDK.
+
+/** The SDK's tool-output image shape (@openai/agents-core shared/media `ToolOutputImage`). */
+type ToolOutputImage = { type: "image"; image: { data: Uint8Array; mediaType: string } };
+
+/** Magic-byte image sniff, in lockstep with the SDK's `sniffImageMediaType`
+ *  (shared/media). Screenshots are always PNG (scrot / ScreenCaptureKit / x11), so
+ *  an unrecognized header defaults to image/png rather than failing the frame. */
+function sniffScreenshotMediaType(bytes: Uint8Array): string {
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return "image/png";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) return "image/gif";
+  if (
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+  ) return "image/webp";
+  return "image/png";
+}
+
+/** Build the SDK `ToolOutputImage` from raw screenshot bytes — the structured shape
+ *  the SDK's `imageOutputFromBytes` produces (`{type:'image', image:{data,mediaType}}`). */
+function imageOutputFromScreenshotBytes(bytes: Uint8Array): ToolOutputImage {
+  return { type: "image", image: { data: Uint8Array.from(bytes), mediaType: sniffScreenshotMediaType(bytes) } };
+}
+
+/** Render an image tool-output as a text-transport string, in lockstep with the
+ *  SDK's private `renderImageForTextTransport` (capabilities/filesystem). Our image
+ *  output always carries `data` as bytes, so it becomes a `data:<mediaType>;base64,…`
+ *  URL — the exact form the text-backend `view_image` hands the model. */
+function renderImageForTextTransport(output: ToolOutputImage | string): string {
+  if (typeof output === "string") return output;
+  const { image } = output;
+  const mediaType = typeof image.mediaType === "string" ? image.mediaType : "application/octet-stream";
+  return `data:${mediaType};base64,${Buffer.from(image.data).toString("base64")}`;
+}
+
+/** Whether the bound model supports the structured tool-output transport, in
+ *  lockstep with the SDK's private `supportsStructuredToolOutputTransport`
+ *  (capabilities/transport): a ChatCompletions-family model — and an UNBOUND model
+ *  (undefined) — does NOT, so it gets the function tools; every other model keeps
+ *  the hosted `computer_use_preview` tool. The codex neutralize trick in index.ts
+ *  drops `_modelInstance`, so this returns false there and the function tools win. */
+function supportsStructuredToolOutputTransport(modelInstance: unknown): boolean {
+  if (!modelInstance) return false;
+  const constructorName =
+    typeof modelInstance === "object" && modelInstance && typeof (modelInstance as { constructor?: unknown }).constructor === "function"
+      ? ((modelInstance as { constructor: { name?: string } }).constructor.name ?? "")
+      : "";
+  return !constructorName.includes("ChatCompletions");
+}
+
+const COMPUTER_READ_ONLY_MESSAGE =
+  "computer-use is read-only for this session — click, double_click, move, scroll, type, keypress, and drag are disabled. Call computer_screenshot to observe the desktop.";
+
+// The two coordinate properties every pointer tool shares. Raw JSON schema (NOT
+// zod: zod is not a @opengeni/runtime dependency) with `strict:false`, mirroring the
+// SDK's own `apply_patch` function-tool schema style.
+const COORD_PROPS = {
+  x: { type: "integer", description: "X coordinate in the pixels of the most recent computer_screenshot" },
+  y: { type: "integer", description: "Y coordinate in the pixels of the most recent computer_screenshot" },
+} as const;
+
+function objectSchema(properties: Record<string, unknown>, required: string[]): Record<string, unknown> {
+  return { type: "object", properties, required, additionalProperties: false };
+}
+
+/**
+ * The FUNCTION-transport computer tools for the codex / text backend, each routing
+ * to the SAME bound `Computer` the hosted `computer_use_preview` tool would drive.
+ * `computer_screenshot` returns the screen as a `data:image/png;base64,…` URL
+ * (imageOutputFromBytes → renderImageForTextTransport — the SDK's text `view_image`
+ * path) so the model SEES the desktop. Write tools return a concise confirmation;
+ * when read-only they return {@link COMPUTER_READ_ONLY_MESSAGE} instead of throwing,
+ * and any action error is returned as a string so a failed action never kills the
+ * turn. Exported so it can be unit-tested against a fake `Computer`.
+ */
+export function computerFunctionTools(
+  computer: Computer,
+  readOnly: boolean,
+  needsApproval?: ComputerUseArgs["needsApproval"],
+): Tool<unknown>[] {
+  const approval = needsApproval !== undefined ? { needsApproval: needsApproval as never } : {};
+  // Perform a WRITE action, surfacing read-only / failures as a model-readable
+  // string rather than an uncaught throw (an uncaught throw becomes a tool error
+  // the backend may 400 on, or kills the step).
+  const write = async (confirmation: string, action: () => void | Promise<void>): Promise<string> => {
+    if (readOnly) return COMPUTER_READ_ONLY_MESSAGE;
+    try {
+      await action();
+      return confirmation;
+    } catch (error) {
+      if (error instanceof ComputerReadOnlyError) return COMPUTER_READ_ONLY_MESSAGE;
+      return `computer action failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  };
+
+  return [
+    tool({
+      name: "computer_screenshot",
+      description:
+        "Capture the current desktop and return it as an image. Call this FIRST and again after each action — all coordinates for click/move/scroll/drag are pixels of the most recent screenshot.",
+      parameters: objectSchema({}, []) as never,
+      strict: false,
+      execute: async () => {
+        // screenshot() returns raw base64 PNG and NEVER an empty string (it throws
+        // instead), so the model can't receive an empty image_url.
+        const b64 = await computer.screenshot();
+        const bytes = Uint8Array.from(Buffer.from(b64, "base64"));
+        return renderImageForTextTransport(imageOutputFromScreenshotBytes(bytes));
+      },
+    }),
+    tool({
+      name: "computer_click",
+      description:
+        "Click the mouse at (x, y). `button` is one of left|right|wheel|back|forward (default left). Take a computer_screenshot first to find coordinates.",
+      parameters: objectSchema(
+        { ...COORD_PROPS, button: { type: "string", enum: ["left", "right", "wheel", "back", "forward"], description: "Mouse button; defaults to left" } },
+        ["x", "y"],
+      ) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { x, y, button } = input as { x: number; y: number; button?: ComputerButton };
+        return write(`clicked ${button ?? "left"} at (${x}, ${y})`, () => computer.click(x, y, button ?? "left"));
+      },
+    }),
+    tool({
+      name: "computer_double_click",
+      description: "Double-click the left mouse button at (x, y). Take a computer_screenshot first to find coordinates.",
+      parameters: objectSchema({ ...COORD_PROPS }, ["x", "y"]) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { x, y } = input as { x: number; y: number };
+        return write(`double-clicked at (${x}, ${y})`, () => computer.doubleClick(x, y));
+      },
+    }),
+    tool({
+      name: "computer_move",
+      description: "Move the mouse cursor to (x, y) without clicking.",
+      parameters: objectSchema({ ...COORD_PROPS }, ["x", "y"]) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { x, y } = input as { x: number; y: number };
+        return write(`moved to (${x}, ${y})`, () => computer.move(x, y));
+      },
+    }),
+    tool({
+      name: "computer_scroll",
+      description:
+        "Scroll at (x, y) by scroll_x / scroll_y pixels (positive scroll_y scrolls down, negative up; positive scroll_x scrolls right).",
+      parameters: objectSchema(
+        {
+          ...COORD_PROPS,
+          scroll_x: { type: "integer", description: "Horizontal scroll amount in pixels (positive = right)" },
+          scroll_y: { type: "integer", description: "Vertical scroll amount in pixels (positive = down)" },
+        },
+        ["x", "y", "scroll_x", "scroll_y"],
+      ) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { x, y, scroll_x, scroll_y } = input as { x: number; y: number; scroll_x: number; scroll_y: number };
+        return write(`scrolled (${scroll_x}, ${scroll_y}) at (${x}, ${y})`, () => computer.scroll(x, y, scroll_x, scroll_y));
+      },
+    }),
+    tool({
+      name: "computer_type",
+      description: "Type a literal text string at the current keyboard focus. Click the target field first.",
+      parameters: objectSchema({ text: { type: "string", description: "The literal text to type" } }, ["text"]) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { text } = input as { text: string };
+        return write(`typed ${text.length} character(s)`, () => computer.type(text));
+      },
+    }),
+    tool({
+      name: "computer_keypress",
+      description:
+        'Press a key or chord. `keys` is an ordered list pressed together, e.g. ["ctrl","c"] or ["Enter"]. Use key names (ctrl, alt, shift, cmd, enter, tab, esc, arrows…), not characters.',
+      parameters: objectSchema(
+        { keys: { type: "array", items: { type: "string" }, description: "Keys pressed together as a chord" } },
+        ["keys"],
+      ) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { keys } = input as { keys: string[] };
+        return write(`pressed ${keys.join("+")}`, () => computer.keypress(keys));
+      },
+    }),
+    tool({
+      name: "computer_drag",
+      description:
+        "Drag the left mouse button along a path of points. `path` is an ordered list of {x, y} pixels; the button is pressed at the first point, moved through each, and released at the last.",
+      parameters: objectSchema(
+        {
+          path: {
+            type: "array",
+            description: "Ordered list of points to drag through",
+            items: {
+              type: "object",
+              properties: { x: { type: "integer" }, y: { type: "integer" } },
+              required: ["x", "y"],
+              additionalProperties: false,
+            },
+          },
+        },
+        ["path"],
+      ) as never,
+      strict: false,
+      ...approval,
+      execute: async (input) => {
+        const { path } = input as { path: Array<{ x: number; y: number }> };
+        const points = path.map((p) => [p.x, p.y] as [number, number]);
+        return write(`dragged through ${points.length} point(s)`, () => computer.drag(points));
+      },
+    }),
+  ] as unknown as Tool<unknown>[];
+}
+
 // ── The capability (the SDK seam) ────────────────────────────────────────────
 
 export type ComputerUseArgs = {
@@ -524,8 +762,19 @@ export function computerUse(args: ComputerUseArgs = {}): ComputerUseCapability {
  * A `Capability` subclass merged into the agent's tool set by SandboxAgent
  * (`tools = [...agent.tools, ...capability.tools()]`). `bind(session)` hands it
  * the LIVE externally-owned session, so the agent's actions and the viewers'
- * pixels are one display. `tools()` returns one `computerTool` over a
- * SandboxComputer bound to that session.
+ * pixels are one display.
+ *
+ * `tools()` is TRANSPORT-AWARE, mirroring the SDK's `filesystem()` capability
+ * (which branches its `view_image` / `apply_patch` on
+ * `supportsStructuredToolOutputTransport(this._modelInstance)`):
+ *   • structured transport (the Responses/OpenAI backend) → the single HOSTED
+ *     `computer_use_preview` tool over a Computer bound to the session (unchanged).
+ *   • text transport (codex / ChatGPT backend — or an unbound model) → a set of
+ *     FUNCTION tools ({@link computerFunctionTools}) that route to the SAME Computer,
+ *     because the codex backend rejects the hosted computer tool type.
+ * The bound model instance is captured by the SDK's `bind().bindRunAs().bindModel()`
+ * chain (base `Capability._modelInstance`); the codex path in index.ts neutralizes
+ * `bindModel` so `_modelInstance` stays undefined here → the function tools win.
  */
 export class ComputerUseCapability extends Capability {
   readonly type = "computer-use";
@@ -550,11 +799,16 @@ export class ComputerUseCapability extends Capability {
           // The SDK base exposes the bound runAs as a protected field.
           ...(typeof this._runAs === "string" ? { runAs: this._runAs } : {}),
         });
-    return [
-      computerTool({
-        computer,
-        ...(this.args.needsApproval !== undefined ? { needsApproval: this.args.needsApproval as never } : {}),
-      }) as unknown as Tool<unknown>,
-    ];
+    // Structured transport keeps the HOSTED computer tool (unchanged); the codex /
+    // text backend gets the FUNCTION tools it can actually call.
+    if (supportsStructuredToolOutputTransport(this._modelInstance)) {
+      return [
+        computerTool({
+          computer,
+          ...(this.args.needsApproval !== undefined ? { needsApproval: this.args.needsApproval as never } : {}),
+        }) as unknown as Tool<unknown>,
+      ];
+    }
+    return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval);
   }
 }

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -7,12 +7,56 @@ import {
   isNativeDesktopSession,
   ComputerUseCapability,
   computerUse,
+  computerFunctionTools,
   ComputerReadOnlyError,
   ComputerUnavailableError,
   ComputerActionError,
   type NativeDesktopSession,
 } from "../src/sandbox-computer";
 import { KeyAction, PointerAction, PointerButton, type DesktopInputRequest } from "@opengeni/agent-proto";
+
+// The SDK reads hosted-vs-function transport from the bound model instance's
+// constructor name (supportsStructuredToolOutputTransport): a name containing
+// "ChatCompletions" (and an UNBOUND model) → text/function transport; anything else
+// → structured/hosted. These two fakes make the branch explicit in the tests.
+class OpenAIResponsesModel {}
+class OpenAIChatCompletionsModel {}
+/** A structured-transport model instance → ComputerUseCapability emits the HOSTED tool. */
+const structuredModel = (): never => new OpenAIResponsesModel() as never;
+/** A ChatCompletions-family instance → ComputerUseCapability emits the FUNCTION tools. */
+const chatCompletionsModel = (): never => new OpenAIChatCompletionsModel() as never;
+
+// A fake Computer that records every method call so the function-tool routing can be
+// asserted without a real desktop. Cast to the SDK `Computer` at the call site.
+function makeFakeComputer(opts: { screenshotB64?: string } = {}) {
+  const calls: Array<[string, ...unknown[]]> = [];
+  const defaultB64 = Buffer.from(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a])).toString("base64");
+  const computer = {
+    environment: "ubuntu" as const,
+    dimensions: [1280, 800] as [number, number],
+    screenshot: async () => { calls.push(["screenshot"]); return opts.screenshotB64 ?? defaultB64; },
+    click: async (x: number, y: number, button: string) => { calls.push(["click", x, y, button]); },
+    doubleClick: async (x: number, y: number) => { calls.push(["doubleClick", x, y]); },
+    move: async (x: number, y: number) => { calls.push(["move", x, y]); },
+    scroll: async (x: number, y: number, sx: number, sy: number) => { calls.push(["scroll", x, y, sx, sy]); },
+    type: async (text: string) => { calls.push(["type", text]); },
+    keypress: async (keys: string[]) => { calls.push(["keypress", keys]); },
+    drag: async (path: [number, number][]) => { calls.push(["drag", path]); },
+    wait: async () => {},
+  };
+  return { computer, calls };
+}
+
+// Index a tool array by name, and invoke a function tool the SDK way (JSON-string
+// input through `.invoke(runContext, input)`).
+const toolsByName = (tools: unknown[]): Record<string, unknown> =>
+  Object.fromEntries((tools as Array<{ name: string }>).map((t) => [t.name, t]));
+const invokeTool = (t: unknown, args: unknown): Promise<unknown> =>
+  (t as { invoke: (ctx: never, input: string) => Promise<unknown> }).invoke({} as never, JSON.stringify(args));
+const FUNCTION_TOOL_NAMES = [
+  "computer_screenshot", "computer_click", "computer_double_click", "computer_move",
+  "computer_scroll", "computer_type", "computer_keypress", "computer_drag",
+];
 
 // A mock provider session that records every command. By default it mimics
 // MODAL: it implements execCommand (the formatted-string contract) and does NOT
@@ -401,7 +445,8 @@ describe("computer backend selection (native vs xdotool)", () => {
   test("ComputerUseCapability bound to a native session drives desktopInput (NOT exec)", async () => {
     const { session, inputs } = makeNativeSession();
     const cap = computerUse({ readOnly: false });
-    cap.bind(session as never);
+    // Structured transport → the single hosted computerTool over the selected Computer.
+    cap.bind(session as never).bindModel("responses", structuredModel());
     const tools = cap.tools();
     expect(tools.length).toBe(1);
     // Reach through the tool to the selected computer and drive a click — it must
@@ -416,7 +461,7 @@ describe("computer backend selection (native vs xdotool)", () => {
   test("ComputerUseCapability bound to a Modal session selects the xdotool SandboxComputer", () => {
     const { session } = makeMockSession();
     const cap = computerUse({ readOnly: false });
-    cap.bind(session as never);
+    cap.bind(session as never).bindModel("responses", structuredModel());
     const tools = cap.tools();
     const computer = (tools[0] as unknown as { computer: unknown }).computer;
     expect(computer).toBeInstanceOf(SandboxComputer);
@@ -424,18 +469,115 @@ describe("computer backend selection (native vs xdotool)", () => {
 });
 
 describe("ComputerUseCapability (the SDK seam)", () => {
-  test("tools() throws before bind(session) and returns one computerTool after", () => {
+  test("tools() throws before bind(session) and returns one HOSTED computerTool on the structured transport", () => {
     const cap = computerUse({ readOnly: false });
     expect(cap).toBeInstanceOf(ComputerUseCapability);
     expect(cap.type).toBe("computer-use");
     // Unbound → requireBoundSession throws.
     expect(() => cap.tools()).toThrow();
     const { session } = makeMockSession();
-    cap.bind(session as never);
+    // Structured transport (a non-ChatCompletions model instance) → hosted tool.
+    cap.bind(session as never).bindModel("responses", structuredModel());
     const tools = cap.tools();
     expect(tools.length).toBe(1);
     // The computer tool wires the model's computer_use_preview surface.
     expect((tools[0] as { type?: string }).type).toBe("computer");
+  });
+});
+
+// ── Transport-aware seam: codex/text FUNCTION tools vs the hosted computer tool ──
+// Mirrors the SDK filesystem capability, which branches view_image/apply_patch on
+// supportsStructuredToolOutputTransport(_modelInstance). ComputerUseCapability now
+// emits the hosted `computer_use_preview` tool on the structured transport and a set
+// of FUNCTION `computer_*` tools on the text/codex transport (an unbound or
+// ChatCompletions-family model), because the codex backend rejects hosted tools.
+describe("ComputerUseCapability transport-aware seam", () => {
+  test("text transport (no structured model bound) → the 8 FUNCTION computer_* tools", () => {
+    const { session } = makeMockSession();
+    const cap = computerUse({ readOnly: false });
+    cap.bind(session as never); // no bindModel → _modelInstance undefined → text transport
+    const names = cap.tools().map((t) => (t as { name?: string }).name);
+    expect(names).toEqual(FUNCTION_TOOL_NAMES);
+    // Every emitted tool is a function tool (not the hosted "computer" type).
+    for (const t of cap.tools()) expect((t as { type?: string }).type).toBe("function");
+  });
+
+  test("a ChatCompletions-family model also gets the FUNCTION tools", () => {
+    const { session } = makeMockSession();
+    const cap = computerUse({});
+    cap.bind(session as never).bindModel("gpt", chatCompletionsModel());
+    const names = cap.tools().map((t) => (t as { name?: string }).name);
+    expect(names).toEqual(FUNCTION_TOOL_NAMES);
+  });
+
+  test("structured transport → the single HOSTED computer tool (unchanged)", () => {
+    const { session } = makeMockSession();
+    const cap = computerUse({});
+    cap.bind(session as never).bindModel("responses", structuredModel());
+    const tools = cap.tools();
+    expect(tools.length).toBe(1);
+    expect((tools[0] as { type?: string }).type).toBe("computer");
+  });
+});
+
+describe("computerFunctionTools (codex text-transport routing)", () => {
+  test("emits all 8 computer_* function tools", () => {
+    const { computer } = makeFakeComputer();
+    const tools = computerFunctionTools(computer as never, false);
+    expect(tools.map((t) => (t as { name?: string }).name)).toEqual(FUNCTION_TOOL_NAMES);
+    for (const t of tools) expect((t as { type?: string }).type).toBe("function");
+  });
+
+  test("click/double_click/move/scroll/type/keypress/drag route to the bound Computer with the exact args", async () => {
+    const { computer, calls } = makeFakeComputer();
+    const t = toolsByName(computerFunctionTools(computer as never, false));
+    await invokeTool(t.computer_click, { x: 10, y: 20 }); // button defaults to left
+    await invokeTool(t.computer_click, { x: 1, y: 2, button: "right" });
+    await invokeTool(t.computer_double_click, { x: 3, y: 4 });
+    await invokeTool(t.computer_move, { x: 5, y: 6 });
+    await invokeTool(t.computer_scroll, { x: 7, y: 8, scroll_x: 0, scroll_y: 300 });
+    await invokeTool(t.computer_type, { text: "hello" });
+    await invokeTool(t.computer_keypress, { keys: ["ctrl", "c"] });
+    await invokeTool(t.computer_drag, { path: [{ x: 0, y: 0 }, { x: 9, y: 9 }] });
+    expect(calls).toEqual([
+      ["click", 10, 20, "left"],
+      ["click", 1, 2, "right"],
+      ["doubleClick", 3, 4],
+      ["move", 5, 6],
+      ["scroll", 7, 8, 0, 300],
+      ["type", "hello"],
+      ["keypress", ["ctrl", "c"]],
+      ["drag", [[0, 0], [9, 9]]],
+    ]);
+  });
+
+  test("computer_screenshot returns a data:image/png;base64 URL built from the Computer's base64 screenshot", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const b64 = Buffer.from(png).toString("base64");
+    const { computer, calls } = makeFakeComputer({ screenshotB64: b64 });
+    const t = toolsByName(computerFunctionTools(computer as never, false));
+    const out = await invokeTool(t.computer_screenshot, {});
+    // Exactly the two-step imageOutputFromBytes → renderImageForTextTransport shape,
+    // mirroring the SDK's text view_image: a data URL whose bytes are the fake's PNG.
+    expect(out).toBe(`data:image/png;base64,${b64}`);
+    expect(calls).toContainEqual(["screenshot"]);
+  });
+
+  test("readOnly returns a clear message and never touches the Computer for writes; screenshot still works", async () => {
+    const { computer, calls } = makeFakeComputer();
+    const t = toolsByName(computerFunctionTools(computer as never, true));
+    const clickOut = await invokeTool(t.computer_click, { x: 1, y: 1 });
+    const typeOut = await invokeTool(t.computer_type, { text: "x" });
+    const dragOut = await invokeTool(t.computer_drag, { path: [{ x: 0, y: 0 }, { x: 1, y: 1 }] });
+    expect(String(clickOut)).toContain("read-only");
+    expect(String(typeOut)).toContain("read-only");
+    expect(String(dragOut)).toContain("read-only");
+    // No write ever reached the Computer.
+    expect(calls.length).toBe(0);
+    // screenshot is a READ — never gated.
+    const shot = await invokeTool(t.computer_screenshot, {});
+    expect(String(shot).startsWith("data:image/")).toBe(true);
+    expect(calls).toEqual([["screenshot"]]);
   });
 });
 
@@ -463,15 +605,25 @@ describe("buildAgentCapabilities computer-use gating (P4.3)", () => {
     expect(t).not.toContain("computer-use");
   });
 
-  test("codex path (structuredToolTransport:false): NO computer-use even with desktop fully on — the hosted computer tool has no function fallback and would 400 the whole turn", () => {
+  test("codex path (structuredToolTransport:false): computer-use ATTACHED and NEUTRALIZED to FUNCTION tools (no longer suppressed)", () => {
     const desktopOn = testSettings({ sandboxBackend: "modal", sandboxDesktopEnabled: true, computerUseEnabled: true });
-    // Same settings that DO attach computer-use on every other backend...
+    // Structured backend attaches computer-use (as before) — the hosted tool path.
     expect(buildAgentCapabilities(desktopOn, []).map((c) => (c as { type?: string }).type)).toContain("computer-use");
-    // ...are suppressed on the codex backend, which rejects the hosted computer tool.
-    const onCodex = buildAgentCapabilities(desktopOn, [], { structuredToolTransport: false }).map((c) => (c as { type?: string }).type);
-    expect(onCodex).not.toContain("computer-use");
-    // filesystem/shell/skills still present — only the unsupported hosted tool is dropped.
-    expect(onCodex).toContain("filesystem");
-    expect(onCodex).toContain("shell");
+    // On the codex backend it is NO LONGER dropped: it is attached and neutralized so
+    // its tools() emits the FUNCTION computer_* tools the codex backend accepts.
+    const codexCaps = buildAgentCapabilities(desktopOn, [], { structuredToolTransport: false });
+    const codexTypes = codexCaps.map((c) => (c as { type?: string }).type);
+    expect(codexTypes).toContain("computer-use");
+    // filesystem/shell still present (unchanged).
+    expect(codexTypes).toContain("filesystem");
+    expect(codexTypes).toContain("shell");
+    // Prove the attached capability emits the FUNCTION tools even when the SDK bind
+    // chain hands it a STRUCTURED model instance: neutralize overrode bindModel to
+    // drop the instance, so tools() falls to the function transport.
+    const computerCap = codexCaps.find((c) => (c as { type?: string }).type === "computer-use") as unknown as ComputerUseCapability;
+    const { session } = makeMockSession();
+    computerCap.bind(session as never).bindModel("responses", structuredModel());
+    const names = computerCap.tools().map((t) => (t as { name?: string }).name);
+    expect(names).toEqual(FUNCTION_TOOL_NAMES);
   });
 });


### PR DESCRIPTION
## The gap

Computer-use was emitted **only** as the SDK's hosted `computer_use_preview` tool, which the ChatGPT/Codex backend rejects. So on codex models — including staging's default **gpt-5.5** — the computer tool was **silently suppressed**: the agent literally had no computer tool to call (it would say *"I'll initialize the remote computer…"* and stop). Computer-use has never worked with the codex-subscription provider.

## The fix — a function-transport variant (mirrors filesystem's `view_image`)

`ComputerUseCapability.tools()` now branches on the bound model instance:
- **structured** model → the unchanged single hosted `computerTool`.
- **text/codex** model → `computer_screenshot` + `computer_click` / `double_click` / `move` / `scroll` / `type` / `keypress` / `drag` **function** tools that route to the SAME bound `Computer` (`NativeDesktopComputer` for self-hosted, `SandboxComputer` for Modal).
- `computer_screenshot` returns the screen as a `data:image/png;base64,…` URL via the same two-step (`imageOutputFromBytes` → `renderImageForTextTransport`) the SDK's text `view_image` uses — so the model can **see** the screen and reason over coordinates.

The worker gate no longer suppresses computer-use on `structuredToolTransport === false`; it applies the same `neutralizeStructuredToolTransport` trick as filesystem so codex turns attach the capability and emit the function tools.

The 3 SDK helpers are private/unexported, so they're reimplemented locally in lockstep (same precedent as `sniffImageMediaType` in `selfhosted/session.ts`); `zod` isn't a runtime dep so the tools use raw JSON-schema params (`strict:false`, the SDK's own `apply_patch` style).

## Verification
- typecheck clean (runtime + api); `sandbox-computer` 41 pass; full runtime suite 455 pass.
- New tests: text transport emits the 8 function tools + routes each to a fake Computer with exact args; `computer_screenshot` returns the data-URL built from the fake's base64; readOnly blocks writes; structured path still returns the single hosted tool; codex `buildAgentCapabilities` now attaches computer-use as function transport.
- **e2e (this PR + a live drive):** whether codex renders a function-tool `data:` image is the one thing to confirm live — it's byte-identical to the SDK's text `view_image` (which already works on codex), and I'll verify with a real gpt-5.5 turn driving the Mac.

Depends on the native computer-use ops (#173) already deployed. Note: separately, the macOS Screen Recording grant must be re-granted after the agent update (unsigned-binary cdhash change) — durable fix is code-signing the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the agent tool surface on Codex and desktop input paths; mitigated by mirroring the existing filesystem neutralization pattern and returning action failures as strings rather than hard tool errors.
> 
> **Overview**
> **Enables computer-use on Codex subscription turns** (e.g. gpt-5.5) where the ChatGPT backend only accepts function tools, not the hosted `computer_use_preview` tool. Previously the capability was dropped on that path, so the agent had no way to drive the desktop.
> 
> `ComputerUseCapability.tools()` now picks transport from the bound model (same pattern as filesystem): **Responses/structured** → single hosted `computerTool`; **text/Codex or unbound model** → eight function tools (`computer_screenshot`, `computer_click`, …) wired to the same `SandboxComputer` / `NativeDesktopComputer`.
> 
> `computer_screenshot` returns a `data:image/png;base64,…` string (SDK-aligned image helpers reimplemented locally). Write actions return confirmations or readable error strings instead of throwing, to avoid tool errors that can break the turn.
> 
> In `buildAgentCapabilities`, Codex turns (`structuredToolTransport === false`) **attach** computer-use again and call `neutralizeStructuredToolTransport` on it (as for filesystem), so `bindModel` does not leave a Responses model instance that would force the hosted tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3f40f10d9695971a6d68aa323421957e4b002b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->