### PR TITLE
fix(sessions): env-aware sandbox grouping — a different environment is a shared-state conflict today

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -522,6 +522,21 @@ export async function createSessionForRequest(
   const sandboxChoice = payload.sandbox ?? (parentSessionId ? "shared" : "new");
   let sandboxGroupId: string | null = null;
   let inheritedBackend: Session["sandboxBackend"] | undefined;
+  // ENV-AWARE GROUPING: under the CURRENT mechanics the workspace Environment is
+  // creation-time box state — the box's manifest env is fixed when it is cold-
+  // created, and the SDK's provided-session guard rejects any manifest-env delta
+  // at attach. A session carrying a DIFFERENT Environment than the box it joins
+  // is therefore a genuine shared-state conflict TODAY: its first turn on a warm
+  // box dies with "Live sandbox sessions cannot change manifest environment
+  // variables" (proven live, sessions 5aee77e9 + 63d18823). Until the Environment
+  // is evicted from the manifest (per-exec, like the git token), grouping must be
+  // env-aware: the INHERITED default falls back to an own box on mismatch (a
+  // credentialed worker spawned from a credential-less manager just works), and
+  // an EXPLICIT shared/{groupId} request with a mismatched Environment fails
+  // fast at create (422) instead of poisoning the session's first turn.
+  const requestedEnvironmentId = payload.environmentId ?? null;
+  const environmentMatchesGroup = (memberEnvironmentId: string | null): boolean =>
+    memberEnvironmentId === requestedEnvironmentId;
   if (sandboxChoice === "shared") {
     if (!parentSessionId) {
       throw new HTTPException(422, { message: "sandbox:'shared' requires a parent session (spawn from inside a session); use 'new' for a top-level create." });
@@ -530,12 +545,25 @@ export async function createSessionForRequest(
     if (!parent) {
       throw new HTTPException(404, { message: `parent session not found in workspace: ${parentSessionId}` });
     }
-    sandboxGroupId = parent.sandboxGroupId;
-    inheritedBackend = parent.sandboxBackend;
+    if (!environmentMatchesGroup(parent.environmentId ?? null)) {
+      if (payload.sandbox === "shared") {
+        // The caller explicitly asked to share while carrying a different
+        // Environment — surface the conflict at create time, not turn time.
+        throw new HTTPException(422, { message: "sandbox:'shared' requires the same environment as the creator's box (the box environment is fixed at creation); omit sandbox or pass 'new' when attaching a different environment." });
+      }
+      // Inherited default: deterministic separation on the genuine shared-state
+      // conflict — the worker gets its own box and its turn runs.
+    } else {
+      sandboxGroupId = parent.sandboxGroupId;
+      inheritedBackend = parent.sandboxBackend;
+    }
   } else if (typeof sandboxChoice === "object") {
     const member = await getAnySessionInGroup(db, workspaceId, sandboxChoice.groupId);
     if (!member) {
       throw new HTTPException(404, { message: `sandbox group not found in workspace: ${sandboxChoice.groupId}` });
+    }
+    if (!environmentMatchesGroup(member.environmentId ?? null)) {
+      throw new HTTPException(422, { message: `sandbox group ${sandboxChoice.groupId} runs a different environment (the box environment is fixed at creation); create with the group's environment or omit sandbox for an own box.` });
     }
     sandboxGroupId = sandboxChoice.groupId;
     inheritedBackend = member.sandboxBackend;

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -655,20 +655,26 @@ function registerWorkspaceOrchestrationTools(
         firstPartyMcpPermissions: z4.array(z4.string()).optional(),
         // Shared-sandbox placement (addendum 05 §D). OMIT (default) to SHARE the
         // creator's box — one filesystem/repo/desktop, N independent conversations;
-        // this is the SAFE DEFAULT and env vars are per-exec, NOT a reason to split.
-        // Pass "new" for a fresh isolated box (a different repo set or a genuinely
-        // separate filesystem), or {groupId} (a sibling session's `sandboxGroupId`
-        // from a prior session_create response) to join that specific sibling's box.
-        // A shared box requires the SAME image; a conflicting image is rejected (B3).
+        // this is the SAFE DEFAULT. Pass "new" for a fresh isolated box (a different
+        // repo set or a genuinely separate filesystem), or {groupId} (a sibling
+        // session's `sandboxGroupId` from a prior session_create response) to join
+        // that specific sibling's box.
+        // Shared state must be compatible: a shared box requires the SAME image
+        // (rejected at the lease layer, B3) and — because the box's environment is
+        // fixed at creation under the current mechanics — the SAME workspace
+        // Environment. The domain layer is env-aware: an inherited default with a
+        // different environmentId silently gets its OWN box (the spawn still works),
+        // while an explicit shared/{groupId} with a mismatched environment 422s at
+        // create. When the Environment is eventually evicted from the box manifest
+        // (per-exec, like the git token), the env check dissolves on its own.
         // The description below is what the AGENT sees (this comment is invisible to
-        // it); keep the two in sync. Grouping stays env-blind (correct) — the only
-        // shared-state hard-fail is the image conflict at the lease layer.
+        // it); keep the two in sync.
         sandbox: z4.union([
           z4.literal("shared"),
           z4.literal("new"),
           z4.object({ groupId: z4.string().uuid() }),
         ]).describe(
-          "Sandbox placement. OMIT (default) to SHARE the creator's box — one filesystem/repo/desktop, N independent conversations; this is the safe default and env vars are per-exec, not a reason to split. Pass 'new' for a fresh isolated box (different repo set or a genuinely separate filesystem). Pass {groupId} to join a specific sibling's box. A shared box requires the same image; a conflicting image is rejected.",
+          "Sandbox placement. OMIT (default) to SHARE the creator's box — one filesystem/repo/desktop, N independent conversations; this is the safe default. If the new session attaches a DIFFERENT environment than the creator's box, the platform automatically gives it its own box (the box environment is fixed at creation), so omitting stays safe. Pass 'new' for a fresh isolated box (different repo set or a genuinely separate filesystem). Pass {groupId} to join a specific sibling's box — requires the same image and the same environment; a conflict is rejected at create.",
         ).optional(),
         // The parent (manager) session is auto-inferred from the caller's
         // worker-signed sessionId claim, so a spawned worker's completion wakes

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -55,7 +55,17 @@ const settings = testSettings({
   sandboxLeaseTtlMs: 1_000,
   sandboxViewerHolderTtlMs: 1_000,
   sandboxIdleGraceMs: 500,
+  // env-aware grouping tests attach a workspace Environment at create.
+  environmentsEncryptionKey: Buffer.alloc(32, 7).toString("base64"),
 });
+
+/** A workspace Environment row (no variables needed — grouping compares ids). */
+async function freshEnvironment(accountId: string, workspaceId: string): Promise<string> {
+  const [e] = await admin<{ id: string }[]>`
+    insert into workspace_environments (account_id, workspace_id, name)
+    values (${accountId}, ${workspaceId}, 'env') returning id`;
+  return e!.id;
+}
 
 async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
   const [a] = await admin<{ id: string }[]>`
@@ -198,6 +208,78 @@ describe("P1.4 shared-sandbox create resolution (real createSessionForRequest + 
       initialMessage: "pin to a machine",
       targetSandboxId: crypto.randomUUID(),
     })).rejects.toMatchObject({ status: 422 });
+  }, 60_000);
+
+  test("ENV-AWARE: inherited default with a DIFFERENT environment falls back to an OWN box (break mode 1 dissolved)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const environmentId = await freshEnvironment(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    // A: credential-less manager (top-level, no environment).
+    const a = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "manager",
+    });
+    // B: credentialed worker spawned FROM INSIDE A, sandbox OMITTED. The old
+    // env-blind default joined A's box and the first turn died on the SDK's
+    // manifest-env guard; env-aware grouping gives B its own box instead.
+    const g = { ...grant(accountId, workspaceId, a.id), permissions: ["sessions:create", "sessions:read", "environments:use"] as AccessGrant["permissions"] };
+    const b = await createSessionForRequest(deps(bus), g, workspaceId, {
+      initialMessage: "worker",
+      environmentId,
+    });
+    expect(b.parentSessionId).toBe(a.id);
+    expect(b.sandboxGroupId).toBe(b.id); // own singleton box, NOT a's group
+    expect(b.sandboxGroupId).not.toBe(a.sandboxGroupId);
+  }, 60_000);
+
+  test("ENV-AWARE: inherited default with the SAME environment still shares", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const environmentId = await freshEnvironment(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const g0 = { ...grant(accountId, workspaceId), permissions: ["sessions:create", "sessions:read", "environments:use"] as AccessGrant["permissions"] };
+    const a = await createSessionForRequest(deps(bus), g0, workspaceId, {
+      initialMessage: "credentialed founder",
+      environmentId,
+    });
+    const g1 = { ...grant(accountId, workspaceId, a.id), permissions: ["sessions:create", "sessions:read", "environments:use"] as AccessGrant["permissions"] };
+    const b = await createSessionForRequest(deps(bus), g1, workspaceId, {
+      initialMessage: "same-env sibling",
+      environmentId,
+    });
+    expect(b.sandboxGroupId).toBe(a.sandboxGroupId);
+  }, 60_000);
+
+  test("ENV-AWARE: EXPLICIT 'shared' with a different environment ⇒ 422 at create (not a dead first turn)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const environmentId = await freshEnvironment(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const a = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "manager",
+    });
+    const g = { ...grant(accountId, workspaceId, a.id), permissions: ["sessions:create", "sessions:read", "environments:use"] as AccessGrant["permissions"] };
+    await expect(createSessionForRequest(deps(bus), g, workspaceId, {
+      initialMessage: "worker",
+      environmentId,
+      sandbox: "shared",
+    })).rejects.toThrow(/same environment/);
+  }, 60_000);
+
+  test("ENV-AWARE: {groupId} join with a different environment ⇒ 422 at create", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const environmentId = await freshEnvironment(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const a = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "founder",
+    });
+    const g = { ...grant(accountId, workspaceId), permissions: ["sessions:create", "sessions:read", "environments:use"] as AccessGrant["permissions"] };
+    await expect(createSessionForRequest(deps(bus), g, workspaceId, {
+      initialMessage: "joiner",
+      environmentId,
+      sandbox: { groupId: a.sandboxGroupId! },
+    })).rejects.toThrow(/different environment/);
   }, 60_000);
 
   test("{groupId} explicit join (I13/OD-S5) ⇒ same group as the sibling", async () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2635,6 +2635,11 @@ export const CreateSessionRequest = z.object({
   // A shared spawn inherits the box's (backend, os) — it is literally the same
   // box; the child cannot pick its own backend. Cross-workspace sharing is
   // forbidden by construction (the parent/group reads are RLS-workspace-scoped).
+  // ENV-AWARE: the box's environment is fixed at creation, so a share requires
+  // the SAME environmentId as the creator's box. On a mismatch the inherited
+  // default silently falls back to an own box; an explicit "shared"/{groupId}
+  // request 422s at create (instead of the first turn dying on the SDK's
+  // manifest-env guard).
   sandbox: z.union([
     z.literal("shared"),
     z.literal("new"),


### PR DESCRIPTION
## The default shared path still killed credentialed workers — proven live, now dissolved at create time

Live e2e on staging (post-#158 + #175): a credentialed session (`environmentId` = lumen, 11 ARM_* vars) joining a credential-less session's WARM box via the group — the exact shape of a geni manager spawning a credentialed worker with the default placement — fails its first turn with:

```
turn.failed: "Live sandbox sessions cannot change manifest environment variables. Create or resume a session with the desired environment instead."
```

(sessions `5aee77e9` 06-29 and `63d18823` tonight — same error, same cause.)

### Why
The box's manifest env is **fixed at cold-create** and the SDK's provided-session guard rejects any target-key delta at attach. #158 evicted the rotating **git token** from the manifest (fixing crash-resume + expiry), but the workspace **Environment (ARM_\*) still rides the manifest env** — so under current mechanics a differing Environment IS a genuine shared-state conflict, exactly like a differing image (B3). The env-blind default from #101 turns that conflict into a guaranteed-dead first turn; the only mitigation was product-side isolation nudges (geni #55) — which the platform model says shouldn't exist.

### Change (domain-layer, grouping otherwise untouched)
- **Inherited default** ("shared" via the worker-signed parent claim) with a mismatched `environmentId` → silently falls back to an **own box**; the spawn just works.
- **Explicit** `"shared"` / `{groupId}` with a mismatched environment → **422 at create** with an actionable message, instead of poisoning the first turn.
- Same `environmentId` (incl. both-null) shares byte-for-byte as before.
- `session_create` tool description + `CreateSessionRequest` contract now state the real compatibility rule (same image AND same environment) — the previous text claimed "env vars are per-exec, not a reason to split", which is the intended END STATE but not the current mechanics, and steered agents into fatal spawns.

When the Environment is eventually evicted from the manifest (per-exec, like the git token in #158), the check compares null==null / same-id and dissolves on its own.

### Verification
- 4 new integration tests on the real `createSessionForRequest` + RLS harness (own-box fallback, same-env still shares, explicit-shared 422, groupId-join 422).
- Full suite: 1927 pass / 0 fail; typecheck clean.
- Staging plan: deploy → re-run the live default-path e2e (credential-less parent, credentialed child, sandbox omitted) → child gets own box and completes; then geni retires its transitional `sandbox:"new"` nudge (pack 0.4.16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gRe8QSUk7nBoPxsDLfLUm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session-create sandbox placement for manager/worker spawns; behavior shifts for mixed-environment defaults but is intentional and covered by integration tests.
> 
> **Overview**
> **Sandbox grouping now treats workspace `environmentId` as part of shared-box compatibility**, because a box’s manifest environment is fixed at creation and a mismatched attach fails on the first turn with the SDK manifest-env guard.
> 
> In **`createSessionForRequest`**, when joining a parent’s box (default shared spawn) or a `{groupId}` sibling, the new session’s `environmentId` is compared to the group member’s. **Same id (including both null) still shares** as before. **Inherited default with a mismatch** no longer joins the parent’s group—the worker gets its **own singleton box** so credentialed spawns from credential-less managers work without `sandbox: "new"`. **Explicit `sandbox: "shared"` or `{groupId}` with a mismatch** returns **422** at create with a clear message instead of a failed first turn.
> 
> **`session_create` MCP copy** and **`CreateSessionRequest` contract comments** are updated to state that shared boxes need the same image and environment (replacing the incorrect “env vars are per-exec” guidance). **Four integration tests** cover own-box fallback, same-env sharing, and both explicit 422 paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca067fece1f12bf4cbb500517c997ebe46466363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->