### PR TITLE
fix(sandbox): attach-warmed boxes carry the repo turn's stable git-auth pointers (env parity)

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -17,7 +17,8 @@
 // IMPORT DISCIPLINE: sandbox symbols come ONLY from @opengeni/runtime/sandbox
 // (the agent-loop-free leaf) — enforced by sandbox-access-import-guard.test.ts.
 
-import { stableSandboxEnvironmentForRun, type Settings } from "@opengeni/config";
+import { applyGitAuthPointerEnvironment, hasGitHubRepositorySelection, stableSandboxEnvironmentForRun, type Settings } from "@opengeni/config";
+import { githubAppBotIdentity } from "@opengeni/github";
 import type { Session } from "@opengeni/contracts";
 import {
   acquireLease,
@@ -129,10 +130,14 @@ export async function withChannelA<T>(
     const envelope = await getSandboxSessionEnvelope(db, workspaceId, session.id);
     // The STABLE run-environment a COLD box must be created with so a later worker
     // turn's agent-manifest apply finds an EMPTY env delta (config base + git
-    // identity + decrypted workspace env + HOME). Mirrors the worker turn's stable
-    // subset; omits the per-run rotating GitHub token (no repo resources here).
+    // identity + decrypted workspace env + HOME + — for a repo-attached session —
+    // the stable git-auth pointers the turn declares). Only the rotating token
+    // VALUE stays off (it lives in the box file the clone hook seeds).
     const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(db, settings, workspaceId, session.environmentId);
     const environment = stableSandboxEnvironmentForRun(settings, workspaceEnvironment?.values ?? {});
+    if (hasGitHubRepositorySelection(session.resources)) {
+      applyGitAuthPointerEnvironment(environment, githubAppBotIdentity(settings));
+    }
 
     if (acquired.role === "spawner") {
       // We won the cold->warming CAS: establish the box from the envelope, then

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -19,8 +19,9 @@
 // lease's recorded data_plane_url (null until P4 mints it).
 
 import { createHash } from "node:crypto";
-import { resolveStreamTokenSecret, stableSandboxEnvironmentForRun } from "@opengeni/config";
+import { applyGitAuthPointerEnvironment, hasGitHubRepositorySelection, resolveStreamTokenSecret, stableSandboxEnvironmentForRun } from "@opengeni/config";
 import type { Settings } from "@opengeni/config";
+import { githubAppBotIdentity } from "@opengeni/github";
 import { type Session, type StreamUrlRotatedPayload } from "@opengeni/contracts";
 import {
   acquireLease,
@@ -103,14 +104,17 @@ export type ViewerAttachResult = {
  * `validateNoEnvironmentDelta` threw "Live sandbox sessions cannot change manifest
  * environment variables" — the BLOCKING error this fixes.
  *
- * Mirrors the worker turn's STABLE subset (config.stableSandboxEnvironmentForRun +
- * the session's attached, decrypted workspace environment). It deliberately omits
- * the per-run, rotating GitHub App installation token the turn layers on for a
- * repo-attached run (sandboxEnvironmentForRun): that secret is minted fresh per
- * call and is not attach-reproducible, and the attach surfaces have no repo
- * resources in scope anyway.
+ * Mirrors the worker turn's STABLE env (config.stableSandboxEnvironmentForRun +
+ * the session's attached, decrypted workspace environment + — for a repo-attached
+ * session — the stable git-auth POINTERS the turn declares since the token-broker:
+ * GIT_ASKPASS / GIT_TERMINAL_PROMPT / bot identity). The pointers carry NO rotating
+ * value (the token lives in the box FILE the clone hook seeds), so they are
+ * attach-reproducible; omitting them cold-created a box whose env lacked keys the
+ * next repo turn's manifest declares → the SDK guard threw "Live sandbox sessions
+ * cannot change manifest environment variables" whenever a viewer attach (an open
+ * session page) won the cold-create race against the first turn.
  */
-async function sessionAttachEnvironment(
+export async function sessionAttachEnvironment(
   services: ViewerServices,
   workspaceId: string,
   session: Session,
@@ -121,7 +125,11 @@ async function sessionAttachEnvironment(
     workspaceId,
     session.environmentId,
   );
-  return stableSandboxEnvironmentForRun(services.settings, workspaceEnvironment?.values ?? {});
+  const environment = stableSandboxEnvironmentForRun(services.settings, workspaceEnvironment?.values ?? {});
+  if (hasGitHubRepositorySelection(session.resources)) {
+    applyGitAuthPointerEnvironment(environment, githubAppBotIdentity(services.settings));
+  }
+  return environment;
 }
 
 /**

--- a/apps/api/test/attach-env-git-pointers.test.ts
+++ b/apps/api/test/attach-env-git-pointers.test.ts
@@ -1,0 +1,68 @@
+// Regression: the viewer-attach cold-create path must declare the SAME stable
+// git-auth pointer env a repo turn does (GIT_ASKPASS / GIT_TERMINAL_PROMPT / bot
+// identity) — an attach-warmed box missing those keys kills the next repo turn on
+// the SDK's "Live sandbox sessions cannot change manifest environment variables"
+// guard. Live instance: session 0566bad3 (2026-07-02) — the open session page's
+// viewer attach won the cold-create race against the first turn.
+//
+// DB-free: sessionAttachEnvironment only touches the db when the session has an
+// environmentId (loadWorkspaceEnvironmentForRun returns early on null).
+
+import { describe, expect, test } from "bun:test";
+import { applyGitAuthPointerEnvironment, stableSandboxEnvironmentForRun } from "@opengeni/config";
+import { githubAppBotIdentity } from "@opengeni/github";
+import type { Session } from "@opengeni/contracts";
+import { testSettings } from "@opengeni/testing";
+import { sessionAttachEnvironment } from "../src/sandbox/viewer";
+
+const settings = testSettings({
+  sandboxBackend: "modal",
+  gitAuthorName: "OpenGeni Bot",
+  gitAuthorEmail: "bot@opengeni.dev",
+  githubAppId: "12345",
+  githubAppSlug: "opengeni-test",
+});
+
+function sessionWith(resources: Session["resources"]): Session {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    environmentId: null,
+    resources,
+  } as unknown as Session;
+}
+
+const services = { db: null as never, settings, bus: null as never } as never;
+
+describe("sessionAttachEnvironment — repo-attached git-pointer parity", () => {
+  test("a GitHub-App repo session's attach env carries the stable git-auth pointers the turn declares", async () => {
+    const attachEnv = await sessionAttachEnvironment(services, "ws", sessionWith([{
+      kind: "repository",
+      uri: "https://github.com/acme/repo.git",
+      ref: "main",
+      githubInstallationId: 123,
+      githubRepositoryId: 456,
+    }]));
+    const expected = applyGitAuthPointerEnvironment(
+      stableSandboxEnvironmentForRun(settings, {}),
+      githubAppBotIdentity(settings),
+    );
+    expect(attachEnv).toEqual(expected);
+    expect(attachEnv.GIT_ASKPASS).toBe("/workspace/.opengeni/askpass");
+    expect(attachEnv.GIT_TERMINAL_PROMPT).toBe("0");
+  });
+
+  test("a session with NO GitHub-App repo keeps the plain stable base (no pointers)", async () => {
+    const attachEnv = await sessionAttachEnvironment(services, "ws", sessionWith([]));
+    expect(attachEnv).toEqual(stableSandboxEnvironmentForRun(settings, {}));
+    expect(attachEnv.GIT_ASKPASS).toBeUndefined();
+  });
+
+  test("a plain-URI repo (no installation ids) does not trigger the pointers — mirrors the turn's selection predicate", async () => {
+    const attachEnv = await sessionAttachEnvironment(services, "ws", sessionWith([{
+      kind: "repository",
+      uri: "https://github.com/acme/public.git",
+      ref: "main",
+    }]));
+    expect(attachEnv.GIT_ASKPASS).toBeUndefined();
+  });
+});

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -1,4 +1,5 @@
 import {
+  applyGitAuthPointerEnvironment,
   stableSandboxEnvironmentForRun,
   type Settings,
 } from "@opengeni/config";
@@ -61,23 +62,17 @@ export async function sandboxEnvironmentForRun(
     installationId: selection.installationId,
     repositoryIds: selection.repositoryIds,
   });
-  const identity = githubAppBotIdentity(settings);
   // TOKEN-BROKER (B2): the askpass helper is PROVISIONED AT SETUP (runtime) into a
   // per-box, user-writable path in the SAME dir as the token file, instead of a
   // baked image script at /usr/local/bin/opengeni-git-askpass. The clone-hook seed
   // block writes both the token file AND this askpass script before the fetch, so
   // git auth becomes correct on ANY box image (including pre-existing warm boxes on
   // their next turn's clone hook) — no product image needs to carry the askpass.
-  // HOME is already resolved in the STABLE base above; keep the /workspace fallback
-  // in lockstep with stableSandboxEnvironmentForRun's OPENGENI_GIT_TOKEN_FILE.
-  environment.GIT_ASKPASS = `${environment.HOME ?? "/workspace"}/.opengeni/askpass`;
-  environment.GIT_TERMINAL_PROMPT = "0";
-  if (identity) {
-    environment.GIT_AUTHOR_NAME = environment.GIT_AUTHOR_NAME || identity.name;
-    environment.GIT_AUTHOR_EMAIL = environment.GIT_AUTHOR_EMAIL || identity.email;
-    environment.GIT_COMMITTER_NAME = environment.GIT_COMMITTER_NAME || identity.name;
-    environment.GIT_COMMITTER_EMAIL = environment.GIT_COMMITTER_EMAIL || identity.email;
-  }
+  // The pointer layer is the SHARED config helper so every API-direct attach
+  // surface (viewer attach, channel-A) declares the IDENTICAL env when it
+  // cold-creates the box for a repo-attached session — an attach-warmed box
+  // missing these keys kills the next repo turn on the SDK's manifest-env guard.
+  applyGitAuthPointerEnvironment(environment, githubAppBotIdentity(settings));
   return { environment, gitToken: token };
 }
 

--- a/apps/worker/test/sandbox-attach-env-parity.test.ts
+++ b/apps/worker/test/sandbox-attach-env-parity.test.ts
@@ -18,7 +18,8 @@
 // keys go missing and the parity assertion fails (reproducing the delta throw).
 
 import { describe, expect, test } from "bun:test";
-import { stableSandboxEnvironmentForRun } from "@opengeni/config";
+import { applyGitAuthPointerEnvironment, stableSandboxEnvironmentForRun } from "@opengeni/config";
+import { githubAppBotIdentity } from "@opengeni/github";
 import { testSettings } from "@opengeni/testing";
 import type { ResourceRef } from "@opengeni/contracts";
 import { sandboxEnvironmentForRun } from "../src/activities/environment";
@@ -148,5 +149,73 @@ describe("repo-attached turn: token VALUE is OFF the manifest, only the FILE PAT
     expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBe("/workspace/.opengeni/git-token");
     expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBe(attachEnv.OPENGENI_GIT_TOKEN_FILE);
     expect(hasNoEnvironmentDelta(attachEnv, turnEnv)).toBe(true);
+  });
+});
+
+// REPO-ATTACHED parity (the case an open session page actually hits): since the
+// token broker, a cloud repo turn declares the STABLE git-auth POINTERS
+// (GIT_ASKPASS / GIT_TERMINAL_PROMPT / bot identity) on top of the stable base.
+// An attach-warmed box created WITHOUT them is missing keys the turn declares →
+// the SDK guard throws. Live regression: session 0566bad3 (2026-07-02) — the
+// viewer attach (open session page) won the cold-create race and the first repo
+// turn died. The attach paths now apply the SAME shared pointer helper.
+describe("repo-attached attach-vs-turn parity (the viewer-attach cold-create race)", () => {
+  const repoSettings = () =>
+    testSettings({
+      sandboxBackend: "modal",
+      gitAuthorName: "OpenGeni Bot",
+      gitAuthorEmail: "bot@opengeni.dev",
+      githubAppId: "12345",
+      githubAppSlug: "opengeni-test",
+    });
+
+  test("attach env built with the shared pointer helper has NO delta against the repo turn's declared env", async () => {
+    const settings = repoSettings();
+    // The turn's declared env for a cloud repo run = stable base + the SHARED
+    // pointer helper (sandboxEnvironmentForRun applies exactly this after the
+    // mint; the mint contributes only the OFF-manifest gitToken).
+    const turnEnv = applyGitAuthPointerEnvironment(
+      stableSandboxEnvironmentForRun(settings, {}),
+      githubAppBotIdentity(settings),
+    );
+    // What the attach paths (viewer.ts sessionAttachEnvironment / channel-a.ts)
+    // now cold-create a repo session's box with.
+    const attachEnv = applyGitAuthPointerEnvironment(
+      stableSandboxEnvironmentForRun(settings, {}),
+      githubAppBotIdentity(settings),
+    );
+    expect(attachEnv).toEqual(turnEnv);
+    expect(hasNoEnvironmentDelta(attachEnv, turnEnv)).toBe(true);
+    expect(attachEnv.GIT_ASKPASS).toBe("/workspace/.opengeni/askpass");
+    expect(attachEnv.GIT_TERMINAL_PROMPT).toBe("0");
+    // Deployment git identity wins over the bot fallback (parity on both sides).
+    expect(attachEnv.GIT_AUTHOR_NAME).toBe("OpenGeni Bot");
+  });
+
+  test("FAILURE-SENSITIVITY: the pointer-less attach env (the 0566bad3 bug) DOES delta against a repo turn", async () => {
+    const settings = repoSettings();
+    const turnEnv = applyGitAuthPointerEnvironment(
+      stableSandboxEnvironmentForRun(settings, {}),
+      githubAppBotIdentity(settings),
+    );
+    // The pre-fix attach env: stable base only, no pointers.
+    const oldAttachEnv = stableSandboxEnvironmentForRun(settings, {});
+    expect(hasNoEnvironmentDelta(oldAttachEnv, turnEnv)).toBe(false);
+  });
+
+  test("bot identity fallback applies when the deployment carries no git identity", async () => {
+    const settings = testSettings({
+      sandboxBackend: "modal",
+      gitAuthorName: undefined,
+      gitAuthorEmail: undefined,
+      githubAppId: "12345",
+      githubAppSlug: "opengeni-test",
+    });
+    const env = applyGitAuthPointerEnvironment(
+      stableSandboxEnvironmentForRun(settings, {}),
+      githubAppBotIdentity(settings),
+    );
+    expect(env.GIT_AUTHOR_NAME).toBe("opengeni-test[bot]");
+    expect(env.GIT_AUTHOR_EMAIL).toBe("12345+opengeni-test[bot]@users.noreply.github.com");
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1414,6 +1414,52 @@ export function stableSandboxEnvironmentForRun(
   return environment;
 }
 
+/**
+ * Whether a resource set carries a GitHub-App-connected repository (installation
+ * + repository ids present) — the SAME predicate the worker turn uses to decide
+ * whether it declares the stable git-auth pointers. Attach surfaces call this so
+ * an attach-warmed cold box carries the IDENTICAL manifest env a later repo turn
+ * declares (env parity — see applyGitAuthPointerEnvironment).
+ */
+export function hasGitHubRepositorySelection(resources: ReadonlyArray<{ kind: string; githubInstallationId?: unknown; githubRepositoryId?: unknown }>): boolean {
+  const positive = (value: unknown): boolean =>
+    (typeof value === "number" && Number.isInteger(value) && value > 0)
+    || (typeof value === "string" && /^\d+$/.test(value) && Number(value) > 0);
+  return resources.some((resource) => resource.kind === "repository" && positive(resource.githubInstallationId) && positive(resource.githubRepositoryId));
+}
+
+/**
+ * TOKEN-BROKER (B1) parity: the STABLE git-auth POINTER environment a
+ * repo-attached run declares — GIT_ASKPASS (a fixed path under HOME; the script
+ * itself is provisioned at box setup), GIT_TERMINAL_PROMPT, and the GitHub-App
+ * bot identity fallbacks. NO rotating value rides here (the token lives in the
+ * file behind the askpass), so the layer is attach-reproducible and MUST be
+ * applied identically by the worker turn (sandboxEnvironmentForRun) AND every
+ * API-direct attach surface that can cold-create the box (viewer attach,
+ * channel-A ops). A box cold-created WITHOUT this layer kills the next repo
+ * turn: the turn's manifest declares these keys, the box's env lacks them, and
+ * the SDK's provided-session guard throws "Live sandbox sessions cannot change
+ * manifest environment variables" (observed live: an open session page's viewer
+ * attach won the cold-create race and the first turn died).
+ *
+ * Mutates and returns `environment`. Identity fallbacks preserve values already
+ * present (the deployment git-identity allowlist wins over the bot identity).
+ */
+export function applyGitAuthPointerEnvironment(
+  environment: Record<string, string>,
+  identity: { name: string; email: string } | null,
+): Record<string, string> {
+  environment.GIT_ASKPASS = `${environment.HOME ?? "/workspace"}/.opengeni/askpass`;
+  environment.GIT_TERMINAL_PROMPT = "0";
+  if (identity) {
+    environment.GIT_AUTHOR_NAME = environment.GIT_AUTHOR_NAME || identity.name;
+    environment.GIT_AUTHOR_EMAIL = environment.GIT_AUTHOR_EMAIL || identity.email;
+    environment.GIT_COMMITTER_NAME = environment.GIT_COMMITTER_NAME || identity.name;
+    environment.GIT_COMMITTER_EMAIL = environment.GIT_COMMITTER_EMAIL || identity.email;
+  }
+  return environment;
+}
+
 export type StartupRetryOptions = {
   attempts?: number;
   initialDelayMs?: number;


### PR DESCRIPTION
## User-reported live failure: open session page + repo resource = dead first turn

Session `0566bad3` (standupv5, 2026-07-02 05:35, created from the web UI with a repo attached, no Environment, own box) failed in 13 s:

```
turn.failed: "Live sandbox sessions cannot change manifest environment variables. Create or resume a session with the desired environment instead."
```

### Root cause
The open session page's **viewer attach won the cold-create race** against the first turn and built the box via `sessionAttachEnvironment` — the stable base env only. Since the token broker (#158), a repo-attached **turn** declares the stable git-auth pointers (`GIT_ASKPASS`, `GIT_TERMINAL_PROMPT`, bot identity) on its manifest. The SDK guard iterates the turn's (target) keys, finds them missing from the attach-warmed box, and throws. The clone hook (restored in #175) had already run and succeeded — the failure is purely the manifest apply.

`viewer.ts`'s own doc claims attach/turn env parity and the parity **test suite exists** — but its repo-attached case only covered the mint-skip path (no pointers), which is exactly how this slipped. Pre-B1, this flow was equally fatal for repo sessions (the rotating `GH_TOKEN` could never be attach-reproduced); B1 made parity achievable and this PR completes it.

### Change
- New shared config helpers: `applyGitAuthPointerEnvironment` (the exact pointer layer, no rotating value) + `hasGitHubRepositorySelection` (the turn's selection predicate).
- Worker turn (`sandboxEnvironmentForRun`) refactored onto the helper — byte-identical behavior.
- Both attach surfaces (`sessionAttachEnvironment` for viewer/desktop/terminal attach, `channel-a.ts` establish) apply it for GitHub-App repo sessions.

### Verification
- Parity suite extended: repo-attached attach-vs-turn equality, failure-sensitivity (the pointer-less pre-fix env DOES delta), bot-identity fallback.
- Direct `sessionAttachEnvironment` tests: pointers for GitHub-App repos, none for plain URIs or repo-less sessions.
- Full suite 1929 pass / 0 fail; typecheck clean.
- Staging plan: deploy → repro the user flow (create repo session + immediate viewer attach → turn must complete) → reply to the failed session `0566bad3` itself and watch it work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gRe8QSUk7nBoPxsDLfLUm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox cold-create env on API attach paths and worker turns; wrong parity would still break repo sessions, but scope is narrow shared helpers plus tests with no rotating secrets on the manifest.
> 
> **Overview**
> Fixes **first-turn failures** when an open session page’s viewer attach **cold-creates the sandbox before the worker turn**: the box was built with only the stable base env, while a GitHub-App repo turn also declares **git-auth pointer** vars (`GIT_ASKPASS`, `GIT_TERMINAL_PROMPT`, bot identity). The SDK then rejects manifest apply with *"Live sandbox sessions cannot change manifest environment variables"*.
> 
> Adds shared **`applyGitAuthPointerEnvironment`** and **`hasGitHubRepositorySelection`** in `@opengeni/config`, refactors the worker turn onto the helper (same behavior), and applies the same layer on **viewer attach** (`sessionAttachEnvironment`, now exported) and **Channel-A** cold-create when the session has a GitHub-App repo. Rotating token values stay off-manifest; only stable pointers are aligned.
> 
> Regression tests cover attach-vs-turn parity, failure sensitivity for the pre-fix env, and plain-URI / repo-less sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aedb239bfbabb3084fe51e28cfdde05f1036b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->