### PR TITLE
fix(computer-use): deliver codex function-tool screenshots as real images the model can see

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1007,6 +1007,12 @@ export function buildAgentCapabilities(
     const computerCapability = computerUse({
       dimensions: [settings.streamResolutionWidth, settings.streamResolutionHeight],
       readOnly: settings.computerUseReadOnly,
+      // On the codex path the function tools deliver screenshots as a real image the
+      // model can see. The ChatGPT/Codex backend rejects HOSTED tool types but DOES
+      // accept `input_image` content items inside a `function_call_output` (proven by
+      // openai/codex codex-rs, whose view_image tool ships exactly that shape) — so a
+      // structured image tool result is seen, where a text data-URL would be unreadable.
+      ...(options.structuredToolTransport === false ? { imageFunctionResults: true } : {}),
     });
     if (options.structuredToolTransport === false) {
       neutralizeStructuredToolTransport(computerCapability);

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -591,17 +591,26 @@ function objectSchema(properties: Record<string, unknown>, required: string[]): 
 /**
  * The FUNCTION-transport computer tools for the codex / text backend, each routing
  * to the SAME bound `Computer` the hosted `computer_use_preview` tool would drive.
- * `computer_screenshot` returns the screen as a `data:image/png;base64,…` URL
- * (imageOutputFromBytes → renderImageForTextTransport — the SDK's text `view_image`
- * path) so the model SEES the desktop. Write tools return a concise confirmation;
- * when read-only they return {@link COMPUTER_READ_ONLY_MESSAGE} instead of throwing,
- * and any action error is returned as a string so a failed action never kills the
- * turn. Exported so it can be unit-tested against a fake `Computer`.
+ * `computer_screenshot` hands the model the desktop two ways, selected by
+ * `imageFunctionResults`:
+ *   • false (chat-completions providers, the default) → the text-transport
+ *     `data:image/png;base64,…` URL (imageOutputFromBytes → renderImageForTextTransport,
+ *     the SDK's text `view_image` path) — those backends can't read structured image
+ *     tool results.
+ *   • true (the codex/ChatGPT backend) → the structured `{type:'image'}` tool output,
+ *     which agents-core normalizes into an `input_image` content item inside the
+ *     function_call_output — the codex /responses backend accepts and SEES it (a text
+ *     data-URL there is just unreadable text). See index.ts for why it's on there.
+ * Write tools return a concise confirmation; when read-only they return
+ * {@link COMPUTER_READ_ONLY_MESSAGE} instead of throwing, and any action error is
+ * returned as a string so a failed action never kills the turn. Exported so it can be
+ * unit-tested against a fake `Computer`.
  */
 export function computerFunctionTools(
   computer: Computer,
   readOnly: boolean,
   needsApproval?: ComputerUseArgs["needsApproval"],
+  imageFunctionResults = false,
 ): Tool<unknown>[] {
   const approval = needsApproval !== undefined ? { needsApproval: needsApproval as never } : {};
   // Perform a WRITE action, surfacing read-only / failures as a model-readable
@@ -630,7 +639,12 @@ export function computerFunctionTools(
         // instead), so the model can't receive an empty image_url.
         const b64 = await computer.screenshot();
         const bytes = Uint8Array.from(Buffer.from(b64, "base64"));
-        return renderImageForTextTransport(imageOutputFromScreenshotBytes(bytes));
+        const image = imageOutputFromScreenshotBytes(bytes);
+        // On the codex backend return the structured image output so the model SEES
+        // the desktop (agents-core normalizes {type:'image'} → an input_image data-URL
+        // content item in the function_call_output); chat-completions providers get
+        // the text data-URL string they expect.
+        return imageFunctionResults ? image : renderImageForTextTransport(image);
       },
     }),
     tool({
@@ -752,6 +766,13 @@ export type ComputerUseArgs = {
   readOnly?: boolean;
   display?: string;
   needsApproval?: boolean | ((ctx: unknown, action: unknown) => boolean | Promise<boolean>);
+  // Deliver screenshots from the FUNCTION tools as a REAL image the model can see
+  // (a structured `{type:'image'}` tool output → agents-core normalizes it to an
+  // `input_image` content item inside the function_call_output) instead of the text
+  // data-URL string. Only the codex/ChatGPT backend can read structured image tool
+  // results; chat-completions providers cannot, so this stays OFF (text rendering)
+  // by default and is turned on only on the codex path (see index.ts).
+  imageFunctionResults?: boolean;
 };
 
 export function computerUse(args: ComputerUseArgs = {}): ComputerUseCapability {
@@ -809,6 +830,6 @@ export class ComputerUseCapability extends Capability {
         }) as unknown as Tool<unknown>,
       ];
     }
-    return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval);
+    return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval, this.args.imageFunctionResults ?? false);
   }
 }

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { testSettings } from "@opengeni/testing";
 import { buildAgentCapabilities } from "../src/index";
 import {
@@ -581,6 +583,99 @@ describe("computerFunctionTools (codex text-transport routing)", () => {
   });
 });
 
+describe("computerFunctionTools image delivery on the codex backend", () => {
+  const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const PNG_B64 = Buffer.from(PNG).toString("base64");
+  const PNG_DATA_URL = `data:image/png;base64,${PNG_B64}`;
+
+  test("imageFunctionResults=false (default): computer_screenshot returns the text data-URL string", async () => {
+    const { computer } = makeFakeComputer({ screenshotB64: PNG_B64 });
+    const t = toolsByName(computerFunctionTools(computer as never, false, undefined, false));
+    const out = await invokeTool(t.computer_screenshot, {});
+    // Chat-completions providers keep the SDK's text view_image rendering EXACTLY.
+    expect(out).toBe(PNG_DATA_URL);
+  });
+
+  test("imageFunctionResults=true: computer_screenshot returns a structured {type:'image'} tool output", async () => {
+    const { computer } = makeFakeComputer({ screenshotB64: PNG_B64 });
+    const t = toolsByName(computerFunctionTools(computer as never, false, undefined, true));
+    const out = (await invokeTool(t.computer_screenshot, {})) as {
+      type: string;
+      image: { data: Uint8Array; mediaType: string };
+    };
+    // NOT a text data-URL string — the structured image the codex backend can SEE.
+    expect(typeof out).toBe("object");
+    expect(out.type).toBe("image");
+    expect(out.image.mediaType).toBe("image/png");
+    expect(Array.from(out.image.data)).toEqual(Array.from(PNG));
+  });
+
+  // The decisive Candidate-A evidence: the structured {type:'image', image:{data:Uint8Array}}
+  // return value NEVER reaches the DB as a Uint8Array. agents-core's getToolCallOutputItem
+  // (runner/toolExecution.mjs — normalizeStructuredToolOutput → toInlineImageString/asDataUrl,
+  // then convertStructuredToolOutputToInputItem) converts the bytes to a base64 data-URL
+  // STRING and persists `{type:'input_image', image:'data:…'}`. That string survives JSON
+  // round-trip, and at request time the codex serializer maps `image` → `image_url`.
+  test("round-trip: tool result → getToolCallOutputItem → JSON → request wire shape has a non-empty input_image image_url", async () => {
+    const { computer } = makeFakeComputer({ screenshotB64: PNG_B64 });
+    const t = toolsByName(computerFunctionTools(computer as never, false, undefined, true));
+    const toolResult = await invokeTool(t.computer_screenshot, {});
+
+    // Reach the REAL agents-core normalizer that builds the persisted function_call_result
+    // (not exported from the package root, so resolve it through @openai/agents' own deps).
+    const req = createRequire(import.meta.url);
+    const agentsReq = createRequire(req.resolve("@openai/agents"));
+    const toolExecPath = join(dirname(agentsReq.resolve("@openai/agents-core")), "runner", "toolExecution.mjs");
+    const { getToolCallOutputItem } = (await import(toolExecPath)) as {
+      getToolCallOutputItem: (
+        toolCall: { name: string; callId: string },
+        output: unknown,
+      ) => { type: string; callId: string; output: unknown };
+    };
+
+    // 1) The tool result becomes the persisted function_call_result raw item.
+    const rawItem = getToolCallOutputItem({ name: "computer_screenshot", callId: "call_1" }, toolResult);
+    expect(Array.isArray(rawItem.output)).toBe(true);
+    const persistedItem = (rawItem.output as Array<Record<string, unknown>>)[0]!;
+    // Persisted as an input_image whose `image` is a data-URL STRING — no Uint8Array.
+    expect(persistedItem.type).toBe("input_image");
+    expect(typeof persistedItem.image).toBe("string");
+    expect(persistedItem.image as string).toBe(PNG_DATA_URL);
+
+    // 2) DB round-trip through JSON.stringify/parse (session_history_items persistence).
+    const replayed = JSON.parse(JSON.stringify(rawItem.output)) as Array<Record<string, unknown>>;
+    // Deep-equal proves nothing degraded (a Uint8Array would round-trip as an
+    // object-of-numbers and break this equality + the request serializer below).
+    expect(replayed).toEqual(rawItem.output as never);
+    const replayedItem = replayed[0]!;
+    expect(typeof replayedItem.image).toBe("string");
+
+    // 3) The request-time serializer (agents-openai openaiResponsesModel.mjs
+    //    convertStructuredOutputToRequestItem input_image branch: reads `image ?? imageUrl`,
+    //    emits `image_url`) turns the replayed item into the codex /responses wire shape.
+    const wire = convertInputImageToRequestItem(replayedItem);
+    expect(wire.type).toBe("input_image");
+    expect(typeof wire.image_url).toBe("string");
+    expect((wire.image_url as string).length).toBeGreaterThan(0);
+    expect(wire.image_url).toBe(PNG_DATA_URL);
+  });
+});
+
+// Faithful copy of the input_image branch of agents-openai's private
+// convertStructuredOutputToRequestItem (openaiResponsesModel.mjs): it is NOT exported,
+// so it is replicated here — the branch reads `image ?? imageUrl` and emits `image_url`.
+function convertInputImageToRequestItem(item: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { type: "input_image" };
+  const imageValue = (item.image ?? item.imageUrl) as unknown;
+  if (typeof imageValue === "string") {
+    result.image_url = imageValue;
+  }
+  if (typeof item.detail === "string") {
+    result.detail = item.detail;
+  }
+  return result;
+}
+
 describe("buildAgentCapabilities computer-use gating (P4.3)", () => {
   const types = (s: Parameters<typeof buildAgentCapabilities>[0]) =>
     buildAgentCapabilities(s, []).map((c) => (c as { type?: string }).type);
@@ -625,5 +720,19 @@ describe("buildAgentCapabilities computer-use gating (P4.3)", () => {
     computerCap.bind(session as never).bindModel("responses", structuredModel());
     const names = computerCap.tools().map((t) => (t as { name?: string }).name);
     expect(names).toEqual(FUNCTION_TOOL_NAMES);
+  });
+
+  test("codex path threads imageFunctionResults:true → the emitted computer_screenshot returns a structured image", async () => {
+    const desktopOn = testSettings({ sandboxBackend: "modal", sandboxDesktopEnabled: true, computerUseEnabled: true });
+    const codexCaps = buildAgentCapabilities(desktopOn, [], { structuredToolTransport: false });
+    const computerCap = codexCaps.find((c) => (c as { type?: string }).type === "computer-use") as unknown as ComputerUseCapability;
+    // A MODAL mock session → SandboxComputer; its base64 screenshot read returns PNG bytes.
+    const { session } = makeMockSession({ pngBytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) });
+    computerCap.bind(session as never).bindModel("responses", structuredModel());
+    const screenshotTool = computerCap.tools().find((t) => (t as { name?: string }).name === "computer_screenshot");
+    const out = (await invokeTool(screenshotTool, {})) as { type?: string; image?: { mediaType?: string } };
+    // Structured image (codex sees it), NOT the text data-URL string.
+    expect(out.type).toBe("image");
+    expect(out.image?.mediaType).toBe("image/png");
   });
 });


### PR DESCRIPTION
On the codex/ChatGPT backend the computer capability runs as FUNCTION `computer_*` tools (hosted tool types are rejected there). `computer_screenshot` returned the screenshot as a text data-URL string — the model received unreadable base64 text and was effectively blind, so computer-use sessions on codex models could act but never see.

The codex `/responses` backend does accept `input_image` content items inside a `function_call_output` — proven by openai/codex codex-rs, whose `view_image` tool ships exactly that shape in production (data-URLs required, remote URLs rejected).

**Change**: add an `imageFunctionResults` option on the computerUse capability, threaded into `computerFunctionTools`, enabled only on the codex path (`structuredToolTransport === false`). When on, `computer_screenshot` returns the structured `{type:'image'}` tool output, which agents-core normalizes into an `input_image` data-URL content item before persistence (DB history item is a plain string; survives JSON round-trip). Chat-completions providers keep the text rendering unchanged. Hosted computer-tool path and history-sanitizer untouched.

**Tests**: 4 new — default-off text regression guard, structured image on, a persistence round-trip driving the real agents-core `getToolCallOutputItem` + JSON round-trip + request serializer asserting a non-empty `input_image.image_url` on the wire, and an index.ts wiring seam test. `tsc --noEmit` clean; `bun test packages/runtime` 483 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches computer-use tool output shaping on the codex path only; wrong flag wiring could break screenshot visibility for one backend class, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **codex/ChatGPT computer-use** sessions where the model could act on the desktop but not see it: on the codex path (`structuredToolTransport === false`), `computer_screenshot` used to return a **text** `data:image/png;base64,…` string, which that backend treats as unreadable text inside `function_call_output`.
> 
> Adds **`imageFunctionResults`** on `computerUse` / `computerFunctionTools`, enabled only when building capabilities for the codex path in `buildAgentCapabilities`. When on, `computer_screenshot` returns a structured **`{type:'image'}`** tool output so agents-core can normalize it to an **`input_image`** item the codex `/responses` backend accepts (same pattern as codex-rs `view_image`). **Chat-completions** and other paths keep the default **text data-URL** behavior (`imageFunctionResults` false).
> 
> Tests cover default text output, structured image output, a **persistence round-trip** through real `getToolCallOutputItem` + JSON + wire `image_url`, and **`buildAgentCapabilities`** wiring on the codex path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1a90ef9a98237b87765d3a96c1a575b9abd810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->