### PR TITLE
fix(computer-use): forward native desktop surface through the routing proxy

### DIFF
--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -66,6 +66,15 @@ export interface RoutableBackendSession {
   supportsPty?(): boolean;
   resolveExposedPort?(port: number): Promise<ExposedPortEndpoint>;
   serializeSessionState?(): Promise<unknown>;
+  // The native-desktop control-plane surface (self-hosted / macOS): a backend that
+  // drives the desktop NATIVELY (input inject + frame capture) instead of shelling
+  // xdotool/scrot over `exec`. Optional like the rest — only a `SelfhostedSession`
+  // implements these; a Modal box does not. The computer-use capability duck-types
+  // on their PRESENCE (`isNativeDesktopSession`) to pick the native vs exec Computer.
+  // `event` is kept `unknown` (mirroring the interface's structural style + avoiding
+  // a proto import into the leaf); the SelfhostedSession takes `DesktopInputRequest["event"]`.
+  desktopInput?(event: unknown): Promise<void>;
+  screenshot?(): Promise<{ png: Uint8Array; width: number; height: number }>;
 }
 
 /** The resolved active backend for an epoch: the live session + the sandbox id it
@@ -171,9 +180,48 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   // of the active backend's `state`). Updated on every resolve.
   private lastResolved: ResolvedActiveBackend | undefined;
 
+  // The native-desktop control-plane ops (self-hosted / macOS). Declared as OPTIONAL
+  // INSTANCE fields — NOT prototype methods — because their PRESENCE is the selection
+  // signal `isNativeDesktopSession` (sandbox-computer.ts) uses to pick the native vs
+  // exec-shelling Computer. If they were unconditional prototype methods, this proxy
+  // would ALWAYS duck-type as native — misclassifying a Modal-fronting proxy (whose
+  // real backend has no native surface) and driving CGEvent/screenshot ops at a box
+  // that cannot serve them. So the constructor assigns them ONLY when the
+  // construction-time default backend actually implements the native surface (below).
+  desktopInput?: (event: unknown) => Promise<void>;
+  screenshot?: () => Promise<{ png: Uint8Array; width: number; height: number }>;
+
   constructor(deps: RoutingSandboxSessionDeps) {
     this.deps = deps;
     this.maxFenceRetries = deps.maxFenceRetries ?? 3;
+
+    // Conditionally expose the native-desktop surface. Presence = the computer-use
+    // native/exec selection signal (isNativeDesktopSession duck-types on
+    // desktopInput+screenshot being functions); unconditional presence would
+    // misclassify Modal-fronting proxies as native. So we mint these per-INSTANCE
+    // arrow properties ONLY when the default backend resolved at construction is
+    // itself native-capable — the machine-primary (selfhosted) case. Each dispatches
+    // to the ACTIVE backend at call-time; if a mid-turn swap lands on a backend that
+    // lacks the op (a cross-kind swap to a Modal box), dispatch throws
+    // RoutingUnsupportedError — a legible tool failure, never a silent Linux-tool
+    // shell onto a Mac.
+    const def = deps.defaultResolved?.session;
+    if (typeof def?.desktopInput === "function" && typeof def?.screenshot === "function") {
+      this.desktopInput = (event: unknown) =>
+        this.dispatch("desktopInput", async (s) => {
+          if (!s.desktopInput) {
+            throw new RoutingUnsupportedError("desktopInput", this.cached?.kind ?? "unknown");
+          }
+          return s.desktopInput(event);
+        });
+      this.screenshot = () =>
+        this.dispatch("screenshot", async (s) => {
+          if (!s.screenshot) {
+            throw new RoutingUnsupportedError("screenshot", this.cached?.kind ?? "unknown");
+          }
+          return s.screenshot();
+        });
+    }
   }
 
   /**

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   RoutingSandboxSession,
+  RoutingUnsupportedError,
   makeActiveBackendResolver,
   MockAgentResponder,
   type ActivePointer,
@@ -27,6 +28,9 @@ import {
   type ResolvedActiveBackend,
   type RoutableSandbox,
 } from "../src/sandbox";
+// The REAL computer-use discriminator — the proxy's native-surface presence must
+// satisfy (and, for Modal, fail) this exact duck-type, not a local reimplementation.
+import { isNativeDesktopSession } from "../src/sandbox-computer";
 
 const WS = "11111111-1111-1111-1111-111111111111";
 const RELAY = { host: "relay.test", port: 443, tls: true } as const;
@@ -59,6 +63,25 @@ class FakeBackend implements RoutableBackendSession {
 
   async readFile(): Promise<Uint8Array> {
     return new TextEncoder().encode(this.tag);
+  }
+}
+
+/** A backend that ALSO implements the native-desktop control-plane surface
+ *  (`desktopInput`/`screenshot`) — the SelfhostedSession shape the computer-use
+ *  capability duck-types as native. Records the events it received so a test can
+ *  assert the proxy dispatched to it with the right args. */
+class NativeFakeBackend extends FakeBackend {
+  readonly desktopEvents: unknown[] = [];
+  screenshots = 0;
+  readonly frame = { png: new Uint8Array([137, 80, 78, 71]), width: 1440, height: 900 };
+
+  async desktopInput(event: unknown): Promise<void> {
+    this.desktopEvents.push(event);
+  }
+
+  async screenshot(): Promise<{ png: Uint8Array; width: number; height: number }> {
+    this.screenshots += 1;
+    return this.frame;
   }
 }
 
@@ -380,5 +403,93 @@ describe("makeActiveBackendResolver — heterogeneous default/modal/selfhosted d
     const r = (await proxy.exec({ cmd: "echo $HOSTNAME" })) as { stdout: string };
     expect(r.stdout.trim()).toBe("laptop-99");
     expect(groupModal.calls).toEqual(["uname"]);
+  });
+});
+
+describe("RoutingSandboxSession — native-desktop surface (machine-primary computer-use)", () => {
+  test("proxy fronting a native-capable default backend duck-types as native + dispatches desktopInput/screenshot to the active backend", async () => {
+    // The bug: a machine-primary session routes computer-use through the proxy, but
+    // the proxy did not forward desktopInput/screenshot → isNativeDesktopSession failed
+    // → the capability bound the Linux exec-shelling SandboxComputer onto the Mac.
+    const native = new NativeFakeBackend("selfhosted");
+    const ptr = mutablePointer({ activeSandboxId: "sbx-self", activeEpoch: 1 });
+    const proxy = new RoutingSandboxSession({
+      defaultResolved: { session: native, sandboxId: "sbx-self", kind: "selfhosted" },
+      readPointer: ptr.read,
+      resolveActiveBackend: async () => ({ session: native, sandboxId: "sbx-self", kind: "selfhosted" }),
+    });
+
+    // The REAL discriminator selects the native computer for this proxy.
+    expect(isNativeDesktopSession(proxy as never)).toBe(true);
+
+    // desktopInput dispatches to the active backend, carrying the event through.
+    const event = { $case: "pointer", pointer: { x: 12, y: 34, action: "click", button: "left" } };
+    await proxy.desktopInput!(event);
+    expect(native.desktopEvents).toEqual([event]);
+
+    // screenshot dispatches and returns the backend's frame.
+    const shot = await proxy.screenshot!();
+    expect(native.screenshots).toBe(1);
+    expect(shot).toEqual(native.frame);
+  });
+
+  test("proxy fronting a Modal-like default backend (no native surface) does NOT duck-type as native (regression: Modal misclassification)", async () => {
+    // A Modal box has no desktopInput/screenshot. The proxy must NOT expose them
+    // (presence is the selection signal), or every Modal-fronting proxy would be
+    // misclassified as native and driven with CGEvent/screenshot ops it can't serve.
+    const modal = new FakeBackend("modal");
+    const ptr = mutablePointer();
+    const proxy = new RoutingSandboxSession({
+      defaultResolved: { session: modal, sandboxId: null, kind: "modal" },
+      readPointer: ptr.read,
+      resolveActiveBackend: async () => ({ session: modal, sandboxId: null, kind: "modal" }),
+    });
+
+    expect(isNativeDesktopSession(proxy as never)).toBe(false);
+    expect(typeof proxy.desktopInput).toBe("undefined");
+    expect(typeof proxy.screenshot).toBe("undefined");
+  });
+
+  test("mid-turn cross-kind swap: default native, pointer swaps to a NON-native backend → screenshot() rejects RoutingUnsupportedError", async () => {
+    // The proxy exposes the native surface (default backend was native), but a
+    // mid-turn swap repoints to a Modal box with no screenshot. Rather than silently
+    // shelling Linux tools onto a Mac (or crashing opaquely), dispatch surfaces a
+    // legible RoutingUnsupportedError the caller can report as a tool failure.
+    const native = new NativeFakeBackend("selfhosted");
+    const modal = new FakeBackend("modal");
+    const ptr = mutablePointer({ activeSandboxId: "sbx-self", activeEpoch: 1 });
+    const proxy = new RoutingSandboxSession({
+      defaultResolved: { session: native, sandboxId: "sbx-self", kind: "selfhosted" },
+      readPointer: ptr.read,
+      resolveActiveBackend: async (pointer): Promise<ResolvedActiveBackend> =>
+        pointer.activeSandboxId === "sbx-self"
+          ? { session: native, sandboxId: "sbx-self", kind: "selfhosted" }
+          : { session: modal, sandboxId: pointer.activeSandboxId, kind: "modal" },
+    });
+
+    // Native surface is present (minted from the native default).
+    expect(typeof proxy.screenshot).toBe("function");
+    // First screenshot lands on the native backend.
+    await proxy.screenshot!();
+    expect(native.screenshots).toBe(1);
+
+    // Swap to the non-native Modal box (epoch bump) → the NEXT screenshot rejects.
+    ptr.swap("sbx-modal");
+    await expect(proxy.screenshot!()).rejects.toBeInstanceOf(RoutingUnsupportedError);
+  });
+
+  test("screenshot return value passes through unchanged ({png,width,height})", async () => {
+    const native = new NativeFakeBackend("selfhosted");
+    const ptr = mutablePointer({ activeSandboxId: "sbx-self", activeEpoch: 1 });
+    const proxy = new RoutingSandboxSession({
+      defaultResolved: { session: native, sandboxId: "sbx-self", kind: "selfhosted" },
+      readPointer: ptr.read,
+      resolveActiveBackend: async () => ({ session: native, sandboxId: "sbx-self", kind: "selfhosted" }),
+    });
+
+    const shot = await proxy.screenshot!();
+    expect(shot.png).toBe(native.frame.png);
+    expect(shot.width).toBe(1440);
+    expect(shot.height).toBe(900);
   });
 });


### PR DESCRIPTION
A machine-primary session (sandbox_backend=selfhosted, active sandbox = a real machine) runs its sandbox ops through `RoutingSandboxSession`, the per-op re-resolving proxy that enables mid-turn machine swaps. The computer-use capability picks its `Computer` implementation via `isNativeDesktopSession`, which duck-types on `desktopInput`/`screenshot` being present. `SelfhostedSession` has those methods — but the proxy didn't forward them, so the duck-type failed and the capability bound the Linux `SandboxComputer`, shelling `scrot`/`xdotool` over exec onto the user's real machine (exit 127 → empty screenshots → the wire backstop fed the model 1×1 placeholder pixels).

Observed live on staging: worker logs full of `ComputerActionError: computer action failed (127): scrot ...` on a macOS Connected Machine session, and every persisted `computer_call_result` carrying `output.data: ""`.

**Fix**: forward the native surface conditionally.
- `RoutableBackendSession` gains optional `desktopInput`/`screenshot` (superset-by-optionality).
- `RoutingSandboxSession` mints them as per-instance properties only when the construction-time default backend is itself native-capable. Presence is the selection signal `isNativeDesktopSession` reads, so unconditional prototype methods would misclassify Modal-fronting proxies as native. Each dispatches to the active backend; a mid-turn cross-kind swap onto a backend lacking the op throws `RoutingUnsupportedError` — a legible tool failure instead of a silent Linux-tool shell onto a Mac.
- Worker wiring already seeds `defaultResolved` unconditionally (`apps/worker/src/sandbox-routing.ts:161`), and the machine-primary path passes the live `SelfhostedSession` there — no wiring change needed.

**Tests**: native default → duck-types native + dispatches with args; Modal default → does not (regression guard); mid-turn swap to non-native → `RoutingUnsupportedError`; screenshot frame passthrough. `tsc` clean, `bun test packages/runtime` 487 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches computer-use backend selection and mid-turn routing for native desktop ops; behavior is guarded by conditional surface exposure and new tests, but wrong classification would still break real-machine sessions.
> 
> **Overview**
> Machine-primary turns route sandbox ops through **`RoutingSandboxSession`**, but the proxy did not expose **`desktopInput`** / **`screenshot`**, so **`isNativeDesktopSession`** failed and computer-use fell back to Linux **`scrot`/`xdotool` over `exec`** on real Mac sessions.
> 
> **`RoutableBackendSession`** gains optional native desktop ops. **`RoutingSandboxSession`** adds them only as **per-instance** properties when the construction-time default backend already implements both—so Modal-fronting proxies are not misclassified as native. Calls dispatch to the active backend; a mid-turn swap to a backend without those ops throws **`RoutingUnsupportedError`**.
> 
> Tests cover native dispatch, Modal absence (regression), cross-kind swap failure, and screenshot frame passthrough via the real **`isNativeDesktopSession`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5fb8cc0741fb34d18cb5f6616d60aaba2a84da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->