### PR TITLE
fix(sandbox): derive sandbox_os from the targeted machine's enrollment OS

### DIFF
--- a/apps/api/src/domain/sessions.ts
+++ b/apps/api/src/domain/sessions.ts
@@ -20,6 +20,7 @@ import {
   createSessionWithIdempotencyKey,
   enqueueSessionTurn,
   getAnySessionInGroup,
+  getEnrollment,
   listDistinctEnvironmentIdsInGroup,
   getSandbox,
   getSession,
@@ -80,6 +81,11 @@ export async function createAndStartSession(input: {
   // omitted ⇒ a singleton group (the new row's own id, today's 1:1 behavior); a
   // shared/{groupId} spawn passes the resolved group so both run in ONE box.
   sandboxGroupId?: string | null;
+  // The OS axis of the session's box (sessions.sandbox_os). Omitted ⇒ the
+  // "linux" default; set only for a machine-targeted top-level create, where the
+  // targeted machine's enrollment OS is threaded in so the row + resume path +
+  // OS-labeling surfaces honestly reflect the machine.
+  sandboxOs?: Session["sandboxOs"];
   // Create-time machine targeting (A-2a, RACE-FREE): the enrolled machine (a
   // sandbox id) to run this session on. When set, the active-sandbox pointer is
   // resolved+validated+seeded (epoch-fenced) INSIDE finishStartSession, AFTER the
@@ -120,6 +126,7 @@ export async function createAndStartSession(input: {
       parentSessionId: input.parentSessionId ?? null,
       createIdempotencyKey: input.createIdempotencyKey,
       sandboxGroupId: input.sandboxGroupId ?? null,
+      ...(input.sandboxOs ? { sandboxOs: input.sandboxOs } : {}),
     });
     if (!created) {
       return keyed;
@@ -139,6 +146,7 @@ export async function createAndStartSession(input: {
     firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
     parentSessionId: input.parentSessionId ?? null,
     sandboxGroupId: input.sandboxGroupId ?? null,
+    ...(input.sandboxOs ? { sandboxOs: input.sandboxOs } : {}),
   });
   return await finishStartSession(input, session);
 }
@@ -609,7 +617,16 @@ export async function createSessionForRequest(
   // worker ignores the active pointer and a home="selfhosted" turn would fall to
   // the registry client with no bound agentId and throw; with the flags off we
   // keep the cloud default and the machine layers as a (pre-honest-label) overlay.
+  // sandbox_os (the OS axis the worker's group-box resume + the OS-labeling
+  // surfaces key off) must ALSO reflect the targeted machine, not the "linux"
+  // schema default — a session run on a macOS Connected Machine that labels
+  // itself linux lies to those surfaces. Derived under the SAME guards as the
+  // backend relabel; the enrollment (joined via the sandbox's enrollmentId)
+  // carries the OS. enrollmentOsValues and the sessions.sandbox_os value set are
+  // both ("linux","macos","windows"), so a known value maps 1:1; any other value
+  // is left to the "linux" default (never write a value no reader understands).
   let machineHomeBackend: Session["sandboxBackend"] | undefined;
+  let machineHomeOs: Session["sandboxOs"] | undefined;
   if (
     payload.targetSandboxId
     && inheritedBackend === undefined
@@ -619,6 +636,12 @@ export async function createSessionForRequest(
     const targetSandbox = await getSandbox(db, workspaceId, payload.targetSandboxId);
     if (targetSandbox?.kind === "selfhosted") {
       machineHomeBackend = "selfhosted";
+      if (targetSandbox.enrollmentId) {
+        const enrollment = await getEnrollment(db, workspaceId, targetSandbox.enrollmentId);
+        if (enrollment && (enrollment.os === "macos" || enrollment.os === "windows" || enrollment.os === "linux")) {
+          machineHomeOs = enrollment.os;
+        }
+      }
     }
   }
   await requireLimit(deps, { accountId: grant.accountId, workspaceId, action: "agent_run:create", quantity: 1, model });
@@ -640,6 +663,10 @@ export async function createSessionForRequest(
     // (machineHomeBackend), overriding the caller/deployment default so the row
     // matches where the session actually runs.
     sandboxBackend: inheritedBackend ?? machineHomeBackend ?? payload.sandboxBackend ?? settings.sandboxBackend,
+    // Mirror the backend relabel on the OS axis: only a machine-targeted
+    // top-level create carries a derived OS; everything else is omitted and the
+    // "linux" default holds (shared spawns keep the parent-box behavior).
+    ...(machineHomeOs ? { sandboxOs: machineHomeOs } : {}),
     sandboxGroupId,
     metadata: payload.metadata,
     environment: environment ? { id: environment.id, name: environment.name } : null,

--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -10,6 +10,9 @@
 //   - a machine-targeted top-level create ⇒ home + first turn sandbox_backend
 //     "selfhosted" (the honest label), overriding the "modal" deployment default.
 //   - a normal top-level create ⇒ unchanged (the "modal" deployment default).
+//   - sandbox_os is derived from the targeted machine's enrollment OS on the SAME
+//     guards: a macOS machine target ⇒ 'macos', a linux machine target ⇒ 'linux',
+//     and a flags-off create leaves the "linux" default (worker ignores the pointer).
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import postgres from "postgres";
@@ -70,7 +73,7 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 
 /** Seed an enrolled, online selfhosted machine (+ its sandbox record) in a fresh
  *  workspace, and return the id + a bus whose responder makes it probe online. */
-async function seedMachine(): Promise<{ accountId: string; workspaceId: string; sandboxId: string; bus: MemoryEventBus }> {
+async function seedMachine(os: "linux" | "macos" | "windows" = "linux"): Promise<{ accountId: string; workspaceId: string; sandboxId: string; bus: MemoryEventBus }> {
   const { accountId, workspaceId } = await freshWorkspace();
   const enrollment = await createEnrollment(db, {
     accountId,
@@ -79,7 +82,7 @@ async function seedMachine(): Promise<{ accountId: string; workspaceId: string; 
     exposure: "whole-machine",
     hasDisplay: true,
     allowScreenControl: true,
-    os: "linux",
+    os,
     arch: "x86_64",
   });
   // Recent lastSeenAt so a probe-miss would be "reconnecting"; the online responder
@@ -109,9 +112,9 @@ function stubWorkflowClient(): SessionWorkflowClient {
   } as unknown as SessionWorkflowClient;
 }
 
-function deps(bus: MemoryEventBus): ApiRouteDeps {
+function deps(bus: MemoryEventBus, settingsOverride?: typeof settings): ApiRouteDeps {
   return {
-    settings,
+    settings: settingsOverride ?? settings,
     db,
     bus,
     workflowClient: stubWorkflowClient(),
@@ -164,10 +167,50 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     });
     // The home is labeled honestly — the machine, not the "modal" deployment default.
     expect(session.sandboxBackend).toBe("selfhosted");
+    // A linux machine ⇒ sandbox_os 'linux' (matches the schema default here, but
+    // it is now DERIVED from the enrollment, not the column default).
+    expect(session.sandboxOs).toBe("linux");
     // The first turn inherits the same home backend (label is consistent end-to-end).
     const [turnRow] = await admin<{ sandbox_backend: string }[]>`
       select sandbox_backend from session_turns where session_id = ${session.id} limit 1`;
     expect(turnRow?.sandbox_backend).toBe("selfhosted");
+  }, 60_000);
+
+  test("a macOS machine target ⇒ home sandbox_os 'macos' (derived from the enrollment)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, sandboxId, bus } = await seedMachine("macos");
+    const session = await createSessionForRequest(deps(bus), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "run this on my mac",
+      targetSandboxId: sandboxId,
+    });
+    // The OS axis reflects the targeted machine — NOT the 'linux' schema default.
+    expect(session.sandboxBackend).toBe("selfhosted");
+    expect(session.sandboxOs).toBe("macos");
+    const [row] = await admin<{ sandbox_os: string }[]>`
+      select sandbox_os from sessions where id = ${session.id} limit 1`;
+    expect(row?.sandbox_os).toBe("macos");
+  }, 60_000);
+
+  test("flags off ⇒ machine target leaves the default sandbox_os 'linux' + backend", async () => {
+    if (!available) return;
+    // A macOS machine target, but ownership/selfhosted routing OFF: the worker
+    // ignores the pointer, so the honest-label derivation must NOT fire — the row
+    // keeps the deployment backend and the 'linux' default (mirrors the backend guard).
+    const flagsOff = testSettings({
+      productAccessMode: "managed",
+      sandboxBackend: "modal",
+      sandboxOwnershipEnabled: false,
+      sandboxSelfhostedEnabled: false,
+      selfhostedRelayUrl: "wss://relay.example",
+      publicBaseUrl: "https://app.example",
+    });
+    const { accountId, workspaceId, sandboxId, bus } = await seedMachine("macos");
+    const session = await createSessionForRequest(deps(bus, flagsOff), grant(accountId, workspaceId), workspaceId, {
+      initialMessage: "run this on my mac (flags off)",
+      targetSandboxId: sandboxId,
+    });
+    expect(session.sandboxBackend).toBe("modal");
+    expect(session.sandboxOs).toBe("linux");
   }, 60_000);
 
   test("a normal top-level create (no machine target) ⇒ unchanged deployment default", async () => {


### PR DESCRIPTION
A top-level session targeted at a macOS Connected Machine got `sandbox_os='linux'` (the schema default): the honest-label block relabeled `sandbox_backend` to `selfhosted` but never derived the OS, so the session row lied to the worker's group-box resume path and every OS-labeling surface (channel-a, viewer, sessions route). Observed live on staging.

Under the same guards as the backend relabel (targetSandboxId + top-level create + ownership/selfhosted flags on + target kind `selfhosted`), read the machine's enrollment OS (the OS lives on the enrollment, not the sandbox row) and thread it into `createAndStartSession`'s new optional `sandboxOs`. Enrollment OS and `sessions.sandbox_os` share the exact value set (`linux|macos|windows`) so known values map 1:1; anything else falls through to the default via an explicit allow-set guard. Non-targeted creates, shared spawns, modal targets, and flag-off deployments are untouched.

Tests: macOS target → `macos` (returned session + DB row), linux target → `linux`, flags-off → defaults. Typecheck clean (apps/api + packages/db); machine-home-backend suite 4/4, viewer regression suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session create labeling and persistence for machine-targeted runs (worker resume and OS surfaces), but scope is narrow and gated on existing feature flags with no change to unrelated create paths.
> 
> **Overview**
> Machine-targeted top-level session creates already relabeled **`sandbox_backend`** to `selfhosted`, but **`sandbox_os`** stayed at the schema default (`linux`), so macOS Connected Machine runs were mislabeled for the worker resume path and OS-labeling UI.
> 
> This change mirrors the existing honest-label guards: when `targetSandboxId` points at a selfhosted sandbox and ownership/selfhosted routing flags are on, it loads the target’s enrollment via **`getEnrollment`** and threads an optional **`sandboxOs`** into **`createAndStartSession`** / session insert (linux|macos|windows only; otherwise the default). Shared spawns, non-targeted creates, and flag-off deployments are unchanged.
> 
> Integration tests in **`machine-home-backend.test.ts`** now cover macOS → `macos`, linux enrollment derivation, and flags-off leaving `modal` + default OS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c5d4ff5b48c559c15baaffde73cc809425f35b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->