### PR TITLE
fix(computer-use): compact structured image tool output in agent.toolCall.output events

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2066,6 +2066,86 @@ function ensureManifest(manifest: Manifest | { root?: string; entries?: Record<s
   });
 }
 
+/** Coerce the various binary shapes a tool-output image `data` field can take into
+ *  a Uint8Array. Handles a live `Uint8Array`, a plain number[] , and the
+ *  object-of-numbers (`{"0":137,"1":80,…}`) that a `Uint8Array` degrades into after
+ *  a JSON round-trip — the exact 10x-bloat shape this normalizer exists to kill. */
+function toImageBytes(data: unknown): Uint8Array | null {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return data.every((n) => typeof n === "number") ? Uint8Array.from(data as number[]) : null;
+  }
+  if (data && typeof data === "object") {
+    const values = Object.values(data as Record<string, unknown>);
+    if (values.length > 0 && values.every((n) => typeof n === "number")) {
+      return Uint8Array.from(values as number[]);
+    }
+  }
+  return null;
+}
+
+/** Compact a structured image tool output — the SDK's `{type:'image', image:{data,mediaType}}`
+ *  shape (produced by the codex-path `computer_screenshot` function tool) OR the already-
+ *  normalized protocol `{type:'input_image', image:'data:…'}` item — into a `data:<mt>;base64,…`
+ *  string. Returns null when `value` is not an image output. */
+function structuredImageToDataUrl(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const v = value as { type?: unknown; image?: unknown };
+  if (v.type === "input_image") {
+    // Protocol item: `image` is already a `data:…` (or plain URL) string.
+    return typeof v.image === "string" && v.image.length > 0 ? v.image : null;
+  }
+  if (v.type !== "image" || !v.image || typeof v.image !== "object") {
+    return null;
+  }
+  const image = v.image as { data?: unknown; mediaType?: unknown; url?: unknown };
+  if (typeof image.url === "string" && image.url.length > 0) {
+    return image.url;
+  }
+  const mediaType = typeof image.mediaType === "string" && image.mediaType.length > 0 ? image.mediaType : "image/png";
+  if (typeof image.data === "string") {
+    return image.data.startsWith("data:") ? image.data : `data:${mediaType};base64,${image.data}`;
+  }
+  const bytes = toImageBytes(image.data);
+  return bytes ? `data:${mediaType};base64,${Buffer.from(bytes).toString("base64")}` : null;
+}
+
+/**
+ * Compact a tool-call output for the `agent.toolCall.output` SESSION EVENT so it
+ * never carries a raw binary payload. The codex-path `computer_screenshot` function
+ * tool returns a structured `{type:'image', image:{data: Uint8Array, mediaType}}`;
+ * captured verbatim its `Uint8Array` JSON-serializes as an object-of-numbers (~12.7MB
+ * per screenshot in session_events — ~10x the base64 form). This mirrors the desktop
+ * screenshot to the SAME compact `data:<mediaType>;base64,…` STRING the HOSTED
+ * `computer_call` event already carries (agents-core sets its output to that data-URL),
+ * so both computer-use transports emit one representation. The full data-URL is kept
+ * (not truncated) because the web timeline RENDERS the screenshot from this event
+ * payload — packages/react/src/timeline/tool-renderers.tsx ComputerCallRenderer
+ * (`out.startsWith("data:image")` → <ScreenshotFigure src={out}/>) and ViewImageRenderer.
+ * Non-image outputs (text strings, MCP `{isError,content}` objects, hosted computer_call
+ * data-URL strings) pass through unchanged.
+ */
+export function normalizeToolOutputForEvent(output: unknown): unknown {
+  const single = structuredImageToDataUrl(output);
+  if (single !== null) {
+    return single;
+  }
+  if (Array.isArray(output)) {
+    const normalized = output.map((el) => structuredImageToDataUrl(el) ?? el);
+    // A lone image content item unwraps to the bare data-URL string the timeline
+    // image renderers expect; a mixed/multi array keeps its (now-compact) shape.
+    if (normalized.length === 1 && typeof normalized[0] === "string") {
+      return normalized[0];
+    }
+    return normalized;
+  }
+  return output;
+}
+
 export function normalizeSdkEvent(event: RunStreamEvent): NormalizedRuntimeEvent[] {
   const out: NormalizedRuntimeEvent[] = [];
   if (event.type === "raw_model_stream_event") {
@@ -2109,7 +2189,9 @@ export function normalizeSdkEvent(event: RunStreamEvent): NormalizedRuntimeEvent
       type: "agent.toolCall.output",
       payload: {
         id: item.rawItem?.callId ?? item.id ?? null,
-        output: item.output,
+        // Compact any structured/binary image output to a data-URL string so a
+        // screenshot never bloats session_events ~10x as an object-of-numbers.
+        output: normalizeToolOutputForEvent(item.output),
       },
     });
   } else if (item.type === "tool_search_call_item") {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -173,6 +173,87 @@ describe("runtime event normalization", () => {
 
     expect(event?.type).toBe("agent.toolCall.created");
     expect((event?.payload as { id: string }).id).toBe("call-1");
+  });
+
+  test("compacts a codex computer_screenshot Uint8Array output to a data-URL string in the event", () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const [event] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: {
+        id: "item-shot",
+        type: "tool_call_output_item",
+        rawItem: { callId: "call-shot", type: "function_call_result" },
+        output: { type: "image", image: { data: pngBytes, mediaType: "image/png" } },
+      },
+    } as any);
+
+    expect(event?.type).toBe("agent.toolCall.output");
+    const payload = event?.payload as { id: string; output: unknown };
+    expect(payload.id).toBe("call-shot");
+    expect(payload.output).toBe(`data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`);
+    // No raw typed-array / object-of-numbers survives into the serialized event.
+    expect(JSON.stringify(event)).not.toContain('"0":137');
+  });
+
+  describe("normalizeToolOutputForEvent", () => {
+    test("Uint8Array structured image → data-URL string", () => {
+      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+      expect(normalizeToolOutputForEvent({ type: "image", image: { data: bytes, mediaType: "image/png" } })).toBe(
+        `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`,
+      );
+    });
+
+    test("object-of-numbers (JSON-round-tripped Uint8Array) → data-URL string", () => {
+      const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+      const roundTripped = JSON.parse(JSON.stringify({ type: "image", image: { data: bytes, mediaType: "image/jpeg" } }));
+      expect(normalizeToolOutputForEvent(roundTripped)).toBe(
+        `data:image/jpeg;base64,${Buffer.from(bytes).toString("base64")}`,
+      );
+    });
+
+    test("defaults media type to image/png when absent", () => {
+      const bytes = new Uint8Array([1, 2, 3]);
+      expect(normalizeToolOutputForEvent({ type: "image", image: { data: bytes } })).toBe(
+        `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`,
+      );
+    });
+
+    test("base64 string / data-URL image data pass through as a data-URL", () => {
+      expect(normalizeToolOutputForEvent({ type: "image", image: { data: "aGk=", mediaType: "image/webp" } })).toBe(
+        "data:image/webp;base64,aGk=",
+      );
+      expect(normalizeToolOutputForEvent({ type: "image", image: { data: "data:image/png;base64,aGk=" } })).toBe(
+        "data:image/png;base64,aGk=",
+      );
+    });
+
+    test("already-normalized input_image content item → its data-URL", () => {
+      expect(normalizeToolOutputForEvent({ type: "input_image", image: "data:image/png;base64,aGk=" })).toBe(
+        "data:image/png;base64,aGk=",
+      );
+    });
+
+    test("a single-image array unwraps to the bare data-URL string", () => {
+      const bytes = new Uint8Array([0x47, 0x49, 0x46, 0x38]);
+      expect(normalizeToolOutputForEvent([{ type: "image", image: { data: bytes, mediaType: "image/gif" } }])).toBe(
+        `data:image/gif;base64,${Buffer.from(bytes).toString("base64")}`,
+      );
+    });
+
+    test("text outputs pass through unchanged", () => {
+      expect(normalizeToolOutputForEvent("plain tool output")).toBe("plain tool output");
+      expect(normalizeToolOutputForEvent("data:image/png;base64,aGk=")).toBe("data:image/png;base64,aGk=");
+    });
+
+    test("hosted computer_call data-URL string output is unchanged", () => {
+      const hosted = "data:image/png;base64,iVBORw0KGgo=";
+      expect(normalizeToolOutputForEvent(hosted)).toBe(hosted);
+    });
+
+    test("MCP isError object output is unchanged", () => {
+      const mcp = { isError: true, content: [{ type: "text", text: "delivery failed" }] };
+      expect(normalizeToolOutputForEvent(mcp)).toEqual(mcp);
+    });
   });
 
   test("uses normal Azure CLI service principal login hook", () => {


### PR DESCRIPTION
The codex-path `computer_screenshot` function tool returns a structured `{type:'image', image:{data: Uint8Array}}` (#184). The model/history path normalizes that to a compact `input_image` data-URL before persistence — but the `agent.toolCall.output` session event captured the raw return, so the `Uint8Array` JSON-serialized as an object-of-numbers: measured **12.7MB per screenshot** in `session_events` on staging (~10× the base64 form), bloating the DB and the timeline fetch path.

Fix at the event seam (`normalizeSdkEvent`, `tool_call_output_item` branch): fold structured image outputs to the same `data:<mediaType>;base64,…` string the hosted `computer_call` event already carries — one representation across both computer-use transports. The full data-URL is kept (not truncated) because the web timeline renders the screenshot from this payload (`ComputerCallRenderer`/`ViewImageRenderer`, `out.startsWith("data:image")`) — which means codex-path screenshots now also render in the timeline. Handles `Uint8Array`, `number[]`, the JSON-round-tripped object-of-numbers, already-normalized `input_image` items, and single-image arrays; text, MCP objects, and hosted data-URLs pass through unchanged. Model/history path untouched.

Tests: 9-case normalizer suite + an event-integration test; `tsc` clean; `bun test packages/runtime` 497 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to session-event serialization for tool outputs; non-image payloads are unchanged and behavior is covered by new unit tests.
> 
> **Overview**
> **`agent.toolCall.output` session events** no longer persist codex-path `computer_screenshot` results as raw `{type:'image', image:{data: Uint8Array}}` payloads. A new **`normalizeToolOutputForEvent`** helper (with **`toImageBytes`** / **`structuredImageToDataUrl`**) folds those shapes—and JSON-round-tripped object-of-numbers—into a single **`data:<mediaType>;base64,…`** string, matching hosted `computer_call` events and avoiding ~10× `session_events` bloat.
> 
> **`normalizeSdkEvent`** applies that normalizer on the **`tool_call_output_item`** branch only; text, MCP objects, and existing data-URL strings pass through. Single-image arrays unwrap to the bare string the timeline expects (`ComputerCallRenderer` / `ViewImageRenderer`).
> 
> Tests add an integration case through **`normalizeSdkEvent`** plus a nine-case **`normalizeToolOutputForEvent`** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8921aafd7c195fa4296757b89ff8d4b1caf7b363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->