### PR TITLE
feat(react): fold the entire settled turn behind one chip — narration included

### DIFF
--- a/.changeset/timeline-turn-group.md
+++ b/.changeset/timeline-turn-group.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Settled turns now collapse the entire turn span behind one summary chip, leaving only the final agent message visible until expanded. Expanding the chip reveals mid-turn narration and nested per-cluster activity summaries.

--- a/packages/react/demo/timeline-fixtures.ts
+++ b/packages/react/demo/timeline-fixtures.ts
@@ -544,6 +544,8 @@ export function completedTurnEvents(): SessionEvent[] {
     },
     turn,
   );
+  log.push("agent.message.delta", { text: "Dependencies are installed; I found one helper import missing in the test setup." }, turn);
+  log.push("agent.message.completed", { text: "Dependencies are installed; I found one helper import missing in the test setup." }, turn);
   log.tool(
     {
       name: "apply_patch_call",
@@ -560,6 +562,8 @@ export function completedTurnEvents(): SessionEvent[] {
     },
     turn,
   );
+  log.push("agent.message.delta", { text: "The helper is patched. I am rerunning the suite before taking the dashboard screenshot." }, turn);
+  log.push("agent.message.completed", { text: "The helper is patched. I am rerunning the suite before taking the dashboard screenshot." }, turn);
   log.tool(
     {
       name: "exec_command",
@@ -573,10 +577,10 @@ export function completedTurnEvents(): SessionEvent[] {
     { name: "computer_call", id: "td-3", raw: { type: "computer_call", action: { type: "screenshot" } }, output: SHOT_DASH },
     turn,
   );
-  log.push("turn.completed", {}, turn);
   log.push("agent.message.completed", {
     text: "Done. The suite is green (128/128) after patching the missing fixture import in `test-helpers.ts`, and here is the dashboard once it built. Want me to wire up CI next?",
   }, turn);
+  log.push("turn.completed", {}, turn);
   return log.events;
 }
 
@@ -584,6 +588,8 @@ export function failedTurnEvents(): SessionEvent[] {
   const log = new EventLog();
   const turn = "turn-fail";
   log.push("user.message", { text: "Deploy the preview to staging." });
+  log.push("agent.message.delta", { text: "I am applying the chart and watching the rollout until Kubernetes reports readiness." }, turn);
+  log.push("agent.message.completed", { text: "I am applying the chart and watching the rollout until Kubernetes reports readiness." }, turn);
   log.tool(
     {
       name: "exec_command",

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -8,6 +8,9 @@ import {
   LightboxProvider,
   MessageTimeline,
   TimelineRow,
+  TurnSummary,
+  type ActivityItem,
+  type TimelineGroup,
 } from "../src/index";
 import {
   cancelledTurnEvents,
@@ -129,12 +132,12 @@ function Harness() {
 
             <Section
               title="Completed turn — folded to a summary chip"
-              hint="A settled turn folds behind one quiet chip. Click to expand."
+              hint="Prompt bubble → one turn chip → final answer; expand for narration and nested tool clusters."
             >
               <MessageTimeline events={completedTurnEvents()} className="max-h-none" />
             </Section>
 
-            <Section title="Failed turn — folds, but the error is never hidden">
+            <Section title="Failed turn — folds, but the error is never hidden" hint="Failed turns start open so the error and folded context stay visible.">
               <MessageTimeline events={failedTurnEvents()} className="max-h-none" />
             </Section>
 
@@ -168,15 +171,76 @@ function RawRail({ events }: { events: ReturnType<typeof tourEvents> }) {
   const groups = useMemo(() => groupTimeline(buildTimeline(events)), [events]);
   return (
     <div className="flex flex-col gap-4">
-      {groups.map((group) =>
-        group.kind === "activity" ? (
-          <ActivityRail key={group.id} items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} />
-        ) : (
-          <TimelineRow key={group.item.id} item={group.item} />
-        ),
-      )}
+      {groups.map((group) => (
+        <RawGroup key={rawGroupKey(group)} group={group} />
+      ))}
     </div>
   );
+}
+
+function RawGroup({ group }: { group: TimelineGroup }) {
+  switch (group.kind) {
+    case "activity":
+      return group.outcome ? (
+        <TurnSummary
+          items={group.items}
+          outcome={group.outcome}
+          failureText={group.failureText}
+          defaultOpen={group.outcome === "failed" ? true : undefined}
+        >
+          <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} />
+        </TurnSummary>
+      ) : (
+        <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} />
+      );
+    case "turn":
+      return (
+        <TurnSummary
+          items={flattenActivities(group.groups)}
+          outcome={group.outcome}
+          failureText={group.failureText}
+          durationMs={durationBetween(group.startedAt, group.endedAt)}
+          defaultOpen={group.outcome === "failed" ? true : undefined}
+        >
+          <div className="flex flex-col gap-4">
+            {group.groups.map((child) => (
+              <RawGroup key={rawGroupKey(child)} group={child} />
+            ))}
+          </div>
+        </TurnSummary>
+      );
+    case "item":
+      return <TimelineRow item={group.item} />;
+  }
+}
+
+function rawGroupKey(group: TimelineGroup): string {
+  switch (group.kind) {
+    case "activity":
+      return group.id;
+    case "turn":
+      return group.id;
+    case "item":
+      return group.item.id;
+  }
+}
+
+function flattenActivities(groups: TimelineGroup[]): ActivityItem[] {
+  const items: ActivityItem[] = [];
+  for (const group of groups) {
+    if (group.kind === "activity") {
+      items.push(...group.items);
+    } else if (group.kind === "turn") {
+      items.push(...flattenActivities(group.groups));
+    }
+  }
+  return items;
+}
+
+function durationBetween(startedAt: string, endedAt: string): number | undefined {
+  const started = Date.parse(startedAt);
+  const ended = Date.parse(endedAt);
+  return Number.isFinite(started) && Number.isFinite(ended) && ended >= started ? ended - started : undefined;
 }
 
 createRoot(document.getElementById("root")!).render(<Harness />);

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -159,11 +159,16 @@ function TimelineGroupView({
   renderMessageText,
   onOpenSession,
   toolRegistry,
+  insideTurn = false,
 }: {
   group: TimelineGroup;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
   toolRegistry: ToolRegistry;
+  /** Rendering inside an expanded turn group: the outer chip already owns the
+      failure surface, so nested chips stay tinted but quiet (no repeated
+      failure text, no auto-open) — one loud error, N calm sub-expands. */
+  insideTurn?: boolean;
 }) {
   switch (group.kind) {
     case "activity":
@@ -171,8 +176,8 @@ function TimelineGroupView({
         <TurnSummary
           items={group.items}
           outcome={group.outcome}
-          failureText={group.failureText}
-          defaultOpen={group.outcome === "failed" ? true : undefined}
+          failureText={insideTurn ? undefined : group.failureText}
+          defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
         >
           <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
         </TurnSummary>
@@ -189,7 +194,9 @@ function TimelineGroupView({
           durationMs={durationBetween(group.startedAt, group.endedAt)}
           defaultOpen={group.outcome === "failed" ? true : undefined}
         >
-          <div className="flex flex-col gap-4">
+          {/* The body wears the timeline's rail language (matching ActivityRail)
+              so nested chips read as contained by the turn, not as siblings. */}
+          <div className="flex flex-col gap-4 border-l-2 border-og-border pl-3 sm:pl-4">
             {group.groups.map((child) => (
               <TimelineGroupView
                 key={timelineGroupKey(child)}
@@ -197,6 +204,7 @@ function TimelineGroupView({
                 renderMessageText={renderMessageText}
                 onOpenSession={onOpenSession}
                 toolRegistry={toolRegistry}
+                insideTurn
               />
             ))}
           </div>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -21,9 +21,11 @@ import {
   defaultToolRegistry,
   groupTimeline,
   LightboxProvider,
+  type ActivityItem,
   type AgentMessageItem,
   type GoalItem,
   type NoticeItem,
+  type TimelineGroup,
   type TimelineItem,
   type ToolRegistry,
   type UserMessageItem,
@@ -104,25 +106,15 @@ export function MessageTimeline({
           {groups.length === 0 && !working
             ? (emptyState ?? <p className="py-10 text-center text-sm text-og-fg-subtle">No activity yet.</p>)
             : null}
-          {groups.map((group) =>
-            group.kind === "activity" ? (
-              group.outcome ? (
-                <TurnSummary
-                  key={group.id}
-                  items={group.items}
-                  outcome={group.outcome}
-                  failureText={group.failureText}
-                  defaultOpen={group.outcome === "failed" ? true : undefined}
-                >
-                  <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
-                </TurnSummary>
-              ) : (
-                <ActivityRail key={group.id} items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
-              )
-            ) : (
-              <TimelineRow key={group.item.id} item={group.item} renderMessageText={renderMessageText} />
-            ),
-          )}
+          {groups.map((group) => (
+            <TimelineGroupView
+              key={timelineGroupKey(group)}
+              group={group}
+              renderMessageText={renderMessageText}
+              onOpenSession={onOpenSession}
+              toolRegistry={toolRegistry}
+            />
+          ))}
           {working ? (
             <div className="animate-og-enter flex items-center gap-2 text-sm">
               <span className="og-shimmer-text font-medium">Working…</span>
@@ -160,6 +152,92 @@ export function MessageTimeline({
     </div>
     </LightboxProvider>
   );
+}
+
+function TimelineGroupView({
+  group,
+  renderMessageText,
+  onOpenSession,
+  toolRegistry,
+}: {
+  group: TimelineGroup;
+  renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
+  onOpenSession?: ((sessionId: string) => void) | undefined;
+  toolRegistry: ToolRegistry;
+}) {
+  switch (group.kind) {
+    case "activity":
+      return group.outcome ? (
+        <TurnSummary
+          items={group.items}
+          outcome={group.outcome}
+          failureText={group.failureText}
+          defaultOpen={group.outcome === "failed" ? true : undefined}
+        >
+          <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
+        </TurnSummary>
+      ) : (
+        <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
+      );
+    case "turn": {
+      const activityItems = flattenActivityItems(group.groups);
+      return (
+        <TurnSummary
+          items={activityItems}
+          outcome={group.outcome}
+          failureText={group.failureText}
+          durationMs={durationBetween(group.startedAt, group.endedAt)}
+          defaultOpen={group.outcome === "failed" ? true : undefined}
+        >
+          <div className="flex flex-col gap-4">
+            {group.groups.map((child) => (
+              <TimelineGroupView
+                key={timelineGroupKey(child)}
+                group={child}
+                renderMessageText={renderMessageText}
+                onOpenSession={onOpenSession}
+                toolRegistry={toolRegistry}
+              />
+            ))}
+          </div>
+        </TurnSummary>
+      );
+    }
+    case "item":
+      return <TimelineRow item={group.item} renderMessageText={renderMessageText} />;
+  }
+}
+
+function timelineGroupKey(group: TimelineGroup): string {
+  switch (group.kind) {
+    case "item":
+      return group.item.id;
+    case "activity":
+      return group.id;
+    case "turn":
+      return group.id;
+  }
+}
+
+function flattenActivityItems(groups: TimelineGroup[]): ActivityItem[] {
+  const items: ActivityItem[] = [];
+  for (const group of groups) {
+    if (group.kind === "activity") {
+      items.push(...group.items);
+    } else if (group.kind === "turn") {
+      items.push(...flattenActivityItems(group.groups));
+    }
+  }
+  return items;
+}
+
+function durationBetween(startedAt: string, endedAt: string): number | undefined {
+  const started = Date.parse(startedAt);
+  const ended = Date.parse(endedAt);
+  if (!Number.isFinite(started) || !Number.isFinite(ended) || ended < started) {
+    return undefined;
+  }
+  return ended - started;
 }
 
 /* --- single rows ------------------------------------------------------------ */

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -380,7 +380,8 @@ export function sessionStatusFromEvents(events: SessionEvent[]): SessionStatus |
 
 /* ----------------------------------------------------------------------------
    Visual grouping: consecutive activity items (reasoning / tools / workers /
-   sandbox) cluster into one collapsible block between chat messages.
+   sandbox) cluster into collapsible blocks. Once a turn settles, the full
+   non-user span folds behind a turn group, with activity blocks nested inside.
    -------------------------------------------------------------------------- */
 
 /**
@@ -414,6 +415,7 @@ export function groupTimeline(items: TimelineItem[]): TimelineGroup[] {
     }
     if (item.kind === "turn-end") {
       stampTurnOutcome(groups, item);
+      foldSettledTurn(groups, item);
       continue;
     }
     groups.push({ kind: "item", item });
@@ -476,6 +478,96 @@ function applyTurnOutcome(group: Extract<TimelineGroup, { kind: "activity" }>, t
   group.outcome = turnEnd.outcome;
   if (turnEnd.failureText) {
     group.failureText = turnEnd.failureText;
+  }
+}
+
+function foldSettledTurn(groups: TimelineGroup[], turnEnd: TurnEndItem): void {
+  let startIndex = groups.length;
+  let stoppedAtForeignTurn = false;
+  while (startIndex > 0) {
+    const previous = groups[startIndex - 1];
+    if (isTurnBoundary(previous)) {
+      break;
+    }
+    if (belongsToDifferentTurn(previous, turnEnd.turnId)) {
+      stoppedAtForeignTurn = true;
+      break;
+    }
+    startIndex -= 1;
+  }
+  if (stoppedAtForeignTurn) {
+    while (startIndex < groups.length && isBetweenTurnDivider(groups[startIndex])) {
+      startIndex += 1;
+    }
+  }
+
+  const collected = groups.slice(startIndex);
+  if (collected.length === 0) {
+    return;
+  }
+
+  const finalMessage = extractFinalAgentMessage(collected, turnEnd);
+  const body = finalMessage ? collected.slice(0, -1) : collected;
+  if (body.length === 0) {
+    return;
+  }
+
+  const firstOccurredAt = groupStartedAt(body[0]) ?? turnEnd.occurredAt;
+  const turnGroup: TimelineGroup = {
+    kind: "turn",
+    id: `turn-${turnEnd.turnId ?? turnEnd.id}`,
+    outcome: turnEnd.outcome,
+    startedAt: firstOccurredAt,
+    endedAt: turnEnd.occurredAt,
+    groups: body,
+  };
+  if (turnEnd.failureText) {
+    turnGroup.failureText = turnEnd.failureText;
+  }
+
+  groups.splice(startIndex, collected.length, ...(finalMessage ? [turnGroup, finalMessage] : [turnGroup]));
+}
+
+function isTurnBoundary(group: TimelineGroup | undefined): boolean {
+  return group?.kind === "turn" || (group?.kind === "item" && group.item.kind === "user-message");
+}
+
+function belongsToDifferentTurn(group: TimelineGroup | undefined, turnId: string | null): boolean {
+  if (!group || !turnId) {
+    return false;
+  }
+  if (group.kind === "activity") {
+    return group.items.length > 0 && group.items.every((item) => item.turnId !== null && item.turnId !== turnId);
+  }
+  return group.kind === "item" && group.item.kind === "agent-message" && group.item.turnId !== null && group.item.turnId !== turnId;
+}
+
+function isBetweenTurnDivider(group: TimelineGroup | undefined): boolean {
+  return group?.kind === "item" && group.item.kind === "session-status" && group.item.status !== "running";
+}
+
+function extractFinalAgentMessage(groups: TimelineGroup[], turnEnd: TurnEndItem): Extract<TimelineGroup, { kind: "item" }> | null {
+  const tail = groups[groups.length - 1];
+  if (tail?.kind !== "item" || tail.item.kind !== "agent-message" || tail.item.streaming) {
+    return null;
+  }
+  if (tail.item.turnId && turnEnd.turnId && tail.item.turnId !== turnEnd.turnId) {
+    return null;
+  }
+  return tail;
+}
+
+function groupStartedAt(group: TimelineGroup | undefined): string | undefined {
+  if (!group) {
+    return undefined;
+  }
+  switch (group.kind) {
+    case "item":
+      return group.item.occurredAt;
+    case "activity":
+      return group.items[0]?.occurredAt;
+    case "turn":
+      return group.startedAt;
   }
 }
 

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -11,10 +11,10 @@ export type { TurnOutcome } from "./types";
 /* ----------------------------------------------------------------------------
    Turn summary
 
-   A completed (or failed/cancelled) turn's activity folds behind one quiet
-   summary chip: "N steps · M files · K commands · 1 screenshot". The chip is the
-   default surface; expanding it reveals the full activity rail (the caller's
-   rendered rows). A live turn never folds — render its rows directly.
+   A completed (or failed/cancelled) turn folds behind one quiet summary chip:
+   "N steps · M files · K commands · 1 screenshot · 4m". The chip is the default
+   surface; expanding it reveals the full settled turn body. A live turn never
+   folds — render its rows directly.
 
    This keeps the timeline calm: a finished turn is a single line until the
    reader chooses to look inside it.
@@ -26,18 +26,20 @@ export type TurnSummaryProps = {
   outcome: TurnOutcome;
   /** A short failure reason shown inline on a failed chip (never hidden). */
   failureText?: string | undefined;
+  /** Elapsed turn duration; shown as a trailing facet when at least 1s. */
+  durationMs?: number | undefined;
   /** Start expanded. */
   defaultOpen?: boolean | undefined;
   /** The rendered activity rail revealed on expand. */
   children: React.ReactNode;
 };
 
-export function TurnSummary({ items, outcome, failureText, defaultOpen, children }: TurnSummaryProps) {
+export function TurnSummary({ items, outcome, failureText, durationMs, defaultOpen, children }: TurnSummaryProps) {
   // An explicit `defaultOpen` always wins; otherwise an ancestor may seed it
   // (screenshot instrumentation); otherwise the turn starts folded.
   const forcedDefaultOpen = useForcedDefaultOpen();
   const [open, setOpen] = useState(defaultOpen ?? forcedDefaultOpen ?? false);
-  const facets = summarizeTurn(items);
+  const facets = summarizeTurn(items, durationMs);
 
   return (
     <Collapsible.Root open={open} onOpenChange={setOpen} className="animate-og-enter">
@@ -91,7 +93,7 @@ export function TurnSummary({ items, outcome, failureText, defaultOpen, children
 }
 
 /** Compose the facet summary line ("14 steps · 3 files · 2 commands · 1 screenshot · 4m"). */
-function summarizeTurn(items: ActivityItem[]): string {
+function summarizeTurn(items: ActivityItem[], durationMs?: number): string {
   let files = 0;
   let commands = 0;
   let screenshots = 0;
@@ -120,5 +122,26 @@ function summarizeTurn(items: ActivityItem[]): string {
   if (screenshots) {
     parts.push(`${screenshots} ${screenshots === 1 ? "screenshot" : "screenshots"}`);
   }
+  const duration = formatDurationFacet(durationMs);
+  if (duration) {
+    parts.push(duration);
+  }
   return parts.join(" · ");
+}
+
+function formatDurationFacet(durationMs: number | undefined): string | null {
+  if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 1000) {
+    return null;
+  }
+  const totalSeconds = Math.floor(durationMs / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${String(minutes).padStart(2, "0")}m`;
 }

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -145,4 +145,13 @@ export type ActivityItem = ReasoningItem | ToolCallItem | WorkerItem | SandboxIt
 
 export type TimelineGroup =
   | { kind: "item"; item: TimelineItem }
-  | { kind: "activity"; id: string; items: ActivityItem[]; outcome?: TurnOutcome; failureText?: string };
+  | { kind: "activity"; id: string; items: ActivityItem[]; outcome?: TurnOutcome; failureText?: string }
+  | {
+      kind: "turn";
+      id: string;
+      outcome: TurnOutcome;
+      failureText?: string;
+      startedAt: string;
+      endedAt: string;
+      groups: TimelineGroup[];
+    };

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
+import { act } from "react";
 import { registerDom, renderComponent, flush } from "./render-hook";
 import { defaultToolRegistry, ActivityRail } from "../src/timeline";
 import type { ToolCallItem, SandboxItem } from "../src/timeline";
@@ -36,10 +37,26 @@ function resetTimelineEvents(): void {
   timelineSequence = 0;
 }
 
+function timelineEventAt(type: string, payload: unknown, occurredAt: string, turnId: string | null = "turn-1"): SessionEvent {
+  timelineSequence += 1;
+  return {
+    id: `timeline-evt-${timelineSequence}`,
+    workspaceId: "ws-1",
+    sessionId: "session-1",
+    sequence: timelineSequence,
+    type,
+    payload,
+    occurredAt,
+    turnId,
+  };
+}
+
+function turnSummaryTriggers(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll("button")).filter((button) => /\d+ steps?/.test(button.textContent ?? ""));
+}
+
 function turnSummaryTrigger(container: HTMLElement): HTMLButtonElement | null {
-  return (
-    Array.from(container.querySelectorAll("button")).find((button) => /\d+ steps?/.test(button.textContent ?? "")) ?? null
-  );
+  return turnSummaryTriggers(container)[0] ?? null;
 }
 
 function toolItem(overrides: Partial<ToolCallItem>): ToolCallItem {
@@ -59,21 +76,35 @@ function toolItem(overrides: Partial<ToolCallItem>): ToolCallItem {
 }
 
 describe("MessageTimeline — settled turn folding", () => {
-  test("settled turn activity renders behind a TurnSummary trigger", async () => {
+  test("settled turn renders one top-level chip, final answer, and folded narration", async () => {
     resetTimelineEvents();
     const events = [
       timelineEvent("user.message", { text: "Run the checks" }),
-      timelineEvent("agent.reasoning.delta", { text: "Checking the suite." }),
       timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }),
-      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "first pass failed" }),
+      timelineEvent("agent.message.completed", { text: "Narration: one fixture needs a quick patch." }),
+      timelineEvent("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "bun test --watch=false" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-2", output: "ok" }),
+      timelineEvent("agent.message.completed", { text: "Final answer: checks are green." }),
       timelineEvent("turn.completed", {}),
     ];
     const r = await renderComponent(<MessageTimeline events={events} />);
     await flush();
 
+    expect(turnSummaryTriggers(r.container)).toHaveLength(1);
+    expect(r.container.textContent).toContain("Final answer: checks are green.");
+    expect(r.container.textContent).not.toContain("Narration: one fixture needs a quick patch.");
+
     const trigger = turnSummaryTrigger(r.container);
     expect(trigger?.textContent).toContain("2 steps");
-    expect(trigger?.textContent).toContain("1 command");
+    expect(trigger?.textContent).toContain("2 commands");
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(r.container.textContent).toContain("Narration: one fixture needs a quick patch.");
+    expect(turnSummaryTriggers(r.container).length).toBeGreaterThan(1);
 
     await r.unmount();
   });
@@ -90,6 +121,41 @@ describe("MessageTimeline — settled turn folding", () => {
 
     expect(turnSummaryTrigger(r.container)).toBeNull();
     expect(r.container.textContent).toContain("Checking the suite.");
+
+    await r.unmount();
+  });
+
+  test("duration facet renders when the settled turn lasts at least one second", async () => {
+    resetTimelineEvents();
+    const start = Date.UTC(2024, 5, 10, 12, 0, 0);
+    const events = [
+      timelineEventAt("user.message", { text: "Run the checks" }, new Date(start).toISOString(), null),
+      timelineEventAt("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }, new Date(start + 1000).toISOString()),
+      timelineEventAt("agent.toolCall.output", { id: "call-1", output: "ok" }, new Date(start + 2000).toISOString()),
+      timelineEventAt("agent.message.completed", { text: "Done." }, new Date(start + 290000).toISOString()),
+      timelineEventAt("turn.completed", {}, new Date(start + 301000).toISOString()),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+
+    expect(turnSummaryTrigger(r.container)?.textContent).toContain("5m");
+
+    await r.unmount();
+  });
+
+  test("duration facet stays hidden below one second", async () => {
+    resetTimelineEvents();
+    const start = Date.UTC(2024, 5, 10, 12, 0, 0);
+    const events = [
+      timelineEventAt("user.message", { text: "Run the checks" }, new Date(start).toISOString(), null),
+      timelineEventAt("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }, new Date(start + 100).toISOString()),
+      timelineEventAt("agent.toolCall.output", { id: "call-1", output: "ok" }, new Date(start + 200).toISOString()),
+      timelineEventAt("turn.completed", {}, new Date(start + 999).toISOString()),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+
+    expect(turnSummaryTrigger(r.container)?.textContent).not.toContain("1s");
 
     await r.unmount();
   });

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -176,6 +176,35 @@ describe("MessageTimeline — settled turn folding", () => {
 
     await r.unmount();
   });
+
+  test("nested chips inside a failed turn stay quiet — the outer chip owns the failure", async () => {
+    resetTimelineEvents();
+    const events = [
+      timelineEvent("user.message", { text: "Deploy preview" }),
+      timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "helm dep update" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      timelineEvent("agent.message.delta", { text: "Dependencies ready, deploying now." }),
+      timelineEvent("agent.message.completed", { text: "Dependencies ready, deploying now." }),
+      timelineEvent("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "helm upgrade preview ./chart" } }),
+      timelineEvent("turn.failed", { error: "provider down" }),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+
+    const triggers = turnSummaryTriggers(r.container);
+    // The open outer chip is the one loud failure surface; nested cluster chips
+    // are closed and never repeat the failure text.
+    const withFailure = triggers.filter((t) => (t.textContent ?? "").includes("provider down"));
+    expect(withFailure).toHaveLength(1);
+    expect(withFailure[0]?.getAttribute("data-state")).toBe("open");
+    const nested = triggers.filter((t) => t !== withFailure[0]);
+    expect(nested.length).toBeGreaterThan(0);
+    for (const chip of nested) {
+      expect(chip.getAttribute("data-state")).toBe("closed");
+    }
+
+    await r.unmount();
+  });
 });
 
 /* ---- Issue 2: multi-file apply_patch count ------------------------------ */

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -35,9 +35,22 @@ function reset(): void {
 }
 
 type ActivityGroup = Extract<TimelineGroup, { kind: "activity" }>;
+type TurnGroup = Extract<TimelineGroup, { kind: "turn" }>;
 
 function activityGroups(groups: TimelineGroup[]): ActivityGroup[] {
-  return groups.filter((group): group is ActivityGroup => group.kind === "activity");
+  const activities: ActivityGroup[] = [];
+  for (const group of groups) {
+    if (group.kind === "activity") {
+      activities.push(group);
+    } else if (group.kind === "turn") {
+      activities.push(...activityGroups(group.groups));
+    }
+  }
+  return activities;
+}
+
+function turnGroups(groups: TimelineGroup[]): TurnGroup[] {
+  return groups.filter((group): group is TurnGroup => group.kind === "turn");
 }
 
 describe("buildTimeline", () => {
@@ -494,6 +507,134 @@ describe("groupTimeline", () => {
     expect(activity?.failureText).toBe("model provider unavailable");
   });
 
+  test("a settled turn folds the full span and leaves the final agent message after it", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("user.message", { text: "ship it" }, { turnId: null }),
+        event("agent.reasoning.delta", { text: "checking" }, { turnId: "turn-fold" }),
+        event("agent.message.completed", { text: "The tests need one patch first." }, { turnId: "turn-fold" }),
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }, { turnId: "turn-fold" }),
+        event("agent.toolCall.output", { id: "call-1", output: "ok" }, { turnId: "turn-fold" }),
+        event("agent.message.completed", { text: "Final answer: tests are green." }, { turnId: "turn-fold" }),
+        event("turn.completed", {}, { turnId: "turn-fold" }),
+      ]),
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item"]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.id).toBe("turn-turn-fold");
+    expect(turn?.outcome).toBe("complete");
+    expect(turn?.groups.map((group) => group.kind)).toEqual(["activity", "item", "activity"]);
+    const final = groups[2];
+    expect(final?.kind).toBe("item");
+    expect(final?.kind === "item" ? final.item : null).toMatchObject({ kind: "agent-message", text: "Final answer: tests are green." });
+  });
+
+  test("a turn that ends on activity folds everything and extracts nothing", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("user.message", { text: "run it" }, { turnId: null }),
+        event("agent.message.completed", { text: "Starting with the build." }, { turnId: "turn-activity-end" }),
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "make build" } }, { turnId: "turn-activity-end" }),
+        event("agent.toolCall.output", { id: "call-1", output: "ok" }, { turnId: "turn-activity-end" }),
+        event("turn.completed", {}, { turnId: "turn-activity-end" }),
+      ]),
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["item", "turn"]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.groups.map((group) => group.kind)).toEqual(["item", "activity"]);
+  });
+
+  test("a steering user message bounds the turn walk-back", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("user.message", { text: "first request" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "setup" } }, { turnId: "turn-steer" }),
+        event("user.message", { text: "actually run tests only" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "bun test" } }, { turnId: "turn-steer" }),
+        event("agent.message.completed", { text: "Final answer after steering." }, { turnId: "turn-steer" }),
+        event("turn.completed", {}, { turnId: "turn-steer" }),
+      ]),
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["item", "activity", "item", "turn", "item"]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.groups.map((group) => group.kind)).toEqual(["activity"]);
+    expect(activityGroups(turn?.groups ?? [])[0]?.items[0]?.id).toBe("evt-4");
+  });
+
+  test("sequential turns fold independently and leave between-turn dividers top-level", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("user.message", { text: "setup" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "setup" } }, { turnId: "turn-1" }),
+        event("agent.message.completed", { text: "Setup complete." }, { turnId: "turn-1" }),
+        event("turn.completed", {}, { turnId: "turn-1" }),
+        event("session.status.changed", { status: "idle" }, { turnId: null }),
+        event("user.message", { text: "deploy" }, { turnId: null }),
+        event("session.status.changed", { status: "running" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "deploy" } }, { turnId: "turn-2" }),
+        event("agent.message.completed", { text: "Deploy failed." }, { turnId: "turn-2" }),
+        event("turn.failed", { error: "deploy failed" }, { turnId: "turn-2" }),
+      ]),
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item", "item", "item", "turn", "item"]);
+    const turns = turnGroups(groups);
+    expect(turns.map((turn) => turn.id)).toEqual(["turn-turn-1", "turn-turn-2"]);
+    expect(turns[0]?.groups.map((group) => group.kind)).toEqual(["activity"]);
+    expect(turns[1]?.groups.map((group) => group.kind)).toEqual(["item", "activity"]);
+    expect(groups[3]?.kind === "item" ? groups[3].item.kind : null).toBe("session-status");
+  });
+
+  test("sequential turns without a user boundary do not absorb the previous final message", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "setup" } }, { turnId: "turn-1" }),
+        event("agent.message.completed", { text: "Setup complete." }, { turnId: "turn-1" }),
+        event("turn.completed", {}, { turnId: "turn-1" }),
+        event("session.status.changed", { status: "idle" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "deploy" } }, { turnId: "turn-2" }),
+        event("agent.message.completed", { text: "Deploy complete." }, { turnId: "turn-2" }),
+        event("turn.completed", {}, { turnId: "turn-2" }),
+      ]),
+    );
+    expect(groups.map((group) => (group.kind === "item" ? `${group.kind}:${group.item.kind}` : group.kind))).toEqual([
+      "turn",
+      "item:agent-message",
+      "item:session-status",
+      "turn",
+      "item:agent-message",
+    ]);
+    const turns = turnGroups(groups);
+    expect(turns.map((turn) => turn.groups.map((group) => group.kind))).toEqual([["activity"], ["activity"]]);
+  });
+
+  test("activity-less turns create no turn group and keep their notice", () => {
+    reset();
+    const groups = groupTimeline(buildTimeline([event("turn.failed", { error: "model provider unavailable" })]));
+    expect(groups.map((group) => group.kind)).toEqual(["item"]);
+    expect(groups[0]?.kind === "item" ? groups[0].item : null).toMatchObject({ kind: "notice", tone: "failed" });
+  });
+
+  test("session status ticks inside a settled turn fold into the body", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("user.message", { text: "run checks" }, { turnId: null }),
+        event("session.status.changed", { status: "running" }, { turnId: null }),
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }, { turnId: "turn-status" }),
+        event("agent.message.completed", { text: "Checks passed." }, { turnId: "turn-status" }),
+        event("turn.completed", {}, { turnId: "turn-status" }),
+      ]),
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item"]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.groups.map((group) => (group.kind === "item" ? group.item.kind : group.kind))).toEqual(["session-status", "activity"]);
+  });
+
   test("live activity groups have no turn outcome", () => {
     reset();
     const groups = groupTimeline(
@@ -515,7 +656,9 @@ describe("groupTimeline", () => {
       ]),
     );
     const activities = activityGroups(groups);
-    expect(groups.map((group) => group.kind)).toEqual(["activity", "item", "activity"]);
+    expect(groups.map((group) => group.kind)).toEqual(["turn"]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.groups.map((group) => group.kind)).toEqual(["activity", "item", "activity"]);
     expect(activities).toHaveLength(2);
     expect(activities.map((group) => group.outcome)).toEqual(["failed", "failed"]);
     expect(activities.map((group) => group.failureText)).toEqual(["compiler exploded", "compiler exploded"]);
@@ -532,6 +675,7 @@ describe("groupTimeline", () => {
       ]),
     );
     const activities = activityGroups(groups);
+    expect(groups.map((group) => group.kind)).toEqual(["turn", "turn"]);
     expect(activities).toHaveLength(2);
     expect(activities.map((group) => group.outcome)).toEqual(["complete", "failed"]);
     expect(activities.map((group) => group.items.map((item) => item.turnId))).toEqual([["turn-1"], ["turn-2"]]);


### PR DESCRIPTION
## What

Follow-up to #183 sharpening the fold to the actual product intent. #183 folded each activity **cluster**, but agents narrate between tool calls, so a long turn still rendered as message/chip/message/chip sprawl — a potentially hours-long trace stayed a wall.

Now, once a turn settles, the timeline shows only: **user message → one summary chip → the turn's final answer.**

- **`groupTimeline`** folds the settled turn's entire span (mid-turn narration, activity clusters, status ticks) into a recursive `turn` group, walking back to the triggering user message. The trailing non-streaming agent message of the turn is the final answer and stays outside, rendered after the chip. A turn that ends on activity folds everything; an activity-less failure keeps its notice; steering user messages bound the walk-back; sequential turns fold independently with between-turn dividers left top-level.
- **`MessageTimeline`** renders groups recursively — expanding the turn chip reveals the narrative with the #183 per-cluster chips nested inside as sub-expands (progressive disclosure for very long turns).
- **`TurnSummary`** gains the duration facet its docstring always promised: `14 steps · 3 files edited · 2 commands · 4m` (trailing `42s` / `14m` / `2h 05m`, omitted under 1s).
- Demo fixtures gain mid-turn narration so the gallery shows the real shape.

Chip visuals unchanged; live turns still never fold. `TimelineGroup` gains the `turn` variant (additive). Changeset: minor `@opengeni/react`.

## Verification

- `bun test packages/react/test`: **378 pass, 0 fail** (new grouping tests: full-span fold + final-message extraction, activity-ended turns, steering boundary, sequential turns, status-tick folding; renderer tests: one top-level chip with final answer visible and narration hidden until expanded, nested sub-chips after expand, duration facet, live turn unchanged).
- `tsc --noEmit` clean; `tsup` + demo build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline grouping and rendering behavior change how long sessions display; edge cases (steering, sequential turns, failures) are heavily tested but consumers depend on the new fold semantics.
> 
> **Overview**
> Settled agent turns now collapse into **one** summary chip instead of alternating message/chip sprawl: the UI shows **user prompt → turn chip → final agent answer**, with mid-turn narration and tool activity hidden until expand.
> 
> **`groupTimeline`** gains `foldSettledTurn` on `turn-end`: it walks back to the user-message boundary (respecting steering messages and foreign `turnId`s), builds a recursive **`turn`** `TimelineGroup`, keeps the trailing non-streaming agent message as the visible final answer, and nests existing activity clusters inside the fold.
> 
> **`MessageTimeline`** renders groups recursively via `TimelineGroupView`: the outer turn uses `TurnSummary` with nested children on a left border; nested activity chips inside a failed turn stay closed and omit repeated failure text so only the outer chip surfaces the error.
> 
> **`TurnSummary`** adds an optional **duration** facet (`42s` / `14m` / `2h 05m`, omitted under 1s) from `startedAt`/`endedAt`.
> 
> Demo fixtures and harness mirror the recursive turn rendering; tests cover folding, final-message extraction, steering boundaries, sequential turns, duration, and nested failure UX. Minor `@opengeni/react` changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb07f39985e6636197f1a39ef8e1aad2b08f6236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->