### PR TITLE
fix(release): add repository fields for npm provenance (7 packages)

### DIFF
--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -39,5 +39,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/codex"
   }
 }

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -35,5 +35,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/documents"
   }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -31,5 +31,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/events"
   }
 }

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -31,5 +31,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/github"
   }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -26,5 +26,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/observability"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,5 +40,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/runtime"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -34,5 +34,10 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cloudgeni-ai/opengeni.git",
+    "directory": "packages/storage"
   }
 }


### PR DESCRIPTION
The Stage C publish partially succeeded (8 of 15 packages). The other seven — codex, documents, events, github, observability, runtime, storage — failed npm E422: sigstore provenance requires `repository.url` in package.json to match the repo, and the newly-flipped manifests lacked the field. This adds it in the exact sdk/react convention (git+https URL + per-package directory). Metadata-only. Merging re-triggers Release, and changesets publish retries exactly the unpublished versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq6ByfGw6dunzaMW6LAeii

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only `package.json` changes with no application or publish-pipeline logic modified.
> 
> **Overview**
> Adds **`repository`** metadata to seven workspace packages (`codex`, `documents`, `events`, `github`, `observability`, `runtime`, `storage`) so npm **sigstore provenance** can validate the publish against the monorepo.
> 
> Each manifest now uses the same shape as other published packages: `git+https://github.com/Cloudgeni-ai/opengeni.git` with a per-package **`directory`**. No runtime or build logic changes—only `package.json` fields to unblock E422 failures on release publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40040e575ae998eb8278484ae6e45717dcb8c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->