### PR TITLE
feat(react): drop queued/running/idle status dividers from the timeline

### DIFF
--- a/.changeset/quiet-status-ticks.md
+++ b/.changeset/quiet-status-ticks.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+The timeline no longer renders queued / running / idle status dividers — they are machinery telemetry the header pill, live shimmer, and turn-chip duration facet already carry. Only attention-worthy statuses (requires_action, failed, cancelled) still earn a divider. Applies retroactively to historical traces since the filter lives in the pure projection.

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -280,6 +280,14 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         if (!isSessionStatus(status)) {
           break;
         }
+        // Only attention-worthy statuses earn a timeline divider. queued /
+        // running / idle are machinery telemetry: the header pill carries the
+        // live status, the shimmer says "running", and the turn chip's duration
+        // facet says how long — a stale "idle · 27s" row is pure noise,
+        // especially in historical traces.
+        if (!ATTENTION_STATUSES.has(status)) {
+          break;
+        }
         const previous = [...items].reverse().find((item): item is SessionStatusItem => item.kind === "session-status");
         if (previous?.status === status) {
           break;
@@ -576,6 +584,9 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 const SESSION_STATUSES: readonly SessionStatus[] = ["queued", "running", "idle", "requires_action", "failed", "cancelled"];
+
+/** Statuses that demand the reader's attention and so earn a timeline divider. */
+const ATTENTION_STATUSES: ReadonlySet<SessionStatus> = new Set(["requires_action", "failed", "cancelled"]);
 
 /** Keep only entries that match the wire shapes; user payloads are untyped. */
 function resourceRefs(value: unknown): import("@opengeni/sdk").ResourceRef[] {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -303,15 +303,21 @@ describe("buildTimeline", () => {
     expect(sandbox.output).toContain("connection refused");
   });
 
-  test("collapses repeated status changes and surfaces notices for failures and interrupts", () => {
+  test("only attention statuses project dividers; repeats collapse; failure/interrupt notices surface", () => {
     reset();
     const items = buildTimeline([
+      // Machinery telemetry — the header pill owns these; no timeline rows.
+      event("session.status.changed", { status: "queued" }),
       event("session.status.changed", { status: "running" }),
-      event("session.status.changed", { status: "running" }),
+      event("session.status.changed", { status: "idle" }),
+      // Attention statuses earn a divider, collapsed on repeat.
+      event("session.status.changed", { status: "requires_action" }),
+      event("session.status.changed", { status: "requires_action" }),
       event("turn.failed", { error: "model provider unavailable" }),
       event("turn.cancelled", {}),
     ]);
     expect(items.map((item) => item.kind)).toEqual(["session-status", "turn-end", "notice", "turn-end", "notice"]);
+    expect(items[0]).toMatchObject({ kind: "session-status", status: "requires_action" });
     expect(items[1]).toMatchObject({ outcome: "failed", failureText: "model provider unavailable" });
     expect(items[2]).toMatchObject({ tone: "failed", text: "model provider unavailable" });
     expect(items[3]).toMatchObject({ outcome: "cancelled", failureText: null });
@@ -580,12 +586,13 @@ describe("groupTimeline", () => {
         event("turn.failed", { error: "deploy failed" }, { turnId: "turn-2" }),
       ]),
     );
-    expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item", "item", "item", "turn", "item"]);
+    // The idle/running ticks between and inside turns project no rows at all —
+    // the shape is purely user → turn → answer, twice.
+    expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item", "item", "turn", "item"]);
     const turns = turnGroups(groups);
     expect(turns.map((turn) => turn.id)).toEqual(["turn-turn-1", "turn-turn-2"]);
     expect(turns[0]?.groups.map((group) => group.kind)).toEqual(["activity"]);
-    expect(turns[1]?.groups.map((group) => group.kind)).toEqual(["item", "activity"]);
-    expect(groups[3]?.kind === "item" ? groups[3].item.kind : null).toBe("session-status");
+    expect(turns[1]?.groups.map((group) => group.kind)).toEqual(["activity"]);
   });
 
   test("sequential turns without a user boundary do not absorb the previous final message", () => {
@@ -601,10 +608,11 @@ describe("groupTimeline", () => {
         event("turn.completed", {}, { turnId: "turn-2" }),
       ]),
     );
+    // No divider row separates the turns anymore; the foreign-turn guard alone
+    // keeps turn-2's walk-back from absorbing turn-1's final message.
     expect(groups.map((group) => (group.kind === "item" ? `${group.kind}:${group.item.kind}` : group.kind))).toEqual([
       "turn",
       "item:agent-message",
-      "item:session-status",
       "turn",
       "item:agent-message",
     ]);
@@ -619,12 +627,13 @@ describe("groupTimeline", () => {
     expect(groups[0]?.kind === "item" ? groups[0].item : null).toMatchObject({ kind: "notice", tone: "failed" });
   });
 
-  test("session status ticks inside a settled turn fold into the body", () => {
+  test("machinery status ticks vanish; attention statuses inside a settled turn fold into the body", () => {
     reset();
     const groups = groupTimeline(
       buildTimeline([
         event("user.message", { text: "run checks" }, { turnId: null }),
         event("session.status.changed", { status: "running" }, { turnId: null }),
+        event("session.status.changed", { status: "requires_action" }, { turnId: null }),
         event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "bun test" } }, { turnId: "turn-status" }),
         event("agent.message.completed", { text: "Checks passed." }, { turnId: "turn-status" }),
         event("turn.completed", {}, { turnId: "turn-status" }),
@@ -632,7 +641,10 @@ describe("groupTimeline", () => {
     );
     expect(groups.map((group) => group.kind)).toEqual(["item", "turn", "item"]);
     const [turn] = turnGroups(groups);
+    // The running tick projected nothing; the requires_action divider folds.
     expect(turn?.groups.map((group) => (group.kind === "item" ? group.item.kind : group.kind))).toEqual(["session-status", "activity"]);
+    const folded = turn?.groups[0];
+    expect(folded?.kind === "item" ? folded.item : null).toMatchObject({ kind: "session-status", status: "requires_action" });
   });
 
   test("live activity groups have no turn outcome", () => {


### PR DESCRIPTION
## What

Follow-up polish on the turn fold (#183, #192). The queued / running / idle status dividers are machinery telemetry, not narrative — the header pill owns the live status, the streaming shimmer already says "running", and the turn chip's duration facet says how long. A stale "idle · 27s" row under a finished turn is exactly the noise the fold exists to remove, and historical traces were full of them.

- `buildTimeline` now projects a `session-status` divider only for **attention-worthy** statuses: `requires_action`, `failed`, `cancelled`. Repeats still collapse. queued/running/idle project nothing.
- Because the filter lives in the pure projection, every historical trace quiets down retroactively — no data change.
- The between-turn idle divider was never load-bearing for turn folding: the foreign-turn walk-back guard alone prevents a turn from absorbing its predecessor's final message (test updated to prove that exact case).

`SessionStatusItem`/`SessionStatusRow` remain in the public API for embedders.

## Verification

- `bun test packages/react/test`: **379 pass, 0 fail** — the four status-divider tests were deliberately rewritten to the new semantics (machinery ticks vanish; attention ticks render, collapse on repeat, and fold into settled turn bodies).
- `tsc --noEmit` clean; `tsup` + demo build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure presentation-layer projection change with no API removal; behavior is covered by updated timeline tests.
> 
> **Overview**
> **Timeline projection** in `buildTimeline` now emits `session-status` divider rows only for **attention-worthy** statuses (`requires_action`, `failed`, `cancelled`). `queued`, `running`, and `idle` `session.status.changed` events are ignored at projection time, so historical traces quiet down without any event-log migration.
> 
> Repeated attention statuses still collapse to a single divider. Turn folding and grouping lose the extra top-level rows that used to come from idle/running ticks between turns; tests were updated to match (foreign-turn walk-back still prevents cross-turn message absorption).
> 
> Public `SessionStatusItem` / `SessionStatusRow` types and rendering are unchanged—fewer items are simply projected. A patch changeset documents the `@opengeni/react` behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e1fea5753862877a4e3c9f51e9030641e67333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->