### PR TITLE
docs: audience-tiered docs map + CI-enforced reference freshness guard

### DIFF
--- a/.agents/skills/opengeni-client/SKILL.md
+++ b/.agents/skills/opengeni-client/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: opengeni-client
+audience: integration-agent
 description: Use when integrating a customer product, coding agent, generic automation agent, CLI, SDK, or backend service with the OpenGeni API. Covers managed API-key auth, configured/self-host bearer auth, workspace discovery, workspace-scoped sessions, choosing a session's compute target (a managed sandbox or an enrolled Connected Machine), machine enrollment (device-flow consent + headless enroll tokens), SSE/event replay, files, documents/search, schedules, GitHub repository resources, billing/limits handling, safe retries, and keeping client guidance aligned with the live OpenGeni service rather than stale docs.
 ---
 
 # OpenGeni Client
+
+This skill is for integration agents building customer products, CLIs, SDK wrappers, or automations against an OpenGeni API service.
 
 Use this skill to help a customer-side agent or product consume OpenGeni as an API service. It is for client integration, not for editing OpenGeni internals.
 

--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: opengeni
+audience: repo-maintainer-agent
 description: >-
   Use when working in, operating, extending, integrating, documenting, or debugging OpenGeni: the session-based agent service with an API, durable event log, Temporal worker, sandboxed OpenAI Agents SDK runtime, file/object storage, MCP tools, scheduled tasks, and self-hosted local stack. Trigger this skill for questions about OpenGeni architecture, client-side API integration, sessions/events, worker orchestration, sandbox backends, file uploads, tools/MCP, scheduling, storage, GitHub integration, configuration, deployment, or how to keep agents using OpenGeni correctly as the repo evolves.
 ---
 
 # OpenGeni
+
+This skill is for repo-maintainer agents working in, operating, or changing the OpenGeni repository.
 
 ## Overview
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Workspace auth/billing static guard
         run: bun scripts/check-workspace-billing-static.ts
 
+      - name: Docs reference freshness guard
+        run: bun scripts/check-docs-refs.ts
+
       - name: Build client packages (contracts + SDK + React)
         run: bun run build:packages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ The agent turn activity is `runAgentTurn`, also registered under the legacy alia
 
 If a change alters architecture, terminology, the run lifecycle, the memory model, or a "do not" guardrail above, update this file, [`docs/architecture.md`](docs/architecture.md), and the relevant `docs/*.md` in the same change. In particular, structural changes (an app/package/sandbox backend added, removed, or renamed; a moved responsibility; a changed invariant, data-flow, or canonical source) belong in `docs/architecture.md` — see its "Keeping this current" section. An out-of-date AGENTS.md or doc is a bug, not a nicety.
 
+## Keeping docs true
+
+Use [`docs/README.md`](docs/README.md) as the docs map. When you move or rename files or packages, run `bun run check:docs-refs` and fix every current-tier reference it reports. A new package needs a package README plus the [`docs/architecture.md`](docs/architecture.md) package table. A new embed surface or port belongs in [`docs/embedding.md`](docs/embedding.md). A new process or command belongs in its canonical home from the docs map; link to that home instead of restating volatile details.
+
 ## Sandbox Notes
 
 Sandbox execution is pluggable. `OPENGENI_SANDBOX_BACKEND` selects one of the backends defined by the `SandboxBackend` enum in `packages/contracts/src/index.ts` (the canonical list): `docker`, `modal`, `local`, `none`, `daytona`, `runloop`, `e2b`, `blaxel`, `cloudflare`, `vercel`, and `selfhosted`. `docker` is the default and the usual local-dev choice; `modal` and the other cloud backends are provisioned, swappable boxes. When you change the set of backends, update the enum first and treat it as the source of truth — this file and the README follow it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ bun run test:e2e
 - Update README or docs when setup, public API, configuration, or user-facing behavior changes.
 - Do not commit secrets, local `.env` files, generated credentials, or private infrastructure details.
 
+## Keeping Docs True
+
+Use [`docs/README.md`](docs/README.md) as the docs map. If you move or rename files or packages, run `bun run check:docs-refs` and fix the current-tier references it reports. New packages need a package README plus an update to the [`docs/architecture.md`](docs/architecture.md) package table. New embed surfaces or ports belong in [`docs/embedding.md`](docs/embedding.md). New processes or commands belong in their canonical home from the docs map; link there instead of copying volatile details into multiple docs.
+
+## Release / Publishing
+
+Release and publishing guidance starts here; executable truth lives in [`package.json`](package.json) and the workflow files under `.github/workflows/`. When publishable packages change, keep changesets, package manifests, and the release workflow expectations aligned.
+
 ## Code Style
 
 - Prefer existing repository patterns over new abstractions.

--- a/agent/README.md
+++ b/agent/README.md
@@ -3,7 +3,7 @@
 The Rust agent that turns a user's own machine into a **Connected Machine** — a
 first-class, co-equal PRIMARY OpenGeni compute target (the `selfhosted` backend,
 internally). This is a standalone Cargo workspace — it is **not** part of the bun
-monorepo (the bun workspaces glob excludes it, and `agent/target/` is gitignored).
+monorepo (the bun workspaces glob excludes it, and Cargo build output is gitignored).
 
 **How the control plane treats a Connected Machine** (canonical:
 [`../docs/architecture.md`](../docs/architecture.md) §3.8 and [`../AGENTS.md`](../AGENTS.md)):

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# OpenGeni Docs Map
+
+This map defines who each doc tier serves and where volatile facts belong.
+
+## Audiences
+
+| Audience | Reads | Notes |
+| --- | --- | --- |
+| Integrator | `README.md`, `docs/embedding.md`, `packages/sdk/README.md` | OSS self-hosters and embedding hosts building against OpenGeni. |
+| Maintainer | `CONTRIBUTING.md`, `docs/architecture.md`, topic docs | Contributors changing code, packages, workflows, or release mechanics. |
+| Repo agent | `AGENTS.md`, `.agents/skills/opengeni/SKILL.md`, this map | Coding agents working in this repository. |
+| Product agent | Bundled skills in `packages/runtime/src/bundled_hashicorp_terraform_skills` | Versioned product content; not covered by this freshness system. |
+| Operator | `docs/deployment.md`, deployment contracts and chart docs | People deploying and operating OpenGeni. |
+| Record | `docs/design/**`, historical results, design dossiers | Point-in-time records; banner-label, never "fix" them. |
+
+## Canonical Homes
+
+| Topic | Current canonical home | Known restatement locations |
+| --- | --- | --- |
+| Architecture & package layout | `docs/architecture.md` | `README.md`, `AGENTS.md`, package READMEs should link or summarize lightly. |
+| Embedding & ports | `docs/embedding.md` | `README.md`, `CONTRIBUTING.md`, SDK/client examples should link. |
+| Run lifecycle | `docs/run-lifecycle.md` | `AGENTS.md`, `.agents/skills/opengeni/SKILL.md`, architecture summaries should link. |
+| Connected machines | `docs/connected-machines.md` | `README.md`, `AGENTS.md`, client docs and skills should link. |
+| Deployment | `docs/deployment.md` | `README.md`, `AGENTS.md`, Helm/Terraform notes should link. |
+| Release/publishing | `CONTRIBUTING.md` § Release / Publishing, plus workflow files as executable truth | `README.md`, package READMEs, architecture release notes should link. |
+| Client/SDK integration | `packages/sdk/README.md` | `README.md`, `docs/embedding.md`, `@opengeni/react` docs should link. |
+
+## Rules
+
+1. Volatile facts such as paths, package names, commands, and env vars live in the canonical home; other docs link instead of restating.
+2. `docs/design/**` is record tier. Add the point-in-time banner and `<!-- docs-refs: record -->` marker; do not "freshen" those docs.
+3. Current-tier freshness is enforced in CI by `scripts/check-docs-refs.ts`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -451,7 +451,7 @@ The current map:
 - **Dev stack.** `bun run dev` (= `scripts/dev-stack.sh`): copy `.env`, pick free ports, `docker compose up` Postgres/NATS/Temporal/MinIO, migrate, build the sandbox image, launch api+worker+web. It auto-selects alternate ports if defaults are taken.
 - **Test tiers.** `test`/`test:unit` (bun test, **no infra**), `test:integration` (a fixed enumerated list of `*.integration.ts`), `test:e2e` (browser harness + Docker sandbox + Channel-A), `test:live` (opt-in via `OPENGENI_ENABLE_LIVE_TESTS`). **Unit tests and typecheck require no Temporal/NATS/Postgres/sandbox/model credentials** — keep new unit tests in that tier.
 - **Typecheck/check/prep.** `typecheck` is a hand-ordered `cd`-chain (add new packages to it). `check` = typecheck + unit + build sdk/react + web build; `check:full`/`prep` add integration + e2e; `check:workspace-billing` adds the static auth/billing guard.
-- **Static guards (build steps).** `publish-closure-guard.ts` (full npm closure has no ignored-package runtime dependencies; `sdk`/`react` remain client-clean), `check-workspace-billing-static.ts` (no unscoped `/v1` routes; Stripe only in `routes/billing.ts`, Better Auth only under `auth/`), `source-hygiene.test.ts` (no raw NUL bytes).
+- **Static guards (build steps).** `scripts/publish-closure-guard.ts` (full npm closure has no ignored-package runtime dependencies; `sdk`/`react` remain client-clean), `scripts/check-workspace-billing-static.ts` (no unscoped `/v1` routes; Stripe only in `routes/billing.ts`, Better Auth only under `auth/`), `scripts/check-docs-refs.ts` (current-tier docs reference existing repo paths and workspace packages), `source-hygiene.test.ts` (no raw NUL bytes).
 - **Changesets / publish.** Releases publish via **npm `changeset publish`** (bun can't emit provenance). Committed publishable `package.json` entry points point at `./src/...` (CI builds from source before `dist` exists); `build-publishable-packages.ts`, `rewrite-entry-points.ts`, and `rewrite-workspace-deps.ts` derive the publishable set from workspace manifests + `.changeset/config.json`, then build, swap to `dist`, and rewrite workspace ranges only in the ephemeral CI checkout. `sdk` + `react` are version-linked; package manifests and `.changeset/config.json` own which leaf packages stay ignored.
 - **CI.** `ci.yml` (typecheck + unit + guards + package/image builds + deployment-artifact validation; asserts no floating `latest` tags), `release.yml` (changesets Version-PR/publish + GHCR images, dormant until `RELEASE_ENABLED=true`), `agent-ci.yml`/`agent-release.yml` (Rust agent, path-filtered, independently versioned via `agent-v*` tags).
 
@@ -514,6 +514,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 
 | Doc | Covers |
 | --- | --- |
+| [`README.md`](README.md) | The audience-tiered docs map: canonical homes, current-vs-record rules, and freshness enforcement. |
 | [`architecture.md`](architecture.md) (this file) | The whole-system map, invariants, repo layout, and the change-decision table. |
 | [`run-lifecycle.md`](run-lifecycle.md) | Turns, the no-length-limit doctrine, the three memory stores, graceful-preempt vs ungraceful-death recovery, provider-item-id stripping. |
 | [`goals.md`](goals.md) | Goal-driven long runs: lifecycle, the replay-safe continuation loop, no-progress/budget guards, goal MCP tools, settings. |
@@ -527,6 +528,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 | [`reliability-fixes.md`](reliability-fixes.md) | Reliability bugs/fixes (bounded Temporal history, orphan repair, scheduled-task/billing idempotency). |
 | [`deployment.md`](deployment.md) | Operator guide: profiles, preflight/stack plans, Helm/Terraform; the disposable-fixtures rule. |
 | [`embedding.md`](embedding.md) | Host-app embedding guide: router mounting, direct core calls, ports/bindings, schema/RLS, worker, and EventBus. |
+| [`connected-machines.md`](connected-machines.md) | Integrator guide for targeting, swapping, enrolling, and operating Connected Machines. |
 | [`design/sandbox-surfacing/`](design/sandbox-surfacing/) | Master design dossier for swappable sandboxes / BYO-compute (including the relay edge). |
 | [`design/desktop-hibernation.md`](design/desktop-hibernation.md) | Research/reference only (NOT shipped) — pause/resume/hibernation primitives across providers. |
 | [`../AGENTS.md`](../AGENTS.md) | How to run the stack + the load-bearing contributor guardrails. |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,7 @@
+<!-- docs-refs: record -->
+
+> **Point-in-time design record.** Written against the tree at authoring time; paths and names may have moved. Code wins.
+
+# Design Records
+
+Design files under `docs/design/` are historical records. Keep them for context, but do not treat their paths, package names, commands, or implementation status as current truth.

--- a/docs/design/sandbox-surfacing/00-master-spine.md
+++ b/docs/design/sandbox-surfacing/00-master-spine.md
@@ -1,3 +1,7 @@
+<!-- docs-refs: record -->
+
+> **Point-in-time design record.** Written against the tree at authoring time; paths and names may have moved. Code wins.
+
 # MASTER SPINE — OpenGeni Multi-Provider, Headless + Desktop, OS-Selectable Sandbox Surfacing
 
 **For:** Jørgen (lead engineer) · **Status:** top-level design of record · **Date:** 2026-06-19

--- a/docs/design/sandbox-surfacing/evidence/ui/byo/INDEX.md
+++ b/docs/design/sandbox-surfacing/evidence/ui/byo/INDEX.md
@@ -1,3 +1,5 @@
+<!-- docs-refs: record -->
+
 # M9 — Bring-your-own-compute UI screenshot evidence (V12)
 
 49 PNGs across **5 passes**, rendering every state-matrix cell of the Machines

--- a/docs/reliability-fixes.md
+++ b/docs/reliability-fixes.md
@@ -22,7 +22,7 @@ Code wins over this summary. Canonical sources:
   `claimNextQueuedTurn`, the reusable-session locked update.
 - `packages/db/drizzle/0014_repair_orphaned_function_call_results.sql` — the
   one-time orphan repair.
-- `apps/api/src/domain/scheduled-tasks.ts` — the manual-trigger idempotency
+- `packages/core/src/domain/scheduled-tasks.ts` — the manual-trigger idempotency
   helpers and `assertReusableSessionRevivable`.
 
 ## The five fixes
@@ -213,8 +213,8 @@ otherwise terminal) reusable session was therefore **revived and billed** on the
 next scheduled fire — the opposite of what cancelling a session should mean.
 
 **The fix.** A shared
-`assertReusableSessionRevivable(status)` (mirrors the API's 409 in
-`apps/api/src/domain/sessions.ts`) refuses **only** `cancelled` (failed / idle
+`assertReusableSessionRevivable(status)` (mirrors the core session guard in
+`packages/core/src/domain/sessions.ts`) refuses **only** `cancelled` (failed / idle
 stay revivable, matching the revivable-failed-sessions contract). It is called
 **twice** in `apps/worker/src/activities/scheduled-tasks.ts`: once on the early
 read after `requireSession`, and again **inside the row lock** on the freshly
@@ -240,7 +240,7 @@ and the lock. Throwing aborts the dispatch rather than resurrecting the session.
 trigger (network blip, lambda re-invocation) never collided — it recorded usage
 **twice** and started **two** workflow runs (double-charge + double-spawn).
 
-**The fix** (`apps/api/src/domain/scheduled-tasks.ts`). Derive everything from a
+**The fix** (`packages/core/src/domain/scheduled-tasks.ts`). Derive everything from a
 **stable trigger token**:
 
 - `scheduledTaskTriggerToken(clientTriggerId)` — uses a client-supplied id when

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "release:publish": "bash scripts/release-publish.sh",
     "check": "bun run typecheck && bun run test:unit && cd packages/sdk && bun run build && cd ../react && bun run build && bun run demo:build && cd ../../apps/web && bun run build",
     "check:full": "bun run check && bun run test:integration && bun run test:e2e",
+    "check:docs-refs": "bun scripts/check-docs-refs.ts",
     "check:workspace-billing": "bun run typecheck && bun test && bun run test:integration && bun scripts/check-workspace-billing-static.ts && cd apps/web && bun run build && cd ../.. && bun run test:e2e",
     "prep": "bun run check:full"
   },

--- a/scripts/check-docs-refs.ts
+++ b/scripts/check-docs-refs.ts
@@ -1,0 +1,215 @@
+import { existsSync } from "node:fs";
+
+type Finding = {
+  file: string;
+  line: number;
+  token: string;
+  reason: string;
+};
+
+const sourceRoots = [
+  "README.md",
+  "AGENTS.md",
+  "CONTRIBUTING.md",
+  "docs",
+  "apps",
+  "packages",
+  "agent",
+  ".agents/skills",
+];
+
+const recordMarker = "<!-- docs-refs: record -->";
+const ignoreMarker = "<!-- docs-refs: ignore -->";
+const pathReferencePattern = /^(?:apps|packages|scripts|docs|deploy|agent|\.github|\.agents)\/[A-Za-z0-9_./-]+$/;
+const packageReferencePattern = /@opengeni\/[a-z0-9-]+/g;
+const inlineCodePattern = /`([^`\n]+)`/g;
+const skippedPathFragments = ["*", "<", ">", "{", "$", "..."];
+const externalPackageAllowlist = new Set<string>();
+
+const [files, workspacePackages] = await Promise.all([listFiles(sourceRoots), listWorkspacePackages()]);
+const findings: Finding[] = [];
+
+for (const file of files.filter(isCurrentTierDoc)) {
+  const text = await Bun.file(file).text().catch(() => "");
+  if (!text || hasRecordMarker(text)) {
+    continue;
+  }
+  checkReferences(file, text, workspacePackages, findings);
+}
+
+if (findings.length > 0) {
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line} — ${finding.token} (${finding.reason})`);
+  }
+  process.exit(1);
+}
+
+console.log("Docs reference freshness guard passed.");
+
+async function listWorkspacePackages(): Promise<Set<string>> {
+  const names = new Set<string>();
+  const workspaceFiles = await listFiles(["apps", "packages"]);
+  for (const file of workspaceFiles) {
+    if (!/^(?:apps|packages)\/[^/]+\/package\.json$/.test(file)) {
+      continue;
+    }
+    const manifest = await Bun.file(file).json().catch(() => null);
+    if (manifest && typeof manifest === "object" && "name" in manifest && typeof manifest.name === "string") {
+      names.add(manifest.name);
+    }
+  }
+  return names;
+}
+
+function checkReferences(file: string, text: string, workspacePackages: Set<string>, out: Finding[]): void {
+  const lines = text.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (line.trimEnd().endsWith(ignoreMarker)) {
+      continue;
+    }
+    const lineNumber = index + 1;
+    const seen = new Set<string>();
+
+    for (const rawToken of extractInlineCodeTokens(line)) {
+      const token = rawToken.trim();
+      const normalizedPath = normalizePathReference(token);
+      if (normalizedPath && shouldCheckPathReference(normalizedPath) && !existsSync(normalizedPath)) {
+        addFinding(out, seen, {
+          file,
+          line: lineNumber,
+          token,
+          reason: `missing repo path ${normalizedPath}`,
+        });
+      }
+    }
+
+    for (const token of extractPackageReferences(line)) {
+      if (!workspacePackages.has(token) && !externalPackageAllowlist.has(token)) {
+        addFinding(out, seen, {
+          file,
+          line: lineNumber,
+          token,
+          reason: "unknown @opengeni workspace package",
+        });
+      }
+    }
+  }
+}
+
+function extractInlineCodeTokens(line: string): string[] {
+  const tokens: string[] = [];
+  inlineCodePattern.lastIndex = 0;
+  for (const match of line.matchAll(inlineCodePattern)) {
+    const token = match[1];
+    if (token) {
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+function extractPackageReferences(line: string): string[] {
+  const tokens: string[] = [];
+  packageReferencePattern.lastIndex = 0;
+  for (const match of line.matchAll(packageReferencePattern)) {
+    const token = match[0];
+    if (token) {
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+function normalizePathReference(token: string): string | null {
+  if (skippedPathFragments.some((fragment) => token.includes(fragment))) {
+    return null;
+  }
+  const withoutLineRef = token.replace(/:\d+$/, "");
+  const normalized = withoutLineRef.replace(/\/+$/, "");
+  if (!pathReferencePattern.test(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function shouldCheckPathReference(token: string): boolean {
+  return !skippedPathFragments.some((fragment) => token.includes(fragment));
+}
+
+function addFinding(out: Finding[], seen: Set<string>, finding: Finding): void {
+  const key = `${finding.token}\0${finding.reason}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  out.push(finding);
+}
+
+function isCurrentTierDoc(file: string): boolean {
+  const normalized = file.replace(/\\/g, "/");
+  if (normalized.startsWith(".changeset/") || normalized.startsWith("docs/design/") || /^CHANGELOG/i.test(normalized)) {
+    return false;
+  }
+  return (
+    normalized === "README.md" ||
+    normalized === "AGENTS.md" ||
+    normalized === "CONTRIBUTING.md" ||
+    /^docs\/[^/]+\.md$/.test(normalized) ||
+    /^apps\/[^/]+\/README\.md$/.test(normalized) ||
+    /^packages\/[^/]+\/README\.md$/.test(normalized) ||
+    normalized === "agent/README.md" ||
+    (normalized.startsWith(".agents/skills/") && normalized.endsWith(".md"))
+  );
+}
+
+function hasRecordMarker(text: string): boolean {
+  return text.split("\n").slice(0, 10).some((line) => line.includes(recordMarker));
+}
+
+async function listFiles(roots: string[]): Promise<string[]> {
+  const existingRoots = roots.filter((root) => existsSync(root));
+  if (existingRoots.length === 0) {
+    return [];
+  }
+  const ripgrep = await runFileListCommand(["rg", "--files", ...existingRoots]);
+  if (ripgrep !== null) {
+    return normalizeFileList(ripgrep);
+  }
+  const git = await runFileListCommand(["git", "ls-files", "--", ...existingRoots]);
+  if (git !== null) {
+    return normalizeFileList(git);
+  }
+  throw new Error("Unable to list source files: neither rg nor git ls-files is available");
+}
+
+async function runFileListCommand(command: string[]): Promise<string | null> {
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn(command, {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && (error as { code?: unknown }).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`${command.join(" ")} failed: ${stderr.trim()}`);
+  }
+  return stdout;
+}
+
+function normalizeFileList(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.includes("/node_modules/"));
+}


### PR DESCRIPTION
Makes documentation freshness a CI property instead of a discipline hope.

- **`scripts/check-docs-refs.ts`** (wired into CI next to the billing guard): every concrete repo-path and `@opengeni/*` reference in current-tier docs/skills must resolve against the tree/workspace manifests. Record tier (`docs/design/**`, changelogs, `<!-- docs-refs: record -->`) exempt; per-line ignore escape hatch.
- **`docs/README.md`** — the docs map: six audiences (integrator / maintainer / repo agent / product agent / operator / record), canonical home per topic, link-don't-restate rule.
- Skill frontmatter gains `audience:` (repo-maintainer-agent vs integration-agent); point-in-time banners on design records.
- "Keeping docs true" checklists in AGENTS.md + CONTRIBUTING.md.
- Fixes the 4 remaining stale refs the new guard found (`docs/reliability-fixes.md` ×3, `agent/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq6ByfGw6dunzaMW6LAeii

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs, contributor guidance, and a read-only CI script only; no runtime, API, or auth behavior changes.
> 
> **Overview**
> Introduces **documentation freshness as a CI check** instead of contributor-only discipline.
> 
> **`scripts/check-docs-refs.ts`** scans current-tier docs and agent skills for inline `` `repo/path` `` and `` `@opengeni/*` `` references; anything that does not exist on disk or in workspace manifests fails the build. **`docs/design/**`**, changelogs, and files with `` `<!-- docs-refs: record -->` `` are skipped; per-line `` `<!-- docs-refs: ignore -->` `` is supported. The guard runs in **`.github/workflows/ci.yml`** next to the billing static guard; **`bun run check:docs-refs`** is added to **`package.json`**.
> 
> **`docs/README.md`** is the new **docs map**: audiences (integrator, maintainer, repo agent, operator, record), canonical homes per topic, and link-don’t-restate rules. **`AGENTS.md`** and **`CONTRIBUTING.md`** add **“Keeping docs true”** checklists pointing at that map. **`.agents/skills/opengeni*`** gain **`audience:`** frontmatter (`repo-maintainer-agent` vs `integration-agent`).
> 
> **Record tier** design docs get point-in-time banners and the record marker so the guard does not try to “fix” history. **`docs/architecture.md`** documents the new guard and links **`connected-machines.md`** in the doc index.
> 
> **Stale refs** caught by the new guard are fixed: **`docs/reliability-fixes.md`** now points scheduled-task helpers at **`packages/core/src/domain/scheduled-tasks.ts`** (not **`apps/api`**); **`agent/README.md`** wording on Cargo output is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83736239d57d3a6c8dd0db757deec9c4144626e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->