### PR TITLE
fix(react): anchor queued user messages at execution time, not arrival

### DIFF
--- a/.changeset/queued-message-anchoring.md
+++ b/.changeset/queued-message-anchoring.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Anchor queued user messages at the turn that actually executes them in the timeline projection, show still-pending queued messages quietly, and ignore cancellation events for queued turns that never started.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -287,8 +287,11 @@ function UserMessageRow({
 }) {
   return (
     <div className="animate-og-enter flex justify-end">
-      <div className="max-w-[85%] min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-og-md leading-6 text-og-fg">
-        {renderMessageText ? renderMessageText(item.text, item) : <Markdown>{item.text}</Markdown>}
+      <div className="flex max-w-[85%] min-w-0 flex-col items-end gap-1">
+        {item.pending ? <span className="px-1 text-og-xs text-og-fg-subtle">queued</span> : null}
+        <div className="w-fit max-w-full min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-og-md leading-6 text-og-fg">
+          {renderMessageText ? renderMessageText(item.text, item) : <Markdown>{item.text}</Markdown>}
+        </div>
       </div>
     </div>
   );

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -34,7 +34,8 @@ const WORKER_INTERRUPT_TOOL = "session_interrupt";
 
 export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   const items: TimelineItem[] = [];
-  const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+  const prescan = prescanTurnAnchors(events);
+  const ordered = orderTimelineEvents(events, prescan);
 
   const last = (): TimelineItem | undefined => items[items.length - 1];
 
@@ -76,6 +77,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           kind: "user-message",
           id: event.id,
           text: typeof payload.text === "string" ? payload.text : "",
+          ...(event.pendingUserMessage ? { pending: true } : {}),
           resources: resourceRefs(payload.resources),
           tools: toolRefs(payload.tools),
           occurredAt: event.occurredAt,
@@ -332,6 +334,12 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "turn.cancelled": {
+        // A retraction of a never-started queued turn is not a turn ending —
+        // the message was withdrawn before any work happened; show nothing.
+        // A null turnId proves nothing, so it keeps the legacy finalize path.
+        if (turnId && !prescan.startedTurnIds.has(turnId)) {
+          break;
+        }
         const hadActivity = hasTurnActivity(items, turnId);
         finalizeOpen(turnId, "cancelled");
         items.push(turnEndItem(event, "cancelled", null));
@@ -432,6 +440,128 @@ export function groupTimeline(items: TimelineItem[]): TimelineGroup[] {
 }
 
 /* --- helpers ---------------------------------------------------------------- */
+
+type TimelineEvent = SessionEvent & { pendingUserMessage?: true };
+
+type TurnAnchorPrescan = {
+  queuedTurnByTrigger: Map<string, string>;
+  startSeqByTrigger: Map<string, number>;
+  cancelledBeforeStartTriggers: Set<string>;
+  startedTurnIds: Set<string>;
+};
+
+function prescanTurnAnchors(events: SessionEvent[]): TurnAnchorPrescan {
+  const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+  const queuedTurnByTrigger = new Map<string, string>();
+  const startSeqByTrigger = new Map<string, number>();
+  const cancelledTurnIds = new Set<string>();
+  const fallbackSeqByTurn = new Map<string, number>();
+  const startedTurnIds = new Set<string>();
+
+  for (const event of ordered) {
+    const payload = asRecord(event.payload);
+    const turnId = event.turnId ?? null;
+    if (event.type === "turn.queued") {
+      const triggerEventId = typeof payload.triggerEventId === "string" ? payload.triggerEventId : null;
+      const queuedTurnId = typeof payload.turnId === "string" ? payload.turnId : turnId;
+      if (triggerEventId && queuedTurnId) {
+        queuedTurnByTrigger.set(triggerEventId, queuedTurnId);
+      }
+      continue;
+    }
+    if (event.type === "turn.started") {
+      const triggerEventId = typeof payload.triggerEventId === "string" ? payload.triggerEventId : null;
+      if (triggerEventId) {
+        startSeqByTrigger.set(triggerEventId, event.sequence);
+      }
+      if (turnId) {
+        startedTurnIds.add(turnId);
+      }
+    } else if (event.type === "turn.cancelled" && turnId) {
+      cancelledTurnIds.add(turnId);
+    }
+
+    if (turnId && event.type !== "turn.queued" && event.type !== "turn.cancelled") {
+      const previous = fallbackSeqByTurn.get(turnId);
+      if (previous === undefined || event.sequence < previous) {
+        fallbackSeqByTurn.set(turnId, event.sequence);
+      }
+    }
+    if (turnId && isAgentActivityEvent(event.type)) {
+      startedTurnIds.add(turnId);
+    }
+  }
+
+  for (const [triggerEventId, turnId] of queuedTurnByTrigger) {
+    if (!startSeqByTrigger.has(triggerEventId)) {
+      const fallbackSeq = fallbackSeqByTurn.get(turnId);
+      if (fallbackSeq !== undefined) {
+        startSeqByTrigger.set(triggerEventId, fallbackSeq);
+      }
+    }
+  }
+
+  const cancelledBeforeStartTriggers = new Set<string>();
+  for (const [triggerEventId, turnId] of queuedTurnByTrigger) {
+    if (cancelledTurnIds.has(turnId) && !startSeqByTrigger.has(triggerEventId) && !fallbackSeqByTurn.has(turnId)) {
+      cancelledBeforeStartTriggers.add(triggerEventId);
+    }
+  }
+
+  return { queuedTurnByTrigger, startSeqByTrigger, cancelledBeforeStartTriggers, startedTurnIds };
+}
+
+function orderTimelineEvents(events: SessionEvent[], prescan: TurnAnchorPrescan): TimelineEvent[] {
+  const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+  const insertions = new Map<number, TimelineEvent[]>();
+  const pending: TimelineEvent[] = [];
+
+  for (const event of ordered) {
+    if (event.type !== "user.message") {
+      continue;
+    }
+    const queuedTurnId = prescan.queuedTurnByTrigger.get(event.id);
+    if (!queuedTurnId) {
+      pushInsertion(insertions, event.sequence, event);
+      continue;
+    }
+    if (prescan.cancelledBeforeStartTriggers.has(event.id)) {
+      continue;
+    }
+    const startSeq = prescan.startSeqByTrigger.get(event.id);
+    if (startSeq !== undefined) {
+      pushInsertion(insertions, startSeq, event);
+      continue;
+    }
+    pending.push({ ...event, pendingUserMessage: true });
+  }
+
+  const projected: TimelineEvent[] = [];
+  for (const event of ordered) {
+    const before = insertions.get(event.sequence);
+    if (before) {
+      projected.push(...before);
+    }
+    if (event.type !== "user.message") {
+      projected.push(event);
+    }
+  }
+  projected.push(...pending);
+  return projected;
+}
+
+function pushInsertion(insertions: Map<number, TimelineEvent[]>, sequence: number, event: SessionEvent): void {
+  const bucket = insertions.get(sequence);
+  if (bucket) {
+    bucket.push(event);
+  } else {
+    insertions.set(sequence, [event]);
+  }
+}
+
+function isAgentActivityEvent(type: string): boolean {
+  return type.startsWith("agent.") || type.startsWith("sandbox.");
+}
 
 function turnEndItem(
   event: SessionEvent,

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -13,6 +13,8 @@ export type UserMessageItem = {
   kind: "user-message";
   id: string;
   text: string;
+  /** Queued for a future turn whose start has not appeared in the event log. */
+  pending?: boolean;
   /** Resources attached to this message (file uploads, repositories). */
   resources: ResourceRef[];
   /** Tools requested for the turn this message starts. */

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -125,6 +125,33 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
+  test("pending queued user messages show the quiet queued hint only while pending", async () => {
+    resetTimelineEvents();
+    const pendingEvents = [
+      timelineEvent("user.message", { text: "Follow up after this turn" }, null),
+      timelineEvent("turn.queued", { turnId: "turn-b", triggerEventId: "timeline-evt-1", source: "user" }, "turn-b"),
+    ];
+    const pending = await renderComponent(<MessageTimeline events={pendingEvents} />);
+    await flush();
+
+    expect(pending.container.textContent).toContain("Follow up after this turn");
+    expect(pending.container.textContent).toContain("queued");
+    await pending.unmount();
+
+    resetTimelineEvents();
+    const anchoredEvents = [
+      timelineEvent("user.message", { text: "Follow up after this turn" }, null),
+      timelineEvent("turn.queued", { turnId: "turn-b", triggerEventId: "timeline-evt-1", source: "user" }, "turn-b"),
+      timelineEvent("turn.started", { triggerEventId: "timeline-evt-1" }, "turn-b"),
+    ];
+    const anchored = await renderComponent(<MessageTimeline events={anchoredEvents} />);
+    await flush();
+
+    expect(anchored.container.textContent).toContain("Follow up after this turn");
+    expect(anchored.container.textContent).not.toContain("queued");
+    await anchored.unmount();
+  });
+
   test("duration facet renders when the settled turn lasts at least one second", async () => {
     resetTimelineEvents();
     const start = Date.UTC(2024, 5, 10, 12, 0, 0);

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -30,6 +30,19 @@ function event(type: string, payload: unknown, options: { turnId?: string | null
   };
 }
 
+function eventAt(sequenceNumber: number, type: string, payload: unknown, options: { turnId?: string | null } = {}): SessionEvent {
+  return {
+    id: `evt-${sequenceNumber}`,
+    workspaceId: "ws-1",
+    sessionId: "session-1",
+    sequence: sequenceNumber,
+    type,
+    payload,
+    occurredAt: new Date(1718000000000 + sequenceNumber * 1000).toISOString(),
+    turnId: options.turnId === undefined ? "turn-1" : options.turnId,
+  };
+}
+
 function reset(): void {
   sequence = 0;
 }
@@ -51,6 +64,10 @@ function activityGroups(groups: TimelineGroup[]): ActivityGroup[] {
 
 function turnGroups(groups: TimelineGroup[]): TurnGroup[] {
   return groups.filter((group): group is TurnGroup => group.kind === "turn");
+}
+
+function flattenActivityIds(group: TurnGroup | undefined): string[] {
+  return activityGroups(group?.groups ?? []).flatMap((activity) => activity.items.map((item) => item.id));
 }
 
 describe("buildTimeline", () => {
@@ -101,6 +118,135 @@ describe("buildTimeline", () => {
     ]);
     expect((items[0] as ToolCallItem).status).toBe("running");
     expect(items[1]?.kind).toBe("user-message");
+  });
+
+  test("legacy user messages with no queued turn keep their ledger position", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "make build" } }, { turnId: "turn-a" }),
+      event("user.message", { text: "legacy steering" }, { turnId: null }),
+      event("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "make test" } }, { turnId: "turn-a" }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["tool-call", "user-message", "tool-call"]);
+    expect((items[1] as UserMessageItem).text).toBe("legacy steering");
+  });
+
+  test("a genesis user message with queued and started events stays first", () => {
+    const items = buildTimeline([
+      eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+      eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+      eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+      eventAt(9, "agent.message.completed", { text: "First answer." }, { turnId: "turn-a" }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["user-message", "agent-message"]);
+    expect((items[0] as UserMessageItem).text).toBe("First message");
+  });
+
+  test("a queued user message anchors where its turn starts instead of its ledger sequence", () => {
+    const groups = groupTimeline(
+      buildTimeline([
+        eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+        eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+        eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+        eventAt(9, "agent.toolCall.created", { id: "call-a-1", name: "exec_command", arguments: { cmd: "first step" } }, { turnId: "turn-a" }),
+        eventAt(16, "user.message", { text: "QUEUED-MSG" }, { turnId: null }),
+        eventAt(17, "turn.queued", { turnId: "turn-b", triggerEventId: "evt-16", source: "user" }, { turnId: "turn-b" }),
+        eventAt(41, "agent.toolCall.created", { id: "call-a-2", name: "exec_command", arguments: { cmd: "second step" } }, { turnId: "turn-a" }),
+        eventAt(57, "agent.message.completed", { text: "Turn A final answer." }, { turnId: "turn-a" }),
+        eventAt(58, "turn.completed", {}, { turnId: "turn-a" }),
+        eventAt(61, "turn.started", { triggerEventId: "evt-16" }, { turnId: "turn-b" }),
+        eventAt(62, "agent.toolCall.created", { id: "call-b-1", name: "exec_command", arguments: { cmd: "queued work" } }, { turnId: "turn-b" }),
+        eventAt(80, "agent.message.completed", { text: "Turn B final answer." }, { turnId: "turn-b" }),
+        eventAt(94, "turn.completed", {}, { turnId: "turn-b" }),
+      ]),
+    );
+
+    expect(groups.map((group) => (group.kind === "item" ? `${group.kind}:${group.item.kind}` : group.kind))).toEqual([
+      "item:user-message",
+      "turn",
+      "item:agent-message",
+      "item:user-message",
+      "turn",
+      "item:agent-message",
+    ]);
+    const turns = turnGroups(groups);
+    expect(turns).toHaveLength(2);
+    expect(flattenActivityIds(turns[0])).toEqual(["evt-9", "evt-41"]);
+    expect(flattenActivityIds(turns[1])).toEqual(["evt-62"]);
+    expect(groups[2]?.kind === "item" ? groups[2].item : null).toMatchObject({ kind: "agent-message", text: "Turn A final answer." });
+    expect(groups[3]?.kind === "item" ? groups[3].item : null).toMatchObject({ kind: "user-message", text: "QUEUED-MSG" });
+  });
+
+  test("a queued user message stays pending at the end until the queued turn starts", () => {
+    const pendingItems = buildTimeline([
+      eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+      eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+      eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+      eventAt(9, "agent.message.delta", { text: "Still working." }, { turnId: "turn-a" }),
+      eventAt(16, "user.message", { text: "Queued follow-up" }, { turnId: null }),
+      eventAt(17, "turn.queued", { turnId: "turn-b", triggerEventId: "evt-16", source: "user" }, { turnId: "turn-b" }),
+    ]);
+    expect(pendingItems.at(-1)).toMatchObject({ kind: "user-message", text: "Queued follow-up", pending: true });
+
+    const anchoredItems = buildTimeline([
+      eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+      eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+      eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+      eventAt(9, "agent.message.delta", { text: "Still working." }, { turnId: "turn-a" }),
+      eventAt(16, "user.message", { text: "Queued follow-up" }, { turnId: null }),
+      eventAt(17, "turn.queued", { turnId: "turn-b", triggerEventId: "evt-16", source: "user" }, { turnId: "turn-b" }),
+      eventAt(57, "agent.message.completed", { text: "Turn A done." }, { turnId: "turn-a" }),
+      eventAt(58, "turn.completed", {}, { turnId: "turn-a" }),
+      eventAt(61, "turn.started", { triggerEventId: "evt-16" }, { turnId: "turn-b" }),
+      eventAt(62, "agent.toolCall.created", { id: "call-b-1", name: "exec_command", arguments: { cmd: "follow-up" } }, { turnId: "turn-b" }),
+    ]);
+    const followUpIndex = anchoredItems.findIndex((item) => item.kind === "user-message" && item.text === "Queued follow-up");
+    const turnBIndex = anchoredItems.findIndex((item) => item.kind === "tool-call" && item.turnId === "turn-b");
+    expect(followUpIndex).toBeGreaterThan(-1);
+    expect(turnBIndex).toBeGreaterThan(followUpIndex);
+    expect(anchoredItems[followUpIndex]).not.toHaveProperty("pending");
+  });
+
+  test("a queued user message cancelled before start is omitted without touching a running turn", () => {
+    const groups = groupTimeline(
+      buildTimeline([
+        eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+        eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+        eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+        eventAt(9, "agent.toolCall.created", { id: "call-a-1", name: "exec_command", arguments: { cmd: "first step" } }, { turnId: "turn-a" }),
+        eventAt(16, "user.message", { text: "Retracted follow-up" }, { turnId: null }),
+        eventAt(17, "turn.queued", { turnId: "turn-b", triggerEventId: "evt-16", source: "user" }, { turnId: "turn-b" }),
+        eventAt(18, "turn.cancelled", { turnId: "turn-b", triggerEventId: "evt-16" }, { turnId: "turn-b" }),
+        eventAt(41, "agent.toolCall.created", { id: "call-a-2", name: "exec_command", arguments: { cmd: "second step" } }, { turnId: "turn-a" }),
+        eventAt(57, "agent.message.completed", { text: "Turn A final answer." }, { turnId: "turn-a" }),
+        eventAt(58, "turn.completed", {}, { turnId: "turn-a" }),
+      ]),
+    );
+
+    expect(JSON.stringify(groups)).not.toContain("Retracted follow-up");
+    expect(JSON.stringify(groups)).not.toContain("Interrupted.");
+    expect(groups.map((group) => (group.kind === "item" ? `${group.kind}:${group.item.kind}` : group.kind))).toEqual([
+      "item:user-message",
+      "turn",
+      "item:agent-message",
+    ]);
+    const [turn] = turnGroups(groups);
+    expect(turn?.outcome).toBe("complete");
+    expect(flattenActivityIds(turn)).toEqual(["evt-9", "evt-41"]);
+  });
+
+  test("a queued turn without turn.started anchors on the first same-turn activity", () => {
+    const items = buildTimeline([
+      eventAt(2, "user.message", { text: "First message" }, { turnId: null }),
+      eventAt(4, "turn.queued", { turnId: "turn-a", triggerEventId: "evt-2", source: "user" }, { turnId: "turn-a" }),
+      eventAt(6, "turn.started", { triggerEventId: "evt-2" }, { turnId: "turn-a" }),
+      eventAt(16, "user.message", { text: "Crash-resumed follow-up" }, { turnId: null }),
+      eventAt(17, "turn.queued", { turnId: "turn-b", triggerEventId: "evt-16", source: "user" }, { turnId: "turn-b" }),
+      eventAt(61, "agent.toolCall.created", { id: "call-b-1", name: "exec_command", arguments: { cmd: "follow-up" } }, { turnId: "turn-b" }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["user-message", "user-message", "tool-call"]);
+    expect(items[1]).toMatchObject({ kind: "user-message", text: "Crash-resumed follow-up" });
+    expect(items[1]).not.toHaveProperty("pending");
   });
 
   test("user messages carry their attached resources and requested tools", () => {
@@ -313,6 +459,7 @@ describe("buildTimeline", () => {
       // Attention statuses earn a divider, collapsed on repeat.
       event("session.status.changed", { status: "requires_action" }),
       event("session.status.changed", { status: "requires_action" }),
+      event("turn.started", { triggerEventId: "evt-start" }),
       event("turn.failed", { error: "model provider unavailable" }),
       event("turn.cancelled", {}),
     ]);
@@ -340,6 +487,7 @@ describe("buildTimeline", () => {
     const items = buildTimeline([
       event("turn.completed", {}, { turnId: "turn-complete" }),
       event("turn.failed", { error: "model provider unavailable" }, { turnId: "turn-failed" }),
+      event("turn.started", { triggerEventId: "evt-cancelled" }, { turnId: "turn-cancelled" }),
       event("turn.cancelled", {}, { turnId: "turn-cancelled" }),
     ]);
     const turnEnds = items.filter((item): item is TurnEndItem => item.kind === "turn-end");
@@ -379,7 +527,7 @@ describe("buildTimeline", () => {
 
   test("cancelled turns without activity keep the interruption notice", () => {
     reset();
-    const items = buildTimeline([event("turn.cancelled", {})]);
+    const items = buildTimeline([event("turn.started", { triggerEventId: "evt-start" }), event("turn.cancelled", {})]);
     expect(items.map((item) => item.kind)).toEqual(["turn-end", "notice"]);
     expect(items[1]).toMatchObject({ tone: "cancelled", text: "Interrupted." });
   });
@@ -695,7 +843,19 @@ describe("groupTimeline", () => {
     expect(activities[1]?.failureText).toBe("deploy failed");
   });
 
-  test("a null-turn turn-end stamps the trailing activity group", () => {
+  test("a null-turn failure stamps the trailing activity group", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "tail logs" } }, { turnId: null }),
+        event("turn.failed", { error: "tail failed" }, { turnId: null }),
+      ]),
+    );
+    const [activity] = activityGroups(groups);
+    expect(activity?.outcome).toBe("failed");
+  });
+
+  test("a null-turn cancellation keeps the legacy finalize path (not a queued retraction)", () => {
     reset();
     const groups = groupTimeline(
       buildTimeline([
@@ -704,7 +864,10 @@ describe("groupTimeline", () => {
       ]),
     );
     const [activity] = activityGroups(groups);
+    // Null turnId proves nothing about queued-turn retraction; the trailing
+    // group still settles as cancelled exactly as before.
     expect(activity?.outcome).toBe("cancelled");
+    expect(activity?.items[0]).toMatchObject({ status: "cancelled" });
   });
 });
 


### PR DESCRIPTION
## The bug (reproduced live on staging)

A message sent while a turn is running is appended to the event ledger at receipt — correct for durability — so its sequence lands **interleaved inside the running turn's trace**. The timeline rendered it there: visually the queued message appeared mid-turn, *before* that turn's final answer (reading as if the answer responded to it), and it chopped the #192 turn fold in half because the fold's walk-back stops at user messages.

Captured event order from the reproduction (session `facd3a71` on staging): `user.message` at seq 16 wedged between turn A's tool calls (seq 9–57); its own turn B only starts at seq 61.

## The fix (client-side; the system is sound)

`turn.queued` / `turn.started` / `turn.cancelled` already carry `triggerEventId` → the message event. `buildTimeline` now prescans that linkage and re-anchors each user message at the point it **took effect**:

- Trigger of a started turn → anchored at its `turn.started`. After a queue **reorder**, the transcript automatically shows messages in true execution order.
- Still queued → rendered at the tail with a quiet `queued` hint (`UserMessageItem.pending`).
- Retracted before start (queued turn deleted) → omitted; the ledger keeps the audit.
- No linkage (legacy logs) → ledger position, byte-for-byte previous behavior.

Bonus correctness: `closeStreamingTail` no longer fires at the send position, so a queued message doesn't visually split the agent's streaming text.

## Latent #192 bug fixed alongside

`DELETE /turns/:turnId` on a queued turn appends `turn.cancelled {turnId, triggerEventId}`. The projection treated every `turn.cancelled` as a turn ending — a retraction would wrap the *still-running* turn's live trace in a "cancelled" fold chip. Now a cancellation of a proven never-started turn (known turnId, no start, no activity) projects nothing; null-turnId cancellations keep the legacy finalize path (owner-review tightening — the agent-written guard also skipped null turnIds, which would have silently dropped legacy interrupts).

## Verification

- `bun test packages/react/test`: **387 pass, 0 fail** — repro-shaped fixture (anchoring + un-chopped fold), pending tail + hint, retraction omission + running-turn immunity, started-turn cancellation unchanged, legacy position, genesis unchanged, null-turnId legacy path.
- `tsc --noEmit` clean; `tsup` + demo build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline projection and turn-cancel handling; mistakes could mis-order messages or hide/show wrong interrupt UI, but scope is client-only with extensive unit/DOM tests and legacy fallbacks.
> 
> **Overview**
> Fixes the transcript showing messages sent during a running turn **mid-turn** (ledger order) instead of when their queued turn actually runs, which also split turn folds and made answers look mis-attributed.
> 
> **`buildTimeline`** now prescans `turn.queued` / `turn.started` / `turn.cancelled` via `triggerEventId`, reorders user messages before projection, and sets **`UserMessageItem.pending`** when a turn has not started yet. Started turns anchor the bubble at `turn.started` (or first same-turn agent activity if `turn.started` is missing); still-queued messages stay at the tail; retracted-before-start messages are dropped from the UI. Unlinked legacy logs keep ledger order.
> 
> **`turn.cancelled`** for a turn that never started no longer finalizes the running turn or shows “Interrupted.”; cancellations with a null `turnId` keep the previous behavior.
> 
> **`UserMessageRow`** shows a subtle **queued** label when `pending` is set. Tests cover anchoring, pending hint, retraction, and fold integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5161c7b1dd4ef173a7e5c2524ca7cec4d8f53b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->