### PR TITLE
fix(recording): skip on-turn recording when the turn's effective backend is a connected machine

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -326,6 +326,45 @@ export async function resolveActiveSandboxBackend(
 }
 
 /**
+ * Decide whether to start on-turn desktop recording for THIS turn.
+ *
+ * On-turn recording runs ffmpeg/x11grab INSIDE the box and reads the .mp4 back
+ * out of the box's /tmp — plumbing that exists only for OpenGeni-operated cloud
+ * boxes (the Modal desktop backend). A turn whose EFFECTIVE backend is a connected
+ * machine ("selfhosted") runs on the user's REAL computer, which has none of that
+ * capture plumbing (and the platform must never shell ffmpeg onto a user's machine
+ * — the same reason the runtime skips its setup hooks for selfhosted). Left ungated
+ * it films nothing, finds no /tmp file, and emits recording.started followed by
+ * recording.failed{box-death} on EVERY machine-primary turn — misleading timeline
+ * noise + wasted work. So gate it off, exactly like a recording-disabled deployment:
+ * skip silently, emit nothing (no new event shape).
+ *
+ * `effectiveBackend` is the resolved ACTIVE backend for the turn
+ * (resolveActiveSandboxBackend) — NOT the session's home backend. A modal-home
+ * session actively swapped onto a machine resolves to "selfhosted" here and
+ * correctly skips; a machine-home turn that degraded back to its cloud group box
+ * (swap-away / flag-off) resolves to undefined and records as before.
+ *
+ * EDGE — mid-turn swap: this is evaluated ONCE at turn start (the box is only filmed
+ * for the duration of one turn). A swap AFTER the recording starts is deliberately
+ * ignored — a partial-turn recording already has defined failure semantics, so we do
+ * not add machinery to stop/restart it mid-turn.
+ */
+export function shouldStartOnTurnRecording(params: {
+  recordingEnabled: boolean;
+  desktopEnabled: boolean;
+  establishedBackendId: string;
+  effectiveBackend: Settings["sandboxBackend"] | undefined;
+}): boolean {
+  return (
+    params.recordingEnabled
+    && params.desktopEnabled
+    && desktopCapableBackend(params.establishedBackendId)
+    && params.effectiveBackend !== "selfhosted"
+  );
+}
+
+/**
  * SELF-HEAL helper for the all-capped rotation idle (invariant 4: BOUNDED, no thrash).
  * The turn hot path never refreshes Codex usage — only the usage API route does — so a
  * window that has actually reset still reads OVER-threshold from the stale cache, which
@@ -1046,9 +1085,15 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // `finally` (read+PUT in this same activity — never a Temporal payload).
       if (
         resolvedSandbox
-        && settings.sandboxDesktopEnabled
-        && settings.recordingEnabled
-        && desktopCapableBackend(resolvedSandbox.established.backendId)
+        && shouldStartOnTurnRecording({
+          recordingEnabled: settings.recordingEnabled,
+          desktopEnabled: settings.sandboxDesktopEnabled,
+          establishedBackendId: resolvedSandbox.established.backendId,
+          // EFFECTIVE (active) backend, not the session home: a machine-primary turn
+          // resolves to "selfhosted" and skips; a swap back to the cloud group box
+          // resolves to undefined and records as before.
+          effectiveBackend: activeSandboxBackend,
+        })
       ) {
         try {
           const begun = await beginRecording({

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
-import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 
 // Item shapes mirror the SDK history representation persisted into
 // session_history_items (type discriminator, camelCase callId).
@@ -369,6 +369,50 @@ describe("active sandbox backend resolution (Case B: clone-onto-real-disk gate)"
     expect(backend).toBe("selfhosted");
     expect(pointerReads).toBe(1);
     expect(kindReads).toBe(1);
+  });
+});
+
+describe("on-turn recording gate (selfhosted machines have no in-box capture plumbing)", () => {
+  const base: Parameters<typeof shouldStartOnTurnRecording>[0] = {
+    recordingEnabled: true,
+    desktopEnabled: true,
+    establishedBackendId: "modal",
+    effectiveBackend: undefined,
+  };
+
+  test("modal cloud box: records (unchanged behavior)", () => {
+    expect(shouldStartOnTurnRecording({ ...base })).toBe(true);
+  });
+
+  test("selfhosted EFFECTIVE backend: does NOT start recording (no recording.started emitted)", () => {
+    // The machine-primary turn establishes the SelfhostedSession (backendId
+    // "selfhosted", which is desktop-capable), so the desktop-capable check alone
+    // would over-trigger. The effective-backend gate is what suppresses it.
+    expect(
+      shouldStartOnTurnRecording({ ...base, establishedBackendId: "selfhosted", effectiveBackend: "selfhosted" }),
+    ).toBe(false);
+  });
+
+  test("modal-home session swapped ONTO a machine: skips (gate is the effective backend, not home)", () => {
+    // Home backend is a cloud box (established could even still read modal in the
+    // degraded no-enrollment edge), but the ACTIVE pointer resolves selfhosted —
+    // recording must skip.
+    expect(shouldStartOnTurnRecording({ ...base, establishedBackendId: "modal", effectiveBackend: "selfhosted" })).toBe(false);
+  });
+
+  test("machine-home turn degraded back to its cloud group box: records (effective backend undefined)", () => {
+    expect(
+      shouldStartOnTurnRecording({ ...base, establishedBackendId: "modal", effectiveBackend: undefined }),
+    ).toBe(true);
+  });
+
+  test("recording disabled by policy: skips regardless of backend", () => {
+    expect(shouldStartOnTurnRecording({ ...base, recordingEnabled: false })).toBe(false);
+    expect(shouldStartOnTurnRecording({ ...base, desktopEnabled: false })).toBe(false);
+  });
+
+  test("headless / non-desktop established backend: skips (existing static feasibility gate holds)", () => {
+    expect(shouldStartOnTurnRecording({ ...base, establishedBackendId: "none" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Every machine-primary turn (and any turn actively swapped onto a connected machine) emitted `recording.started` followed by `recording.failed {reason: box-death, "recording file missing on box: /tmp/og-rec-*.mp4"}` — observed on every staging computer-use session against a real Mac. On-turn recording is ffmpeg/x11grab **inside the box** with the .mp4 read back from `/tmp`: plumbing that exists only for OpenGeni-operated cloud boxes, and which the platform must never shell onto a user's real computer (same doctrine as the selfhosted setup-hook exemption).

Gate the decision on the turn's **effective** (active) backend, not the session home: new pure `shouldStartOnTurnRecording()` keeps the existing flag + `desktopCapableBackend` checks and adds `effectiveBackend !== "selfhosted"`, fed by the same `resolveActiveSandboxBackend` value already used to gate platform setup. Machine-primary and swapped-onto-machine turns skip silently (identical to a recording-disabled deployment — no new event shape); cloud-box turns unchanged. The sandbox descriptor's `Recording.available == DesktopStream.available` invariant is deliberately untouched. Mid-turn swaps are evaluated once at turn start (documented).

Tests: 6 new cases (modal records; selfhosted skips; swapped-onto-machine skips; degraded-back-to-cloud records; policy-disabled skips; headless skips). `tsc` clean; agent-turn suite 27 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow worker change behind a new pure gate with unit tests; cloud recording behavior is unchanged when effective backend is not selfhosted.
> 
> **Overview**
> **Stops bogus on-turn desktop recordings** on connected machines and mid-turn swaps to selfhosted, where in-box ffmpeg capture does not exist and every turn was emitting `recording.started` then `recording.failed` (missing `/tmp` mp4).
> 
> Adds pure **`shouldStartOnTurnRecording()`** that keeps the existing recording/desktop/`desktopCapableBackend` checks and adds **`effectiveBackend !== "selfhosted"`**, using the same **`activeSandboxBackend`** from `resolveActiveSandboxBackend` already used for clone/setup gating. Cloud-primary turns and machine-home sessions degraded back to the group cloud box still record; machine-primary and swapped-onto-machine turns skip silently with no timeline events.
> 
> Six unit tests cover modal vs selfhosted effective backend, swap scenarios, policy off, and headless backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045f3a05a60a0b88458b5623f13ff9727e5f9f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->