### PR TITLE
chore(release): republish @opengeni/contracts with current export surface

### DIFF
--- a/.changeset/contracts-export-sync.md
+++ b/.changeset/contracts-export-sync.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/contracts": minor
+---
+
+Republish contracts so the registry version carries the current export surface (`MintEnrollTokenRequest` and the machines/enroll types) that `@opengeni/api-router@0.2.x` imports — the previously published 0.3.0 predates them.


### PR DESCRIPTION
`@opengeni/api-router@0.2.0` (published from current main) imports `MintEnrollTokenRequest` from `@opengeni/contracts`, but the registry's `contracts@0.3.0` predates Stage C and lacks it — the pair is runtime-incompatible for external consumers. No contracts changeset existed in the Stage C wave, so it never republished. This adds one (minor). Follow-up worth noting: the publish closure guard validates dependency topology but not export compatibility across published versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq6ByfGw6dunzaMW6LAeii

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changeset with no code or API edits in the diff; risk is limited to versioning/publish timing, not behavioral changes in this PR.
> 
> **Overview**
> Adds a **minor** Changesets entry for `@opengeni/contracts` so the next publish pushes the export surface that already exists in the repo (including `MintEnrollTokenRequest` and related machines/enroll types).
> 
> Registry `contracts@0.3.0` was published before those exports landed, while `@opengeni/api-router@0.2.x` imports them — external installs can break at runtime. **No application or package source changes** in this PR; it only schedules the republish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7921f0a14491ef70d2d0e41ebe22885290aa5693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->