### PR TITLE
polish: UI/UX program — one design language, honest states, mobile-first

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -199,7 +199,7 @@ function RootIndexRoute() {
   const context = useAppContext();
   const workspaceId = context.accessContext.defaultWorkspaceId ?? context.workspaces[0]?.id ?? context.accessContext.workspaceGrants[0]?.workspaceId;
   if (!workspaceId) {
-    return <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />;
+    return <ProblemPanel title="No workspace access" description="You don't have access to any workspace yet." />;
   }
   return <Navigate to="/workspaces/$workspaceId/sessions" params={{ workspaceId }} replace />;
 }
@@ -296,7 +296,7 @@ function BillingReturnRoute() {
   const { checkout } = billingReturnRoute.useSearch();
   const workspaceId = context.accessContext.defaultWorkspaceId ?? context.workspaces[0]?.id ?? context.accessContext.workspaceGrants[0]?.workspaceId;
   if (!workspaceId) {
-    return <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />;
+    return <ProblemPanel title="No workspace access" description="You don't have access to any workspace yet." />;
   }
   return (
     <Navigate
@@ -309,5 +309,5 @@ function BillingReturnRoute() {
 }
 
 function NotFoundRoute() {
-  return <ProblemPanel title="Page not found" description="This OpenGeni console route does not exist. Workspace-scoped URLs are required." />;
+  return <ProblemPanel title="Page not found" description="This page doesn't exist. Open a workspace to continue." />;
 }

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -76,8 +76,8 @@ export function ConsoleComposer(props: {
         <p
           data-testid="delivery-mode-hint"
           className={cn(
-            "px-1.5 pt-1.5 text-[11px] leading-4",
-            composer.mode === "steer" ? "text-amber-300/90" : "text-[color:var(--color-fg-subtle)]",
+            "px-1.5 pt-1.5 text-2xs",
+            composer.mode === "steer" ? "text-status-running/90" : "text-fg-subtle",
           )}
         >
           {deliveryModeExplanation(composer.mode, props.status ?? null)}
@@ -88,15 +88,15 @@ export function ConsoleComposer(props: {
 }
 
 /**
- * The compose-time queue-vs-steer choice. Queue is the calm default; steer is
- * visually loud (amber) because it interrupts whatever the agent is doing.
+ * The compose-time queue-vs-steer choice. Queue is the calm default; steer
+ * uses the running status tone because it interrupts the current turn.
  */
 function DeliveryModeToggle({ composer, disabled }: { composer: ComposerState; disabled?: boolean }) {
   return (
     <div
       role="radiogroup"
       aria-label="Delivery mode"
-      className="flex h-8 shrink-0 items-center gap-0.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/60 p-0.5"
+      className="flex h-8 shrink-0 items-center gap-0.5 rounded-full border border-border bg-bg/60 p-0.5"
     >
       <button
         type="button"
@@ -108,8 +108,8 @@ function DeliveryModeToggle({ composer, disabled }: { composer: ComposerState; d
         className={cn(
           "inline-flex h-7 items-center gap-1 rounded-full px-2.5 text-xs font-medium transition-colors",
           composer.mode === "queue"
-            ? "bg-[color:var(--color-surface-2)] text-[color:var(--color-fg)]"
-            : "text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]",
+            ? "bg-surface-2 text-fg"
+            : "text-fg-muted hover:text-fg",
         )}
       >
         <ListPlusIcon className="size-3.5" />
@@ -125,8 +125,8 @@ function DeliveryModeToggle({ composer, disabled }: { composer: ComposerState; d
         className={cn(
           "inline-flex h-7 items-center gap-1 rounded-full px-2.5 text-xs font-medium transition-colors",
           composer.mode === "steer"
-            ? "bg-amber-500/20 text-amber-200"
-            : "text-[color:var(--color-fg-muted)] hover:text-amber-200",
+            ? "bg-status-running/20 text-status-running"
+            : "text-fg-muted hover:text-status-running",
         )}
       >
         <ZapIcon className="size-3.5" />

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 
 // Cache TTL: a row whose cached snapshot is older than this (or never fetched)
@@ -45,15 +46,15 @@ export function UsageBar({ label, window, now }: { label: string; window: CodexU
   const secs = secondsUntilReset(window, now);
   return (
     <div className="grid gap-1">
-      <div className="flex items-center justify-between text-xs text-[color:var(--color-fg-muted)]">
+      <div className="flex items-center justify-between text-xs text-fg-muted">
         <span>{label}</span>
         <span>
           {limitReached ? "limit reached" : `${pct}% used`}
           {secs ? ` · ${resetLabel(secs)}` : ""}
         </span>
       </div>
-      <div className="h-1.5 overflow-hidden rounded-full bg-[color:var(--color-surface-2)]">
-        <div className={`h-full rounded-full ${danger ? "bg-amber-500" : "bg-[color:var(--color-brand)]"}`} style={{ width: `${pct}%` }} />
+      <div className="h-1.5 overflow-hidden rounded-full bg-surface-2">
+        <div className={`h-full rounded-full ${danger ? "bg-status-waiting" : "bg-brand"}`} style={{ width: `${pct}%` }} />
       </div>
     </div>
   );
@@ -82,14 +83,14 @@ function AccountUsage({
 
   // loading — a live refresh is in flight and we have nothing cached yet.
   if (refreshing && !fiveHour && !weekly) {
-    return <div className="h-3 w-2/3 animate-pulse rounded bg-[color:var(--color-surface-2)]" />;
+    return <div className="h-3 w-2/3 animate-pulse rounded bg-surface-2" />;
   }
   // error — a refresh/needs_relogin or transient 401. Subtle inline, not a hard block.
   if (status === "error" && !fiveHour && !weekly) {
     return (
-      <div className="text-xs text-[color:var(--color-fg-subtle)]">
+      <div className="text-xs text-fg-subtle">
         usage unavailable ·{" "}
-        <button type="button" className="underline hover:text-[color:var(--color-fg)]" onClick={onRetry}>
+        <button type="button" className="underline hover:text-fg" onClick={onRetry}>
           retry
         </button>
       </div>
@@ -105,7 +106,7 @@ function AccountUsage({
       <UsageBar label="5-hour" window={fiveHour} now={now} />
       <UsageBar label="Weekly" window={weekly} now={now} />
       {limitReached ? (
-        <div className="flex items-center gap-1.5 text-xs text-amber-500">
+        <div className="flex items-center gap-1.5 text-xs text-status-waiting">
           <TriangleAlertIcon className="size-3.5" /> Usage limit reached
         </div>
       ) : null}
@@ -312,14 +313,14 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
   };
 
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <SparklesIcon className="size-3.5 text-[color:var(--color-brand)]" />
+            <SparklesIcon className="size-3.5 text-brand" />
             Codex subscriptions
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+          <p className="mt-1 text-xs text-fg-muted">
             Connect one or more ChatGPT plans to run agents on your subscription. Turns using a <span className="font-medium">Codex</span> model spend
             your ChatGPT usage — <span className="font-medium">no API credits</span>.
           </p>
@@ -332,15 +333,15 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
       </div>
 
       {accounts.length > 1 && canManage ? (
-        <div className="grid gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3">
+        <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
           <label className="flex cursor-pointer items-center justify-between gap-3">
             <span className="text-xs">
               <span className="font-medium">Auto-rotate subscriptions</span>
-              <span className="ml-1 text-[color:var(--color-fg-subtle)]">— fail over to another plan when one hits its cap, never mid-turn.</span>
+              <span className="ml-1 text-fg-subtle">— fail over to another plan when one hits its cap, never mid-turn.</span>
             </span>
             <input
               type="checkbox"
-              className="size-4 accent-[color:var(--color-brand)]"
+              className="size-4 accent-brand"
               checked={rotationEnabled}
               disabled={busy}
               onChange={(e) => void setRotation({ rotationEnabled: e.target.checked })}
@@ -348,9 +349,9 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
           </label>
           {rotationEnabled ? (
             <label className="flex items-center justify-between gap-3 text-xs">
-              <span className="text-[color:var(--color-fg-muted)]">Strategy</span>
-              <select
-                className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1 text-xs"
+              <span className="text-fg-muted">Strategy</span>
+              <Select
+                className="h-7 bg-surface text-xs"
                 value={rotationStrategy}
                 disabled={busy}
                 onChange={(e) => void setRotation({ rotationStrategy: e.target.value as CodexRotationSettings["rotationStrategy"] })}
@@ -358,28 +359,28 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                 <option value="most_remaining">Most remaining quota</option>
                 <option value="round_robin">Round-robin</option>
                 <option value="drain_then_next">Drain then next</option>
-              </select>
+              </Select>
             </label>
           ) : null}
         </div>
       ) : null}
 
       {loading ? (
-        <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-subtle)]"><Loader2Icon className="size-3.5 animate-spin" /> Loading subscriptions…</div>
+        <div className="flex items-center gap-2 text-xs text-fg-subtle"><Loader2Icon className="size-3.5 animate-spin" /> Loading subscriptions…</div>
       ) : pending ? (
-        <div className="grid gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3">
-          <div className="text-xs text-[color:var(--color-fg-muted)]">Enter this code at the OpenAI page (opened in a new tab), then leave this open:</div>
+        <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
+          <div className="text-xs text-fg-muted">Enter this code at the OpenAI page (opened in a new tab), then leave this open:</div>
           <div className="flex items-center gap-2">
-            <code className="rounded bg-[color:var(--color-surface-2)] px-3 py-1.5 text-lg font-semibold tracking-widest">{pending.userCode}</code>
+            <code className="rounded bg-surface-2 px-3 py-1.5 text-lg font-semibold tracking-widest">{pending.userCode}</code>
             <Button asChild type="button" variant="secondary" size="sm">
               <a href={pending.verificationUri} target="_blank" rel="noopener noreferrer">Open auth page <ExternalLinkIcon className="size-3.5" /></a>
             </Button>
           </div>
-          <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-subtle)]"><Loader2Icon className="size-3.5 animate-spin" /> Waiting for authorization…</div>
+          <div className="flex items-center gap-2 text-xs text-fg-subtle"><Loader2Icon className="size-3.5 animate-spin" /> Waiting for authorization…</div>
         </div>
       ) : accounts.length === 0 ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-xs text-[color:var(--color-fg-subtle)]">Not connected. Connecting needs admin access and a ChatGPT Plus/Pro/Team plan.</p>
+          <p className="text-xs text-fg-subtle">Not connected. Connecting needs admin access and a ChatGPT Plus/Pro/Team plan.</p>
           {canManage ? (
             <Button type="button" size="sm" disabled={busy} onClick={() => void connect()}>
               {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <SparklesIcon className="size-3.5" />} Connect Codex
@@ -392,13 +393,13 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
             const isActive = account.id === activeAccountId;
             const needsRelogin = account.status !== "active" && account.lastError != null;
             return (
-              <div key={account.id} className="grid gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3">
+              <div key={account.id} className="grid gap-2 rounded-md border border-border bg-bg p-3">
                 <div className="flex items-center gap-3">
                   <label className="flex cursor-pointer items-center" title="Used when a session isn't pinned to a specific subscription">
                     <input
                       type="radio"
                       name="codex-active"
-                      className="size-3.5 accent-[color:var(--color-brand)]"
+                      className="size-3.5 accent-brand"
                       checked={isActive}
                       disabled={!canManage || busy}
                       onChange={() => { if (!isActive) void activate(account.id); }}
@@ -428,14 +429,14 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                         {accountDisplay(account)}
                       </button>
                     )}
-                    <div className="mt-0.5 truncate text-xs text-[color:var(--color-fg-subtle)]">
+                    <div className="mt-0.5 truncate text-xs text-fg-subtle">
                       {account.email ? `${account.email} · ` : ""}
                       {account.status === "active" ? "Token valid" : account.status}
                       {account.expiresAt ? ` · expires ${new Date(account.expiresAt).toLocaleString()}` : ""}
                     </div>
                   </div>
                   {account.plan ? (
-                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-300">
+                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-status-idle/30 bg-status-idle/10 px-2 py-0.5 text-xs text-status-idle">
                       {account.plan} plan
                     </span>
                   ) : null}
@@ -445,14 +446,14 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                       : 0;
                     if (coolingSecs > 0) {
                       return (
-                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-300" title="Rotated off after hitting its cap; skipped until reset">
+                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-status-waiting/30 bg-status-waiting/10 px-2 py-0.5 text-2xs text-status-waiting" title="Rotated off after hitting its cap; skipped until reset">
                           cooling down · {resetLabel(coolingSecs)}
                         </span>
                       );
                     }
                     if (isActive) {
                       return (
-                        <span className="shrink-0 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+                        <span className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">
                           {rotationEnabled ? "Active · default when idle" : "Active"}
                         </span>
                       );
@@ -461,7 +462,7 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                   })()}
                 </div>
                 {needsRelogin ? (
-                  <div className="flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-200">
+                  <div className="flex items-center gap-1.5 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-status-waiting">
                     <TriangleAlertIcon className="size-3.5" /> {account.lastError ?? "Reconnect needed."}
                   </div>
                 ) : (
@@ -492,7 +493,7 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
               </div>
             );
           })}
-          <p className="text-[11px] text-[color:var(--color-fg-subtle)]">
+          <p className="text-2xs text-fg-subtle">
             {rotationEnabled ? (
               <>Auto-rotating across {accounts.length} subscriptions by <span className="font-medium">{ROTATION_STRATEGY_LABELS[rotationStrategy]}</span>. Pinned sessions stay on their pin.</>
             ) : (

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MetaChip } from "@/components/ui/meta-chip";
 import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 
@@ -115,7 +116,8 @@ function AccountUsage({
 }
 
 function accountDisplay(account: CodexAccount): string {
-  return account.label ?? account.email ?? account.plan ?? account.chatgptAccountId ?? "Codex account";
+  // Never fall back to the raw chatgpt account id as a display label.
+  return account.label ?? account.email ?? account.plan ?? "Codex account";
 }
 
 export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId: string; canManage: boolean }) {
@@ -270,7 +272,7 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
       await refreshAccounts();
       toast.success("Rotation settings updated");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to update rotation");
+      toast.error(error instanceof Error ? error.message : "Failed to update rotation settings");
     } finally {
       setBusy(false);
     }
@@ -283,7 +285,7 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
       await refreshAccounts();
       toast.success("Subscription disconnected");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to disconnect");
+      toast.error(error instanceof Error ? error.message : "Failed to disconnect subscription");
     } finally {
       setBusy(false);
     }
@@ -296,7 +298,7 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
       await client.renameCodexAccount(workspaceId, accountId, label.trim() === "" ? null : label.trim());
       await refreshAccounts();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to rename");
+      toast.error(error instanceof Error ? error.message : "Failed to rename subscription");
     } finally {
       setBusy(false);
     }
@@ -431,14 +433,12 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                     )}
                     <div className="mt-0.5 truncate text-xs text-fg-subtle">
                       {account.email ? `${account.email} · ` : ""}
-                      {account.status === "active" ? "Token valid" : account.status}
+                      {account.status === "active" ? "Token valid" : account.status.replaceAll("_", " ")}
                       {account.expiresAt ? ` · expires ${new Date(account.expiresAt).toLocaleString()}` : ""}
                     </div>
                   </div>
                   {account.plan ? (
-                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-status-idle/30 bg-status-idle/10 px-2 py-0.5 text-xs text-status-idle">
-                      {account.plan} plan
-                    </span>
+                    <MetaChip dot="idle" rounded="full">{account.plan} plan</MetaChip>
                   ) : null}
                   {(() => {
                     const coolingSecs = account.exhaustedUntil
@@ -446,9 +446,9 @@ export function CodexSubscriptionsCard({ workspaceId, canManage }: { workspaceId
                       : 0;
                     if (coolingSecs > 0) {
                       return (
-                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-status-waiting/30 bg-status-waiting/10 px-2 py-0.5 text-2xs text-status-waiting" title="Rotated off after hitting its cap; skipped until reset">
-                          cooling down · {resetLabel(coolingSecs)}
-                        </span>
+                        <MetaChip dot="waiting" rounded="full" title="Rotated off after hitting its cap; skipped until reset">
+                          Cooling down · {resetLabel(coolingSecs)}
+                        </MetaChip>
                       );
                     }
                     if (isActive) {

--- a/apps/web/src/components/common.tsx
+++ b/apps/web/src/components/common.tsx
@@ -8,8 +8,8 @@ import { cn } from "@/lib/utils";
 export function LoadingPanel({ label }: { label: string }) {
   return (
     <section className="grid flex-1 place-items-center px-4 text-center">
-      <div className="max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 text-sm text-[color:var(--color-fg-muted)]">
-        <Loader2Icon className="mx-auto mb-3 size-5 animate-spin text-[color:var(--color-fg)]" />
+      <div className="max-w-sm rounded-lg border border-border bg-surface p-5 text-sm text-fg-muted">
+        <Loader2Icon className="mx-auto mb-3 size-5 animate-spin text-fg" />
         {label}
       </div>
     </section>
@@ -19,10 +19,10 @@ export function LoadingPanel({ label }: { label: string }) {
 export function ProblemPanel(props: { title: string; description: string; action?: ReactNode }) {
   return (
     <section className="grid flex-1 place-items-center px-4 text-center">
-      <div className="w-full max-w-md rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5">
-        <AlertTriangleIcon className="mx-auto mb-3 size-5 text-amber-300" />
+      <div className="w-full max-w-md rounded-lg border border-border bg-surface p-5">
+        <AlertTriangleIcon className="mx-auto mb-3 size-5 text-status-waiting" />
         <h1 className="text-base font-semibold">{props.title}</h1>
-        <p className="mt-2 text-sm leading-5 text-[color:var(--color-fg-muted)]">{props.description}</p>
+        <p className="mt-2 text-sm leading-5 text-fg-muted">{props.description}</p>
         {props.action ? <div className="mt-4 flex justify-center">{props.action}</div> : null}
       </div>
     </section>
@@ -31,15 +31,15 @@ export function ProblemPanel(props: { title: string; description: string; action
 
 export function ConnectionPill({ state }: { state: SessionEventsConnectionState }) {
   const tone = {
-    connecting: "bg-amber-400",
-    reconnecting: "bg-amber-400",
-    live: "bg-emerald-400",
-    idle: "bg-zinc-500",
-    ended: "bg-zinc-500",
-    error: "bg-red-400",
+    connecting: "bg-status-running",
+    reconnecting: "bg-status-running",
+    live: "bg-status-idle",
+    idle: "bg-status-cancelled",
+    ended: "bg-status-cancelled",
+    error: "bg-status-failed",
   }[state];
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-2 py-1 text-xs font-medium text-[color:var(--color-fg-muted)]">
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-1 text-xs font-medium text-fg-muted">
       <span className={cn("size-2 rounded-full", tone)} />
       <span>{state}</span>
     </span>
@@ -49,8 +49,8 @@ export function ConnectionPill({ state }: { state: SessionEventsConnectionState 
 export function InspectorSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="min-w-0 space-y-2">
-      <h3 className="text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">{title}</h3>
-      <div className="min-w-0 overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3">
+      <h3 className="text-xs font-medium uppercase tracking-wider text-fg-subtle">{title}</h3>
+      <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-surface/45 p-3">
         {children}
       </div>
     </section>
@@ -62,9 +62,9 @@ export function InfoRow({ label, value }: { label: string; value: ReactNode }) {
     ? <span className="min-w-0 truncate">{value}</span>
     : value;
   return (
-    <div className="grid min-h-7 min-w-0 grid-cols-[5.25rem_minmax(0,1fr)] items-center gap-3 border-b border-[color:var(--color-border)]/70 py-1.5 last:border-b-0">
-      <span className="min-w-0 truncate text-xs text-[color:var(--color-fg-subtle)]">{label}</span>
-      <span className="flex min-w-0 justify-end overflow-hidden text-right text-xs text-[color:var(--color-fg-muted)]">{renderedValue}</span>
+    <div className="grid min-h-7 min-w-0 grid-cols-[5.25rem_minmax(0,1fr)] items-center gap-3 border-b border-border/70 py-1.5 last:border-b-0">
+      <span className="min-w-0 truncate text-xs text-fg-subtle">{label}</span>
+      <span className="flex min-w-0 justify-end overflow-hidden text-right text-xs text-fg-muted">{renderedValue}</span>
     </div>
   );
 }
@@ -77,7 +77,7 @@ export function CopyableMono({ value }: { value: string }) {
         void navigator.clipboard.writeText(value);
         toast.success("Copied");
       }}
-      className="flex w-full min-w-0 max-w-full items-center justify-end gap-1 rounded px-1 py-0.5 font-mono text-[11px] text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]"
+      className="flex w-full min-w-0 max-w-full items-center justify-end gap-1 rounded px-1 py-0.5 font-mono text-2xs text-fg-muted hover:bg-surface-2 hover:text-fg"
       title={value}
     >
       <span className="min-w-0 truncate text-right">{value}</span>
@@ -89,13 +89,13 @@ export function CopyableMono({ value }: { value: string }) {
 /** Standard page header: icon, title, blurb, and trailing actions. */
 export function PageHeader(props: { icon: ReactNode; title: string; description: string; actions?: ReactNode }) {
   return (
-    <div className="flex flex-col gap-3 border-b border-[color:var(--color-border)] pb-4 lg:flex-row lg:items-center lg:justify-between">
+    <div className="flex flex-col gap-3 border-b border-border pb-4 lg:flex-row lg:items-center lg:justify-between">
       <div className="min-w-0">
         <div className="flex items-center gap-2 text-base font-semibold">
-          <span className="text-[color:var(--color-brand)]">{props.icon}</span>
+          <span className="text-brand">{props.icon}</span>
           {props.title}
         </div>
-        <p className="mt-1 text-sm leading-5 text-[color:var(--color-fg-muted)]">{props.description}</p>
+        <p className="mt-1 text-sm leading-5 text-fg-muted">{props.description}</p>
       </div>
       {props.actions ? <div className="flex min-w-0 flex-wrap items-center gap-2">{props.actions}</div> : null}
     </div>
@@ -104,7 +104,7 @@ export function PageHeader(props: { icon: ReactNode; title: string; description:
 
 export function EmptyState({ children }: { children: ReactNode }) {
   return (
-    <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-4 text-sm text-[color:var(--color-fg-subtle)]">
+    <div className="rounded-lg border border-dashed border-border p-4 text-sm text-fg-subtle">
       {children}
     </div>
   );
@@ -117,16 +117,16 @@ export function EmptyState({ children }: { children: ReactNode }) {
  */
 export function LoadErrorState({ title, error, onRetry }: { title: string; error?: Error | null; onRetry: () => void }) {
   return (
-    <div className="flex items-start gap-2 rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+    <div className="flex items-start gap-2 rounded-lg border border-status-failed/40 bg-status-failed/10 p-3 text-sm text-status-failed">
       <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium">{title}</div>
-        {error?.message ? <div className="mt-0.5 break-words text-xs leading-4 text-red-200/80">{error.message}</div> : null}
+        {error?.message ? <div className="mt-0.5 break-words text-xs leading-4 text-status-failed/80">{error.message}</div> : null}
       </div>
       <button
         type="button"
         onClick={onRetry}
-        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-red-500/40 px-2 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/20"
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-status-failed/40 px-2 text-xs font-medium text-status-failed transition-colors hover:bg-status-failed/20"
       >
         <RefreshCwIcon className="size-3" />
         Retry

--- a/apps/web/src/components/common.tsx
+++ b/apps/web/src/components/common.tsx
@@ -29,19 +29,26 @@ export function ProblemPanel(props: { title: string; description: string; action
   );
 }
 
+/**
+ * Connection health, shown only when it needs a word (doctrine D2). Healthy
+ * states (live / idle / ended) render nothing — the session status badge is the
+ * single persistent pill, so there is no "live" + "Idle" double-green. The pill
+ * surfaces only while the stream is degraded, in sentence case.
+ */
 export function ConnectionPill({ state }: { state: SessionEventsConnectionState }) {
-  const tone = {
-    connecting: "bg-status-running",
-    reconnecting: "bg-status-running",
-    live: "bg-status-idle",
-    idle: "bg-status-cancelled",
-    ended: "bg-status-cancelled",
-    error: "bg-status-failed",
-  }[state];
+  const degraded: Partial<Record<SessionEventsConnectionState, { label: string; dot: string; text: string }>> = {
+    connecting: { label: "Connecting…", dot: "bg-status-running", text: "text-status-running" },
+    reconnecting: { label: "Reconnecting…", dot: "bg-status-running", text: "text-status-running" },
+    error: { label: "Stream error", dot: "bg-status-failed", text: "text-status-failed" },
+  };
+  const meta = degraded[state];
+  if (!meta) {
+    return null;
+  }
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-1 text-xs font-medium text-fg-muted">
-      <span className={cn("size-2 rounded-full", tone)} />
-      <span>{state}</span>
+    <span className={cn("inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-1 text-xs font-medium", meta.text)}>
+      <span className={cn("size-2 rounded-full motion-safe:animate-pulse", meta.dot)} />
+      <span>{meta.label}</span>
     </span>
   );
 }

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -29,30 +29,30 @@ const markdownComponents: StreamdownComponents = {
   ol: ({ className, ...props }) => <ol className={cn("my-1.5 list-decimal space-y-0.5 pl-5 first:mt-0 last:mb-0", className)} {...props} />,
   li: ({ className, ...props }) => <li className={cn("pl-0.5", className)} {...props} />,
   blockquote: ({ className, ...props }) => (
-    <blockquote className={cn("my-2 border-l-2 border-[color:var(--color-border-strong)] pl-3 text-[color:var(--color-fg-muted)]", className)} {...props} />
+    <blockquote className={cn("my-2 border-l-2 border-border-strong pl-3 text-fg-muted", className)} {...props} />
   ),
   a: ({ className, ...props }) => (
     <a
-      className={cn("font-medium text-[color:var(--color-brand)] underline decoration-[color:var(--color-brand)]/40 underline-offset-2 hover:decoration-[color:var(--color-brand)]", className)}
+      className={cn("font-medium text-brand underline decoration-brand/40 underline-offset-2 hover:decoration-brand", className)}
       target="_blank"
       rel="noreferrer noopener"
       {...props}
     />
   ),
   inlineCode: ({ className, ...props }) => (
-    <code className={cn("rounded bg-[color:var(--color-surface-2)] px-1 py-0.5 font-mono text-[0.86em] text-[color:var(--color-fg)]", className)} {...props} />
+    <code className={cn("rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.86em] text-fg", className)} {...props} />
   ),
   pre: ({ className, ...props }) => (
-    <pre className={cn("my-2 max-w-full overflow-x-auto rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 font-mono text-xs leading-5 text-[color:var(--color-fg-muted)] first:mt-0 last:mb-0", className)} {...props} />
+    <pre className={cn("my-2 max-w-full overflow-x-auto rounded-md border border-border bg-surface p-3 font-mono text-xs leading-5 text-fg-muted first:mt-0 last:mb-0", className)} {...props} />
   ),
   table: ({ className, ...props }) => (
     <div className="my-2 max-w-full overflow-x-auto">
       <table className={cn("min-w-full border-collapse text-left text-xs", className)} {...props} />
     </div>
   ),
-  thead: ({ className, ...props }) => <thead className={cn("border-b border-[color:var(--color-border)] text-[color:var(--color-fg)]", className)} {...props} />,
-  tbody: ({ className, ...props }) => <tbody className={cn("divide-y divide-[color:var(--color-border)]/70", className)} {...props} />,
+  thead: ({ className, ...props }) => <thead className={cn("border-b border-border text-fg", className)} {...props} />,
+  tbody: ({ className, ...props }) => <tbody className={cn("divide-y divide-border/70", className)} {...props} />,
   th: ({ className, ...props }) => <th className={cn("whitespace-nowrap px-2 py-1.5 font-medium", className)} {...props} />,
-  td: ({ className, ...props }) => <td className={cn("px-2 py-1.5 align-top text-[color:var(--color-fg-muted)]", className)} {...props} />,
-  hr: ({ className, ...props }) => <hr className={cn("my-3 border-[color:var(--color-border)]", className)} {...props} />,
+  td: ({ className, ...props }) => <td className={cn("px-2 py-1.5 align-top text-fg-muted", className)} {...props} />,
+  hr: ({ className, ...props }) => <hr className={cn("my-3 border-border", className)} {...props} />,
 };

--- a/apps/web/src/components/permission-picker.tsx
+++ b/apps/web/src/components/permission-picker.tsx
@@ -16,7 +16,7 @@ export function PermissionGroupPicker(props: {
     <div className="grid gap-3">
       {props.groups.map((group) => (
         <div key={group.label} className="grid gap-1.5">
-          <div className="text-xs font-medium text-[color:var(--color-fg-muted)]">{group.label}</div>
+          <div className="text-xs font-medium text-fg-muted">{group.label}</div>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {group.permissions.map((permission) => {
               const delegable = props.delegable ? props.delegable.has(permission) : true;
@@ -24,7 +24,7 @@ export function PermissionGroupPicker(props: {
                 <label
                   key={permission}
                   title={delegable ? undefined : "Your grant cannot delegate this permission"}
-                  className={`flex items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-2 py-1.5 text-xs ${delegable && !props.disabled ? "" : "cursor-not-allowed opacity-50"}`}
+                  className={`flex items-center gap-2 rounded-md border border-border bg-bg/35 px-2 py-1.5 text-xs ${delegable && !props.disabled ? "" : "cursor-not-allowed opacity-50"}`}
                 >
                   <input
                     type="checkbox"

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -71,23 +71,23 @@ export function ModelPicker(props: {
           size="sm"
           disabled={props.disabled}
           aria-label="Model and effort"
-          className="h-8 max-w-[14rem] gap-1 rounded-full border border-transparent px-2.5 text-xs text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]"
+          className="h-8 max-w-[14rem] gap-1 rounded-full border border-transparent px-2.5 text-xs text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg"
         >
-          <span className="truncate font-medium text-[color:var(--color-fg)]">{selectedModelLabel(choices, props.model)}</span>
+          <span className="truncate font-medium text-fg">{selectedModelLabel(choices, props.model)}</span>
           <span>{labelEffort(props.effort)}</span>
           <ChevronDownIcon className="size-3 shrink-0" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="top" sideOffset={8} className="w-56 rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 shadow-xl">
-        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">Effort</DropdownMenuLabel>
+      <DropdownMenuContent align="start" side="top" sideOffset={8} className="w-56 rounded-xl border-border bg-surface p-2 shadow-xl">
+        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-fg-subtle">Effort</DropdownMenuLabel>
         {effortOptions.map((option) => (
           <DropdownMenuItem key={option} onSelect={() => props.onEffortChange(option)} className="h-8 cursor-pointer rounded-md px-2 text-sm">
             <span>{labelEffort(option)}</span>
             {option === props.effort ? <CheckIcon className="ml-auto size-4" /> : null}
           </DropdownMenuItem>
         ))}
-        <DropdownMenuSeparator className="my-2 bg-[color:var(--color-border)]" />
-        <DropdownMenuLabel className="px-2 pt-0 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">Model</DropdownMenuLabel>
+        <DropdownMenuSeparator className="my-2 bg-border" />
+        <DropdownMenuLabel className="px-2 pt-0 pb-1 text-xs font-normal text-fg-subtle">Model</DropdownMenuLabel>
         {choices.map((choice, index) => (
           <ModelChoiceRow
             key={choice.id}
@@ -114,7 +114,7 @@ function ModelChoiceRow(props: {
   return (
     <>
       {props.showProviderLabel ? (
-        <DropdownMenuLabel className="px-2 pt-1 pb-0.5 text-[10px] font-normal uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+        <DropdownMenuLabel className="px-2 pt-1 pb-0.5 text-2xs font-normal uppercase tracking-wide text-fg-subtle">
           {props.choice.providerLabel}
         </DropdownMenuLabel>
       ) : null}
@@ -130,8 +130,8 @@ function pillClass(active: boolean): string {
   return cn(
     "h-8 max-w-[12rem] gap-1.5 rounded-full border px-2.5 text-xs",
     active
-      ? "border-[color:var(--color-brand)]/35 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]"
-      : "border-transparent text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
+      ? "border-brand/35 bg-brand/10 text-fg"
+      : "border-transparent text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg",
   );
 }
 
@@ -170,8 +170,8 @@ export function EnabledMcpToolPicker(props: {
           <ChevronDownIcon className="size-3 shrink-0" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="top" sideOffset={8} className="w-72 rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 shadow-xl">
-        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">Enabled MCPs</DropdownMenuLabel>
+      <DropdownMenuContent align="start" side="top" sideOffset={8} className="w-72 rounded-xl border-border bg-surface p-2 shadow-xl">
+        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-fg-subtle">Enabled MCPs</DropdownMenuLabel>
         {props.servers.map((server) => (
           <DropdownMenuItem
             key={server.id}
@@ -182,7 +182,7 @@ export function EnabledMcpToolPicker(props: {
             className="h-9 cursor-pointer rounded-md px-2 text-sm"
           >
             <span className="min-w-0 flex-1 truncate">{server.name}</span>
-            <span className="ml-2 max-w-24 truncate font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{server.id}</span>
+            <span className="ml-2 max-w-24 truncate font-mono text-2xs text-fg-subtle">{server.id}</span>
             {props.selectedIds.has(server.id) ? <CheckIcon className="ml-2 size-4 shrink-0" /> : null}
           </DropdownMenuItem>
         ))}

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -175,6 +175,7 @@ export function EnabledMcpToolPicker(props: {
         {props.servers.map((server) => (
           <DropdownMenuItem
             key={server.id}
+            title={server.id}
             onSelect={(event) => {
               event.preventDefault();
               toggle(server.id);
@@ -182,7 +183,6 @@ export function EnabledMcpToolPicker(props: {
             className="h-9 cursor-pointer rounded-md px-2 text-sm"
           >
             <span className="min-w-0 flex-1 truncate">{server.name}</span>
-            <span className="ml-2 max-w-24 truncate font-mono text-2xs text-fg-subtle">{server.id}</span>
             {props.selectedIds.has(server.id) ? <CheckIcon className="ml-2 size-4 shrink-0" /> : null}
           </DropdownMenuItem>
         ))}

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -42,26 +42,26 @@ export function RailFooter() {
   const image = context.authSession?.user.image ?? undefined;
 
   return (
-    <div className="mt-auto border-t border-[color:var(--color-border)] p-2">
+    <div className="mt-auto border-t border-border p-2">
       <div className={rail.collapsed ? "grid justify-items-center gap-1" : "flex items-center gap-1.5"}>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
               aria-label="Account menu"
-              className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+              className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none"
             >
               <Avatar size="sm">
                 {image ? <AvatarImage src={image} alt="" /> : null}
-                <AvatarFallback className="bg-[color:var(--color-surface-3)] text-[11px] text-[color:var(--color-fg-muted)]">
+                <AvatarFallback className="bg-surface-3 text-2xs text-fg-muted">
                   {userInitial(displayName)}
                 </AvatarFallback>
               </Avatar>
               {!rail.collapsed ? (
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium text-[color:var(--color-fg)]">{displayName}</span>
+                  <span className="block truncate text-xs font-medium text-fg">{displayName}</span>
                   {secondary && secondary !== displayName ? (
-                    <span className="block truncate text-[10px] text-[color:var(--color-fg-subtle)]">{secondary}</span>
+                    <span className="block truncate text-2xs text-fg-subtle">{secondary}</span>
                   ) : null}
                 </span>
               ) : null}
@@ -71,7 +71,7 @@ export function RailFooter() {
             <DropdownMenuLabel className="grid gap-0.5">
               <span className="truncate text-sm">{displayName}</span>
               {secondary && secondary !== displayName ? (
-                <span className="truncate text-xs font-normal text-[color:var(--color-fg-subtle)]">{secondary}</span>
+                <span className="truncate text-xs font-normal text-fg-subtle">{secondary}</span>
               ) : null}
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
@@ -113,7 +113,7 @@ export function RailFooter() {
               size="icon-sm"
               aria-label={rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
               onClick={rail.toggleCollapsed}
-              className="shrink-0 text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg)]"
+              className="shrink-0 text-fg-subtle hover:text-fg"
             >
               {rail.collapsed ? <ChevronsRightIcon className="size-4" /> : <ChevronsLeftIcon className="size-4" />}
             </Button>

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -42,14 +42,14 @@ export function RailFooter() {
   const image = context.authSession?.user.image ?? undefined;
 
   return (
-    <div className="mt-auto border-t border-border p-2">
+    <div className="mt-auto border-t border-border p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
       <div className={rail.collapsed ? "grid justify-items-center gap-1" : "flex items-center gap-1.5"}>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
               aria-label="Account menu"
-              className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none"
+              className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none pointer-coarse:py-2"
             >
               <Avatar size="sm">
                 {image ? <AvatarImage src={image} alt="" /> : null}

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -159,7 +159,14 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
   }
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4">
+    <header
+      className={cn(
+        "flex shrink-0 items-center gap-3 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4",
+        // The session strip carries a two-line block (title + meta) — it gets
+        // breathing room; the plain mobile brand strip stays slim.
+        showSessionActions ? "h-14" : "h-12",
+      )}
+    >
       {rail.isMobile ? (
         <Button
           ref={hamburgerRef}
@@ -175,13 +182,15 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
 
       {showSessionActions && context.session ? (
         <>
-          <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-px">
             <SessionTitleEditor session={context.session} onRename={context.updateSessionTitle} />
-            <div className="flex min-w-0 items-center gap-1 truncate text-xs text-fg-subtle">
-              <span className="truncate">
+            {/* One quiet metadata voice: no label-colon grammar, no separator
+                soup — the model·effort token, then the sandbox pill (its own
+                shape, no interposed dot), then the codex indicator. */}
+            <div className="flex min-w-0 items-center gap-1.5 text-2xs leading-4 text-fg-subtle">
+              <span className="shrink-0">
                 {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")}
               </span>
-              <span aria-hidden>·</span>
               <SessionSandboxSwitcher workspaceId={context.session.workspaceId} sessionId={context.session.id} />
               {/* Codex-prefix-gated inside the component: absent for host-credit sessions. */}
               <CodexAccountIndicator
@@ -191,20 +200,20 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
               />
             </div>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1.5">
+            <ConnectionPill state={context.connectionState} />
+            <SessionStatusBadge status={context.session.status} />
             {context.keyAuthRequired ? (
               <Button type="button" variant="ghost" size="icon-sm" onClick={context.forgetAccessKey} aria-label="Clear access key">
                 <LockIcon className="size-4" />
               </Button>
             ) : null}
-            <ConnectionPill state={context.connectionState} />
-            <SessionStatusBadge status={context.session.status} />
             <Button
               type="button"
               variant={context.inspectorOpen ? "secondary" : "ghost"}
               size="icon-sm"
               onClick={() => context.setInspectorOpen((open) => !open)}
-              aria-label="Toggle session rail"
+              aria-label={context.inspectorOpen ? "Hide session panel" : "Show session panel"}
             >
               <PanelRightIcon className="size-4" />
             </Button>
@@ -246,6 +255,10 @@ function SessionTitleEditor(props: {
 
   if (rename.editing) {
     return (
+      // A calm in-place edit: same size and position as the display title, a
+      // soft surface tint + hairline instead of a loud focus ring. The global
+      // focus-ring rule is what painted the old blue box; opting out here keeps
+      // the rename feeling like editing the text, not filling in a form field.
       <input
         ref={rename.inputRef}
         value={rename.draft}
@@ -262,30 +275,34 @@ function SessionTitleEditor(props: {
         }}
         maxLength={SESSION_TITLE_MAX_LENGTH}
         aria-label="Session title"
-        className="w-full truncate rounded-sm bg-transparent text-sm font-medium outline-none ring-1 ring-ring/40 focus-visible:ring-ring"
+        className="-mx-1.5 w-full truncate rounded-md bg-surface-2/70 px-1.5 text-sm font-medium leading-5 outline-none ring-1 ring-border-strong focus:outline-none focus-visible:outline-none"
+        style={{ outline: "none" }}
       />
     );
   }
 
   return (
-    <div className="flex min-w-0 items-center gap-1">
+    <div className="group/title flex min-w-0 items-center gap-0.5">
       <button
         type="button"
         onClick={rename.startEditing}
         title={`${display} · click to rename`}
-        className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
+        className="min-w-0 shrink truncate rounded-sm text-left text-sm font-medium leading-5 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
       >
         {display}
       </button>
+      {/* The pencil earns its pixels only when relevant: hidden at rest,
+          revealed on hover/focus, always present on coarse pointers where
+          hover doesn't exist. */}
       <Button
         type="button"
         variant="ghost"
         size="icon-xs"
         onClick={rename.startEditing}
         aria-label="Rename session"
-        className="shrink-0 text-fg-subtle hover:text-fg"
+        className="shrink-0 text-fg-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover/title:opacity-100 pointer-coarse:opacity-100"
       >
-        <PencilIcon className="size-3.5" />
+        <PencilIcon className="size-3" />
       </Button>
     </div>
   );

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -28,7 +28,7 @@ import type { Session } from "@/types";
 function RailBody() {
   const rail = useRail();
   return (
-    <div className="flex h-full min-h-0 flex-col bg-[color:var(--color-surface)]/40">
+    <div className="flex h-full min-h-0 flex-col bg-surface/40">
       {/* Brand */}
       <div className={cn("flex h-12 shrink-0 items-center", rail.collapsed ? "justify-center px-2" : "px-3")}>
         <Link
@@ -37,7 +37,7 @@ function RailBody() {
           className="flex items-center gap-2 rounded-md text-[15px] font-semibold focus-visible:outline-none"
           aria-label="OpenGeni home"
         >
-          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
             <SparkleIcon className="size-3.5" />
           </span>
           {!rail.collapsed ? <span className="truncate">OpenGeni</span> : null}
@@ -50,7 +50,7 @@ function RailBody() {
         <WorkspaceNav />
       </div>
 
-      <div className="my-2 border-t border-[color:var(--color-border)]" />
+      <div className="my-2 border-t border-border" />
 
       {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
 
@@ -98,7 +98,7 @@ export function RailShell({ children }: { children: ReactNode }) {
             aria-label="Primary"
             data-collapsed={rail.collapsed}
             className={cn(
-              "motion-safe:transition-[width] motion-safe:duration-150 shrink-0 border-r border-[color:var(--color-border)]",
+              "motion-safe:transition-[width] motion-safe:duration-150 shrink-0 border-r border-border",
               rail.collapsed ? "w-[56px]" : "w-[260px]",
             )}
           >
@@ -145,7 +145,7 @@ function CanvasTopStrip() {
   }
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)]/75 px-3 backdrop-blur sm:px-4">
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4">
       {rail.isMobile ? (
         <Button
           type="button"
@@ -162,7 +162,7 @@ function CanvasTopStrip() {
         <>
           <div className="min-w-0 flex-1">
             <SessionTitleEditor session={context.session} onRename={context.updateSessionTitle} />
-            <div className="flex min-w-0 items-center gap-1 truncate text-xs text-[color:var(--color-fg-subtle)]">
+            <div className="flex min-w-0 items-center gap-1 truncate text-xs text-fg-subtle">
               <span className="truncate">
                 {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")}
               </span>
@@ -201,7 +201,7 @@ function CanvasTopStrip() {
           params={{ workspaceId: rail.workspaceId }}
           className="flex items-center gap-2 text-sm font-semibold"
         >
-          <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <span className="flex size-5 items-center justify-center rounded bg-brand-strong/20 text-brand">
             <SparkleIcon className="size-3" />
           </span>
           OpenGeni
@@ -247,7 +247,7 @@ function SessionTitleEditor(props: {
         }}
         maxLength={SESSION_TITLE_MAX_LENGTH}
         aria-label="Session title"
-        className="w-full truncate rounded-sm bg-transparent text-sm font-medium outline-none ring-1 ring-[color:var(--color-ring)]/40 focus-visible:ring-[color:var(--color-ring)]"
+        className="w-full truncate rounded-sm bg-transparent text-sm font-medium outline-none ring-1 ring-ring/40 focus-visible:ring-ring"
       />
     );
   }
@@ -258,7 +258,7 @@ function SessionTitleEditor(props: {
         type="button"
         onClick={rename.startEditing}
         title={`${display} · click to rename`}
-        className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium hover:text-[color:var(--color-fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
+        className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
       >
         {display}
       </button>
@@ -268,7 +268,7 @@ function SessionTitleEditor(props: {
         size="icon-xs"
         onClick={rename.startEditing}
         aria-label="Rename session"
-        className="shrink-0 text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg)]"
+        className="shrink-0 text-fg-subtle hover:text-fg"
       >
         <PencilIcon className="size-3.5" />
       </Button>

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -6,7 +6,7 @@
 import { SessionStatus as SessionStatusBadge } from "@opengeni/react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { LockIcon, MenuIcon, PanelRightIcon, PencilIcon, SparkleIcon } from "lucide-react";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode, type RefObject } from "react";
 
 import { ConnectionPill } from "@/components/common";
 import { RailFooter } from "@/components/rail/rail-footer";
@@ -28,7 +28,7 @@ import type { Session } from "@/types";
 function RailBody() {
   const rail = useRail();
   return (
-    <div className="flex h-full min-h-0 flex-col bg-surface/40">
+    <div className="flex h-full min-h-0 flex-col bg-surface/40 pt-[env(safe-area-inset-top)]">
       {/* Brand */}
       <div className={cn("flex h-12 shrink-0 items-center", rail.collapsed ? "justify-center px-2" : "px-3")}>
         <Link
@@ -46,13 +46,15 @@ function RailBody() {
 
       <SwitcherBlock />
 
-      <div className="mt-2">
-        <WorkspaceNav />
+      {/* Sessions — the product's primary object — sit directly under the
+          switcher (D4.1); the secondary workspace-config group drops below. */}
+      <div className="mt-2 flex min-h-0 flex-1 flex-col">
+        {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
       </div>
 
       <div className="my-2 border-t border-border" />
 
-      {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
+      <WorkspaceNav />
 
       <RailFooter />
     </div>
@@ -62,6 +64,10 @@ function RailBody() {
 export function RailShell({ children }: { children: ReactNode }) {
   const rail = useRail();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  // Focus returns here when the mobile drawer closes (D9.1): the drawer is a
+  // controlled Sheet with no in-tree trigger, so radix can't restore focus on
+  // its own — we point it back at the hamburger that opened it.
+  const hamburgerRef = useRef<HTMLButtonElement>(null);
 
   // Close the mobile drawer on route change.
   useEffect(() => {
@@ -109,7 +115,15 @@ export function RailShell({ children }: { children: ReactNode }) {
         {/* Mobile overlay drawer. */}
         {rail.isMobile ? (
           <Sheet open={rail.drawerOpen} onOpenChange={rail.setDrawerOpen}>
-            <SheetContent side="left" showCloseButton={false} className="w-[260px] gap-0 p-0">
+            <SheetContent
+              side="left"
+              showCloseButton={false}
+              className="w-[260px] max-w-[85vw] gap-0 p-0"
+              onCloseAutoFocus={(event) => {
+                event.preventDefault();
+                hamburgerRef.current?.focus();
+              }}
+            >
               <nav aria-label="Primary" className="h-full">
                 <RailBody />
               </nav>
@@ -119,7 +133,7 @@ export function RailShell({ children }: { children: ReactNode }) {
 
         {/* Main canvas. */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          <CanvasTopStrip />
+          <CanvasTopStrip hamburgerRef={hamburgerRef} />
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
         </div>
       </div>
@@ -132,7 +146,7 @@ export function RailShell({ children }: { children: ReactNode }) {
  * session routes it also carries the session title/status, the connection and
  * lock pills, and the inspector toggle — moved here from the old top header.
  */
-function CanvasTopStrip() {
+function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonElement | null> }) {
   const rail = useRail();
   const context = useAppContext();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -148,6 +162,7 @@ function CanvasTopStrip() {
     <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4">
       {rail.isMobile ? (
         <Button
+          ref={hamburgerRef}
           type="button"
           variant="ghost"
           size="icon-sm"

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -1,8 +1,8 @@
 // The session list — the rail's home. Reuses the same useWorkspaceSessions
 // hook the old sessions index used, groups by recency (running pinned on top),
 // and supports ArrowUp/Down + Enter keyboard navigation. Each row is a status
-// dot + single-line truncated title + hover-revealed relative time. The active
-// session (from the URL) is highlighted with an accent bar.
+// dot + single-line truncated title + relative time (visible at rest). The
+// active session (from the URL) is highlighted with an accent bar.
 import { useWorkspaceSessions } from "@opengeni/react";
 import { useRouterState } from "@tanstack/react-router";
 import { EllipsisIcon, MessagesSquareIcon, PencilIcon, PlusIcon } from "lucide-react";
@@ -215,7 +215,7 @@ function SessionRow(props: {
   const rename = useInlineRename(props.session, props.onRename);
 
   const rowClassName = cn(
-    "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors",
+    "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors pointer-coarse:h-10",
     "hover:bg-surface-2",
     props.active
       ? "bg-surface-3 font-medium text-fg"
@@ -277,7 +277,10 @@ function SessionRow(props: {
           {/* min-w-0 + truncate: the title must always ellipsis, never butt the
               rail border. */}
           <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
-          <span className="shrink-0 text-2xs tabular-nums text-fg-subtle opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-0">
+          {/* Relative time is visible at rest (the list is grouped by recency),
+              and steps aside on hover/focus so the rename overflow can slot in.
+              On coarse pointers there is no hover, so the time stays visible. */}
+          <span className="shrink-0 text-2xs tabular-nums text-fg-subtle transition-opacity group-hover:opacity-0 group-focus-within:opacity-0 pointer-coarse:group-hover:opacity-100">
             {relativeTimeLabel(props.session.updatedAt)}
           </span>
           <RowRenameMenu onRename={rename.startEditing} />
@@ -384,8 +387,14 @@ function EmptySessions({ onStart }: { onStart: () => void }) {
  */
 export function CollapsedSessionsButton() {
   const rail = useRail();
-  const { sessions } = useWorkspaceSessions({ limit: 50, pollIntervalMs: 15_000 });
+  const { sessions, loading, error } = useWorkspaceSessions({ limit: 50, pollIntervalMs: 15_000 });
   const runningCount = useMemo(() => groupSessionsForRail(sessions).running.length, [sessions]);
+  // The collapsed rail can't render the expanded list's loading/error copy, so
+  // it mirrors those states: a failed load shows a failed-tone marker + tooltip
+  // (expanding reveals the retry), a first load shows a gentle pulse.
+  const failed = Boolean(error) && sessions.length === 0;
+  const firstLoad = loading && sessions.length === 0;
+  const tooltip = failed ? "Session history is unavailable" : "Sessions";
   return (
     <div className="flex flex-1 flex-col items-center gap-1 px-2 pt-1">
       <Tooltip>
@@ -394,19 +403,21 @@ export function CollapsedSessionsButton() {
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label={`Sessions${runningCount > 0 ? ` (${runningCount} running)` : ""}`}
+            aria-label={failed ? "Sessions (history unavailable)" : `Sessions${runningCount > 0 ? ` (${runningCount} running)` : ""}`}
             onClick={() => rail.setCollapsed(false)}
             className="relative text-fg-muted hover:text-fg"
           >
-            <MessagesSquareIcon className="size-4" />
-            {runningCount > 0 ? (
+            <MessagesSquareIcon className={cn("size-4", firstLoad && "motion-safe:animate-pulse")} />
+            {failed ? (
+              <span className="absolute -right-0.5 -top-0.5 flex size-2 rounded-full bg-status-failed" />
+            ) : runningCount > 0 ? (
               <span className="absolute -right-0.5 -top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-brand-strong px-1 text-2xs font-semibold leading-tight text-brand-fg">
                 {runningCount}
               </span>
             ) : null}
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="right">Sessions</TooltipContent>
+        <TooltipContent side="right">{tooltip}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -96,7 +96,7 @@ export function SessionList() {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex min-w-0 items-center justify-between gap-2 px-3 pb-1 pt-1">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+        <span className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
           Sessions
         </span>
         <Tooltip>
@@ -107,7 +107,7 @@ export function SessionList() {
               size="icon-xs"
               aria-label="New session"
               onClick={rail.startNewSession}
-              className="text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+              className="text-fg-muted hover:text-fg"
             >
               <PlusIcon className="size-3.5" />
             </Button>
@@ -122,14 +122,14 @@ export function SessionList() {
         aria-label="Sessions"
         tabIndex={0}
         onKeyDown={onKeyDown}
-        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2 outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-ring)]/40"
+        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2 outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
       >
         {loading && sessions.length === 0 ? (
           <SessionListSkeleton />
         ) : error && sessions.length === 0 ? (
-          <div className="px-2 py-3 text-xs text-[color:var(--color-fg-subtle)]">
+          <div className="px-2 py-3 text-xs text-fg-subtle">
             Session history is unavailable.{" "}
-            <button type="button" className="underline hover:text-[color:var(--color-fg)]" onClick={() => void refresh()}>
+            <button type="button" className="underline hover:text-fg" onClick={() => void refresh()}>
               Retry
             </button>
           </div>
@@ -180,7 +180,7 @@ function SessionGroup(props: {
 }) {
   return (
     <div className="mb-1.5 min-w-0">
-      <p className="px-2 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+      <p className="px-2 pb-0.5 pt-2 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
         {props.label}
       </p>
       <div className="grid min-w-0 grid-cols-1 gap-px">
@@ -216,11 +216,11 @@ function SessionRow(props: {
 
   const rowClassName = cn(
     "group relative flex h-8 w-full items-center gap-2 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors",
-    "hover:bg-[color:var(--color-surface-2)]",
+    "hover:bg-surface-2",
     props.active
-      ? "bg-[color:var(--color-surface-3)] font-medium text-[color:var(--color-fg)]"
-      : "text-[color:var(--color-fg-muted)]",
-    props.focused && !props.active ? "bg-[color:var(--color-surface-2)]/60" : "",
+      ? "bg-surface-3 font-medium text-fg"
+      : "text-fg-muted",
+    props.focused && !props.active ? "bg-surface-2/60" : "",
   );
 
   // While renaming, the row body becomes an inline input. Keep it as a
@@ -249,7 +249,7 @@ function SessionRow(props: {
           }}
           maxLength={SESSION_TITLE_MAX_LENGTH}
           aria-label="Session title"
-          className="min-w-0 flex-1 truncate rounded-sm bg-transparent text-sm outline-none ring-1 ring-[color:var(--color-ring)]/40 focus-visible:ring-[color:var(--color-ring)]"
+          className="min-w-0 flex-1 truncate rounded-sm bg-transparent text-sm outline-none ring-1 ring-ring/40 focus-visible:ring-ring"
         />
       </div>
     );
@@ -277,7 +277,7 @@ function SessionRow(props: {
           {/* min-w-0 + truncate: the title must always ellipsis, never butt the
               rail border. */}
           <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
-          <span className="shrink-0 text-[10px] tabular-nums text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-0">
+          <span className="shrink-0 text-2xs tabular-nums text-fg-subtle opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-0">
             {relativeTimeLabel(props.session.updatedAt)}
           </span>
           <RowRenameMenu onRename={rename.startEditing} />
@@ -298,7 +298,7 @@ function ActiveAccent({ active }: { active: boolean }) {
   return (
     <span
       className={cn(
-        "absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] transition-opacity",
+        "absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-brand transition-opacity",
         active ? "opacity-100" : "opacity-0",
       )}
     />
@@ -321,7 +321,7 @@ function RowRenameMenu({ onRename }: { onRename: () => void }) {
           size="icon-xs"
           aria-label="Session actions"
           onClick={(event) => event.stopPropagation()}
-          className="shrink-0 text-[color:var(--color-fg-subtle)] opacity-0 transition-opacity hover:text-[color:var(--color-fg)] focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+          className="shrink-0 text-fg-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
         >
           <EllipsisIcon className="size-3.5" />
         </Button>
@@ -342,27 +342,25 @@ function RowRenameMenu({ onRename }: { onRename: () => void }) {
 }
 
 /**
- * Rail-local status dot with the rail's intent semantics: RUNNING reads as a
- * positive, active state (brand blue) with a breathing pulse; FAILED is danger
- * red; everything idle/terminal is a calm muted gray. This deliberately differs
- * from the shared package badge (whose running hue is amber) so a running
- * session in the list never reads as an error.
+ * Rail-local status dot with the app status tokens: running/queued pulse with
+ * the running tone, requires-action pulses with the waiting tone, failures use
+ * failed, and idle/terminal states fall back to cancelled.
  */
 function RailStatusDot({ status }: { status: Session["status"] }) {
   const running = status === "running" || status === "queued";
   const needsAttention = status === "requires_action";
   const failed = status === "failed";
-  const color = running
-    ? "var(--color-brand)"
+  const tone = running
+    ? "bg-status-running"
     : needsAttention
-      ? "var(--color-status-running)" // app's amber "attention" hue
+      ? "bg-status-waiting"
       : failed
-        ? "var(--color-status-failed)"
-        : "var(--color-fg-subtle)";
+        ? "bg-status-failed"
+        : "bg-status-cancelled";
   return (
-    <span className="relative inline-flex size-1.5 shrink-0 rounded-full" style={{ backgroundColor: `color-mix(in oklch, ${color} 92%, transparent)` }}>
+    <span className={cn("relative inline-flex size-1.5 shrink-0 rounded-full", tone)}>
       {running || needsAttention ? (
-        <span className="absolute inset-0 animate-og-pulse rounded-full" style={{ backgroundColor: color }} />
+        <span className={cn("absolute inset-0 animate-og-pulse rounded-full", tone)} />
       ) : null}
     </span>
   );
@@ -370,8 +368,8 @@ function RailStatusDot({ status }: { status: Session["status"] }) {
 
 function EmptySessions({ onStart }: { onStart: () => void }) {
   return (
-    <div className="mt-2 grid gap-2 rounded-lg border border-dashed border-[color:var(--color-border)] px-3 py-4 text-center">
-      <p className="text-xs text-[color:var(--color-fg-subtle)]">No sessions yet</p>
+    <div className="mt-2 grid gap-2 rounded-lg border border-dashed border-border px-3 py-4 text-center">
+      <p className="text-xs text-fg-subtle">No sessions yet</p>
       <Button type="button" size="sm" onClick={onStart} className="mx-auto">
         <PlusIcon className="size-3.5" />
         Start your first session
@@ -398,11 +396,11 @@ export function CollapsedSessionsButton() {
             size="icon-sm"
             aria-label={`Sessions${runningCount > 0 ? ` (${runningCount} running)` : ""}`}
             onClick={() => rail.setCollapsed(false)}
-            className="relative text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+            className="relative text-fg-muted hover:text-fg"
           >
             <MessagesSquareIcon className="size-4" />
             {runningCount > 0 ? (
-              <span className="absolute -right-0.5 -top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-[color:var(--color-brand-strong)] px-1 text-[9px] font-semibold leading-tight text-[color:var(--color-brand-fg)]">
+              <span className="absolute -right-0.5 -top-0.5 flex min-w-3.5 items-center justify-center rounded-full bg-brand-strong px-1 text-2xs font-semibold leading-tight text-brand-fg">
                 {runningCount}
               </span>
             ) : null}
@@ -418,7 +416,7 @@ export function CollapsedSessionsButton() {
             size="icon-sm"
             aria-label="New session"
             onClick={rail.startNewSession}
-            className="text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
+            className="text-fg-muted hover:text-fg"
           >
             <PlusIcon className="size-4" />
           </Button>
@@ -434,8 +432,8 @@ function SessionListSkeleton() {
     <div className="grid gap-1 px-1 pt-2">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="flex h-8 items-center gap-2 px-1">
-          <span className="size-1.5 shrink-0 rounded-full bg-[color:var(--color-surface-3)]" />
-          <span className="h-3 flex-1 animate-pulse rounded bg-[color:var(--color-surface-2)]" />
+          <span className="size-1.5 shrink-0 rounded-full bg-surface-3" />
+          <span className="h-3 flex-1 animate-pulse rounded bg-surface-2" />
         </div>
       ))}
     </div>

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -21,12 +21,27 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
 import { useRail } from "@/components/rail/rail-context";
-import { organizationsForSubject, orgLabel, workspacesInOrg } from "@/lib/org";
+import { organizationsForSubject, workspacesInOrg } from "@/lib/org";
 import { workspaceCreationAccountId } from "@/lib/workspaces";
-import type { Workspace } from "@/types";
+import type { AccountGrant, Workspace } from "@/types";
 
 function workspaceInitial(workspace: Workspace | null): string {
   return (workspace?.name.trim()[0] ?? "W").toUpperCase();
+}
+
+/**
+ * The org's human name if the access grant carries one, else null. The
+ * always-visible switcher line prefers this and falls back to a generic
+ * "Organization" — never a raw account id (the id stays available in the
+ * org-switch menu and settings, which keep `orgLabel`'s id fallback).
+ */
+function orgDisplayName(accountId: string | null, grants: AccountGrant[]): string | null {
+  if (!accountId) {
+    return null;
+  }
+  const grant = grants.find((candidate) => candidate.accountId === accountId);
+  const name = grant?.metadata && typeof grant.metadata.accountName === "string" ? grant.metadata.accountName : undefined;
+  return name?.trim() || null;
 }
 
 export function SwitcherBlock() {
@@ -36,7 +51,7 @@ export function SwitcherBlock() {
   const activeAccountId = activeWorkspace?.accountId ?? context.accessContext.defaultAccountId ?? null;
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
-  const currentOrgLabel = activeAccountId ? orgLabel(activeAccountId, context.accessContext.accountGrants) : "Organization";
+  const currentOrgLabel = orgDisplayName(activeAccountId, context.accessContext.accountGrants) ?? "Organization";
   const orgWorkspaces = activeAccountId ? workspacesInOrg(context.workspaces, activeAccountId) : context.workspaces;
 
   const createAccountId = workspaceCreationAccountId(context.accessContext, activeWorkspace?.accountId ?? null);

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -91,7 +91,7 @@ export function SwitcherBlock() {
           <button
             type="button"
             aria-label={`Workspace: ${activeWorkspace?.name ?? "switch workspace"}`}
-            className="mx-auto flex size-9 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 text-sm font-semibold text-[color:var(--color-fg)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+            className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
           >
             {workspaceInitial(activeWorkspace)}
           </button>
@@ -122,17 +122,17 @@ export function SwitcherBlock() {
       >
         <button
           type="button"
-          className="group flex w-full items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50 px-2 py-1.5 text-left transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)] focus-visible:outline-none"
+          className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
         >
           <Avatar size="sm" className="rounded-md">
-            <AvatarFallback className="rounded-md bg-[color:var(--color-brand-strong)]/25 text-[11px] font-semibold text-[color:var(--color-brand)]">
+            <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
               {workspaceInitial(activeWorkspace)}
             </AvatarFallback>
           </Avatar>
           <span className="min-w-0 flex-1 truncate text-sm font-medium" title={activeWorkspace?.name}>
             {activeWorkspace?.name ?? "Select workspace"}
           </span>
-          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
         </button>
       </WorkspaceMenu>
 
@@ -158,7 +158,7 @@ function OrgLine(props: {
   // Exactly one org: a static muted label, no useless switcher.
   if (props.orgs.length <= 1) {
     return (
-      <span className="flex min-w-0 items-center gap-1 px-0.5 text-[11px] font-medium text-[color:var(--color-fg-subtle)]" title={props.currentLabel}>
+      <span className="flex min-w-0 items-center gap-1 px-0.5 text-2xs font-medium text-fg-subtle" title={props.currentLabel}>
         <BuildingIcon className="size-3 shrink-0" />
         <span className="min-w-0 truncate">{props.currentLabel}</span>
       </span>
@@ -170,7 +170,7 @@ function OrgLine(props: {
         <button
           type="button"
           aria-label="Switch organization"
-          className="flex min-w-0 items-center gap-1 rounded px-0.5 py-0.5 text-[11px] font-medium text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)] focus-visible:outline-none"
+          className="flex min-w-0 items-center gap-1 rounded px-0.5 py-0.5 text-2xs font-medium text-fg-subtle transition-colors hover:text-fg-muted focus-visible:outline-none"
         >
           <BuildingIcon className="size-3 shrink-0" />
           <span className="min-w-0 truncate">{props.currentLabel}</span>
@@ -178,7 +178,7 @@ function OrgLine(props: {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-56">
-        <DropdownMenuLabel className="text-[color:var(--color-fg-subtle)]">Organizations</DropdownMenuLabel>
+        <DropdownMenuLabel className="text-fg-subtle">Organizations</DropdownMenuLabel>
         {props.orgs.map((org) => (
           <DropdownMenuItem
             key={org.accountId}
@@ -188,11 +188,11 @@ function OrgLine(props: {
               }
             }}
           >
-            <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-surface-3)] text-[10px] font-semibold">
+            <span className="flex size-5 items-center justify-center rounded bg-surface-3 text-2xs font-semibold">
               {org.label.replace(/^Org\s+/, "").slice(0, 2).toUpperCase()}
             </span>
             <span className="min-w-0 flex-1 truncate">{org.label}</span>
-            {org.accountId === props.activeAccountId ? <CheckIcon className="size-4 text-[color:var(--color-brand)]" /> : null}
+            {org.accountId === props.activeAccountId ? <CheckIcon className="size-4 text-brand" /> : null}
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
@@ -226,17 +226,17 @@ function WorkspaceMenu(props: {
         {rail.collapsed ? <TooltipContent side="right">Switch workspace</TooltipContent> : null}
       </Tooltip>
       <DropdownMenuContent align={props.align} className="min-w-60" side={rail.collapsed ? "right" : "bottom"}>
-        <DropdownMenuLabel className="text-[color:var(--color-fg-subtle)]">Workspaces</DropdownMenuLabel>
+        <DropdownMenuLabel className="text-fg-subtle">Workspaces</DropdownMenuLabel>
         {props.workspaces.map((workspace) => (
           <DropdownMenuItem
             key={workspace.id}
             onSelect={() => props.onSelect(workspace.id)}
           >
-            <span className="flex size-5 items-center justify-center rounded bg-[color:var(--color-surface-3)] text-[10px] font-semibold">
+            <span className="flex size-5 items-center justify-center rounded bg-surface-3 text-2xs font-semibold">
               {workspaceInitial(workspace)}
             </span>
             <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
-            {workspace.id === props.activeWorkspaceId ? <CheckIcon className="size-4 text-[color:var(--color-brand)]" /> : null}
+            {workspace.id === props.activeWorkspaceId ? <CheckIcon className="size-4 text-brand" /> : null}
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -26,12 +26,12 @@ type NavTarget =
   | "/workspaces/$workspaceId/documents"
   | "/workspaces/$workspaceId/settings";
 
-const CONFIG_ITEMS: Array<{ to: NavTarget; icon: LucideIcon; label: string }> = [
-  { to: "/workspaces/$workspaceId/environments", icon: BoxIcon, label: "Environments" },
-  { to: "/workspaces/$workspaceId/machines", icon: LaptopIcon, label: "Machines" },
-  { to: "/workspaces/$workspaceId/capabilities", icon: PlugIcon, label: "Capabilities" },
-  { to: "/workspaces/$workspaceId/schedules", icon: CalendarClockIcon, label: "Schedules" },
-  { to: "/workspaces/$workspaceId/documents", icon: FileSearchIcon, label: "Documents" },
+const CONFIG_ITEMS: Array<{ to: NavTarget; icon: LucideIcon; label: string; description: string }> = [
+  { to: "/workspaces/$workspaceId/environments", icon: BoxIcon, label: "Environments", description: "Secret variable sets for sandboxes" },
+  { to: "/workspaces/$workspaceId/machines", icon: LaptopIcon, label: "Machines", description: "Your own connected computers" },
+  { to: "/workspaces/$workspaceId/capabilities", icon: PlugIcon, label: "Capabilities", description: "Packs, MCP servers, and tools" },
+  { to: "/workspaces/$workspaceId/schedules", icon: CalendarClockIcon, label: "Schedules", description: "Run agents on a schedule" },
+  { to: "/workspaces/$workspaceId/documents", icon: FileSearchIcon, label: "Documents", description: "Indexed knowledge for agents" },
 ];
 
 export function WorkspaceNav() {
@@ -50,6 +50,7 @@ export function WorkspaceNav() {
           workspaceId={rail.workspaceId}
           icon={<item.icon className="size-4" />}
           label={item.label}
+          description={item.description}
           collapsed={rail.collapsed}
         />
       ))}
@@ -58,7 +59,8 @@ export function WorkspaceNav() {
           to="/workspaces/$workspaceId/settings"
           workspaceId={rail.workspaceId}
           icon={<SettingsIcon className="size-4" />}
-          label="Settings"
+          label="Workspace settings"
+          description="Name, API keys, and members"
           collapsed={rail.collapsed}
         />
       </div>
@@ -71,6 +73,8 @@ export function RailNavItem(props: {
   workspaceId: string;
   icon: ReactNode;
   label: string;
+  /** One-line orientation for an opaque label — surfaced in the tooltip. */
+  description?: string;
   collapsed: boolean;
   /** Optional search params (Capabilities Packs subsection, etc.). */
   search?: Record<string, string>;
@@ -82,11 +86,14 @@ export function RailNavItem(props: {
       {...(props.search ? { search: props.search } : {})}
       activeProps={{ "data-active": "true" }}
       aria-label={props.collapsed ? props.label : undefined}
+      // The description labels an otherwise opaque nav item; a title keeps it
+      // reachable on the expanded rail without a hover-only requirement.
+      title={props.description && !props.collapsed ? props.description : undefined}
       className={cn(
-        "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted transition-colors",
+        "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10",
         "hover:bg-surface-2 hover:text-fg",
         "data-[active=true]:bg-surface-2 data-[active=true]:text-fg",
-        props.collapsed ? "w-8 justify-center" : "gap-2.5 px-2.5",
+        props.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
       )}
     >
       {/* Left accent bar on the active route. */}
@@ -102,7 +109,10 @@ export function RailNavItem(props: {
   return (
     <Tooltip>
       <TooltipTrigger asChild>{link}</TooltipTrigger>
-      <TooltipContent side="right">{props.label}</TooltipContent>
+      <TooltipContent side="right" className="max-w-52">
+        <p className="font-medium">{props.label}</p>
+        {props.description ? <p className="text-fg-subtle">{props.description}</p> : null}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -39,7 +39,7 @@ export function WorkspaceNav() {
   return (
     <nav aria-label="Workspace" className={cn("grid gap-0.5", rail.collapsed ? "px-2" : "px-2")}>
       {!rail.collapsed ? (
-        <p className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+        <p className="px-2 pb-1 pt-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
           Workspace
         </p>
       ) : null}
@@ -53,7 +53,7 @@ export function WorkspaceNav() {
           collapsed={rail.collapsed}
         />
       ))}
-      <div className={cn("mt-1 border-t border-[color:var(--color-border)]/60 pt-1", rail.collapsed ? "mx-1" : "")}>
+      <div className={cn("mt-1 border-t border-border/60 pt-1", rail.collapsed ? "mx-1" : "")}>
         <RailNavItem
           to="/workspaces/$workspaceId/settings"
           workspaceId={rail.workspaceId}
@@ -83,14 +83,14 @@ export function RailNavItem(props: {
       activeProps={{ "data-active": "true" }}
       aria-label={props.collapsed ? props.label : undefined}
       className={cn(
-        "group relative flex h-8 items-center rounded-md text-sm font-medium text-[color:var(--color-fg-muted)] transition-colors",
-        "hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
-        "data-[active=true]:bg-[color:var(--color-surface-2)] data-[active=true]:text-[color:var(--color-fg)]",
+        "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted transition-colors",
+        "hover:bg-surface-2 hover:text-fg",
+        "data-[active=true]:bg-surface-2 data-[active=true]:text-fg",
         props.collapsed ? "w-8 justify-center" : "gap-2.5 px-2.5",
       )}
     >
       {/* Left accent bar on the active route. */}
-      <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-[color:var(--color-brand)] opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
+      <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
       <span className="shrink-0">{props.icon}</span>
       {!props.collapsed ? <span className="min-w-0 truncate">{props.label}</span> : null}
     </Link>

--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -8,7 +8,9 @@ import {
   PlusIcon,
   RefreshCwIcon,
   Trash2Icon,
+  XIcon,
 } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -24,6 +26,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MetaChip } from "@/components/ui/meta-chip";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { repoCountLabel } from "@/lib/format";
 import {
@@ -66,6 +69,9 @@ export function RepositoryContextPicker(props: {
   const manualCount = props.manualRepos.filter((repo) => repo.url.trim().length > 0).length;
   const selectedCount = selectedInstalledCount + manualCount;
   const setupOpen = props.githubAppOpen;
+  // Two-step inline confirm for removing a manual repo, so a stray click in a
+  // dense picker doesn't drop a repo the user typed out.
+  const [confirmRemoveId, setConfirmRemoveId] = useState<number | null>(null);
 
   return (
     <DropdownMenu>
@@ -138,16 +144,9 @@ export function RepositoryContextPicker(props: {
                         </span>
                       </span>
                       <span className="flex shrink-0 items-center gap-2">
-                        <span
-                          className={cn(
-                            "rounded-full border px-1.5 py-0.5 text-2xs font-medium",
-                            props.configured
-                              ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
-                              : "border-status-waiting/30 bg-status-waiting/10 text-status-waiting",
-                          )}
-                        >
-                          {props.configured ? "Ready" : "Setup"}
-                        </span>
+                        <MetaChip dot={props.configured ? "idle" : "waiting"} rounded="full">
+                          {props.configured ? "Configured" : "Not set up"}
+                        </MetaChip>
                         <ChevronDownIcon className={cn("size-3.5 text-fg-subtle transition-transform", setupOpen && "rotate-180")} />
                       </span>
                     </button>
@@ -255,9 +254,9 @@ export function RepositoryContextPicker(props: {
                                     </span>
                                   </span>
                                   {blocked ? (
-                                    <span className="rounded-full border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">other app</span>
+                                    <MetaChip dot="waiting" rounded="full">Other app</MetaChip>
                                   ) : checked ? (
-                                    <span className="rounded-full border border-status-idle/30 px-1.5 py-0.5 text-2xs text-status-idle">selected</span>
+                                    <MetaChip dot="idle" rounded="full">Selected</MetaChip>
                                   ) : null}
                                 </button>
                                 {checked ? (
@@ -326,9 +325,40 @@ export function RepositoryContextPicker(props: {
                                 className="h-8 pl-7 text-xs"
                               />
                             </div>
-                            <Button type="button" variant="ghost" size="icon-sm" onClick={() => props.onManualRemove(repo.id)} disabled={props.pending} aria-label="Remove repository" className="size-8">
-                              <Trash2Icon className="size-3.5" />
-                            </Button>
+                            {confirmRemoveId === repo.id ? (
+                              <div className="flex items-center gap-1">
+                                <Button
+                                  type="button"
+                                  variant="destructive"
+                                  size="icon-sm"
+                                  onClick={() => {
+                                    props.onManualRemove(repo.id);
+                                    setConfirmRemoveId(null);
+                                  }}
+                                  disabled={props.pending}
+                                  aria-label="Confirm remove repository"
+                                  title="Remove"
+                                  className="size-8"
+                                >
+                                  <CheckIcon className="size-3.5" />
+                                </Button>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  onClick={() => setConfirmRemoveId(null)}
+                                  aria-label="Keep repository"
+                                  title="Cancel"
+                                  className="size-8"
+                                >
+                                  <XIcon className="size-3.5" />
+                                </Button>
+                              </div>
+                            ) : (
+                              <Button type="button" variant="ghost" size="icon-sm" onClick={() => setConfirmRemoveId(repo.id)} disabled={props.pending} aria-label="Remove repository" title="Remove" className="size-8">
+                                <Trash2Icon className="size-3.5" />
+                              </Button>
+                            )}
                           </div>
                         ))
                       )}
@@ -378,7 +408,7 @@ export function ScheduledTaskRepositoryPicker(props: {
         nextResource,
       ]);
     } catch (error) {
-      toast.error("Repository could not be selected", { description: error instanceof Error ? error.message : String(error) });
+      toast.error("Couldn't select the repository", { description: error instanceof Error ? error.message : String(error) });
     }
   }
 
@@ -454,9 +484,9 @@ export function ScheduledTaskRepositoryPicker(props: {
                           <span className="mt-0.5 block truncate text-2xs text-fg-subtle">default {repo.defaultBranch}</span>
                         </span>
                         {blocked ? (
-                          <span className="rounded-full border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">other app</span>
+                          <MetaChip dot="waiting" rounded="full">Other app</MetaChip>
                         ) : checked ? (
-                          <span className="rounded-full border border-status-idle/30 px-1.5 py-0.5 text-2xs text-status-idle">selected</span>
+                          <MetaChip dot="idle" rounded="full">Selected</MetaChip>
                         ) : null}
                       </button>
                       {resource ? (

--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -78,8 +78,8 @@ export function RepositoryContextPicker(props: {
           aria-label="Repository context"
           className={cn(
             "h-8 max-w-[13rem] gap-1.5 rounded-full border border-transparent px-2.5 text-xs",
-            "text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]",
-            selectedCount > 0 && "border-[color:var(--color-brand)]/35 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]",
+            "text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg",
+            selectedCount > 0 && "border-brand/35 bg-brand/10 text-fg",
           )}
         >
           <GitBranchIcon className="size-3.5" />
@@ -87,7 +87,7 @@ export function RepositoryContextPicker(props: {
           <span
             className={cn(
               "size-1.5 shrink-0 rounded-full",
-              props.configured ? "bg-emerald-400" : "bg-amber-400",
+              props.configured ? "bg-status-idle" : "bg-status-waiting",
             )}
             aria-hidden="true"
           />
@@ -99,13 +99,13 @@ export function RepositoryContextPicker(props: {
         align="start"
         side="top"
         sideOffset={8}
-        className="w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-0 shadow-2xl"
+        className="w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-xl border-border bg-surface p-0 shadow-2xl"
       >
         <div onKeyDown={(event) => event.stopPropagation()}>
-          <div className="flex items-center justify-between gap-3 border-b border-[color:var(--color-border)] px-3 py-2.5">
+          <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
             <div className="min-w-0">
-              <div className="truncate text-sm font-medium text-[color:var(--color-fg)]">Repository context</div>
-              <div className="mt-0.5 truncate text-[11px] text-[color:var(--color-fg-subtle)]">
+              <div className="truncate text-sm font-medium text-fg">Repository context</div>
+              <div className="mt-0.5 truncate text-2xs text-fg-subtle">
                 {selectedCount > 0 ? `${repoCountLabel(selectedCount)} selected for this session` : "Optional repositories for the sandbox"}
               </div>
             </div>
@@ -125,44 +125,44 @@ export function RepositoryContextPicker(props: {
           <ScrollArea className="max-h-[min(70vh,620px)]">
             <div className="space-y-3 p-3">
               <Collapsible open={setupOpen} onOpenChange={props.onGitHubAppOpenChange}>
-                <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/25">
+                <div className="rounded-lg border border-border bg-bg/25">
                   <CollapsibleTrigger asChild>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-[color:var(--color-surface-2)]/60"
+                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-surface-2/60"
                     >
                       <span className="min-w-0">
-                        <span className="block truncate text-xs font-medium text-[color:var(--color-fg)]">GitHub App</span>
-                        <span className="mt-0.5 block truncate text-[11px] text-[color:var(--color-fg-subtle)]">
+                        <span className="block truncate text-xs font-medium text-fg">GitHub App</span>
+                        <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
                           {props.configured ? "Configured for scoped repository tokens" : "Set up GitHub App access"}
                         </span>
                       </span>
                       <span className="flex shrink-0 items-center gap-2">
                         <span
                           className={cn(
-                            "rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                            "rounded-full border px-1.5 py-0.5 text-2xs font-medium",
                             props.configured
-                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                              : "border-amber-500/30 bg-amber-500/10 text-amber-200",
+                              ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
+                              : "border-status-waiting/30 bg-status-waiting/10 text-status-waiting",
                           )}
                         >
                           {props.configured ? "Ready" : "Setup"}
                         </span>
-                        <ChevronDownIcon className={cn("size-3.5 text-[color:var(--color-fg-subtle)] transition-transform", setupOpen && "rotate-180")} />
+                        <ChevronDownIcon className={cn("size-3.5 text-fg-subtle transition-transform", setupOpen && "rotate-180")} />
                       </span>
                     </button>
                   </CollapsibleTrigger>
 
                   <CollapsibleContent>
-                    <div className="space-y-3 border-t border-[color:var(--color-border)] p-3">
-                      <p className="text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                    <div className="space-y-3 border-t border-border p-3">
+                      <p className="text-xs leading-5 text-fg-muted">
                         {props.configured
                           ? "The app is used for repository listing, scoped clone tokens, pushes, and pull requests."
                           : "Create a prefilled app, add the generated values to .env, then restart API and worker."}
                       </p>
                       <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
                         <div className="min-w-0">
-                          <Label htmlFor="github-org-menu" className="text-[11px] text-[color:var(--color-fg-subtle)]">Organization</Label>
+                          <Label htmlFor="github-org-menu" className="text-2xs text-fg-subtle">Organization</Label>
                           <Input
                             id="github-org-menu"
                             value={props.org}
@@ -192,41 +192,41 @@ export function RepositoryContextPicker(props: {
                 </div>
               </Collapsible>
 
-              <section className="overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/25">
-                <div className="flex items-center justify-between gap-3 border-b border-[color:var(--color-border)] px-3 py-2">
-                  <div className="text-xs font-medium text-[color:var(--color-fg)]">Installed repositories</div>
-                  <div className="text-[11px] text-[color:var(--color-fg-subtle)]">
+              <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
+                <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+                  <div className="text-xs font-medium text-fg">Installed repositories</div>
+                  <div className="text-2xs text-fg-subtle">
                     {props.configured ? `${props.repositories.length} available` : "GitHub not configured"}
                   </div>
                 </div>
 
                 {!props.configured ? (
-                  <div className="p-3 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                  <div className="p-3 text-xs leading-5 text-fg-muted">
                     Configure and install the GitHub App to select repositories.
                   </div>
                 ) : props.repoBusy ? (
-                  <div className="flex items-center gap-2 p-3 text-xs text-[color:var(--color-fg-muted)]">
+                  <div className="flex items-center gap-2 p-3 text-xs text-fg-muted">
                     <Loader2Icon className="size-3.5 animate-spin" />
                     Loading repositories
                   </div>
                 ) : props.repositories.length === 0 ? (
-                  <div className="p-3 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                  <div className="p-3 text-xs leading-5 text-fg-muted">
                     No installed repositories found. Install the app on a repository, then refresh.
                   </div>
                 ) : (
                   <div className="max-h-80 overflow-auto">
                     {props.groups.map((group) => (
-                      <div key={group.installationId} className="border-b border-[color:var(--color-border)] last:border-b-0">
-                        <div className="flex items-center justify-between gap-3 bg-[color:var(--color-surface)]/45 px-3 py-1.5">
-                          <div className="min-w-0 truncate text-[11px] font-medium text-[color:var(--color-fg-muted)]">{group.label}</div>
-                          <div className="shrink-0 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">{group.repositories.length} repos</div>
+                      <div key={group.installationId} className="border-b border-border last:border-b-0">
+                        <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
+                          <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">{group.label}</div>
+                          <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">{group.repositories.length} repos</div>
                         </div>
-                        <div className="divide-y divide-[color:var(--color-border)]/70">
+                        <div className="divide-y divide-border/70">
                           {group.repositories.map((repo) => {
                             const checked = props.selectedRepoIds.has(repo.id);
                             const blocked = props.selectedInstallationId !== null && props.selectedInstallationId !== repo.installationId && !checked;
                             return (
-                              <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-[color:var(--color-surface-2)]/45", blocked && "opacity-55")}>
+                              <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-surface-2/45", blocked && "opacity-55")}>
                                 <button
                                   type="button"
                                   onClick={() => props.onToggleRepo(repo)}
@@ -239,30 +239,30 @@ export function RepositoryContextPicker(props: {
                                     className={cn(
                                       "flex size-4 items-center justify-center rounded border",
                                       checked
-                                        ? "border-[color:var(--color-brand)] bg-[color:var(--color-brand-strong)] text-[color:var(--color-brand-fg)]"
-                                        : "border-[color:var(--color-border-strong)] bg-[color:var(--color-surface)]",
+                                        ? "border-brand bg-brand-strong text-brand-fg"
+                                        : "border-border-strong bg-surface",
                                     )}
                                   >
                                     {checked ? <CheckIcon className="size-3" /> : null}
                                   </span>
                                   <span className="min-w-0">
                                     <span className="flex min-w-0 items-center gap-1.5">
-                                      <span className="truncate text-xs font-medium text-[color:var(--color-fg)]">{repo.fullName}</span>
-                                      {repo.private ? <LockIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" /> : null}
+                                      <span className="truncate text-xs font-medium text-fg">{repo.fullName}</span>
+                                      {repo.private ? <LockIcon className="size-3 shrink-0 text-fg-subtle" /> : null}
                                     </span>
-                                    <span className="mt-0.5 block truncate text-[11px] text-[color:var(--color-fg-subtle)]">
+                                    <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
                                       default {repo.defaultBranch}
                                     </span>
                                   </span>
                                   {blocked ? (
-                                    <span className="rounded-full border border-amber-500/30 px-1.5 py-0.5 text-[10px] text-amber-200">other app</span>
+                                    <span className="rounded-full border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">other app</span>
                                   ) : checked ? (
-                                    <span className="rounded-full border border-emerald-500/30 px-1.5 py-0.5 text-[10px] text-emerald-300">selected</span>
+                                    <span className="rounded-full border border-status-idle/30 px-1.5 py-0.5 text-2xs text-status-idle">selected</span>
                                   ) : null}
                                 </button>
                                 {checked ? (
                                   <div className="mt-2 flex items-center gap-2 pl-6">
-                                    <GitBranchIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+                                    <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
                                     <Input
                                       value={props.selectedRepoRefs[repo.id] ?? repo.defaultBranch}
                                       onChange={(event) => props.onRefChange(repo.id, event.target.value)}
@@ -285,13 +285,13 @@ export function RepositoryContextPicker(props: {
               </section>
 
               <Collapsible open={props.manualOpen} onOpenChange={props.onManualOpenChange}>
-                <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/25">
+                <div className="rounded-lg border border-border bg-bg/25">
                   <div className="flex items-center justify-between gap-2 px-3 py-2">
                     <CollapsibleTrigger asChild>
-                      <button type="button" className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left text-xs font-medium text-[color:var(--color-fg)]">
-                        <ChevronDownIcon className={cn("size-3.5 shrink-0 text-[color:var(--color-fg-subtle)] transition-transform", props.manualOpen && "rotate-180")} />
+                      <button type="button" className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left text-xs font-medium text-fg">
+                        <ChevronDownIcon className={cn("size-3.5 shrink-0 text-fg-subtle transition-transform", props.manualOpen && "rotate-180")} />
                         <span className="truncate">Manual repositories</span>
-                        {manualCount > 0 ? <span className="rounded-full border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">{manualCount}</span> : null}
+                        {manualCount > 0 ? <span className="rounded-full border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{manualCount}</span> : null}
                       </button>
                     </CollapsibleTrigger>
                     <Button type="button" variant="ghost" size="xs" onClick={props.onManualAdd} disabled={props.pending} className="h-7 text-xs">
@@ -301,9 +301,9 @@ export function RepositoryContextPicker(props: {
                   </div>
 
                   <CollapsibleContent>
-                    <div className="space-y-2 border-t border-[color:var(--color-border)] p-3">
+                    <div className="space-y-2 border-t border-border p-3">
                       {props.manualRepos.length === 0 ? (
-                        <p className="text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                        <p className="text-xs leading-5 text-fg-muted">
                           Add HTTPS Git repositories that do not use the GitHub App token.
                         </p>
                       ) : (
@@ -317,7 +317,7 @@ export function RepositoryContextPicker(props: {
                               className="h-8 text-xs"
                             />
                             <div className="relative">
-                              <GitBranchIcon className="pointer-events-none absolute left-2.5 top-2 size-3.5 text-[color:var(--color-fg-subtle)]" />
+                              <GitBranchIcon className="pointer-events-none absolute left-2.5 top-2 size-3.5 text-fg-subtle" />
                               <Input
                                 value={repo.ref}
                                 onChange={(event) => props.onManualUpdate(repo.id, { ref: event.target.value })}
@@ -392,11 +392,11 @@ export function ScheduledTaskRepositoryPicker(props: {
   }
 
   return (
-    <section className="overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/25">
-      <div className="flex items-center justify-between gap-3 border-b border-[color:var(--color-border)] px-3 py-2">
+    <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
         <div>
-          <div className="text-xs font-medium text-[color:var(--color-fg)]">Repositories</div>
-          <div className="mt-0.5 text-[11px] text-[color:var(--color-fg-subtle)]">{repoCountLabel(repositoryResources.length)} attached to this task</div>
+          <div className="text-xs font-medium text-fg">Repositories</div>
+          <div className="mt-0.5 text-2xs text-fg-subtle">{repoCountLabel(repositoryResources.length)} attached to this task</div>
         </div>
         <Button type="button" variant="ghost" size="xs" onClick={() => void props.onRefresh()} disabled={!props.configured || props.repoBusy || props.busy}>
           <RefreshCwIcon className={cn("size-3", props.repoBusy && "animate-spin")} />
@@ -405,29 +405,29 @@ export function ScheduledTaskRepositoryPicker(props: {
       </div>
 
       {!props.configured ? (
-        <div className="p-3 text-xs leading-5 text-[color:var(--color-fg-muted)]">Configure the GitHub App to select repositories for scheduled runs.</div>
+        <div className="p-3 text-xs leading-5 text-fg-muted">Configure the GitHub App to select repositories for scheduled runs.</div>
       ) : props.repoBusy ? (
-        <div className="flex items-center gap-2 p-3 text-xs text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 p-3 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
           Loading repositories
         </div>
       ) : props.repositories.length === 0 ? (
-        <div className="p-3 text-xs leading-5 text-[color:var(--color-fg-muted)]">No installed repositories found.</div>
+        <div className="p-3 text-xs leading-5 text-fg-muted">No installed repositories found.</div>
       ) : (
         <div className="max-h-72 overflow-auto">
           {props.groups.map((group) => (
-            <div key={group.installationId} className="border-b border-[color:var(--color-border)] last:border-b-0">
-              <div className="flex items-center justify-between gap-3 bg-[color:var(--color-surface)]/45 px-3 py-1.5">
-                <div className="min-w-0 truncate text-[11px] font-medium text-[color:var(--color-fg-muted)]">{group.label}</div>
-                <div className="shrink-0 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">{group.repositories.length} repos</div>
+            <div key={group.installationId} className="border-b border-border last:border-b-0">
+              <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
+                <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">{group.label}</div>
+                <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">{group.repositories.length} repos</div>
               </div>
-              <div className="divide-y divide-[color:var(--color-border)]/70">
+              <div className="divide-y divide-border/70">
                 {group.repositories.map((repo) => {
                   const resource = repositoryResources.find((item) => isRepositoryResourceForGitHubRepo(item, repo));
                   const checked = Boolean(resource);
                   const blocked = selectedInstallationId !== null && selectedInstallationId !== repo.installationId && !checked;
                   return (
-                    <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-[color:var(--color-surface-2)]/45", blocked && "opacity-55")}>
+                    <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-surface-2/45", blocked && "opacity-55")}>
                       <button
                         type="button"
                         onClick={() => toggleRepo(repo)}
@@ -440,28 +440,28 @@ export function ScheduledTaskRepositoryPicker(props: {
                           className={cn(
                             "flex size-4 items-center justify-center rounded border",
                             checked
-                              ? "border-[color:var(--color-brand)] bg-[color:var(--color-brand-strong)] text-[color:var(--color-brand-fg)]"
-                              : "border-[color:var(--color-border-strong)] bg-[color:var(--color-surface)]",
+                              ? "border-brand bg-brand-strong text-brand-fg"
+                              : "border-border-strong bg-surface",
                           )}
                         >
                           {checked ? <CheckIcon className="size-3" /> : null}
                         </span>
                         <span className="min-w-0">
                           <span className="flex min-w-0 items-center gap-1.5">
-                            <span className="truncate text-xs font-medium text-[color:var(--color-fg)]">{repo.fullName}</span>
-                            {repo.private ? <LockIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" /> : null}
+                            <span className="truncate text-xs font-medium text-fg">{repo.fullName}</span>
+                            {repo.private ? <LockIcon className="size-3 shrink-0 text-fg-subtle" /> : null}
                           </span>
-                          <span className="mt-0.5 block truncate text-[11px] text-[color:var(--color-fg-subtle)]">default {repo.defaultBranch}</span>
+                          <span className="mt-0.5 block truncate text-2xs text-fg-subtle">default {repo.defaultBranch}</span>
                         </span>
                         {blocked ? (
-                          <span className="rounded-full border border-amber-500/30 px-1.5 py-0.5 text-[10px] text-amber-200">other app</span>
+                          <span className="rounded-full border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">other app</span>
                         ) : checked ? (
-                          <span className="rounded-full border border-emerald-500/30 px-1.5 py-0.5 text-[10px] text-emerald-300">selected</span>
+                          <span className="rounded-full border border-status-idle/30 px-1.5 py-0.5 text-2xs text-status-idle">selected</span>
                         ) : null}
                       </button>
                       {resource ? (
                         <div className="mt-2 flex items-center gap-2 pl-6">
-                          <GitBranchIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+                          <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
                           <Input
                             value={resource.ref}
                             onChange={(event) => updateRef(repo, event.target.value)}
@@ -483,7 +483,7 @@ export function ScheduledTaskRepositoryPicker(props: {
       )}
 
       {preservedRepositoryResources.length > 0 || fileResources.length > 0 ? (
-        <div className="border-t border-[color:var(--color-border)] px-3 py-2 text-[11px] text-[color:var(--color-fg-subtle)]">
+        <div className="border-t border-border px-3 py-2 text-2xs text-fg-subtle">
           Preserving {preservedRepositoryResources.length} manual repository resource{preservedRepositoryResources.length === 1 ? "" : "s"}
           {fileResources.length > 0 ? ` and ${fileResources.length} file resource${fileResources.length === 1 ? "" : "s"}` : ""}.
         </div>

--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -13,14 +13,14 @@ import type { FileAsset, ResourceRef, Session } from "@/types";
 
 export function TerminalSessionBanner(props: { session: Session; onNewSession: () => void }) {
   return (
-    <div className="mb-4 flex flex-col gap-3 rounded-lg border border-zinc-500/30 bg-zinc-500/10 p-3 text-zinc-100 sm:flex-row sm:items-center sm:justify-between">
+    <div className="mb-4 flex flex-col gap-3 rounded-lg border border-status-cancelled/30 bg-status-cancelled/10 p-3 text-status-cancelled sm:flex-row sm:items-center sm:justify-between">
       <div className="flex min-w-0 gap-2.5">
-        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-zinc-300" />
+        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-cancelled" />
         <div className="min-w-0">
           <div className="text-sm font-medium">
             This session was cancelled and cannot be continued.
           </div>
-          <div className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+          <div className="mt-1 text-xs text-fg-muted">
             Historical session from {formatTimestamp(props.session.createdAt)}.
           </div>
         </div>
@@ -41,16 +41,16 @@ export function TerminalSessionBanner(props: { session: Session; onNewSession: (
 export function FailedSessionBanner({ failure }: { failure: SessionFailureSummary }) {
   return (
     <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
-      <div data-testid="failed-session-banner" className="flex gap-2.5 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-red-100">
-        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-red-300" />
+      <div data-testid="failed-session-banner" className="flex gap-2.5 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed">
+        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
         <div className="min-w-0 text-sm">
           <span className="font-medium">This session failed{failure.failedAt ? ` ${formatTimestamp(failure.failedAt)}` : ""}.</span>{" "}
           {failure.reason ? (
-            <span className="text-red-200/90">{failure.reason}</span>
+            <span className="text-status-failed/90">{failure.reason}</span>
           ) : (
-            <span className="text-[color:var(--color-fg-muted)]">No failure detail was recorded.</span>
+            <span className="text-fg-muted">No failure detail was recorded.</span>
           )}
-          <div className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+          <div className="mt-1 text-xs text-fg-muted">
             {failure.redispatchCount > 0 ? (
               <>The platform re-dispatched {failure.redispatchCount} timed-out turn{failure.redispatchCount === 1 ? "" : "s"} after worker restarts before this failure. </>
             ) : null}
@@ -67,18 +67,18 @@ export function FailedSessionBanner({ failure }: { failure: SessionFailureSummar
 
 export function TerminalSessionArchive(props: { session: Session; eventCount: number }) {
   return (
-    <div className="grid min-h-[18rem] place-items-center rounded-lg border border-dashed border-[color:var(--color-border)] px-4 py-10 text-center">
+    <div className="grid min-h-[18rem] place-items-center rounded-lg border border-dashed border-border px-4 py-10 text-center">
       <div className="max-w-md">
-        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-md bg-[color:var(--color-surface-2)] text-[color:var(--color-fg-muted)]">
+        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-md bg-surface-2 text-fg-muted">
           <TerminalIcon className="size-4" />
         </div>
         <div className="text-sm font-medium">
           Historical cancelled session
         </div>
-        <p className="mt-1 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+        <p className="mt-1 text-xs leading-5 text-fg-muted">
           This is a saved event log from {formatTimestamp(props.session.createdAt)}, not a current run. Sanitized debug metadata is available in the inspector.
         </p>
-        <div className="mt-3 text-[11px] uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+        <div className="mt-3 text-2xs uppercase tracking-wide text-fg-subtle">
           {props.eventCount} timeline item{props.eventCount === 1 ? "" : "s"}
         </div>
       </div>
@@ -98,7 +98,7 @@ export function UserMessageBody({ workspaceId, item }: { workspaceId: string; it
           {repositoryResources.map((resource) => (
             <span
               key={`${resource.uri}:${resource.ref}:${resource.mountPath ?? ""}`}
-              className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]"
+              className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg-muted"
             >
               <GitBranchIcon className="size-3.5 shrink-0" />
               <span className="truncate">{repositoryDisplayName(resource)}</span>
@@ -107,7 +107,7 @@ export function UserMessageBody({ workspaceId, item }: { workspaceId: string; it
           {item.tools.map((tool) => (
             <span
               key={`${tool.kind}:${tool.id}`}
-              className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg-muted"
             >
               <WrenchIcon className="size-3.5" />
               <span>{tool.id}</span>
@@ -156,7 +156,7 @@ export function MessageFileAttachment({ workspaceId, resource }: { workspaceId: 
       type="button"
       onClick={() => void openFile()}
       disabled={busy}
-      className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)] disabled:opacity-60"
+      className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg-muted hover:text-fg disabled:opacity-60"
     >
       {isImage ? <ImageIcon className="size-3.5 shrink-0" /> : <FileJsonIcon className="size-3.5 shrink-0" />}
       <span className="truncate">{file?.filename ?? resource.fileId}</span>

--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -21,7 +21,7 @@ export function TerminalSessionBanner(props: { session: Session; onNewSession: (
             This session was cancelled and cannot be continued.
           </div>
           <div className="mt-1 text-xs text-fg-muted">
-            Historical session from {formatTimestamp(props.session.createdAt)}.
+            Started {formatTimestamp(props.session.createdAt)}.
           </div>
         </div>
       </div>
@@ -34,9 +34,9 @@ export function TerminalSessionBanner(props: { session: Session; onNewSession: (
 }
 
 /**
- * Failure honesty: the reason the session failed, how often the platform
- * re-dispatched turns after worker deaths, and the fact that the composer
- * stays usable — sending a message revives the session.
+ * Failure honesty: the reason the session failed, how many turns timed out and
+ * were retried automatically before it, and the fact that the composer stays
+ * usable — sending a message revives the session.
  */
 export function FailedSessionBanner({ failure }: { failure: SessionFailureSummary }) {
   return (
@@ -52,7 +52,7 @@ export function FailedSessionBanner({ failure }: { failure: SessionFailureSummar
           )}
           <div className="mt-1 text-xs text-fg-muted">
             {failure.redispatchCount > 0 ? (
-              <>The platform re-dispatched {failure.redispatchCount} timed-out turn{failure.redispatchCount === 1 ? "" : "s"} after worker restarts before this failure. </>
+              <>{failure.redispatchCount} turn{failure.redispatchCount === 1 ? "" : "s"} timed out and {failure.redispatchCount === 1 ? "was" : "were"} retried automatically before this failure. </>
             ) : null}
             {failure.failedTurnCount > 1 ? (
               <>{failure.failedTurnCount} turns have failed in this session. </>
@@ -73,7 +73,7 @@ export function TerminalSessionArchive(props: { session: Session; eventCount: nu
           <TerminalIcon className="size-4" />
         </div>
         <div className="text-sm font-medium">
-          Historical cancelled session
+          Cancelled session (read-only)
         </div>
         <p className="mt-1 text-xs leading-5 text-fg-muted">
           This is a saved event log from {formatTimestamp(props.session.createdAt)}, not a current run. Sanitized debug metadata is available in the inspector.

--- a/apps/web/src/components/session/codex-account-indicator.tsx
+++ b/apps/web/src/components/session/codex-account-indicator.tsx
@@ -48,11 +48,11 @@ function MiniBar({ account, className }: { account: CodexAccount | undefined | n
   const danger = pct <= 10;
   return (
     <span
-      className={`inline-block h-1 w-8 shrink-0 overflow-hidden rounded-full bg-[color:var(--color-surface-2)] ${className ?? ""}`}
+      className={`inline-block h-1 w-8 shrink-0 overflow-hidden rounded-full bg-surface-2 ${className ?? ""}`}
       title={`${pct}% remaining`}
     >
       <span
-        className={`block h-full rounded-full ${danger ? "bg-amber-500" : "bg-[color:var(--color-brand)]"}`}
+        className={`block h-full rounded-full ${danger ? "bg-status-waiting" : "bg-brand"}`}
         style={{ width: `${pct}%` }}
       />
     </span>
@@ -95,12 +95,12 @@ export function CodexAccountIndicator({
           type="button"
           variant="ghost"
           size="sm"
-          className="h-7 max-w-[14rem] gap-1 rounded-full border border-transparent px-2 text-xs text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]"
+          className="h-7 max-w-[14rem] gap-1 rounded-full border border-transparent px-2 text-xs text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg"
         >
-          <SparklesIcon className="size-3 shrink-0 text-[color:var(--color-brand)]" />
-          <span className="hidden truncate text-[color:var(--color-fg-subtle)] sm:inline">Account:</span>
-          <span className="truncate font-medium text-[color:var(--color-fg)]">{triggerLabel}</span>
-          {plan ? <span className="hidden shrink-0 text-[color:var(--color-fg-subtle)] md:inline">· {plan}</span> : null}
+          <SparklesIcon className="size-3 shrink-0 text-brand" />
+          <span className="hidden truncate text-fg-subtle sm:inline">Account:</span>
+          <span className="truncate font-medium text-fg">{triggerLabel}</span>
+          {plan ? <span className="hidden shrink-0 text-fg-subtle md:inline">· {plan}</span> : null}
           <MiniBar account={effective} className="hidden sm:inline-block" />
           {codex.pinning ? (
             <Loader2Icon className="size-3 shrink-0 animate-spin" />
@@ -113,9 +113,9 @@ export function CodexAccountIndicator({
         align="end"
         side="bottom"
         sideOffset={8}
-        className="w-64 rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 shadow-xl"
+        className="w-64 rounded-xl border-border bg-surface p-2 shadow-xl"
       >
-        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">
+        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-fg-subtle">
           Run inference on
         </DropdownMenuLabel>
 
@@ -131,7 +131,7 @@ export function CodexAccountIndicator({
           }}
           className="flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 text-sm"
         >
-          <SparklesIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <SparklesIcon className="size-3.5 shrink-0 text-fg-subtle" />
           <span className="min-w-0 flex-1 truncate">Auto (workspace default)</span>
           {codex.pinningTarget === AUTO ? (
             <Loader2Icon className="ml-1 size-4 shrink-0 animate-spin" />
@@ -159,7 +159,7 @@ export function CodexAccountIndicator({
               <span className="min-w-0 flex-1 truncate">{accountLabel(account)}</span>
               <MiniBar account={account} />
               {account.status !== "active" ? (
-                <span className="shrink-0 text-[10px] text-amber-500">{account.status === "needs_relogin" ? "relogin" : account.status}</span>
+                <span className="shrink-0 text-2xs text-status-waiting">{account.status === "needs_relogin" ? "relogin" : account.status}</span>
               ) : null}
               {isPinning ? (
                 <Loader2Icon className="ml-1 size-4 shrink-0 animate-spin" />
@@ -171,14 +171,14 @@ export function CodexAccountIndicator({
         })}
 
         {!hasAccounts ? (
-          <p className="px-2 pt-1 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">No Codex subscriptions connected.</p>
+          <p className="px-2 pt-1 text-2xs text-fg-subtle">No Codex subscriptions connected.</p>
         ) : null}
         {codex.mutationError ? (
-          <p className="px-2 pt-1 text-[11px] leading-4 text-[color:var(--color-danger)]">
+          <p className="px-2 pt-1 text-2xs text-danger">
             Switch failed: {codex.mutationError.message}
           </p>
         ) : (
-          <p className="px-2 pt-1 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">Applies next turn.</p>
+          <p className="px-2 pt-1 text-2xs text-fg-subtle">Applies next turn.</p>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/session/goal-card.tsx
+++ b/apps/web/src/components/session/goal-card.tsx
@@ -25,7 +25,7 @@ export function GoalCard({ goal, events }: {
   return (
     <div data-testid="goal-card" className="min-w-0 space-y-2">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-fg-subtle">
           <FlagIcon className="size-3.5" />
           Goal
         </h3>
@@ -33,7 +33,7 @@ export function GoalCard({ goal, events }: {
       </div>
 
       {goal.loading && !record ? (
-        <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-xs text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-3 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
           Loading goal
         </div>
@@ -41,22 +41,22 @@ export function GoalCard({ goal, events }: {
         <div
           className={cn(
             "rounded-lg border p-2.5",
-            record.status === "active" && "border-[color:var(--color-brand)]/35 bg-[color:var(--color-brand)]/5",
-            record.status === "paused" && "border-amber-500/30 bg-amber-500/5",
-            record.status === "completed" && "border-emerald-500/30 bg-emerald-500/5",
+            record.status === "active" && "border-brand/35 bg-brand/5",
+            record.status === "paused" && "border-status-waiting/30 bg-status-waiting/5",
+            record.status === "completed" && "border-status-idle/30 bg-status-idle/5",
           )}
         >
-          <div className="text-xs leading-5 text-[color:var(--color-fg)]">{record.text}</div>
+          <div className="text-xs leading-5 text-fg">{record.text}</div>
           {record.successCriteria ? (
-            <div className="mt-1.5 text-[11px] leading-4 text-[color:var(--color-fg-muted)]">
+            <div className="mt-1.5 text-2xs text-fg-muted">
               <span className="font-medium">Done when:</span> {record.successCriteria}
             </div>
           ) : null}
           {record.status === "paused" && record.rationale ? (
-            <div className="mt-1.5 text-[11px] leading-4 text-amber-200/90">Paused: {record.rationale}</div>
+            <div className="mt-1.5 text-2xs text-status-waiting/90">Paused: {record.rationale}</div>
           ) : null}
           {record.status === "completed" && record.evidence ? (
-            <div className="mt-1.5 text-[11px] leading-4 text-emerald-200/90">Evidence: {record.evidence}</div>
+            <div className="mt-1.5 text-2xs text-status-idle/90">Evidence: {record.evidence}</div>
           ) : null}
 
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -92,9 +92,9 @@ export function GoalCard({ goal, events }: {
       ) : null}
 
       {goal.mutationError ? (
-        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs leading-4 text-red-200">
+        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
           <span className="min-w-0 flex-1">{goal.mutationError.message}</span>
-          <button type="button" onClick={goal.clearMutationError} aria-label="Dismiss goal error" className="shrink-0 rounded p-0.5 hover:bg-red-500/20">
+          <button type="button" onClick={goal.clearMutationError} aria-label="Dismiss goal error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
             <XIcon className="size-3" />
           </button>
         </div>
@@ -102,15 +102,15 @@ export function GoalCard({ goal, events }: {
 
       {goalEvents.length > 0 ? (
         <details className="group">
-          <summary className="cursor-pointer list-none text-[11px] font-medium text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg-muted)]">
+          <summary className="cursor-pointer list-none text-2xs font-medium text-fg-subtle hover:text-fg-muted">
             <ChevronDownIcon className="mr-1 inline size-3 transition-transform group-open:rotate-180" />
             Goal history ({goalEvents.length})
           </summary>
           <ol className="mt-2 space-y-1" aria-label="Goal event history">
             {goalEvents.slice(0, 20).map((event) => (
-              <li key={event.id} className="flex items-center justify-between gap-2 rounded-md border border-[color:var(--color-border)]/70 bg-[color:var(--color-bg)]/25 px-2 py-1.5 text-[11px]">
-                <span className="min-w-0 truncate font-medium text-[color:var(--color-fg-muted)]">{eventLabel(event.type)}</span>
-                <span className="shrink-0 text-[10px] text-[color:var(--color-fg-subtle)]">{formatTimestamp(event.occurredAt)}</span>
+              <li key={event.id} className="flex items-center justify-between gap-2 rounded-md border border-border/70 bg-bg/25 px-2 py-1.5 text-2xs">
+                <span className="min-w-0 truncate font-medium text-fg-muted">{eventLabel(event.type)}</span>
+                <span className="shrink-0 text-2xs text-fg-subtle">{formatTimestamp(event.occurredAt)}</span>
               </li>
             ))}
           </ol>
@@ -132,14 +132,14 @@ export function GoalChip({ goal }: { goal: UseGoalResult }) {
       title={record.text}
       className={cn(
         "inline-flex max-w-56 items-center gap-1.5 rounded-full border px-2 py-1 text-xs font-medium",
-        record.status === "active" && "border-[color:var(--color-brand)]/40 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]",
-        record.status === "paused" && "border-amber-500/40 bg-amber-500/10 text-amber-200",
-        record.status === "completed" && "border-emerald-500/40 bg-emerald-500/10 text-emerald-300",
+        record.status === "active" && "border-brand/40 bg-brand/10 text-fg",
+        record.status === "paused" && "border-status-waiting/40 bg-status-waiting/10 text-status-waiting",
+        record.status === "completed" && "border-status-idle/40 bg-status-idle/10 text-status-idle",
       )}
     >
       <FlagIcon className="size-3 shrink-0" />
       <span className="min-w-0 truncate">{record.text}</span>
-      <span className="shrink-0 font-mono text-[10px] opacity-75">
+      <span className="shrink-0 font-mono text-2xs opacity-75">
         {record.status === "paused" ? "paused" : record.status === "completed" ? "done" : `${record.autoContinuations}↻ ${record.noProgressStreak}∅`}
       </span>
     </span>
@@ -150,10 +150,10 @@ function GoalStatusPill({ status }: { status: "active" | "paused" | "completed" 
   return (
     <span
       className={cn(
-        "rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
-        status === "active" && "border-[color:var(--color-brand)]/40 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]",
-        status === "paused" && "border-amber-500/40 bg-amber-500/10 text-amber-200",
-        status === "completed" && "border-emerald-500/40 bg-emerald-500/10 text-emerald-300",
+        "rounded-full border px-1.5 py-0.5 text-2xs font-medium",
+        status === "active" && "border-brand/40 bg-brand/10 text-fg",
+        status === "paused" && "border-status-waiting/40 bg-status-waiting/10 text-status-waiting",
+        status === "completed" && "border-status-idle/40 bg-status-idle/10 text-status-idle",
       )}
     >
       {status}
@@ -165,13 +165,13 @@ function CounterChip({ label, value, tone }: { label: string; value: string; ton
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px]",
+        "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-2xs",
         tone === "warn"
-          ? "border-amber-500/40 bg-amber-500/10 text-amber-200"
-          : "border-[color:var(--color-border)] text-[color:var(--color-fg-subtle)]",
+          ? "border-status-waiting/40 bg-status-waiting/10 text-status-waiting"
+          : "border-border text-fg-subtle",
       )}
     >
-      <span className="font-mono font-medium text-[color:var(--color-fg-muted)]">{value}</span>
+      <span className="font-mono font-medium text-fg-muted">{value}</span>
       {label}
     </span>
   );

--- a/apps/web/src/components/session/goal-card.tsx
+++ b/apps/web/src/components/session/goal-card.tsx
@@ -8,6 +8,8 @@ import type { SessionEvent } from "@opengeni/sdk";
 import { ChevronDownIcon, FlagIcon, Loader2Icon, PauseIcon, PlayIcon, XIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { MetaChip } from "@/components/ui/meta-chip";
+import { Notice } from "@/components/ui/notice";
 import { eventLabel } from "@/lib/events";
 import { formatTimestamp } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -60,17 +62,15 @@ export function GoalCard({ goal, events }: {
           ) : null}
 
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            <CounterChip
-              label="auto-continuations"
-              value={record.maxAutoContinuations !== null ? `${record.autoContinuations}/${record.maxAutoContinuations}` : String(record.autoContinuations)}
-              tone={record.maxAutoContinuations !== null && record.autoContinuations >= record.maxAutoContinuations ? "warn" : "default"}
-            />
-            <CounterChip
-              label="no-progress streak"
-              value={String(record.noProgressStreak)}
-              tone={record.noProgressStreak >= 2 ? "warn" : "default"}
-            />
-            <CounterChip label="v" value={String(record.version)} tone="default" />
+            <MetaChip dot={record.maxAutoContinuations !== null && record.autoContinuations >= record.maxAutoContinuations ? "waiting" : undefined}>
+              {record.maxAutoContinuations !== null
+                ? `${record.autoContinuations} of ${record.maxAutoContinuations} auto-continues`
+                : `${record.autoContinuations} auto-continue${record.autoContinuations === 1 ? "" : "s"}`}
+            </MetaChip>
+            <MetaChip dot={record.noProgressStreak >= 2 ? "waiting" : undefined}>
+              {record.noProgressStreak} stalled check{record.noProgressStreak === 1 ? "" : "s"}
+            </MetaChip>
+            <MetaChip>version {record.version}</MetaChip>
           </div>
 
           {record.status !== "completed" ? (
@@ -92,12 +92,16 @@ export function GoalCard({ goal, events }: {
       ) : null}
 
       {goal.mutationError ? (
-        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
-          <span className="min-w-0 flex-1">{goal.mutationError.message}</span>
-          <button type="button" onClick={goal.clearMutationError} aria-label="Dismiss goal error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
-            <XIcon className="size-3" />
-          </button>
-        </div>
+        <Notice
+          tone="failed"
+          action={(
+            <button type="button" onClick={goal.clearMutationError} aria-label="Dismiss goal error" className="rounded p-0.5 text-fg-subtle hover:bg-surface-2 hover:text-fg">
+              <XIcon className="size-3.5" />
+            </button>
+          )}
+        >
+          {goal.mutationError.message}
+        </Notice>
       ) : null}
 
       {goalEvents.length > 0 ? (
@@ -120,16 +124,26 @@ export function GoalCard({ goal, events }: {
   );
 }
 
-/** The compact goal chip for the session header: status + counters at a glance. */
+const GOAL_STATUS_LABEL: Record<"active" | "paused" | "completed", string> = {
+  active: "Active",
+  paused: "Paused",
+  completed: "Completed",
+};
+
+/** The compact goal chip for the session header: status at a glance, full
+ *  counters (auto-continues, stalled checks, version) in the tooltip so no
+ *  cryptic glyphs leak into the chip. */
 export function GoalChip({ goal }: { goal: UseGoalResult }) {
   const record = goal.goal;
   if (!record) {
     return null;
   }
+  const suffix = record.status === "paused" ? "Paused" : record.status === "completed" ? "Done" : null;
+  const tooltip = `${record.text} — ${record.autoContinuations} auto-continues, ${record.noProgressStreak} stalled checks, version ${record.version}`;
   return (
     <span
       data-testid="goal-chip"
-      title={record.text}
+      title={tooltip}
       className={cn(
         "inline-flex max-w-56 items-center gap-1.5 rounded-full border px-2 py-1 text-xs font-medium",
         record.status === "active" && "border-brand/40 bg-brand/10 text-fg",
@@ -139,9 +153,7 @@ export function GoalChip({ goal }: { goal: UseGoalResult }) {
     >
       <FlagIcon className="size-3 shrink-0" />
       <span className="min-w-0 truncate">{record.text}</span>
-      <span className="shrink-0 font-mono text-2xs opacity-75">
-        {record.status === "paused" ? "paused" : record.status === "completed" ? "done" : `${record.autoContinuations}↻ ${record.noProgressStreak}∅`}
-      </span>
+      {suffix ? <span className="shrink-0 text-2xs opacity-75">{suffix}</span> : null}
     </span>
   );
 }
@@ -156,23 +168,7 @@ function GoalStatusPill({ status }: { status: "active" | "paused" | "completed" 
         status === "completed" && "border-status-idle/40 bg-status-idle/10 text-status-idle",
       )}
     >
-      {status}
-    </span>
-  );
-}
-
-function CounterChip({ label, value, tone }: { label: string; value: string; tone: "default" | "warn" }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-2xs",
-        tone === "warn"
-          ? "border-status-waiting/40 bg-status-waiting/10 text-status-waiting"
-          : "border-border text-fg-subtle",
-      )}
-    >
-      <span className="font-mono font-medium text-fg-muted">{value}</span>
-      {label}
+      {GOAL_STATUS_LABEL[status]}
     </span>
   );
 }

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -31,6 +31,16 @@ export function SessionInspector(props: {
   // active (or selfhosted is disabled → the fleet 404s to empty).
   const fleet = useMachines({ sessionId: props.session.id, pollIntervalMs: 10000 });
   const activeMachine = fleet.machines.find((machine) => machine.active && machine.kind === "selfhosted") ?? null;
+  // Compute context, honestly: don't fall back to the home backend while the
+  // fleet is still resolving — that reads "modal" even when a machine runs the
+  // turn. Show a loading/unavailable note until we actually know.
+  const computeUnknown = fleet.machines.length === 0 && (fleet.loading || Boolean(fleet.error));
+  const computeLabel = activeMachine ? "Machine" : "Sandbox";
+  const computeValue = activeMachine
+    ? activeMachine.name
+    : computeUnknown
+      ? (fleet.loading ? "Checking…" : "Unavailable")
+      : props.session.sandboxBackend;
   const displayEvents = props.events.map((event) => sanitizeEventForDisplay(event, props.session.status));
   const sortedEvents = [...displayEvents].sort((a, b) => b.sequence - a.sequence);
   const lifecycleEvents = [...displayEvents]
@@ -77,12 +87,9 @@ export function SessionInspector(props: {
               <InspectorSection title="Runtime">
                 <InfoRow label="Model" value={props.session.model} />
                 <InfoRow label="Effort" value={String(props.session.metadata.reasoningEffort ?? "low")} />
-                <InfoRow
-                  label={activeMachine ? "Machine" : "Sandbox"}
-                  value={activeMachine ? activeMachine.name : props.session.sandboxBackend}
-                />
+                <InfoRow label={computeLabel} value={computeValue} />
                 <InfoRow label="Environment" value={props.session.environmentId ? <CopyableMono value={props.session.environmentId} /> : "none"} />
-                <InfoRow label="Stream" value={<ConnectionPill state={props.connectionState} />} />
+                <InfoRow label="Stream" value={props.connectionState} />
               </InspectorSection>
 
               <InspectorSection title="Repositories">

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -40,24 +40,24 @@ export function SessionInspector(props: {
 
   return (
     <div className="flex h-full min-h-[28rem] w-full min-w-0 flex-col overflow-hidden">
-      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-[color:var(--color-border)] px-3 py-3">
+      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3">
         <div className="flex min-w-0 items-center gap-2">
-          <FileJsonIcon className="size-4 shrink-0 text-[color:var(--color-brand)]" />
+          <FileJsonIcon className="size-4 shrink-0 text-brand" />
           <div className="min-w-0">
             <div className="text-sm font-medium">{terminalSession ? "Archived debug" : "Debug"}</div>
-            <div className="truncate text-xs text-[color:var(--color-fg-subtle)]">{props.events.length} events{terminalSession ? " · sanitized" : ""}</div>
+            <div className="truncate text-xs text-fg-subtle">{props.events.length} events{terminalSession ? " · sanitized" : ""}</div>
           </div>
         </div>
         <ConnectionPill state={props.connectionState} />
       </div>
 
       <Tabs defaultValue="overview" className="min-h-0 min-w-0 flex-1 gap-0 overflow-hidden">
-        <div className="min-w-0 border-b border-[color:var(--color-border)] px-2 py-2">
-          <TabsList className="grid h-8 w-full min-w-0 grid-cols-4 rounded-md bg-[color:var(--color-bg)] p-1">
-            <TabsTrigger value="overview" className="h-6 min-w-0 rounded px-1 text-[11px]">Overview</TabsTrigger>
-            <TabsTrigger value="events" className="h-6 min-w-0 rounded px-1 text-[11px]">Events</TabsTrigger>
-            <TabsTrigger value="timeline" className="h-6 min-w-0 rounded px-1 text-[11px]">Timeline</TabsTrigger>
-            <TabsTrigger value="raw" className="h-6 min-w-0 rounded px-1 text-[11px]">Raw</TabsTrigger>
+        <div className="min-w-0 border-b border-border px-2 py-2">
+          <TabsList className="grid h-8 w-full min-w-0 grid-cols-4 rounded-md bg-bg p-1">
+            <TabsTrigger value="overview" className="h-6 min-w-0 rounded px-1 text-2xs">Overview</TabsTrigger>
+            <TabsTrigger value="events" className="h-6 min-w-0 rounded px-1 text-2xs">Events</TabsTrigger>
+            <TabsTrigger value="timeline" className="h-6 min-w-0 rounded px-1 text-2xs">Timeline</TabsTrigger>
+            <TabsTrigger value="raw" className="h-6 min-w-0 rounded px-1 text-2xs">Raw</TabsTrigger>
           </TabsList>
         </div>
 
@@ -87,16 +87,16 @@ export function SessionInspector(props: {
 
               <InspectorSection title="Repositories">
                 {repositories.length === 0 ? (
-                  <p className="text-xs text-[color:var(--color-fg-subtle)]">No repositories selected for this session.</p>
+                  <p className="text-xs text-fg-subtle">No repositories selected for this session.</p>
                 ) : (
                   <div className="min-w-0 space-y-2">
                     {repositories.map((resource, index) => (
-                      <div key={`${resource.uri}:${index}`} className="min-w-0 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-2">
+                      <div key={`${resource.uri}:${index}`} className="min-w-0 rounded-md border border-border bg-bg/35 p-2">
                         <div className="min-w-0 truncate text-xs font-medium">{repositoryDisplayName(resource)}</div>
-                        <div className="mt-1 min-w-0 truncate font-mono text-[11px] text-[color:var(--color-fg-subtle)]">{resource.uri}</div>
-                        <div className="mt-2 flex min-w-0 flex-wrap gap-1.5 text-[11px] text-[color:var(--color-fg-subtle)]">
-                          <span className="max-w-full truncate rounded border border-[color:var(--color-border)] px-1.5 py-0.5">ref {resource.ref}</span>
-                          {resource.mountPath ? <span className="max-w-full truncate rounded border border-[color:var(--color-border)] px-1.5 py-0.5">{resource.mountPath}</span> : null}
+                        <div className="mt-1 min-w-0 truncate font-mono text-2xs text-fg-subtle">{resource.uri}</div>
+                        <div className="mt-2 flex min-w-0 flex-wrap gap-1.5 text-2xs text-fg-subtle">
+                          <span className="max-w-full truncate rounded border border-border px-1.5 py-0.5">ref {resource.ref}</span>
+                          {resource.mountPath ? <span className="max-w-full truncate rounded border border-border px-1.5 py-0.5">{resource.mountPath}</span> : null}
                         </div>
                       </div>
                     ))}
@@ -119,12 +119,12 @@ export function SessionInspector(props: {
           <ScrollArea className="h-full min-w-0">
             <div className="min-w-0 space-y-2 p-3">
               {lifecycleEvents.map((event) => (
-                <div key={event.id} className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-2">
+                <div key={event.id} className="rounded-md border border-border bg-bg/35 p-2">
                   <div className="flex items-center justify-between gap-2 text-xs">
                     <span className="truncate font-medium">{eventLabel(event.type)}</span>
-                    <span className="shrink-0 font-mono text-[11px] text-[color:var(--color-fg-subtle)]">#{event.sequence}</span>
+                    <span className="shrink-0 font-mono text-2xs text-fg-subtle">#{event.sequence}</span>
                   </div>
-                  <div className="mt-1 text-[11px] text-[color:var(--color-fg-subtle)]">{formatTimestamp(event.occurredAt)}</div>
+                  <div className="mt-1 text-2xs text-fg-subtle">{formatTimestamp(event.occurredAt)}</div>
                 </div>
               ))}
             </div>
@@ -142,21 +142,21 @@ export function SessionInspector(props: {
 function EventDebugRow({ event }: { event: SessionEvent }) {
   const [open, setOpen] = useState(false);
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="min-w-0 overflow-hidden rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35">
+    <Collapsible open={open} onOpenChange={setOpen} className="min-w-0 overflow-hidden rounded-md border border-border bg-bg/35">
       <CollapsibleTrigger asChild>
         <button type="button" className="flex w-full min-w-0 items-center justify-between gap-2 p-2 text-left">
           <div className="min-w-0">
             <div className="truncate text-xs font-medium">{eventLabel(event.type)}</div>
-            <div className="mt-1 truncate font-mono text-[11px] text-[color:var(--color-fg-subtle)]">{event.turnId ?? event.id}</div>
+            <div className="mt-1 truncate font-mono text-2xs text-fg-subtle">{event.turnId ?? event.id}</div>
           </div>
           <div className="shrink-0 text-right">
-            <div className="font-mono text-[11px] text-[color:var(--color-fg-muted)]">#{event.sequence}</div>
-            <div className="mt-1 text-[11px] text-[color:var(--color-fg-subtle)]">{formatTimestamp(event.occurredAt)}</div>
+            <div className="font-mono text-2xs text-fg-muted">#{event.sequence}</div>
+            <div className="mt-1 text-2xs text-fg-subtle">{formatTimestamp(event.occurredAt)}</div>
           </div>
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <pre className="max-h-72 max-w-full overflow-auto border-t border-[color:var(--color-border)] p-2 text-[11px] leading-5 text-[color:var(--color-fg-muted)]">
+        <pre className="max-h-72 max-w-full overflow-auto border-t border-border p-2 text-2xs leading-5 text-fg-muted">
           {JSON.stringify(event.payload, null, 2)}
         </pre>
       </CollapsibleContent>
@@ -168,7 +168,7 @@ function RawJsonPane({ value }: { value: unknown }) {
   const json = JSON.stringify(value, null, 2);
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <div className="flex items-center justify-end border-b border-[color:var(--color-border)] p-2">
+      <div className="flex items-center justify-end border-b border-border p-2">
         <Button
           type="button"
           variant="ghost"
@@ -183,7 +183,7 @@ function RawJsonPane({ value }: { value: unknown }) {
         </Button>
       </div>
       <ScrollArea className="min-h-0 min-w-0 flex-1">
-        <pre className="max-w-full overflow-auto p-3 text-[11px] leading-5 text-[color:var(--color-fg-muted)]">{json}</pre>
+        <pre className="max-w-full overflow-auto p-3 text-2xs leading-5 text-fg-muted">{json}</pre>
       </ScrollArea>
     </div>
   );

--- a/apps/web/src/components/session/queue-rail.tsx
+++ b/apps/web/src/components/session/queue-rail.tsx
@@ -7,7 +7,6 @@
 import type { UseTurnQueueResult } from "@opengeni/react";
 import type { SessionStatus, SessionTurn } from "@opengeni/sdk";
 import {
-  AlertTriangleIcon,
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
@@ -21,6 +20,8 @@ import {
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Notice } from "@/components/ui/notice";
+import { StatusDot, STATUS_META, type StatusTone } from "@/components/ui/status-dot";
 import { formatElapsedSeconds, formatTimestamp } from "@/lib/format";
 import { listViewState } from "@/lib/load-state";
 import {
@@ -110,29 +111,35 @@ export function QueueRail({ queue, sessionStatus }: {
           <ListPlusIcon className="size-3.5" />
           Turn queue
         </h3>
-        <span className="text-2xs text-fg-subtle">
-          {queue.queue.length > 0 ? `${queue.queue.length} queued` : activeTurnView === "error" ? "unavailable" : "empty"}
-        </span>
+        {queue.queue.length > 0 ? (
+          <span className="text-2xs text-fg-subtle">{queue.queue.length} queued</span>
+        ) : null}
       </div>
 
       {claimedNotice ? (
-        <div className="flex items-start gap-2 rounded-md border border-status-waiting/40 bg-status-waiting/10 p-2 text-xs leading-4 text-status-waiting">
-          <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1">{claimedNotice}</span>
-          <button type="button" onClick={() => setClaimedNotice(null)} aria-label="Dismiss" className="shrink-0 rounded p-0.5 hover:bg-status-waiting/20">
-            <XIcon className="size-3" />
-          </button>
-        </div>
+        <Notice
+          tone="waiting"
+          action={(
+            <button type="button" onClick={() => setClaimedNotice(null)} aria-label="Dismiss" className="rounded p-0.5 text-fg-subtle hover:bg-surface-2 hover:text-fg">
+              <XIcon className="size-3.5" />
+            </button>
+          )}
+        >
+          {claimedNotice}
+        </Notice>
       ) : null}
 
       {queue.mutationError ? (
-        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
-          <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1">{queue.mutationError.message}</span>
-          <button type="button" onClick={queue.clearMutationError} aria-label="Dismiss queue error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
-            <XIcon className="size-3" />
-          </button>
-        </div>
+        <Notice
+          tone="failed"
+          action={(
+            <button type="button" onClick={queue.clearMutationError} aria-label="Dismiss queue error" className="rounded p-0.5 text-fg-subtle hover:bg-surface-2 hover:text-fg">
+              <XIcon className="size-3.5" />
+            </button>
+          )}
+        >
+          {queue.mutationError.message}
+        </Notice>
       ) : null}
 
       {queue.activeTurn ? (
@@ -140,16 +147,19 @@ export function QueueRail({ queue, sessionStatus }: {
       ) : activeTurnView === "loading" ? (
         <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-3 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
-          Loading turns
+          Loading turns…
         </div>
       ) : activeTurnView === "error" ? (
-        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed" role="alert">
-          <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1">Couldn't load the turn queue{queue.error?.message ? ` — ${queue.error.message}` : ""}</span>
-          <Button type="button" variant="ghost" size="xs" onClick={() => void queue.refresh()} className="shrink-0 text-status-failed hover:bg-status-failed/20 hover:text-status-failed">
-            Retry
-          </Button>
-        </div>
+        <Notice
+          tone="failed"
+          action={(
+            <Button type="button" variant="ghost" size="xs" onClick={() => void queue.refresh()} className="text-status-failed hover:bg-status-failed/20 hover:text-status-failed">
+              Retry
+            </Button>
+          )}
+        >
+          Couldn't load the turn queue{queue.error?.message ? ` — ${queue.error.message}` : ""}
+        </Notice>
       ) : (
         <div className="rounded-lg border border-dashed border-border p-3 text-xs leading-5 text-fg-subtle">
           {sessionStatus === "failed"
@@ -274,10 +284,10 @@ export function QueueRail({ queue, sessionStatus }: {
           </summary>
           <ol className="mt-2 space-y-1">
             {history.slice(0, 12).map((turn) => (
-              <li key={turn.id} className="flex min-w-0 items-center gap-2 rounded-md border border-border/70 bg-bg/25 px-2 py-1.5">
-                <TurnStatusDot status={turn.status} />
-                <span className="min-w-0 flex-1 truncate text-2xs text-fg-muted">{turn.prompt}</span>
-                <span className="shrink-0 text-2xs text-fg-subtle">{turn.status}</span>
+              <li key={turn.id} className="flex min-w-0 items-start gap-2 rounded-md border border-border/70 bg-bg/25 px-2 py-1.5">
+                <TurnStatusDot status={turn.status} className="mt-1" />
+                <span className="line-clamp-2 min-w-0 flex-1 text-2xs leading-4 text-fg-muted" title={turn.prompt}>{turn.prompt}</span>
+                <span className="shrink-0 text-2xs text-fg-subtle">{turnStatusLabel(turn.status)}</span>
               </li>
             ))}
           </ol>
@@ -307,10 +317,10 @@ function ActiveTurnCard({ turn }: { turn: SessionTurn }) {
       <div className="flex items-center justify-between gap-2">
         <span className="flex min-w-0 items-center gap-1.5 text-xs font-medium">
           <TurnStatusDot status={turn.status} />
-          {awaitingApproval ? "Awaiting approval" : "Running"}
+          {awaitingApproval ? "Waiting on you" : "Running"}
         </span>
         <span className="shrink-0 font-mono text-2xs text-fg-muted" aria-label="Elapsed time">
-          {turn.startedAt ? formatElapsedSeconds(turnElapsedSeconds(turn, now)) : "starting"}
+          {turn.startedAt ? formatElapsedSeconds(turnElapsedSeconds(turn, now)) : "Starting…"}
         </span>
       </div>
       <div className="mt-1.5 line-clamp-3 text-xs leading-5 text-fg">{turn.prompt}</div>
@@ -323,19 +333,37 @@ function ActiveTurnCard({ turn }: { turn: SessionTurn }) {
   );
 }
 
-function TurnStatusDot({ status }: { status: SessionTurn["status"] }) {
-  return (
-    <span
-      className={cn(
-        "size-2 shrink-0 rounded-full",
-        status === "running" && "animate-pulse bg-status-running",
-        status === "requires_action" && "animate-pulse bg-status-waiting",
-        status === "queued" && "bg-status-queued",
-        status === "completed" && "bg-status-idle",
-        status === "failed" && "bg-status-failed",
-        status === "cancelled" && "bg-status-cancelled",
-      )}
-      aria-hidden="true"
-    />
-  );
+// Turn lifecycle → the one status language (doctrine D2). Note "completed" reads
+// as the idle hue but keeps its own "Completed" word in history: a finished turn
+// isn't "Idle".
+function turnStatusTone(status: SessionTurn["status"]): StatusTone {
+  switch (status) {
+    case "running":
+      return "running";
+    case "requires_action":
+      return "waiting";
+    case "completed":
+      return "idle";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "queued";
+  }
+}
+
+function turnStatusLabel(status: SessionTurn["status"]): string {
+  if (status === "completed") {
+    return "Completed";
+  }
+  if (status === "requires_action") {
+    return STATUS_META.waiting.label;
+  }
+  return STATUS_META[turnStatusTone(status)].label;
+}
+
+function TurnStatusDot({ status, className }: { status: SessionTurn["status"]; className?: string }) {
+  const tone = turnStatusTone(status);
+  return <StatusDot tone={tone} pulse={tone === "running" || tone === "waiting"} className={className} />;
 }

--- a/apps/web/src/components/session/queue-rail.tsx
+++ b/apps/web/src/components/session/queue-rail.tsx
@@ -106,30 +106,30 @@ export function QueueRail({ queue, sessionStatus }: {
   return (
     <div data-testid="queue-rail" className="min-w-0 space-y-3">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[color:var(--color-fg-subtle)]">
+        <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-fg-subtle">
           <ListPlusIcon className="size-3.5" />
           Turn queue
         </h3>
-        <span className="text-[11px] text-[color:var(--color-fg-subtle)]">
+        <span className="text-2xs text-fg-subtle">
           {queue.queue.length > 0 ? `${queue.queue.length} queued` : activeTurnView === "error" ? "unavailable" : "empty"}
         </span>
       </div>
 
       {claimedNotice ? (
-        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs leading-4 text-amber-200">
+        <div className="flex items-start gap-2 rounded-md border border-status-waiting/40 bg-status-waiting/10 p-2 text-xs leading-4 text-status-waiting">
           <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">{claimedNotice}</span>
-          <button type="button" onClick={() => setClaimedNotice(null)} aria-label="Dismiss" className="shrink-0 rounded p-0.5 hover:bg-amber-500/20">
+          <button type="button" onClick={() => setClaimedNotice(null)} aria-label="Dismiss" className="shrink-0 rounded p-0.5 hover:bg-status-waiting/20">
             <XIcon className="size-3" />
           </button>
         </div>
       ) : null}
 
       {queue.mutationError ? (
-        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs leading-4 text-red-200">
+        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
           <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">{queue.mutationError.message}</span>
-          <button type="button" onClick={queue.clearMutationError} aria-label="Dismiss queue error" className="shrink-0 rounded p-0.5 hover:bg-red-500/20">
+          <button type="button" onClick={queue.clearMutationError} aria-label="Dismiss queue error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
             <XIcon className="size-3" />
           </button>
         </div>
@@ -138,20 +138,20 @@ export function QueueRail({ queue, sessionStatus }: {
       {queue.activeTurn ? (
         <ActiveTurnCard turn={queue.activeTurn} />
       ) : activeTurnView === "loading" ? (
-        <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 text-xs text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-3 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
           Loading turns
         </div>
       ) : activeTurnView === "error" ? (
-        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs leading-4 text-red-200" role="alert">
+        <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed" role="alert">
           <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">Couldn't load the turn queue{queue.error?.message ? ` — ${queue.error.message}` : ""}</span>
-          <Button type="button" variant="ghost" size="xs" onClick={() => void queue.refresh()} className="shrink-0 text-red-200 hover:bg-red-500/20 hover:text-red-100">
+          <Button type="button" variant="ghost" size="xs" onClick={() => void queue.refresh()} className="shrink-0 text-status-failed hover:bg-status-failed/20 hover:text-status-failed">
             Retry
           </Button>
         </div>
       ) : (
-        <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-3 text-xs leading-5 text-[color:var(--color-fg-subtle)]">
+        <div className="rounded-lg border border-dashed border-border p-3 text-xs leading-5 text-fg-subtle">
           {sessionStatus === "failed"
             ? "No turn is running — the session failed. Send a message to revive it."
             : "No turn is running. New messages start immediately."}
@@ -179,8 +179,8 @@ export function QueueRail({ queue, sessionStatus }: {
                 void dropOn(turn.id);
               }}
               className={cn(
-                "group rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-2 transition-colors",
-                dropTargetId === turn.id && draggedTurnId !== turn.id && "border-[color:var(--color-brand)]/60 bg-[color:var(--color-brand)]/10",
+                "group rounded-lg border border-border bg-surface/45 p-2 transition-colors",
+                dropTargetId === turn.id && draggedTurnId !== turn.id && "border-brand/60 bg-brand/10",
                 draggedTurnId === turn.id && "opacity-50",
               )}
             >
@@ -191,7 +191,7 @@ export function QueueRail({ queue, sessionStatus }: {
                     onChange={(event) => setEditDraft(event.target.value)}
                     autoFocus
                     aria-label={`Edit queued turn ${index + 1}`}
-                    className="min-h-16 w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 py-2 text-xs leading-5"
+                    className="min-h-16 w-full rounded-md border border-border bg-bg px-2.5 py-2 text-xs leading-5"
                   />
                   <div className="flex items-center justify-end gap-1.5">
                     <Button type="button" variant="ghost" size="xs" onClick={() => setEditingTurnId(null)}>
@@ -205,13 +205,13 @@ export function QueueRail({ queue, sessionStatus }: {
                 </div>
               ) : (
                 <div className="flex min-w-0 items-start gap-2">
-                  <span className="mt-0.5 flex shrink-0 cursor-grab items-center gap-1 text-[color:var(--color-fg-subtle)]" title="Drag to reorder">
+                  <span className="mt-0.5 flex shrink-0 cursor-grab items-center gap-1 text-fg-subtle" title="Drag to reorder">
                     <GripVerticalIcon className="size-3.5" />
-                    <span className="font-mono text-[10px]">#{index + 1}</span>
+                    <span className="font-mono text-2xs">#{index + 1}</span>
                   </span>
                   <div className="min-w-0 flex-1">
-                    <div className="line-clamp-2 text-xs leading-5 text-[color:var(--color-fg)]">{turn.prompt}</div>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">
+                    <div className="line-clamp-2 text-xs leading-5 text-fg">{turn.prompt}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-2xs text-fg-subtle">
                       <span>{turnSourceLabel(turn.source)}</span>
                       <span>{formatTimestamp(turn.createdAt)}</span>
                     </div>
@@ -254,7 +254,7 @@ export function QueueRail({ queue, sessionStatus }: {
                       disabled={queue.mutating}
                       onClick={() => void queue.removeTurn(turn.id)}
                       aria-label="Delete queued turn"
-                      className="hover:text-red-300"
+                      className="hover:text-status-failed"
                     >
                       <Trash2Icon className="size-3.5" />
                     </Button>
@@ -268,16 +268,16 @@ export function QueueRail({ queue, sessionStatus }: {
 
       {history.length > 0 ? (
         <details className="group">
-          <summary className="cursor-pointer list-none text-[11px] font-medium text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg-muted)]">
+          <summary className="cursor-pointer list-none text-2xs font-medium text-fg-subtle hover:text-fg-muted">
             <ChevronDownIcon className="mr-1 inline size-3 transition-transform group-open:rotate-180" />
             {history.length} finished turn{history.length === 1 ? "" : "s"}
           </summary>
           <ol className="mt-2 space-y-1">
             {history.slice(0, 12).map((turn) => (
-              <li key={turn.id} className="flex min-w-0 items-center gap-2 rounded-md border border-[color:var(--color-border)]/70 bg-[color:var(--color-bg)]/25 px-2 py-1.5">
+              <li key={turn.id} className="flex min-w-0 items-center gap-2 rounded-md border border-border/70 bg-bg/25 px-2 py-1.5">
                 <TurnStatusDot status={turn.status} />
-                <span className="min-w-0 flex-1 truncate text-[11px] text-[color:var(--color-fg-muted)]">{turn.prompt}</span>
-                <span className="shrink-0 text-[10px] text-[color:var(--color-fg-subtle)]">{turn.status}</span>
+                <span className="min-w-0 flex-1 truncate text-2xs text-fg-muted">{turn.prompt}</span>
+                <span className="shrink-0 text-2xs text-fg-subtle">{turn.status}</span>
               </li>
             ))}
           </ol>
@@ -300,8 +300,8 @@ function ActiveTurnCard({ turn }: { turn: SessionTurn }) {
       className={cn(
         "rounded-lg border p-2.5",
         awaitingApproval
-          ? "border-amber-500/40 bg-amber-500/10"
-          : "border-[color:var(--color-brand)]/40 bg-[color:var(--color-brand)]/10",
+          ? "border-status-waiting/40 bg-status-waiting/10"
+          : "border-brand/40 bg-brand/10",
       )}
     >
       <div className="flex items-center justify-between gap-2">
@@ -309,12 +309,12 @@ function ActiveTurnCard({ turn }: { turn: SessionTurn }) {
           <TurnStatusDot status={turn.status} />
           {awaitingApproval ? "Awaiting approval" : "Running"}
         </span>
-        <span className="shrink-0 font-mono text-[11px] text-[color:var(--color-fg-muted)]" aria-label="Elapsed time">
+        <span className="shrink-0 font-mono text-2xs text-fg-muted" aria-label="Elapsed time">
           {turn.startedAt ? formatElapsedSeconds(turnElapsedSeconds(turn, now)) : "starting"}
         </span>
       </div>
-      <div className="mt-1.5 line-clamp-3 text-xs leading-5 text-[color:var(--color-fg)]">{turn.prompt}</div>
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">
+      <div className="mt-1.5 line-clamp-3 text-xs leading-5 text-fg">{turn.prompt}</div>
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-2xs text-fg-subtle">
         <span>{turnSourceLabel(turn.source)}</span>
         <span>{turn.model}</span>
         <span>{turn.reasoningEffort}</span>
@@ -328,12 +328,12 @@ function TurnStatusDot({ status }: { status: SessionTurn["status"] }) {
     <span
       className={cn(
         "size-2 shrink-0 rounded-full",
-        status === "running" && "animate-pulse bg-emerald-400",
-        status === "requires_action" && "animate-pulse bg-amber-400",
-        status === "queued" && "bg-sky-400",
-        status === "completed" && "bg-emerald-600",
-        status === "failed" && "bg-red-400",
-        status === "cancelled" && "bg-zinc-500",
+        status === "running" && "animate-pulse bg-status-running",
+        status === "requires_action" && "animate-pulse bg-status-waiting",
+        status === "queued" && "bg-status-queued",
+        status === "completed" && "bg-status-idle",
+        status === "failed" && "bg-status-failed",
+        status === "cancelled" && "bg-status-cancelled",
       )}
       aria-hidden="true"
     />

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -45,9 +45,9 @@ export function SessionSandboxSwitcher({
   const hasChoices = machines.length > 1 && fleet.canAttach;
   if (!hasChoices) {
     return (
-      <span className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-fg-subtle">
+      <span className="inline-flex min-w-0 items-center gap-1 truncate text-2xs text-fg-subtle">
         <ServerIcon className="size-3 shrink-0" />
-        <span className="truncate">Run on: {activeName}</span>
+        <span className="truncate">{activeName}</span>
       </span>
     );
   }
@@ -59,12 +59,12 @@ export function SessionSandboxSwitcher({
           type="button"
           variant="ghost"
           size="sm"
-          className="h-7 max-w-[12rem] gap-1 rounded-full border border-transparent px-2 text-xs text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg"
+          className="h-6 max-w-[12rem] gap-1 rounded-full border border-transparent px-1.5 text-2xs text-fg-subtle hover:border-border hover:bg-surface-2 hover:text-fg"
         >
           <ServerIcon className="size-3 shrink-0" />
-          {/* Label hides on narrow widths → an icon-only collapse. */}
-          <span className="hidden truncate text-fg-subtle sm:inline">Run on:</span>
-          <span className="truncate font-medium text-fg">{activeName}</span>
+          {/* Just the target's name — "Run on" is the dropdown's label, not
+              header-line grammar. */}
+          <span className="truncate">{activeName}</span>
           {fleet.attaching ? (
             <Loader2Icon className="size-3 shrink-0 animate-spin" />
           ) : (

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -45,7 +45,7 @@ export function SessionSandboxSwitcher({
   const hasChoices = machines.length > 1 && fleet.canAttach;
   if (!hasChoices) {
     return (
-      <span className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-[color:var(--color-fg-subtle)]">
+      <span className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-fg-subtle">
         <ServerIcon className="size-3 shrink-0" />
         <span className="truncate">Run on: {activeName}</span>
       </span>
@@ -59,12 +59,12 @@ export function SessionSandboxSwitcher({
           type="button"
           variant="ghost"
           size="sm"
-          className="h-7 max-w-[12rem] gap-1 rounded-full border border-transparent px-2 text-xs text-[color:var(--color-fg-muted)] hover:border-[color:var(--color-border)] hover:bg-[color:var(--color-surface-2)] hover:text-[color:var(--color-fg)]"
+          className="h-7 max-w-[12rem] gap-1 rounded-full border border-transparent px-2 text-xs text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg"
         >
           <ServerIcon className="size-3 shrink-0" />
           {/* Label hides on narrow widths → an icon-only collapse. */}
-          <span className="hidden truncate text-[color:var(--color-fg-subtle)] sm:inline">Run on:</span>
-          <span className="truncate font-medium text-[color:var(--color-fg)]">{activeName}</span>
+          <span className="hidden truncate text-fg-subtle sm:inline">Run on:</span>
+          <span className="truncate font-medium text-fg">{activeName}</span>
           {fleet.attaching ? (
             <Loader2Icon className="size-3 shrink-0 animate-spin" />
           ) : (
@@ -76,9 +76,9 @@ export function SessionSandboxSwitcher({
         align="end"
         side="bottom"
         sideOffset={8}
-        className="w-60 rounded-xl border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-2 shadow-xl"
+        className="w-60 rounded-xl border-border bg-surface p-2 shadow-xl"
       >
-        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-[color:var(--color-fg-subtle)]">
+        <DropdownMenuLabel className="px-2 pt-1 pb-1 text-xs font-normal text-fg-subtle">
           Run on
         </DropdownMenuLabel>
         {machines.map((machine) => {
@@ -98,10 +98,10 @@ export function SessionSandboxSwitcher({
               }}
               className="flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 text-sm"
             >
-              <ServerIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+              <ServerIcon className="size-3.5 shrink-0 text-fg-subtle" />
               <span className="min-w-0 flex-1 truncate">{machine.name}</span>
               {machine.state !== "online" && !machine.active ? (
-                <span className="shrink-0 text-[10px] text-[color:var(--color-fg-subtle)]">{machine.state}</span>
+                <span className="shrink-0 text-2xs text-fg-subtle">{machine.state}</span>
               ) : null}
               {swapping ? (
                 <Loader2Icon className="ml-1 size-4 shrink-0 animate-spin" />
@@ -112,7 +112,7 @@ export function SessionSandboxSwitcher({
           );
         })}
         {fleet.mutationError ? (
-          <p className="px-2 pt-1 text-[11px] leading-4 text-[color:var(--color-danger)]">
+          <p className="px-2 pt-1 text-2xs text-danger">
             Swap failed: {fleet.mutationError.message}
           </p>
         ) : null}

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -47,7 +47,8 @@ export function SessionSandboxSwitcher({
     return (
       <span className="inline-flex min-w-0 items-center gap-1 truncate text-2xs text-fg-subtle">
         <ServerIcon className="size-3 shrink-0" />
-        <span className="truncate">{activeName}</span>
+        <span className="shrink-0">on</span>
+        <span className="truncate text-fg-muted">{activeName}</span>
       </span>
     );
   }
@@ -62,9 +63,10 @@ export function SessionSandboxSwitcher({
           className="h-6 max-w-[12rem] gap-1 rounded-full border border-transparent px-1.5 text-2xs text-fg-subtle hover:border-border hover:bg-surface-2 hover:text-fg"
         >
           <ServerIcon className="size-3 shrink-0" />
-          {/* Just the target's name — "Run on" is the dropdown's label, not
-              header-line grammar. */}
-          <span className="truncate">{activeName}</span>
+          {/* Natural-language "on {target}" — semantic without the colon-label
+              grammar; "Run on" remains the dropdown menu's label. */}
+          <span className="shrink-0">on</span>
+          <span className="truncate text-fg-muted">{activeName}</span>
           {fleet.attaching ? (
             <Loader2Icon className="size-3 shrink-0 animate-spin" />
           ) : (

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -273,7 +273,10 @@ export function useSandboxWorkspaceTabs({
       if (pending || caps.state === "error") {
         tabs.push({
           id: "sandbox",
-          label: "Sandbox",
+          // Named for its state, not a noun: a cold user reading "Sandbox"
+          // learns nothing; "Connecting…" / "Sandbox offline" say exactly why
+          // Files/Terminal/Desktop aren't here yet.
+          label: caps.state === "error" ? "Sandbox offline" : "Connecting…",
           content: withMachineBar(
             <SandboxStatusPanel isError={caps.state === "error"} error={caps.error} onRetry={caps.renegotiate} />,
           ),

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -20,9 +20,11 @@ import {
   type XtermTheme,
 } from "@opengeni/react";
 import { MachineDockBar, SharedMachineDisclosure, useMachines, type MachineView } from "@opengeni/react/machines";
+import { Loader2Icon, RefreshCwIcon } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/context";
 import type { SessionEvent } from "@/types";
 
@@ -155,7 +157,34 @@ export function useSandboxWorkspaceTabs({
     // selfhosted machine (the dock-parity contract). Omitted only when the fleet
     // hasn't resolved an active machine yet (graceful, never a crash).
     const withMachineBar = (surface: ReactNode): ReactNode => {
-      if (!activeMachine) return surface;
+      if (!activeMachine) {
+        // Don't let the dock bar vanish while the fleet is still resolving or
+        // failed — keep a stable placeholder/error chip above the surface.
+        if (machines.loading || machines.error) {
+          return (
+            <div className="flex h-full min-h-0 flex-col">
+              <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-xs text-fg-muted">
+                {machines.error ? (
+                  <>
+                    <span className="min-w-0 flex-1 truncate text-fg-muted">Sandbox connection unavailable</span>
+                    <Button type="button" variant="ghost" size="xs" onClick={() => void machines.refresh()}>
+                      <RefreshCwIcon className="size-3" />
+                      Retry
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Loader2Icon className="size-3.5 shrink-0 animate-spin" />
+                    <span className="min-w-0 flex-1 truncate">Connecting sandbox…</span>
+                  </>
+                )}
+              </div>
+              <div className="min-h-0 flex-1">{surface}</div>
+            </div>
+          );
+        }
+        return surface;
+      }
       return (
         <div className="flex h-full min-h-0 flex-col">
           <MachineDockBar
@@ -178,7 +207,7 @@ export function useSandboxWorkspaceTabs({
         label: "Files",
         badge:
           dirtyCount > 0 ? (
-            <span className="rounded-[var(--og-radius-xs,3px)] bg-og-accent-soft px-1 text-2xs text-og-fg-muted">
+            <span className="rounded-sm bg-og-accent-soft px-1 text-2xs text-og-fg-muted">
               {dirtyCount}
             </span>
           ) : undefined,
@@ -218,8 +247,8 @@ export function useSandboxWorkspaceTabs({
         id: "desktop",
         label: "Desktop",
         badge: watchDesktop ? (
-          <span className="rounded-[var(--og-radius-xs,3px)] bg-og-status-running/20 px-1 text-2xs text-og-status-running">
-            live
+          <span className="rounded-sm bg-og-status-running/20 px-1 text-2xs text-og-status-running">
+            Live
           </span>
         ) : undefined,
         content: withMachineBar(
@@ -233,6 +262,23 @@ export function useSandboxWorkspaceTabs({
           />,
         ),
       });
+    }
+
+    // No surface is advertised yet: instead of silently hiding Files/Terminal/
+    // Desktop, show why — a quiet "Connecting sandbox…" tab while capabilities
+    // negotiate, or an unavailable state with retry when negotiation failed. So
+    // the "watch and steer" promise is visibly in flight, never just absent.
+    if (tabs.length === 0) {
+      const pending = caps.state === "negotiating" || caps.state === "cold";
+      if (pending || caps.state === "error") {
+        tabs.push({
+          id: "sandbox",
+          label: "Sandbox",
+          content: withMachineBar(
+            <SandboxStatusPanel isError={caps.state === "error"} error={caps.error} onRetry={caps.renegotiate} />,
+          ),
+        });
+      }
     }
 
     const defaultTab = tabs[0]?.id ?? "files";
@@ -251,7 +297,48 @@ export function useSandboxWorkspaceTabs({
     terminal,
     xtermTheme,
     capabilities,
+    caps.state,
+    caps.error,
     caps.viewerCapReached,
+    machines.loading,
+    machines.error,
     activeMachine,
   ]);
+}
+
+/** The Sandbox tab's stand-in while capabilities are negotiating or after a
+ *  negotiation failure — a quiet placeholder, never a silently missing surface. */
+function SandboxStatusPanel({
+  isError,
+  error,
+  onRetry,
+}: {
+  isError: boolean;
+  error: Error | null;
+  onRetry: () => void;
+}) {
+  if (isError) {
+    return (
+      <div className="grid h-full place-items-center p-6 text-center">
+        <div className="max-w-sm space-y-3">
+          <p className="text-sm font-medium text-fg">Sandbox unavailable</p>
+          <p className="text-sm leading-5 text-fg-muted">
+            {error?.message ?? "Couldn't reach the sandbox for this session."}
+          </p>
+          <Button type="button" variant="secondary" size="sm" onClick={onRetry}>
+            <RefreshCwIcon className="size-3.5" />
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="grid h-full place-items-center p-6 text-center">
+      <div className="flex items-center gap-2 text-sm text-fg-muted">
+        <Loader2Icon className="size-4 animate-spin" />
+        Connecting sandbox…
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -178,7 +178,7 @@ export function useSandboxWorkspaceTabs({
         label: "Files",
         badge:
           dirtyCount > 0 ? (
-            <span className="rounded-[var(--og-radius-xs,3px)] bg-[color:var(--og-color-accent-soft,#2a2a2a)] px-1 text-[9px] text-[color:var(--og-color-fg-muted,#aaa)]">
+            <span className="rounded-[var(--og-radius-xs,3px)] bg-og-accent-soft px-1 text-2xs text-og-fg-muted">
               {dirtyCount}
             </span>
           ) : undefined,
@@ -199,7 +199,7 @@ export function useSandboxWorkspaceTabs({
         id: "terminal",
         label: "Terminal",
         content: withMachineBar(
-          <div className="h-full bg-[color:var(--og-color-bg,var(--color-bg))] p-1">
+          <div className="h-full bg-og-bg p-1">
             <SandboxTerminal
               result={terminal}
               terminalCapability={capabilities?.Terminal ?? null}
@@ -218,7 +218,7 @@ export function useSandboxWorkspaceTabs({
         id: "desktop",
         label: "Desktop",
         badge: watchDesktop ? (
-          <span className="rounded-[var(--og-radius-xs,3px)] bg-[color:var(--og-color-status-running,#d29922)]/20 px-1 text-[9px] text-[color:var(--og-color-status-running,#d29922)]">
+          <span className="rounded-[var(--og-radius-xs,3px)] bg-og-status-running/20 px-1 text-2xs text-og-status-running">
             live
           </span>
         ) : undefined,

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -43,16 +43,25 @@ export function ConfirmDialog({
   confirmLabel: string;
   cancelLabel?: string;
   destructive?: boolean;
-  /** May be async; the dialog shows pending state and closes on success. */
-  onConfirm: () => void | Promise<void>;
+  /**
+   * May be async; the dialog shows pending state while it runs. The dialog
+   * closes on success — returning `false` (or throwing) keeps it open so a
+   * failed mutation never reads as a completed one. Handlers that catch their
+   * own errors (to toast) must return `false` on the failure path.
+   */
+  onConfirm: () => void | boolean | Promise<void | boolean>;
 }) {
   const [pending, setPending] = useState(false);
 
   const confirm = async () => {
     setPending(true);
     try {
-      await onConfirm();
-      onOpenChange(false);
+      const result = await onConfirm();
+      if (result !== false) {
+        onOpenChange(false);
+      }
+    } catch {
+      // The handler surfaces its own error (toast/notice); stay open for retry.
     } finally {
       setPending(false);
     }

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,85 @@
+import { useState, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/* ----------------------------------------------------------------------------
+   ConfirmDialog — the one gate for destructive actions (doctrine D5).
+
+   No bare trash icons that fire immediately: irreversible actions open this,
+   with a title that names the object ("Delete environment 'staging'?"), a
+   consequence sentence, and a destructive-styled confirm labeled with the
+   verb + object ("Delete environment"), never "OK"/"Confirm". The typed-name
+   Danger-zone pattern remains the higher bar for workspace deletion.
+   -------------------------------------------------------------------------- */
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  destructive = true,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Names the object: "Delete environment 'staging'?" */
+  title: ReactNode;
+  /** One consequence sentence: what is lost, whether it can be undone. */
+  description?: ReactNode;
+  /** Optional extra content (e.g. an affected-items list). */
+  children?: ReactNode;
+  /** Verb + object: "Delete environment", "Revoke key". */
+  confirmLabel: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  /** May be async; the dialog shows pending state and closes on success. */
+  onConfirm: () => void | Promise<void>;
+}) {
+  const [pending, setPending] = useState(false);
+
+  const confirm = async () => {
+    setPending(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (pending ? undefined : onOpenChange(next))}>
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        {children}
+        <DialogFooter>
+          <Button type="button" variant="ghost" disabled={pending} onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "default"}
+            disabled={pending}
+            onClick={() => void confirm()}
+          >
+            {pending ? "Working…" : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -61,7 +61,17 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          // Base + shared animation (fade). On phones the dialog is a
+          // near-full-width bottom sheet that scrolls internally; from `sm` up it
+          // is the centered modal (max-sm/sm scope the two presentations so they
+          // never fight — one change every Dialog consumer inherits, D9.5).
+          "fixed z-50 grid gap-4 border bg-background shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+          // Phone: bottom sheet.
+          "inset-x-0 bottom-0 max-h-[90dvh] overflow-y-auto rounded-t-lg border-b-0 p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))]",
+          "max-sm:data-[state=closed]:slide-out-to-bottom max-sm:data-[state=open]:slide-in-from-bottom",
+          // Tablet and up: centered modal.
+          "sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:w-full sm:max-w-lg sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:border-b sm:p-6 sm:pb-6",
+          "sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/* ----------------------------------------------------------------------------
+   EmptyState — a designed empty, not an apology (doctrine D5).
+
+   Every zero-data surface renders this: an optional icon, a short factual
+   title (fragment, no period), ONE orienting sentence (what this area is for
+   or what will appear here), and the primary action to change that — inside
+   the empty state, not off in a distant header.
+   -------------------------------------------------------------------------- */
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid place-items-center gap-1.5 rounded-lg border border-dashed border-border px-6 py-10 text-center",
+        className,
+      )}
+    >
+      {icon ? (
+        <span className="mb-1 flex size-9 items-center justify-center rounded-full bg-surface-2 text-fg-subtle">
+          {icon}
+        </span>
+      ) : null}
+      <p className="text-sm font-medium text-fg">{title}</p>
+      {description ? <p className="max-w-sm text-sm leading-5 text-fg-muted">{description}</p> : null}
+      {action ? <div className="mt-2.5">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/meta-chip.tsx
+++ b/apps/web/src/components/ui/meta-chip.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { STATUS_META, type StatusTone } from "@/components/ui/status-dot";
+
+/* ----------------------------------------------------------------------------
+   MetaChip — the one quiet metadata chip (doctrine D7).
+
+   Replaces the dozens of hand-rolled `rounded border px-1.5 text-[10px]`
+   clones. Follows the chip doctrine: no filled pills, color only via an
+   optional status dot — the text itself stays muted. Anything louder than
+   this is not a chip; it's a Notice or a Button.
+   -------------------------------------------------------------------------- */
+
+export function MetaChip({
+  children,
+  dot,
+  rounded = "md",
+  title,
+  className,
+}: {
+  children: ReactNode;
+  /** Optional status dot; the one permitted hint of color. */
+  dot?: StatusTone;
+  rounded?: "md" | "full";
+  title?: string;
+  className?: string;
+}) {
+  return (
+    <span
+      title={title}
+      className={cn(
+        "inline-flex max-w-full items-center gap-1.5 border border-border bg-surface-2/60 px-1.5 py-0.5 text-2xs font-medium text-fg-muted",
+        rounded === "full" ? "rounded-full" : "rounded-md",
+        className,
+      )}
+    >
+      {dot ? <span aria-hidden className={cn("size-1.5 shrink-0 rounded-full", STATUS_META[dot].dot)} /> : null}
+      <span className="min-w-0 truncate">{children}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/notice.tsx
+++ b/apps/web/src/components/ui/notice.tsx
@@ -1,0 +1,59 @@
+import { CircleAlertIcon, CircleCheckIcon, InfoIcon, TriangleAlertIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/* ----------------------------------------------------------------------------
+   Notice — the one inline panel for states that need a quiet word (doctrine D7).
+
+   Replaces every hand-rolled amber/red/emerald box. Tone budget follows the
+   chip doctrine's spirit: color marks the exception, so `muted` is the default
+   and tinted tones are reserved for states that genuinely differ (a failure,
+   an action waiting on the user, a one-time success confirmation).
+   -------------------------------------------------------------------------- */
+
+export type NoticeTone = "muted" | "info" | "success" | "waiting" | "failed";
+
+const TONE: Record<NoticeTone, { box: string; icon: string; glyph: typeof InfoIcon }> = {
+  muted: { box: "border-border bg-surface/40 text-fg-muted", icon: "text-fg-subtle", glyph: InfoIcon },
+  info: { box: "border-brand/30 bg-brand/[0.06] text-fg", icon: "text-brand", glyph: InfoIcon },
+  success: { box: "border-status-idle/30 bg-status-idle/[0.06] text-fg", icon: "text-status-idle", glyph: CircleCheckIcon },
+  waiting: { box: "border-status-waiting/30 bg-status-waiting/[0.06] text-fg", icon: "text-status-waiting", glyph: CircleAlertIcon },
+  failed: { box: "border-status-failed/30 bg-status-failed/[0.06] text-fg", icon: "text-status-failed", glyph: TriangleAlertIcon },
+};
+
+export function Notice({
+  tone = "muted",
+  title,
+  children,
+  action,
+  icon,
+  className,
+}: {
+  tone?: NoticeTone;
+  /** Short bolded lead. Omit for a single-sentence notice. */
+  title?: ReactNode;
+  children?: ReactNode;
+  /** Right-aligned action (a small Button or link). */
+  action?: ReactNode;
+  /** Override the tone glyph; pass null to render no icon. */
+  icon?: ReactNode | null;
+  className?: string;
+}) {
+  const meta = TONE[tone];
+  const Glyph = meta.glyph;
+  return (
+    <div className={cn("flex items-start gap-2.5 rounded-lg border p-3 text-sm", meta.box, className)}>
+      {icon === null ? null : (
+        <span className={cn("mt-0.5 shrink-0", meta.icon)}>{icon ?? <Glyph className="size-4" />}</span>
+      )}
+      <div className="min-w-0 flex-1">
+        {title ? <div className="font-medium">{title}</div> : null}
+        {children ? (
+          <div className={cn("break-words text-sm leading-5", title ? "mt-0.5 text-fg-muted" : "")}>{children}</div>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,25 @@
+import { ChevronDownIcon } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Select = React.forwardRef<HTMLSelectElement, React.ComponentProps<"select">>(
+  ({ className, children, ...props }, ref) => (
+    <span className="relative inline-block max-w-full">
+      <select
+        ref={ref}
+        className={cn(
+          "h-9 w-full appearance-none rounded-md border border-border bg-bg px-2.5 pr-8 text-sm transition-colors hover:border-border-strong focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      <ChevronDownIcon aria-hidden="true" className="pointer-events-none absolute right-2.5 top-1/2 size-4 -translate-y-1/2 text-fg-subtle" />
+    </span>
+  ),
+)
+Select.displayName = "Select"
+
+export { Select }

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -60,9 +60,9 @@ function SheetContent({
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            "inset-y-0 right-0 h-full w-3/4 max-w-[85vw] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 max-w-[85vw] border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
           side === "top" &&
             "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -21,10 +21,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--color-popover)",
-          "--normal-text": "var(--color-popover-foreground)",
-          "--normal-border": "var(--color-border)",
-          "--border-radius": "var(--radius-md)",
+          "--normal-bg": "var(--og-color-surface-3)",
+          "--normal-text": "var(--og-color-fg)",
+          "--normal-border": "var(--og-color-border)",
+          "--border-radius": "var(--og-radius-md)",
         } as React.CSSProperties
       }
       {...props}

--- a/apps/web/src/components/ui/status-dot.tsx
+++ b/apps/web/src/components/ui/status-dot.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/lib/utils";
+
+/* ----------------------------------------------------------------------------
+   StatusDot — the ONE status color language (doctrine D2).
+
+   Every surface that renders a lifecycle state (session rail, header badge,
+   queue rail, document indexing, schedule state, connection health) maps its
+   domain state onto one of these six tones and renders this dot. No surface
+   invents its own palette. Labels are sentence case; the tone-to-hue mapping
+   comes from the og status tokens and nowhere else.
+   -------------------------------------------------------------------------- */
+
+export type StatusTone =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "idle"
+  | "failed"
+  | "cancelled";
+
+export const STATUS_META: Record<StatusTone, { dot: string; text: string; label: string }> = {
+  queued: { dot: "bg-status-queued", text: "text-status-queued", label: "Queued" },
+  running: { dot: "bg-status-running", text: "text-status-running", label: "Running" },
+  waiting: { dot: "bg-status-waiting", text: "text-status-waiting", label: "Waiting on you" },
+  idle: { dot: "bg-status-idle", text: "text-status-idle", label: "Idle" },
+  failed: { dot: "bg-status-failed", text: "text-status-failed", label: "Failed" },
+  cancelled: { dot: "bg-status-cancelled", text: "text-status-cancelled", label: "Cancelled" },
+};
+
+export function StatusDot({
+  tone,
+  pulse,
+  className,
+}: {
+  tone: StatusTone;
+  /** Gentle pulse for genuinely live states (running). Respects reduced motion. */
+  pulse?: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-block size-2 shrink-0 rounded-full",
+        STATUS_META[tone].dot,
+        pulse && "motion-safe:animate-pulse",
+        className,
+      )}
+    />
+  );
+}

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -661,7 +661,7 @@ export function RootRouteComponent() {
   } satisfies AppContextValue : null;
 
   return (
-    <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-[color:var(--color-bg)] text-[color:var(--color-fg)]">
+    <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-bg text-fg">
       <Toaster richColors theme="dark" />
       {!clientConfig && !configError ? (
         <LoadingPanel label="Loading OpenGeni" />
@@ -728,19 +728,19 @@ function AccessKeyPanel(props: {
   return (
     <section className="flex flex-1 items-center justify-center px-4">
       <form
-        className="w-full max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 shadow-sm"
+        className="w-full max-w-sm rounded-lg border border-border bg-surface p-5 shadow-sm"
         onSubmit={(event) => {
           event.preventDefault();
           props.onSubmit();
         }}
       >
         <div className="mb-4 flex items-center gap-3">
-          <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <span className="flex size-9 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
             <LockIcon className="size-4" />
           </span>
           <div>
             <h1 className="text-base font-semibold">Access key required</h1>
-            <p className="text-sm text-[color:var(--color-fg-subtle)]">
+            <p className="text-sm text-fg-subtle">
               Enter the {props.authMode === "configuredToken" ? "configured bearer token" : "deployment key"} for this OpenGeni instance.
             </p>
           </div>
@@ -809,22 +809,22 @@ function ManagedAuthPanel(props: {
   return (
     <section className="flex flex-1 items-center justify-center px-4">
       <form
-        className="w-full max-w-sm rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-5 shadow-sm"
+        className="w-full max-w-sm rounded-lg border border-border bg-surface p-5 shadow-sm"
         onSubmit={(event) => {
           event.preventDefault();
           void submit();
         }}
       >
         <div className="mb-4 flex items-center gap-3">
-          <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <span className="flex size-9 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
             <UserIcon className="size-4" />
           </span>
           <div>
             <h1 className="text-base font-semibold">{mode === "signup" ? "Create account" : "Sign in"}</h1>
-            <p className="text-sm text-[color:var(--color-fg-subtle)]">Email and password access for the managed console.</p>
+            <p className="text-sm text-fg-subtle">Email and password access for the managed console.</p>
           </div>
         </div>
-        <div className="mb-4 grid grid-cols-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-1">
+        <div className="mb-4 grid grid-cols-2 rounded-md border border-border bg-bg p-1">
           <Button type="button" size="sm" variant={mode === "signin" ? "secondary" : "ghost"} onClick={() => setMode("signin")}>Sign in</Button>
           <Button type="button" size="sm" variant={mode === "signup" ? "secondary" : "ghost"} onClick={() => setMode("signup")}>Sign up</Button>
         </div>

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -168,7 +168,14 @@ export function RootRouteComponent() {
   // so each open session keeps its own choice independently.
   const [modelBySession, setModelBySession] = useState<Record<string, string>>({});
   const [reasoningEffort, setReasoningEffort] = useState<IntelligenceEffort>("low");
-  const [inspectorOpen, setInspectorOpen] = useState(true);
+  // The dock is open by default on desktop, but on narrow viewports (<1024px)
+  // the dock renders as a full-screen overlay — so it must start CLOSED there or
+  // a phone opening a session would land with the overlay covering the
+  // transcript. Only the initial default is viewport-aware; the user's later
+  // toggles are never overridden.
+  const [inspectorOpen, setInspectorOpen] = useState<boolean>(() =>
+    typeof window === "undefined" ? true : !window.matchMedia("(max-width: 1023px)").matches,
+  );
   const [connectionState, setConnectionState] = useState<SessionEventsConnectionState>("idle");
   const [manualRepos, setManualRepos] = useState<RepoDraft[]>([]);
   const [manualReposOpen, setManualReposOpen] = useState(false);
@@ -346,8 +353,11 @@ export function RootRouteComponent() {
     }
     setWorkspaces((current) => upsertWorkspace(current, created));
     // Refresh grants so the new workspace's owner permissions apply at once;
-    // the workspace itself is already usable if this refresh fails.
-    await client.getAccessContext().then(setAccessContext).catch(() => undefined);
+    // the workspace itself is already usable if this refresh fails — surface a
+    // soft warning so a stale permission set doesn't fail silently.
+    await client.getAccessContext().then(setAccessContext).catch(() => {
+      toast.warning("Permissions may be out of date", { description: "Reload if something looks off." });
+    });
     return created;
   }
 
@@ -387,7 +397,9 @@ export function RootRouteComponent() {
       return false;
     }
     setWorkspaces((current) => current.filter((workspace) => workspace.id !== workspaceId));
-    await client.getAccessContext().then(setAccessContext).catch(() => undefined);
+    await client.getAccessContext().then(setAccessContext).catch(() => {
+      toast.warning("Permissions may be out of date", { description: "Reload if something looks off." });
+    });
     return true;
   }
 
@@ -691,7 +703,7 @@ export function RootRouteComponent() {
       ) : accessLoading || !appContext ? (
         <LoadingPanel label="Loading workspace access" />
       ) : !defaultWorkspaceId ? (
-        <ProblemPanel title="No workspace access" description="This subject does not have access to any OpenGeni workspace." />
+        <ProblemPanel title="No workspace access" description="You don't have access to any workspace yet." />
       ) : (
         <AppContext.Provider value={appContext}>
           <Outlet />
@@ -755,7 +767,7 @@ function AccessKeyPanel(props: {
           className="mt-2"
           autoFocus
         />
-        <Button type="submit" className="mt-4 w-full">
+        <Button type="submit" className="mt-4 w-full" disabled={props.accessKeyDraft.trim().length === 0}>
           <CheckIcon className="size-4" />
           Continue
         </Button>

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,4 +1,4 @@
-import { buildTimeline, type TimelineItem } from "@opengeni/react";
+import { buildTimeline, humanizeFailureReason, type TimelineItem } from "@opengeni/react";
 
 import type { Session, SessionEvent, SessionStatus } from "@/types";
 
@@ -97,7 +97,7 @@ export function summarizeSessionFailure(events: SessionEvent[], sessionStatus: S
       const payload = sanitized.payload && typeof sanitized.payload === "object" && !Array.isArray(sanitized.payload)
         ? sanitized.payload as Record<string, unknown>
         : {};
-      reason = failurePayloadMessage(payload) ?? reason;
+      reason = humanizeFailureReason(failurePayloadMessage(payload) ?? null) ?? reason;
       failedAt = event.occurredAt;
     }
   }

--- a/apps/web/src/lib/machine-selectability.test.ts
+++ b/apps/web/src/lib/machine-selectability.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { isMachineComputeSelectable } from "./machine-selectability";
 
-// The session "Run on" pickers (sessions-index machine <select> + the in-session
+// The session "Run on" pickers (sessions-index machine picker + the in-session
 // sandbox-switcher) gate selectability through this helper. The backend attach
 // gate is liveness-only, so any REACHABLE machine — online, headless
 // (display_unavailable), or one whose screen control isn't consented

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -7,7 +7,6 @@
 import { useEnvironments, usePacks } from "@opengeni/react";
 import {
   CalendarClockIcon,
-  CheckIcon,
   ChevronDownIcon,
   ContainerIcon,
   FileCode2Icon,
@@ -27,10 +26,14 @@ import {
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
-import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { MetaChip } from "@/components/ui/meta-chip";
 import { Select } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAppContext } from "@/context";
 import {
   capabilityCounts,
@@ -65,6 +68,9 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
   const [registryQuery, setRegistryQuery] = useState("");
   const [registryBusy, setRegistryBusy] = useState(false);
   const [registryResults, setRegistryResults] = useState<CapabilityCatalogItem[]>([]);
+  // The query that produced the results on screen, so a completed search that
+  // found nothing reads as "No matches" rather than the initial help text.
+  const [registrySearched, setRegistrySearched] = useState<string | null>(null);
   const [addForm, setAddForm] = useState<CapabilityFormState>(() => emptyCapabilityForm());
   // Packs are their own data source (manifests + installations) so the rich
   // subsection can register/unregister and attach environments; the generic
@@ -104,6 +110,13 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
     }
   }
 
+  // The header refresh reloads both data sources (catalog + packs), so the
+  // page has ONE refresh affordance and no per-section duplicate.
+  function refreshAll() {
+    void refresh();
+    void packs.refresh();
+  }
+
   async function toggleCapability(item: CapabilityCatalogItem) {
     setBusyId(item.id);
     try {
@@ -127,12 +140,18 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
   }
 
   async function searchRegistry() {
+    if (!registryQuery.trim()) return;
     setRegistryBusy(true);
     try {
       const response = await client.discoverMcpCapabilities(workspaceId, { query: registryQuery, limit: 30 });
       setRegistryResults(response.items);
+      setRegistrySearched(registryQuery.trim());
     } catch (error) {
-      toast.error("MCP Registry search failed", { description: error instanceof Error ? error.message : String(error) });
+      // Clear stale results so a failed search never leaves prior matches
+      // reading as current; the toast carries the cause.
+      setRegistryResults([]);
+      setRegistrySearched(null);
+      toast.error("Registry search failed", { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setRegistryBusy(false);
     }
@@ -149,9 +168,9 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       if (enableAfterAdd) {
         onRuntimeChanged();
       }
-      toast.success(enableAfterAdd ? "Public MCP added and enabled" : "Public MCP added");
+      toast.success(enableAfterAdd ? "Remote MCP added and enabled" : "Remote MCP added");
     } catch (error) {
-      const copy = capabilityErrorToast(error, "Failed to add public MCP");
+      const copy = capabilityErrorToast(error, "Failed to add remote MCP");
       toast.error(copy.title, { description: copy.description });
     } finally {
       setBusyId(null);
@@ -188,6 +207,10 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
 
   // --- Packs subsection actions ------------------------------------------------------------
 
+  // Mutation helpers return { ok } after a real awaited result. Errors are
+  // caught synchronously here (from the client call) instead of read back from
+  // the hook's mutationError, which React only commits on a later render — the
+  // read-after-await race that used to drop or misreport pack failures.
   async function registerPackManifest(manifestDraft: string): Promise<boolean> {
     let manifest: unknown;
     try {
@@ -196,18 +219,16 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       toast.error("Manifest must be valid JSON");
       return false;
     }
-    const registered = await packs.register(manifest as Parameters<typeof packs.register>[0]);
-    if (registered) {
-      toast.success(`Pack ${registered.pack.id}@${registered.pack.version} registered`);
-      await refresh();
+    try {
+      const registered = await client.registerPack(workspaceId, manifest as Parameters<typeof client.registerPack>[1]);
+      await Promise.all([packs.refresh(), refresh()]);
+      toast.success(`Registered ${registered.pack.name} v${registered.pack.version}`);
       return true;
-    }
-    if (packs.mutationError) {
-      const copy = capabilityErrorToast(packs.mutationError, "Failed to register pack");
+    } catch (error) {
+      const copy = capabilityErrorToast(error, "Failed to register pack");
       toast.error(copy.title, { description: copy.description });
-      packs.clearMutationError();
+      return false;
     }
-    return false;
   }
 
   async function enablePack(pack: CapabilityPack, environmentId: string | undefined) {
@@ -218,7 +239,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       await client.enableCapability(workspaceId, `pack:${pack.id}`, environmentId ? { environmentId } : {});
       await Promise.all([packs.refresh(), refresh()]);
       onRuntimeChanged();
-      toast.success(`Pack ${pack.name} enabled`);
+      toast.success(`Enabled ${pack.name}`);
     } catch (error) {
       const copy = capabilityErrorToast(error, "Failed to enable pack");
       toast.error(copy.title, { description: copy.description });
@@ -234,7 +255,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       await client.disableCapability(workspaceId, `pack:${pack.id}`);
       await Promise.all([packs.refresh(), refresh()]);
       onRuntimeChanged();
-      toast.success(`Pack ${pack.name} disabled`);
+      toast.success(`Disabled ${pack.name}`);
     } catch (error) {
       const copy = capabilityErrorToast(error, "Failed to disable pack");
       toast.error(copy.title, { description: copy.description });
@@ -246,15 +267,12 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
   async function unregisterPack(pack: CapabilityPack) {
     setBusyId(`pack:${pack.id}`);
     try {
-      const removed = await packs.remove(pack.id);
-      if (removed) {
-        toast.success(`Pack ${pack.id} unregistered`);
-        await refresh();
-      } else if (packs.mutationError) {
-        const copy = capabilityErrorToast(packs.mutationError, "Failed to unregister pack");
-        toast.error(copy.title, { description: copy.description });
-        packs.clearMutationError();
-      }
+      await client.deletePack(workspaceId, pack.id);
+      await Promise.all([packs.refresh(), refresh()]);
+      toast.success(`Unregistered ${pack.name}`);
+    } catch (error) {
+      const copy = capabilityErrorToast(error, "Failed to unregister pack");
+      toast.error(copy.title, { description: copy.description });
     } finally {
       setBusyId(null);
     }
@@ -266,15 +284,15 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
         <PageHeader
           icon={<PlugIcon className="size-4" />}
           title="Capabilities"
-          description="Enable runtime packs and MCPs, and track APIs, skills, and plugins for this workspace."
+          description="Enable packs and MCPs, and track APIs, skills, and plugins."
           actions={(
             <>
               <div className="relative min-w-56 flex-1 sm:flex-none">
                 <SearchIcon className="pointer-events-none absolute left-2.5 top-2.5 size-3.5 text-fg-subtle" />
                 <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search catalog" className="h-9 pl-8 text-sm" />
               </div>
-              <Button type="button" variant="ghost" size="sm" onClick={() => void refresh()} disabled={loading} className="h-9">
-                <RefreshCwIcon className={cn("size-3.5", loading && "animate-spin")} />
+              <Button type="button" variant="ghost" size="sm" onClick={refreshAll} disabled={loading || packs.loading} className="h-9 pointer-coarse:min-h-10">
+                <RefreshCwIcon className={cn("size-3.5", (loading || packs.loading) && "animate-spin")} />
                 Refresh
               </Button>
             </>
@@ -308,21 +326,36 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
                 onRegister={registerPackManifest}
                 onEnable={(pack, environmentId) => void enablePack(pack, environmentId)}
                 onDisable={(pack) => void disablePack(pack)}
-                onUnregister={(pack) => void unregisterPack(pack)}
+                onUnregister={unregisterPack}
               />
             ) : null}
 
             {filter === "pack" ? null : catalogView === "loading" ? (
-              <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-4 text-sm text-fg-muted">
-                <Loader2Icon className="size-4 animate-spin" />
-                Loading capabilities
+              <div className="grid gap-2">
+                {[0, 1, 2].map((row) => (
+                  <div key={row} className="rounded-lg border border-border bg-surface/45 p-3">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="size-7 rounded-md" />
+                      <Skeleton className="h-4 w-40" />
+                    </div>
+                    <Skeleton className="mt-2 h-3 w-3/4" />
+                  </div>
+                ))}
               </div>
             ) : catalogView === "error" ? (
               <LoadErrorState title="Couldn't load capabilities" error={loadError} onRetry={() => void refresh()} />
             ) : visibleItems.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-fg-muted">
-                {catalogView === "empty" ? "No capabilities in this workspace yet." : "No capabilities match this filter."}
-              </div>
+              catalogView === "empty" ? (
+                <EmptyState
+                  icon={<PlugIcon className="size-4" />}
+                  title="No capabilities yet"
+                  description="Add remote MCP servers, APIs, skills, and plugins from the panel on the right, then enable them here."
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-fg-muted">
+                  No capabilities match this filter
+                </div>
+              )
             ) : (
               <div className="grid gap-2">
                 {visibleItems.map((item) => (
@@ -341,7 +374,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
             <section className="rounded-lg border border-border bg-surface/45 p-3">
               <div className="flex items-center gap-2 text-sm font-medium">
                 <GlobeIcon className="size-4 text-brand" />
-                Public MCP Registry
+                Public MCP registry
               </div>
               <div className="mt-3 flex gap-2">
                 <Input
@@ -353,46 +386,53 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
                     if (event.key === "Enter") void searchRegistry();
                   }}
                 />
-                <Button type="button" size="sm" disabled={registryBusy} onClick={() => void searchRegistry()} className="h-8 shrink-0 text-xs">
+                <Button type="button" variant="secondary" size="sm" disabled={registryBusy || !registryQuery.trim()} onClick={() => void searchRegistry()} className="h-8 shrink-0 text-xs">
                   {registryBusy ? <Loader2Icon className="size-3.5 animate-spin" /> : <SearchIcon className="size-3.5" />}
                   Search
                 </Button>
               </div>
               <div className="mt-3 max-h-[28rem] space-y-2 overflow-auto pr-1">
-                {registryResults.length === 0 ? (
-                  <div className="rounded-md border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
-                    Search returns public remote MCP servers that expose streamable HTTP endpoints.
-                  </div>
-                ) : registryResults.map((item) => (
-                  <div key={item.id} className="rounded-md border border-border bg-bg/35 p-2">
-                    <div className="min-w-0 truncate text-xs font-medium">{item.name}</div>
-                    {item.description ? <p className="mt-1 line-clamp-2 text-2xs text-fg-muted">{item.description}</p> : null}
-                    <div className="mt-2 truncate font-mono text-2xs text-fg-subtle">{item.endpointUrl}</div>
-                    <div className="mt-2 flex justify-end gap-1.5">
-                      <Button type="button" variant="ghost" size="xs" disabled={busyId === item.id} onClick={() => void addRegistryItem(item, false)}>
-                        <PlusIcon className="size-3" />
-                        Add
-                      </Button>
-                      <Button
-                        type="button"
-                        size="xs"
-                        disabled={busyId === item.id || !item.runtime.available}
-                        title={!item.runtime.available ? item.runtime.notes ?? "This MCP is not available for runtime use yet." : undefined}
-                        onClick={() => void addRegistryItem(item, true)}
-                      >
-                        {busyId === item.id ? <Loader2Icon className="size-3 animate-spin" /> : <CheckIcon className="size-3" />}
-                        Enable
-                      </Button>
+                {registryResults.length > 0 ? (
+                  registryResults.map((item) => (
+                    <div key={item.id} className="rounded-md border border-border bg-bg/35 p-2">
+                      <div className="min-w-0 truncate text-xs font-medium">{item.name}</div>
+                      {item.description ? <p className="mt-1 line-clamp-2 text-2xs text-fg-muted">{item.description}</p> : null}
+                      <div className="mt-2 truncate font-mono text-2xs text-fg-subtle">{item.endpointUrl}</div>
+                      <div className="mt-2 flex justify-end gap-1.5">
+                        <Button type="button" variant="ghost" size="xs" disabled={busyId === item.id} onClick={() => void addRegistryItem(item, false)}>
+                          <PlusIcon className="size-3" />
+                          Add
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="xs"
+                          disabled={busyId === item.id || !item.runtime.available}
+                          title={!item.runtime.available ? item.runtime.notes ?? "This MCP isn't available for runtime use yet" : undefined}
+                          onClick={() => void addRegistryItem(item, true)}
+                        >
+                          {busyId === item.id ? <Loader2Icon className="size-3 animate-spin" /> : <PlusIcon className="size-3" />}
+                          Add and enable
+                        </Button>
+                      </div>
                     </div>
+                  ))
+                ) : registrySearched ? (
+                  <div className="rounded-md border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
+                    No registry servers match “{registrySearched}”.
                   </div>
-                ))}
+                ) : (
+                  <div className="rounded-md border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
+                    Search public remote MCP servers to add to this workspace.
+                  </div>
+                )}
               </div>
             </section>
 
             <section className="rounded-lg border border-border bg-surface/45 p-3">
               <div className="flex items-center gap-2 text-sm font-medium">
                 <PlusIcon className="size-4 text-brand" />
-                Add Capability
+                Add capability
               </div>
               <div className="mt-3 grid gap-2">
                 <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
@@ -408,17 +448,27 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
                   </Select>
                   <Input value={addForm.name} onChange={(event) => setAddForm((current) => ({ ...current, name: event.target.value }))} placeholder="Name" className="h-8 text-xs" />
                 </div>
-                <Input value={addForm.endpointUrl} onChange={(event) => setAddForm((current) => ({ ...current, endpointUrl: event.target.value }))} placeholder="Endpoint URL" className="h-8 text-xs" />
-                <Input value={addForm.homepageUrl} onChange={(event) => setAddForm((current) => ({ ...current, homepageUrl: event.target.value }))} placeholder="Homepage URL" className="h-8 text-xs" />
-                <Input value={addForm.installUrl} onChange={(event) => setAddForm((current) => ({ ...current, installUrl: event.target.value }))} placeholder="Install URL" className="h-8 text-xs" />
-                <Input value={addForm.category} onChange={(event) => setAddForm((current) => ({ ...current, category: event.target.value }))} placeholder="Category" className="h-8 text-xs" />
-                <Input value={addForm.tags} onChange={(event) => setAddForm((current) => ({ ...current, tags: event.target.value }))} placeholder="Tags, comma separated" className="h-8 text-xs" />
-                <textarea
-                  value={addForm.description}
-                  onChange={(event) => setAddForm((current) => ({ ...current, description: event.target.value }))}
-                  placeholder="Description"
-                  className="min-h-16 rounded-md border border-border bg-bg px-3 py-2 text-xs"
-                />
+                <details className="group rounded-md border border-border bg-surface/30 transition-colors open:bg-surface/50">
+                  <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+                    <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+                    <span>Advanced</span>
+                    <span className="text-fg-subtle/70">·</span>
+                    <span className="truncate">URLs, category, tags, description</span>
+                  </summary>
+                  <div className="grid gap-2 px-3 pb-3">
+                    <Input value={addForm.endpointUrl} onChange={(event) => setAddForm((current) => ({ ...current, endpointUrl: event.target.value }))} placeholder="Endpoint URL" className="h-8 text-xs" />
+                    <Input value={addForm.homepageUrl} onChange={(event) => setAddForm((current) => ({ ...current, homepageUrl: event.target.value }))} placeholder="Homepage URL" className="h-8 text-xs" />
+                    <Input value={addForm.installUrl} onChange={(event) => setAddForm((current) => ({ ...current, installUrl: event.target.value }))} placeholder="Install URL" className="h-8 text-xs" />
+                    <Input value={addForm.category} onChange={(event) => setAddForm((current) => ({ ...current, category: event.target.value }))} placeholder="Category" className="h-8 text-xs" />
+                    <Input value={addForm.tags} onChange={(event) => setAddForm((current) => ({ ...current, tags: event.target.value }))} placeholder="Tags, comma separated" className="h-8 text-xs" />
+                    <textarea
+                      value={addForm.description}
+                      onChange={(event) => setAddForm((current) => ({ ...current, description: event.target.value }))}
+                      placeholder="Description"
+                      className="min-h-16 rounded-md border border-border bg-bg px-3 py-2 text-xs"
+                    />
+                  </div>
+                </details>
                 <label className="flex items-center gap-2 text-xs text-fg-muted">
                   <input
                     type="checkbox"
@@ -449,9 +499,15 @@ function CapabilityRow({ item, busy, onToggle }: {
   const canToggle = item.enabled
     ? item.kind === "pack" || (item.source !== "built_in" && item.source !== "configured")
     : item.kind !== "mcp" || item.runtime.available;
+  const isRuntime = item.kind === "pack" || item.kind === "mcp";
   const toggleTitle = !canToggle && item.kind === "mcp"
-    ? item.runtime.notes ?? "This MCP is not available for runtime use yet."
+    ? item.runtime.notes ?? "This MCP isn't available for runtime use yet"
     : undefined;
+  // State lives in the pill; the button carries only the action. An enabled
+  // built-in/configured capability has no action, so it shows no button.
+  const actionLabel = item.enabled
+    ? canToggle ? (isRuntime ? "Disable" : "Untrack") : null
+    : isRuntime ? "Enable" : "Track";
   const packContents = summarizePackContents(item);
   return (
     <article className="grid min-w-0 gap-3 rounded-lg border border-border bg-surface/45 p-3 lg:grid-cols-[minmax(0,1fr)_auto]">
@@ -463,27 +519,26 @@ function CapabilityRow({ item, busy, onToggle }: {
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
               <h3 className="truncate text-sm font-medium">{item.name}</h3>
-              <CapabilityStatusPill enabled={item.enabled} source={item.source} reason={item.enabledReason} />
+              <CapabilityStatusChip enabled={item.enabled} source={item.source} reason={item.enabledReason} />
             </div>
             <div className="mt-0.5 flex min-w-0 flex-wrap gap-1.5 text-2xs text-fg-subtle">
               <span>{item.kind}</span>
               <span>{item.source.replaceAll("_", " ")}</span>
               <span>{item.category}</span>
-              {item.runtime.mcpServerId ? <span className="font-mono">{item.runtime.mcpServerId}</span> : null}
             </div>
           </div>
         </div>
         {item.description ? <p className="mt-2 line-clamp-2 text-xs leading-5 text-fg-muted">{item.description}</p> : null}
         <div className="mt-2 flex min-w-0 flex-wrap gap-1.5">
           {item.tags.slice(0, 5).map((tag) => (
-            <span key={tag} className="max-w-full truncate rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{tag}</span>
+            <MetaChip key={tag}>{tag}</MetaChip>
           ))}
-          {item.endpointUrl ? <CapabilityLink href={item.endpointUrl} label="endpoint" /> : null}
-          {item.homepageUrl ? <CapabilityLink href={item.homepageUrl} label="home" /> : null}
-          {item.installUrl && item.installUrl !== item.homepageUrl ? <CapabilityLink href={item.installUrl} label="install" /> : null}
+          {item.endpointUrl ? <CapabilityLink href={item.endpointUrl} label="Endpoint" /> : null}
+          {item.homepageUrl ? <CapabilityLink href={item.homepageUrl} label="Home" /> : null}
+          {item.installUrl && item.installUrl !== item.homepageUrl ? <CapabilityLink href={item.installUrl} label="Install" /> : null}
         </div>
       </div>
-      <div className="flex items-center justify-end gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-2">
         {packContents?.hasContents ? (
           <Button
             type="button"
@@ -497,18 +552,22 @@ function CapabilityRow({ item, busy, onToggle }: {
             Contents
           </Button>
         ) : null}
-        <Button
-          type="button"
-          size="sm"
-          variant={item.enabled ? "secondary" : "default"}
-          disabled={busy || !canToggle}
-          onClick={onToggle}
-          className="h-8 min-w-24 text-xs"
-          title={toggleTitle}
-        >
-          {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : item.enabled ? <CheckIcon className="size-3.5" /> : <PlusIcon className="size-3.5" />}
-          {capabilityToggleLabel(item, canToggle)}
-        </Button>
+        {actionLabel ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={busy || !canToggle}
+            onClick={onToggle}
+            className="h-8 min-w-24 text-xs pointer-coarse:min-h-10"
+            title={toggleTitle}
+          >
+            {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : item.enabled ? <XIcon className="size-3.5" /> : <PlusIcon className="size-3.5" />}
+            {actionLabel}
+          </Button>
+        ) : (
+          <span title={toggleTitle} className="text-2xs text-fg-subtle">Built in</span>
+        )}
       </div>
       {packContents && expanded ? <PackContentsPanel contents={packContents} /> : null}
     </article>
@@ -522,7 +581,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
         {contents.mcpServerIds.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {contents.mcpServerIds.map((id) => (
-              <span key={id} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{id}</span>
+              <MetaChip key={id} className="font-mono">{id}</MetaChip>
             ))}
           </div>
         ) : <PackEmptyText />}
@@ -537,7 +596,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
         {contents.skills.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {contents.skills.map((skill) => (
-              <span key={skill} className="rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{skill}</span>
+              <MetaChip key={skill}>{skill}</MetaChip>
             ))}
           </div>
         ) : <PackEmptyText />}
@@ -550,7 +609,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
               <div key={connector.id} className="min-w-0">
                 <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                   <span className="truncate text-xs font-medium">{connector.name}</span>
-                  {connector.required ? <span className="rounded border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">required</span> : null}
+                  {connector.required ? <MetaChip dot="waiting">Required</MetaChip> : null}
                 </div>
                 <div className="mt-0.5 text-2xs text-fg-subtle">
                   {[connector.authModel, connector.providers.join(", "), connector.scopes.length ? `${connector.scopes.length} scopes` : null].filter(Boolean).join(" / ")}
@@ -600,38 +659,20 @@ function PackContentsSection({ title, children }: { title: string; children: Rea
 }
 
 function PackEmptyText() {
-  return <div className="text-2xs text-fg-subtle">None declared.</div>;
+  return <div className="text-2xs text-fg-subtle">None declared</div>;
 }
 
-function CapabilityStatusPill(props: { enabled: boolean; source: string; reason: string | null }) {
-  return (
-    <span
-      className={cn(
-        "shrink-0 rounded-full border px-1.5 py-0.5 text-2xs font-medium",
-        props.enabled
-          ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
-          : "border-border bg-bg text-fg-subtle",
-      )}
-    >
-      {props.enabled ? props.reason ?? "enabled" : props.source === "manual" ? "added" : "available"}
-    </span>
-  );
-}
-
-function capabilityToggleLabel(item: CapabilityCatalogItem, canToggle: boolean): string {
-  if (item.kind !== "pack" && item.kind !== "mcp") {
-    if (!item.enabled) {
-      return "Track";
-    }
-    return canToggle ? "Untrack" : "Tracked";
+function CapabilityStatusChip(props: { enabled: boolean; source: string; reason: string | null }) {
+  if (props.enabled) {
+    return <MetaChip dot="idle" rounded="full">{props.reason ?? "Enabled"}</MetaChip>;
   }
-  return item.enabled ? canToggle ? "Disable" : "Ready" : "Enable";
+  return <MetaChip rounded="full">{props.source === "manual" ? "Added" : "Available"}</MetaChip>;
 }
 
 function CapabilityLink({ href, label }: { href: string; label: string }) {
   return (
-    <a href={href} target="_blank" rel="noreferrer noopener" className="max-w-full truncate rounded border border-border px-1.5 py-0.5 text-2xs text-brand hover:bg-surface-2">
-      {label}
+    <a href={href} target="_blank" rel="noreferrer noopener" className="inline-flex max-w-full items-center rounded-md border border-border bg-surface-2/60 px-1.5 py-0.5 text-2xs font-medium text-brand hover:bg-surface-2">
+      <span className="min-w-0 truncate">{label}</span>
     </a>
   );
 }
@@ -659,13 +700,13 @@ function PacksSection(props: {
   onRegister: (manifestDraft: string) => Promise<boolean>;
   onEnable: (pack: CapabilityPack, environmentId: string | undefined) => void;
   onDisable: (pack: CapabilityPack) => void;
-  onUnregister: (pack: CapabilityPack) => void;
+  onUnregister: (pack: CapabilityPack) => Promise<void>;
 }) {
   const { packs } = props;
   const [registerOpen, setRegisterOpen] = useState(false);
   const [manifestDraft, setManifestDraft] = useState("");
   // Honest list state: a failed load renders as an error with retry, never as
-  // the "No packs are available…" empty state.
+  // the empty state.
   const packsView = listViewState({ loading: packs.loading, error: packs.error, count: packs.packs.length });
 
   async function register() {
@@ -688,32 +729,29 @@ function PacksSection(props: {
             Complete agent capabilities: a sandbox image, skills, tools, connectors, knowledge, and schedule templates that enable as one unit.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <Button type="button" variant="ghost" size="sm" onClick={() => void packs.refresh()} disabled={packs.loading} className="h-8 text-xs">
-            <RefreshCwIcon className={cn("size-3.5", packs.loading && "animate-spin")} />
-            Refresh
-          </Button>
-          <Button type="button" size="sm" onClick={() => setRegisterOpen((open) => !open)} className="h-8 text-xs">
-            <PlusIcon className="size-3.5" />
-            Register manifest
-          </Button>
-        </div>
+        <Button type="button" variant="secondary" size="sm" onClick={() => setRegisterOpen((open) => !open)} className="h-8 shrink-0 text-xs">
+          <PlusIcon className="size-3.5" />
+          Add manifest
+        </Button>
       </div>
 
       {registerOpen ? (
         <div className="mt-3 grid gap-2 rounded-lg border border-border bg-bg/35 p-3">
+          <p className="text-2xs leading-5 text-fg-subtle">
+            Paste a pack manifest as JSON. It registers a workspace-scoped pack you can then enable.
+          </p>
           <textarea
             value={manifestDraft}
             onChange={(event) => setManifestDraft(event.target.value)}
-            placeholder='{"id": "my-pack", "name": "My pack", "description": "...", "role": "...", "category": "...", "version": "1.0.0", ...}'
+            placeholder='{"id": "my-pack", "name": "My pack", "description": "…", "role": "…", "category": "…", "version": "1.0.0", …}'
             className="min-h-40 rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs leading-5"
             aria-label="Pack manifest JSON"
           />
           <div className="flex justify-end gap-2">
             <Button type="button" variant="ghost" size="sm" onClick={() => setRegisterOpen(false)}>Cancel</Button>
             <Button type="button" size="sm" disabled={packs.mutating || !manifestDraft.trim()} onClick={() => void register()}>
-              {packs.mutating ? <Loader2Icon className="size-3.5 animate-spin" /> : <CheckIcon className="size-3.5" />}
-              Register
+              {packs.mutating ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
+              Register pack
             </Button>
           </div>
         </div>
@@ -721,14 +759,24 @@ function PacksSection(props: {
 
       <div className="mt-3 grid gap-3">
         {packsView === "loading" ? (
-          <div className="flex items-center gap-2 rounded-lg border border-border bg-bg/35 p-4 text-sm text-fg-muted">
-            <Loader2Icon className="size-4 animate-spin" />
-            Loading packs
+          <div className="rounded-lg border border-border bg-bg/35 p-3">
+            <Skeleton className="h-4 w-44" />
+            <Skeleton className="mt-2 h-3 w-3/4" />
           </div>
         ) : packsView === "error" ? (
           <LoadErrorState title="Couldn't load packs" error={packs.error} onRetry={() => void packs.refresh()} />
         ) : packsView === "empty" ? (
-          <EmptyState>No packs are available to this workspace.</EmptyState>
+          <EmptyState
+            icon={<PackageIcon className="size-4" />}
+            title="No packs yet"
+            description="Register a pack manifest to add a complete agent capability to this workspace."
+            action={(
+              <Button type="button" size="sm" onClick={() => setRegisterOpen(true)}>
+                <PlusIcon className="size-3.5" />
+                Add manifest
+              </Button>
+            )}
+          />
         ) : (
           packs.packs.map((pack) => (
             <PackCard
@@ -755,12 +803,13 @@ function PackCard(props: {
   busy: boolean;
   onEnable: (environmentId: string | undefined) => void;
   onDisable: () => void;
-  onUnregister: () => void;
+  onUnregister: () => Promise<void>;
 }) {
   const { pack, installation } = props;
   const enabled = installation?.status === "active";
   const [expanded, setExpanded] = useState(false);
   const [environmentId, setEnvironmentId] = useState("");
+  const [confirmUnregister, setConfirmUnregister] = useState(false);
   const needsEnvironment = pack.environment?.required === true;
 
   return (
@@ -769,17 +818,12 @@ function PackCard(props: {
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h3 className="truncate text-sm font-medium">{pack.name}</h3>
-            <span className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">v{pack.version}</span>
-            <span
-              className={cn(
-                "rounded-full border px-1.5 py-0.5 text-2xs font-medium",
-                enabled
-                  ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
-                  : "border-border bg-bg text-fg-subtle",
-              )}
-            >
-              {enabled ? "enabled" : installation ? "disabled" : "available"}
-            </span>
+            <MetaChip className="font-mono">v{pack.version}</MetaChip>
+            {enabled ? (
+              <MetaChip dot="idle" rounded="full">Enabled</MetaChip>
+            ) : (
+              <MetaChip rounded="full">{installation ? "Disabled" : "Available"}</MetaChip>
+            )}
           </div>
           <p className="mt-1 line-clamp-2 text-xs leading-5 text-fg-muted">{pack.description}</p>
           <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-fg-subtle">
@@ -795,36 +839,37 @@ function PackCard(props: {
           {pack.skills.length > 0 ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
               {pack.skills.map((skill) => (
-                <span key={skill.name} title={skill.description} className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">
-                  <SparkleIcon className="size-3" />
+                <MetaChip key={skill.name} title={skill.description}>
+                  <SparkleIcon className="size-3 shrink-0" />
                   {skill.name}
-                </span>
+                </MetaChip>
               ))}
             </div>
           ) : null}
         </div>
 
         <div className="flex shrink-0 flex-col items-end gap-2">
-          <div className="flex items-center gap-1.5">
+          <div className="flex flex-wrap items-center justify-end gap-1.5">
             <Button type="button" variant="ghost" size="sm" className="h-8 text-xs" aria-expanded={expanded} onClick={() => setExpanded((open) => !open)}>
               <ChevronDownIcon className={cn("size-3.5 transition-transform", expanded && "rotate-180")} />
               Contents
             </Button>
             {enabled ? (
-              <Button type="button" variant="secondary" size="sm" className="h-8 min-w-24 text-xs" disabled={props.busy} onClick={props.onDisable}>
+              <Button type="button" variant="secondary" size="sm" className="h-8 min-w-24 text-xs pointer-coarse:min-h-10" disabled={props.busy} onClick={props.onDisable}>
                 {props.busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
                 Disable
               </Button>
             ) : (
               <Button
                 type="button"
+                variant="secondary"
                 size="sm"
-                className="h-8 min-w-24 text-xs"
+                className="h-8 min-w-24 text-xs pointer-coarse:min-h-10"
                 disabled={props.busy || (needsEnvironment && !environmentId)}
-                title={needsEnvironment && !environmentId ? "This pack requires an environment attachment" : undefined}
+                title={needsEnvironment && !environmentId ? "This pack needs an environment attached first" : undefined}
                 onClick={() => props.onEnable(environmentId || undefined)}
               >
-                {props.busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <CheckIcon className="size-3.5" />}
+                {props.busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
                 Enable
               </Button>
             )}
@@ -832,11 +877,11 @@ function PackCard(props: {
               type="button"
               variant="ghost"
               size="icon-sm"
-              aria-label={`Unregister pack ${pack.id}`}
+              aria-label={`Unregister ${pack.name}`}
               className="hover:text-status-failed"
               disabled={props.busy}
-              title="Unregister this workspace pack (built-ins cannot be removed)"
-              onClick={props.onUnregister}
+              title="Unregister this pack (built-ins can't be removed)"
+              onClick={() => setConfirmUnregister(true)}
             >
               <Trash2Icon className="size-3.5" />
             </Button>
@@ -865,7 +910,7 @@ function PackCard(props: {
             {pack.tools.length > 0 ? (
               <div className="flex flex-wrap gap-1.5">
                 {pack.tools.map((tool) => (
-                  <span key={`${tool.kind}:${tool.id}`} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{tool.id}</span>
+                  <MetaChip key={`${tool.kind}:${tool.id}`} className="font-mono">{tool.id}</MetaChip>
                 ))}
               </div>
             ) : <PackNone />}
@@ -893,7 +938,7 @@ function PackCard(props: {
                   <div key={connector.id} className="min-w-0">
                     <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                       <span className="truncate text-xs font-medium">{connector.name}</span>
-                      {connector.required ? <span className="rounded border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">required</span> : null}
+                      {connector.required ? <MetaChip dot="waiting">Required</MetaChip> : null}
                     </div>
                     <div className="text-2xs text-fg-subtle">
                       {[connector.authModel, connector.providers.join(", "), connector.scopes.length ? `${connector.scopes.length} scopes` : null].filter(Boolean).join(" / ")}
@@ -936,7 +981,7 @@ function PackCard(props: {
               {pack.environment.requiredVariables.length > 0 ? (
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
                   {pack.environment.requiredVariables.map((name) => (
-                    <span key={name} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{name}</span>
+                    <MetaChip key={name} className="font-mono">{name}</MetaChip>
                   ))}
                 </div>
               ) : null}
@@ -944,6 +989,17 @@ function PackCard(props: {
           ) : null}
         </div>
       ) : null}
+
+      <ConfirmDialog
+        open={confirmUnregister}
+        onOpenChange={setConfirmUnregister}
+        title={`Unregister ${pack.name}?`}
+        description={enabled
+          ? "This pack is enabled. Unregistering removes it from the workspace and disables it for every session."
+          : "This removes the pack from the workspace. You can register its manifest again later."}
+        confirmLabel="Unregister pack"
+        onConfirm={props.onUnregister}
+      />
     </article>
   );
 }
@@ -961,5 +1017,5 @@ function PackSection({ title, icon, children }: { title: string; icon: ReactNode
 }
 
 function PackNone() {
-  return <div className="text-2xs text-fg-subtle">None declared.</div>;
+  return <div className="text-2xs text-fg-subtle">None declared</div>;
 }

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -30,6 +30,7 @@ import { toast } from "sonner";
 import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 import {
   capabilityCounts,
@@ -269,7 +270,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
           actions={(
             <>
               <div className="relative min-w-56 flex-1 sm:flex-none">
-                <SearchIcon className="pointer-events-none absolute left-2.5 top-2.5 size-3.5 text-[color:var(--color-fg-subtle)]" />
+                <SearchIcon className="pointer-events-none absolute left-2.5 top-2.5 size-3.5 text-fg-subtle" />
                 <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search catalog" className="h-9 pl-8 text-sm" />
               </div>
               <Button type="button" variant="ghost" size="sm" onClick={() => void refresh()} disabled={loading} className="h-9">
@@ -292,7 +293,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
             >
               {capabilityKindIcon(kind)}
               {capabilityFilterLabel(kind)}
-              <span className="ml-1 rounded-full border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">{counts[kind]}</span>
+              <span className="ml-1 rounded-full border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{counts[kind]}</span>
             </Button>
           ))}
         </div>
@@ -312,14 +313,14 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
             ) : null}
 
             {filter === "pack" ? null : catalogView === "loading" ? (
-              <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-4 text-sm text-[color:var(--color-fg-muted)]">
+              <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-4 text-sm text-fg-muted">
                 <Loader2Icon className="size-4 animate-spin" />
                 Loading capabilities
               </div>
             ) : catalogView === "error" ? (
               <LoadErrorState title="Couldn't load capabilities" error={loadError} onRetry={() => void refresh()} />
             ) : visibleItems.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-6 text-center text-sm text-[color:var(--color-fg-muted)]">
+              <div className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-fg-muted">
                 {catalogView === "empty" ? "No capabilities in this workspace yet." : "No capabilities match this filter."}
               </div>
             ) : (
@@ -336,10 +337,10 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
             )}
           </div>
 
-          <aside className="min-w-0 space-y-4 border-t border-[color:var(--color-border)] pt-4 xl:border-t-0 xl:border-l xl:pl-4 xl:pt-0">
-            <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3">
+          <aside className="min-w-0 space-y-4 border-t border-border pt-4 xl:border-t-0 xl:border-l xl:pl-4 xl:pt-0">
+            <section className="rounded-lg border border-border bg-surface/45 p-3">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <GlobeIcon className="size-4 text-[color:var(--color-brand)]" />
+                <GlobeIcon className="size-4 text-brand" />
                 Public MCP Registry
               </div>
               <div className="mt-3 flex gap-2">
@@ -359,14 +360,14 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
               </div>
               <div className="mt-3 max-h-[28rem] space-y-2 overflow-auto pr-1">
                 {registryResults.length === 0 ? (
-                  <div className="rounded-md border border-dashed border-[color:var(--color-border)] p-3 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                  <div className="rounded-md border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
                     Search returns public remote MCP servers that expose streamable HTTP endpoints.
                   </div>
                 ) : registryResults.map((item) => (
-                  <div key={item.id} className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-2">
+                  <div key={item.id} className="rounded-md border border-border bg-bg/35 p-2">
                     <div className="min-w-0 truncate text-xs font-medium">{item.name}</div>
-                    {item.description ? <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[color:var(--color-fg-muted)]">{item.description}</p> : null}
-                    <div className="mt-2 truncate font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{item.endpointUrl}</div>
+                    {item.description ? <p className="mt-1 line-clamp-2 text-2xs text-fg-muted">{item.description}</p> : null}
+                    <div className="mt-2 truncate font-mono text-2xs text-fg-subtle">{item.endpointUrl}</div>
                     <div className="mt-2 flex justify-end gap-1.5">
                       <Button type="button" variant="ghost" size="xs" disabled={busyId === item.id} onClick={() => void addRegistryItem(item, false)}>
                         <PlusIcon className="size-3" />
@@ -388,15 +389,15 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
               </div>
             </section>
 
-            <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3">
+            <section className="rounded-lg border border-border bg-surface/45 p-3">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <PlusIcon className="size-4 text-[color:var(--color-brand)]" />
+                <PlusIcon className="size-4 text-brand" />
                 Add Capability
               </div>
               <div className="mt-3 grid gap-2">
                 <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
-                  <select
-                    className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs"
+                  <Select
+                    className="h-8 text-xs"
                     value={addForm.kind}
                     onChange={(event) => setAddForm((current) => ({ ...current, kind: event.target.value as CapabilityFormState["kind"] }))}
                   >
@@ -404,7 +405,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
                     <option value="api">API</option>
                     <option value="skill">Skill</option>
                     <option value="plugin">Plugin</option>
-                  </select>
+                  </Select>
                   <Input value={addForm.name} onChange={(event) => setAddForm((current) => ({ ...current, name: event.target.value }))} placeholder="Name" className="h-8 text-xs" />
                 </div>
                 <Input value={addForm.endpointUrl} onChange={(event) => setAddForm((current) => ({ ...current, endpointUrl: event.target.value }))} placeholder="Endpoint URL" className="h-8 text-xs" />
@@ -416,9 +417,9 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
                   value={addForm.description}
                   onChange={(event) => setAddForm((current) => ({ ...current, description: event.target.value }))}
                   placeholder="Description"
-                  className="min-h-16 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-xs"
+                  className="min-h-16 rounded-md border border-border bg-bg px-3 py-2 text-xs"
                 />
-                <label className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+                <label className="flex items-center gap-2 text-xs text-fg-muted">
                   <input
                     type="checkbox"
                     checked={addForm.enableAfterAdd}
@@ -453,10 +454,10 @@ function CapabilityRow({ item, busy, onToggle }: {
     : undefined;
   const packContents = summarizePackContents(item);
   return (
-    <article className="grid min-w-0 gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+    <article className="grid min-w-0 gap-3 rounded-lg border border-border bg-surface/45 p-3 lg:grid-cols-[minmax(0,1fr)_auto]">
       <div className="min-w-0">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[color:var(--color-brand)]">
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-bg text-brand">
             {capabilityKindIcon(item.kind)}
           </span>
           <div className="min-w-0">
@@ -464,7 +465,7 @@ function CapabilityRow({ item, busy, onToggle }: {
               <h3 className="truncate text-sm font-medium">{item.name}</h3>
               <CapabilityStatusPill enabled={item.enabled} source={item.source} reason={item.enabledReason} />
             </div>
-            <div className="mt-0.5 flex min-w-0 flex-wrap gap-1.5 text-[11px] text-[color:var(--color-fg-subtle)]">
+            <div className="mt-0.5 flex min-w-0 flex-wrap gap-1.5 text-2xs text-fg-subtle">
               <span>{item.kind}</span>
               <span>{item.source.replaceAll("_", " ")}</span>
               <span>{item.category}</span>
@@ -472,10 +473,10 @@ function CapabilityRow({ item, busy, onToggle }: {
             </div>
           </div>
         </div>
-        {item.description ? <p className="mt-2 line-clamp-2 text-xs leading-5 text-[color:var(--color-fg-muted)]">{item.description}</p> : null}
+        {item.description ? <p className="mt-2 line-clamp-2 text-xs leading-5 text-fg-muted">{item.description}</p> : null}
         <div className="mt-2 flex min-w-0 flex-wrap gap-1.5">
           {item.tags.slice(0, 5).map((tag) => (
-            <span key={tag} className="max-w-full truncate rounded border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">{tag}</span>
+            <span key={tag} className="max-w-full truncate rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{tag}</span>
           ))}
           {item.endpointUrl ? <CapabilityLink href={item.endpointUrl} label="endpoint" /> : null}
           {item.homepageUrl ? <CapabilityLink href={item.homepageUrl} label="home" /> : null}
@@ -516,17 +517,17 @@ function CapabilityRow({ item, busy, onToggle }: {
 
 function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
   return (
-    <div className="grid gap-3 border-t border-[color:var(--color-border)] pt-3 lg:col-span-2 md:grid-cols-2">
+    <div className="grid gap-3 border-t border-border pt-3 lg:col-span-2 md:grid-cols-2">
       <PackContentsSection title="MCPs">
         {contents.mcpServerIds.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {contents.mcpServerIds.map((id) => (
-              <span key={id} className="rounded border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{id}</span>
+              <span key={id} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{id}</span>
             ))}
           </div>
         ) : <PackEmptyText />}
         {contents.firstPartyMcpTools.length > 0 ? (
-          <div className="mt-2 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          <div className="mt-2 text-2xs text-fg-subtle">
             Tools: {contents.firstPartyMcpTools.join(", ")}
           </div>
         ) : null}
@@ -536,7 +537,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
         {contents.skills.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {contents.skills.map((skill) => (
-              <span key={skill} className="rounded border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">{skill}</span>
+              <span key={skill} className="rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{skill}</span>
             ))}
           </div>
         ) : <PackEmptyText />}
@@ -549,9 +550,9 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
               <div key={connector.id} className="min-w-0">
                 <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                   <span className="truncate text-xs font-medium">{connector.name}</span>
-                  {connector.required ? <span className="rounded border border-amber-500/30 px-1.5 py-0.5 text-[10px] text-amber-300">required</span> : null}
+                  {connector.required ? <span className="rounded border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">required</span> : null}
                 </div>
-                <div className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+                <div className="mt-0.5 text-2xs text-fg-subtle">
                   {[connector.authModel, connector.providers.join(", "), connector.scopes.length ? `${connector.scopes.length} scopes` : null].filter(Boolean).join(" / ")}
                 </div>
               </div>
@@ -566,7 +567,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
             {contents.knowledge.map((knowledge) => (
               <div key={knowledge.id} className="min-w-0">
                 <div className="truncate text-xs font-medium">{knowledge.name}</div>
-                {knowledge.description ? <div className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">{knowledge.description}</div> : null}
+                {knowledge.description ? <div className="mt-0.5 line-clamp-2 text-2xs text-fg-subtle">{knowledge.description}</div> : null}
               </div>
             ))}
           </div>
@@ -579,7 +580,7 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
             {contents.scheduledTaskTemplates.map((template) => (
               <div key={template.id} className="min-w-0">
                 <div className="truncate text-xs font-medium">{template.name}</div>
-                <div className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">{template.scheduleSummary}</div>
+                <div className="mt-0.5 text-2xs text-fg-subtle">{template.scheduleSummary}</div>
               </div>
             ))}
           </div>
@@ -592,24 +593,24 @@ function PackContentsPanel({ contents }: { contents: PackContentsSummary }) {
 function PackContentsSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="min-w-0">
-      <div className="mb-1.5 text-[11px] font-semibold text-[color:var(--color-fg-subtle)]">{title}</div>
+      <div className="mb-1.5 text-2xs font-semibold text-fg-subtle">{title}</div>
       {children}
     </section>
   );
 }
 
 function PackEmptyText() {
-  return <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">None declared.</div>;
+  return <div className="text-2xs text-fg-subtle">None declared.</div>;
 }
 
 function CapabilityStatusPill(props: { enabled: boolean; source: string; reason: string | null }) {
   return (
     <span
       className={cn(
-        "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+        "shrink-0 rounded-full border px-1.5 py-0.5 text-2xs font-medium",
         props.enabled
-          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-          : "border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[color:var(--color-fg-subtle)]",
+          ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
+          : "border-border bg-bg text-fg-subtle",
       )}
     >
       {props.enabled ? props.reason ?? "enabled" : props.source === "manual" ? "added" : "available"}
@@ -629,7 +630,7 @@ function capabilityToggleLabel(item: CapabilityCatalogItem, canToggle: boolean):
 
 function CapabilityLink({ href, label }: { href: string; label: string }) {
   return (
-    <a href={href} target="_blank" rel="noreferrer noopener" className="max-w-full truncate rounded border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-brand)] hover:bg-[color:var(--color-surface-2)]">
+    <a href={href} target="_blank" rel="noreferrer noopener" className="max-w-full truncate rounded border border-border px-1.5 py-0.5 text-2xs text-brand hover:bg-surface-2">
       {label}
     </a>
   );
@@ -676,14 +677,14 @@ function PacksSection(props: {
   }
 
   return (
-    <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3">
+    <section className="rounded-lg border border-border bg-surface/45 p-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-sm font-medium">
-            <PackageIcon className="size-4 text-[color:var(--color-brand)]" />
+            <PackageIcon className="size-4 text-brand" />
             Packs
           </div>
-          <p className="mt-1 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+          <p className="mt-1 text-xs leading-5 text-fg-muted">
             Complete agent capabilities: a sandbox image, skills, tools, connectors, knowledge, and schedule templates that enable as one unit.
           </p>
         </div>
@@ -700,12 +701,12 @@ function PacksSection(props: {
       </div>
 
       {registerOpen ? (
-        <div className="mt-3 grid gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-3">
+        <div className="mt-3 grid gap-2 rounded-lg border border-border bg-bg/35 p-3">
           <textarea
             value={manifestDraft}
             onChange={(event) => setManifestDraft(event.target.value)}
             placeholder='{"id": "my-pack", "name": "My pack", "description": "...", "role": "...", "category": "...", "version": "1.0.0", ...}'
-            className="min-h-40 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 font-mono text-xs leading-5"
+            className="min-h-40 rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs leading-5"
             aria-label="Pack manifest JSON"
           />
           <div className="flex justify-end gap-2">
@@ -720,7 +721,7 @@ function PacksSection(props: {
 
       <div className="mt-3 grid gap-3">
         {packsView === "loading" ? (
-          <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-4 text-sm text-[color:var(--color-fg-muted)]">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-bg/35 p-4 text-sm text-fg-muted">
             <Loader2Icon className="size-4 animate-spin" />
             Loading packs
           </div>
@@ -763,38 +764,38 @@ function PackCard(props: {
   const needsEnvironment = pack.environment?.required === true;
 
   return (
-    <article className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 p-3">
+    <article className="rounded-lg border border-border bg-bg/35 p-3">
       <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h3 className="truncate text-sm font-medium">{pack.name}</h3>
-            <span className="rounded border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]">v{pack.version}</span>
+            <span className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">v{pack.version}</span>
             <span
               className={cn(
-                "rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                "rounded-full border px-1.5 py-0.5 text-2xs font-medium",
                 enabled
-                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                  : "border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[color:var(--color-fg-subtle)]",
+                  ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
+                  : "border-border bg-bg text-fg-subtle",
               )}
             >
               {enabled ? "enabled" : installation ? "disabled" : "available"}
             </span>
           </div>
-          <p className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--color-fg-muted)]">{pack.description}</p>
-          <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-[color:var(--color-fg-subtle)]">
+          <p className="mt-1 line-clamp-2 text-xs leading-5 text-fg-muted">{pack.description}</p>
+          <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-fg-subtle">
             <span>{pack.role}</span>
             <span>{pack.category}</span>
             {pack.sandboxImage ? (
               <span className="flex min-w-0 items-center gap-1" title={pack.sandboxImage}>
                 <ContainerIcon className="size-3 shrink-0" />
-                <span className="max-w-72 truncate font-mono text-[10px]">{pack.sandboxImage}</span>
+                <span className="max-w-72 truncate font-mono text-2xs">{pack.sandboxImage}</span>
               </span>
             ) : null}
           </div>
           {pack.skills.length > 0 ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
               {pack.skills.map((skill) => (
-                <span key={skill.name} title={skill.description} className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-fg-subtle)]">
+                <span key={skill.name} title={skill.description} className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">
                   <SparkleIcon className="size-3" />
                   {skill.name}
                 </span>
@@ -832,7 +833,7 @@ function PackCard(props: {
               variant="ghost"
               size="icon-sm"
               aria-label={`Unregister pack ${pack.id}`}
-              className="hover:text-red-300"
+              className="hover:text-status-failed"
               disabled={props.busy}
               title="Unregister this workspace pack (built-ins cannot be removed)"
               onClick={props.onUnregister}
@@ -842,29 +843,29 @@ function PackCard(props: {
           </div>
           {pack.environment ? (
             <div className="flex items-center gap-1.5">
-              <select
+              <Select
                 value={environmentId}
                 onChange={(event) => setEnvironmentId(event.target.value)}
                 aria-label={`Environment for ${pack.name}`}
-                className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs"
+                className="h-8 text-xs"
               >
                 <option value="">{needsEnvironment ? "Choose environment (required)" : "No environment"}</option>
                 {props.environments.map((environment) => (
                   <option key={environment.id} value={environment.id}>{environment.name}</option>
                 ))}
-              </select>
+              </Select>
             </div>
           ) : null}
         </div>
       </div>
 
       {expanded ? (
-        <div className="mt-3 grid gap-3 border-t border-[color:var(--color-border)] pt-3 md:grid-cols-2">
+        <div className="mt-3 grid gap-3 border-t border-border pt-3 md:grid-cols-2">
           <PackSection title="Tools" icon={<PlugIcon className="size-3" />}>
             {pack.tools.length > 0 ? (
               <div className="flex flex-wrap gap-1.5">
                 {pack.tools.map((tool) => (
-                  <span key={`${tool.kind}:${tool.id}`} className="rounded border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{tool.id}</span>
+                  <span key={`${tool.kind}:${tool.id}`} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{tool.id}</span>
                 ))}
               </div>
             ) : <PackNone />}
@@ -876,7 +877,7 @@ function PackCard(props: {
                 {pack.skills.map((skill) => (
                   <div key={skill.name} className="min-w-0">
                     <div className="truncate text-xs font-medium">{skill.name}</div>
-                    <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+                    <div className="text-2xs text-fg-subtle">
                       {skill.description ?? "No description"} · {skill.files.length} file{skill.files.length === 1 ? "" : "s"}
                     </div>
                   </div>
@@ -892,9 +893,9 @@ function PackCard(props: {
                   <div key={connector.id} className="min-w-0">
                     <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                       <span className="truncate text-xs font-medium">{connector.name}</span>
-                      {connector.required ? <span className="rounded border border-amber-500/30 px-1.5 py-0.5 text-[10px] text-amber-300">required</span> : null}
+                      {connector.required ? <span className="rounded border border-status-waiting/30 px-1.5 py-0.5 text-2xs text-status-waiting">required</span> : null}
                     </div>
-                    <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+                    <div className="text-2xs text-fg-subtle">
                       {[connector.authModel, connector.providers.join(", "), connector.scopes.length ? `${connector.scopes.length} scopes` : null].filter(Boolean).join(" / ")}
                     </div>
                   </div>
@@ -909,7 +910,7 @@ function PackCard(props: {
                 {pack.knowledge.map((knowledge) => (
                   <div key={knowledge.id} className="min-w-0">
                     <div className="truncate text-xs font-medium">{knowledge.name}</div>
-                    {knowledge.description ? <div className="line-clamp-2 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">{knowledge.description}</div> : null}
+                    {knowledge.description ? <div className="line-clamp-2 text-2xs text-fg-subtle">{knowledge.description}</div> : null}
                   </div>
                 ))}
               </div>
@@ -922,7 +923,7 @@ function PackCard(props: {
                 {pack.scheduledTaskTemplates.map((template) => (
                   <div key={template.id} className="min-w-0">
                     <div className="truncate text-xs font-medium">{template.name}</div>
-                    <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">{scheduleLabel(template.defaultSchedule)}</div>
+                    <div className="text-2xs text-fg-subtle">{scheduleLabel(template.defaultSchedule)}</div>
                   </div>
                 ))}
               </div>
@@ -931,11 +932,11 @@ function PackCard(props: {
 
           {pack.environment ? (
             <PackSection title="Environment" icon={<ContainerIcon className="size-3" />}>
-              <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">{pack.environment.description}</div>
+              <div className="text-2xs text-fg-subtle">{pack.environment.description}</div>
               {pack.environment.requiredVariables.length > 0 ? (
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
                   {pack.environment.requiredVariables.map((name) => (
-                    <span key={name} className="rounded border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{name}</span>
+                    <span key={name} className="rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle">{name}</span>
                   ))}
                 </div>
               ) : null}
@@ -950,7 +951,7 @@ function PackCard(props: {
 function PackSection({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
   return (
     <section className="min-w-0">
-      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold text-[color:var(--color-fg-subtle)]">
+      <div className="mb-1.5 flex items-center gap-1.5 text-2xs font-semibold text-fg-subtle">
         {icon}
         {title}
       </div>
@@ -960,5 +961,5 @@ function PackSection({ title, icon, children }: { title: string; icon: ReactNode
 }
 
 function PackNone() {
-  return <div className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">None declared.</div>;
+  return <div className="text-2xs text-fg-subtle">None declared.</div>;
 }

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -270,9 +270,11 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       await client.deletePack(workspaceId, pack.id);
       await Promise.all([packs.refresh(), refresh()]);
       toast.success(`Unregistered ${pack.name}`);
+      return true;
     } catch (error) {
       const copy = capabilityErrorToast(error, "Failed to unregister pack");
       toast.error(copy.title, { description: copy.description });
+      return false;
     } finally {
       setBusyId(null);
     }
@@ -700,20 +702,32 @@ function PacksSection(props: {
   onRegister: (manifestDraft: string) => Promise<boolean>;
   onEnable: (pack: CapabilityPack, environmentId: string | undefined) => void;
   onDisable: (pack: CapabilityPack) => void;
-  onUnregister: (pack: CapabilityPack) => Promise<void>;
+  onUnregister: (pack: CapabilityPack) => Promise<boolean>;
 }) {
   const { packs } = props;
   const [registerOpen, setRegisterOpen] = useState(false);
   const [manifestDraft, setManifestDraft] = useState("");
+  // Registration runs through a direct client call (not the packs hook), so the
+  // hook's `mutating` flag never covers it — this local flag owns the button's
+  // pending/disabled state and blocks double-submits.
+  const [registering, setRegistering] = useState(false);
   // Honest list state: a failed load renders as an error with retry, never as
   // the empty state.
   const packsView = listViewState({ loading: packs.loading, error: packs.error, count: packs.packs.length });
 
   async function register() {
-    const registered = await props.onRegister(manifestDraft);
-    if (registered) {
-      setRegisterOpen(false);
-      setManifestDraft("");
+    if (registering) {
+      return;
+    }
+    setRegistering(true);
+    try {
+      const registered = await props.onRegister(manifestDraft);
+      if (registered) {
+        setRegisterOpen(false);
+        setManifestDraft("");
+      }
+    } finally {
+      setRegistering(false);
     }
   }
 
@@ -749,8 +763,8 @@ function PacksSection(props: {
           />
           <div className="flex justify-end gap-2">
             <Button type="button" variant="ghost" size="sm" onClick={() => setRegisterOpen(false)}>Cancel</Button>
-            <Button type="button" size="sm" disabled={packs.mutating || !manifestDraft.trim()} onClick={() => void register()}>
-              {packs.mutating ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
+            <Button type="button" size="sm" disabled={registering || !manifestDraft.trim()} onClick={() => void register()}>
+              {registering ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
               Register pack
             </Button>
           </div>
@@ -803,7 +817,7 @@ function PackCard(props: {
   busy: boolean;
   onEnable: (environmentId: string | undefined) => void;
   onDisable: () => void;
-  onUnregister: () => Promise<void>;
+  onUnregister: () => Promise<boolean>;
 }) {
   const { pack, installation } = props;
   const enabled = installation?.status === "active";

--- a/apps/web/src/routes/device.tsx
+++ b/apps/web/src/routes/device.tsx
@@ -161,9 +161,9 @@ export function DeviceRoute({ userCode: userCodeFromUrl }: { userCode?: string |
   if (lookingUp && !lookup && phase !== "error") {
     return (
       <DeviceShell>
-        <div className="mx-auto flex w-full max-w-md items-center justify-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6 text-sm text-[color:var(--color-fg-muted)]">
+        <div className="mx-auto flex w-full max-w-md items-center justify-center gap-2 rounded-lg border border-border bg-surface p-6 text-sm text-fg-muted">
           <LaptopIcon className="size-4 animate-pulse" />
-          Looking up <span className="font-mono text-[color:var(--color-fg)]">{userCode}</span>…
+          Looking up <span className="font-mono text-fg">{userCode}</span>…
         </div>
       </DeviceShell>
     );
@@ -197,7 +197,7 @@ const EMPTY_MACHINE: EnrollmentConsentMachine = {
 /** Centered page chrome shared by every device-page state. */
 function DeviceShell({ children }: { children: ReactNode }) {
   return (
-    <main className="flex min-h-dvh flex-1 items-center justify-center bg-[color:var(--color-bg)] px-4 py-10 text-[color:var(--color-fg)]">
+    <main className="flex min-h-dvh flex-1 items-center justify-center bg-bg px-4 py-10 text-fg">
       <div className="w-full max-w-md">{children}</div>
     </main>
   );
@@ -208,12 +208,12 @@ function DeviceShell({ children }: { children: ReactNode }) {
 function SignInPrompt({ userCode }: { userCode: string }) {
   return (
     <DeviceShell>
-      <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6 text-center">
-        <span className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+      <div className="rounded-lg border border-border bg-surface p-6 text-center">
+        <span className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-brand-strong/20 text-brand">
           <LogInIcon className="size-5" />
         </span>
         <h1 className="text-base font-semibold">Sign in to approve this machine</h1>
-        <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-[color:var(--color-fg-muted)]">
+        <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-fg-muted">
           You need to be signed in to the workspace that owns this machine before you can grant it access. Sign in, then
           you'll return here to review the request.
         </p>
@@ -245,19 +245,19 @@ function CodeEntry({
   return (
     <DeviceShell>
       <form
-        className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-6"
+        className="rounded-lg border border-border bg-surface p-6"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmit();
         }}
       >
         <div className="mb-4 flex items-center gap-3">
-          <span className="flex size-9 items-center justify-center rounded-md bg-[color:var(--color-brand-strong)]/20 text-[color:var(--color-brand)]">
+          <span className="flex size-9 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
             <LaptopIcon className="size-4" />
           </span>
           <div>
             <h1 className="text-base font-semibold">Approve a machine</h1>
-            <p className="text-sm text-[color:var(--color-fg-muted)]">
+            <p className="text-sm text-fg-muted">
               Enter the code shown on the machine you're enrolling.
             </p>
           </div>

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -209,21 +209,21 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         />
 
         <div className="mt-5 grid min-h-0 flex-1 gap-4 lg:grid-cols-[240px_minmax(0,1fr)_360px]">
-          <aside className="min-w-0 border-b border-[color:var(--color-border)] pb-4 lg:border-b-0 lg:border-r lg:pr-4">
+          <aside className="min-w-0 border-b border-border pb-4 lg:border-b-0 lg:border-r lg:pr-4">
             <div className="mb-2 flex items-center justify-between gap-2">
-              <div className="text-xs font-medium uppercase text-[color:var(--color-fg-subtle)]">Bases</div>
-              <div className="text-[11px] text-[color:var(--color-fg-subtle)]">{bases.length}</div>
+              <div className="text-xs font-medium uppercase text-fg-subtle">Bases</div>
+              <div className="text-2xs text-fg-subtle">{bases.length}</div>
             </div>
             <div className="space-y-1">
               {basesView === "loading" ? (
-                <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] p-3 text-xs text-[color:var(--color-fg-muted)]">
+                <div className="flex items-center gap-2 rounded-lg border border-border p-3 text-xs text-fg-muted">
                   <Loader2Icon className="size-3.5 animate-spin" />
                   Loading bases
                 </div>
               ) : basesView === "error" ? (
                 <LoadErrorState title="Couldn't load document bases" error={basesError} onRetry={() => void refreshBases()} />
               ) : basesView === "empty" ? (
-                <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-3 text-xs text-[color:var(--color-fg-muted)]">
+                <div className="rounded-lg border border-dashed border-border p-3 text-xs text-fg-muted">
                   Create a document base to start.
                 </div>
               ) : bases.map((base) => (
@@ -234,8 +234,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   className={cn(
                     "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-xs",
                     selectedBaseId === base.id
-                      ? "border-[color:var(--color-brand)]/40 bg-[color:var(--color-brand)]/10 text-[color:var(--color-fg)]"
-                      : "border-[color:var(--color-border)] bg-[color:var(--color-bg)]/25 text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-surface-2)]",
+                      ? "border-brand/40 bg-brand/10 text-fg"
+                      : "border-border bg-bg/25 text-fg-muted hover:bg-surface-2",
                   )}
                 >
                   <span className="truncate">{base.name}</span>
@@ -251,7 +251,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="min-w-0">
                     <div className="truncate text-base font-medium">{selectedBase.name}</div>
-                    <div className="text-xs text-[color:var(--color-fg-subtle)]">
+                    <div className="text-xs text-fg-subtle">
                       {documents.length} files · {failedDocuments.length} failed
                     </div>
                   </div>
@@ -289,26 +289,26 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
 
                 <div className="mt-4 space-y-2">
                   {documentsView === "loading" ? (
-                    <div className="flex items-center justify-center gap-2 rounded-lg border border-[color:var(--color-border)] p-6 text-xs text-[color:var(--color-fg-muted)]">
+                    <div className="flex items-center justify-center gap-2 rounded-lg border border-border p-6 text-xs text-fg-muted">
                       <Loader2Icon className="size-3.5 animate-spin" />
                       Loading documents
                     </div>
                   ) : documentsView === "error" ? (
                     <LoadErrorState title="Couldn't load documents" error={documentsError} onRetry={() => selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined} />
                   ) : documentsView === "empty" ? (
-                    <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-6 text-center text-xs text-[color:var(--color-fg-muted)]">
+                    <div className="rounded-lg border border-dashed border-border p-6 text-center text-xs text-fg-muted">
                       Upload files to index this base.
                     </div>
                   ) : (
                     documents.map((document) => (
-                      <div key={document.id} className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 px-3 py-2.5">
+                      <div key={document.id} className="flex items-start justify-between gap-3 rounded-lg border border-border bg-surface/35 px-3 py-2.5">
                         <div className="min-w-0">
                           <div className="truncate text-sm font-medium">{document.title}</div>
-                          <div className="mt-1 text-[11px] text-[color:var(--color-fg-subtle)]">
+                          <div className="mt-1 text-2xs text-fg-subtle">
                             {document.status} · {document.chunkCount} chunks · {document.parser}
                           </div>
                           {document.status === "failed" && document.error ? (
-                            <div className="mt-2 line-clamp-2 max-w-3xl text-xs leading-5 text-[color:var(--color-danger)]">
+                            <div className="mt-2 line-clamp-2 max-w-3xl text-xs leading-5 text-danger">
                               {document.error}
                             </div>
                           ) : null}
@@ -335,15 +335,15 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                 </div>
               </>
             ) : (
-              <div className="grid min-h-48 place-items-center text-center text-xs text-[color:var(--color-fg-muted)]">
+              <div className="grid min-h-48 place-items-center text-center text-xs text-fg-muted">
                 Select or create a base.
               </div>
             )}
           </div>
 
-          <aside className="min-w-0 border-t border-[color:var(--color-border)] pt-4 lg:border-t-0 lg:border-l lg:pl-4 lg:pt-0">
+          <aside className="min-w-0 border-t border-border pt-4 lg:border-t-0 lg:border-l lg:pl-4 lg:pt-0">
             <div className="flex items-center gap-2 text-sm font-medium">
-              <FileSearchIcon className="size-4 text-[color:var(--color-brand)]" />
+              <FileSearchIcon className="size-4 text-brand" />
               Search
             </div>
             <div className="mt-3 grid gap-2">
@@ -366,16 +366,16 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
             <div className="mt-4 space-y-2">
               {results.length > 0 ? (
                 results.map((result) => (
-                  <div key={result.chunkId} className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3">
+                  <div key={result.chunkId} className="rounded-lg border border-border bg-surface/35 p-3">
                     <div className="flex items-center justify-between gap-2 text-xs">
-                      <span className="truncate font-medium text-[color:var(--color-fg)]">{result.title}</span>
-                      <span className="shrink-0 text-[color:var(--color-fg-subtle)]">{Math.round(result.score * 100)}%</span>
+                      <span className="truncate font-medium text-fg">{result.title}</span>
+                      <span className="shrink-0 text-fg-subtle">{Math.round(result.score * 100)}%</span>
                     </div>
-                    <p className="mt-2 line-clamp-4 text-xs leading-5 text-[color:var(--color-fg-muted)]">{result.text}</p>
+                    <p className="mt-2 line-clamp-4 text-xs leading-5 text-fg-muted">{result.text}</p>
                   </div>
                 ))
               ) : (
-                <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-4 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                <div className="rounded-lg border border-dashed border-border p-4 text-xs leading-5 text-fg-muted">
                   Search results appear here for the selected base.
                 </div>
               )}
@@ -392,9 +392,9 @@ function DocumentStatusDot({ status }: { status: IndexedDocument["status"] }) {
     <span
       className={cn(
         "size-2.5 shrink-0 rounded-full",
-        status === "ready" && "bg-emerald-400",
-        status === "failed" && "bg-red-400",
-        (status === "queued" || status === "indexing") && "bg-amber-300",
+        status === "ready" && "bg-status-idle",
+        status === "failed" && "bg-status-failed",
+        (status === "queued" || status === "indexing") && "bg-status-waiting",
       )}
       aria-label={status}
       title={status}

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -6,7 +6,10 @@ import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { Notice } from "@/components/ui/notice";
+import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext } from "@/context";
 import { listViewState } from "@/lib/load-state";
 import { cn } from "@/lib/utils";
@@ -29,9 +32,16 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const [creatingBase, setCreatingBase] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [searching, setSearching] = useState(false);
+  // The query behind the results on screen, so a completed search that found
+  // nothing reads as "No results" rather than the initial prompt.
+  const [searched, setSearched] = useState<string | null>(null);
   const [retryingIds, setRetryingIds] = useState<Set<string>>(() => new Set());
   const [retryingAll, setRetryingAll] = useState(false);
+  // Set when background indexing-status polling fails, so stale "indexing…"
+  // rows carry a visible notice instead of silently freezing.
+  const [pollFailed, setPollFailed] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
   const selectedBase = bases.find((base) => base.id === selectedBaseId) ?? null;
   const failedDocuments = documents.filter((document) => document.status === "failed");
   // Honest list states: an initial fetch renders as loading and a failed load
@@ -45,10 +55,12 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   }, [workspaceId]);
 
   useEffect(() => {
+    setResults([]);
+    setSearched(null);
+    setPollFailed(false);
     if (!selectedBaseId) {
       setDocuments([]);
       setDocumentsError(null);
-      setResults([]);
       return;
     }
     void refreshDocuments(selectedBaseId);
@@ -59,7 +71,12 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
       return;
     }
     const timer = window.setInterval(() => {
-      void client.listDocuments(workspaceId, selectedBaseId).then(setDocuments).catch(() => undefined);
+      void client.listDocuments(workspaceId, selectedBaseId)
+        .then((next) => {
+          setDocuments(next);
+          setPollFailed(false);
+        })
+        .catch(() => setPollFailed(true));
     }, 1200);
     return () => window.clearInterval(timer);
   }, [workspaceId, selectedBaseId, documents]);
@@ -101,6 +118,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
       setBases((current) => [...current, base]);
       setSelectedBaseId(base.id);
       setName("");
+      toast.success("Document base created", { description: `“${base.name}” is ready for uploads.` });
     } catch (error) {
       toast.error("Failed to create document base", { description: error instanceof Error ? error.message : String(error) });
     } finally {
@@ -136,7 +154,12 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
     try {
       const response = await client.searchDocuments(workspaceId, selectedBaseId, { query: query.trim(), limit: 8 });
       setResults(response.results);
+      setSearched(query.trim());
     } catch (error) {
+      // Clear stale matches so a failed search never leaves prior results
+      // reading as current; the toast carries the cause.
+      setResults([]);
+      setSearched(null);
       toast.error("Document search failed", { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setSearching(false);
@@ -188,21 +211,22 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         <PageHeader
           icon={<FileSearchIcon className="size-4" />}
           title="Documents"
-          description="Manage indexed document bases for agent search and retry failed document indexing."
+          description="Indexed document bases the agent can search."
           actions={(
             <div className="flex min-w-0 gap-2">
               <Input
+                ref={nameInputRef}
                 value={name}
                 onChange={(event) => setName(event.target.value)}
-                placeholder="New base"
+                placeholder="New base name"
                 className="h-8 min-w-0 text-xs"
                 onKeyDown={(event) => {
                   if (event.key === "Enter") void handleCreateBase();
                 }}
               />
-              <Button type="button" size="sm" onClick={() => void handleCreateBase()} disabled={creatingBase || !name.trim()} className="h-8 shrink-0">
+              <Button type="button" size="sm" onClick={() => void handleCreateBase()} disabled={creatingBase || !name.trim()} className="h-8 shrink-0 pointer-coarse:min-h-10">
                 {creatingBase ? <Loader2Icon className="size-3.5 animate-spin" /> : <PlusIcon className="size-3.5" />}
-                Create
+                Create base
               </Button>
             </div>
           )}
@@ -223,8 +247,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
               ) : basesView === "error" ? (
                 <LoadErrorState title="Couldn't load document bases" error={basesError} onRetry={() => void refreshBases()} />
               ) : basesView === "empty" ? (
-                <div className="rounded-lg border border-dashed border-border p-3 text-xs text-fg-muted">
-                  Create a document base to start.
+                <div className="rounded-lg border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
+                  No bases yet. Name one above to start indexing documents.
                 </div>
               ) : bases.map((base) => (
                 <button
@@ -288,6 +312,25 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                 </div>
 
                 <div className="mt-4 space-y-2">
+                  {pollFailed ? (
+                    <Notice
+                      tone="waiting"
+                      title="Indexing status may be stale"
+                      action={(
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined}
+                        >
+                          <RefreshCwIcon className="size-3" />
+                          Refresh
+                        </Button>
+                      )}
+                    >
+                      Couldn't reach the server to refresh indexing progress. It will keep retrying.
+                    </Notice>
+                  ) : null}
                   {documentsView === "loading" ? (
                     <div className="flex items-center justify-center gap-2 rounded-lg border border-border p-6 text-xs text-fg-muted">
                       <Loader2Icon className="size-3.5 animate-spin" />
@@ -296,9 +339,19 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   ) : documentsView === "error" ? (
                     <LoadErrorState title="Couldn't load documents" error={documentsError} onRetry={() => selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined} />
                   ) : documentsView === "empty" ? (
-                    <div className="rounded-lg border border-dashed border-border p-6 text-center text-xs text-fg-muted">
-                      Upload files to index this base.
-                    </div>
+                    <EmptyState
+                      icon={<FilesIcon className="size-4" />}
+                      title="No documents yet"
+                      description={fileUploadsEnabled
+                        ? "Upload files to index them for agent search."
+                        : "File uploads are turned off for this deployment."}
+                      action={fileUploadsEnabled ? (
+                        <Button type="button" size="sm" disabled={uploading} onClick={() => fileInputRef.current?.click()}>
+                          {uploading ? <Loader2Icon className="size-3.5 animate-spin" /> : <FilesIcon className="size-3.5" />}
+                          Upload files
+                        </Button>
+                      ) : undefined}
+                    />
                   ) : (
                     documents.map((document) => (
                       <div key={document.id} className="flex items-start justify-between gap-3 rounded-lg border border-border bg-surface/35 px-3 py-2.5">
@@ -314,7 +367,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                           ) : null}
                         </div>
                         <div className="flex shrink-0 items-center gap-2 pt-0.5">
-                          <DocumentStatusDot status={document.status} />
+                          <StatusDot tone={documentStatusTone(document.status)} pulse={document.status === "indexing"} />
+                          <span className="sr-only">{document.status}</span>
                           {document.status === "failed" ? (
                             <Button
                               type="button"
@@ -334,10 +388,24 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   )}
                 </div>
               </>
+            ) : basesView === "empty" ? (
+              <EmptyState
+                icon={<FileSearchIcon className="size-4" />}
+                title="Create your first base"
+                description="A document base is an indexed corpus the agent can search. Name one and upload files to it."
+                action={(
+                  <Button type="button" size="sm" onClick={() => nameInputRef.current?.focus()}>
+                    <PlusIcon className="size-3.5" />
+                    Create base
+                  </Button>
+                )}
+              />
             ) : (
-              <div className="grid min-h-48 place-items-center text-center text-xs text-fg-muted">
-                Select or create a base.
-              </div>
+              <EmptyState
+                icon={<FileSearchIcon className="size-4" />}
+                title="No base selected"
+                description="Pick a base on the left to upload and search its documents."
+              />
             )}
           </div>
 
@@ -374,9 +442,13 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                     <p className="mt-2 line-clamp-4 text-xs leading-5 text-fg-muted">{result.text}</p>
                   </div>
                 ))
+              ) : searched ? (
+                <div className="rounded-lg border border-dashed border-border p-4 text-xs leading-5 text-fg-muted">
+                  No results for “{searched}”.
+                </div>
               ) : (
                 <div className="rounded-lg border border-dashed border-border p-4 text-xs leading-5 text-fg-muted">
-                  Search results appear here for the selected base.
+                  Results appear here.
                 </div>
               )}
             </div>
@@ -387,17 +459,9 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   );
 }
 
-function DocumentStatusDot({ status }: { status: IndexedDocument["status"] }) {
-  return (
-    <span
-      className={cn(
-        "size-2.5 shrink-0 rounded-full",
-        status === "ready" && "bg-status-idle",
-        status === "failed" && "bg-status-failed",
-        (status === "queued" || status === "indexing") && "bg-status-waiting",
-      )}
-      aria-label={status}
-      title={status}
-    />
-  );
+function documentStatusTone(status: IndexedDocument["status"]): StatusTone {
+  if (status === "ready") return "idle";
+  if (status === "failed") return "failed";
+  if (status === "indexing") return "running";
+  return "waiting";
 }

--- a/apps/web/src/routes/environments.tsx
+++ b/apps/web/src/routes/environments.tsx
@@ -78,7 +78,7 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
       />
 
       {createOpen ? (
-        <div className="mt-4 grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 sm:grid-cols-[14rem_minmax(0,1fr)_auto]">
+        <div className="mt-4 grid gap-3 rounded-lg border border-border bg-surface p-3 sm:grid-cols-[14rem_minmax(0,1fr)_auto]">
           <div className="grid gap-1.5">
             <Label htmlFor="environment-name">Name</Label>
             <Input id="environment-name" value={createName} onChange={(event) => setCreateName(event.target.value)} placeholder="staging-aws" className="h-9" autoFocus />
@@ -98,7 +98,7 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
 
       <div className="mt-5 grid gap-3">
         {environmentsView === "loading" ? (
-          <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-4 text-sm text-[color:var(--color-fg-muted)]">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-4 text-sm text-fg-muted">
             <Loader2Icon className="size-4 animate-spin" />
             Loading environments
           </div>
@@ -131,9 +131,9 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
           ))
         )}
         {environments.mutationError ? (
-          <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs leading-4 text-red-200">
+          <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
             <span className="min-w-0 flex-1">{environments.mutationError.message}</span>
-            <button type="button" onClick={environments.clearMutationError} aria-label="Dismiss environment error" className="shrink-0 rounded p-0.5 hover:bg-red-500/20">
+            <button type="button" onClick={environments.clearMutationError} aria-label="Dismiss environment error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
               <XIcon className="size-3" />
             </button>
           </div>
@@ -203,7 +203,7 @@ function EnvironmentCard(props: {
   }
 
   return (
-    <article className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-3">
+    <article className="rounded-lg border border-border bg-surface/45 p-3">
       <div className="flex min-w-0 items-start justify-between gap-3">
         {editing ? (
           <div className="grid min-w-0 flex-1 gap-2 sm:grid-cols-2">
@@ -213,10 +213,10 @@ function EnvironmentCard(props: {
         ) : (
           <div className="min-w-0">
             <div className="truncate text-sm font-medium">{environment.name}</div>
-            <div className="mt-0.5 text-xs text-[color:var(--color-fg-muted)]">
+            <div className="mt-0.5 text-xs text-fg-muted">
               {environment.description ?? "No description"}
             </div>
-            <div className="mt-1 text-[11px] text-[color:var(--color-fg-subtle)]">
+            <div className="mt-1 text-2xs text-fg-subtle">
               {environment.variables.length} variable{environment.variables.length === 1 ? "" : "s"} · updated {formatTimestamp(environment.updatedAt)}
             </div>
           </div>
@@ -244,7 +244,7 @@ function EnvironmentCard(props: {
                 variant="ghost"
                 size="icon-sm"
                 aria-label="Delete environment"
-                className="hover:text-red-300"
+                className="hover:text-status-failed"
                 disabled={props.mutating || props.attachedSessions.length > 0 || props.attachedTasks.length > 0}
                 title={props.attachedSessions.length > 0 || props.attachedTasks.length > 0 ? "Detach it from sessions and tasks first" : "Delete environment"}
                 onClick={() => void props.onDelete()}
@@ -258,24 +258,24 @@ function EnvironmentCard(props: {
 
       <div className="mt-3 space-y-1.5">
         {environment.variables.length === 0 ? (
-          <p className="text-xs text-[color:var(--color-fg-subtle)]">No variables yet.</p>
+          <p className="text-xs text-fg-subtle">No variables yet.</p>
         ) : (
           environment.variables.map((variable) => (
-            <div key={variable.name} className="rounded-md border border-[color:var(--color-border)]/70 bg-[color:var(--color-bg)]/25 px-2.5 py-1.5">
+            <div key={variable.name} className="rounded-md border border-border/70 bg-bg/25 px-2.5 py-1.5">
               <div className="flex min-w-0 items-center gap-2">
-                <KeyRoundIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+                <KeyRoundIcon className="size-3 shrink-0 text-fg-subtle" />
                 <span className="min-w-0 flex-1 truncate font-mono text-xs">{variable.name}</span>
-                <span className="shrink-0 text-[10px] text-[color:var(--color-fg-subtle)]">
+                <span className="shrink-0 text-2xs text-fg-subtle">
                   v{variable.version} · {formatTimestamp(variable.updatedAt)}
                 </span>
-                <span className="shrink-0 rounded border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]" title="Values are write-only and never returned by the API">
+                <span className="shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-2xs text-fg-subtle" title="Values are write-only and never returned by the API">
                   ••••••
                 </span>
                 <Button
                   type="button"
                   variant="ghost"
                   size="xs"
-                  className="h-6 shrink-0 text-[11px]"
+                  className="h-6 shrink-0 text-2xs"
                   disabled={props.mutating}
                   onClick={() => {
                     setRotatingName((current) => current === variable.name ? null : variable.name);
@@ -289,7 +289,7 @@ function EnvironmentCard(props: {
                   variant="ghost"
                   size="icon-xs"
                   aria-label={`Delete variable ${variable.name}`}
-                  className="shrink-0 hover:text-red-300"
+                  className="shrink-0 hover:text-status-failed"
                   disabled={props.mutating}
                   onClick={() => void props.onDeleteVariable(variable.name).then((removed) => {
                     if (removed) {
@@ -345,14 +345,14 @@ function EnvironmentCard(props: {
       </div>
 
       {(props.attachedSessions.length > 0 || props.attachedTasks.length > 0) ? (
-        <div className="mt-3 border-t border-[color:var(--color-border)]/70 pt-2 text-[11px] text-[color:var(--color-fg-subtle)]">
-          <span className="font-medium text-[color:var(--color-fg-muted)]">Attached to:</span>{" "}
+        <div className="mt-3 border-t border-border/70 pt-2 text-2xs text-fg-subtle">
+          <span className="font-medium text-fg-muted">Attached to:</span>{" "}
           {props.attachedSessions.slice(0, 4).map((session) => (
             <Link
               key={session.id}
               to="/workspaces/$workspaceId/sessions/$sessionId"
               params={{ workspaceId: props.workspaceId, sessionId: session.id }}
-              className="mr-2 underline decoration-[color:var(--color-border-strong)] underline-offset-2 hover:text-[color:var(--color-fg)]"
+              className="mr-2 underline decoration-border-strong underline-offset-2 hover:text-fg"
             >
               session “{session.initialMessage.slice(0, 32)}{session.initialMessage.length > 32 ? "…" : ""}”
             </Link>

--- a/apps/web/src/routes/environments.tsx
+++ b/apps/web/src/routes/environments.tsx
@@ -12,15 +12,19 @@ import {
   PlusIcon,
   RefreshCwIcon,
   Trash2Icon,
-  XIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MetaChip } from "@/components/ui/meta-chip";
+import { Notice } from "@/components/ui/notice";
+import { Skeleton } from "@/components/ui/skeleton";
 import { formatTimestamp } from "@/lib/format";
 import { listViewState } from "@/lib/load-state";
 import type { ScheduledTask, Session, WorkspaceEnvironment } from "@/types";
@@ -28,8 +32,16 @@ import type { ScheduledTask, Session, WorkspaceEnvironment } from "@/types";
 export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
   const environments = useEnvironments();
   // Attachment views: which sessions and scheduled tasks carry each environment.
-  const { sessions } = useWorkspaceSessions({ limit: 100 });
-  const { tasks } = useScheduledTasks();
+  const { sessions, loading: sessionsLoading, error: sessionsError } = useWorkspaceSessions({ limit: 100 });
+  const { tasks, loading: tasksLoading, error: tasksError } = useScheduledTasks();
+  // Fail closed: never delete an environment while its attachment set is
+  // unknown (initial load or a failed read) — a false-empty attachment view
+  // could otherwise let a still-referenced environment be removed.
+  const attachmentsUnknown =
+    sessionsError !== null ||
+    tasksError !== null ||
+    (sessionsLoading && sessions.length === 0) ||
+    (tasksLoading && tasks.length === 0);
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createDescription, setCreateDescription] = useState("");
@@ -98,16 +110,34 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
 
       <div className="mt-5 grid gap-3">
         {environmentsView === "loading" ? (
-          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-4 text-sm text-fg-muted">
-            <Loader2Icon className="size-4 animate-spin" />
-            Loading environments
-          </div>
+          <>
+            {[0, 1].map((key) => (
+              <div key={key} className="rounded-lg border border-border bg-surface/45 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 space-y-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-56" />
+                  </div>
+                  <Skeleton className="size-8 rounded-md" />
+                </div>
+                <Skeleton className="mt-3 h-8 w-full" />
+              </div>
+            ))}
+          </>
         ) : environmentsView === "error" ? (
           <LoadErrorState title="Couldn't load environments" error={environments.error} onRetry={() => void environments.refresh()} />
         ) : environmentsView === "empty" ? (
-          <EmptyState>
-            No environments yet. Create one to give sessions and scheduled tasks credentials without pasting secrets into prompts.
-          </EmptyState>
+          <EmptyState
+            icon={<BoxIcon className="size-4" />}
+            title="No environments yet"
+            description="Create one to give sessions and scheduled tasks credentials without pasting secrets into prompts."
+            action={(
+              <Button type="button" size="sm" onClick={() => setCreateOpen(true)}>
+                <PlusIcon className="size-3.5" />
+                New environment
+              </Button>
+            )}
+          />
         ) : (
           environments.environments.map((environment) => (
             <EnvironmentCard
@@ -116,6 +146,7 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
               environment={environment}
               attachedSessions={sessions.filter((session) => session.environmentId === environment.id)}
               attachedTasks={tasks.filter((task) => task.environmentId === environment.id)}
+              attachmentsUnknown={attachmentsUnknown}
               mutating={environments.mutating}
               onUpdate={(patch) => environments.update(environment.id, patch)}
               onDelete={async () => {
@@ -131,12 +162,16 @@ export function EnvironmentsRoute({ workspaceId }: { workspaceId: string }) {
           ))
         )}
         {environments.mutationError ? (
-          <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2 text-xs leading-4 text-status-failed">
-            <span className="min-w-0 flex-1">{environments.mutationError.message}</span>
-            <button type="button" onClick={environments.clearMutationError} aria-label="Dismiss environment error" className="shrink-0 rounded p-0.5 hover:bg-status-failed/20">
-              <XIcon className="size-3" />
-            </button>
-          </div>
+          <Notice
+            tone="failed"
+            action={(
+              <Button type="button" variant="ghost" size="xs" onClick={environments.clearMutationError}>
+                Dismiss
+              </Button>
+            )}
+          >
+            {environments.mutationError.message}
+          </Notice>
         ) : null}
       </div>
     </div>
@@ -148,6 +183,7 @@ function EnvironmentCard(props: {
   environment: WorkspaceEnvironment;
   attachedSessions: Session[];
   attachedTasks: ScheduledTask[];
+  attachmentsUnknown: boolean;
   mutating: boolean;
   onUpdate: (patch: { name?: string; description?: string | null }) => Promise<WorkspaceEnvironment | null>;
   onDelete: () => Promise<boolean>;
@@ -163,6 +199,16 @@ function EnvironmentCard(props: {
   // Per-variable rotate drafts (write-only value entry).
   const [rotatingName, setRotatingName] = useState<string | null>(null);
   const [rotateValue, setRotateValue] = useState("");
+  // Destructive confirms (D5): delete the environment, or one of its variables.
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmDeleteVariable, setConfirmDeleteVariable] = useState<string | null>(null);
+  const attachmentCount = props.attachedSessions.length + props.attachedTasks.length;
+  const deleteBlocked = attachmentCount > 0 || props.attachmentsUnknown;
+  const deleteBlockedReason = props.attachmentsUnknown
+    ? "Checking where this environment is used…"
+    : attachmentCount > 0
+      ? "Detach it from sessions and tasks first"
+      : undefined;
 
   async function saveDetails() {
     const result = await props.onUpdate({
@@ -245,9 +291,9 @@ function EnvironmentCard(props: {
                 size="icon-sm"
                 aria-label="Delete environment"
                 className="hover:text-status-failed"
-                disabled={props.mutating || props.attachedSessions.length > 0 || props.attachedTasks.length > 0}
-                title={props.attachedSessions.length > 0 || props.attachedTasks.length > 0 ? "Detach it from sessions and tasks first" : "Delete environment"}
-                onClick={() => void props.onDelete()}
+                disabled={props.mutating || deleteBlocked}
+                title={deleteBlockedReason ?? "Delete environment"}
+                onClick={() => setConfirmDelete(true)}
               >
                 <Trash2Icon className="size-3.5" />
               </Button>
@@ -258,7 +304,7 @@ function EnvironmentCard(props: {
 
       <div className="mt-3 space-y-1.5">
         {environment.variables.length === 0 ? (
-          <p className="text-xs text-fg-subtle">No variables yet.</p>
+          <p className="text-xs text-fg-subtle">No variables yet — add one below to inject it into the sandbox.</p>
         ) : (
           environment.variables.map((variable) => (
             <div key={variable.name} className="rounded-md border border-border/70 bg-bg/25 px-2.5 py-1.5">
@@ -291,11 +337,7 @@ function EnvironmentCard(props: {
                   aria-label={`Delete variable ${variable.name}`}
                   className="shrink-0 hover:text-status-failed"
                   disabled={props.mutating}
-                  onClick={() => void props.onDeleteVariable(variable.name).then((removed) => {
-                    if (removed) {
-                      toast.success(`Variable ${variable.name} deleted`);
-                    }
-                  })}
+                  onClick={() => setConfirmDeleteVariable(variable.name)}
                 >
                   <Trash2Icon className="size-3" />
                 </Button>
@@ -344,25 +386,60 @@ function EnvironmentCard(props: {
         </Button>
       </div>
 
-      {(props.attachedSessions.length > 0 || props.attachedTasks.length > 0) ? (
-        <div className="mt-3 border-t border-border/70 pt-2 text-2xs text-fg-subtle">
-          <span className="font-medium text-fg-muted">Attached to:</span>{" "}
-          {props.attachedSessions.slice(0, 4).map((session) => (
-            <Link
-              key={session.id}
-              to="/workspaces/$workspaceId/sessions/$sessionId"
-              params={{ workspaceId: props.workspaceId, sessionId: session.id }}
-              className="mr-2 underline decoration-border-strong underline-offset-2 hover:text-fg"
-            >
-              session “{session.initialMessage.slice(0, 32)}{session.initialMessage.length > 32 ? "…" : ""}”
-            </Link>
-          ))}
-          {props.attachedSessions.length > 4 ? <span className="mr-2">+{props.attachedSessions.length - 4} more sessions</span> : null}
-          {props.attachedTasks.map((task) => (
-            <span key={task.id} className="mr-2">task “{task.name}”</span>
-          ))}
+      {attachmentCount > 0 ? (
+        <div className="mt-3 border-t border-border/70 pt-2">
+          <span className="text-2xs font-medium text-fg-muted">Attached to</span>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {props.attachedSessions.slice(0, 4).map((session) => (
+              <Link
+                key={session.id}
+                to="/workspaces/$workspaceId/sessions/$sessionId"
+                params={{ workspaceId: props.workspaceId, sessionId: session.id }}
+                className="min-w-0 max-w-full rounded-md hover:text-fg"
+                title={session.initialMessage}
+              >
+                <MetaChip className="hover:border-border-strong">
+                  session · {session.initialMessage}
+                </MetaChip>
+              </Link>
+            ))}
+            {props.attachedSessions.length > 4 ? (
+              <MetaChip>+{props.attachedSessions.length - 4} more sessions</MetaChip>
+            ) : null}
+            {props.attachedTasks.map((task) => (
+              <MetaChip key={task.id} title={task.name}>
+                task · {task.name}
+              </MetaChip>
+            ))}
+          </div>
         </div>
       ) : null}
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title={`Delete environment “${environment.name}”?`}
+        description="Its variables are removed and sessions can no longer use them. This can't be undone."
+        confirmLabel="Delete environment"
+        onConfirm={() => void props.onDelete()}
+      />
+      <ConfirmDialog
+        open={confirmDeleteVariable !== null}
+        onOpenChange={(next) => setConfirmDeleteVariable(next ? confirmDeleteVariable : null)}
+        title={`Delete variable “${confirmDeleteVariable ?? ""}”?`}
+        description="Sessions using this environment can no longer read it. This can't be undone."
+        confirmLabel="Delete variable"
+        onConfirm={async () => {
+          const name = confirmDeleteVariable;
+          if (!name) {
+            return;
+          }
+          const removed = await props.onDeleteVariable(name);
+          if (removed) {
+            toast.success(`Variable ${name} deleted`);
+          }
+        }}
+      />
     </article>
   );
 }

--- a/apps/web/src/routes/environments.tsx
+++ b/apps/web/src/routes/environments.tsx
@@ -421,7 +421,7 @@ function EnvironmentCard(props: {
         title={`Delete environment “${environment.name}”?`}
         description="Its variables are removed and sessions can no longer use them. This can't be undone."
         confirmLabel="Delete environment"
-        onConfirm={() => void props.onDelete()}
+        onConfirm={() => props.onDelete()}
       />
       <ConfirmDialog
         open={confirmDeleteVariable !== null}
@@ -438,6 +438,7 @@ function EnvironmentCard(props: {
           if (removed) {
             toast.success(`Variable ${name} deleted`);
           }
+          return removed;
         }}
       />
     </article>

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -163,7 +163,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
           type="button"
           variant="ghost"
           size="sm"
-          className="-ml-1 w-fit text-[color:var(--color-fg-muted)]"
+          className="-ml-1 w-fit text-fg-muted"
           onClick={() => setMode("token")}
         >
           <ArrowLeftIcon className="size-4" />
@@ -180,7 +180,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
           onCopyInstall={() => void navigator.clipboard.writeText(installCommand)}
           className="border-0 shadow-none"
         />
-        <p className="text-center text-[11px] leading-4 text-[color:var(--color-fg-muted)]">
+        <p className="text-center text-2xs text-fg-muted">
           Screen control is granted on the approval page when you confirm the code.
         </p>
       </div>
@@ -189,11 +189,11 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-[12px] leading-4 text-[color:var(--color-fg-muted)]">
+      <p className="text-[12px] leading-4 text-fg-muted">
         Run this on the machine you want to share. It enrolls instantly as an agent sandbox — no approval step.
       </p>
 
-      <label className="flex items-start gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/40 px-2.5 py-2 text-[12px] leading-4 text-[color:var(--color-fg)]">
+      <label className="flex items-start gap-2 rounded-md border border-border bg-bg/40 px-2.5 py-2 text-[12px] leading-4 text-fg">
         <input
           type="checkbox"
           className="mt-0.5"
@@ -203,16 +203,16 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
         />
         <span className="flex flex-col gap-0.5">
           <span className="flex items-center gap-1.5 font-medium">
-            <MonitorIcon className="size-3.5 text-[color:var(--color-fg-muted)]" />
+            <MonitorIcon className="size-3.5 text-fg-muted" />
             Allow screen control
           </span>
-          <span className="text-[11px] text-[color:var(--color-fg-muted)]">
+          <span className="text-2xs text-fg-muted">
             Let agents view and control this machine&apos;s screen (mouse + keyboard). Leave off for a headless sandbox.
           </span>
         </span>
       </label>
 
-      <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-[12px] leading-4 text-amber-200">
+      <div className="flex items-start gap-2 rounded-md border border-status-waiting/40 bg-status-waiting/10 p-2.5 text-[12px] leading-4 text-status-waiting">
         <AlertTriangleIcon className="mt-px size-3.5 shrink-0" />
         <span>
           <span className="font-semibold">Secret — copy it now.</span> This command embeds a one-time enroll token that
@@ -221,12 +221,12 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
       </div>
 
       {minting ? (
-        <div className="flex items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-2.5 text-[12px] text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 rounded-md border border-border bg-bg p-2.5 text-[12px] text-fg-muted">
           <Loader2Icon className="size-4 animate-spin" />
           Minting enroll token…
         </div>
       ) : error ? (
-        <div className="flex flex-col gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-2.5 text-[12px] leading-4 text-red-200">
+        <div className="flex flex-col gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2.5 text-[12px] leading-4 text-status-failed">
           <span>Could not create an enroll token. {error}</span>
           <Button
             type="button"
@@ -241,14 +241,14 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
         </div>
       ) : token ? (
         <>
-          <div className="flex items-center justify-between rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-2.5 py-1.5 text-[11px] text-[color:var(--color-fg-muted)]">
+          <div className="flex items-center justify-between rounded-md border border-border bg-surface-2/60 px-2.5 py-1.5 text-2xs text-fg-muted">
             <span>Expires {formatExpiry(token.expiresAt, token.expiresInSeconds)}</span>
             <Button type="button" variant="ghost" size="xs" onClick={() => void mint(allowScreenControl)} disabled={minting}>
               Regenerate
             </Button>
           </div>
-          <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-2.5">
-            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-4 text-[color:var(--color-fg)]">
+          <div className="rounded-md border border-border bg-bg p-2.5">
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-2xs text-fg">
               {command}
             </pre>
           </div>
@@ -259,19 +259,19 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
         </>
       ) : null}
 
-      <div className="mt-1 border-t border-[color:var(--color-border)] pt-3">
+      <div className="mt-1 border-t border-border pt-3">
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          className="w-full justify-between text-[color:var(--color-fg-muted)]"
+          className="w-full justify-between text-fg-muted"
           onClick={() => setMode("manual")}
         >
           <span className="flex items-center gap-2">
             <TerminalIcon className="size-4" />
             Approve manually instead
           </span>
-          <span className="text-[11px]">device flow</span>
+          <span className="text-2xs">device flow</span>
         </Button>
       </div>
     </div>

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -24,6 +24,8 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { OpenGeniApiError } from "@opengeni/sdk";
+
 import { apiBaseUrl } from "@/api";
 import { PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
@@ -84,6 +86,12 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   // (falling back to the page origin), never a hardcoded marketing domain.
   const origin = apiBaseUrl || (typeof window !== "undefined" ? window.location.origin : "");
 
+  // A 404 from the machines API means the deployment doesn't enable connected
+  // machines at all. That's a configuration fact, not a failure — render a calm
+  // explanation instead of a red load error with a pointless retry (mirrors the
+  // composer's handling in sessions-index).
+  const featureUnavailable = machines.error instanceof OpenGeniApiError && machines.error.status === 404;
+
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
       <PageHeader
@@ -93,17 +101,23 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       />
 
       <div className="mt-5">
-        <MachinesDashboard
-          machines={machines.machines}
-          activeSandboxId={machines.activeSandboxId}
-          loading={machines.loading}
-          error={machines.error}
-          onRefresh={() => void machines.refresh()}
-          onEnroll={() => setEnrollOpen(true)}
-          {...(machines.canAttach
-            ? { onAttach: (m) => void machines.attach(m.sandboxId), attachingSandboxId: machines.attachingSandboxId }
-            : {})}
-        />
+        {featureUnavailable ? (
+          <Notice tone="muted">
+            Connected machines aren't enabled on this deployment. Sessions run on the managed sandbox.
+          </Notice>
+        ) : (
+          <MachinesDashboard
+            machines={machines.machines}
+            activeSandboxId={machines.activeSandboxId}
+            loading={machines.loading}
+            error={machines.error}
+            onRefresh={() => void machines.refresh()}
+            onEnroll={() => setEnrollOpen(true)}
+            {...(machines.canAttach
+              ? { onAttach: (m) => void machines.attach(m.sandboxId), attachingSandboxId: machines.attachingSandboxId }
+              : {})}
+          />
+        )}
       </div>
 
       <Dialog open={enrollOpen} onOpenChange={setEnrollOpen}>

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -8,11 +8,11 @@
 import {
   EnrollmentDeviceFlow,
   MachinesDashboard,
+  connectionStatusForState,
   useMachines,
   type DeviceFlowPhase,
 } from "@opengeni/react/machines";
 import {
-  AlertTriangleIcon,
   ArrowLeftIcon,
   CheckIcon,
   CopyIcon,
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { apiBaseUrl } from "@/api";
 import { PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
+import { Notice } from "@/components/ui/notice";
 import { deviceVerificationUri, installOneLiner } from "@/lib/deployment";
 import {
   Dialog,
@@ -37,9 +38,47 @@ import {
 } from "@/components/ui/dialog";
 import { useAppContext } from "@/context";
 
+/** Copy to the clipboard and toast the outcome — clipboard access can be denied
+ *  (permissions, insecure context), so failures surface instead of vanishing. */
+async function copyToClipboard(text: string, successMessage: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+    return true;
+  } catch {
+    toast.error("Couldn't copy to the clipboard", { description: "Copy it manually instead." });
+    return false;
+  }
+}
+
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   const machines = useMachines({ pollIntervalMs: 5000 });
   const [enrollOpen, setEnrollOpen] = useState(false);
+
+  // "Machine connected" moment: watch the polled fleet and, once a machine first
+  // shows online (a fresh enrollment coming up, or a reconnect), toast it. The
+  // first poll seeds the baseline silently so existing machines don't announce.
+  const onlineSeenRef = useRef<Set<string> | null>(null);
+  useEffect(() => {
+    const online = new Set(
+      machines.machines
+        .filter((machine) => !machine.isSessionGroup && connectionStatusForState(machine.state) === "online")
+        .map((machine) => machine.sandboxId),
+    );
+    const previous = onlineSeenRef.current;
+    if (previous) {
+      for (const machine of machines.machines) {
+        if (
+          !machine.isSessionGroup &&
+          connectionStatusForState(machine.state) === "online" &&
+          !previous.has(machine.sandboxId)
+        ) {
+          toast.success(`${machine.name} connected`, { description: "It's ready to run sessions." });
+        }
+      }
+    }
+    onlineSeenRef.current = online;
+  }, [machines.machines]);
 
   // The install/approve URLs are deployment-relative: same origin as the API
   // (falling back to the page origin), never a hardcoded marketing domain.
@@ -50,7 +89,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       <PageHeader
         icon={<LaptopIcon className="size-4" />}
         title="Machines"
-        description="Your own computers, enrolled as agent sandboxes. Run the install one-liner on a machine and it appears here — driveable from any session alongside the Modal sandbox."
+        description="Your own computers, enrolled as agent sandboxes. Run the install one-liner on a machine and it appears here — usable from any session alongside the managed sandbox."
       />
 
       <div className="mt-5">
@@ -149,9 +188,11 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
     if (!command) {
       return;
     }
-    void navigator.clipboard.writeText(command);
-    setCopied(true);
-    toast.success("Install command copied");
+    void copyToClipboard(command, "Install command copied").then((ok) => {
+      if (ok) {
+        setCopied(true);
+      }
+    });
   }
 
   if (mode === "manual") {
@@ -177,7 +218,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
           verificationUri={verificationUri}
           installCommand={installCommand}
           phase={"pending" satisfies DeviceFlowPhase}
-          onCopyInstall={() => void navigator.clipboard.writeText(installCommand)}
+          onCopyInstall={() => void copyToClipboard(installCommand, "Install command copied")}
           className="border-0 shadow-none"
         />
         <p className="text-center text-2xs text-fg-muted">
@@ -189,11 +230,11 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-[12px] leading-4 text-fg-muted">
+      <p className="text-xs leading-4 text-fg-muted">
         Run this on the machine you want to share. It enrolls instantly as an agent sandbox — no approval step.
       </p>
 
-      <label className="flex items-start gap-2 rounded-md border border-border bg-bg/40 px-2.5 py-2 text-[12px] leading-4 text-fg">
+      <label className="flex items-start gap-2 rounded-md border border-border bg-bg/40 px-2.5 py-2 text-xs leading-4 text-fg">
         <input
           type="checkbox"
           className="mt-0.5"
@@ -212,33 +253,28 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
         </span>
       </label>
 
-      <div className="flex items-start gap-2 rounded-md border border-status-waiting/40 bg-status-waiting/10 p-2.5 text-[12px] leading-4 text-status-waiting">
-        <AlertTriangleIcon className="mt-px size-3.5 shrink-0" />
-        <span>
-          <span className="font-semibold">Secret — copy it now.</span> This command embeds a one-time enroll token that
-          grants enrollment into this workspace until it expires. Anyone who has it can enroll a machine here.
-        </span>
-      </div>
+      <Notice tone="waiting" title="Secret — copy it now">
+        This command embeds a one-time enroll token that grants enrollment into this workspace until it expires. Anyone
+        who has it can enroll a machine here.
+      </Notice>
 
       {minting ? (
-        <div className="flex items-center gap-2 rounded-md border border-border bg-bg p-2.5 text-[12px] text-fg-muted">
-          <Loader2Icon className="size-4 animate-spin" />
+        <Notice tone="muted" icon={<Loader2Icon className="size-4 animate-spin" />}>
           Minting enroll token…
-        </div>
+        </Notice>
       ) : error ? (
-        <div className="flex flex-col gap-2 rounded-md border border-status-failed/40 bg-status-failed/10 p-2.5 text-[12px] leading-4 text-status-failed">
-          <span>Could not create an enroll token. {error}</span>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={() => void mint(allowScreenControl)}
-          >
-            <TerminalIcon className="size-4" />
-            Try again
-          </Button>
-        </div>
+        <Notice
+          tone="failed"
+          title="Could not create an enroll token"
+          action={(
+            <Button type="button" variant="outline" size="sm" onClick={() => void mint(allowScreenControl)}>
+              <TerminalIcon className="size-4" />
+              Try again
+            </Button>
+          )}
+        >
+          {error}
+        </Notice>
       ) : token ? (
         <>
           <div className="flex items-center justify-between rounded-md border border-border bg-surface-2/60 px-2.5 py-1.5 text-2xs text-fg-muted">

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -33,6 +33,7 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
   const organizationLabel = accountId ? orgLabel(accountId, context.accessContext.accountGrants) : "Organization";
   const [billing, setBilling] = useState<BillingSummary | null>(null);
   const [billingError, setBillingError] = useState<Error | null>(null);
+  const [billingLoading, setBillingLoading] = useState(false);
   const [entitlements, setEntitlements] = useState<BillingEntitlementsResponse | null>(null);
   const [entitlementsError, setEntitlementsError] = useState<Error | null>(null);
   const [topupAmount, setTopupAmount] = useState("25.00");
@@ -71,12 +72,15 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
       setBillingError(null);
       return;
     }
+    setBillingLoading(true);
     try {
       setBilling(await client.getBilling({ accountId }));
       setBillingError(null);
     } catch (error) {
       setBilling(null);
       setBillingError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setBillingLoading(false);
     }
   }
 
@@ -145,14 +149,16 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-medium">Credits</h2>
-              <p className="mt-1 text-xs text-fg-muted">
+              <p className="mt-1 flex items-center gap-1.5 text-xs text-fg-muted">
                 {billing
                   ? `${formatMoneyMicros(billing.balance.balanceMicros, billing.balance.currency)} available`
                   : !canReadBilling || !accountId
-                    ? "This subject cannot read billing for the organization."
+                    ? "You don't have permission to view billing."
                     : billingError
-                      ? "Billing balance failed to load."
-                      : "Billing balance unavailable"}
+                      ? "Couldn't load your balance"
+                      : billingLoading
+                        ? <><Loader2Icon className="size-3.5 animate-spin" />Loading balance…</>
+                        : "Billing balance unavailable"}
               </p>
             </div>
             <span className="rounded-full border border-border px-2 py-1 text-xs text-fg-muted">
@@ -258,7 +264,7 @@ function EntitlementsSection(props: {
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-fg-subtle">This subject cannot read billing entitlements for the organization.</p>
+        <p className="text-xs text-fg-subtle">You don't have permission to view plan limits.</p>
       ) : props.error ? (
         <LoadErrorState title="Couldn't load entitlements" error={props.error} onRetry={props.onRetry} />
       ) : !props.entitlements ? (
@@ -298,7 +304,7 @@ function UsageSection(props: {
             <ActivityIcon className="size-3.5 text-brand" />
             Usage
           </h2>
-          <p className="mt-1 text-xs text-fg-muted">Recent metered events for this organization, straight from the billing ledger.</p>
+          <p className="mt-1 text-xs text-fg-muted">Recent metered usage for this organization.</p>
         </div>
         <Button type="button" variant="ghost" size="sm" disabled={!props.enabled || props.loading} onClick={props.onRefresh}>
           <RefreshCwIcon className={props.loading ? "size-3.5 animate-spin" : "size-3.5"} />
@@ -307,7 +313,7 @@ function UsageSection(props: {
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-fg-subtle">This subject cannot read billing usage for the organization.</p>
+        <p className="text-xs text-fg-subtle">You don't have permission to view usage.</p>
       ) : props.error && props.usage.length === 0 ? (
         // Honest failed-load state: a failed usage read must never render as
         // "No usage recorded yet." (usage already on screen keeps rendering).
@@ -318,7 +324,7 @@ function UsageSection(props: {
           Loading usage
         </div>
       ) : props.usage.length === 0 ? (
-        <p className="text-xs text-fg-subtle">No usage recorded yet.</p>
+        <p className="text-xs text-fg-subtle">No usage recorded yet</p>
       ) : (
         <>
           <div className="flex flex-wrap gap-2">
@@ -378,10 +384,10 @@ function MembersSection(props: { workspaceId: string; canManage: boolean; subjec
           </h2>
           <p className="mt-1 text-xs text-fg-muted">Who can act in this organization.</p>
         </div>
-        <Button asChild type="button" variant="ghost" size="sm">
+        <Button asChild type="button" variant="secondary" size="sm">
           <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId: props.workspaceId }}>
             <UsersIcon className="size-3.5" />
-            Manage members
+            People with access
           </Link>
         </Button>
       </div>

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -126,11 +126,11 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
           ) : undefined}
         />
 
-        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
               <h2 className="text-sm font-medium">Organization name</h2>
-              <p className="mt-1 truncate text-xs text-[color:var(--color-fg-muted)]">{organizationLabel}</p>
+              <p className="mt-1 truncate text-xs text-fg-muted">{organizationLabel}</p>
             </div>
             <Button asChild type="button" variant="ghost" size="sm">
               <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId }}>
@@ -141,11 +141,11 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
           </div>
         </section>
 
-        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-medium">Credits</h2>
-              <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+              <p className="mt-1 text-xs text-fg-muted">
                 {billing
                   ? `${formatMoneyMicros(billing.balance.balanceMicros, billing.balance.currency)} available`
                   : !canReadBilling || !accountId
@@ -155,7 +155,7 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
                       : "Billing balance unavailable"}
               </p>
             </div>
-            <span className="rounded-full border border-[color:var(--color-border)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]">
+            <span className="rounded-full border border-border px-2 py-1 text-xs text-fg-muted">
               {billing?.mode ?? "unknown"}
             </span>
           </div>
@@ -168,7 +168,7 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
                 <label className="grid gap-1">
                   <span className="sr-only">Credit amount</span>
                   <input
-                    className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 text-sm outline-none focus:border-[color:var(--color-fg-muted)]"
+                    className="h-9 rounded-md border border-border bg-bg px-3 text-sm outline-none focus:border-fg-muted"
                     inputMode="decimal"
                     min="5"
                     max="10000"
@@ -188,10 +188,10 @@ export function OrgSettingsRoute({ workspaceId, checkout }: { workspaceId: strin
                   </Button>
                 ))}
               </div>
-              <p className="text-xs text-[color:var(--color-fg-subtle)]">Minimum top-up is $5.00.</p>
+              <p className="text-xs text-fg-subtle">Minimum top-up is $5.00.</p>
             </div>
           ) : (
-            <p className="text-xs text-[color:var(--color-fg-subtle)]">Credit checkout is available when Stripe billing is enabled for this deployment.</p>
+            <p className="text-xs text-fg-subtle">Credit checkout is available when Stripe billing is enabled for this deployment.</p>
           )}
         </section>
 
@@ -243,37 +243,37 @@ function EntitlementsSection(props: {
 }) {
   const rows = props.entitlements ? entitlementEntries(props.entitlements.entitlements) : [];
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <GaugeIcon className="size-3.5 text-[color:var(--color-brand)]" />
+            <GaugeIcon className="size-3.5 text-brand" />
             Plan & entitlements
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">The limits and features this organization runs under.</p>
+          <p className="mt-1 text-xs text-fg-muted">The limits and features this organization runs under.</p>
         </div>
-        <span className="rounded-full border border-[color:var(--color-border)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]">
+        <span className="rounded-full border border-border px-2 py-1 text-xs text-fg-muted">
           {props.entitlements?.mode ?? "unknown"}
         </span>
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing entitlements for the organization.</p>
+        <p className="text-xs text-fg-subtle">This subject cannot read billing entitlements for the organization.</p>
       ) : props.error ? (
         <LoadErrorState title="Couldn't load entitlements" error={props.error} onRetry={props.onRetry} />
       ) : !props.entitlements ? (
-        <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
           Loading entitlements
         </div>
       ) : rows.length === 0 ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">No entitlement limits — this deployment does not restrict the organization.</p>
+        <p className="text-xs text-fg-subtle">No entitlement limits — this deployment does not restrict the organization.</p>
       ) : (
         <div className="flex flex-wrap gap-2">
           {rows.map((row) => (
-            <span key={row.name} className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-2 py-1 text-xs">
+            <span key={row.name} className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg/35 px-2 py-1 text-xs">
               <span className="font-medium">{row.name}</span>
-              <span className="font-mono text-[11px] text-[color:var(--color-fg-muted)]">{row.value}</span>
+              <span className="font-mono text-2xs text-fg-muted">{row.value}</span>
             </span>
           ))}
         </div>
@@ -291,14 +291,14 @@ function UsageSection(props: {
 }) {
   const summary = useMemo(() => aggregateUsage(props.usage), [props.usage]);
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <ActivityIcon className="size-3.5 text-[color:var(--color-brand)]" />
+            <ActivityIcon className="size-3.5 text-brand" />
             Usage
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Recent metered events for this organization, straight from the billing ledger.</p>
+          <p className="mt-1 text-xs text-fg-muted">Recent metered events for this organization, straight from the billing ledger.</p>
         </div>
         <Button type="button" variant="ghost" size="sm" disabled={!props.enabled || props.loading} onClick={props.onRefresh}>
           <RefreshCwIcon className={props.loading ? "size-3.5 animate-spin" : "size-3.5"} />
@@ -307,25 +307,25 @@ function UsageSection(props: {
       </div>
 
       {!props.enabled ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot read billing usage for the organization.</p>
+        <p className="text-xs text-fg-subtle">This subject cannot read billing usage for the organization.</p>
       ) : props.error && props.usage.length === 0 ? (
         // Honest failed-load state: a failed usage read must never render as
         // "No usage recorded yet." (usage already on screen keeps rendering).
         <LoadErrorState title="Couldn't load usage" error={props.error} onRetry={props.onRefresh} />
       ) : props.loading && props.usage.length === 0 ? (
-        <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+        <div className="flex items-center gap-2 text-xs text-fg-muted">
           <Loader2Icon className="size-3.5 animate-spin" />
           Loading usage
         </div>
       ) : props.usage.length === 0 ? (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">No usage recorded yet.</p>
+        <p className="text-xs text-fg-subtle">No usage recorded yet.</p>
       ) : (
         <>
           <div className="flex flex-wrap gap-2">
             {summary.map((entry) => (
-              <span key={`${entry.eventType}:${entry.unit}`} className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-2 py-1 text-xs">
+              <span key={`${entry.eventType}:${entry.unit}`} className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg/35 px-2 py-1 text-xs">
                 <span className="font-medium">{entry.eventType}</span>
-                <span className="font-mono text-[11px] text-[color:var(--color-fg-muted)]">
+                <span className="font-mono text-2xs text-fg-muted">
                   {Number.isInteger(entry.total) ? entry.total : entry.total.toFixed(4)} {entry.unit}
                 </span>
               </span>
@@ -333,7 +333,7 @@ function UsageSection(props: {
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full border-collapse text-left text-xs">
-              <thead className="border-b border-[color:var(--color-border)] text-[color:var(--color-fg)]">
+              <thead className="border-b border-border text-fg">
                 <tr>
                   <th className="whitespace-nowrap px-2 py-1.5 font-medium">Event</th>
                   <th className="whitespace-nowrap px-2 py-1.5 font-medium">Quantity</th>
@@ -341,17 +341,17 @@ function UsageSection(props: {
                   <th className="whitespace-nowrap px-2 py-1.5 font-medium">Occurred</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-[color:var(--color-border)]/70">
+              <tbody className="divide-y divide-border/70">
                 {props.usage.slice(0, 30).map((event) => (
                   <tr key={event.id}>
-                    <td className="px-2 py-1.5 text-[color:var(--color-fg-muted)]">{event.eventType}</td>
-                    <td className="whitespace-nowrap px-2 py-1.5 font-mono text-[color:var(--color-fg-muted)]">
+                    <td className="px-2 py-1.5 text-fg-muted">{event.eventType}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 font-mono text-fg-muted">
                       {Number.isInteger(event.quantity) ? event.quantity : event.quantity.toFixed(6)} {event.unit}
                     </td>
-                    <td className="max-w-44 truncate px-2 py-1.5 font-mono text-[10px] text-[color:var(--color-fg-subtle)]">
+                    <td className="max-w-44 truncate px-2 py-1.5 font-mono text-2xs text-fg-subtle">
                       {event.sourceResourceType ? `${event.sourceResourceType}:${event.sourceResourceId ?? ""}` : "—"}
                     </td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-[color:var(--color-fg-subtle)]">{formatTimestamp(event.occurredAt)}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-fg-subtle">{formatTimestamp(event.occurredAt)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -369,14 +369,14 @@ function UsageSection(props: {
  *  access; this read-only card stays honest by showing only the caller. */
 function MembersSection(props: { workspaceId: string; canManage: boolean; subjectLabel: string; role: string | null }) {
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <UsersIcon className="size-3.5 text-[color:var(--color-brand)]" />
+            <UsersIcon className="size-3.5 text-brand" />
             Members
           </h2>
-          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Who can act in this organization.</p>
+          <p className="mt-1 text-xs text-fg-muted">Who can act in this organization.</p>
         </div>
         <Button asChild type="button" variant="ghost" size="sm">
           <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId: props.workspaceId }}>
@@ -385,16 +385,16 @@ function MembersSection(props: { workspaceId: string; canManage: boolean; subjec
           </Link>
         </Button>
       </div>
-      <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2">
         <div className="min-w-0">
           <div className="truncate text-sm font-medium">{props.subjectLabel}</div>
-          <div className="mt-0.5 truncate text-xs text-[color:var(--color-fg-subtle)]">You{props.role ? ` · ${props.role}` : ""}</div>
+          <div className="mt-0.5 truncate text-xs text-fg-subtle">You{props.role ? ` · ${props.role}` : ""}</div>
         </div>
-        <span className="shrink-0 rounded-full border border-[color:var(--color-border)] px-2 py-1 text-xs text-[color:var(--color-fg-muted)]">
+        <span className="shrink-0 rounded-full border border-border px-2 py-1 text-xs text-fg-muted">
           {props.role ?? "member"}
         </span>
       </div>
-      <p className="text-xs text-[color:var(--color-fg-subtle)]">
+      <p className="text-xs text-fg-subtle">
         Access is granted per workspace. Manage members in Workspace settings → People with access.
         {props.canManage ? "" : " Only organization admins can change organization-level roles."}
       </p>

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   BotIcon,
   CalendarClockIcon,
+  ChevronDownIcon,
   HistoryIcon,
   Loader2Icon,
   PauseIcon,
@@ -17,12 +18,17 @@ import {
 import { useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
-import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { ScheduledTaskRepositoryPicker } from "@/components/repository-picker";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MetaChip } from "@/components/ui/meta-chip";
+import { Notice } from "@/components/ui/notice";
 import { Select } from "@/components/ui/select";
+import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext } from "@/context";
 import { formatTimestamp } from "@/lib/format";
 import { listViewState } from "@/lib/load-state";
@@ -46,10 +52,15 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<Error | null>(null);
   const [runs, setRuns] = useState<Record<string, ScheduledTaskRun[]>>({});
+  // Per-task run-history load failures, so a failed history fetch shows an
+  // error with retry instead of a false "No runs yet".
+  const [runErrors, setRunErrors] = useState<Record<string, boolean>>({});
+  const [reloadingRunsFor, setReloadingRunsFor] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [historyTaskId, setHistoryTaskId] = useState<string | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<ScheduledTask | null>(null);
   const canAttachOpenGeniTool = context.clientConfig.mcpServers.some((server) => server.id === "opengeni");
   // Honest list state: the initial fetch renders as loading and a failed load
   // as an error with retry — never as the "No scheduled tasks." empty state.
@@ -69,14 +80,38 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
       const next = await client.listScheduledTasks(workspaceId);
       setTasks(next);
       setLoadError(null);
-      const entries = await Promise.all(next.slice(0, 12).map(async (task) =>
-        [task.id, await client.listScheduledTaskRuns(workspaceId, task.id).catch(() => [] as ScheduledTaskRun[])] as const));
-      setRuns(Object.fromEntries(entries));
+      // Track each task's run-history load outcome separately: a failed history
+      // fetch must surface as an error row, never as a false "No runs yet".
+      const entries = await Promise.all(next.slice(0, 12).map(async (task) => {
+        try {
+          return [task.id, { runs: await client.listScheduledTaskRuns(workspaceId, task.id), error: false }] as const;
+        } catch {
+          return [task.id, { runs: [] as ScheduledTaskRun[], error: true }] as const;
+        }
+      }));
+      setRuns(Object.fromEntries(entries.map(([id, value]) => [id, value.runs])));
+      setRunErrors(Object.fromEntries(entries.map(([id, value]) => [id, value.error])));
     } catch (error) {
       setLoadError(error instanceof Error ? error : new Error(String(error)));
       toast.error("Failed to load scheduled tasks", { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setLoading(false);
+    }
+  }
+
+  // Retry a single task's run history after a failed load, without reloading
+  // the whole list.
+  async function reloadRuns(taskId: string) {
+    setReloadingRunsFor(taskId);
+    try {
+      const taskRuns = await client.listScheduledTaskRuns(workspaceId, taskId);
+      setRuns((current) => ({ ...current, [taskId]: taskRuns }));
+      setRunErrors((current) => ({ ...current, [taskId]: false }));
+    } catch (error) {
+      setRunErrors((current) => ({ ...current, [taskId]: true }));
+      toast.error("Couldn't load run history", { description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setReloadingRunsFor(null);
     }
   }
 
@@ -132,6 +167,13 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
     }
   }
 
+  const ACTION_ERROR: Record<"pause" | "resume" | "trigger" | "delete", string> = {
+    pause: "Couldn't pause the task",
+    resume: "Couldn't resume the task",
+    trigger: "Couldn't run the task",
+    delete: "Couldn't delete the task",
+  };
+
   async function taskAction(task: ScheduledTask, action: "pause" | "resume" | "trigger" | "delete") {
     setBusyTaskId(task.id);
     try {
@@ -149,7 +191,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
       }
       await refresh();
     } catch (error) {
-      toast.error("Scheduled task action failed", { description: error instanceof Error ? error.message : String(error) });
+      toast.error(ACTION_ERROR[action], { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setBusyTaskId(null);
     }
@@ -163,21 +205,21 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
         description="Recurring or one-shot agent runs with run history per task."
         actions={(
           <>
-            <Button type="button" variant="ghost" size="sm" onClick={() => void refresh()} className="h-9">
-              <RefreshCwIcon className="size-3.5" />
+            <Button type="button" variant="ghost" size="sm" onClick={() => void refresh()} disabled={loading} className="h-9 pointer-coarse:min-h-10">
+              <RefreshCwIcon className={cn("size-3.5", loading && "animate-spin")} />
               Refresh
             </Button>
             <Button
               type="button"
               size="sm"
-              className="h-9"
+              className="h-9 pointer-coarse:min-h-10"
               onClick={() => {
                 setOpen((value) => !value);
                 setEditingTaskId(null);
               }}
             >
               <PlusIcon className="size-3.5" />
-              New
+              New schedule
             </Button>
           </>
         )}
@@ -204,7 +246,24 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
         ) : tasksView === "error" ? (
           <LoadErrorState title="Couldn't load scheduled tasks" error={loadError} onRetry={() => void refresh()} />
         ) : tasksView === "empty" ? (
-          <EmptyState>No scheduled tasks.</EmptyState>
+          <EmptyState
+            icon={<CalendarClockIcon className="size-4" />}
+            title="No scheduled tasks yet"
+            description="Create one to run the agent on a schedule — recurring or one-shot."
+            action={(
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => {
+                  setOpen(true);
+                  setEditingTaskId(null);
+                }}
+              >
+                <PlusIcon className="size-3.5" />
+                New schedule
+              </Button>
+            )}
+          />
         ) : tasks.map((task) => {
           const taskRuns = runs[task.id] ?? [];
           const lastRun = summarizeLastRun(taskRuns);
@@ -214,16 +273,9 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="truncate text-sm font-medium">{task.name}</span>
-                    <span
-                      className={cn(
-                        "shrink-0 rounded-full border px-1.5 py-0.5 text-2xs font-medium",
-                        task.status === "active"
-                          ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
-                          : "border-status-waiting/30 bg-status-waiting/10 text-status-waiting",
-                      )}
-                    >
-                      {task.status}
-                    </span>
+                    <MetaChip dot={task.status === "active" ? "idle" : "waiting"} rounded="full">
+                      {task.status === "active" ? "Active" : "Paused"}
+                    </MetaChip>
                   </div>
                   <div className="mt-1 text-xs text-fg-subtle">
                     {scheduleLabel(task.schedule)} · {task.runMode.replaceAll("_", " ")}
@@ -301,7 +353,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
                   onSubmit={(form) => void saveTask(task, form)}
                   onCancel={() => setEditingTaskId(null)}
                   secondaryActions={(
-                    <Button type="button" variant="destructive" size="sm" disabled={busyTaskId === task.id} onClick={() => void taskAction(task, "delete")}>
+                    <Button type="button" variant="destructive" size="sm" disabled={busyTaskId === task.id} onClick={() => setConfirmDelete(task)}>
                       <Trash2Icon className="size-3.5" />
                       Delete
                     </Button>
@@ -311,8 +363,26 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
 
               {historyTaskId === task.id ? (
                 <div className="mt-3 border-t border-border pt-2">
-                  {taskRuns.length === 0 ? (
-                    <p className="px-1 py-2 text-xs text-fg-subtle">No runs recorded for this task yet.</p>
+                  {runErrors[task.id] ? (
+                    <Notice
+                      tone="failed"
+                      action={(
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          disabled={reloadingRunsFor === task.id}
+                          onClick={() => void reloadRuns(task.id)}
+                        >
+                          {reloadingRunsFor === task.id ? <Loader2Icon className="size-3 animate-spin" /> : <RefreshCwIcon className="size-3" />}
+                          Retry
+                        </Button>
+                      )}
+                    >
+                      Couldn't load this task's run history.
+                    </Notice>
+                  ) : taskRuns.length === 0 ? (
+                    <p className="px-1 py-2 text-xs text-fg-subtle">No runs yet</p>
                   ) : (
                     <ol className="grid gap-1" aria-label={`${task.name} run history`}>
                       {taskRuns.map((run) => (
@@ -326,14 +396,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
                             className="flex w-full items-center justify-between gap-2 rounded border border-border px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-surface-2 disabled:opacity-60"
                           >
                             <span className="flex min-w-0 items-center gap-2">
-                              <span
-                                className={cn(
-                                  "size-2 shrink-0 rounded-full",
-                                  run.status === "dispatched" && "bg-status-idle",
-                                  run.status === "failed" && "bg-status-failed",
-                                  run.status === "queued" && "bg-status-waiting",
-                                )}
-                              />
+                              <StatusDot tone={runStatusTone(run.status)} />
                               <span className="shrink-0">{run.triggerType}</span>
                               <span className="shrink-0">{run.status}</span>
                               {run.error ? <span className="min-w-0 truncate text-status-failed">{run.error}</span> : null}
@@ -351,8 +414,28 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
           );
         })}
       </div>
+
+      <ConfirmDialog
+        open={confirmDelete !== null}
+        onOpenChange={(next) => (next ? undefined : setConfirmDelete(null))}
+        title={confirmDelete ? `Delete “${confirmDelete.name}”?` : "Delete scheduled task?"}
+        description="This deletes the schedule and stops future runs. Sessions it already created are kept."
+        confirmLabel="Delete task"
+        onConfirm={async () => {
+          if (confirmDelete) {
+            await taskAction(confirmDelete, "delete");
+            setConfirmDelete(null);
+          }
+        }}
+      />
     </div>
   );
+}
+
+function runStatusTone(status: ScheduledTaskRun["status"]): StatusTone {
+  if (status === "dispatched") return "idle";
+  if (status === "failed") return "failed";
+  return "waiting";
 }
 
 function ScheduledTaskForm(props: {
@@ -385,18 +468,15 @@ function ScheduledTaskForm(props: {
             onChange={(event) => update("scheduleType", event.target.value as ScheduledTaskFormState["scheduleType"])}
           >
             <option value="once">Once</option>
-            <option value="interval">Interval</option>
-            <option value="calendar">Daily</option>
+            <option value="interval">Repeat on an interval</option>
+            <option value="calendar">Daily at a time</option>
           </Select>
         </div>
       </div>
-      <textarea
-        value={form.prompt}
-        onChange={(event) => update("prompt", event.target.value)}
-        className="min-h-20 rounded-md border border-border bg-bg px-3 py-2 text-sm"
-        placeholder="What should the agent do on schedule?"
-      />
-      <div className="grid gap-2 sm:grid-cols-3">
+      <div className="grid gap-1.5">
+        <Label>
+          {form.scheduleType === "once" ? "Run at" : form.scheduleType === "interval" ? "Every (minutes)" : "Time of day"}
+        </Label>
         {form.scheduleType === "once" ? (
           <Input type="datetime-local" value={form.runAt} onChange={(event) => update("runAt", event.target.value)} />
         ) : form.scheduleType === "interval" ? (
@@ -404,41 +484,69 @@ function ScheduledTaskForm(props: {
         ) : (
           <Input type="time" value={form.calendarTime} onChange={(event) => update("calendarTime", event.target.value)} />
         )}
-        <Select
-          value={form.runMode}
-          onChange={(event) => update("runMode", event.target.value as ScheduledTask["runMode"])}
-        >
-          <option value="new_session_per_run">New session per run</option>
-          <option value="reusable_session">Reusable session</option>
-        </Select>
-        <Select
-          value={form.overlapPolicy}
-          onChange={(event) => update("overlapPolicy", event.target.value as ScheduledTask["overlapPolicy"])}
-        >
-          <option value="allow_concurrent">Allow concurrent</option>
-          <option value="skip">Skip overlapping</option>
-          <option value="buffer_one">Buffer one</option>
-        </Select>
       </div>
-      <label className="flex items-center gap-2 text-xs text-fg-muted">
-        <input
-          type="checkbox"
-          checked={form.includeOpenGeniTool}
-          disabled={!props.canAttachOpenGeniTool}
-          onChange={(event) => update("includeOpenGeniTool", event.target.checked)}
+      <div className="grid gap-1.5">
+        <Label>Prompt</Label>
+        <textarea
+          value={form.prompt}
+          onChange={(event) => update("prompt", event.target.value)}
+          className="min-h-20 rounded-md border border-border bg-bg px-3 py-2 text-sm"
+          placeholder="What should the agent do on schedule?"
         />
-        Attach OpenGeni MCP tool
-      </label>
-      <ScheduledTaskRepositoryPicker
-        configured={context.githubStatus?.configured === true}
-        repositories={context.githubRepos}
-        groups={context.repositoryGroups}
-        resources={form.resources}
-        busy={props.busy}
-        repoBusy={context.repoBusy}
-        onRefresh={() => context.refreshGitHub(props.workspaceId, undefined, { sync: true })}
-        onResourcesChange={(resources) => update("resources", resources)}
-      />
+      </div>
+
+      <details className="group rounded-md border border-border bg-surface/30 transition-colors open:bg-surface/50">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+          <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+          <span>Advanced</span>
+          <span className="text-fg-subtle/70">·</span>
+          <span className="truncate">session reuse, overlaps, tools, repositories</span>
+        </summary>
+        <div className="grid gap-3 px-3 pb-3">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-1.5">
+              <Label>Session</Label>
+              <Select
+                value={form.runMode}
+                onChange={(event) => update("runMode", event.target.value as ScheduledTask["runMode"])}
+              >
+                <option value="new_session_per_run">New session each run</option>
+                <option value="reusable_session">Reuse one session</option>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label>If a run is still going</Label>
+              <Select
+                value={form.overlapPolicy}
+                onChange={(event) => update("overlapPolicy", event.target.value as ScheduledTask["overlapPolicy"])}
+              >
+                <option value="allow_concurrent">Run both at once</option>
+                <option value="skip">Skip the new run</option>
+                <option value="buffer_one">Queue one run</option>
+              </Select>
+            </div>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-fg-muted">
+            <input
+              type="checkbox"
+              checked={form.includeOpenGeniTool}
+              disabled={!props.canAttachOpenGeniTool}
+              onChange={(event) => update("includeOpenGeniTool", event.target.checked)}
+            />
+            Let the agent use OpenGeni tools
+          </label>
+          <ScheduledTaskRepositoryPicker
+            configured={context.githubStatus?.configured === true}
+            repositories={context.githubRepos}
+            groups={context.repositoryGroups}
+            resources={form.resources}
+            busy={props.busy}
+            repoBusy={context.repoBusy}
+            onRefresh={() => context.refreshGitHub(props.workspaceId, undefined, { sync: true })}
+            onResourcesChange={(resources) => update("resources", resources)}
+          />
+        </div>
+      </details>
       <div className="flex flex-wrap items-center justify-end gap-2">
         {props.onCancel ? (
           <Button type="button" variant="ghost" size="sm" disabled={props.busy} onClick={props.onCancel}>

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -190,8 +190,10 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
         toast.success("Scheduled task deleted");
       }
       await refresh();
+      return true;
     } catch (error) {
       toast.error(ACTION_ERROR[action], { description: error instanceof Error ? error.message : String(error) });
+      return false;
     } finally {
       setBusyTaskId(null);
     }
@@ -421,12 +423,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
         title={confirmDelete ? `Delete “${confirmDelete.name}”?` : "Delete scheduled task?"}
         description="This deletes the schedule and stops future runs. Sessions it already created are kept."
         confirmLabel="Delete task"
-        onConfirm={async () => {
-          if (confirmDelete) {
-            await taskAction(confirmDelete, "delete");
-            setConfirmDelete(null);
-          }
-        }}
+        onConfirm={() => (confirmDelete ? taskAction(confirmDelete, "delete") : false)}
       />
     </div>
   );

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -22,6 +22,7 @@ import { ScheduledTaskRepositoryPicker } from "@/components/repository-picker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 import { formatTimestamp } from "@/lib/format";
 import { listViewState } from "@/lib/load-state";
@@ -196,7 +197,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
 
       <div className="mt-4 grid gap-2">
         {tasksView === "loading" ? (
-          <div className="flex items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/45 p-4 text-sm text-[color:var(--color-fg-muted)]">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface/45 p-4 text-sm text-fg-muted">
             <Loader2Icon className="size-4 animate-spin" />
             Loading scheduled tasks
           </div>
@@ -208,30 +209,30 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
           const taskRuns = runs[task.id] ?? [];
           const lastRun = summarizeLastRun(taskRuns);
           return (
-            <div key={task.id} className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3">
+            <div key={task.id} className="rounded-lg border border-border bg-surface p-3">
               <div className="flex min-w-0 items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="truncate text-sm font-medium">{task.name}</span>
                     <span
                       className={cn(
-                        "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                        "shrink-0 rounded-full border px-1.5 py-0.5 text-2xs font-medium",
                         task.status === "active"
-                          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                          : "border-amber-500/30 bg-amber-500/10 text-amber-200",
+                          ? "border-status-idle/30 bg-status-idle/10 text-status-idle"
+                          : "border-status-waiting/30 bg-status-waiting/10 text-status-waiting",
                       )}
                     >
                       {task.status}
                     </span>
                   </div>
-                  <div className="mt-1 text-xs text-[color:var(--color-fg-subtle)]">
+                  <div className="mt-1 text-xs text-fg-subtle">
                     {scheduleLabel(task.schedule)} · {task.runMode.replaceAll("_", " ")}
                   </div>
                   {lastRun ? (
                     <div
                       className={cn(
-                        "mt-1 truncate text-[11px]",
-                        lastRun.tone === "failed" ? "text-red-300" : lastRun.tone === "pending" ? "text-amber-200" : "text-[color:var(--color-fg-subtle)]",
+                        "mt-1 truncate text-2xs",
+                        lastRun.tone === "failed" ? "text-status-failed" : lastRun.tone === "pending" ? "text-status-waiting" : "text-fg-subtle",
                       )}
                     >
                       {lastRun.label}
@@ -260,7 +261,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
                   >
                     <HistoryIcon className="size-3.5" />
                     Runs
-                    {taskRuns.length > 0 ? <span className="ml-1 rounded-full border border-[color:var(--color-border)] px-1.5 py-0.5 text-[10px]">{taskRuns.length}</span> : null}
+                    {taskRuns.length > 0 ? <span className="ml-1 rounded-full border border-border px-1.5 py-0.5 text-2xs">{taskRuns.length}</span> : null}
                   </Button>
                   <Button
                     type="button"
@@ -309,9 +310,9 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
               ) : null}
 
               {historyTaskId === task.id ? (
-                <div className="mt-3 border-t border-[color:var(--color-border)] pt-2">
+                <div className="mt-3 border-t border-border pt-2">
                   {taskRuns.length === 0 ? (
-                    <p className="px-1 py-2 text-xs text-[color:var(--color-fg-subtle)]">No runs recorded for this task yet.</p>
+                    <p className="px-1 py-2 text-xs text-fg-subtle">No runs recorded for this task yet.</p>
                   ) : (
                     <ol className="grid gap-1" aria-label={`${task.name} run history`}>
                       {taskRuns.map((run) => (
@@ -322,21 +323,21 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
                             onClick={() => run.sessionId
                               ? void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: run.sessionId } })
                               : undefined}
-                            className="flex w-full items-center justify-between gap-2 rounded border border-[color:var(--color-border)] px-2 py-1.5 text-left text-xs text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-surface-2)] disabled:opacity-60"
+                            className="flex w-full items-center justify-between gap-2 rounded border border-border px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-surface-2 disabled:opacity-60"
                           >
                             <span className="flex min-w-0 items-center gap-2">
                               <span
                                 className={cn(
                                   "size-2 shrink-0 rounded-full",
-                                  run.status === "dispatched" && "bg-emerald-400",
-                                  run.status === "failed" && "bg-red-400",
-                                  run.status === "queued" && "bg-amber-300",
+                                  run.status === "dispatched" && "bg-status-idle",
+                                  run.status === "failed" && "bg-status-failed",
+                                  run.status === "queued" && "bg-status-waiting",
                                 )}
                               />
                               <span className="shrink-0">{run.triggerType}</span>
                               <span className="shrink-0">{run.status}</span>
-                              {run.error ? <span className="min-w-0 truncate text-red-300">{run.error}</span> : null}
-                              {run.sessionId ? <span className="min-w-0 truncate font-mono text-[10px] text-[color:var(--color-fg-subtle)]">{run.sessionId}</span> : null}
+                              {run.error ? <span className="min-w-0 truncate text-status-failed">{run.error}</span> : null}
+                              {run.sessionId ? <span className="min-w-0 truncate font-mono text-2xs text-fg-subtle">{run.sessionId}</span> : null}
                             </span>
                             <span className="shrink-0">{formatTimestamp(run.firedAt)}</span>
                           </button>
@@ -371,7 +372,7 @@ function ScheduledTaskForm(props: {
   };
 
   return (
-    <div className="mt-4 grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3">
+    <div className="mt-4 grid gap-3 rounded-lg border border-border bg-surface p-3">
       <div className="grid gap-2 sm:grid-cols-2">
         <div className="grid gap-1.5">
           <Label>Name</Label>
@@ -379,21 +380,20 @@ function ScheduledTaskForm(props: {
         </div>
         <div className="grid gap-1.5">
           <Label>Schedule</Label>
-          <select
-            className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
+          <Select
             value={form.scheduleType}
             onChange={(event) => update("scheduleType", event.target.value as ScheduledTaskFormState["scheduleType"])}
           >
             <option value="once">Once</option>
             <option value="interval">Interval</option>
             <option value="calendar">Daily</option>
-          </select>
+          </Select>
         </div>
       </div>
       <textarea
         value={form.prompt}
         onChange={(event) => update("prompt", event.target.value)}
-        className="min-h-20 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm"
+        className="min-h-20 rounded-md border border-border bg-bg px-3 py-2 text-sm"
         placeholder="What should the agent do on schedule?"
       />
       <div className="grid gap-2 sm:grid-cols-3">
@@ -404,25 +404,23 @@ function ScheduledTaskForm(props: {
         ) : (
           <Input type="time" value={form.calendarTime} onChange={(event) => update("calendarTime", event.target.value)} />
         )}
-        <select
-          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
+        <Select
           value={form.runMode}
           onChange={(event) => update("runMode", event.target.value as ScheduledTask["runMode"])}
         >
           <option value="new_session_per_run">New session per run</option>
           <option value="reusable_session">Reusable session</option>
-        </select>
-        <select
-          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-sm"
+        </Select>
+        <Select
           value={form.overlapPolicy}
           onChange={(event) => update("overlapPolicy", event.target.value as ScheduledTask["overlapPolicy"])}
         >
           <option value="allow_concurrent">Allow concurrent</option>
           <option value="skip">Skip overlapping</option>
           <option value="buffer_one">Buffer one</option>
-        </select>
+        </Select>
       </div>
-      <label className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+      <label className="flex items-center gap-2 text-xs text-fg-muted">
         <input
           type="checkbox"
           checked={form.includeOpenGeniTool}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1,7 +1,7 @@
 // The session view — the console's centerpiece. Live timeline on the left;
 // the session rail (turn queue + goal, or debug inspector) on the right.
 // The composer is queue-by-default with explicit steer; failed sessions stay
-// honest (reason + re-dispatch history) and revivable from the same composer.
+// honest (reason + retry history) and revivable from the same composer.
 import {
   MessageTimeline,
   projectPendingApprovals,
@@ -17,7 +17,7 @@ import {
   type UserMessageItem,
 } from "@opengeni/react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { CheckIcon, XIcon } from "lucide-react";
+import { CheckIcon, Loader2Icon, MessagesSquareIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -40,6 +40,8 @@ import { SessionInspector } from "@/components/session/inspector";
 import { QueueRail } from "@/components/session/queue-rail";
 import { useSandboxWorkspaceTabs } from "@/components/session/sandbox-workspace";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Notice } from "@/components/ui/notice";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { WorkspaceDock, type WorkspaceTab } from "@opengeni/react";
 import { useAppContext } from "@/context";
@@ -153,8 +155,8 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       onClearView={clearView}
       onOpenSession={(nextSessionId) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: nextSessionId } })}
       onNewSession={() => void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } })}
-      onApprove={(approvalId) => void approve(approvalId, "approve")}
-      onReject={(approvalId) => void approve(approvalId, "reject")}
+      onApprove={(approvalId) => approve(approvalId, "approve")}
+      onReject={(approvalId) => approve(approvalId, "reject")}
     />
   );
 
@@ -179,7 +181,8 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     try {
       await context.client.sendApprovalDecision(workspaceId, sessionId, { approvalId, decision });
     } catch (error) {
-      toast.error("Failed to submit the approval decision", { description: error instanceof Error ? error.message : String(error) });
+      toast.error("Couldn't submit the decision", { description: error instanceof Error ? error.message : String(error) });
+      throw error instanceof Error ? error : new Error(String(error));
     }
   }
 }
@@ -256,12 +259,38 @@ function SessionChatPane(props: {
   onClearView: () => void;
   onOpenSession: (sessionId: string) => void;
   onNewSession: () => void;
-  onApprove: (approvalId: string) => void;
-  onReject: (approvalId: string) => void;
+  onApprove: (approvalId: string) => Promise<void>;
+  onReject: (approvalId: string) => Promise<void>;
 }) {
   const context = useAppContext();
   const codexModels = useCodexModels(props.session.workspaceId);
   const terminal = isTerminalSessionStatus(props.session.status);
+  // Per-approval decision state: an in-flight decision disables both buttons for
+  // that approval and shows progress; a settled one can never double-submit even
+  // if the strip lingers for a beat before the status flips.
+  const [approvalPending, setApprovalPending] = useState<Record<string, "approve" | "reject">>({});
+  const [approvalSettled, setApprovalSettled] = useState<Record<string, "approve" | "reject">>({});
+  const decideApproval = useCallback(
+    async (approvalId: string, decision: "approve" | "reject") => {
+      if (approvalPending[approvalId] || approvalSettled[approvalId]) {
+        return;
+      }
+      setApprovalPending((current) => ({ ...current, [approvalId]: decision }));
+      try {
+        await (decision === "approve" ? props.onApprove(approvalId) : props.onReject(approvalId));
+        setApprovalSettled((current) => ({ ...current, [approvalId]: decision }));
+      } catch {
+        // The route already surfaced a toast; leave the buttons live to retry.
+      } finally {
+        setApprovalPending((current) => {
+          const next = { ...current };
+          delete next[approvalId];
+          return next;
+        });
+      }
+    },
+    [approvalPending, approvalSettled, props],
+  );
   // Workspace-scoped: the provider (mounted on the workspace route) supplies
   // the workspaceId, so the hook needs no positional argument.
   const attachments = useFileAttachments();
@@ -334,9 +363,12 @@ function SessionChatPane(props: {
               renderMessageText={renderMessageText}
               onOpenSession={props.onOpenSession}
               emptyState={(
-                <div className="grid min-h-[24rem] place-items-center rounded-lg border border-dashed border-border text-sm text-fg-subtle">
-                  Waiting for session activity
-                </div>
+                <EmptyState
+                  className="min-h-[24rem]"
+                  icon={<MessagesSquareIcon className="size-4" />}
+                  title="Waiting for the first step"
+                  description="The agent's steps will appear here as it works."
+                />
               )}
             />
           </div>
@@ -349,24 +381,29 @@ function SessionChatPane(props: {
       {props.approvals.length > 0 && props.session.status === "requires_action" ? (
         <div className="mx-auto w-full max-w-3xl shrink-0 px-4 sm:px-6">
           <div className="grid max-h-64 gap-3 overflow-y-auto pb-2">
-            {props.approvals.map((approval) => (
-              <div key={approval.id} className="rounded-lg border border-status-waiting/40 bg-status-waiting/10 p-3">
-                <div className="text-sm font-medium">{approval.name}</div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded-md bg-bg p-3 text-xs text-fg-muted">
-                  {JSON.stringify(approval.arguments ?? approval.raw ?? {}, null, 2)}
-                </pre>
-                <div className="mt-3 flex justify-end gap-2">
-                  <Button size="sm" onClick={() => props.onApprove(approval.id)}>
-                    <CheckIcon className="size-3.5" />
-                    Approve
-                  </Button>
-                  <Button size="sm" variant="destructive" onClick={() => props.onReject(approval.id)}>
-                    <XIcon className="size-3.5" />
-                    Reject
-                  </Button>
-                </div>
-              </div>
-            ))}
+            {props.approvals.map((approval) => {
+              const pending = approvalPending[approval.id];
+              const settled = approvalSettled[approval.id];
+              const busy = Boolean(pending) || Boolean(settled);
+              const payload = JSON.stringify(approval.arguments ?? approval.raw ?? {}, null, 2);
+              return (
+                <Notice key={approval.id} tone="waiting" title={approval.name}>
+                  <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-2/60 p-2.5 font-mono text-xs leading-5 text-fg-muted">
+                    {payload}
+                  </pre>
+                  <div className="mt-3 flex justify-end gap-2">
+                    <Button size="sm" disabled={busy} onClick={() => void decideApproval(approval.id, "approve")}>
+                      {pending === "approve" ? <Loader2Icon className="size-3.5 animate-spin" /> : <CheckIcon className="size-3.5" />}
+                      {settled === "approve" ? "Approved" : "Approve"}
+                    </Button>
+                    <Button size="sm" variant="destructive" disabled={busy} onClick={() => void decideApproval(approval.id, "reject")}>
+                      {pending === "reject" ? <Loader2Icon className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
+                      {settled === "reject" ? "Rejected" : "Reject"}
+                    </Button>
+                  </div>
+                </Notice>
+              );
+            })}
           </div>
         </div>
       ) : null}
@@ -382,11 +419,11 @@ function SessionChatPane(props: {
             commandContext={commandContext}
             onClearView={props.onClearView}
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
-            placeholder={terminal
-              ? `Session is ${props.session.status}.`
+            placeholder={props.session.status === "cancelled"
+              ? "This session was cancelled."
               : props.session.status === "failed"
-                ? "Send a message to revive this session..."
-                : "Send a follow-up..."}
+                ? "This session failed — send a message to revive it."
+                : "Send a follow-up…"}
             controls={(
               <div className="flex min-w-0 items-center gap-1.5">
                 <ModelPicker

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -270,6 +270,16 @@ function SessionChatPane(props: {
   // if the strip lingers for a beat before the status flips.
   const [approvalPending, setApprovalPending] = useState<Record<string, "approve" | "reject">>({});
   const [approvalSettled, setApprovalSettled] = useState<Record<string, "approve" | "reject">>({});
+  // Decision state is scoped to ONE requires_action pause. Once the session
+  // resumes, both maps reset — otherwise a later approval that reuses an id
+  // (including the index-fallback ids) would render permanently disabled, and
+  // long sessions would accumulate stale entries.
+  useEffect(() => {
+    if (props.session.status !== "requires_action") {
+      setApprovalPending((current) => (Object.keys(current).length ? {} : current));
+      setApprovalSettled((current) => (Object.keys(current).length ? {} : current));
+    }
+  }, [props.session.status]);
   const decideApproval = useCallback(
     async (approvalId: string, decision: "approve" | "reject") => {
       if (approvalPending[approvalId] || approvalSettled[approvalId]) {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -334,7 +334,7 @@ function SessionChatPane(props: {
               renderMessageText={renderMessageText}
               onOpenSession={props.onOpenSession}
               emptyState={(
-                <div className="grid min-h-[24rem] place-items-center rounded-lg border border-dashed border-[color:var(--color-border)] text-sm text-[color:var(--color-fg-subtle)]">
+                <div className="grid min-h-[24rem] place-items-center rounded-lg border border-dashed border-border text-sm text-fg-subtle">
                   Waiting for session activity
                 </div>
               )}
@@ -350,9 +350,9 @@ function SessionChatPane(props: {
         <div className="mx-auto w-full max-w-3xl shrink-0 px-4 sm:px-6">
           <div className="grid max-h-64 gap-3 overflow-y-auto pb-2">
             {props.approvals.map((approval) => (
-              <div key={approval.id} className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+              <div key={approval.id} className="rounded-lg border border-status-waiting/40 bg-status-waiting/10 p-3">
                 <div className="text-sm font-medium">{approval.name}</div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded-md bg-[color:var(--color-bg)] p-3 text-xs text-[color:var(--color-fg-muted)]">
+                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded-md bg-bg p-3 text-xs text-fg-muted">
                   {JSON.stringify(approval.arguments ?? approval.raw ?? {}, null, 2)}
                 </pre>
                 <div className="mt-3 flex justify-end gap-2">

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -15,7 +15,7 @@
 // collapses to the clean sandbox-only flow (just the managed sandbox fields). The
 // control appears once machines exist, or once the user reveals it via a
 // lightweight local opt-in.
-import { useEnvironments, useWorkspaceSessions, type ComposerState } from "@opengeni/react";
+import { FILE_ONLY_MESSAGE_TEXT, useEnvironments, useWorkspaceSessions, type ComposerState } from "@opengeni/react";
 import { useMachines, type MachineView } from "@opengeni/react/machines";
 import { OpenGeniApiError } from "@opengeni/sdk";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -82,7 +82,12 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
     value: message,
     setValue: setMessage,
     sending: context.busy,
-    canSend: message.trim().length > 0 && !context.busy && !attachments.uploading && computeReady,
+    // Mirrors useComposer's gate: a ready attachment with no typed draft is a
+    // sendable file-only message (the API requires non-empty text, so send()
+    // substitutes FILE_ONLY_MESSAGE_TEXT).
+    canSend:
+      (message.trim().length > 0 || attachments.readyResources.length > 0) &&
+      !context.busy && !attachments.uploading && computeReady,
     // Queue-vs-steer is meaningless before the session exists.
     mode: "queue",
     setMode: () => {},
@@ -91,7 +96,7 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
     error: null,
     clearError: () => {},
     send: async () => {
-      const text = message.trim();
+      const text = message.trim() || (attachments.readyResources.length > 0 ? FILE_ONLY_MESSAGE_TEXT : "");
       if (!text || context.busy || attachments.uploading || !computeReady) {
         return false;
       }

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -15,11 +15,12 @@
 // collapses to the clean sandbox-only flow (just the managed sandbox fields). The
 // control appears once machines exist, or once the user reveals it via a
 // lightweight local opt-in.
-import { useEnvironments, type ComposerState } from "@opengeni/react";
+import { useEnvironments, useWorkspaceSessions, type ComposerState } from "@opengeni/react";
 import { useMachines, type MachineView } from "@opengeni/react/machines";
-import { useNavigate } from "@tanstack/react-router";
+import { OpenGeniApiError } from "@opengeni/sdk";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { ArrowRightIcon, BoxIcon, CheckIcon, ChevronDownIcon, FlagIcon, FolderIcon, GitBranchIcon, MonitorOffIcon, ServerIcon, ShieldIcon, SlidersHorizontalIcon } from "lucide-react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { PermissionGroupPicker } from "@/components/permission-picker";
@@ -31,8 +32,11 @@ import { RepositoryContextPicker } from "@/components/repository-picker";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Notice } from "@/components/ui/notice";
 import { Select } from "@/components/ui/select";
+import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext } from "@/context";
+import { groupSessionsForRail, relativeTimeLabel } from "@/lib/sessions-group";
 import { useCodexModels } from "@/lib/use-codex-models";
 import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 import { sessionMcpPermissionGroups } from "@/lib/permissions";
@@ -47,7 +51,7 @@ import {
   type SessionDraft,
 } from "@/lib/session-create";
 import { cn } from "@/lib/utils";
-import type { SandboxBackend } from "@/types";
+import type { SandboxBackend, Session } from "@/types";
 
 const examples = [
   "Inspect the repository and summarize the infrastructure layout.",
@@ -132,7 +136,7 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
           attachments={attachments}
           autoFocus
           fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
-          placeholder="Describe a task for the agent..."
+          placeholder="Describe a task for the agent…"
           controls={<SessionControlStrip workspaceId={workspaceId} />}
         />
 
@@ -173,7 +177,79 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
           disabled={context.busy}
         />
       </div>
+
+      <RecentSessions workspaceId={workspaceId} />
     </div>
+  );
+}
+
+// ── Recent sessions — the quiet main-canvas browser the rail can't be (D4.2) ──
+// A calm section below the composer: the most recent sessions as compact rows
+// (status dot, title, repo/model meta, relative time), linking straight in. It
+// reuses the same useWorkspaceSessions hook the rail runs on and renders only
+// when sessions exist, so the hero stays the composer.
+function RecentSessions({ workspaceId }: { workspaceId: string }) {
+  const { sessions } = useWorkspaceSessions({ limit: 12, pollIntervalMs: 30_000 });
+  const recent = useMemo(() => {
+    const { running, grouped } = groupSessionsForRail(sessions);
+    return [...running, ...grouped.flatMap((bucket) => bucket.sessions)].slice(0, 6);
+  }, [sessions]);
+
+  if (recent.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-12">
+      <h2 className="mb-2 px-0.5 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+        Recent sessions
+      </h2>
+      <ul className="grid gap-1">
+        {recent.map((session) => (
+          <RecentSessionRow key={session.id} workspaceId={workspaceId} session={session} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+const SESSION_STATUS_TONE: Record<Session["status"], StatusTone> = {
+  queued: "queued",
+  running: "running",
+  requires_action: "waiting",
+  idle: "idle",
+  failed: "failed",
+  cancelled: "cancelled",
+};
+
+/** A short `owner/repo` label from the session's first repository resource. */
+function sessionRepoLabel(session: Session): string | null {
+  const repo = session.resources.find((resource) => resource.kind === "repository");
+  if (!repo || repo.kind !== "repository") {
+    return null;
+  }
+  const parts = repo.uri.replace(/\.git$/, "").split("/").filter(Boolean);
+  return parts.length >= 2 ? parts.slice(-2).join("/") : parts.at(-1) ?? null;
+}
+
+function RecentSessionRow({ workspaceId, session }: { workspaceId: string; session: Session }) {
+  const title = session.title?.trim() || session.initialMessage?.trim() || "Untitled session";
+  const meta = [session.model, sessionRepoLabel(session)].filter(Boolean).join(" · ");
+  return (
+    <li>
+      <Link
+        to="/workspaces/$workspaceId/sessions/$sessionId"
+        params={{ workspaceId, sessionId: session.id }}
+        className="group flex items-center gap-3 rounded-lg border border-border bg-surface/40 px-3 py-2.5 transition-colors hover:border-border-strong hover:bg-surface-2/60"
+      >
+        <StatusDot tone={SESSION_STATUS_TONE[session.status]} pulse={session.status === "running"} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm text-fg">{title}</span>
+          {meta ? <span className="mt-0.5 block truncate text-2xs text-fg-subtle">{meta}</span> : null}
+        </span>
+        <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{relativeTimeLabel(session.updatedAt)}</span>
+      </Link>
+    </li>
   );
 }
 
@@ -282,6 +358,11 @@ function ComputeTargetControl(props: {
   const fleet = useMachines({ pollIntervalMs: 10000 });
   const machines = fleet.machines.filter((machine) => machine.kind === "selfhosted");
   const fleetEmpty = machines.length === 0;
+  // A 404 is the expected "self-hosted machines are disabled here" signal, not a
+  // failure — only a genuine load error (network/5xx) is surfaced, so the machine
+  // option isn't silently swallowed by a transient outage (states #4).
+  const fleetLoadFailed =
+    fleet.error != null && !(fleet.error instanceof OpenGeniApiError && fleet.error.status === 404);
   // Preserve the last managed backend override across kind toggles (lossless) so
   // toggling machine→sandbox returns to the prior choice, not a forced reset.
   const lastBackend = useRef<SandboxBackend | "">(draft.compute.kind === "sandbox" ? draft.compute.backend : "");
@@ -341,6 +422,7 @@ function ComputeTargetControl(props: {
           onChange={onChange}
           disabled={props.disabled}
         />
+        {fleetLoadFailed ? <FleetErrorNotice onRetry={() => void fleet.refresh()} /> : null}
         <RevealConnectedMachinesButton onClick={revealConnectedMachines} disabled={props.disabled} />
       </section>
     );
@@ -356,19 +438,21 @@ function ComputeTargetControl(props: {
           selected={draft.compute.kind === "sandbox"}
           disabled={props.disabled}
           icon={<BoxIcon className="size-4 shrink-0" />}
-          title="Managed Sandbox"
-          subtitle="A fresh box, set up for you"
+          title="Managed sandbox"
+          subtitle="A fresh sandbox, set up for you"
           onClick={() => selectKind("sandbox")}
         />
         <ComputeKindButton
           selected={draft.compute.kind === "machine"}
           disabled={props.disabled || fleetEmpty}
           icon={<ServerIcon className="size-4 shrink-0" />}
-          title="Connected Machine"
-          subtitle={fleetEmpty ? "Connect one to use it" : "Run on your own machine"}
+          title="Connected machine"
+          subtitle={fleetLoadFailed ? "Couldn't load machines" : fleetEmpty ? "Connect one to use it" : "Run on your own machine"}
           onClick={() => selectKind("machine")}
         />
       </div>
+
+      {fleetLoadFailed ? <FleetErrorNotice onRetry={() => void fleet.refresh()} /> : null}
 
       {draft.compute.kind === "sandbox" ? (
         <ManagedSandboxFields
@@ -470,7 +554,7 @@ function ManagedSandboxFields(props: {
         </div>
         <p className="flex items-center gap-1.5 text-2xs text-fg-subtle">
           <FolderIcon className="size-3 shrink-0" />
-          Cloned into <span className="font-mono text-fg-muted">/workspace</span>, the fixed sandbox root.
+          Repositories are cloned into <span className="font-mono text-fg-muted">/workspace</span>.
         </p>
       </div>
 
@@ -503,7 +587,7 @@ function ManagedSandboxFields(props: {
           <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
           <span>Advanced</span>
           <span className="text-fg-subtle/70">·</span>
-          <span className="truncate">backend {backendSummary}</span>
+          <span className="truncate">backend: {backendSummary}</span>
         </summary>
         <div className="grid gap-2 px-3 pb-3">
           <Select
@@ -698,6 +782,24 @@ function RevealConnectedMachinesButton(props: { onClick: () => void; disabled: b
   );
 }
 
+// A genuine fleet-load failure (not the expected selfhosted-disabled 404): a
+// calm, retryable note so the machine option is never silently swallowed.
+function FleetErrorNotice({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Notice
+      tone="muted"
+      className="p-2.5 text-xs"
+      action={
+        <button type="button" onClick={onRetry} className="text-xs font-medium text-fg-muted underline underline-offset-2 hover:text-fg">
+          Retry
+        </button>
+      }
+    >
+      Couldn&apos;t load your connected machines.
+    </Notice>
+  );
+}
+
 function FolderRadio(props: {
   checked: boolean;
   disabled: boolean;
@@ -829,7 +931,7 @@ function OptionalSessionOptions(props: {
               />
             ) : (
               <p className="text-2xs text-fg-subtle">
-                By default the session&apos;s OpenGeni MCP tool can use the platform on your behalf inside this workspace.
+                By default this session can use OpenGeni tools on your behalf in this workspace.
               </p>
             )}
           </div>

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -31,6 +31,7 @@ import { RepositoryContextPicker } from "@/components/repository-picker";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 import { useCodexModels } from "@/lib/use-codex-models";
 import { isMachineComputeSelectable } from "@/lib/machine-selectability";
@@ -120,7 +121,7 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
         <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
           What should the agent do?
         </h1>
-        <p className="max-w-md text-sm text-[color:var(--color-fg-muted)]">
+        <p className="max-w-md text-sm text-fg-muted">
           It runs in a live sandbox you can watch and steer.
         </p>
       </section>
@@ -145,9 +146,9 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
                 disabled={context.busy}
                 className={cn(
                   "max-w-full truncate rounded-full border px-3 py-1 text-left text-xs",
-                  "border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50",
-                  "text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]",
-                  "hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]",
+                  "border-border bg-surface-2/50",
+                  "text-fg-muted hover:text-fg",
+                  "hover:border-border-strong hover:bg-surface-2",
                   "transition-colors active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
                 )}
               >
@@ -347,7 +348,7 @@ function ComputeTargetControl(props: {
 
   return (
     <section className="mt-5 grid gap-3">
-      <p className="px-0.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[color:var(--color-fg-subtle)]">
+      <p className="px-0.5 text-2xs font-medium uppercase tracking-[0.08em] text-fg-subtle">
         Where should this run?
       </p>
       <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
@@ -412,29 +413,29 @@ function ComputeKindButton(props: {
         "group flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-[color,background-color,border-color,box-shadow]",
         "disabled:cursor-not-allowed disabled:opacity-50",
         props.selected
-          ? "border-[color:var(--color-brand)]/60 bg-[color:var(--color-brand)]/[0.08] ring-1 ring-inset ring-[color:var(--color-brand)]/20"
-          : "border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]/60",
+          ? "border-brand/60 bg-brand/[0.08] ring-1 ring-inset ring-brand/20"
+          : "border-border bg-surface/40 hover:border-border-strong hover:bg-surface-2/60",
       )}
     >
       <span
         className={cn(
           "mt-0.5 transition-colors",
-          props.selected ? "text-[color:var(--color-brand)]" : "text-[color:var(--color-fg-subtle)] group-hover:text-[color:var(--color-fg-muted)]",
+          props.selected ? "text-brand" : "text-fg-subtle group-hover:text-fg-muted",
         )}
       >
         {props.icon}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium text-[color:var(--color-fg)]">{props.title}</span>
-        <span className="mt-0.5 block truncate text-[11px] text-[color:var(--color-fg-subtle)]">{props.subtitle}</span>
+        <span className="block truncate text-sm font-medium text-fg">{props.title}</span>
+        <span className="mt-0.5 block truncate text-2xs text-fg-subtle">{props.subtitle}</span>
       </span>
       <span
         aria-hidden
         className={cn(
           "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full transition-all",
           props.selected
-            ? "scale-100 bg-[color:var(--color-brand)] text-[color:var(--color-brand-fg)]"
-            : "scale-90 border border-[color:var(--color-border-strong)] opacity-0 group-hover:opacity-60",
+            ? "scale-100 bg-brand text-brand-fg"
+            : "scale-90 border border-border-strong opacity-0 group-hover:opacity-60",
         )}
       >
         <CheckIcon className="size-2.5" strokeWidth={3} />
@@ -458,28 +459,27 @@ function ManagedSandboxFields(props: {
   const backendSummary = [selectedBackend?.label, ...(selectedBackend?.chips ?? [])].filter(Boolean).join(" · ");
 
   return (
-    <div className="grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
+    <div className="grid gap-4 rounded-lg border border-border bg-surface/40 p-3.5">
       <div className="grid gap-2">
         <Label className="flex items-center gap-1.5 text-xs">
-          <GitBranchIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <GitBranchIcon className="size-3 shrink-0 text-fg-subtle" />
           Repository + branch
         </Label>
         <div>
           <WorkspaceRepositoryPicker workspaceId={props.workspaceId} disabled={props.disabled} />
         </div>
-        <p className="flex items-center gap-1.5 text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+        <p className="flex items-center gap-1.5 text-2xs text-fg-subtle">
           <FolderIcon className="size-3 shrink-0" />
-          Cloned into <span className="font-mono text-[color:var(--color-fg-muted)]">/workspace</span>, the fixed sandbox root.
+          Cloned into <span className="font-mono text-fg-muted">/workspace</span>, the fixed sandbox root.
         </p>
       </div>
 
-      <div className="grid gap-2 border-t border-[color:var(--color-border)] pt-4">
+      <div className="grid gap-2 border-t border-border pt-4">
         <Label className="flex items-center gap-1.5 text-xs">
-          <BoxIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <BoxIcon className="size-3 shrink-0 text-fg-subtle" />
           Environment
         </Label>
-        <select
-          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        <Select
           value={draft.environmentId}
           disabled={props.disabled}
           onChange={(event) => onChange({ ...draft, environmentId: event.target.value })}
@@ -490,24 +490,23 @@ function ManagedSandboxFields(props: {
               {environment.name} ({environment.variables.length} vars)
             </option>
           ))}
-        </select>
-        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+        </Select>
+        <p className="text-2xs text-fg-subtle">
           Variables are set in the sandbox at start. Their values stay write-only.
         </p>
       </div>
 
       {/* Low-level sandbox backend override — demoted into this kind's Advanced
           detail, descriptor-driven from CAPABILITY_DESCRIPTORS. */}
-      <details className="group rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/30 transition-colors open:bg-[color:var(--color-surface)]/50">
-        <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-[11px] text-[color:var(--color-fg-subtle)] transition-colors hover:text-[color:var(--color-fg-muted)]">
+      <details className="group rounded-md border border-border bg-surface/30 transition-colors open:bg-surface/50">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
           <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
           <span>Advanced</span>
-          <span className="text-[color:var(--color-fg-subtle)]/70">·</span>
+          <span className="text-fg-subtle/70">·</span>
           <span className="truncate">backend {backendSummary}</span>
         </summary>
         <div className="grid gap-2 px-3 pb-3">
-          <select
-            className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          <Select
             value={compute.backend}
             disabled={props.disabled}
             onChange={(event) => onChange({ ...draft, compute: { kind: "sandbox", backend: event.target.value as SandboxBackend | "" } })}
@@ -518,8 +517,8 @@ function ManagedSandboxFields(props: {
                 {option.chips.length > 0 ? ` · ${option.chips.join(" · ")}` : ""}
               </option>
             ))}
-          </select>
-          <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+          </Select>
+          <p className="text-2xs text-fg-subtle">
             Forces the underlying sandbox type. Leave on the deployment default unless you need a specific backend.
           </p>
         </div>
@@ -547,14 +546,13 @@ function ConnectedMachineFields(props: {
   const capabilityChips = selfhostedCapabilityChips(pickedMachine);
 
   return (
-    <div className="grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
+    <div className="grid gap-4 rounded-lg border border-border bg-surface/40 p-3.5">
       <div className="grid gap-2">
         <Label className="flex items-center gap-1.5 text-xs">
-          <ServerIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <ServerIcon className="size-3 shrink-0 text-fg-subtle" />
           Machine
         </Label>
-        <select
-          className="h-9 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 text-sm transition-colors hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        <Select
           value={compute.sandboxId ?? ""}
           disabled={props.disabled}
           onChange={(event) => setCompute({ ...compute, sandboxId: event.target.value || null })}
@@ -569,20 +567,20 @@ function ConnectedMachineFields(props: {
               {machine.state !== "online" ? ` (${machine.state})` : ""}
             </option>
           ))}
-        </select>
+        </Select>
         <div className="flex flex-wrap items-center gap-1.5">
           {capabilityChips.map((chip) => (
             <CapabilityChip key={chip}>{chip}</CapabilityChip>
           ))}
           {pickedMachine && !pickedMachine.hasDisplay ? (
-            <span className="inline-flex items-center gap-1 rounded-md border border-dashed border-[color:var(--color-border-strong)] px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--color-fg-subtle)]">
+            <span className="inline-flex items-center gap-1 rounded-md border border-dashed border-border-strong px-1.5 py-0.5 text-2xs font-medium text-fg-subtle">
               <MonitorOffIcon className="size-3 shrink-0" />
               No display
             </span>
           ) : null}
         </div>
         {compute.sandboxId === null ? (
-          <p className="text-[11px] leading-4 text-[color:var(--color-fg-muted)]">
+          <p className="text-2xs text-fg-muted">
             Pick a machine to run on.
           </p>
         ) : null}
@@ -590,9 +588,9 @@ function ConnectedMachineFields(props: {
 
       {/* Project / folder — the agent's working directory on the machine (D4/D5,
           functional via Stage A's workingDir for root + custom path). */}
-      <div className="grid gap-2.5 border-t border-[color:var(--color-border)] pt-4">
+      <div className="grid gap-2.5 border-t border-border pt-4">
         <Label className="flex items-center gap-1.5 text-xs">
-          <FolderIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <FolderIcon className="size-3 shrink-0 text-fg-subtle" />
           Project / folder
         </Label>
         <div className="grid gap-2">
@@ -629,38 +627,38 @@ function ConnectedMachineFields(props: {
             />
           ) : null}
         </div>
-        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+        <p className="text-2xs text-fg-subtle">
           Where the agent, terminal, and file dock open. Defaults to the machine&apos;s workspace root.
         </p>
       </div>
 
       {/* Repositories — grayed: a connected machine uses its own checkout & git
           auth (D3), so the workspace repo selection is never cloned onto it. */}
-      <div className="grid gap-2 border-t border-[color:var(--color-border)] pt-4">
-        <Label className="flex items-center justify-between gap-1.5 text-xs text-[color:var(--color-fg-subtle)]">
+      <div className="grid gap-2 border-t border-border pt-4">
+        <Label className="flex items-center justify-between gap-1.5 text-xs text-fg-subtle">
           <span className="flex items-center gap-1.5">
             <GitBranchIcon className="size-3 shrink-0" />
             Repositories
           </span>
-          <span className="rounded border border-[color:var(--color-border)] px-1.5 py-px text-[10px] font-normal text-[color:var(--color-fg-subtle)]">
+          <span className="rounded border border-border px-1.5 py-px text-2xs font-normal text-fg-subtle">
             Not cloned here
           </span>
         </Label>
         <div className="pointer-events-none select-none opacity-45">
           <WorkspaceRepositoryPicker workspaceId={props.workspaceId} disabled />
         </div>
-        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+        <p className="text-2xs text-fg-subtle">
           This machine uses its own checkout &amp; git auth, so your selected repositories aren&apos;t cloned onto it.
         </p>
       </div>
 
       {/* Environment injection — hidden on a connected machine (D2). */}
-      <div className="grid gap-1 border-t border-[color:var(--color-border)] pt-4">
-        <p className="flex items-center gap-1.5 text-xs text-[color:var(--color-fg-subtle)]">
+      <div className="grid gap-1 border-t border-border pt-4">
+        <p className="flex items-center gap-1.5 text-xs text-fg-subtle">
           <BoxIcon className="size-3 shrink-0" />
           No environment is injected here.
         </p>
-        <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+        <p className="text-2xs text-fg-subtle">
           The machine&apos;s own environment &amp; git credentials apply.
         </p>
       </div>
@@ -670,7 +668,7 @@ function ConnectedMachineFields(props: {
 
 function CapabilityChip({ children }: { children: ReactNode }) {
   return (
-    <span className="inline-flex items-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/60 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--color-fg-muted)]">
+    <span className="inline-flex items-center rounded-md border border-border bg-surface-2/60 px-1.5 py-0.5 text-2xs font-medium text-fg-muted">
       {children}
     </span>
   );
@@ -686,12 +684,12 @@ function RevealConnectedMachinesButton(props: { onClick: () => void; disabled: b
       onClick={props.onClick}
       disabled={props.disabled}
       className={cn(
-        "group inline-flex items-center gap-2 justify-self-start rounded-md px-1.5 py-1 text-[11px] transition-colors",
-        "text-[color:var(--color-fg-subtle)] hover:text-[color:var(--color-fg-muted)]",
+        "group inline-flex items-center gap-2 justify-self-start rounded-md px-1.5 py-1 text-2xs transition-colors",
+        "text-fg-subtle hover:text-fg-muted",
         "disabled:cursor-not-allowed disabled:opacity-60",
       )}
     >
-      <span className="flex size-5 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-2)]/50 text-[color:var(--color-fg-subtle)] transition-colors group-hover:border-[color:var(--color-border-strong)] group-hover:text-[color:var(--color-fg-muted)]">
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-md border border-border bg-surface-2/50 text-fg-subtle transition-colors group-hover:border-border-strong group-hover:text-fg-muted">
         <ServerIcon className="size-3" />
       </span>
       <span>Run on your own connected machine</span>
@@ -721,19 +719,19 @@ function FolderRadio(props: {
         className={cn(
           "flex size-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
           props.checked
-            ? "border-[color:var(--color-brand)]"
-            : "border-[color:var(--color-border-strong)] group-hover:border-[color:var(--color-fg-subtle)]",
+            ? "border-brand"
+            : "border-border-strong group-hover:border-fg-subtle",
         )}
       >
-        {props.checked ? <span className="size-1.5 rounded-full bg-[color:var(--color-brand-strong)]" /> : null}
+        {props.checked ? <span className="size-1.5 rounded-full bg-brand-strong" /> : null}
       </span>
-      <span className="font-medium text-[color:var(--color-fg)]">{props.label}</span>
+      <span className="font-medium text-fg">{props.label}</span>
       {props.badge ? (
-        <span className="rounded border border-[color:var(--color-border)] px-1 py-px text-[9px] font-medium uppercase tracking-wide text-[color:var(--color-fg-subtle)]">
+        <span className="rounded border border-border px-1 py-px text-2xs font-medium uppercase tracking-wide text-fg-subtle">
           {props.badge}
         </span>
       ) : null}
-      <span className="text-[11px] text-[color:var(--color-fg-subtle)]">— {props.hint}</span>
+      <span className="text-2xs text-fg-subtle">— {props.hint}</span>
     </button>
   );
 }
@@ -759,21 +757,21 @@ function OptionalSessionOptions(props: {
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className="flex w-full items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 px-3 py-2.5 text-left text-xs text-[color:var(--color-fg-muted)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-surface-2)]/60 hover:text-[color:var(--color-fg)]"
+          className="flex w-full items-center gap-2 rounded-lg border border-border bg-surface/40 px-3 py-2.5 text-left text-xs text-fg-muted transition-colors hover:border-border-strong hover:bg-surface-2/60 hover:text-fg"
         >
-          <SlidersHorizontalIcon className="size-3.5 shrink-0 text-[color:var(--color-fg-subtle)]" />
+          <SlidersHorizontalIcon className="size-3.5 shrink-0 text-fg-subtle" />
           <span className="font-medium">Goal &amp; tool permissions</span>
-          <span className="min-w-0 flex-1 truncate text-[11px] text-[color:var(--color-fg-subtle)]">
+          <span className="min-w-0 flex-1 truncate text-2xs text-fg-subtle">
             {summary.length > 0 ? summary.join(" · ") : "Optional — run toward a goal, limit tool access"}
           </span>
           <ChevronDownIcon className={cn("size-3.5 shrink-0 transition-transform", props.open && "rotate-180")} />
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="mt-2 grid gap-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/40 p-3.5">
+        <div className="mt-2 grid gap-4 rounded-lg border border-border bg-surface/40 p-3.5">
           <div className="grid gap-2">
             <Label className="flex items-center gap-1.5 text-xs">
-              <FlagIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+              <FlagIcon className="size-3 shrink-0 text-fg-subtle" />
               Goal (optional)
             </Label>
             <textarea
@@ -781,7 +779,7 @@ function OptionalSessionOptions(props: {
               disabled={props.disabled}
               onChange={(event) => update({ goalText: event.target.value })}
               placeholder="Keep the session working on its own between your messages…"
-              className="min-h-14 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm transition-colors placeholder:text-[color:var(--color-fg-subtle)] hover:border-[color:var(--color-border-strong)] focus-visible:border-[color:var(--color-ring)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              className="min-h-14 rounded-md border border-border bg-bg px-3 py-2 text-sm transition-colors placeholder:text-fg-subtle hover:border-border-strong focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             />
             <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem]">
               <Input
@@ -803,15 +801,15 @@ function OptionalSessionOptions(props: {
           </div>
 
           <div className="grid gap-2">
-            <label className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+            <label className="flex items-center gap-2 text-xs text-fg-muted">
               <input
                 type="checkbox"
                 checked={draft.customMcpPermissions}
                 disabled={props.disabled}
                 onChange={(event) => update({ customMcpPermissions: event.target.checked })}
-                className="size-3.5 accent-[color:var(--color-brand-strong)]"
+                className="size-3.5 accent-brand-strong"
               />
-              <ShieldIcon className="size-3 shrink-0 text-[color:var(--color-fg-subtle)]" />
+              <ShieldIcon className="size-3 shrink-0 text-fg-subtle" />
               Restrict this session&apos;s OpenGeni tool permissions
             </label>
             {draft.customMcpPermissions ? (
@@ -830,7 +828,7 @@ function OptionalSessionOptions(props: {
                 }}
               />
             ) : (
-              <p className="text-[11px] leading-4 text-[color:var(--color-fg-subtle)]">
+              <p className="text-2xs text-fg-subtle">
                 By default the session&apos;s OpenGeni MCP tool can use the platform on your behalf inside this workspace.
               </p>
             )}

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -192,13 +192,13 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
         />
 
         {/* Workspace name / rename */}
-        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
           <div>
             <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <PencilIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              <PencilIcon className="size-3.5 text-brand" />
               Workspace name
             </h2>
-            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">The name shows everywhere this workspace appears.</p>
+            <p className="mt-1 text-xs text-fg-muted">The name shows everywhere this workspace appears.</p>
           </div>
           {canRename ? (
             <form
@@ -215,7 +215,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
               </Button>
             </form>
           ) : (
-            <p className="text-xs text-[color:var(--color-fg-subtle)]">Only workspace admins can rename this workspace.</p>
+            <p className="text-xs text-fg-subtle">Only workspace admins can rename this workspace.</p>
           )}
         </section>
 
@@ -223,13 +223,13 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
         <MembersSection workspaceId={workspaceId} canManage={canManageMembers} />
 
         {/* Environments link */}
-        <section className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+        <section className="flex items-center justify-between gap-3 rounded-lg border border-border bg-surface p-4">
           <div className="min-w-0">
             <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <BoxIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              <BoxIcon className="size-3.5 text-brand" />
               Environments
             </h2>
-            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Variable sets injected into sandboxes at session start.</p>
+            <p className="mt-1 text-xs text-fg-muted">Variable sets injected into sandboxes at session start.</p>
           </div>
           <Button asChild type="button" variant="secondary" size="sm">
             <Link to="/workspaces/$workspaceId/environments" params={{ workspaceId }}>
@@ -242,19 +242,19 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
         <CodexSubscriptionsCard workspaceId={workspaceId} canManage={canDeleteWorkspace} />
 
         {/* API keys (moved from the old account page) */}
-        <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
           <div>
             <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <KeyRoundIcon className="size-3.5 text-[color:var(--color-brand)]" />
+              <KeyRoundIcon className="size-3.5 text-brand" />
               API keys
             </h2>
-            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">Workspace-scoped keys for calling OpenGeni from another product.</p>
+            <p className="mt-1 text-xs text-fg-muted">Workspace-scoped keys for calling OpenGeni from another product.</p>
           </div>
           {createdToken ? (
-            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
-              <div className="text-xs font-medium text-emerald-200">Token shown once</div>
+            <div className="rounded-md border border-status-idle/30 bg-status-idle/10 p-3">
+              <div className="text-xs font-medium text-status-idle">Token shown once</div>
               <div className="mt-2 flex min-w-0 items-center gap-2">
-                <code className="min-w-0 flex-1 truncate rounded bg-[color:var(--color-bg)] px-2 py-1.5 text-xs">{createdToken}</code>
+                <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs">{createdToken}</code>
                 <Button type="button" variant="ghost" size="icon-sm" onClick={() => void navigator.clipboard.writeText(createdToken)}>
                   <CopyIcon className="size-3.5" />
                 </Button>
@@ -271,7 +271,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
                 </Button>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-[color:var(--color-fg-subtle)]">A key can only carry permissions your own grant can delegate.</p>
+                <p className="text-xs text-fg-subtle">A key can only carry permissions your own grant can delegate.</p>
                 <Button type="button" variant="ghost" size="sm" disabled={delegablePermissions.size === 0} onClick={() => setSelectedPermissions(new Set(delegablePermissions))}>
                   Select all delegable
                 </Button>
@@ -284,7 +284,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
               />
             </>
           ) : (
-            <p className="text-xs text-[color:var(--color-fg-subtle)]">This subject cannot manage API keys for this workspace.</p>
+            <p className="text-xs text-fg-subtle">This subject cannot manage API keys for this workspace.</p>
           )}
           <div className="grid gap-2">
             {apiKeysError ? (
@@ -292,10 +292,10 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
             ) : apiKeys.length === 0 ? (
               <EmptyState>No API keys.</EmptyState>
             ) : apiKeys.map((apiKey) => (
-              <div key={apiKey.id} className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
+              <div key={apiKey.id} className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2">
                 <div className="min-w-0">
                   <div className="truncate text-sm font-medium">{apiKey.name}</div>
-                  <div className="mt-1 truncate text-xs text-[color:var(--color-fg-subtle)]">{apiKey.prefix}... · {apiKey.revokedAt ? "revoked" : "active"}</div>
+                  <div className="mt-1 truncate text-xs text-fg-subtle">{apiKey.prefix}... · {apiKey.revokedAt ? "revoked" : "active"}</div>
                 </div>
                 <Button type="button" variant="ghost" size="sm" disabled={busy || Boolean(apiKey.revokedAt)} onClick={() => void revokeKey(apiKey.id)}>
                   <Trash2Icon className="size-3.5" />
@@ -430,13 +430,13 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
+    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
       <div>
         <h2 className="flex items-center gap-1.5 text-sm font-medium">
-          <UsersIcon className="size-3.5 text-[color:var(--color-brand)]" />
+          <UsersIcon className="size-3.5 text-brand" />
           People with access
         </h2>
-        <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">People who can act in this workspace, and what each one can do.</p>
+        <p className="mt-1 text-xs text-fg-muted">People who can act in this workspace, and what each one can do.</p>
       </div>
 
       {canManage ? (
@@ -461,28 +461,28 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
           </Button>
         </form>
       ) : (
-        <p className="text-xs text-[color:var(--color-fg-subtle)]">Only members who can manage people can add or remove access.</p>
+        <p className="text-xs text-fg-subtle">Only members who can manage people can add or remove access.</p>
       )}
 
       <div className="grid gap-2">
         {error ? (
           <LoadErrorState title="Couldn't load members" error={error} onRetry={() => void refresh()} />
         ) : !loaded ? (
-          <div className="flex items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+          <div className="flex items-center gap-2 text-xs text-fg-muted">
             <Loader2Icon className="size-3.5 animate-spin" />
             Loading members
           </div>
         ) : userMembers.length === 0 ? (
           <EmptyState>No people have access yet.</EmptyState>
         ) : userMembers.map((member) => (
-          <div key={member.subjectId} className="grid gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]/35 px-3 py-2">
+          <div key={member.subjectId} className="grid gap-2 rounded-lg border border-border bg-bg/35 px-3 py-2">
             <div className="flex min-w-0 items-center justify-between gap-3">
               <div className="min-w-0">
                 <div className="truncate text-sm font-medium">
                   {member.subjectLabel ?? member.subjectId}
-                  {member.subjectId === callerSubjectId ? <span className="ml-1.5 text-[color:var(--color-fg-subtle)]">(you)</span> : null}
+                  {member.subjectId === callerSubjectId ? <span className="ml-1.5 text-fg-subtle">(you)</span> : null}
                 </div>
-                <div className="mt-1 truncate text-xs text-[color:var(--color-fg-subtle)]">
+                <div className="mt-1 truncate text-xs text-fg-subtle">
                   {member.role} · {member.permissions.length} permission{member.permissions.length === 1 ? "" : "s"}
                 </div>
               </div>
@@ -500,7 +500,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
               ) : null}
             </div>
             {canManage && editing === member.subjectId ? (
-              <div className="grid gap-3 border-t border-[color:var(--color-border)] pt-3">
+              <div className="grid gap-3 border-t border-border pt-3">
                 <PermissionGroupPicker
                   groups={workspaceMemberPermissionGroups}
                   selected={editPermissions}
@@ -556,13 +556,13 @@ function DangerZone(props: {
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-[color:var(--color-status-failed)]/30 bg-[color:var(--color-status-failed)]/5 p-4">
+    <section className="grid gap-3 rounded-lg border border-status-failed/30 bg-status-failed/5 p-4">
       <div>
-        <h2 className="flex items-center gap-1.5 text-sm font-medium text-[color:var(--color-status-failed)]">
+        <h2 className="flex items-center gap-1.5 text-sm font-medium text-status-failed">
           <TriangleAlertIcon className="size-3.5" />
           Danger zone
         </h2>
-        <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+        <p className="mt-1 text-xs text-fg-muted">
           Workspace deletion is irreversible and removes every session, environment, and API key.
         </p>
       </div>
@@ -583,9 +583,9 @@ function DangerZone(props: {
           </Button>
         </span>
         {disabledReason ? (
-          <p className="mt-1.5 text-[11px] text-[color:var(--color-fg-subtle)]">{disabledReason}</p>
+          <p className="mt-1.5 text-2xs text-fg-subtle">{disabledReason}</p>
         ) : (
-          <p className="mt-1.5 text-[11px] text-[color:var(--color-fg-subtle)]">Stop any running sessions first; deletion is refused while one is live.</p>
+          <p className="mt-1.5 text-2xs text-fg-subtle">Stop any running sessions first; deletion is refused while one is live.</p>
         )}
       </div>
 
@@ -605,7 +605,7 @@ function DangerZone(props: {
             </DialogHeader>
             <div className="mt-4 grid gap-1.5">
               <Label htmlFor="confirm-workspace-name">
-                Type <span className="font-mono text-[color:var(--color-fg)]">{props.workspaceName}</span> to confirm
+                Type <span className="font-mono text-fg">{props.workspaceName}</span> to confirm
               </Label>
               <Input
                 id="confirm-workspace-name"

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -23,9 +23,10 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { CodexSubscriptionsCard } from "@/components/codex-connection";
-import { EmptyState, LoadErrorState, PageHeader } from "@/components/common";
+import { LoadErrorState, PageHeader } from "@/components/common";
 import { PermissionGroupPicker } from "@/components/permission-picker";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   Dialog,
   DialogContent,
@@ -34,8 +35,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Notice } from "@/components/ui/notice";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAppContext } from "@/context";
 import { orgLabel } from "@/lib/org";
 import {
@@ -68,9 +72,11 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
 
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [apiKeysError, setApiKeysError] = useState<Error | null>(null);
+  const [apiKeysLoaded, setApiKeysLoaded] = useState(false);
   const [apiKeyName, setApiKeyName] = useState("Default API key");
   const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(() => new Set(defaultApiKeyPermissions));
   const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [revokingKey, setRevokingKey] = useState<ApiKey | null>(null);
   const [busy, setBusy] = useState(false);
   const canManageApiKeys = hasWorkspacePermission(context.accessContext, workspaceId, "api_keys:manage");
   const workspaceGrant = context.accessContext.workspaceGrants.find((grant) => grant.workspaceId === workspaceId) ?? null;
@@ -92,6 +98,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
     if (!canManageApiKeys) {
       setApiKeys([]);
       setApiKeysError(null);
+      setApiKeysLoaded(true);
       return;
     }
     try {
@@ -100,6 +107,8 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
     } catch (error) {
       setApiKeys([]);
       setApiKeysError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setApiKeysLoaded(true);
     }
   }
 
@@ -137,6 +146,15 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
       toast.error("Failed to create API key", { description: error instanceof Error ? error.message : String(error) });
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function copyToken(token: string) {
+    try {
+      await navigator.clipboard.writeText(token);
+      toast.success("Token copied");
+    } catch {
+      toast.error("Couldn't copy the token", { description: "Copy it manually instead." });
     }
   }
 
@@ -251,15 +269,20 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
             <p className="mt-1 text-xs text-fg-muted">Workspace-scoped keys for calling OpenGeni from another product.</p>
           </div>
           {createdToken ? (
-            <div className="rounded-md border border-status-idle/30 bg-status-idle/10 p-3">
-              <div className="text-xs font-medium text-status-idle">Token shown once</div>
+            <Notice tone="success" title="Copy this token now — it won't be shown again.">
               <div className="mt-2 flex min-w-0 items-center gap-2">
-                <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs">{createdToken}</code>
-                <Button type="button" variant="ghost" size="icon-sm" onClick={() => void navigator.clipboard.writeText(createdToken)}>
+                <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs text-fg">{createdToken}</code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Copy token"
+                  onClick={() => void copyToken(createdToken)}
+                >
                   <CopyIcon className="size-3.5" />
                 </Button>
               </div>
-            </div>
+            </Notice>
           ) : null}
           {canManageApiKeys ? (
             <>
@@ -284,20 +307,35 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
               />
             </>
           ) : (
-            <p className="text-xs text-fg-subtle">This subject cannot manage API keys for this workspace.</p>
+            <p className="text-xs text-fg-subtle">You don't have permission to manage API keys here.</p>
           )}
           <div className="grid gap-2">
             {apiKeysError ? (
               <LoadErrorState title="Couldn't load API keys" error={apiKeysError} onRetry={() => void refreshApiKeys()} />
+            ) : !apiKeysLoaded ? (
+              <>
+                {[0, 1].map((key) => (
+                  <div key={key} className="flex items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2">
+                    <div className="min-w-0 space-y-1.5">
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                    <Skeleton className="h-8 w-20 rounded-md" />
+                  </div>
+                ))}
+              </>
             ) : apiKeys.length === 0 ? (
-              <EmptyState>No API keys.</EmptyState>
+              <EmptyState
+                title="No API keys yet"
+                description={canManageApiKeys ? "Create one above to call OpenGeni from another product." : "Keys created here call OpenGeni from another product."}
+              />
             ) : apiKeys.map((apiKey) => (
               <div key={apiKey.id} className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2">
                 <div className="min-w-0">
                   <div className="truncate text-sm font-medium">{apiKey.name}</div>
-                  <div className="mt-1 truncate text-xs text-fg-subtle">{apiKey.prefix}... · {apiKey.revokedAt ? "revoked" : "active"}</div>
+                  <div className="mt-1 truncate text-xs text-fg-subtle">{apiKey.prefix}… · {apiKey.revokedAt ? "revoked" : "active"}</div>
                 </div>
-                <Button type="button" variant="ghost" size="sm" disabled={busy || Boolean(apiKey.revokedAt)} onClick={() => void revokeKey(apiKey.id)}>
+                <Button type="button" variant="ghost" size="sm" disabled={busy || Boolean(apiKey.revokedAt)} onClick={() => setRevokingKey(apiKey)}>
                   <Trash2Icon className="size-3.5" />
                   Revoke
                 </Button>
@@ -305,6 +343,19 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
             ))}
           </div>
         </section>
+
+        <ConfirmDialog
+          open={revokingKey !== null}
+          onOpenChange={(next) => setRevokingKey(next ? revokingKey : null)}
+          title={`Revoke API key “${revokingKey?.name ?? ""}”?`}
+          description={`Any product calling OpenGeni with ${revokingKey?.prefix ?? ""}… stops working immediately. This can't be undone.`}
+          confirmLabel="Revoke key"
+          onConfirm={async () => {
+            if (revokingKey) {
+              await revokeKey(revokingKey.id);
+            }
+          }}
+        />
 
         {/* Danger zone */}
         <DangerZone
@@ -329,6 +380,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   const [busy, setBusy] = useState(false);
   const [editing, setEditing] = useState<string | null>(null);
   const [editPermissions, setEditPermissions] = useState<Set<string>>(() => new Set());
+  const [removingMember, setRemovingMember] = useState<WorkspaceMember | null>(null);
   const callerSubjectId = context.accessContext.subjectId;
 
   // Only USER subjects are people; api_key subjects belong to the API keys
@@ -414,9 +466,6 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   }
 
   async function removeMember(member: WorkspaceMember) {
-    if (!window.confirm(`Remove ${member.subjectLabel ?? member.subjectId} from this workspace?`)) {
-      return;
-    }
     setBusy(true);
     try {
       await client.removeWorkspaceMember(workspaceId, member.subjectId);
@@ -473,7 +522,10 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
             Loading members
           </div>
         ) : userMembers.length === 0 ? (
-          <EmptyState>No people have access yet.</EmptyState>
+          <EmptyState
+            title="Only you have access"
+            description={canManage ? "Add a teammate by email above to share this workspace." : undefined}
+          />
         ) : userMembers.map((member) => (
           <div key={member.subjectId} className="grid gap-2 rounded-lg border border-border bg-bg/35 px-3 py-2">
             <div className="flex min-w-0 items-center justify-between gap-3">
@@ -492,7 +544,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
                     <ChevronDownIcon className={`size-3.5 transition-transform ${editing === member.subjectId ? "rotate-180" : ""}`} />
                     Edit
                   </Button>
-                  <Button type="button" variant="ghost" size="sm" disabled={busy || member.subjectId === callerSubjectId} onClick={() => void removeMember(member)}>
+                  <Button type="button" variant="ghost" size="sm" disabled={busy || member.subjectId === callerSubjectId} onClick={() => setRemovingMember(member)}>
                     <Trash2Icon className="size-3.5" />
                     Remove
                   </Button>
@@ -518,6 +570,19 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
           </div>
         ))}
       </div>
+
+      <ConfirmDialog
+        open={removingMember !== null}
+        onOpenChange={(next) => setRemovingMember(next ? removingMember : null)}
+        title={`Remove ${removingMember?.subjectLabel ?? removingMember?.subjectId ?? ""} from this workspace?`}
+        description="They lose access to this workspace immediately. You can add them again later."
+        confirmLabel="Remove access"
+        onConfirm={async () => {
+          if (removingMember) {
+            await removeMember(removingMember);
+          }
+        }}
+      />
     </section>
   );
 }

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -164,8 +164,10 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
       const revoked = await client.deleteApiKey(workspaceId, apiKeyId);
       setApiKeys((current) => current.map((key) => key.id === revoked.id ? revoked : key));
       toast.success("API key revoked");
+      return true;
     } catch (error) {
       toast.error("Failed to revoke API key", { description: error instanceof Error ? error.message : String(error) });
+      return false;
     } finally {
       setBusy(false);
     }
@@ -350,11 +352,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
           title={`Revoke API key “${revokingKey?.name ?? ""}”?`}
           description={`Any product calling OpenGeni with ${revokingKey?.prefix ?? ""}… stops working immediately. This can't be undone.`}
           confirmLabel="Revoke key"
-          onConfirm={async () => {
-            if (revokingKey) {
-              await revokeKey(revokingKey.id);
-            }
-          }}
+          onConfirm={() => (revokingKey ? revokeKey(revokingKey.id) : false)}
         />
 
         {/* Danger zone */}
@@ -471,8 +469,10 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
       await client.removeWorkspaceMember(workspaceId, member.subjectId);
       setMembers((current) => current.filter((existing) => existing.subjectId !== member.subjectId));
       toast.success("Member removed");
+      return true;
     } catch (caught) {
       toast.error("Failed to remove member", { description: caught instanceof Error ? caught.message : String(caught) });
+      return false;
     } finally {
       setBusy(false);
     }
@@ -577,11 +577,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
         title={`Remove ${removingMember?.subjectLabel ?? removingMember?.subjectId ?? ""} from this workspace?`}
         description="They lose access to this workspace immediately. You can add them again later."
         confirmLabel="Remove access"
-        onConfirm={async () => {
-          if (removingMember) {
-            await removeMember(removingMember);
-          }
-        }}
+        onConfirm={() => (removingMember ? removeMember(removingMember) : false)}
       />
     </section>
   );

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -46,7 +46,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
         <RailShell>
           <ProblemPanel
             title="Workspace unavailable"
-            description="The URL workspace is not available to this subject."
+            description="You don't have access to this workspace."
             action={<Button asChild type="button" variant="secondary"><Link to="/">Open default workspace</Link></Button>}
           />
         </RailShell>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11,42 +11,43 @@
 
 /* ---------------------------------------------------------------------------
    Design tokens
-   Dark-only palette. One calm accent. Status hues are muted and desaturated
-   so they inform without shouting. All colors use OKLCH for perceptual
-   consistency.
+   Tailwind bridge for the canonical @opengeni/react token palette.
    --------------------------------------------------------------------------- */
 @theme {
   --font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono Variable", ui-monospace, SFMono-Regular,
     Menlo, monospace;
 
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
+
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 14px;
   --radius-xl: 20px;
 
-  /* Core neutrals */
-  --color-bg: oklch(0.16 0.012 260);
-  --color-surface: oklch(0.19 0.014 260);
-  --color-surface-2: oklch(0.22 0.015 260);
-  --color-surface-3: oklch(0.26 0.016 260);
-  --color-border: oklch(0.30 0.015 260);
-  --color-border-strong: oklch(0.42 0.018 260);
-  --color-fg: oklch(0.96 0.005 260);
-  --color-fg-muted: oklch(0.74 0.012 260);
-  --color-fg-subtle: oklch(0.58 0.013 260);
+  --color-bg: var(--og-color-bg);
+  --color-surface: var(--og-color-surface-1);
+  --color-surface-2: var(--og-color-surface-2);
+  --color-surface-3: var(--og-color-surface-3);
+  --color-border: var(--og-color-border);
+  --color-border-strong: var(--og-color-border-strong);
+  --color-fg: var(--og-color-fg);
+  --color-fg-muted: var(--og-color-fg-muted);
+  --color-fg-subtle: var(--og-color-fg-subtle);
 
-  /* Brand accent */
-  --color-brand: oklch(0.72 0.15 255);
-  --color-brand-strong: oklch(0.62 0.18 255);
-  --color-brand-fg: oklch(0.98 0.005 260);
+  --color-brand: var(--og-color-accent);
+  --color-brand-strong: var(--og-color-accent-deep);
+  --color-brand-fg: var(--og-color-accent-fg);
 
-  /* Status — desaturated so badges stay calm */
-  --color-status-running: oklch(0.78 0.11 80);
-  --color-status-waiting: oklch(0.70 0.02 260);
-  --color-status-success: oklch(0.78 0.12 155);
-  --color-status-failed: oklch(0.72 0.14 20);
-  --color-status-cancelled: oklch(0.62 0.05 260);
+  --color-status-queued: var(--og-color-status-queued);
+  --color-status-running: var(--og-color-status-running);
+  --color-status-idle: var(--og-color-status-idle);
+  --color-status-waiting: var(--og-color-status-waiting);
+  --color-status-success: var(--og-color-status-idle);
+  --color-status-failed: var(--og-color-status-failed);
+  --color-status-cancelled: var(--og-color-status-cancelled);
+  --color-danger: var(--og-color-danger);
 
   /* shadcn compatibility — map canonical token names to ours */
   --color-background: var(--color-bg);
@@ -70,8 +71,8 @@
   --color-accent: var(--color-surface-2);
   --color-accent-foreground: var(--color-fg);
 
-  --color-destructive: oklch(0.65 0.18 22);
-  --color-destructive-foreground: oklch(0.98 0.005 260);
+  --color-destructive: var(--og-color-danger);
+  --color-destructive-foreground: var(--og-color-accent-fg);
 
   --color-input: var(--color-surface-2);
   --color-ring: var(--color-brand);

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,7 +1,7 @@
 import type { ClientModel, SessionStatus } from "@opengeni/sdk";
-import { ArrowUpIcon, FileIcon, ImageIcon, LoaderCircleIcon, PaperclipIcon, SquareIcon, XIcon } from "lucide-react";
+import { ArrowUpIcon, FileIcon, ImageIcon, LoaderCircleIcon, PaperclipIcon, RotateCwIcon, SquareIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode, type RefObject } from "react";
 import { argHint } from "../commands/registry";
 import type { Notice, SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
@@ -303,7 +303,9 @@ export function ChatComposer({
   const activeNotice = notice ?? (composer.error ? { tone: "error" as const, message: composer.error.message || "Sending failed — your draft is still here. Try again." } : null);
 
   return (
-    <div className={cn("og-root", className)}>
+    // Respect the iOS home-indicator inset so the sticky composer never sits
+    // under it (0 on non-notch devices and desktop, so it's inert there).
+    <div className={cn("og-root", className)} style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
       <div className="relative">
         {paletteEnabled ? (
           <CommandPalette
@@ -354,7 +356,11 @@ export function ChatComposer({
             </div>
           ) : null}
           {attachments && attachments.attachments.length > 0 ? (
-            <AttachmentChips attachments={attachments.attachments} onRemove={attachments.remove} />
+            <AttachmentChips
+              attachments={attachments.attachments}
+              onRemove={attachments.remove}
+              onRetry={attachments.retry}
+            />
           ) : null}
           {header}
           <textarea
@@ -373,7 +379,9 @@ export function ChatComposer({
             aria-controls={paletteEnabled && palette.open ? listboxId : undefined}
             aria-activedescendant={paletteEnabled && palette.open ? `${listboxId}-option-${palette.highlight}` : undefined}
             className={cn(
-              "block w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-[15px] leading-6",
+              // Font size steps up to 16px below `md` so iOS never zooms the
+              // viewport on focus; desktop keeps the 15px og-md rhythm.
+              "block w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-base leading-6 md:text-og-md",
               // The wrapper owns the whole-composer focus affordance (focus-within
               // border + soft glow). Suppress any self-scoped focus outline on the
               // textarea itself: `focus:outline-none` alone only sets outline-style
@@ -391,11 +399,15 @@ export function ChatComposer({
               command={pendingDangerCommand}
               onCancel={() => confirmState.resolve(false)}
               onConfirm={() => confirmState.resolve(true)}
+              returnFocusRef={textareaRef}
             />
           ) : (
-            <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
+            <div className="flex items-end gap-2 px-2.5 pb-2.5 pt-1">
               {attachments || models || controlsStart ? (
-                <span className="flex min-w-0 items-center gap-1.5">
+                // The control group wraps onto extra rows when it can't fit
+                // (narrow viewports) instead of clipping under the rounded
+                // corner; send/stop stays anchored bottom-right (shrink-0).
+                <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
                   {attachments ? (
                     <>
                       <input
@@ -432,11 +444,11 @@ export function ChatComposer({
                   {controlsStart}
                 </span>
               ) : (
-                <span className="px-1.5 text-[11px] text-og-fg-subtle max-sm:hidden">
+                <span className="min-w-0 flex-1 px-1.5 text-og-xs text-og-fg-subtle max-sm:hidden">
                   {hint ?? "Enter to send · Shift+Enter for a new line · / for commands"}
                 </span>
               )}
-              <span className="flex items-center gap-1.5">
+              <span className="ml-auto flex shrink-0 items-center gap-1.5">
                 <AnimatePresence initial={false}>
                   {active ? (
                     <motion.button
@@ -451,7 +463,7 @@ export function ChatComposer({
                       aria-label="Stop the current turn"
                       title="Stop the current turn"
                       className={cn(
-                        "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border",
+                        "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11",
                         "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
                         "hover:border-og-status-failed/50 hover:text-og-status-failed",
                         "disabled:opacity-50",
@@ -476,7 +488,7 @@ export function ChatComposer({
                   disabled={!canSend || disabled === true || commandDraftBlocked}
                   aria-label="Send message"
                   className={cn(
-                    "inline-flex size-8 items-center justify-center rounded-og-md",
+                    "inline-flex size-8 items-center justify-center rounded-og-md pointer-coarse:size-11",
                     "bg-og-accent text-og-accent-fg shadow-og-sm",
                     "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
                     "hover:bg-og-accent-strong active:scale-95",
@@ -521,33 +533,66 @@ export function ChatComposer({
   );
 }
 
-/** The danger confirm bar — reuses og-status-failed tokens (like the stop control). */
-function ConfirmBar({ command, onCancel, onConfirm }: { command: SlashCommand; onCancel: () => void; onConfirm: () => void }) {
+/**
+ * The danger confirm bar — reuses og-status-failed tokens (like the stop
+ * control). Inline (not a modal) but keyboard-complete: Escape cancels, focus
+ * moves to the primary action when it appears and returns to the composer on
+ * dismiss, and the primary button names the action rather than a bare "Confirm".
+ */
+function ConfirmBar({
+  command,
+  onCancel,
+  onConfirm,
+  returnFocusRef,
+}: {
+  command: SlashCommand;
+  onCancel: () => void;
+  onConfirm: () => void;
+  /** Focus returns here when the bar dismisses (the composer textarea). */
+  returnFocusRef?: RefObject<HTMLTextAreaElement | null> | undefined;
+}) {
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const descriptionId = useId();
+  useEffect(() => {
+    const returnTo = returnFocusRef?.current ?? null;
+    confirmRef.current?.focus();
+    return () => {
+      returnTo?.focus();
+    };
+  }, [returnFocusRef]);
   return (
     <div
       role="alertdialog"
       aria-label={`Confirm /${command.name}`}
+      aria-describedby={descriptionId}
       data-testid="danger-confirm"
-      className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          onCancel();
+        }
+      }}
+      className="flex items-end justify-between gap-2 px-2.5 pb-2.5 pt-1"
     >
-      <span className="px-1.5 text-[12px] text-og-status-failed">
+      <span id={descriptionId} className="min-w-0 flex-1 px-1.5 text-og-sm text-og-status-failed">
         Run <span className="font-mono">/{command.name}</span>? {command.description}
       </span>
-      <span className="flex items-center gap-1.5">
+      <span className="flex shrink-0 items-center gap-1.5">
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-og-md border border-og-border bg-og-surface-2 px-2.5 py-1 text-[12px] text-og-fg-muted hover:bg-og-surface-3"
+          className="rounded-og-md border border-og-border bg-og-surface-2 px-2.5 py-1 text-og-sm text-og-fg-muted hover:bg-og-surface-3 pointer-coarse:min-h-10"
         >
           Cancel
         </button>
         <button
+          ref={confirmRef}
           type="button"
-          autoFocus
           onClick={onConfirm}
-          className="rounded-og-md border border-og-status-failed/50 bg-og-status-failed/15 px-2.5 py-1 text-[12px] text-og-status-failed hover:bg-og-status-failed/25"
+          className="rounded-og-md border border-og-status-failed/50 bg-og-status-failed/15 px-2.5 py-1 text-og-sm text-og-status-failed hover:bg-og-status-failed/25 pointer-coarse:min-h-10"
         >
-          Confirm
+          Run /{command.name}
         </button>
       </span>
     </div>
@@ -557,51 +602,73 @@ function ConfirmBar({ command, onCancel, onConfirm }: { command: SlashCommand; o
 /**
  * The attachment-chips strip rendered above the textarea while files are
  * attached. Each chip shows an image preview (or a type icon), the filename,
- * an upload/size/failed status line, and a remove control. Styled with the
+ * an upload/size/failed status line, and a remove control. A failed upload
+ * surfaces its actual error (inline, full text on hover via `title`) and offers
+ * a retry alongside remove — a failed attachment never blocks send (only an
+ * in-progress upload does), and removing it clears the way. Styled with the
  * package's og-* tokens so it themes in any consumer.
  */
-function AttachmentChips({ attachments, onRemove }: {
+function AttachmentChips({ attachments, onRemove, onRetry }: {
   attachments: UseFileAttachmentsResult["attachments"];
   onRemove: (id: string) => void;
+  onRetry?: ((id: string) => void) | undefined;
 }) {
   return (
     <div className="flex flex-wrap gap-2 border-b border-og-border px-3 py-2">
-      {attachments.map((attachment) => (
-        <div
-          key={attachment.id}
-          className={cn(
-            "flex min-w-0 max-w-[240px] items-center gap-2 rounded-og-md border px-2 py-1.5",
-            "border-og-border bg-og-surface-2 text-xs",
-          )}
-        >
-          {attachment.previewUrl ? (
-            <img src={attachment.previewUrl} alt="" className="size-8 shrink-0 rounded object-cover" />
-          ) : attachment.contentType.startsWith("image/") ? (
-            <ImageIcon className="size-4 shrink-0 text-og-fg-muted" />
-          ) : (
-            <FileIcon className="size-4 shrink-0 text-og-fg-muted" />
-          )}
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-medium text-og-fg">{attachment.name}</div>
-            <div className={cn(
-              "truncate text-[11px]",
-              attachment.status === "failed" ? "text-og-status-failed" : "text-og-fg-subtle",
+      {attachments.map((attachment) => {
+        const failed = attachment.status === "failed";
+        const statusText = attachment.status === "uploading"
+          ? "Uploading"
+          : failed
+            ? attachment.error || "Upload failed"
+            : formatBytes(attachment.sizeBytes);
+        return (
+          <div
+            key={attachment.id}
+            className={cn(
+              "flex min-w-0 max-w-[240px] items-center gap-2 rounded-og-md border px-2 py-1.5 text-og-sm",
+              failed ? "border-og-status-failed/40 bg-og-status-failed/10" : "border-og-border bg-og-surface-2",
             )}
-            >
-              {attachment.status === "uploading" ? "Uploading" : attachment.status === "failed" ? "Upload failed" : formatBytes(attachment.sizeBytes)}
-            </div>
-          </div>
-          {attachment.status === "uploading" ? <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" /> : null}
-          <button
-            type="button"
-            onClick={() => onRemove(attachment.id)}
-            className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg"
-            aria-label={`Remove ${attachment.name}`}
           >
-            <XIcon className="size-3.5" />
-          </button>
-        </div>
-      ))}
+            {attachment.previewUrl ? (
+              <img src={attachment.previewUrl} alt="" className="size-8 shrink-0 rounded object-cover" />
+            ) : attachment.contentType.startsWith("image/") ? (
+              <ImageIcon className="size-4 shrink-0 text-og-fg-muted" />
+            ) : (
+              <FileIcon className="size-4 shrink-0 text-og-fg-muted" />
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-medium text-og-fg">{attachment.name}</div>
+              <div
+                className={cn("truncate text-og-xs", failed ? "text-og-status-failed" : "text-og-fg-subtle")}
+                title={failed ? statusText : undefined}
+              >
+                {statusText}
+              </div>
+            </div>
+            {attachment.status === "uploading" ? <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" /> : null}
+            {failed && onRetry ? (
+              <button
+                type="button"
+                onClick={() => onRetry(attachment.id)}
+                className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:size-8"
+                aria-label={`Retry ${attachment.name}`}
+                title="Retry upload"
+              >
+                <RotateCwIcon className="size-3.5" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => onRemove(attachment.id)}
+              className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:size-8"
+              aria-label={`Remove ${attachment.name}`}
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -616,8 +683,8 @@ function HelpPanel({ commands, onClose }: { commands: readonly SlashCommand[]; o
       className="mt-2 overflow-hidden rounded-og-lg border border-og-border bg-og-surface-2"
     >
       <div className="flex items-center justify-between border-b border-og-border px-3 py-1.5">
-        <span className="text-[12px] font-medium text-og-fg">Commands</span>
-        <button type="button" onClick={onClose} className="text-[11px] text-og-fg-subtle hover:text-og-fg">
+        <span className="text-og-sm font-medium text-og-fg">Commands</span>
+        <button type="button" onClick={onClose} className="text-og-xs text-og-fg-subtle hover:text-og-fg">
           Close
         </button>
       </div>
@@ -626,13 +693,13 @@ function HelpPanel({ commands, onClose }: { commands: readonly SlashCommand[]; o
           const hint = argHint(command.args);
           return (
             <li key={command.name} className="flex items-baseline gap-2 px-3 py-1">
-              <span className="font-mono text-[12px] text-og-accent">
+              <span className="font-mono text-og-sm text-og-accent">
                 /{command.name}
                 {hint ? <span className="ml-1 text-og-fg-subtle">{hint}</span> : null}
               </span>
-              <span className="text-[12px] text-og-fg-muted">{command.description}</span>
+              <span className="text-og-sm text-og-fg-muted">{command.description}</span>
               {command.danger ? (
-                <span className="ml-auto rounded-og-xs bg-og-status-failed/15 px-1 text-[10px] uppercase tracking-wide text-og-status-failed">
+                <span className="ml-auto rounded-og-xs bg-og-status-failed/15 px-1 text-og-xs uppercase tracking-wide text-og-status-failed">
                   danger
                 </span>
               ) : null}

--- a/packages/react/src/components/code-editor.tsx
+++ b/packages/react/src/components/code-editor.tsx
@@ -278,38 +278,38 @@ export function CodeEditor({
       style={editorVars}
     >
       {/* Save bar: dirty indicator + status + the explicit Save button. */}
-      <div className="flex shrink-0 items-center gap-2 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))] px-2 py-1">
+      <div className="flex shrink-0 items-center gap-2 border-b border-og-border bg-og-surface-1 px-2 py-1">
         <span
           className={cn(
             "size-1.5 shrink-0 rounded-full transition-colors",
             readOnly
               ? "bg-transparent"
               : dirty
-                ? "bg-[color:var(--og-color-status-running,var(--color-warning,#d29922))]"
-                : "bg-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]",
+                ? "bg-og-status-running"
+                : "bg-og-status-idle",
           )}
           title={readOnly ? "read-only" : dirty ? "unsaved changes" : "saved"}
         />
-        <span className="truncate font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[11px] text-[color:var(--og-color-fg-muted,var(--color-fg-muted,#aaa))]">
+        <span className="truncate font-og-mono text-og-xs text-og-fg-muted">
           {fileName}
           {dirty && !readOnly ? " •" : ""}
         </span>
         <div className="ml-auto flex shrink-0 items-center gap-2">
           {saveError && (
             <span
-              className="max-w-[220px] truncate text-[10px] text-[color:var(--og-color-danger,var(--color-danger,#f85149))]"
+              className="max-w-[220px] truncate text-og-xs text-og-status-failed"
               title={saveError.message}
             >
               {saveError.message}
             </span>
           )}
           {!saveError && savedTick && (
-            <span className="text-[10px] text-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]">
+            <span className="text-og-xs text-og-status-idle">
               Saved
             </span>
           )}
           {readOnly ? (
-            <span className="text-[10px] uppercase tracking-wide text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+            <span className="text-og-xs uppercase tracking-wide text-og-fg-subtle">
               Read-only
             </span>
           ) : (
@@ -318,10 +318,10 @@ export function CodeEditor({
               onClick={() => void save()}
               disabled={saving || !dirty}
               className={cn(
-                "flex items-center gap-1 rounded-[var(--og-radius-sm,4px)] border border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] px-1.5 py-0.5 text-[10px]",
+                "flex items-center gap-1 rounded-og-sm border border-og-border px-1.5 py-0.5 text-og-xs pointer-coarse:min-h-10",
                 saving || !dirty
-                  ? "cursor-default text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))] opacity-60"
-                  : "text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))] hover:bg-[color:var(--og-color-accent-soft,var(--color-surface-2,#222))]",
+                  ? "cursor-default text-og-fg-subtle opacity-60"
+                  : "text-og-fg hover:bg-og-accent-soft",
               )}
               title="Save (⌘/Ctrl+S)"
             >
@@ -347,7 +347,7 @@ export function CodeEditor({
             basicSetup={true}
             extensions={cmExtensions}
             height="100%"
-            className="og-cm-editor min-h-full text-[12.5px]"
+            className="og-cm-editor min-h-full text-og-sm"
             onChange={
               readOnly
                 ? undefined
@@ -365,8 +365,8 @@ export function CodeEditor({
 
 /** og-* themed CSS-var overrides handed to CodeMirror's container. */
 const editorVars = {
-  "--og-cm-bg": "var(--og-color-bg, #0d0d0d)",
-  fontFamily: "var(--og-font-mono, var(--font-mono, monospace))",
+  "--og-cm-bg": "var(--og-color-bg)",
+  fontFamily: "var(--og-font-mono)",
 } as CSSProperties;
 
 function PlainTextarea({
@@ -384,14 +384,14 @@ function PlainTextarea({
       readOnly={readOnly}
       spellCheck={false}
       onChange={(e) => onChange(e.target.value)}
-      className="h-full w-full resize-none bg-transparent p-2 font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[12px] leading-[18px] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))] outline-none"
+      className="h-full w-full resize-none bg-transparent p-2 font-og-mono text-og-sm text-og-fg outline-none"
     />
   );
 }
 
 function EditorSkeleton() {
   return (
-    <div className="p-3 text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+    <div className="p-3 text-og-sm text-og-fg-subtle">
       Loading editor…
     </div>
   );

--- a/packages/react/src/components/desktop-viewer.tsx
+++ b/packages/react/src/components/desktop-viewer.tsx
@@ -84,6 +84,10 @@ type DesktopUiState =
   | "error" // RFB error / securityfailure after a connect.
   | "connected"; // live framebuffer painting.
 
+// Media-inspection exception: the framebuffer sits on true black so screenshots
+// and desktop pixels are not tinted by the product chrome palette.
+const DESKTOP_MEDIA_BACKGROUND = "#000";
+
 /** Reasons that are genuinely-unavailable (never warmable from the viewer). A
  *  `lease_cold` is deliberately EXCLUDED — that's the warmable cold state. */
 function isHardUnavailable(reason: CapabilityUnavailableReason | null): boolean {
@@ -369,11 +373,11 @@ export function DesktopViewer({
   return (
     <div
       className={cn(
-        "relative h-full w-full overflow-hidden bg-black",
-        inControl &&
-          "ring-2 ring-inset ring-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]",
+        "relative h-full w-full overflow-hidden",
+        inControl && "ring-2 ring-inset ring-og-accent",
         className,
       )}
+      style={{ backgroundColor: DESKTOP_MEDIA_BACKGROUND }}
       data-opengeni-desktop
       data-state={stream.state}
       data-ui-state={uiState}
@@ -399,15 +403,15 @@ export function DesktopViewer({
           `connecting` UI-state (every other non-connected state has an explicit
           overlay). A spinner + transitional copy makes it feel live. */}
       {uiState === "connecting" && (
-        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 text-og-fg-subtle">
           <span className="relative flex items-center justify-center">
             <MonitorIcon className="size-8 opacity-30" strokeWidth={1.5} />
             <LoaderCircleIcon
-              className="absolute size-12 animate-og-spin text-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] opacity-70"
+              className="absolute size-12 animate-og-spin text-og-accent opacity-70"
               strokeWidth={1.25}
             />
           </span>
-          <span className="text-xs">Connecting to the desktop…</span>
+          <span className="text-og-sm">Connecting to the desktop…</span>
         </div>
       )}
 
@@ -438,7 +442,7 @@ export function DesktopViewer({
             !serverAllowsControl
               ? capability?.client === "frames"
                 ? "View-only — live control isn't available for this machine yet."
-                : "This deployment streams the desktop read-only"
+                : "This deployment streams the desktop read-only."
               : undefined
           }
           onTakeControl={() => setTakeControl(true)}
@@ -481,36 +485,36 @@ function TakeControlCallToAction({
         title={disabled ? disabledReason : "Take control of the desktop"}
         onClick={onTakeControl}
         className={cn(
-          "group pointer-events-auto flex items-center gap-3 rounded-[var(--og-radius-lg,12px)] border px-5 py-3",
-          "border-[color:var(--og-color-border,var(--color-border,#2a2a2a))]",
-          "bg-[color:var(--og-color-bg,#0d0d0d)]/85 backdrop-blur-md",
-          "shadow-[var(--og-shadow-lg,0_10px_30px_-10px_rgba(0,0,0,0.6))]",
+          "group pointer-events-auto flex items-center gap-3 rounded-og-lg border px-5 py-3",
+          "border-og-border",
+          "bg-og-bg/85 backdrop-blur-md",
+          "shadow-og-lg",
           "outline-none transition-all duration-150 ease-out",
-          "focus-visible:ring-2 focus-visible:ring-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+          "focus-visible:ring-2 focus-visible:ring-og-accent focus-visible:ring-offset-2 focus-visible:ring-offset-og-bg",
           disabled
             ? "cursor-not-allowed opacity-60"
             : cn(
                 "cursor-pointer opacity-90 hover:-translate-y-0.5 hover:opacity-100",
-                "hover:border-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]",
-                "hover:bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]/10",
+                "hover:border-og-accent",
+                "hover:bg-og-accent/10",
               ),
         )}
       >
         <span
           className={cn(
             "flex size-9 shrink-0 items-center justify-center rounded-full transition-colors",
-            "bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]",
-            "text-[color:var(--og-color-accent-fg,#fff)]",
+            "bg-og-accent",
+            "text-og-accent-fg",
             disabled ? "" : "group-hover:scale-105",
           )}
         >
           <MousePointerClickIcon className="size-5" strokeWidth={2} />
         </span>
         <span className="flex flex-col items-start leading-tight">
-          <span className="text-sm font-semibold text-[color:var(--og-color-fg,#e6e6e6)]">
+          <span className="text-og-base font-semibold text-og-fg">
             Take control
           </span>
-          <span className="text-[11px] text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+          <span className="text-og-xs text-og-fg-subtle">
             {disabled && disabledReason ? disabledReason : "Drive the mouse & keyboard"}
           </span>
         </span>
@@ -530,15 +534,15 @@ function TakeControlCallToAction({
 function InControlBar({ shared, onRelease }: { shared: boolean; onRelease: () => void }) {
   return (
     <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between gap-2 p-2">
-      <span className="pointer-events-auto inline-flex items-center gap-2 rounded-[var(--og-radius-sm,4px)] bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] px-2.5 py-1 text-[11px] font-medium text-[color:var(--og-color-accent-fg,#fff)] shadow-[var(--og-shadow-md)]">
+      <span className="pointer-events-auto inline-flex items-center gap-2 rounded-og-sm bg-og-accent px-2.5 py-1 text-og-xs font-medium text-og-accent-fg shadow-og-md">
         <span className="size-1.5 animate-pulse rounded-full bg-current" aria-hidden />
         You&apos;re in control
         <span className="opacity-75">· click Return control (or Ctrl+Alt+Shift)</span>
       </span>
       <div className="pointer-events-auto flex items-center gap-1.5">
         {shared && (
-          <span className="rounded-[var(--og-radius-sm,4px)] bg-[color:var(--og-color-danger,var(--color-danger,#f85149))]/85 px-2 py-0.5 text-[10px] text-white">
-            Shared box — others are watching
+          <span className="rounded-og-sm bg-og-status-failed/85 px-2 py-0.5 text-og-xs text-og-accent-fg">
+            Shared sandbox — others are watching
           </span>
         )}
         <button
@@ -546,9 +550,9 @@ function InControlBar({ shared, onRelease }: { shared: boolean; onRelease: () =>
           onClick={onRelease}
           title="Return control (or press Ctrl+Alt+Shift)"
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-[var(--og-radius-sm,4px)] border px-2.5 py-1 text-[11px] font-semibold shadow-[var(--og-shadow-md)] transition-colors",
-            "border-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] bg-[color:var(--og-color-bg,#0d0d0d)]/90 text-[color:var(--og-color-fg,#e6e6e6)] backdrop-blur-sm",
-            "outline-none hover:bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] hover:text-[color:var(--og-color-accent-fg,#fff)] focus-visible:ring-2 focus-visible:ring-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]",
+            "inline-flex items-center gap-1.5 rounded-og-sm border px-2.5 py-1 text-og-xs font-semibold shadow-og-md transition-colors",
+            "border-og-accent bg-og-bg/90 text-og-fg backdrop-blur-sm",
+            "outline-none hover:bg-og-accent hover:text-og-accent-fg focus-visible:ring-2 focus-visible:ring-og-accent",
           )}
         >
           <MonitorIcon className="size-3.5" strokeWidth={2} aria-hidden />
@@ -568,7 +572,7 @@ function unavailableCopy(reason: CapabilityUnavailableReason | null): string {
     case "os_unsupported":
       return "The sandbox OS does not support a desktop stream.";
     case "not_provisioned":
-      return "No display stack is provisioned on this box yet.";
+      return "This sandbox doesn't have a desktop yet.";
     case "disabled_by_policy":
       return "Desktop streaming is disabled on this deployment.";
     case "lease_cold":
@@ -589,14 +593,14 @@ function unavailableCopy(reason: CapabilityUnavailableReason | null): string {
  */
 function WarmingNotice({ onRetry }: { onRetry?: (() => void) | undefined }) {
   return (
-    <div className="flex max-w-sm flex-col items-center gap-3 rounded-lg border border-[color:var(--color-border,#2a2a2a)] bg-[color:var(--color-bg,#0d0d0d)]/90 p-5 text-center text-sm text-[color:var(--color-fg,#e6e6e6)] backdrop-blur-sm">
+    <div className="flex max-w-sm flex-col items-center gap-3 rounded-og-lg border border-og-border bg-og-bg/90 p-5 text-center text-og-base text-og-fg backdrop-blur-sm">
       <LoaderCircleIcon
-        className="size-7 animate-og-spin text-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]"
+        className="size-7 animate-og-spin text-og-accent"
         strokeWidth={1.5}
       />
       <div className="space-y-1">
         <div className="font-medium">Warming the sandbox…</div>
-        <p className="text-xs text-[color:var(--color-fg-subtle,#888)]">
+        <p className="text-og-sm text-og-fg-subtle">
           Spinning up the desktop — this takes a few seconds.
         </p>
       </div>
@@ -604,7 +608,7 @@ function WarmingNotice({ onRetry }: { onRetry?: (() => void) | undefined }) {
         <button
           type="button"
           onClick={onRetry}
-          className="rounded border border-[color:var(--color-border,#2a2a2a)] px-3 py-1.5 text-xs text-[color:var(--color-fg-muted,#aaa)] transition-colors hover:text-[color:var(--color-fg,#e6e6e6)]"
+          className="rounded-og-sm border border-og-border px-3 py-1.5 text-og-sm text-og-fg-muted transition-colors hover:text-og-fg pointer-coarse:min-h-10"
         >
           Taking too long? Retry
         </button>
@@ -615,19 +619,19 @@ function WarmingNotice({ onRetry }: { onRetry?: (() => void) | undefined }) {
 
 function DefaultConsentGate({ shared, onAccept }: { shared: boolean; onAccept: () => void }) {
   return (
-    <div className="max-w-sm rounded-lg border border-[color:var(--color-border,#2a2a2a)] bg-[color:var(--color-bg,#0d0d0d)] p-4 text-center text-sm text-[color:var(--color-fg,#e6e6e6)]">
+    <div className="max-w-sm rounded-og-lg border border-og-border bg-og-bg p-4 text-center text-og-base text-og-fg">
       <div className="mb-1 font-medium">Watch the live desktop?</div>
-      <p className="mb-3 text-xs text-[color:var(--color-fg-subtle,#888)]">
+      <p className="mb-3 text-og-sm text-og-fg-subtle">
         The desktop pixel stream is <strong>un-redacted</strong> — it can show secrets the agent prints
         on screen.
         {shared
-          ? " This box is shared: you will also see sibling sessions' agents on the same screen."
+          ? " This sandbox is shared: you'll also see other sessions' agents on the same screen."
           : ""}
       </p>
       <button
         type="button"
         onClick={onAccept}
-        className="rounded bg-[color:var(--color-brand,#3b82f6)] px-3 py-1.5 text-xs font-medium text-white"
+        className="rounded-og-sm bg-og-accent px-3 py-1.5 text-og-sm font-medium text-og-accent-fg pointer-coarse:min-h-10"
       >
         I understand — show the desktop
       </button>
@@ -637,17 +641,17 @@ function DefaultConsentGate({ shared, onAccept }: { shared: boolean; onAccept: (
 
 function defaultNotice(title: string, body: string, onRetry?: () => void): ReactNode {
   return (
-    <div className="max-w-sm rounded-lg border border-[color:var(--color-border,#2a2a2a)] bg-[color:var(--color-bg,#0d0d0d)] p-4 text-center text-sm text-[color:var(--color-fg,#e6e6e6)]">
+    <div className="max-w-sm rounded-og-lg border border-og-border bg-og-bg p-4 text-center text-og-base text-og-fg">
       <div className="mb-1 flex items-center justify-center gap-1.5 font-medium">
         {onRetry && <WifiOffIcon className="size-4 opacity-70" strokeWidth={1.75} />}
         {title}
       </div>
-      <p className="text-xs text-[color:var(--color-fg-subtle,#888)]">{body}</p>
+      <p className="text-og-sm text-og-fg-subtle">{body}</p>
       {onRetry && (
         <button
           type="button"
           onClick={onRetry}
-          className="mt-3 rounded border border-[color:var(--color-border,#2a2a2a)] px-3 py-1.5 text-xs transition-colors hover:border-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]"
+          className="mt-3 rounded-og-sm border border-og-border px-3 py-1.5 text-og-sm transition-colors hover:border-og-accent pointer-coarse:min-h-10"
         >
           Reconnect
         </button>

--- a/packages/react/src/components/diff-view.tsx
+++ b/packages/react/src/components/diff-view.tsx
@@ -60,8 +60,8 @@ export function DiffView({
 
   if (diff.length === 0) {
     return (
-      <div className={cn("p-3 text-xs text-[color:var(--color-fg-subtle,#888)]", className)}>
-        {emptyState ?? (isRepo ? "No changes." : "No repository mounted.")}
+      <div className={cn("p-3 text-og-sm text-og-fg-subtle", className)}>
+        {emptyState ?? (isRepo ? "No changes" : "No repository mounted")}
       </div>
     );
   }
@@ -93,29 +93,29 @@ function FileDiffBlock({
   onSelect?: (() => void) | undefined;
 }) {
   return (
-    <section className="mb-2 overflow-hidden rounded border border-[color:var(--color-border,#2a2a2a)]">
+    <section className="mb-2 overflow-hidden rounded-og-sm border border-og-border">
       <header
         className={cn(
-          "flex items-center justify-between gap-2 border-b border-[color:var(--color-border,#2a2a2a)] bg-[color:var(--color-bg-subtle,#161616)] px-2 py-1 text-xs",
+          "flex items-center justify-between gap-2 border-b border-og-border bg-og-surface-1 px-2 py-1 text-og-sm",
           onSelect && "cursor-pointer",
         )}
         onClick={onSelect}
       >
-        <span className="truncate font-mono">
+        <span className="truncate font-og-mono">
           {file.oldPath && file.oldPath !== file.path ? `${file.oldPath} → ${file.path}` : file.path}
         </span>
         <span className="flex shrink-0 items-center gap-2">
-          <span className="rounded bg-[color:var(--color-bg,#0d0d0d)] px-1 py-0.5 text-[10px] uppercase tracking-wide text-[color:var(--color-fg-subtle,#888)]">
+          <span className="rounded-og-xs bg-og-bg px-1 py-0.5 text-og-xs text-og-fg-subtle">
             {STATUS_LABEL[file.status]}
           </span>
-          <span className="text-[color:var(--color-success,#3fb950)]">+{file.additions}</span>
-          <span className="text-[color:var(--color-danger,#f85149)]">−{file.deletions}</span>
+          <span className="text-og-status-idle">+{file.additions}</span>
+          <span className="text-og-status-failed">−{file.deletions}</span>
         </span>
       </header>
       {file.isBinary ? (
-        <div className="px-2 py-3 text-xs text-[color:var(--color-fg-subtle,#888)]">Binary file not shown.</div>
+        <div className="px-2 py-3 text-og-sm text-og-fg-subtle">Binary file not shown</div>
       ) : file.truncated ? (
-        <div className="px-2 py-3 text-xs text-[color:var(--color-fg-subtle,#888)]">Diff too large — truncated.</div>
+        <div className="px-2 py-3 text-og-sm text-og-fg-subtle">Diff too large — truncated</div>
       ) : layout === "split" ? (
         <SplitHunks file={file} theme={theme} />
       ) : (
@@ -126,8 +126,8 @@ function FileDiffBlock({
 }
 
 function lineBg(type: GitDiffLine["type"], theme: DiffTheme | undefined): string | undefined {
-  if (type === "add") return theme?.addBackground ?? "var(--color-diff-add, rgba(63,185,80,0.15))";
-  if (type === "del") return theme?.delBackground ?? "var(--color-diff-del, rgba(248,81,73,0.15))";
+  if (type === "add") return theme?.addBackground ?? "var(--og-color-diff-add-bg)";
+  if (type === "del") return theme?.delBackground ?? "var(--og-color-diff-del-bg)";
   if (type === "meta") return undefined;
   return theme?.contextBackground;
 }
@@ -140,11 +140,11 @@ function marker(type: GitDiffLine["type"]): string {
 
 function UnifiedHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | undefined }) {
   return (
-    <div className="font-mono text-[11px] leading-tight">
+    <div className="font-og-mono text-og-xs">
       {file.hunks.map((hunk, hi) => (
         <div key={`${file.path}-h${hi}`}>
           <div
-            className="px-2 py-0.5 text-[color:var(--color-info,#58a6ff)]"
+            className="px-2 py-0.5 text-og-accent"
             style={{ color: theme?.metaForeground }}
           >
             {hunk.header}
@@ -155,13 +155,13 @@ function UnifiedHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | u
               className="flex"
               style={{ backgroundColor: lineBg(line.type, theme) }}
             >
-              <span className="w-10 shrink-0 select-none px-1 text-right text-[color:var(--color-fg-subtle,#666)]">
+              <span className="w-10 shrink-0 select-none px-1 text-right text-og-fg-subtle">
                 {line.oldNo ?? ""}
               </span>
-              <span className="w-10 shrink-0 select-none px-1 text-right text-[color:var(--color-fg-subtle,#666)]">
+              <span className="w-10 shrink-0 select-none px-1 text-right text-og-fg-subtle">
                 {line.newNo ?? ""}
               </span>
-              <span className="w-4 shrink-0 select-none text-center text-[color:var(--color-fg-subtle,#888)]">
+              <span className="w-4 shrink-0 select-none text-center text-og-fg-subtle">
                 {marker(line.type)}
               </span>
               <span className="whitespace-pre-wrap break-all px-1">{line.text}</span>
@@ -175,7 +175,7 @@ function UnifiedHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | u
 
 function SplitHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | undefined }) {
   return (
-    <div className="font-mono text-[11px] leading-tight">
+    <div className="font-og-mono text-og-xs">
       {file.hunks.map((hunk, hi) => {
         // Pair del/add lines side-by-side; context spans both columns.
         const left: (GitDiffLine | null)[] = [];
@@ -193,7 +193,7 @@ function SplitHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | und
         const rows = Math.max(left.length, right.length);
         return (
           <div key={`${file.path}-h${hi}`}>
-            <div className="px-2 py-0.5 text-[color:var(--color-info,#58a6ff)]" style={{ color: theme?.metaForeground }}>
+            <div className="px-2 py-0.5 text-og-accent" style={{ color: theme?.metaForeground }}>
               {hunk.header}
             </div>
             {Array.from({ length: rows }).map((_, ri) => {
@@ -205,16 +205,16 @@ function SplitHunks({ file, theme }: { file: GitFileDiff; theme: DiffTheme | und
                     className="flex w-1/2 min-w-0"
                     style={{ backgroundColor: l ? lineBg(l.type, theme) : undefined }}
                   >
-                    <span className="w-10 shrink-0 select-none px-1 text-right text-[color:var(--color-fg-subtle,#666)]">
+                    <span className="w-10 shrink-0 select-none px-1 text-right text-og-fg-subtle">
                       {l?.oldNo ?? ""}
                     </span>
                     <span className="whitespace-pre-wrap break-all px-1">{l?.text ?? ""}</span>
                   </span>
                   <span
-                    className="flex w-1/2 min-w-0 border-l border-[color:var(--color-border,#2a2a2a)]"
+                    className="flex w-1/2 min-w-0 border-l border-og-border"
                     style={{ backgroundColor: r ? lineBg(r.type, theme) : undefined }}
                   >
-                    <span className="w-10 shrink-0 select-none px-1 text-right text-[color:var(--color-fg-subtle,#666)]">
+                    <span className="w-10 shrink-0 select-none px-1 text-right text-og-fg-subtle">
                       {r?.newNo ?? ""}
                     </span>
                     <span className="whitespace-pre-wrap break-all px-1">{r?.text ?? ""}</span>

--- a/packages/react/src/components/enrollment-consent.tsx
+++ b/packages/react/src/components/enrollment-consent.tsx
@@ -43,8 +43,8 @@ function Capability({ icon, title, body }: { icon: ReactNode; title: string; bod
     <li className="flex items-start gap-2.5">
       <span className="mt-0.5 shrink-0 text-og-status-failed">{icon}</span>
       <span className="min-w-0">
-        <span className="block text-[13px] font-medium text-og-fg">{title}</span>
-        <span className="block text-[12px] text-og-fg-muted">{body}</span>
+        <span className="block text-og-base font-medium text-og-fg">{title}</span>
+        <span className="block text-og-sm text-og-fg-muted">{body}</span>
       </span>
     </li>
   );
@@ -113,15 +113,15 @@ export function EnrollmentConsent({
           <ShieldAlertIcon className="size-5" aria-hidden />
         </span>
         <div className="min-w-0">
-          <h1 className="text-base font-semibold text-og-fg">Give the agent your whole machine?</h1>
-          <p className="mt-1 text-[13px] text-og-fg-muted">
+          <h1 className="text-og-md font-semibold text-og-fg">Give the agent your whole machine?</h1>
+          <p className="mt-1 text-og-base text-og-fg-muted">
             Approving lets the OpenGeni agent run on <span className="font-medium text-og-fg">{machine.machineName}</span> with
             full access. This is your real computer — not a sandbox.
           </p>
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 rounded-og-md border border-og-border bg-og-surface-2 px-3 py-2 text-[12px]">
+      <div className="flex flex-wrap items-center gap-2 rounded-og-md border border-og-border bg-og-surface-2 px-3 py-2 text-og-sm">
         <LaptopIcon className="size-4 text-og-fg-subtle" aria-hidden />
         <span className="font-medium text-og-fg">{machine.machineName}</span>
         <span className="font-og-mono text-og-fg-subtle">
@@ -163,21 +163,21 @@ export function EnrollmentConsent({
             checked={allowScreenControl}
             disabled={busy}
             onChange={(e) => setAllowScreenControl(e.target.checked)}
-            className="mt-0.5 size-4 accent-[var(--og-color-accent)]"
+            className="mt-0.5 size-4 accent-og-accent"
           />
           <span className="min-w-0">
-            <span className="flex items-center gap-1.5 text-[13px] font-medium text-og-fg">
+            <span className="flex items-center gap-1.5 text-og-base font-medium text-og-fg">
               <ScreenShareIcon className="size-3.5 text-og-fg-muted" aria-hidden />
               Also let the agent control my mouse & keyboard
             </span>
-            <span className="mt-0.5 block text-[12px] text-og-fg-muted">
+            <span className="mt-0.5 block text-og-sm text-og-fg-muted">
               Optional. Enables computer-use — the agent can move the pointer, type, and click on this machine's desktop. Leave
               off to let it only watch.
             </span>
           </span>
         </label>
       ) : (
-        <p className="flex items-start gap-2 rounded-og-md border border-og-border bg-og-bg px-3 py-2 text-[12px] text-og-fg-muted">
+        <p className="flex items-start gap-2 rounded-og-md border border-og-border bg-og-bg px-3 py-2 text-og-sm text-og-fg-muted">
           <CircleAlertIcon className="mt-px size-3.5 shrink-0 text-og-fg-subtle" aria-hidden />
           This machine has no display, so screen control isn't available — files, terminal, and git only.
         </p>
@@ -189,7 +189,7 @@ export function EnrollmentConsent({
           data-deny
           disabled={busy}
           onClick={() => onDeny?.()}
-          className="flex-1 rounded-og-sm border border-og-border px-3 py-2 text-sm font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg disabled:opacity-50"
+          className="flex-1 rounded-og-sm border border-og-border px-3 py-2 text-og-sm font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg disabled:opacity-50 pointer-coarse:min-h-10"
         >
           Cancel
         </button>
@@ -198,7 +198,7 @@ export function EnrollmentConsent({
           data-approve
           disabled={busy}
           onClick={() => onApprove?.(allowScreenControl)}
-          className="flex-1 rounded-og-sm bg-og-status-failed px-3 py-2 text-sm font-semibold text-white transition-colors hover:opacity-90 disabled:opacity-50"
+          className="flex-1 rounded-og-sm bg-og-status-failed px-3 py-2 text-og-sm font-semibold text-og-accent-fg transition-colors hover:opacity-90 disabled:opacity-50 pointer-coarse:min-h-10"
         >
           {busy ? "Connecting…" : "Grant full access"}
         </button>
@@ -238,8 +238,8 @@ function ConsentResult({
       <span className={cn("flex size-10 items-center justify-center rounded-full bg-og-surface-2", iconClass)}>
         <LaptopIcon className="size-5" aria-hidden />
       </span>
-      <h1 className="text-base font-semibold text-og-fg">{title}</h1>
-      <p className="max-w-sm text-[13px] text-og-fg-muted">{body}</p>
+      <h1 className="text-og-md font-semibold text-og-fg">{title}</h1>
+      <p className="max-w-sm text-og-base text-og-fg-muted">{body}</p>
     </div>
   );
 }

--- a/packages/react/src/components/file-browser.tsx
+++ b/packages/react/src/components/file-browser.tsx
@@ -51,11 +51,11 @@ export type FileBrowserProps = {
 };
 
 const STATUS_TINT: Record<NonNullable<FileTreeNode["status"]>, string> = {
-  added: "text-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]",
-  modified: "text-[color:var(--og-color-status-running,var(--color-warning,#d29922))]",
-  deleted: "text-[color:var(--og-color-danger,var(--color-danger,#f85149))] line-through",
-  renamed: "text-[color:var(--og-color-accent,var(--color-info,#58a6ff))]",
-  untracked: "text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]",
+  added: "text-og-status-idle",
+  modified: "text-og-status-running",
+  deleted: "text-og-status-failed line-through",
+  renamed: "text-og-accent",
+  untracked: "text-og-fg-subtle",
 };
 
 /** Parent dir of a workspace-relative POSIX path ("" for a root entry). */
@@ -397,15 +397,9 @@ export function FileBrowser({
     };
   }, [menu]);
 
-  if (result.error && result.tree.length === 0) {
-    return (
-      <div className={cn("p-3 text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]", className)}>
-        {fallback ?? `Files unavailable: ${result.error.message}`}
-      </div>
-    );
-  }
-
+  const showErrorEmpty = result.error && result.tree.length === 0 && !draftCreate;
   const showEmpty = !result.loading && result.tree.length === 0 && !draftCreate;
+  const showToolbar = supportsMutation || Boolean(result.error) || result.loading;
 
   const renderRow = (node: FileTreeNode, depth: number): ReactNode => {
     const isOpen = expanded.has(node.path);
@@ -489,13 +483,11 @@ export function FileBrowser({
               setMenu({ node, x: e.clientX, y: e.clientY });
             }}
             className={cn(
-              "group flex w-full items-center gap-1 truncate rounded px-1 py-0.5 text-left text-xs",
-              "hover:bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]",
-              isSelected && "bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]",
-              isCursor &&
-                "outline outline-1 -outline-offset-1 outline-[color:var(--og-color-accent,var(--color-info,#58a6ff))]",
-              isDropTarget &&
-                "ring-1 ring-inset ring-[color:var(--og-color-accent,var(--color-info,#58a6ff))] bg-[color:var(--og-color-accent-soft,rgba(88,166,255,0.12))]",
+              "group flex w-full items-center gap-1 truncate rounded-og-sm px-1 py-0.5 text-left text-og-sm pointer-coarse:min-h-10",
+              "hover:bg-og-surface-2",
+              isSelected && "bg-og-surface-2",
+              isCursor && "outline outline-1 -outline-offset-1 outline-og-accent",
+              isDropTarget && "bg-og-accent-soft ring-1 ring-inset ring-og-accent",
               node.status ? STATUS_TINT[node.status] : undefined,
             )}
             style={{ paddingLeft: `${depth * 12 + 4}px` }}
@@ -503,7 +495,7 @@ export function FileBrowser({
             {isDir ? (
               isLoading ? (
                 <Loader2Icon
-                  className="size-3 shrink-0 animate-spin text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]"
+                  className="size-3 shrink-0 animate-spin text-og-fg-subtle"
                   aria-label="Loading"
                 />
               ) : (
@@ -526,7 +518,7 @@ export function FileBrowser({
                   const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
                   setMenu({ node, x: rect.right, y: rect.bottom });
                 }}
-                className="ml-auto hidden shrink-0 px-1 text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))] group-hover:inline"
+                className="ml-auto hidden shrink-0 px-1 text-og-fg-subtle hover:text-og-fg group-hover:inline"
               >
                 ⋯
               </span>
@@ -555,7 +547,7 @@ export function FileBrowser({
             {[0, 1, 2].map((i) => (
               <div
                 key={i}
-                className="h-2.5 animate-pulse rounded bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]"
+                className="h-2.5 animate-pulse rounded-og-sm bg-og-surface-2"
                 style={{ width: `${70 - i * 12}%` }}
               />
             ))}
@@ -570,34 +562,38 @@ export function FileBrowser({
 
   return (
     <div className={cn("flex min-w-0 flex-col", className)}>
-      {supportsMutation && (
-        <div className="flex shrink-0 items-center gap-0.5 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] px-1 py-1">
-          <ToolbarButton label="New file" onClick={() => startCreate("file")} disabled={busy}>
-            <FilePlusIcon className="size-3.5" />
-          </ToolbarButton>
-          <ToolbarButton label="New folder" onClick={() => startCreate("dir")} disabled={busy}>
-            <FolderPlusIcon className="size-3.5" />
-          </ToolbarButton>
-          <ToolbarButton
-            label="Rename"
-            onClick={() => {
-              const node = cursor ? findNode(result.tree, cursor) : undefined;
-              if (node) startRename(node);
-            }}
-            disabled={busy || !cursor}
-          >
-            <PencilIcon className="size-3.5" />
-          </ToolbarButton>
-          <ToolbarButton
-            label="Delete"
-            onClick={() => {
-              const node = cursor ? findNode(result.tree, cursor) : undefined;
-              if (node) void runDelete(node);
-            }}
-            disabled={busy || !cursor}
-          >
-            <Trash2Icon className="size-3.5" />
-          </ToolbarButton>
+      {showToolbar && (
+        <div className="flex shrink-0 flex-wrap items-center gap-0.5 border-b border-og-border px-1 py-1">
+          {supportsMutation ? (
+            <>
+              <ToolbarButton label="New file" onClick={() => startCreate("file")} disabled={busy}>
+                <FilePlusIcon className="size-3.5" />
+              </ToolbarButton>
+              <ToolbarButton label="New folder" onClick={() => startCreate("dir")} disabled={busy}>
+                <FolderPlusIcon className="size-3.5" />
+              </ToolbarButton>
+              <ToolbarButton
+                label="Rename"
+                onClick={() => {
+                  const node = cursor ? findNode(result.tree, cursor) : undefined;
+                  if (node) startRename(node);
+                }}
+                disabled={busy || !cursor}
+              >
+                <PencilIcon className="size-3.5" />
+              </ToolbarButton>
+              <ToolbarButton
+                label="Delete"
+                onClick={() => {
+                  const node = cursor ? findNode(result.tree, cursor) : undefined;
+                  if (node) void runDelete(node);
+                }}
+                disabled={busy || !cursor}
+              >
+                <Trash2Icon className="size-3.5" />
+              </ToolbarButton>
+            </>
+          ) : null}
           <span className="ml-auto" />
           <ToolbarButton label="Refresh" onClick={() => void result.refresh()} disabled={busy || result.loading}>
             <RefreshCwIcon className={cn("size-3.5", result.loading && "animate-spin")} />
@@ -633,7 +629,7 @@ export function FileBrowser({
         }
         className={cn(
           "min-w-0 flex-1 overflow-auto p-1 outline-none",
-          dragOver === "" && "ring-1 ring-inset ring-[color:var(--og-color-accent,var(--color-info,#58a6ff))]",
+          dragOver === "" && "ring-1 ring-inset ring-og-accent",
         )}
         data-opengeni-file-tree
       >
@@ -647,9 +643,22 @@ export function FileBrowser({
             onCancel={() => setDraftCreate(null)}
           />
         )}
-        {showEmpty ? (
-          <div className="p-2 text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
-            {emptyState ?? "No files."}
+        {showErrorEmpty ? (
+          <div className="flex flex-col items-start gap-2 p-2 text-og-sm text-og-fg-subtle">
+            <div>{fallback ?? `Could not load files: ${result.error?.message ?? "refresh the file list to try again"}`}</div>
+            <button
+              type="button"
+              onClick={() => void result.refresh()}
+              disabled={result.loading}
+              className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:min-h-10"
+            >
+              <RefreshCwIcon className={cn("size-3.5", result.loading && "animate-spin")} aria-hidden />
+              Retry
+            </button>
+          </div>
+        ) : showEmpty ? (
+          <div className="p-2 text-og-sm text-og-fg-subtle">
+            {emptyState ?? "This directory is empty"}
           </div>
         ) : (
           result.tree.map((node) => renderRow(node, 0))
@@ -690,8 +699,8 @@ function ToolbarButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "inline-flex items-center justify-center rounded p-1 text-[color:var(--og-color-fg-muted,var(--color-fg-muted,#aaa))]",
-        "hover:bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]",
+        "inline-flex items-center justify-center rounded-og-sm p-1 text-og-fg-muted pointer-coarse:min-h-10 pointer-coarse:min-w-10",
+        "hover:bg-og-surface-2 hover:text-og-fg",
         "disabled:cursor-not-allowed disabled:opacity-40",
       )}
     >
@@ -759,8 +768,8 @@ function InlineInput({
           e.stopPropagation();
         }}
         className={cn(
-          "min-w-0 flex-1 rounded border bg-[color:var(--og-color-bg,var(--color-bg,#0d0d0d))] px-1 py-0 text-xs",
-          "border-[color:var(--og-color-accent,var(--color-info,#58a6ff))] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]",
+          "min-w-0 flex-1 rounded-og-sm border bg-og-bg px-1 py-0 text-og-sm",
+          "border-og-accent text-og-fg",
           "outline-none",
         )}
       />
@@ -801,11 +810,9 @@ function ContextMenu({
         onClick();
       }}
       className={cn(
-        "flex w-full items-center gap-2 px-2.5 py-1 text-left text-xs",
-        "hover:bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]",
-        danger
-          ? "text-[color:var(--og-color-danger,var(--color-danger,#f85149))]"
-          : "text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]",
+        "flex w-full items-center gap-2 px-2.5 py-1 text-left text-og-sm pointer-coarse:min-h-10",
+        "hover:bg-og-surface-2",
+        danger ? "text-og-status-failed" : "text-og-fg",
       )}
     >
       {icon}
@@ -820,15 +827,15 @@ function ContextMenu({
       style={{ left, top }}
       className={cn(
         "fixed z-50 min-w-[160px] overflow-hidden rounded-md border py-1 shadow-lg",
-        "border-[color:var(--og-color-border,var(--color-border,#2a2a2a))]",
-        "bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))]",
+        "border-og-border",
+        "bg-og-surface-1",
       )}
     >
       {isDir && (
         <>
           {item("New file", <FilePlusIcon className="size-3.5" />, onNewFile)}
           {item("New folder", <FolderPlusIcon className="size-3.5" />, onNewFolder)}
-          <div className="my-1 h-px bg-[color:var(--og-color-border,var(--color-border,#2a2a2a))]" />
+          <div className="my-1 h-px bg-og-border" />
         </>
       )}
       {item("Rename", <PencilIcon className="size-3.5" />, onRename)}

--- a/packages/react/src/components/fleet-tile.tsx
+++ b/packages/react/src/components/fleet-tile.tsx
@@ -60,11 +60,11 @@ export function FleetTile({ session, title, subtitle, onOpen, className }: Fleet
         )}
       />
       <span className="flex w-full items-start justify-between gap-3">
-        <span className="line-clamp-2 min-w-0 text-sm font-medium leading-snug text-og-fg">{title ?? sessionDisplayTitle(session)}</span>
+        <span className="line-clamp-2 min-w-0 text-og-base font-medium leading-snug text-og-fg">{title ?? sessionDisplayTitle(session)}</span>
         <SessionStatus status={session.status} size="sm" className="mt-px" />
       </span>
-      {subtitle ? <span className="line-clamp-1 text-xs text-og-fg-muted">{subtitle}</span> : null}
-      <span className="mt-auto flex w-full items-center gap-2 text-[11px] text-og-fg-subtle">
+      {subtitle ? <span className="line-clamp-1 text-og-sm text-og-fg-muted">{subtitle}</span> : null}
+      <span className="mt-auto flex w-full items-center gap-2 text-og-xs text-og-fg-subtle">
         <span className="font-og-mono">{session.id.slice(0, 8)}</span>
         <span aria-hidden>·</span>
         <span className="truncate">{session.model}</span>

--- a/packages/react/src/components/machine-card.tsx
+++ b/packages/react/src/components/machine-card.tsx
@@ -60,17 +60,17 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
           </span>
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="truncate text-sm font-medium text-og-fg">{machine.name}</span>
+              <span className="truncate text-og-base font-medium text-og-fg">{machine.name}</span>
               {machine.active ? (
                 <span
                   data-active-marker
-                  className="shrink-0 rounded-full border border-og-accent/30 bg-og-accent-soft px-1.5 py-px text-[10px] font-medium text-og-accent"
+                  className="shrink-0 rounded-full border border-og-accent/30 bg-og-accent-soft px-1.5 py-px text-og-xs font-medium text-og-accent"
                 >
                   Active
                 </span>
               ) : null}
             </div>
-            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-og-fg-subtle">
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-og-xs text-og-fg-subtle">
               <span className="capitalize">{machine.isSessionGroup ? "session sandbox" : machine.kind}</span>
               <span aria-hidden>·</span>
               <span className="font-og-mono">
@@ -94,7 +94,7 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
       {shared ? (
         <p
           data-shared-disclosure
-          className="flex items-center gap-1.5 rounded-og-md border border-og-accent/25 bg-og-accent-soft px-2.5 py-1.5 text-[11px] text-og-fg-muted"
+          className="flex items-center gap-1.5 rounded-og-md border border-og-accent/25 bg-og-accent-soft px-2.5 py-1.5 text-og-xs text-og-fg-muted"
         >
           <UsersIcon className="size-3.5 shrink-0 text-og-accent" aria-hidden />
           Shared — {machine.sharedSessionCount} sessions are on this machine.
@@ -103,7 +103,7 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
 
       <MachineMetrics metrics={machine.metrics} />
 
-      <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-og-fg-subtle">
+      <div className="mt-1 flex items-center justify-between gap-3 text-og-xs text-og-fg-subtle">
         <span>
           {machine.lastSeenAt ? <>Last seen {formatRelativeTime(machine.lastSeenAt)}</> : "Never connected"}
         </span>
@@ -116,7 +116,7 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
             disabled={attaching}
             onClick={() => onAttach?.(machine)}
             className={cn(
-              "rounded-og-sm border border-og-border px-2.5 py-1 text-[11px] font-medium text-og-fg-muted transition-colors",
+              "rounded-og-sm border border-og-border px-2.5 py-1 text-og-xs font-medium text-og-fg-muted transition-colors pointer-coarse:min-h-10",
               "hover:border-og-border-strong hover:text-og-fg disabled:cursor-not-allowed disabled:opacity-50",
             )}
           >

--- a/packages/react/src/components/machine-status-pill.tsx
+++ b/packages/react/src/components/machine-status-pill.tsx
@@ -80,7 +80,7 @@ export function ConnectionStatusPill({ status, label, size = "md", className }: 
       data-connection-status={status}
       className={cn(
         "og-root inline-flex shrink-0 items-center rounded-full border font-medium",
-        size === "sm" ? "gap-1 px-1.5 py-px text-[10px]" : "gap-1.5 px-2 py-0.5 text-xs",
+        size === "sm" ? "gap-1 px-1.5 py-px text-og-xs" : "gap-1.5 px-2 py-0.5 text-og-sm",
         meta.badgeClassName,
         className,
       )}
@@ -132,7 +132,7 @@ export function MachineStatusPill({ state, sharedSessionCount, size = "md", clas
           data-state-badge={state}
           className={cn(
             "inline-flex shrink-0 items-center rounded-full border font-medium",
-            size === "sm" ? "px-1.5 py-px text-[10px]" : "px-2 py-0.5 text-xs",
+            size === "sm" ? "px-1.5 py-px text-og-xs" : "px-2 py-0.5 text-og-sm",
             stateBadge.badgeClassName,
           )}
         >
@@ -145,7 +145,7 @@ export function MachineStatusPill({ state, sharedSessionCount, size = "md", clas
           className={cn(
             "inline-flex shrink-0 items-center gap-1 rounded-full border font-medium",
             "text-og-accent border-og-accent/30 bg-og-accent-soft",
-            size === "sm" ? "px-1.5 py-px text-[10px]" : "px-2 py-0.5 text-xs",
+            size === "sm" ? "px-1.5 py-px text-og-xs" : "px-2 py-0.5 text-og-sm",
           )}
           title={`${sharedSessionCount} sessions are on this machine`}
         >

--- a/packages/react/src/components/machines-dashboard.tsx
+++ b/packages/react/src/components/machines-dashboard.tsx
@@ -30,8 +30,8 @@ function EmptyState({ onEnroll }: { onEnroll?: (() => void) | undefined }) {
         <LaptopIcon className="size-5" aria-hidden />
       </span>
       <div className="space-y-1">
-        <p className="text-sm font-medium text-og-fg">No machines yet</p>
-        <p className="max-w-xs text-[12px] text-og-fg-muted">
+        <p className="text-og-base font-medium text-og-fg">No machines yet</p>
+        <p className="max-w-xs text-og-sm text-og-fg-muted">
           Enroll your own computer to run the agent on it — your files, your terminal, your desktop.
         </p>
       </div>
@@ -40,7 +40,7 @@ function EmptyState({ onEnroll }: { onEnroll?: (() => void) | undefined }) {
           type="button"
           data-enroll-cta
           onClick={onEnroll}
-          className="inline-flex items-center gap-1.5 rounded-og-sm bg-og-accent px-3 py-1.5 text-xs font-medium text-og-accent-fg transition-colors hover:bg-og-accent-strong"
+          className="inline-flex items-center gap-1.5 rounded-og-sm bg-og-accent px-3 py-1.5 text-og-sm font-medium text-og-accent-fg transition-colors hover:bg-og-accent-strong pointer-coarse:min-h-10"
         >
           <PlusIcon className="size-3.5" aria-hidden />
           Enroll a machine
@@ -54,16 +54,18 @@ function Header({
   count,
   onEnroll,
   onRefresh,
+  loading,
 }: {
   count: number;
   onEnroll?: (() => void) | undefined;
   onRefresh?: (() => void) | undefined;
+  loading?: boolean | undefined;
 }): ReactNode {
   return (
     <div className="flex items-center justify-between gap-3">
       <div className="flex items-baseline gap-2">
-        <h2 className="text-sm font-semibold text-og-fg">Machines</h2>
-        <span className="font-og-mono text-[11px] text-og-fg-subtle">{count}</span>
+        <h2 className="text-og-base font-semibold text-og-fg">Machines</h2>
+        <span className="font-og-mono text-og-xs text-og-fg-subtle">{count}</span>
       </div>
       <div className="flex items-center gap-1.5">
         {onRefresh ? (
@@ -74,7 +76,7 @@ function Header({
             title="Refresh"
             className="rounded-og-sm p-1.5 text-og-fg-subtle transition-colors hover:bg-og-surface-2 hover:text-og-fg"
           >
-            <RefreshCwIcon className="size-3.5" aria-hidden />
+            <RefreshCwIcon className={cn("size-3.5", loading && "animate-og-spin")} aria-hidden />
           </button>
         ) : null}
         {onEnroll ? (
@@ -82,10 +84,10 @@ function Header({
             type="button"
             data-enroll-cta
             onClick={onEnroll}
-            className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2.5 py-1 text-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg"
+            className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2.5 py-1 text-og-sm font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg pointer-coarse:min-h-10"
           >
             <PlusIcon className="size-3.5" aria-hidden />
-            Enroll
+            Enroll machine
           </button>
         ) : null}
       </div>
@@ -95,7 +97,7 @@ function Header({
 
 /**
  * The workspace Machines dashboard: the fleet of selfhosted enrollments + the
- * session's Modal sandbox, each with its connection-status pill, state badges,
+ * session's managed sandbox, each with its connection-status pill, state badges,
  * latest metrics, and an attach/swap affordance. Renders the empty state (no
  * machines → enroll CTA), a load error, and the populated grid. The component
  * is purely presentational — feed it `MachinesResponse` data via `useMachines`.
@@ -115,15 +117,27 @@ export function MachinesDashboard({
 
   return (
     <section data-machines-dashboard className={cn("og-root flex flex-col gap-3", className)}>
-      <Header count={machines.length} onEnroll={onEnroll} onRefresh={onRefresh} />
+      <Header count={machines.length} onEnroll={onEnroll} onRefresh={onRefresh} loading={loading} />
 
       {error ? (
-        <p
+        <div
           data-machines-error
-          className="rounded-og-md border border-og-status-failed/30 bg-og-status-failed/10 px-3 py-2 text-[12px] text-og-status-failed"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-og-md border border-og-status-failed/30 bg-og-status-failed/10 px-3 py-2 text-og-sm text-og-status-failed"
         >
-          Could not load machines: {error.message}
-        </p>
+          <span>Could not load machines: {error.message}</span>
+          {onRefresh ? (
+            <button
+              type="button"
+              data-machines-retry
+              onClick={onRefresh}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-status-failed/30 px-2 py-1 text-og-xs font-medium transition-colors hover:border-og-status-failed/50 disabled:cursor-not-allowed disabled:opacity-60 pointer-coarse:min-h-10"
+            >
+              <RefreshCwIcon className={cn("size-3.5", loading && "animate-og-spin")} aria-hidden />
+              {loading ? "Retrying…" : "Retry"}
+            </button>
+          ) : null}
+        </div>
       ) : null}
 
       {loading && machines.length === 0 ? (

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -36,12 +36,12 @@ const components: Components = {
     </h2>
   ),
   h3: ({ children, ...props }) => (
-    <h3 className="mt-4 mb-1.5 text-[15px] font-semibold tracking-tight text-og-fg first:mt-0" {...props}>
+    <h3 className="mt-4 mb-1.5 text-og-md font-semibold tracking-tight text-og-fg first:mt-0" {...props}>
       {children}
     </h3>
   ),
   h4: ({ children, ...props }) => (
-    <h4 className="mt-4 mb-1.5 text-sm font-semibold uppercase tracking-[0.04em] text-og-fg-muted first:mt-0" {...props}>
+    <h4 className="mt-4 mb-1.5 text-og-sm font-semibold uppercase tracking-[0.04em] text-og-fg-muted first:mt-0" {...props}>
       {children}
     </h4>
   ),
@@ -94,7 +94,7 @@ const components: Components = {
         {...props}
         type="checkbox"
         disabled
-        className="mr-2 size-3.5 translate-y-[2px] cursor-default appearance-none rounded-[3px] border border-og-border bg-og-surface-1 align-baseline checked:border-og-accent checked:bg-og-accent checked:[background-image:url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22white%22%20stroke-width%3D%221.6%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M2.5%206.2l2.2%202.2%204.6-4.8%22%2F%3E%3C%2Fsvg%3E')] checked:bg-[length:11px_11px] checked:bg-center checked:bg-no-repeat"
+        className="mr-2 size-3.5 translate-y-[2px] cursor-default accent-og-accent align-baseline"
       />
     ) : (
       <input type={type} {...props} />
@@ -113,7 +113,7 @@ const components: Components = {
   // the `pre` renderer), so a `code` reaching here is treated as inline.
   code: ({ children, className: _className, ...props }) => (
     <code
-      className="rounded-og-xs border border-og-border bg-og-surface-1 px-1 py-0.5 font-og-mono text-[0.85em] text-og-fg"
+      className="rounded-og-xs border border-og-border bg-og-surface-1 px-1 py-0.5 font-og-mono text-og-sm text-og-fg"
       {...props}
     >
       {children}
@@ -123,7 +123,7 @@ const components: Components = {
   // visual consistency (bordered, scrollable, mono, surface background).
   pre: ({ children, ...props }) => (
     <pre
-      className="my-3 max-h-96 overflow-auto rounded-og-md border border-og-border bg-og-bg/60 p-3 font-og-mono text-[12.5px] leading-5 text-og-fg-muted [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit first:mt-0 last:mb-0"
+      className="my-3 max-h-96 overflow-auto rounded-og-md border border-og-border bg-og-bg/60 p-3 font-og-mono text-og-sm text-og-fg-muted [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit first:mt-0 last:mb-0"
       {...props}
     >
       {children}
@@ -131,7 +131,7 @@ const components: Components = {
   ),
   table: ({ children, ...props }) => (
     <div className="my-3 max-w-full overflow-x-auto rounded-og-md border border-og-border first:mt-0 last:mb-0">
-      <table className="w-full border-collapse text-[13px]" {...props}>
+      <table className="w-full border-collapse text-og-base" {...props}>
         {children}
       </table>
     </div>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import type { ComponentType } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { cn } from "../lib/cn";
 import { formatRelativeTime, truncate } from "../lib/format";
 import { Markdown } from "./markdown";
@@ -78,9 +78,37 @@ export function MessageTimeline({
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [pinned, setPinned] = useState(true);
+  // Mirror `pinned` into a ref so the ResizeObserver callback (a stable closure)
+  // always reads the live value without re-subscribing on every scroll.
+  const pinnedRef = useRef(true);
+  // The reader's visual anchor: the topmost still-visible timeline element and
+  // its offset from the viewport top. Recaptured on scroll and after every
+  // height change, it lets us hold the reader's position when content above the
+  // viewport expands or collapses (e.g. a turn folds when it settles).
+  const anchorRef = useRef<{ el: Element; top: number } | null>(null);
   const lastItem = resolvedItems[resolvedItems.length - 1];
   const streaming = lastItem !== undefined && (lastItem.kind === "agent-message" || lastItem.kind === "reasoning") && lastItem.streaming;
   const working = status === "running" && !streaming;
+
+  // Snapshot the topmost visible element and where it sits in the viewport, so a
+  // later reflow can restore it to the same spot.
+  const captureAnchor = useCallback(() => {
+    const node = scrollRef.current;
+    const inner = node?.firstElementChild;
+    if (!node || !inner) {
+      anchorRef.current = null;
+      return;
+    }
+    const containerTop = node.getBoundingClientRect().top;
+    for (const child of Array.from(inner.children)) {
+      const rect = child.getBoundingClientRect();
+      if (rect.bottom > containerTop + 1) {
+        anchorRef.current = { el: child, top: rect.top - containerTop };
+        return;
+      }
+    }
+    anchorRef.current = null;
+  }, []);
 
   // Follow the stream while pinned to the bottom; never fight the reader.
   useEffect(() => {
@@ -90,12 +118,51 @@ export function MessageTimeline({
     }
   }, [resolvedItems, working, autoFollow, pinned]);
 
+  // Scroll anchoring: when the content reflows (a fold expands/collapses, a
+  // stream appends), keep following the bottom if pinned; otherwise pin the
+  // reader's anchor in place. A change ABOVE the anchor shifts its viewport
+  // offset — we correct scrollTop by that shift so the reader never gets yanked.
+  // A change BELOW the anchor (a bottom append while scrolled up) leaves the
+  // anchor put, so `diff` is 0 and we leave scrollTop alone.
+  useEffect(() => {
+    const node = scrollRef.current;
+    const inner = node?.firstElementChild;
+    if (!node || !inner || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      const current = scrollRef.current;
+      if (!current) {
+        return;
+      }
+      if (autoFollow && pinnedRef.current) {
+        current.scrollTop = current.scrollHeight;
+      } else {
+        const anchor = anchorRef.current;
+        if (anchor && anchor.el.isConnected) {
+          const containerTop = current.getBoundingClientRect().top;
+          const now = anchor.el.getBoundingClientRect().top - containerTop;
+          const diff = now - anchor.top;
+          if (diff !== 0) {
+            current.scrollTop += diff;
+          }
+        }
+      }
+      captureAnchor();
+    });
+    observer.observe(inner);
+    return () => observer.disconnect();
+  }, [autoFollow, captureAnchor]);
+
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
       return;
     }
-    setPinned(node.scrollHeight - node.scrollTop - node.clientHeight < 48);
+    const nextPinned = node.scrollHeight - node.scrollTop - node.clientHeight < 48;
+    pinnedRef.current = nextPinned;
+    setPinned(nextPinned);
+    captureAnchor();
   };
 
   return (
@@ -135,6 +202,7 @@ export function MessageTimeline({
               if (node) {
                 node.scrollTo({ top: node.scrollHeight, behavior: "smooth" });
               }
+              pinnedRef.current = true;
               setPinned(true);
             }}
             className={cn(

--- a/packages/react/src/components/pierre-diff.tsx
+++ b/packages/react/src/components/pierre-diff.tsx
@@ -98,16 +98,15 @@ export function PierreDiff({
 
   // Pierre renders inside a shadow DOM, so host CSS can't reach it — but it reads
   // a set of `--diffs-*-override` custom properties through the shadow boundary.
-  // Pin the diff's own base background to the dock surface (Pierre's dark default
-  // is pure #000, which reads as a seam against our #0d0d0d panel) and quiet the
-  // hunk-separator slab so the collapsed-context row isn't a heavy gray bar.
+  // Pin the diff's own base background to the dock surface and quiet the hunk
+  // separator slab so collapsed context rows do not become heavy bars.
   const pierreVars = {
-    "--diffs-dark-bg": "var(--og-color-bg, #0d0d0d)",
-    "--diffs-light-bg": "var(--og-color-bg, #ffffff)",
-    "--diffs-bg-buffer-override": "var(--og-color-surface-1, #161616)",
-    "--diffs-bg-separator-override": "var(--og-color-surface-1, #161616)",
-    "--diffs-font-size": "12.5px",
-    "--diffs-line-height": "20px",
+    "--diffs-dark-bg": "var(--og-color-bg)",
+    "--diffs-light-bg": "var(--og-color-bg)",
+    "--diffs-bg-buffer-override": "var(--og-color-surface-1)",
+    "--diffs-bg-separator-override": "var(--og-color-surface-1)",
+    "--diffs-font-size": "var(--og-code-font-size)",
+    "--diffs-line-height": "var(--og-code-line-height)",
   } as CSSProperties;
 
   return (
@@ -133,7 +132,7 @@ export function PierreDiff({
 
 function DiffSkeleton() {
   return (
-    <div className="p-3 text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+    <div className="p-3 text-og-sm text-og-fg-subtle">
       Loading diff…
     </div>
   );

--- a/packages/react/src/components/pierre-file.tsx
+++ b/packages/react/src/components/pierre-file.tsx
@@ -99,12 +99,12 @@ export function PierreFile({
   // Same shadow-DOM override vars as PierreDiff: pin the base background to the
   // dock surface so the viewer reads as part of the panel, not a black seam.
   const pierreVars = {
-    "--diffs-dark-bg": "var(--og-color-bg, #0d0d0d)",
-    "--diffs-light-bg": "var(--og-color-bg, #ffffff)",
-    "--diffs-bg-buffer-override": "var(--og-color-surface-1, #161616)",
-    "--diffs-bg-separator-override": "var(--og-color-surface-1, #161616)",
-    "--diffs-font-size": "12.5px",
-    "--diffs-line-height": "20px",
+    "--diffs-dark-bg": "var(--og-color-bg)",
+    "--diffs-light-bg": "var(--og-color-bg)",
+    "--diffs-bg-buffer-override": "var(--og-color-surface-1)",
+    "--diffs-bg-separator-override": "var(--og-color-surface-1)",
+    "--diffs-font-size": "var(--og-code-font-size)",
+    "--diffs-line-height": "var(--og-code-line-height)",
   } as CSSProperties;
 
   return (
@@ -125,7 +125,7 @@ export function PierreFile({
 function PlainFile({ name, contents }: { name: string; contents: string }) {
   return (
     <pre
-      className="overflow-auto whitespace-pre p-2 font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[12px] leading-[18px] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
+      className="overflow-auto whitespace-pre p-2 font-og-mono text-og-sm text-og-fg"
       data-file={name}
     >
       {contents}
@@ -135,7 +135,7 @@ function PlainFile({ name, contents }: { name: string; contents: string }) {
 
 function FileSkeleton() {
   return (
-    <div className="p-3 text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+    <div className="p-3 text-og-sm text-og-fg-subtle">
       Loading file…
     </div>
   );

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -30,15 +30,15 @@ export type SandboxFilesProps = {
 };
 
 const STATUS_TINT: Record<GitFileDiff["status"], string> = {
-  added: "text-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]",
-  modified: "text-[color:var(--og-color-status-running,var(--color-warning,#d29922))]",
-  deleted: "text-[color:var(--og-color-danger,var(--color-danger,#f85149))]",
-  renamed: "text-[color:var(--og-color-accent,var(--color-info,#58a6ff))]",
-  copied: "text-[color:var(--og-color-accent,var(--color-info,#58a6ff))]",
-  untracked: "text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]",
-  ignored: "text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]",
-  conflicted: "text-[color:var(--og-color-danger,var(--color-danger,#f85149))]",
-  typechange: "text-[color:var(--og-color-status-running,var(--color-warning,#d29922))]",
+  added: "text-og-status-idle",
+  modified: "text-og-status-running",
+  deleted: "text-og-status-failed",
+  renamed: "text-og-accent",
+  copied: "text-og-accent",
+  untracked: "text-og-fg-subtle",
+  ignored: "text-og-fg-subtle",
+  conflicted: "text-og-status-failed",
+  typechange: "text-og-status-running",
 };
 
 const STATUS_LETTER: Record<GitFileDiff["status"], string> = {
@@ -158,13 +158,13 @@ export function SandboxFiles({
           className={cn(
             "min-h-0 overflow-auto",
             wide
-              ? "w-[280px] shrink-0 border-r border-[color:var(--og-color-border,var(--color-border,#2a2a2a))]"
+              ? "w-[280px] shrink-0 border-r border-og-border"
               : "flex-1",
           )}
         >
           {changed.length > 0 && (
-            <div className="border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))]">
-              <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+            <div className="border-b border-og-border">
+              <div className="px-2 py-1 text-og-xs font-medium uppercase tracking-wide text-og-fg-subtle">
                 Changes · {changed.length}
               </div>
               <ul className="pb-1">
@@ -174,14 +174,13 @@ export function SandboxFiles({
                       type="button"
                       onClick={() => selectFile(file.path)}
                       className={cn(
-                        "flex w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-xs hover:bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]",
-                        file.path === effectiveSelected &&
-                          "bg-[color:var(--og-color-surface-2,var(--color-bg-subtle,#1c1c1c))]",
+                        "flex w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-10",
+                        file.path === effectiveSelected && "bg-og-surface-2",
                       )}
                     >
                       <span
                         className={cn(
-                          "w-3 shrink-0 text-center font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[10px]",
+                          "w-3 shrink-0 text-center font-og-mono text-og-xs",
                           STATUS_TINT[file.status],
                         )}
                       >
@@ -189,11 +188,11 @@ export function SandboxFiles({
                       </span>
                       <FileIcon className="size-3.5 shrink-0 opacity-70" />
                       <span className="truncate">{file.path}</span>
-                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-[10px]">
-                        <span className="text-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]">
+                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-og-xs">
+                        <span className="text-og-status-idle">
                           +{file.additions}
                         </span>
-                        <span className="text-[color:var(--og-color-danger,var(--color-danger,#f85149))]">
+                        <span className="text-og-status-failed">
                           −{file.deletions}
                         </span>
                       </span>
@@ -204,14 +203,14 @@ export function SandboxFiles({
             </div>
           )}
 
-          <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+          <div className="px-2 py-1 text-og-xs font-medium uppercase tracking-wide text-og-fg-subtle">
             Files
           </div>
           <FileBrowser
             result={files}
             selectedPath={effectiveSelected ?? undefined}
             onSelectFile={selectFile}
-            emptyState="No files."
+            emptyState="This directory is empty"
             className="min-w-0"
           />
         </div>
@@ -223,14 +222,14 @@ export function SandboxFiles({
             "flex min-h-0 min-w-0 flex-col",
             wide
               ? "flex-1"
-              : "flex-[1.4] border-t border-[color:var(--og-color-border,var(--color-border,#2a2a2a))]",
+              : "flex-[1.4] border-t border-og-border",
           )}
         >
-          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))] px-2 py-1">
-            <span className="truncate font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[11px] text-[color:var(--og-color-fg-muted,var(--color-fg-muted,#aaa))]">
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-og-border bg-og-surface-1 px-2 py-1">
+            <span className="min-w-0 truncate font-og-mono text-og-xs text-og-fg-muted">
               {effectiveSelected ?? "No file selected"}
             </span>
-            <div className="flex shrink-0 items-center gap-1">
+            <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-1">
               {/* The Working/Staged + Unified/Split toggles only apply to a diff.
                   Hide them in the read-only viewer (a non-changed tree file). */}
               {selectedDiff && stagedGit && (
@@ -306,7 +305,7 @@ export function SandboxFiles({
               ) : fileView.content !== null ? (
                 <>
                 {fileView.truncated && (
-                  <div className="border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))] px-2 py-1 text-[10px] text-[color:var(--og-color-status-running,var(--color-warning,#d29922))]">
+                  <div className="border-b border-og-border bg-og-surface-1 px-2 py-1 text-og-xs text-og-status-running">
                     Large file — showing a truncated preview ({fileView.sizeBytes ?? 0} bytes loaded). Editing is disabled to avoid corrupting the file.
                   </div>
                 )}
@@ -316,14 +315,14 @@ export function SandboxFiles({
                     contents={fileView.content}
                     themeType={resolvedTheme}
                     fallback={
-                      <pre className="overflow-auto whitespace-pre p-2 font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[12px] leading-[18px]">
+                      <pre className="overflow-auto whitespace-pre p-2 font-og-mono text-og-sm text-og-fg">
                         {fileView.content}
                       </pre>
                     }
                     className="p-1"
                   />
                 ) : (
-                  <pre className="overflow-auto whitespace-pre p-2 font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[12px] leading-[18px]">
+                  <pre className="overflow-auto whitespace-pre p-2 font-og-mono text-og-sm text-og-fg">
                     {fileView.content}
                   </pre>
                 )}
@@ -350,27 +349,25 @@ export function SandboxFiles({
 function GitHeader({ git, dirtyCount }: { git: UseSandboxGitResult; dirtyCount: number }) {
   const dirty = dirtyCount > 0;
   return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))] px-2 py-1 text-xs">
+    <div className="flex shrink-0 items-center gap-2 border-b border-og-border bg-og-surface-1 px-2 py-1 text-og-sm">
       <span
         className={cn(
           "size-2 shrink-0 rounded-full",
-          dirty
-            ? "bg-[color:var(--og-color-status-running,var(--color-warning,#d29922))]"
-            : "bg-[color:var(--og-color-status-idle,var(--color-success,#3fb950))]",
+          dirty ? "bg-og-status-running" : "bg-og-status-idle",
         )}
         title={dirty ? `${dirtyCount} changed` : "clean"}
       />
-      <span className="truncate font-[family-name:var(--og-font-mono,var(--font-mono,monospace))] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]">
+      <span className="truncate font-og-mono text-og-fg">
         {git.branch ?? (git.isRepo ? "(detached)" : "no repo")}
       </span>
       {(git.ahead > 0 || git.behind > 0) && (
-        <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+        <span className="flex shrink-0 items-center gap-1.5 text-og-xs text-og-fg-subtle">
           {git.ahead > 0 && <span>↑{git.ahead}</span>}
           {git.behind > 0 && <span>↓{git.behind}</span>}
         </span>
       )}
       {dirty && (
-        <span className="ml-auto shrink-0 text-[10px] text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+        <span className="ml-auto shrink-0 text-og-xs text-og-fg-subtle">
           {dirtyCount} changed
         </span>
       )}
@@ -388,17 +385,17 @@ function Segmented({
   onChange: (value: string) => void;
 }) {
   return (
-    <div className="flex items-center rounded-[var(--og-radius-sm,4px)] border border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] p-0.5">
+    <div className="flex flex-wrap items-center rounded-og-sm border border-og-border p-0.5">
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
           onClick={() => onChange(opt.value)}
           className={cn(
-            "rounded-[var(--og-radius-xs,3px)] px-1.5 py-0.5 text-[10px]",
+            "rounded-og-xs px-1.5 py-0.5 text-og-xs pointer-coarse:min-h-10",
             opt.value === value
-              ? "bg-[color:var(--og-color-accent-soft,var(--color-surface-2,#222))] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
-              : "text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]",
+              ? "bg-og-accent-soft text-og-fg"
+              : "text-og-fg-subtle hover:text-og-fg",
           )}
         >
           {opt.label}
@@ -499,7 +496,7 @@ function Notice({ children, className }: { children: ReactNode; className?: stri
   return (
     <div
       className={cn(
-        "flex h-full items-center justify-center p-4 text-center text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]",
+        "flex h-full items-center justify-center p-4 text-center text-og-sm text-og-fg-subtle",
         className,
       )}
     >

--- a/packages/react/src/components/sandbox-terminal.tsx
+++ b/packages/react/src/components/sandbox-terminal.tsx
@@ -181,7 +181,7 @@ export function SandboxTerminal({
         convertEol: true,
         disableStdin: !interactive,
         cursorBlink: interactive,
-        fontFamily: fontFamily ?? "var(--og-font-mono, var(--font-mono, monospace))",
+        fontFamily: fontFamily ?? "var(--og-font-mono)",
         fontSize: fontSize ?? 13,
         lineHeight: 1.25,
         // A little breathing room from the panel edge so output isn't flush to
@@ -318,23 +318,21 @@ export function SandboxTerminal({
   return (
     <div className={cn("relative flex h-full w-full flex-col overflow-hidden", className)}>
       {showHeader && (
-        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] px-2 py-1 text-[11px] text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-og-border px-2 py-1 text-og-xs text-og-fg-subtle">
           <span className="flex min-w-0 items-center gap-1.5">
             <span
               className={cn(
                 "size-1.5 shrink-0 rounded-full",
-                result.running
-                  ? "bg-[color:var(--og-color-status-running,var(--color-status-running,#d29922))]"
-                  : "bg-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]",
+                result.running ? "bg-og-status-running" : "bg-og-fg-subtle",
               )}
             />
-            <span className="truncate font-[family-name:var(--og-font-mono,var(--font-mono,monospace))]">
+            <span className="truncate font-og-mono">
               pty: {shell ?? "shell"}
             </span>
           </span>
           <span className="flex shrink-0 items-center gap-2">
             {!interactive && (
-              <span className="rounded-[var(--og-radius-sm,4px)] bg-[color:var(--og-color-surface-2,var(--color-surface-2,#161616))] px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+              <span className="rounded-og-sm bg-og-surface-2 px-1.5 py-0.5 text-og-xs uppercase tracking-wide">
                 read-only
               </span>
             )}
@@ -344,7 +342,7 @@ export function SandboxTerminal({
                 termRef.current?.clear();
                 writtenRef.current = new Set();
               }}
-              className="rounded-[var(--og-radius-sm,4px)] px-1.5 py-0.5 text-[10px] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
+              className="rounded-og-sm px-1.5 py-0.5 text-og-xs hover:text-og-fg pointer-coarse:min-h-10"
             >
               Clear
             </button>
@@ -355,7 +353,7 @@ export function SandboxTerminal({
           with the terminal surface (capture so they win even though xterm's own
           listeners stop propagation). The host warms the box for pty-ws here. */}
       <div
-        className="relative min-h-0 flex-1 bg-[color:var(--og-color-bg,var(--color-bg,#0d0d0d))] px-2 py-1.5"
+        className="relative min-h-0 flex-1 bg-og-bg px-2 py-1.5"
         onPointerDownCapture={onActivate}
         onFocusCapture={onActivate}
       >
@@ -379,7 +377,7 @@ const XTERM_BASE_CSS = `
 .xterm.focus,.xterm:focus{outline:none}
 .xterm .xterm-helpers{position:absolute;top:0;z-index:5}
 .xterm .xterm-helper-textarea{padding:0;border:0;margin:0;position:absolute;opacity:0;left:-9999em;top:0;width:0;height:0;z-index:-5;white-space:nowrap;overflow:hidden;resize:none}
-.xterm .composition-view{background:#000;color:#FFF;display:none;position:absolute;white-space:nowrap;z-index:1}
+.xterm .composition-view{background:var(--og-color-bg);color:var(--og-color-fg);display:none;position:absolute;white-space:nowrap;z-index:1}
 .xterm .composition-view.active{display:block}
 .xterm .xterm-viewport{background-color:transparent;overflow-y:scroll;cursor:default;position:absolute;right:0;left:0;top:0;bottom:0}
 .xterm .xterm-screen{position:relative}
@@ -418,7 +416,7 @@ function ensureXtermBaseCss(): void {
 
 function TerminalPlaceholder() {
   return (
-    <div className="absolute inset-0 flex items-center justify-center text-xs text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
+    <div className="absolute inset-0 flex items-center justify-center text-og-sm text-og-fg-subtle">
       Loading terminal…
     </div>
   );

--- a/packages/react/src/components/session-status.tsx
+++ b/packages/react/src/components/session-status.tsx
@@ -30,7 +30,7 @@ export const SESSION_STATUS_META: Record<SessionStatusValue, SessionStatusMeta> 
     pulse: false,
   },
   requires_action: {
-    label: "Needs you",
+    label: "Waiting on you",
     dotClassName: "bg-og-status-waiting",
     badgeClassName: "text-og-status-waiting border-og-status-waiting/35 bg-og-status-waiting/10",
     pulse: true,
@@ -65,7 +65,7 @@ export function SessionStatus({ status, label, size = "md", className }: Session
       data-status={status}
       className={cn(
         "og-root inline-flex shrink-0 items-center rounded-full border font-medium",
-        size === "sm" ? "gap-1 px-1.5 py-px text-[10px]" : "gap-1.5 px-2 py-0.5 text-xs",
+        size === "sm" ? "gap-1 px-1.5 py-px text-og-xs" : "gap-1.5 px-2 py-0.5 text-xs",
         meta.badgeClassName,
         className,
       )}

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -4,6 +4,7 @@ import {
   Maximize2Icon,
   Minimize2Icon,
   PanelRightCloseIcon,
+  XIcon,
 } from "lucide-react";
 import {
   Group,
@@ -49,8 +50,42 @@ export type WorkspaceDockProps = {
  * restore button returns). Layout persists via `useDefaultLayout` keyed on
  * `autoSaveId`. Maximize is a mode ABOVE the Group (a `fixed inset-0` overlay) —
  * pushing a Panel to ~100% still fights min sizes and leaves a chat sliver.
+ *
+ * Below {@link DOCK_OVERLAY_BREAKPOINT} the side-by-side split can't work on a
+ * phone-width viewport, so the resizable panels are dropped entirely: the
+ * primary pane goes full-width and the dock becomes a full-screen overlay driven
+ * by the same `collapsed` / `onCollapsedChange` contract (collapsed → hidden).
+ * No drag splitter renders below the breakpoint.
  */
 const useDockLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/**
+ * The dock stops being a side column at this width and becomes a full-screen
+ * overlay — matches the app's rail-drawer breakpoint (the single `isMobile`
+ * source). The package can't read app context, so it detects the width itself.
+ */
+const DOCK_OVERLAY_BREAKPOINT = 1024;
+
+/** SSR-safe `(max-width: …)` match; false until mounted, then live. */
+function useIsNarrow(maxWidth: number): boolean {
+  const [narrow, setNarrow] = useState(false);
+  useDockLayoutEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia(`(max-width: ${maxWidth - 1}px)`);
+    const update = () => setNarrow(mql.matches);
+    update();
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", update);
+      return () => mql.removeEventListener("change", update);
+    }
+    // Legacy Safari.
+    mql.addListener(update);
+    return () => mql.removeListener(update);
+  }, [maxWidth]);
+  return narrow;
+}
 
 export function WorkspaceDock({
   primary,
@@ -65,6 +100,7 @@ export function WorkspaceDock({
   maxSize = 70,
   className,
 }: WorkspaceDockProps) {
+  const narrow = useIsNarrow(DOCK_OVERLAY_BREAKPOINT);
   const dockPanelRef = usePanelRef();
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [maximized, setMaximized] = useState(false);
@@ -117,16 +153,6 @@ export function WorkspaceDock({
     // rebuild tab JSX frequently; only id changes can invalidate the active tab.
   }, [tabIds, firstTabId, current, setTab]);
 
-  // Esc restores from maximize.
-  useEffect(() => {
-    if (!maximized) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMaximized(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [maximized]);
-
   const collapse = useCallback(() => {
     dockPanelRef.current?.collapse();
     setCollapsed(true);
@@ -136,14 +162,76 @@ export function WorkspaceDock({
     setCollapsed(false);
   }, [dockPanelRef, setCollapsed]);
 
+  // Esc restores from maximize (desktop) and closes the mobile overlay.
+  useEffect(() => {
+    const overlayOpen = maximized || (narrow && !collapsed);
+    if (!overlayOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (maximized) setMaximized(false);
+      else collapse();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [maximized, narrow, collapsed, collapse]);
+
+  // Below the breakpoint the dock is a full-screen overlay, not a resizable
+  // column: primary goes full-width and no splitter ever mounts. The overlay is
+  // driven by the same `collapsed` contract (collapsed → hidden).
+  if (narrow) {
+    return (
+      <div className={cn("relative flex h-full min-h-0 w-full min-w-0", className)}>
+        <div className="min-h-0 min-w-0 flex-1">{primary}</div>
+        {!collapsed && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Workspace"
+            className="fixed inset-0 z-40 flex flex-col bg-og-bg"
+            style={{
+              paddingTop: "env(safe-area-inset-top)",
+              paddingBottom: "env(safe-area-inset-bottom)",
+            }}
+          >
+            <DockChrome
+              tabs={tabs}
+              current={current}
+              onTab={setTab}
+              controls={
+                <ChromeButton onClick={collapse} title="Close workspace" label="Close workspace">
+                  <XIcon className="size-4" />
+                </ChromeButton>
+              }
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
   const dockChrome = (
     <DockChrome
       tabs={tabs}
       current={current}
       onTab={setTab}
-      maximized={maximized}
-      onToggleMaximize={() => setMaximized((m) => !m)}
-      onCollapse={maximized ? () => setMaximized(false) : collapse}
+      controls={
+        <>
+          <ChromeButton
+            onClick={() => setMaximized((m) => !m)}
+            title={maximized ? "Restore (Esc)" : "Maximize"}
+            label={maximized ? "Restore dock" : "Maximize dock"}
+          >
+            {maximized ? <Minimize2Icon className="size-3.5" /> : <Maximize2Icon className="size-3.5" />}
+          </ChromeButton>
+          <ChromeButton
+            onClick={maximized ? () => setMaximized(false) : collapse}
+            title={maximized ? "Restore" : "Collapse"}
+            label={maximized ? "Restore dock" : "Collapse dock"}
+          >
+            <PanelRightCloseIcon className="size-3.5" />
+          </ChromeButton>
+        </>
+      }
     />
   );
 
@@ -161,7 +249,7 @@ export function WorkspaceDock({
 
         {!collapsed && (
           <Separator className="group relative w-1.5 shrink-0 outline-none">
-            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[color:var(--og-color-border,var(--color-border,#2a2a2a))] transition-colors group-hover:bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))] group-data-[separator-state=dragging]:bg-[color:var(--og-color-accent,var(--color-brand,#3b82f6))]" />
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-og-border transition-colors group-hover:bg-og-accent group-data-[separator-state=dragging]:bg-og-accent" />
           </Separator>
         )}
 
@@ -186,7 +274,7 @@ export function WorkspaceDock({
           {/* Hidden behind the overlay while maximized (avoids double-mounting
               the surfaces). */}
           {!collapsed && !maximized && (
-            <div className="flex h-full min-h-0 min-w-0 flex-col border-l border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-bg,var(--color-bg,#0d0d0d))]">
+            <div className="flex h-full min-h-0 min-w-0 flex-col border-l border-og-border bg-og-bg">
               {dockChrome}
             </div>
           )}
@@ -199,7 +287,7 @@ export function WorkspaceDock({
           type="button"
           onClick={expand}
           title="Open workspace"
-          className="absolute inset-y-0 right-0 flex w-6 shrink-0 items-center justify-center border-l border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] bg-[color:var(--og-color-surface-1,var(--color-surface,#161616))] text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
+          className="absolute inset-y-0 right-0 flex w-6 shrink-0 items-center justify-center border-l border-og-border bg-og-surface-1 text-og-fg-subtle hover:text-og-fg"
         >
           <ChevronsLeftRightIcon className="size-3.5" />
         </button>
@@ -207,7 +295,7 @@ export function WorkspaceDock({
 
       {/* Maximize overlay: full-workspace surface above everything. */}
       {maximized && (
-        <div className="fixed inset-0 z-40 flex flex-col bg-[color:var(--og-color-bg,var(--color-bg,#0d0d0d))]">
+        <div className="fixed inset-0 z-40 flex flex-col bg-og-bg">
           {dockChrome}
         </div>
       )}
@@ -215,26 +303,54 @@ export function WorkspaceDock({
   );
 }
 
+/** A dock-chrome control button — compact on fine pointers, ≥40px on coarse. */
+function ChromeButton({
+  onClick,
+  title,
+  label,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={label}
+      className="inline-flex items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg pointer-coarse:size-10"
+    >
+      {children}
+    </button>
+  );
+}
+
 function DockChrome({
   tabs,
   current,
   onTab,
-  maximized,
-  onToggleMaximize,
-  onCollapse,
+  controls,
 }: {
   tabs: WorkspaceTab[];
   current: string;
   onTab: (id: string) => void;
-  maximized: boolean;
-  onToggleMaximize: () => void;
-  onCollapse: () => void;
+  /** Right-aligned chrome controls (maximize / collapse, or the overlay close). */
+  controls: ReactNode;
 }) {
   const active = tabs.find((t) => t.id === current) ?? tabs[0];
   return (
     <>
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[color:var(--og-color-border,var(--color-border,#2a2a2a))] px-1.5 py-1">
-        <div className="flex min-w-0 items-center gap-0.5" role="tablist">
+      <div className="flex shrink-0 items-center gap-2 border-b border-og-border px-1.5 py-1">
+        {/* The tab list scrolls horizontally when it can't fit — it must never
+            grow into or overlap the chrome controls (they stay shrink-0). The
+            scrollbar is hidden to keep the strip calm. */}
+        <div
+          className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="tablist"
+        >
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -243,35 +359,18 @@ function DockChrome({
               aria-selected={tab.id === current}
               onClick={() => onTab(tab.id)}
               className={cn(
-                "flex items-center gap-1 rounded-[var(--og-radius-sm,4px)] px-2 py-1 text-[11px] font-medium transition-colors",
+                "flex shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors pointer-coarse:min-h-10",
                 tab.id === current
-                  ? "bg-[color:var(--og-color-accent-soft,var(--color-surface-2,#222))] text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
-                  : "text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]",
+                  ? "bg-og-accent-soft text-og-fg"
+                  : "text-og-fg-subtle hover:text-og-fg",
               )}
             >
-              <span className="truncate">{tab.label}</span>
+              <span>{tab.label}</span>
               {tab.badge}
             </button>
           ))}
         </div>
-        <div className="flex shrink-0 items-center gap-0.5 text-[color:var(--og-color-fg-subtle,var(--color-fg-subtle,#888))]">
-          <button
-            type="button"
-            onClick={onToggleMaximize}
-            title={maximized ? "Restore (Esc)" : "Maximize"}
-            className="rounded-[var(--og-radius-sm,4px)] p-1 hover:bg-[color:var(--og-color-surface-2,var(--color-surface-2,#222))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
-          >
-            {maximized ? <Minimize2Icon className="size-3.5" /> : <Maximize2Icon className="size-3.5" />}
-          </button>
-          <button
-            type="button"
-            onClick={onCollapse}
-            title={maximized ? "Restore" : "Collapse"}
-            className="rounded-[var(--og-radius-sm,4px)] p-1 hover:bg-[color:var(--og-color-surface-2,var(--color-surface-2,#222))] hover:text-[color:var(--og-color-fg,var(--color-fg,#e6e6e6))]"
-          >
-            <PanelRightCloseIcon className="size-3.5" />
-          </button>
-        </div>
+        <div className="flex shrink-0 items-center gap-0.5 text-og-fg-subtle">{controls}</div>
       </div>
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden" role="tabpanel">
         {active?.content}

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -106,6 +106,12 @@ export function WorkspaceDock({
   const [maximized, setMaximized] = useState(false);
   const [internalTab, setInternalTab] = useState(tabs[0]?.id ?? "");
   const collapsed = collapsedProp ?? internalCollapsed;
+  // When the host supplies `collapsed` it owns the open/close affordance (e.g.
+  // the app header's panel toggle) — the dock must not offer a SECOND
+  // open/close control (duplicate buttons with near-identical icons read as a
+  // bug). Standalone (uncontrolled) usage keeps the built-in collapse button
+  // and the thin re-open rail as its only affordances.
+  const hostControlled = collapsedProp !== undefined;
 
   // Persisted layout (width split) keyed by autoSaveId.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -223,13 +229,11 @@ export function WorkspaceDock({
           >
             {maximized ? <Minimize2Icon className="size-3.5" /> : <Maximize2Icon className="size-3.5" />}
           </ChromeButton>
-          <ChromeButton
-            onClick={maximized ? () => setMaximized(false) : collapse}
-            title={maximized ? "Restore" : "Collapse"}
-            label={maximized ? "Restore dock" : "Collapse dock"}
-          >
-            <PanelRightCloseIcon className="size-3.5" />
-          </ChromeButton>
+          {hostControlled ? null : (
+            <ChromeButton onClick={collapse} title="Collapse" label="Collapse dock">
+              <PanelRightCloseIcon className="size-3.5" />
+            </ChromeButton>
+          )}
         </>
       }
     />
@@ -281,8 +285,9 @@ export function WorkspaceDock({
         </Panel>
       </Group>
 
-      {/* Collapsed rail: a thin tab on the right edge that re-opens the dock. */}
-      {collapsed && !maximized && (
+      {/* Collapsed rail: the standalone fallback re-open affordance. Hidden
+          when the host controls collapse — its own toggle is the one way in. */}
+      {collapsed && !maximized && !hostControlled && (
         <button
           type="button"
           onClick={expand}

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,5 +1,5 @@
 import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 
 export type UseFileAttachmentsOptions = ClientOverride & {
@@ -39,6 +39,11 @@ export type UseFileAttachmentsResult = {
   addFiles: (files: Iterable<File>) => void;
   /** Clipboard path — applies `pasteFilter` (default `image/*`) then uploads. */
   addFromPaste: (event: { clipboardData: DataTransfer | null }) => void;
+  /**
+   * Re-run the upload for a `failed` attachment, in place (same id, same
+   * source file). No-op for an id that isn't a known failed upload.
+   */
+  retry: (id: string) => void;
   /** Remove one attachment; revokes its object-URL. */
   remove: (id: string) => void;
   /** Remove all; revokes every object-URL. Call from `useComposer`'s `onSent`. */
@@ -60,10 +65,33 @@ export function useFileAttachments(options: UseFileAttachmentsOptions = {}): Use
   const { client, workspaceId } = useOpenGeni(options);
   const pasteFilter = options.pasteFilter ?? isImage;
   const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+  // Keep the source File per attachment id so a failed upload can be retried
+  // in place. Cleared on remove/clear so it never outlives its attachment.
+  const sources = useRef<Map<string, File>>(new Map());
+
+  // Run (or re-run) the upload for one already-tracked attachment id. Sets it
+  // back to `uploading`, then resolves to `ready` (with the asset) or `failed`
+  // (with the error message).
+  const startUpload = useCallback((id: string, file: File) => {
+    void client.uploadFile(workspaceId, {
+      filename: file.name || "file",
+      contentType: file.type || "application/octet-stream",
+      data: file,
+    }).then((asset) => {
+      setAttachments((current) => current.map((attachment) => attachment.id === id
+        ? { ...attachment, status: "ready", file: asset, name: asset.filename, contentType: asset.contentType, sizeBytes: asset.sizeBytes, error: undefined }
+        : attachment));
+    }).catch((error: unknown) => {
+      setAttachments((current) => current.map((attachment) => attachment.id === id
+        ? { ...attachment, status: "failed", error: error instanceof Error ? error.message : String(error) }
+        : attachment));
+    });
+  }, [client, workspaceId]);
 
   const addFiles = useCallback((files: Iterable<File>) => {
     for (const file of files) {
       const id = crypto.randomUUID();
+      sources.current.set(id, file);
       const previewUrl = isImage(file) ? URL.createObjectURL(file) : undefined;
       setAttachments((current) => [...current, {
         id,
@@ -73,21 +101,20 @@ export function useFileAttachments(options: UseFileAttachmentsOptions = {}): Use
         status: "uploading",
         ...(previewUrl ? { previewUrl } : {}),
       }]);
-      void client.uploadFile(workspaceId, {
-        filename: file.name || "file",
-        contentType: file.type || "application/octet-stream",
-        data: file,
-      }).then((asset) => {
-        setAttachments((current) => current.map((attachment) => attachment.id === id
-          ? { ...attachment, status: "ready", file: asset, name: asset.filename, contentType: asset.contentType, sizeBytes: asset.sizeBytes }
-          : attachment));
-      }).catch((error: unknown) => {
-        setAttachments((current) => current.map((attachment) => attachment.id === id
-          ? { ...attachment, status: "failed", error: error instanceof Error ? error.message : String(error) }
-          : attachment));
-      });
+      startUpload(id, file);
     }
-  }, [client, workspaceId]);
+  }, [startUpload]);
+
+  const retry = useCallback((id: string) => {
+    const file = sources.current.get(id);
+    if (!file) {
+      return;
+    }
+    setAttachments((current) => current.map((attachment) => attachment.id === id
+      ? { ...attachment, status: "uploading", error: undefined }
+      : attachment));
+    startUpload(id, file);
+  }, [startUpload]);
 
   const addFromPaste = useCallback((event: { clipboardData: DataTransfer | null }) => {
     const clipboardFiles = event.clipboardData?.files;
@@ -101,6 +128,7 @@ export function useFileAttachments(options: UseFileAttachmentsOptions = {}): Use
   }, [addFiles, pasteFilter]);
 
   const remove = useCallback((id: string) => {
+    sources.current.delete(id);
     setAttachments((current) => {
       const removed = current.find((attachment) => attachment.id === id);
       if (removed?.previewUrl) {
@@ -111,6 +139,7 @@ export function useFileAttachments(options: UseFileAttachmentsOptions = {}): Use
   }, []);
 
   const clear = useCallback(() => {
+    sources.current.clear();
     setAttachments((current) => {
       for (const attachment of current) {
         if (attachment.previewUrl) {
@@ -129,6 +158,7 @@ export function useFileAttachments(options: UseFileAttachmentsOptions = {}): Use
     uploading: attachments.some((attachment) => attachment.status === "uploading"),
     addFiles,
     addFromPaste,
+    retry,
     remove,
     clear,
   };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,7 +13,7 @@ export { useSession, isTitleEvent } from "./hooks/use-session";
 export type { UseSessionOptions, UseSessionResult } from "./hooks/use-session";
 export { useSessionEvents } from "./hooks/use-session-events";
 export type { SessionEventsConnectionState, UseSessionEventsOptions, UseSessionEventsResult } from "./hooks/use-session-events";
-export { useComposer, composeSendInput, shouldSubmitOnKey } from "./hooks/use-composer";
+export { useComposer, composeSendInput, shouldSubmitOnKey, FILE_ONLY_MESSAGE_TEXT } from "./hooks/use-composer";
 export type { ComposerMode, ComposerSendExtras, ComposerState, UseComposerOptions } from "./hooks/use-composer";
 export { useFileAttachments } from "./hooks/use-file-attachments";
 export type { FileAttachment, UseFileAttachmentsOptions, UseFileAttachmentsResult } from "./hooks/use-file-attachments";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -242,4 +242,4 @@ export { xtermThemeFromTokens } from "./lib/xterm-theme";
 
 // Utilities
 export { cn } from "./lib/cn";
-export { formatBytes, formatRelativeTime, stringifyPayload, truncate, tryParseJson } from "./lib/format";
+export { formatBytes, formatRelativeTime, humanizeFailureReason, stringifyPayload, truncate, tryParseJson } from "./lib/format";

--- a/packages/react/src/lib/format.ts
+++ b/packages/react/src/lib/format.ts
@@ -82,3 +82,35 @@ export function tryParseJson(text: string): unknown {
     return undefined;
   }
 }
+
+/**
+ * Humanize engine/provider failure text before it reaches the timeline or a
+ * failure banner. Raw provider errors leak the wrong audience's instructions —
+ * "Incorrect API key … find your API key at platform.openai.com" tells a
+ * managed-deployment USER to fix credentials only an OPERATOR controls (and is
+ * flatly wrong for Azure or subscription-backed engines). Auth and quota
+ * failures collapse to one neutral, honest sentence; every other reason passes
+ * through untouched. Raw payloads stay available in the debug surfaces.
+ */
+export function humanizeFailureReason(reason: string | null): string | null {
+  if (!reason) {
+    return reason;
+  }
+  const normalized = reason.toLowerCase();
+  const authFailure =
+    normalized.includes("incorrect api key") ||
+    normalized.includes("invalid api key") ||
+    normalized.includes("invalid_api_key") ||
+    normalized.includes("platform.openai.com/account/api-keys") ||
+    (normalized.includes("401") && (normalized.includes("api key") || normalized.includes("unauthorized")));
+  if (authFailure) {
+    return "The model provider rejected this deployment's engine credentials. Sending messages won't help until the deployment's engine configuration is fixed.";
+  }
+  const quotaFailure =
+    normalized.includes("insufficient_quota") ||
+    normalized.includes("exceeded your current quota");
+  if (quotaFailure) {
+    return "The model provider refused the request: this deployment's provider quota is exhausted.";
+  }
+  return reason;
+}

--- a/packages/react/src/lib/xterm-theme.ts
+++ b/packages/react/src/lib/xterm-theme.ts
@@ -1,8 +1,8 @@
 import type { XtermTheme } from "../components/sandbox-terminal";
 
 /**
- * Derive an xterm `ITheme` subset from the live OKLCH `--og-*` token system (or
- * the app's `--color-*` aliases). Reads the COMPUTED values so xterm — which
+ * Derive an xterm `ITheme` subset from the live OKLCH `--og-*` token system.
+ * Reads the COMPUTED values so xterm — which
  * paints into a canvas and can't consume CSS vars — gets concrete colors. Call
  * on mount and re-derive on a `data-og-theme` flip.
  *
@@ -12,16 +12,13 @@ export function xtermThemeFromTokens(root?: HTMLElement | null): XtermTheme | un
   if (typeof window === "undefined" || typeof getComputedStyle === "undefined") return undefined;
   const el = root ?? document.documentElement;
   const style = getComputedStyle(el);
-  const read = (names: string[]): string | undefined => {
-    for (const name of names) {
-      const value = style.getPropertyValue(name).trim();
-      if (value) return value;
-    }
-    return undefined;
+  const read = (name: string): string | undefined => {
+    const value = style.getPropertyValue(name).trim();
+    return value || undefined;
   };
-  const bg = read(["--og-color-bg", "--color-bg"]);
-  const fg = read(["--og-color-fg", "--color-fg"]);
-  const accent = read(["--og-color-accent", "--color-brand", "--color-accent"]);
+  const bg = read("--og-color-bg");
+  const fg = read("--og-color-fg");
+  const accent = read("--og-color-accent");
   const theme: XtermTheme = {};
   if (bg) theme.background = bg;
   if (fg) theme.foreground = fg;

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -200,7 +200,7 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
           type="button"
           onClick={() => item.workerSessionId && onOpenSession(item.workerSessionId)}
           className={cn(
-            "shrink-0 self-center rounded-og-sm border border-og-border px-2.5 py-1 text-og-sm font-medium text-og-fg-muted",
+            "shrink-0 self-center rounded-og-sm border border-og-border px-2.5 py-1 text-og-sm font-medium text-og-fg-muted pointer-coarse:py-2",
             "outline-none transition-colors duration-150 hover:border-og-border-strong hover:text-og-fg",
             "focus-visible:ring-2 focus-visible:ring-og-accent",
           )}

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1,5 +1,5 @@
 import type { SessionEvent, SessionStatus } from "@opengeni/sdk";
-import { tryParseJson } from "../lib/format";
+import { humanizeFailureReason, tryParseJson } from "../lib/format";
 import type {
   AgentMessageItem,
   ActivityItem,
@@ -775,7 +775,9 @@ function failureMessage(payload: Record<string, unknown>): string | null {
   for (const key of ["error", "message"] as const) {
     const value = payload[key];
     if (typeof value === "string" && value.trim().length > 0) {
-      return value;
+      // Auth/quota provider errors are rewritten for the right audience
+      // (raw text remains in the event payload for debug surfaces).
+      return humanizeFailureReason(value);
     }
   }
   return null;

--- a/packages/react/src/timeline/screenshot-lightbox.tsx
+++ b/packages/react/src/timeline/screenshot-lightbox.tsx
@@ -136,7 +136,7 @@ function LightboxRoot({ children }: { children: ReactNode }) {
                         {state.caption}
                       </figcaption>
                     ) : (
-                      <figcaption className="font-og-mono text-[10px] uppercase tracking-[0.1em] text-white/35">
+                      <figcaption className="font-og-mono text-og-xs uppercase tracking-[0.1em] text-white/35">
                         Esc or click outside to close
                       </figcaption>
                     )}

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -155,6 +155,9 @@ export function ActivityDisclosure({
   const rowClass = cn(
     "group/disclosure flex w-full min-w-0 items-center gap-2 rounded-og-sm px-1.5 py-1.5 text-left text-og-base",
     "text-og-fg-muted transition-colors duration-150",
+    // A tool row is a touch target on coarse pointers: grow its padding so the
+    // hit area clears the 40px minimum without loosening the dense desktop rail.
+    "pointer-coarse:py-2.5",
   );
   // The chevron rotates to point down when open; it tracks `data-state` on this
   // same row (the Trigger), so the affordance never freezes.
@@ -295,7 +298,7 @@ export function TermBlock({
   const showHeader = command != null || workdir != null;
 
   return (
-    <div className="overflow-hidden rounded-og-sm border border-og-border bg-og-bg/70">
+    <div className="min-w-0 overflow-hidden rounded-og-sm border border-og-border bg-og-bg/70">
       {showHeader ? (
         <div className="flex items-center gap-2 border-b border-og-border/70 px-2.5 py-1.5">
           <span className="select-none text-og-status-idle">$</span>

--- a/packages/react/src/timeline/tool-diff.tsx
+++ b/packages/react/src/timeline/tool-diff.tsx
@@ -49,7 +49,7 @@ function LayoutToggle({ layout, onChange }: { layout: "unified" | "split"; onCha
           type="button"
           onClick={() => onChange(value)}
           className={cn(
-            "rounded-[5px] px-2 py-[3px] text-[11px] font-medium capitalize transition-colors",
+            "rounded-og-xs px-2 py-[3px] text-og-xs font-medium capitalize transition-colors",
             layout === value ? "bg-og-surface-2 text-og-fg" : "text-og-fg-subtle hover:text-og-fg-muted",
           )}
         >

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -46,6 +46,9 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
       <Collapsible.Trigger
         className={cn(
           "group flex w-full items-center gap-2.5 rounded-og-md border px-3 py-2 text-left text-og-base transition-colors",
+          // A folded turn is a touch target on coarse pointers: grow the row so
+          // it clears the 40px minimum without disturbing the calm desktop rhythm.
+          "pointer-coarse:py-2.5",
           // Only a failed turn earns the one filled/tinted card in the timeline;
           // complete and cancelled stay flat and calm.
           outcome === "failed"
@@ -83,6 +86,21 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
             <span className="text-og-status-failed"> · {failureText}</span>
           ) : null}
           {outcome === "cancelled" ? <span className="text-og-fg-subtle"> · interrupted</span> : null}
+        </span>
+        {/* The disclosure hint. Calm at rest on fine pointers (revealed on hover
+            and keyboard focus), but always present on coarse pointers where there
+            is no hover to lean on — so the fold never reads as a static status
+            line. Purely visual: the trigger's aria-expanded already conveys state
+            to assistive tech, so the hint is hidden from the accessible name. */}
+        <span
+          aria-hidden
+          className={cn(
+            "ml-auto shrink-0 pl-2 text-og-xs text-og-fg-subtle transition-opacity duration-150",
+            "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
+            "pointer-coarse:opacity-100",
+          )}
+        >
+          {open ? "hide steps" : "show steps"}
         </span>
       </Collapsible.Trigger>
       <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-og-collapse data-[state=open]:animate-og-expand">

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -17,6 +17,8 @@
   --og-font-sans: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
   --og-font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   --og-font-features: "cv11", "ss01", "ss03";
+  --og-code-font-size: 12px;
+  --og-code-line-height: 18px;
 
   /* Radius ----------------------------------------------------------------- */
   --og-radius-xs: 4px;
@@ -60,6 +62,8 @@
   --og-color-status-failed: oklch(0.7 0.16 22);
   --og-color-status-cancelled: oklch(0.6 0.035 260);
   --og-color-danger: oklch(0.66 0.18 22);
+  --og-color-diff-add-bg: color-mix(in oklch, var(--og-color-status-idle) 14%, transparent);
+  --og-color-diff-del-bg: color-mix(in oklch, var(--og-color-status-failed) 14%, transparent);
 
   /* Elevation ----------------------------------------------------------------
      Dark surfaces barely cast shadows; elevation reads mostly from the
@@ -103,6 +107,8 @@
   --og-color-status-failed: oklch(0.55 0.19 22);
   --og-color-status-cancelled: oklch(0.55 0.025 260);
   --og-color-danger: oklch(0.55 0.2 22);
+  --og-color-diff-add-bg: color-mix(in oklch, var(--og-color-status-idle) 12%, transparent);
+  --og-color-diff-del-bg: color-mix(in oklch, var(--og-color-status-failed) 12%, transparent);
 
   --og-shadow-sm: 0 1px 2px oklch(0.2 0.02 260 / 0.07);
   --og-shadow-md: 0 2px 8px oklch(0.2 0.02 260 / 0.09), 0 1px 2px oklch(0.2 0.02 260 / 0.06);

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -48,6 +48,7 @@
   /* Accent — one brand hue, used sparingly ----------------------------------- */
   --og-color-accent: oklch(0.72 0.15 255);
   --og-color-accent-strong: oklch(0.78 0.14 255);
+  --og-color-accent-deep: oklch(0.62 0.18 255);
   --og-color-accent-fg: oklch(0.985 0.005 260);
   --og-color-accent-soft: color-mix(in oklch, var(--og-color-accent) 16%, transparent);
 
@@ -91,6 +92,7 @@
 
   --og-color-accent: oklch(0.55 0.18 255);
   --og-color-accent-strong: oklch(0.48 0.19 255);
+  --og-color-accent-deep: oklch(0.44 0.19 255);
   --og-color-accent-fg: oklch(0.985 0.005 260);
   --og-color-accent-soft: color-mix(in oklch, var(--og-color-accent) 11%, transparent);
 

--- a/packages/react/test/chat-composer-uploads.test.tsx
+++ b/packages/react/test/chat-composer-uploads.test.tsx
@@ -50,6 +50,7 @@ function makeAttachments(overrides: Partial<UseFileAttachmentsResult> = {}): Use
     uploading: false,
     addFiles: () => {},
     addFromPaste: () => {},
+    retry: () => {},
     remove: () => {},
     clear: () => {},
     ...overrides,

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -86,19 +86,19 @@ describe("DiffView", () => {
   test("distinguishes 'no changes' (repo) from 'no repository' (no repo)", async () => {
     const repo = await renderComponent(<DiffView diff={[]} isRepo={true} />);
     await flush();
-    expect(repo.container.textContent).toContain("No changes.");
+    expect(repo.container.textContent).toContain("No changes");
     await repo.unmount();
 
     const noRepo = await renderComponent(<DiffView diff={[]} isRepo={false} />);
     await flush();
-    expect(noRepo.container.textContent).toContain("No repository mounted.");
+    expect(noRepo.container.textContent).toContain("No repository mounted");
     await noRepo.unmount();
   });
 
   test("binary files are not rendered as text", async () => {
     const r = await renderComponent(<DiffView diff={[fakeFileDiff({ isBinary: true, hunks: [] })]} />);
     await flush();
-    expect(r.container.textContent).toContain("Binary file not shown.");
+    expect(r.container.textContent).toContain("Binary file not shown");
     await r.unmount();
   });
 });

--- a/packages/react/test/use-file-attachments.test.tsx
+++ b/packages/react/test/use-file-attachments.test.tsx
@@ -184,6 +184,46 @@ describe("useFileAttachments", () => {
     await hook.unmount();
   });
 
+  test("retry(id) re-uploads a failed attachment in place -> ready, clearing its error", async () => {
+    let calls = 0;
+    const asset = fakeAsset({ id: "recovered", filename: "recovered.png" });
+    const client = fakeClient({
+      uploadFile: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("transient network error");
+        }
+        return asset;
+      },
+    });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.addFiles([imageFile()]));
+    await flush();
+    const id = hook.result.current.attachments[0]!.id;
+    expect(hook.result.current.attachments[0]!.status).toBe("failed");
+    expect(hook.result.current.attachments[0]!.error).toBe("transient network error");
+
+    await flushing(() => hook.result.current.retry(id));
+    await flush();
+    const attachment = hook.result.current.attachments[0]!;
+    expect(attachment.status).toBe("ready");
+    expect(attachment.error).toBeUndefined();
+    expect(hook.result.current.readyResources).toEqual([{ kind: "file", fileId: asset.id }]);
+    expect(calls).toBe(2);
+    await hook.unmount();
+  });
+
+  test("retry(id) is a no-op for an unknown / already-removed id", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(() => useFileAttachments({ client, workspaceId: WORKSPACE_ID }), undefined);
+
+    await flushing(() => hook.result.current.retry("nope"));
+    await flush();
+    expect(hook.result.current.attachments).toHaveLength(0);
+    await hook.unmount();
+  });
+
   test("uploading is true while an upload is pending and flips false once it resolves", async () => {
     let resolveUpload!: (asset: FileAsset) => void;
     const pending = new Promise<FileAsset>((resolve) => { resolveUpload = resolve; });

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -28,6 +28,28 @@ function ControlledDock(props: { onCollapsedChange: (collapsed: boolean) => void
   );
 }
 
+/** Force `useIsNarrow` to report a phone-width viewport for the callback's span. */
+async function withNarrowViewport(run: () => Promise<void>): Promise<void> {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  })) as unknown as typeof window.matchMedia;
+  try {
+    await run();
+  } finally {
+    window.matchMedia = original;
+  }
+}
+
 describe("WorkspaceDock", () => {
   test("dock collapse controls can be owned by the host", async () => {
     const changes: boolean[] = [];
@@ -50,5 +72,28 @@ describe("WorkspaceDock", () => {
     expect(rendered.container.textContent ?? "").toContain("Run content");
 
     await rendered.unmount();
+  });
+
+  test("below the breakpoint the dock is a full-screen overlay with no resize splitter", async () => {
+    await withNarrowViewport(async () => {
+      const changes: boolean[] = [];
+      const rendered = await renderComponent(
+        <ControlledDock onCollapsedChange={(collapsed) => changes.push(collapsed)} />,
+      );
+
+      // No drag splitter renders on a phone-width viewport.
+      expect(rendered.container.querySelector("[data-separator-state]")).toBeNull();
+      // The dock content is presented as a modal overlay, not a side column.
+      const overlay = rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]');
+      expect(overlay).not.toBeNull();
+      expect(overlay?.textContent ?? "").toContain("Run content");
+
+      // The overlay's own close control drives the same collapsed contract.
+      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      expect(changes.at(-1)).toBe(true);
+      expect(rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]')).toBeNull();
+
+      await rendered.unmount();
+    });
   });
 });

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -51,24 +51,40 @@ async function withNarrowViewport(run: () => Promise<void>): Promise<void> {
 }
 
 describe("WorkspaceDock", () => {
-  test("dock collapse controls can be owned by the host", async () => {
-    const changes: boolean[] = [];
+  test("a host-controlled dock offers no built-in open/close controls", async () => {
+    // The host's own toggle is the ONE open/close affordance: no chrome
+    // Collapse button (it duplicated the host toggle) and no re-open rail.
     const rendered = await renderComponent(
-      <ControlledDock onCollapsedChange={(collapsed) => changes.push(collapsed)} />,
+      <ControlledDock onCollapsedChange={() => {}} />,
     );
 
     expect(rendered.container.textContent ?? "").toContain("Run content");
+    expect(rendered.container.querySelector('[title="Collapse"]')).toBeNull();
     expect(rendered.container.querySelector('[title="Open workspace"]')).toBeNull();
+    // Maximize remains: a distinct mode, not an open/close duplicate.
+    expect(rendered.container.querySelector('[title="Maximize"]')).not.toBeNull();
+
+    await rendered.unmount();
+  });
+
+  test("an uncontrolled dock keeps its own collapse button and re-open rail", async () => {
+    const rendered = await renderComponent(
+      <WorkspaceDock
+        autoSaveId="og.test.workspace-dock-uncontrolled"
+        primary={<div>Chat pane</div>}
+        tabs={[{ id: "run", label: "Run", content: <div>Run content</div> }]}
+      />,
+    );
+
+    expect(rendered.container.textContent ?? "").toContain("Run content");
 
     await click(rendered.container.querySelector('[title="Collapse"]'));
 
-    expect(changes.at(-1)).toBe(true);
     expect(rendered.container.textContent ?? "").not.toContain("Run content");
     expect(rendered.container.querySelector('[title="Open workspace"]')).not.toBeNull();
 
     await click(rendered.container.querySelector('[title="Open workspace"]'));
 
-    expect(changes.at(-1)).toBe(false);
     expect(rendered.container.textContent ?? "").toContain("Run content");
 
     await rendered.unmount();


### PR DESCRIPTION
A coordinated UI/UX polish program across apps/web and packages/react, driven by a written doctrine (audits: consistency, UX states, copy/AI-slop, IA, plus desktop + 390px/768px screenshot evidence from staging).

## What changed

**Foundation — one design language**
- One token source: the app `@theme` now aliases the canonical `--og-*` palette (was a subtly-diverged duplicate); full og status-token set adopted; new `--og-color-accent-deep` fill token; `--text-2xs` floor (9–11px arbitrary sizes eliminated)
- Zero `[color:var(...)]` class idioms, zero raw Tailwind palette colors (amber/emerald/red/zinc/sky…) in either package; legacy GitHub-hex fallbacks (`#3fb950` et al.) purged from the sandbox/editor/viewer components
- Shared primitives: `Notice`, `StatusDot`+`STATUS_META`, `MetaChip`, `EmptyState`, `ConfirmDialog`, `Select`

**One status language (D2)** — session rail, header badge, queue dots, document/schedule states all map to the six og status tokens; the header's double-green "live"+"Idle" pills are gone (connection pill only appears when degraded); "Waiting on you" vocabulary unified.

**Honest states (D5)** — false-empty states eliminated (schedules run history, API keys flash, machine fleet errors, capability tabs vanishing); approvals can't double-submit; destructive actions (env/variable delete, key revoke, pack unregister, schedule delete, member remove) go through ConfirmDialog naming the object; guided EmptyStates with inline CTAs; upload errors show the real cause + retry.

**IA (D4)** — rail inverted (sessions above config), home gains a quiet "Recent sessions" section, nav labels tooltip'd, "Settings"→"Workspace settings", raw org-id label removed, session-list times visible at rest, Debug demoted, capabilities page de-noised (one primary per region, one chip language).

**Copy** — jargon purge (subject→you, vendor name→managed sandbox, box→sandbox, dispatch/worker-restart→plain language), sentence case, fragment/period conventions, `…` everywhere, verb-first buttons naming objects.

**Mobile (D9)** — the dock is a full-screen overlay below 1024px (panels never mount; fixes the squeezed-sliver session view at 390px); tab strip scrolls instead of colliding with window controls (was broken at 390/768/1024); composer controls wrap with anchored ≥44px send, 16px textarea below md (no iOS zoom), safe-area padding; `inspectorOpen` defaults closed on narrow viewports; dialogs present bottom-sheet-style on phones; no hover-only information on coarse pointers (turn-chip "show steps" hint always visible on touch); timeline scroll-anchoring so expanding/collapsing folds never yanks the reading position.

## Verification
- typecheck green (apps/web + packages/react), production build green
- 515/515 tests pass (3 new: dock overlay, attachment retry × 2)
- independent gpt-5.5 correctness review of the full range (findings addressed pre-merge)
- before/after screenshot passes on staging at 1440/768/390 to follow post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface-area visual and copy changes across core session, rail, and sandbox flows could regress layout or status semantics on edge connection/fleet states, though behavior is mostly presentational with added loading guards.
> 
> **Overview**
> This is a broad **apps/web** polish pass that replaces ad-hoc `[color:var(...)]` and raw palette classes with semantic tokens (`text-fg-muted`, `text-status-*`, `text-2xs`, etc.) and routes repeated UI through new shared primitives: **`Notice`**, **`MetaChip`**, **`EmptyState`**, **`ConfirmDialog`**, and a styled **`Select`**.
> 
> **Status and copy** are aligned to one vocabulary: **`ConnectionPill`** only shows when the event stream is degraded; steer/queue and rail dots use **status tones** instead of amber/emerald one-offs; failure/cancel banners and queue labels use plainer language (e.g. turn retries vs “worker re-dispatch”). **Problem routes** and several toasts use more user-facing wording.
> 
> **Information architecture** in the rail puts **sessions above workspace config**, expands nav tooltips/descriptions, and improves the org switcher so the visible line prefers a human org name over raw IDs. The **session header** gets a taller meta row, reordered connection/status pills, quieter title rename, and sandbox/Codex indicators with less “label:” grammar.
> 
> **Honest / safer states**: sandbox workspace tabs show **connecting/offline/retry** instead of vanishing; the inspector avoids labeling compute as the home backend while the fleet is still loading; Codex UI drops raw account IDs as display labels and standardizes chips; repository manual-remove gets a **two-step confirm**; goal/queue errors move to **`Notice`**.
> 
> **Mobile (D9)**: dialogs default to a **bottom sheet** on small screens; sheets cap width; rail footer and drawer add **safe-area** padding and **focus return** to the menu button after the drawer closes; touch targets get `pointer-coarse` tweaks (session rows, nav, pencil affordances).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f87f6f0ae419789152d0ff1a2ecb2bd4f6a044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->