### PR TITLE
build(relay): slim the relay image build context (380 MiB → ~8 MiB)

### DIFF
--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,0 +1,13 @@
+# Context-slimming for image builds whose context ROOT is agent/ — i.e. the
+# relay image (`az acr build --file agent/crates/opengeni-relay/Dockerfile agent`).
+# Nested .dockerignore files are invisible to repo-root-context builds, so this
+# CANNOT affect the api image, whose root context deliberately carries
+# install/baked ("the agent ships inside the control-plane").
+#
+# install/baked holds ~370 MiB of per-SHA baked agent binaries the relay build
+# never reads (its COPY . . feeds only the Rust workspace build); shipping them
+# made the relay context upload 380 MiB and exposed every staging build to ACR
+# connection resets (two consecutive failures on 2026-07-02).
+install/baked
+# Host-side cargo build outputs; the image builds its own target inside.
+target


### PR DESCRIPTION
The relay image's \`az acr build\` context root is \`agent/\`, which carries the CI-baked per-SHA agent binaries under \`install/baked\` (~370 MiB) that the relay Dockerfile never reads (\`COPY . .\` feeds only the Rust workspace build). The 380 MiB context upload failed twice consecutively today with ACR \`ConnectionResetError(104)\` mid-upload, blocking staging builds.

Add \`agent/.dockerignore\` excluding \`install/baked\` (+ host \`target/\`). Nested .dockerignore files are invisible to repo-root-context builds, so the api image — whose root context deliberately ships the baked agents ("the agent ships inside the control-plane") — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-context-only change for the relay image; API images and runtime behavior are unaffected by design.
> 
> **Overview**
> Adds **`agent/.dockerignore`** so relay image builds that use **`agent/`** as the Docker context no longer upload **`install/baked`** (~370 MiB of CI-baked per-SHA agent binaries the relay Dockerfile never uses) or host **`target/`** cargo output. The goal is to shrink the context from ~380 MiB to on the order of ~8 MiB and avoid ACR upload **`ConnectionResetError`** failures during staging builds.
> 
> Because a nested **`.dockerignore`** only applies when the context root is **`agent/`**, repo-root API/control-plane builds that intentionally ship **`install/baked`** inside the image are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c0e07a6ac39adcd6f7d5f01ae0567cd1542cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->