### PR TITLE
chore(release): republish closure with contracts ^0.4.0 ranges

### DIFF
--- a/.changeset/closure-range-cascade.md
+++ b/.changeset/closure-range-cascade.md
@@ -1,0 +1,19 @@
+---
+"@opengeni/agent-proto": patch
+"@opengeni/api-router": patch
+"@opengeni/codex": patch
+"@opengeni/config": patch
+"@opengeni/core": patch
+"@opengeni/db": patch
+"@opengeni/documents": patch
+"@opengeni/events": patch
+"@opengeni/github": patch
+"@opengeni/observability": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
+"@opengeni/storage": patch
+"@opengeni/worker-bundle": patch
+---
+
+Republish the closure so published manifests reference `@opengeni/contracts@^0.4.0`. The previous `^0.3.0` ranges exclude 0.4.0 under 0.x caret semantics, causing consumers to nest a stale contracts copy that lacks the current export surface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ Use [`docs/README.md`](docs/README.md) as the docs map. If you move or rename fi
 
 Release and publishing guidance starts here; executable truth lives in [`package.json`](package.json) and the workflow files under `.github/workflows/`. When publishable packages change, keep changesets, package manifests, and the release workflow expectations aligned.
 
+Two publish-coherence rules learned the hard way (all versions are 0.x):
+
+- **A minor bump of a package must cascade to its dependents.** Published manifests carry caret ranges (`^0.3.0`), and under 0.x caret semantics a minor bump (0.3.0 → 0.4.0) leaves every dependent's range. Add a patch changeset covering the dependent closure in the same release, or external consumers nest a stale copy of the bumped package.
+- **Publish-mode Release runs only on a Version-Packages-PR merge commit.** Any other push to `main` produces a version-mode run that just refreshes the Version PR. To ship a publish, merge the Version PR deliberately and watch that specific run.
+
 ## Code Style
 
 - Prefer existing repository patterns over new abstractions.


### PR DESCRIPTION
Follow-up to the contracts@0.4.0 republish: under 0.x caret semantics, the closure's published `^0.3.0` ranges exclude 0.4.0, so consumers nest a stale contracts and hit the same missing-export failure. Patch changeset across all dependents → next publish emits `^0.4.0`. Also records the two publish-coherence rules in CONTRIBUTING § Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbPQr8kJmVXyZ2tGwCnDhE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and contributor docs only; no runtime or API code changes.
> 
> **Overview**
> Adds a **patch changeset** across fifteen publishable `@opengeni/*` packages so the next release republishes the full dependency closure with manifests pointing at **`@opengeni/contracts@^0.4.0`**. Under **0.x caret rules**, existing published **`^0.3.0`** ranges do not resolve to **0.4.0**, so external installs can pull a nested, outdated contracts copy and hit missing-export errors after contracts was bumped to **0.4.0**.
> 
> **CONTRIBUTING.md** § Release / Publishing now documents two **publish-coherence** rules: cascade patch changesets to dependents when a dependency gets a minor bump on 0.x, and only expect a publish-mode Release workflow run when the Version Packages PR merge commit lands on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e735e06dfb7a29307e71ce2159ee55942d0508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->