### PR TITLE
fix(agent): fast-phase reconnect backoff — machine attach recovers in seconds after a control-plane deploy

### DIFF
--- a/agent/crates/opengeni-agent/src/backoff.rs
+++ b/agent/crates/opengeni-agent/src/backoff.rs
@@ -8,6 +8,24 @@
 //! across the whole window *and* keeps the expected delay low, beating
 //! "equal jitter" and plain capped-exponential for de-correlating reconnects.
 //!
+//! ## Fast phase (recover a rolling-deploy blip in seconds, not minutes)
+//!
+//! The control-plane connection, its RPC responder subscription, AND the ~5s
+//! liveness heartbeat all ride ONE NATS connection (see `supervisor.rs`). When a
+//! control-plane rolling deploy briefly drops that connection, everything the
+//! control plane sees of the machine — `last_seen_at` and the attach-gate ping —
+//! goes dark together and only returns once this backoff lets the agent re-dial.
+//! With a pure `1s→60s` exponential, a ~2-minute deploy window pushes the ceiling
+//! to the 60s cap, so recovery lags the deploy by up to a full cap window (and
+//! compounds on any failed attempt) — observed as multi-minute "machine offline;
+//! cannot attach" outages after every deploy. So [`Backoff::standard`] runs a
+//! FAST PHASE first: the initial `fast_attempts` attempts draw within a small
+//! `fast_ceiling` (≈30s of ~1.5s-median retries) to catch a returning control
+//! plane within a few seconds, THEN falls back to the exponential up to `cap`
+//! (now 10s, not 60s) so a genuinely PROLONGED outage still de-correlates the
+//! fleet reconnect (the #1-outage-cause storm protection is retained, just bounded
+//! to a tighter cap). Full jitter spreads the herd across every window.
+//!
 //! The struct is deliberately decoupled from any clock or RNG source it cannot be
 //! unit-tested against: [`Backoff::ceiling`] is the pure, exactly-checkable bound
 //! and [`Backoff::next_delay`] draws within it. The supervisor sleeps for the
@@ -24,26 +42,60 @@ use std::time::Duration;
 pub struct Backoff {
     base: Duration,
     cap: Duration,
+    /// The ceiling used during the initial FAST phase — each of the first
+    /// `fast_attempts` reconnect delays is drawn uniformly in `[0, fast_ceiling]`
+    /// so a brief control-plane blip (a rolling api/relay deploy) is retried
+    /// within ~`fast_ceiling` rather than waiting out the exponential climb.
+    /// `Duration::ZERO` with `fast_attempts == 0` disables the fast phase (a pure
+    /// exponential backoff — what [`Backoff::new`] builds).
+    fast_ceiling: Duration,
+    /// How many initial attempts stay in the fast phase before the exponential
+    /// (`base` → `cap`) backoff takes over for a PROLONGED outage.
+    fast_attempts: u32,
     attempt: u32,
 }
 
 impl Backoff {
-    /// Builds a backoff with the given `base` (the first window's ceiling) and
-    /// `cap` (the maximum window the exponential is clamped to). The dossier
-    /// §10.6 cadence is `base = 1s`, `cap = 60s`; see [`Backoff::standard`].
+    /// Builds a PURE exponential backoff with the given `base` (the first
+    /// window's ceiling) and `cap` (the maximum window the exponential is clamped
+    /// to) — no fast phase. For the control-plane cadence with the fast-recovery
+    /// phase, use [`Backoff::standard`] / [`Backoff::with_fast_phase`].
     #[must_use]
     pub fn new(base: Duration, cap: Duration) -> Self {
         Self {
             base,
             cap,
+            fast_ceiling: Duration::ZERO,
+            fast_attempts: 0,
             attempt: 0,
         }
     }
 
-    /// The dossier-standard reconnect backoff: base 1s, cap 60s (§10.6).
+    /// Builds a two-phase backoff: the first `fast_attempts` delays draw within
+    /// `fast_ceiling` (fast recovery of a short blip), then the exponential
+    /// `base` → `cap` takes over (storm protection for a prolonged outage).
+    #[must_use]
+    pub fn with_fast_phase(base: Duration, cap: Duration, fast_ceiling: Duration, fast_attempts: u32) -> Self {
+        Self {
+            fast_ceiling,
+            fast_attempts,
+            ..Self::new(base, cap)
+        }
+    }
+
+    /// The standard control-plane reconnect backoff. FAST PHASE: 20 attempts
+    /// drawn in `[0, 3s]` (≈30s of ~1.5s-median retries) so a rolling-deploy blip
+    /// is recovered within a few seconds. COOL PHASE: exponential `1s → 10s` cap
+    /// — a tighter cap than the historical 60s so a prolonged-outage reconnect
+    /// wait is bounded to ≤10s while full jitter still de-correlates the fleet.
     #[must_use]
     pub fn standard() -> Self {
-        Self::new(Duration::from_secs(1), Duration::from_secs(60))
+        Self::with_fast_phase(
+            Duration::from_secs(1),
+            Duration::from_secs(10),
+            Duration::from_secs(3),
+            20,
+        )
     }
 
     /// The exponential ceiling for the *current* attempt: `min(cap, base*2^n)`,
@@ -52,14 +104,21 @@ impl Backoff {
     /// pin exactly.
     #[must_use]
     pub fn ceiling(&self) -> Duration {
-        // base * 2^attempt, computed in nanoseconds (already u128) with saturating
-        // shifts so we never panic on overflow; clamp to `cap`.
+        // Fast phase: the first `fast_attempts` attempts draw within the fixed
+        // small `fast_ceiling` so a brief control-plane blip recovers quickly.
+        if self.attempt < self.fast_attempts {
+            return self.fast_ceiling;
+        }
+        // Cool phase: base * 2^n (n counted from the END of the fast phase),
+        // computed in nanoseconds (already u128) with saturating shifts so we
+        // never panic on overflow; clamp to `cap`.
+        let n = self.attempt - self.fast_attempts;
         let base_nanos = self.base.as_nanos();
         // Saturate the shift: anything past 127 bits is already way beyond `cap`.
-        let scaled = if self.attempt >= 127 {
+        let scaled = if n >= 127 {
             u128::MAX
         } else {
-            base_nanos.saturating_mul(1u128 << self.attempt)
+            base_nanos.saturating_mul(1u128 << n)
         };
         let cap_nanos = self.cap.as_nanos();
         let bounded = scaled.min(cap_nanos);
@@ -131,7 +190,7 @@ mod tests {
         let cap = Duration::from_secs(10);
         let mut rng = StdRng::seed_from_u64(0xC0FF_EE99);
         for attempt in 0..40u32 {
-            let b = Backoff { base, cap, attempt };
+            let b = Backoff { base, cap, fast_ceiling: Duration::ZERO, fast_attempts: 0, attempt };
             let ceiling = b.ceiling();
             // Draw repeatedly at this fixed attempt.
             for _ in 0..200 {
@@ -146,6 +205,8 @@ mod tests {
         let b = Backoff {
             base: Duration::from_secs(1),
             cap: Duration::from_secs(60),
+            fast_ceiling: Duration::ZERO,
+            fast_attempts: 0,
             attempt: u32::MAX,
         };
         // Must not panic and must clamp to the cap.
@@ -153,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn reset_returns_to_base_window() {
+    fn reset_returns_to_fast_window() {
         let mut b = Backoff::standard();
         for _ in 0..5 {
             let _ = b.next_delay();
@@ -161,7 +222,28 @@ mod tests {
         assert!(b.attempt() > 0);
         b.reset();
         assert_eq!(b.attempt(), 0);
-        assert_eq!(b.ceiling(), Duration::from_secs(1));
+        // After a reset the next disconnect starts in the FAST phase again (the
+        // standard backoff's first-window ceiling is `fast_ceiling` = 3s).
+        assert_eq!(b.ceiling(), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn standard_fast_phase_then_exponential_to_ten_second_cap() {
+        // The reconnect-latency fix: the standard backoff spends its first 20
+        // attempts in a 3s fast window (so a rolling-deploy blip is retried
+        // ~every ≤3s and recovers in seconds), THEN backs off exponentially to a
+        // 10s cap (down from 60s) — bounding a prolonged-outage reconnect wait.
+        let mut b = Backoff::standard();
+        for _ in 0..20 {
+            assert_eq!(b.ceiling(), Duration::from_secs(3));
+            let _ = b.next_delay();
+        }
+        // Cool phase: 1s, 2s, 4s, 8s, then clamped at the 10s cap (NOT 60s).
+        let expected = [1u64, 2, 4, 8, 10, 10, 10];
+        for want_secs in expected {
+            assert_eq!(b.ceiling(), Duration::from_secs(want_secs));
+            let _ = b.next_delay();
+        }
     }
 
     #[test]

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -12,9 +12,13 @@
 //!    [`Platform`] and replying on the message's reply inbox.
 //! 3. **Heartbeats** every 5s on the events subject with a metrics sample so the
 //!    control plane can dead-detect a vanished agent (§10.6 cadence).
-//! 4. On **any disconnect**, sleeps a full-jitter [`Backoff`] delay (base 1s, cap
-//!    60s) before reconnecting — NEVER a tight loop (the #1 outage cause). A
-//!    reconnect re-subscribes the RPC subject (a fresh subscription).
+//! 4. On **any disconnect**, sleeps a full-jitter [`Backoff::standard`] delay (a
+//!    ~30s FAST phase of ≤3s retries so a rolling-deploy blip recovers in
+//!    seconds, then exponential up to a 10s cap for a prolonged outage) before
+//!    reconnecting — NEVER a tight loop (the #1 outage cause). A reconnect
+//!    re-subscribes the RPC subject (a fresh subscription), which — together with
+//!    the ~5s heartbeat on this same connection — is what restores the machine's
+//!    `last_seen`/ping liveness the attach gate reads.
 //! 5. On a **clean stop** (SIGINT/SIGTERM) sends a [`GoingOffline`] event and
 //!    closes cleanly so the lease flips offline IMMEDIATELY (§23.0), rather than
 //!    waiting on heartbeat dead-detection.


### PR DESCRIPTION
After every staging deploy that cycles the api/relay pods, enrolled machines were un-attachable ("sandbox is offline; cannot attach to a non-online machine") for many minutes — measured **~24 minutes** for the 11:00Z deploy today (first post-restart auth-callout grant at 11:24:21Z).

**Diagnosis (evidence over hypothesis)**: the control-plane RPC responder subscription AND the ~5s liveness heartbeat ride ONE async-nats connection in the agent; `enrollments.last_seen_at` is written only by the NATS heartbeat consumer. On a connection drop everything goes dark together, and the api-side probe correctly reports offline — the entire outage duration is the agent's reconnect backoff: a pure 1s→60s full-jitter exponential with no fast-retry window, so a ~2-minute deploy pushes it to the 60s cap and recovery lags by cap-sized windows. NATS itself was stable (2d17h, 0 restarts) — api-side and probe-semantics hypotheses ruled out; no server change needed or made.

**Fix**: `Backoff::standard()` becomes two-phase — a fast phase (first 20 attempts drawn in [0,3s], ≈30s of ~1.5s-median retries) that catches a returning control plane within seconds, then the exponential up to a 10s cap (down from 60s) so a genuinely prolonged outage still de-correlates the fleet (full-jitter storm protection retained). `Backoff::new` stays pure-exponential; reset-on-successful-connect contract unchanged.

Gates: cargo check clean, clippy clean, 80/80 tests pass (incl. new fast-phase→exponential-cap test).

Live verification plan: after this ships in the baked agent + the machine updates, the next staging deploy is the natural repro — auth-callout re-grant should follow the relay's return by seconds (was ~24 min).

Noted for follow-up (not changed here): `.max_reconnects(Some(1))` on the async-nats client is a minor amplifier if the fast phase alone doesn't fully close the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent resiliency timing for all control-plane disconnects; wrong parameters could cause reconnect storms or still-long outages, but behavior is unit-tested and storm protection (full jitter, capped delays) is preserved.
> 
> **Overview**
> **Replaces the control-plane reconnect delay schedule** so brief NATS drops (e.g. rolling api/relay deploys) recover in seconds instead of climbing toward long multi-minute gaps.
> 
> `Backoff::standard()` is now **two-phase**: the first 20 attempts jitter within a **3s** ceiling (~30s of quick retries), then full-jitter exponential **1s → 10s** (cap lowered from **60s**). `Backoff::new` remains a pure exponential with no fast phase; **`Backoff::with_fast_phase`** configures the new behavior. **`ceiling()`** uses the fast window until `fast_attempts` are exhausted, then exponential from attempt zero of the cool phase. **Reset-on-success** still restarts at the fast phase (3s ceiling).
> 
> Supervisor module docs are updated to describe the new `Backoff::standard()` cadence and tie reconnect to restoring RPC + heartbeat liveness for attach gates. Tests cover fast-then-10s-cap sequencing and reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e7693381a9d2aa9bfa97982d2e4890c9ddb048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->