### PR TITLE
fix(install): Developer-ID-preferring, xattr-safe bundle signing + graceful no-args launch

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -161,6 +161,14 @@ jobs:
         working-directory: agent
         run: bash install/test/ci-install-smoke.sh
 
+      - name: Simulate the macOS app-bundle assembly (mocked codesign/security)
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: agent
+        # Runs on Linux + macOS runners alike: sources install.sh as a library and
+        # drives the darwin bundle-signing/atomic-swap helpers with mocked tools.
+        run: sh install/test/macos-bundle-sim.sh
+
       - name: Smoke the install script (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -44,7 +44,7 @@ mod update;
 
 use std::sync::Arc;
 
-use clap::Parser as _;
+use clap::{CommandFactory as _, Parser as _};
 use opengeni_agent_platform::{NativePlatform, Platform};
 use opengeni_agent_stream::{RelayHub, RelayHubConfig};
 use tracing::{error, info, warn};
@@ -103,7 +103,20 @@ async fn dispatch_command(cli: Cli) -> anyhow_lite::Result {
         .api_url
         .clone()
         .unwrap_or_else(|| DEFAULT_API_URL.to_string());
-    match cli.command.unwrap_or_default() {
+    let Some(command) = cli.command else {
+        // No subcommand. This is reached BOTH by a bare `opengeni-agent` in a
+        // terminal AND by a Finder/Raycast/`open` launch of the .app bundle, which
+        // execs the binary with no args and no controlling TTY. A blind
+        // enroll-if-needed-then-serve (the old `Command::default()` = `run`) turns
+        // that GUI launch into a headless process with no visible UI — which
+        // LaunchServices reports as "the application does not respond" and which,
+        // when not yet enrolled, drops into an invisible device-flow that can never
+        // show its user code. So branch on enrollment: a double-click of an ENROLLED
+        // machine starts the agent (the nicest outcome), and an un-enrolled one
+        // prints usage and exits promptly — never a zombie.
+        return run_default(&api_url).await;
+    };
+    match command {
         Command::Run(args) => run(args, &api_url).await,
         Command::Enroll(args) => enroll_command(args, &api_url).await.map(|_| ()),
         Command::Service(args) => service::run(&args).map_err(string_err),
@@ -116,6 +129,30 @@ async fn dispatch_command(cli: Cli) -> anyhow_lite::Result {
                 .map_err(string_err)
         }
         Command::Uninstall(args) => uninstall::run(&args).map_err(string_err),
+    }
+}
+
+/// Handles a bare `opengeni-agent` invocation (no subcommand) so a GUI launch of
+/// the .app bundle NEVER hangs as a headless zombie (dossier §23.0; the
+/// REPLACE_APP incident). Finder/Raycast/`open` exec the binary with no args and
+/// no TTY:
+///   * already enrolled → behave exactly like `run` (a double-click starts the
+///     agent — the nicest outcome; it serves deliberately until stopped);
+///   * not enrolled (or credentials unreadable) → print usage to stderr and exit 0
+///     promptly, rather than dropping into an invisible device-flow enroll that
+///     needs a workspace id + a visible TTY and would otherwise appear to hang.
+async fn run_default(api_url: &str) -> anyhow_lite::Result {
+    if let Ok(Some(_)) = config::load_credentials() {
+        run(RunArgs::default(), api_url).await
+    } else {
+        // Not enrolled (or creds unreadable): show how to get started and exit
+        // cleanly. Help goes to stderr so a `opengeni-agent | …` pipe is unchanged.
+        eprintln!("{}", Cli::command().render_help());
+        eprintln!(
+            "This machine is not enrolled yet. Run `opengeni-agent enroll` (see the \
+             Machines page for the one-liner), then `opengeni-agent run`."
+        );
+        Ok(())
     }
 }
 

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -370,8 +370,115 @@ link_macos_cli() {
   printf '%s' "$_install_dir/opengeni-agent"
 }
 
-# Assemble an ad-hoc-signed app bundle around the verified binary and symlink the
-# CLI into it. Echoes the CLI path on stdout (logs go to stderr via log()).
+# Probe the login keychain for a "Developer ID Application" code-signing identity
+# and remember the chosen one in two globals: OPENGENI_SIGN_IDENTITY_HASH (the
+# 40-hex SHA-1 to pass to `codesign --sign`, empty if none) and
+# OPENGENI_SIGN_IDENTITY_NAME (the human label, for the log line). Called directly
+# (NOT via `$(...)`) so the globals survive — a command substitution runs in a
+# subshell and would drop them. When several identities are present it
+# deterministically picks the FIRST that `security` lists and logs that choice.
+# WHY: macOS keys TCC (Screen Recording / Accessibility) grants to the signing
+# identity, so re-signing every update with the SAME Developer ID keeps the grants;
+# an ad-hoc signature loses them on any update.
+OPENGENI_SIGN_IDENTITY_HASH=""
+OPENGENI_SIGN_IDENTITY_NAME=""
+macos_developer_id_identity() {
+  OPENGENI_SIGN_IDENTITY_HASH=""
+  OPENGENI_SIGN_IDENTITY_NAME=""
+  command -v security >/dev/null 2>&1 || return 0
+  # `security find-identity -v -p codesigning` lines look like:
+  #   1) <40-hex-sha1> "Developer ID Application: Name (TEAMID)"
+  _ids="$(security find-identity -v -p codesigning 2>/dev/null | grep 'Developer ID Application')" \
+    || _ids=""
+  [ -n "$_ids" ] || return 0
+  _n="$(printf '%s\n' "$_ids" | grep -c 'Developer ID Application')"
+  _line="$(printf '%s\n' "$_ids" | head -n1)"
+  _hash="$(printf '%s\n' "$_line" | awk '{print $2}')"
+  [ -n "$_hash" ] || return 0
+  OPENGENI_SIGN_IDENTITY_HASH="$_hash"
+  OPENGENI_SIGN_IDENTITY_NAME="$(printf '%s\n' "$_line" | sed -n 's/.*"\(.*\)".*/\1/p')"
+  if [ "$_n" -gt 1 ]; then
+    log "found $_n Developer ID Application identities; deterministically using the first: $OPENGENI_SIGN_IDENTITY_NAME ($_hash)"
+  fi
+}
+
+# Code-sign a STAGED bundle (it lives in a temp dir, NOT ~/Applications yet): strip
+# quarantine/provenance xattrs, sign with the user's Developer ID when present else
+# ad-hoc, then hard-verify. WHY temp-dir + `xattr -cr`: signing in place on a live
+# bundle repeatedly failed `codesign --verify --deep --strict` with "invalid
+# resource directory" (a sealed leftover *.cstemp / macOS provenance xattrs); a
+# clean staged copy scrubbed of xattrs is what actually verifies. A `--verify
+# --strict` failure here is FATAL (the caller never swaps a broken bundle in).
+# NOTE: POSIX sh has no locals — every var here is global. Use `_bundle` (not the
+# caller's `_app`) so this never clobbers the install path the caller swaps in.
+macos_sign_bundle() {
+  _bundle="$1"
+
+  # Strip quarantine/provenance xattrs the download or copy may have set — the
+  # suspected cause of the in-place "invalid resource directory" verify failures.
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -cr "$_bundle" 2>/dev/null || true
+  fi
+
+  if ! command -v codesign >/dev/null 2>&1; then
+    log "warning: codesign not found (unexpected on macOS); skipping signing + verification"
+    return 0
+  fi
+
+  macos_developer_id_identity
+  if [ -n "$OPENGENI_SIGN_IDENTITY_HASH" ]; then
+    # Signing with the user's identity may pop a one-time Keychain consent prompt —
+    # that is expected and desirable (it is what makes the TCC grants durable).
+    if codesign --force --sign "$OPENGENI_SIGN_IDENTITY_HASH" \
+        --identifier "$OPENGENI_APP_BUNDLE_ID" "$_bundle" >/dev/null 2>&1; then
+      log "signed with Developer ID \"$OPENGENI_SIGN_IDENTITY_NAME\" (approve the Keychain prompt if it appears); grants will survive updates that re-sign with this identity"
+    else
+      log "warning: Developer ID signing failed; falling back to ad-hoc (grants will NOT survive updates)"
+      codesign --force --sign - --identifier "$OPENGENI_APP_BUNDLE_ID" "$_bundle" >/dev/null 2>&1 \
+        || log "warning: ad-hoc codesign failed; the app runs but macOS may re-prompt for permissions"
+    fi
+  else
+    codesign --force --sign - --identifier "$OPENGENI_APP_BUNDLE_ID" "$_bundle" >/dev/null 2>&1 \
+      || log "warning: ad-hoc codesign failed; the app runs but macOS may re-prompt for permissions"
+    log "ad-hoc signed (no Developer ID identity found); grants will not survive updates"
+  fi
+
+  # Hard-verify the freshly-signed STAGED bundle before it is swapped into place.
+  codesign --verify --strict "$_bundle" >/dev/null 2>&1 \
+    || die 2 "codesign --verify --strict FAILED for the freshly-signed bundle; not installing"
+}
+
+# Atomically replace the installed bundle at $2 with the staged+verified bundle at
+# $1: move any existing bundle aside to a dot-prefixed .bak, move the new one into
+# place, drop the .bak on success. On ANY failure restore the .bak and die loudly —
+# the user is NEVER left without a working bundle.
+macos_swap_bundle_into_place() {
+  _new="$1"; _dst="$2"
+  _bak=""
+  if [ -e "$_dst" ] || [ -L "$_dst" ]; then
+    _bak="$(dirname "$_dst")/.$(basename "$_dst").bak.$$"
+    rm -rf "$_bak" 2>/dev/null || true
+    mv "$_dst" "$_bak" || die 2 "cannot move the existing bundle aside ($_dst)"
+  fi
+  if mv "$_new" "$_dst" 2>/dev/null; then
+    if [ -n "$_bak" ]; then rm -rf "$_bak" 2>/dev/null || true; fi
+    return 0
+  fi
+  # The install failed: put the old bundle back so the user keeps a working app.
+  if [ -n "$_bak" ]; then
+    if mv "$_bak" "$_dst" 2>/dev/null; then
+      die 2 "failed to install the new bundle to $_dst; restored the previous bundle"
+    fi
+    die 2 "failed to install the new bundle to $_dst AND could not restore the backup at $_bak"
+  fi
+  die 2 "failed to install the new bundle to $_dst"
+}
+
+# Assemble an app bundle around the verified binary and symlink the CLI into it.
+# Assembled in a temp dir, signed (Developer ID when available, else ad-hoc) +
+# verified there, then atomically swapped into ~/Applications — NEVER signed in
+# place (see macos_sign_bundle for why). Echoes the CLI path on stdout (logs go to
+# stderr via log()).
 install_macos_local_bundle() {
   _bin="$1"; _install_dir="$2"
   _app="$HOME/Applications/$OPENGENI_APP_NAME.app"
@@ -386,23 +493,21 @@ install_macos_local_bundle() {
     log "OPENGENI_INSTALL_REPLACE_APP=1 — replacing the existing signed app bundle"
   fi
 
-  # Assemble fresh. Reached only for an absent bundle, an ad-hoc bundle (safe to
-  # replace), or an explicit forced replace.
-  rm -rf "$_app"
-  mkdir -p "$_app/Contents/MacOS" || die 2 "cannot create $_app"
-  cp "$_bin" "$_app/Contents/MacOS/opengeni-agent" || die 2 "cannot populate $_app"
-  chmod 0755 "$_app/Contents/MacOS/opengeni-agent"
-  write_info_plist "$_app/Contents/Info.plist" "$(resolve_app_version "$_app/Contents/MacOS/opengeni-agent")"
+  # Assemble FRESH in a temp dir. Reached only for an absent bundle, an ad-hoc
+  # bundle (safe to replace), or an explicit forced replace.
+  _stage="$TMPDIR_OG/local-bundle-stage"
+  rm -rf "$_stage"
+  _staged_app="$_stage/$OPENGENI_APP_NAME.app"
+  mkdir -p "$_staged_app/Contents/MacOS" || die 2 "cannot create the staging bundle"
+  cp "$_bin" "$_staged_app/Contents/MacOS/opengeni-agent" || die 2 "cannot populate the staging bundle"
+  chmod 0755 "$_staged_app/Contents/MacOS/opengeni-agent"
+  write_info_plist "$_staged_app/Contents/Info.plist" \
+    "$(resolve_app_version "$_staged_app/Contents/MacOS/opengeni-agent")"
 
-  # Ad-hoc sign the WHOLE bundle with the stable identifier (codesign ships with
-  # macOS). `--force` re-signs cleanly; a failure is non-fatal (the agent still
-  # runs) but is called out because it means macOS may re-prompt for permissions.
-  if command -v codesign >/dev/null 2>&1; then
-    codesign --force --sign - --identifier "$OPENGENI_APP_BUNDLE_ID" "$_app" >/dev/null 2>&1 \
-      || log "warning: ad-hoc codesign failed; the app runs but macOS may re-prompt for permissions"
-  else
-    log "warning: codesign not found (unexpected on macOS); skipping ad-hoc signing"
-  fi
+  macos_sign_bundle "$_staged_app"
+
+  mkdir -p "$HOME/Applications" || die 2 "cannot create $HOME/Applications"
+  macos_swap_bundle_into_place "$_staged_app" "$_app"
   log "installed app bundle at $_app"
   link_macos_cli "$_app" "$_install_dir"
 }
@@ -453,14 +558,30 @@ install_macos_prebuilt_bundle() {
   if macos_bundle_is_signed_nonadhoc "$_app" && [ "${OPENGENI_INSTALL_REPLACE_APP:-0}" != "1" ]; then
     log "kept the existing signed \"$OPENGENI_APP_NAME.app\" (its signature holds your macOS grants). Set OPENGENI_INSTALL_REPLACE_APP=1 to replace it."
   else
-    mkdir -p "$_apps" || die 2 "cannot create $_apps"
-    rm -rf "$_app"
+    # Extract into a temp staging dir, scrub the download's quarantine xattrs, verify
+    # the (already Developer-ID + notarized) signature there, then atomically swap it
+    # into ~/Applications. We do NOT re-sign a prebuilt bundle — that would break its
+    # notarization; xattr-scrub + verify + atomic swap is all this path needs.
+    _stage="$TMPDIR_OG/prebuilt-bundle-stage"
+    rm -rf "$_stage"
+    mkdir -p "$_stage" || die 2 "cannot create the staging dir"
     # ditto/unzip both ship with macOS; the archive's root entry is the .app dir.
     if command -v ditto >/dev/null 2>&1; then
-      ditto -x -k "$_zip" "$_apps" || die 3 "failed to extract the app bundle"
+      ditto -x -k "$_zip" "$_stage" || die 3 "failed to extract the app bundle"
     else
-      unzip -oq "$_zip" -d "$_apps" || die 3 "failed to extract the app bundle"
+      unzip -oq "$_zip" -d "$_stage" || die 3 "failed to extract the app bundle"
     fi
+    _staged_app="$_stage/$OPENGENI_APP_NAME.app"
+    [ -d "$_staged_app" ] || die 3 "the archive did not contain \"$OPENGENI_APP_NAME.app\""
+    if command -v xattr >/dev/null 2>&1; then
+      xattr -cr "$_staged_app" 2>/dev/null || true
+    fi
+    if command -v codesign >/dev/null 2>&1; then
+      codesign --verify --strict "$_staged_app" >/dev/null 2>&1 \
+        || die 2 "codesign --verify --strict FAILED for the prebuilt bundle; not installing"
+    fi
+    mkdir -p "$_apps" || die 2 "cannot create $_apps"
+    macos_swap_bundle_into_place "$_staged_app" "$_app"
     log "installed notarized app bundle at $_app"
   fi
   link_macos_cli "$_app" "$_install_dir"
@@ -598,4 +719,10 @@ finish() {
   fi
 }
 
-main "$@"
+# Run the installer — UNLESS sourced with OPENGENI_INSTALL_LIB=1, which lets the
+# darwin bundle-assembly simulation (agent/install/test/macos-bundle-sim.sh) load
+# these helper functions and exercise them with mocked codesign/security/xattr,
+# without the network download + real install. A normal `curl … | sh` never sets it.
+if [ "${OPENGENI_INSTALL_LIB:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/agent/install/test/macos-bundle-sim.sh
+++ b/agent/install/test/macos-bundle-sim.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# macOS app-bundle assembly SIMULATION (dossier §23; the REPLACE_APP incident).
+#
+# install.sh's darwin bundle path signs + verifies + atomically installs an app
+# bundle around the verified binary. This test SOURCES install.sh as a library
+# (OPENGENI_INSTALL_LIB=1, which skips `main`) and drives the bundle helpers with
+# MOCKED codesign / security / xattr on PATH, so the darwin-only logic is exercised
+# on any host (Linux CI included) with no real signing or network.
+#
+# It proves:
+#   1. a "Developer ID Application" identity present  -> signed with it
+#      (`codesign --sign <hash>`, log "signed with Developer ID …");
+#   2. no Developer ID identity                       -> ad-hoc signed
+#      (`codesign --sign -`, log "ad-hoc signed (no Developer ID identity found)");
+#   3. several Developer ID identities                -> the FIRST is chosen
+#      (deterministic) and logged;
+#   4. an atomic-swap FAILURE                         -> the previous bundle is
+#      restored from its .bak and the installer dies loudly (rc 2).
+#
+# Usage:  sh agent/install/test/macos-bundle-sim.sh
+set -eu
+
+WORK="$(mktemp -d)"
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+
+# --- Mock external macOS tools on PATH --------------------------------------
+# security: emit the identity list from $MOCK_SECURITY_FILE (empty list if unset).
+cat > "$BIN/security" <<'SH'
+#!/bin/sh
+# Only `find-identity -v -p codesigning` is used by install.sh.
+if [ -n "${MOCK_SECURITY_FILE:-}" ] && [ -f "$MOCK_SECURITY_FILE" ]; then
+  cat "$MOCK_SECURITY_FILE"
+else
+  echo "     0 valid identities found"
+fi
+SH
+
+# codesign: record each invocation to $MOCK_CODESIGN_LOG; honor the -dv / --verify /
+# sign forms. `codesign -dv <app>` (bundle-signed probe) returns 1 (not signed).
+cat > "$BIN/codesign" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "${MOCK_CODESIGN_LOG:-/dev/null}"
+case " $* " in
+  *" -dv "*|*" -d "*) echo "no signature" >&2; exit 1 ;;
+  *" --verify "*) [ "${MOCK_CODESIGN_VERIFY_FAIL:-0}" = "1" ] && exit 1; exit 0 ;;
+  *) [ "${MOCK_CODESIGN_SIGN_FAIL:-0}" = "1" ] && exit 1; exit 0 ;;
+esac
+SH
+
+# xattr: record + succeed (the real one strips extended attributes).
+cat > "$BIN/xattr" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "${MOCK_XATTR_LOG:-/dev/null}"
+exit 0
+SH
+
+chmod 0755 "$BIN/security" "$BIN/codesign" "$BIN/xattr"
+PATH="$BIN:$PATH"; export PATH
+
+# --- Load install.sh as a library (skips main) ------------------------------
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# Pin a version so resolve_app_version never execs the (fake) binary.
+OPENGENI_AGENT_VERSION="9.9.9"; export OPENGENI_AGENT_VERSION
+# shellcheck source=/dev/null  # dynamic path; install.sh is loaded as a library here
+OPENGENI_INSTALL_LIB=1 . "$REPO_ROOT/agent/install/install.sh"
+set +e   # sourcing turned on `set -e`; drive assertions manually + trap `die` in subshells.
+
+# Our own cleanup (replaces install.sh's EXIT trap, which targets its own TMPDIR_OG).
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# Give the sourced helpers a scratch dir to stage bundles in.
+TMPDIR_OG="$WORK/og-tmp"; mkdir -p "$TMPDIR_OG"
+
+PASS=0; FAIL=0
+ok()  { echo "  PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# A throwaway "verified binary".
+FAKE_BIN="$WORK/opengeni-agent-universal-apple-darwin"
+printf 'fake mach-o\n' > "$FAKE_BIN"
+
+# Run install_macos_local_bundle in an isolated HOME, capturing its logs.
+# $1=label (unique HOME + log), rest handled by env the caller already set.
+run_local_install() {
+  _home="$WORK/home-$1"; rm -rf "$_home"; mkdir -p "$_home"
+  MOCK_CODESIGN_LOG="$WORK/codesign-$1.log"; : > "$MOCK_CODESIGN_LOG"
+  export MOCK_CODESIGN_LOG
+  HOME="$_home" install_macos_local_bundle "$FAKE_BIN" "$_home/bin" \
+    >"$WORK/out-$1" 2>"$WORK/log-$1"
+}
+
+echo "SIM 1: a Developer ID Application identity is present -> signed with it"
+DEVID_HASH="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+printf '  1) %s "Developer ID Application: Jorgen (TEAM123)"\n     1 valid identities found\n' \
+  "$DEVID_HASH" > "$WORK/sec-one"
+MOCK_SECURITY_FILE="$WORK/sec-one" run_local_install one
+if grep -q -- "--sign $DEVID_HASH" "$WORK/codesign-one.log"; then
+  ok "codesign invoked with the Developer ID hash"
+else
+  bad "codesign was NOT invoked with the Developer ID hash"; cat "$WORK/codesign-one.log"
+fi
+if grep -q 'signed with Developer ID "Developer ID Application: Jorgen (TEAM123)"' "$WORK/log-one"; then
+  ok "logged the Developer ID signing line"
+else
+  bad "missing the Developer ID signing log line"; cat "$WORK/log-one"
+fi
+if [ -d "$WORK/home-one/Applications/OpenGeni Agent.app" ]; then
+  ok "bundle installed under \$HOME/Applications"
+else
+  bad "bundle not installed"; ls -la "$WORK/home-one/Applications" 2>&1
+fi
+
+echo "SIM 2: NO Developer ID identity -> ad-hoc signed"
+MOCK_SECURITY_FILE="" run_local_install adhoc
+if grep -q -- "--sign - " "$WORK/codesign-adhoc.log" || grep -q -- "--sign -$" "$WORK/codesign-adhoc.log"; then
+  ok "codesign invoked ad-hoc (--sign -)"
+else
+  bad "codesign was NOT invoked ad-hoc"; cat "$WORK/codesign-adhoc.log"
+fi
+if grep -q 'ad-hoc signed (no Developer ID identity found)' "$WORK/log-adhoc"; then
+  ok "logged the ad-hoc fallback line"
+else
+  bad "missing the ad-hoc fallback log line"; cat "$WORK/log-adhoc"
+fi
+
+echo "SIM 3: several Developer ID identities -> the FIRST is chosen deterministically"
+FIRST_HASH="1111111111111111111111111111111111111111"
+SECOND_HASH="2222222222222222222222222222222222222222"
+{
+  printf '  1) %s "Developer ID Application: First (TEAMAAA)"\n' "$FIRST_HASH"
+  printf '  2) %s "Developer ID Application: Second (TEAMBBB)"\n' "$SECOND_HASH"
+  printf '     2 valid identities found\n'
+} > "$WORK/sec-many"
+MOCK_SECURITY_FILE="$WORK/sec-many" run_local_install many
+if grep -q -- "--sign $FIRST_HASH" "$WORK/codesign-many.log" \
+   && ! grep -q -- "--sign $SECOND_HASH" "$WORK/codesign-many.log"; then
+  ok "signed with the FIRST identity, not the second"
+else
+  bad "did not deterministically pick the first identity"; cat "$WORK/codesign-many.log"
+fi
+if grep -q 'found 2 Developer ID Application identities; deterministically using the first' "$WORK/log-many"; then
+  ok "logged the multi-identity disambiguation"
+else
+  bad "missing the multi-identity log line"; cat "$WORK/log-many"
+fi
+
+echo "SIM 4: an atomic-swap failure restores the previous bundle (.bak) and dies (rc 2)"
+DST="$WORK/apps/OpenGeni Agent.app"
+mkdir -p "$DST/Contents/MacOS"
+printf 'ORIGINAL\n' > "$DST/Contents/marker"
+# Force the "move the new bundle into place" mv to fail by handing it a source that
+# does not exist; the move-aside + restore paths use the real mv.
+( macos_swap_bundle_into_place "$WORK/does-not-exist.app" "$DST" ) >"$WORK/swap-out" 2>&1
+rc=$?
+if [ "$rc" -eq 2 ]; then ok "swap failure exited with rc 2 (die)"; else bad "swap failure rc=$rc (expected 2)"; cat "$WORK/swap-out"; fi
+if [ -f "$DST/Contents/marker" ] && grep -q ORIGINAL "$DST/Contents/marker"; then
+  ok "previous bundle restored from .bak"
+else
+  bad "previous bundle was NOT restored"; ls -la "$WORK/apps" 2>&1
+fi
+# No .bak litter should remain in the apps dir.
+if ls "$WORK/apps"/.*.bak.* >/dev/null 2>&1; then
+  bad "a .bak backup was left behind after restore"; ls -la "$WORK/apps"
+else
+  ok "no .bak backup left behind"
+fi
+
+echo ""
+echo "SIM RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Three fixes from today's live REPLACE_APP incident (a user's Developer-ID bundle was replaced by an ad-hoc one, orphaning his TCC grants while his signing identity sat in the keychain; recovery surfaced an in-place-codesign failure mode; and a Raycast launch left a 16-minute headless zombie).

1. **Prefer the user's Developer ID over ad-hoc**: the darwin bundle paths probe `security find-identity` for a "Developer ID Application" identity and sign with it when present (stable `ai.opengeni.agent` identifier; deterministic first-match if several; logged either way, including the expected Keychain prompt). Replace-path updates become grant-preserving whenever the same identity re-signs. No identity → ad-hoc exactly as before, with an honest "grants will not survive updates" line.
2. **Never sign in place**: assemble/extract in a temp stage, `xattr -cr`, `codesign --verify --strict` there (fatal on failure), then atomically swap (old → dot-`.bak`, restore on any failure). In-place `codesign --force` reproducibly fails strict verification on macOS provenance xattrs (verified live). Prebuilt bundles are verify-only (re-signing would break notarization).
3. **Graceful no-args launch**: bare `opengeni-agent` (what Finder/Raycast/`open` exec) previously defaulted into enroll-if-needed + headless serve — "application does not respond" + invisible device-flow when un-enrolled. Now: enrolled → behaves as `run` (double-click starts the agent); un-enrolled → usage + "run `opengeni-agent enroll`" to stderr, exit 0 promptly. Never a zombie.

Also: install.sh gains a sourcing guard for unit-testing its darwin helpers; new `macos-bundle-sim.sh` (10 cases: identity present/absent/several, swap-failure restore, preservation) wired into agent CI on Linux+macOS. `curl|sh` behavior byte-identical (Linux smoke).

Gates: shellcheck clean, bash -n all, sim 10/10, cargo check/clippy/test (79/79) green.

Follow-up filed separately: single-instance guard for `run` (two concurrent enrolled agents are possible today, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS install/signing behavior and default no-subcommand agent entry (GUI launches); mistakes could break installs or confuse unenrolled users, but swap rollback and strict verify reduce install bricking risk.
> 
> **Overview**
> Addresses macOS install/replace and GUI launch issues from the REPLACE_APP incident: **TCC grants**, **in-place codesign failures**, and **headless zombies** on Finder/Raycast launches.
> 
> **`install.sh` (Darwin):** Bundle assembly no longer signs in `~/Applications`. It stages in a temp dir, runs `xattr -cr`, signs with the first **Developer ID Application** from the keychain when available (else ad-hoc), requires `codesign --verify --strict` before install, then **atomically swaps** (backup + restore on failure). Prebuilt notarized zips are verify-only (no re-sign). `OPENGENI_INSTALL_LIB=1` allows sourcing without running `main`.
> 
> **`opengeni-agent`:** A bare invocation (no subcommand) no longer always maps to implicit `run`. **Enrolled** machines still run like `opengeni-agent run`; **unenrolled** machines print help plus enroll guidance on stderr and exit 0 instead of hanging in device-flow serve.
> 
> **CI:** `macos-bundle-sim.sh` exercises signing identity selection, ad-hoc fallback, and swap rollback with mocked `codesign`/`security` on Linux and macOS install-smoke legs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4a4f87ea07a8ba2146bd477b9bfb4a1f8c9666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->