### PR TITLE
refactor(computer-use): explicit tool-transport mode over the ChatCompletions constructor-name sniff

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -51,8 +51,9 @@ import {
   summarizeForCompaction,
   type SandboxFileDownload,
   type OpenGeniRuntime,
+  type ComputerToolMode,
 } from "@opengeni/runtime";
-import { calculateModelUsageCostMicros, configuredModelPricing, configuredStaticUsageLimits, sandboxWarmRateMicrosPerSecond, type ModelUsageInput, type Settings } from "@opengeni/config";
+import { calculateModelUsageCostMicros, configuredModelPricing, configuredStaticUsageLimits, sandboxWarmRateMicrosPerSecond, type ModelUsageInput, type ModelProviderApi, type RegistryProviderKind, type Settings } from "@opengeni/config";
 import { CancelledFailure } from "@temporalio/activity";
 import { settingsWithCodexCredential, settingsWithEnabledCapabilityMcpServers } from "./capabilities";
 import { chooseRotationActive, computeIdleDelayMs, computeReactiveRotationResume, type CodexRotationStrategy, type RotationDecision } from "./codex-rotation";
@@ -362,6 +363,43 @@ export function shouldStartOnTurnRecording(params: {
     && desktopCapableBackend(params.establishedBackendId)
     && params.effectiveBackend !== "selfhosted"
   );
+}
+
+/**
+ * Decide the EXPLICIT computer-use tool transport for THIS turn.
+ *
+ * The runtime's SDK-mirrored capability would otherwise pick hosted-vs-function
+ * tools by string-sniffing the bound model instance's constructor name for
+ * "ChatCompletions" (supportsStructuredToolOutputTransport). That is fragile: a
+ * wrapped / proxied / minified model instance defeats the sniff and a
+ * chat-completions provider would silently get the HOSTED `computer_use_preview`
+ * tool it 400s on every turn. So the mode is decided HERE — the worker's model
+ * resolution is the ONE place a provider's true wire identity is authoritative —
+ * and threaded to the runtime as an explicit flag (buildAgent → computerToolMode):
+ *   • codex-subscription → "function-image": the ChatGPT/Codex backend rejects
+ *     hosted tool types but SEES structured `input_image` tool results.
+ *   • a "chat" (OpenAIChatCompletionsModel wire) provider → "function-text": it takes
+ *     function tools but can't read structured image results, so screenshots render
+ *     as a text data-URL.
+ *   • everything else — built-in Azure/OpenAI responses, registry "responses"
+ *     providers, AND the LEGACY global-client fallback (resolveTurnModel returned
+ *     null) — → "hosted": real Responses hosted-tool support.
+ *
+ * Pure + exported so the mapping is unit-testable without a live turn.
+ */
+export function computerToolModeForTurn(
+  resolvedModel: { provider: { kind: RegistryProviderKind; api: ModelProviderApi } } | null,
+): ComputerToolMode {
+  if (!resolvedModel) {
+    return "hosted"; // legacy built-in Responses client — real hosted support
+  }
+  if (resolvedModel.provider.kind === "codex-subscription") {
+    return "function-image";
+  }
+  if (resolvedModel.provider.api === "chat") {
+    return "function-text";
+  }
+  return "hosted";
 }
 
 /**
@@ -1200,8 +1238,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // providers = the SDK's own ChatCompletions detection) keeps the SDK
             // default.
             structuredToolTransport: resolvedModel.provider.kind !== "codex-subscription",
+            // EXPLICIT computer-use tool transport, derived from the resolved provider's
+            // authoritative wire identity (codex → function-image, chat → function-text,
+            // responses → hosted) so the runtime never string-sniffs the model instance's
+            // constructor name. See {@link computerToolModeForTurn}.
+            computerToolMode: computerToolModeForTurn(resolvedModel),
           }
-          : {}),
+          // LEGACY global-client fallback (resolveTurnModel returned null → the model
+          // is not in the registry, served by the built-in OpenAI/Azure Responses
+          // client). That backend has real hosted support, so pin computerToolMode to
+          // "hosted" EXPLICITLY rather than leaving the runtime to sniff the instance.
+          : { computerToolMode: computerToolModeForTurn(null) }),
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(workspaceAgentInstructions ? { instructionsTemplate: workspaceAgentInstructions } : {}),
         ...(workspaceEnvironment

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { CancelledFailure } from "@temporalio/activity";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
-import { historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { computerToolModeForTurn, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 
 // Item shapes mirror the SDK history representation persisted into
 // session_history_items (type discriminator, camelCase callId).
@@ -432,3 +432,32 @@ describe("worker shutdown preemption", () => {
     expect(WORKER_SHUTDOWN_RESUME_TEXT).toContain("check whether it already happened");
   });
 });
+
+// The worker is the ONE place provider identity is authoritative, so it derives the
+// EXPLICIT computer-use tool transport there instead of letting the runtime string-sniff
+// the model instance's constructor name. This seam pins the provider→mode mapping.
+describe("computerToolModeForTurn (explicit computer-use transport derivation)", () => {
+  const resolved = (kind: RegistryProviderKind, api: ModelProviderApi) =>
+    ({ provider: { kind, api } }) as Parameters<typeof computerToolModeForTurn>[0];
+
+  test("codex-subscription → function-image (ChatGPT backend rejects hosted tools, SEES structured images)", () => {
+    // api is irrelevant once kind is codex-subscription — codex wins.
+    expect(computerToolModeForTurn(resolved("codex-subscription", "responses"))).toBe("function-image");
+    expect(computerToolModeForTurn(resolved("codex-subscription", "chat"))).toBe("function-image");
+  });
+
+  test("a chat-wire (OpenAIChatCompletionsModel) provider → function-text", () => {
+    expect(computerToolModeForTurn(resolved("api-key", "chat"))).toBe("function-text");
+  });
+
+  test("a registry responses provider → hosted", () => {
+    expect(computerToolModeForTurn(resolved("api-key", "responses"))).toBe("hosted");
+  });
+
+  test("the LEGACY global-client fallback (resolveTurnModel → null) → hosted EXPLICITLY", () => {
+    expect(computerToolModeForTurn(null)).toBe("hosted");
+  });
+});
+
+type RegistryProviderKind = "api-key" | "codex-subscription";
+type ModelProviderApi = "responses" | "chat";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -91,7 +91,7 @@ import {
   restoredSandboxSessionStateFromEntry,
   setSelfhostedApplyDiff,
 } from "./sandbox";
-import { computerUse } from "./sandbox-computer";
+import { computerUse, type ComputerToolMode } from "./sandbox-computer";
 
 // P4.3 computer-use surface (the agent's :0 driver). Re-exported from the barrel
 // so callers (the worker, live proofs) reach SandboxComputer/ComputerUseCapability
@@ -106,6 +106,7 @@ export {
   ComputerActionError,
   type SandboxComputerOptions,
   type ComputerUseArgs,
+  type ComputerToolMode,
 } from "./sandbox-computer";
 
 // The agent-loop-free sandbox leaf (createSandboxClient + resume/recovery
@@ -643,6 +644,12 @@ export type BuildAgentOptions = {
   encryptedReasoning?: boolean;
   contextWindowTokens?: number;
   structuredToolTransport?: boolean;
+  // EXPLICIT computer-use tool transport, decided where provider identity is
+  // authoritative (the worker's model resolution — agent-turn.ts). Threaded into
+  // buildAgentCapabilities → computerUse({toolMode}) so tool selection never rests
+  // on the SDK's constructor-name sniff. When omitted, the legacy sniff +
+  // `structuredToolTransport` neutralize path is preserved byte-for-byte.
+  computerToolMode?: ComputerToolMode;
   // The LIVE, by-reference connector-namespace Set from prepareAgentTools
   // (codexConnectorNamespaces): fills during each turn's codex_apps tools/list,
   // read per model call by the codex tool_search description so the model sees
@@ -864,6 +871,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
       compactionMode,
       contextWindowTokens,
       ...(options.structuredToolTransport !== undefined ? { structuredToolTransport: options.structuredToolTransport } : {}),
+      ...(options.computerToolMode !== undefined ? { computerToolMode: options.computerToolMode } : {}),
     }),
   });
   agentFileDownloads.set(agent, normalizeSandboxFileDownloads(options.fileResourceDownloads ?? []).filter((download) => !download.content));
@@ -961,7 +969,16 @@ function neutralizeStructuredToolTransport(capability: ReturnType<typeof filesys
 export function buildAgentCapabilities(
   settings: Settings,
   packSkills: PackSkill[],
-  options: { compactionMode?: ContextCompactionMode; contextWindowTokens?: number; structuredToolTransport?: boolean } = {},
+  options: {
+    compactionMode?: ContextCompactionMode;
+    contextWindowTokens?: number;
+    structuredToolTransport?: boolean;
+    // EXPLICIT computer-use transport (see BuildAgentOptions.computerToolMode). When
+    // present, computerUse() is handed the mode directly and its tools() obeys it
+    // without the constructor-name sniff. When absent, the legacy neutralize +
+    // imageFunctionResults path (driven by structuredToolTransport) is unchanged.
+    computerToolMode?: ComputerToolMode;
+  } = {},
 ): ReturnType<typeof Capabilities.default> {
   const mode = options.compactionMode ?? resolveContextCompactionMode(settings);
   const contextWindowTokens = options.contextWindowTokens ?? settings.contextWindowTokens;
@@ -996,25 +1013,37 @@ export function buildAgentCapabilities(
     && settings.sandboxDesktopEnabled
     && desktopCapableBackend(settings.sandboxBackend)
   ) {
-    // computer-use is now transport-aware, exactly like filesystem: its `tools()`
-    // emits the HOSTED `computer_use_preview` tool on the structured transport and a
-    // set of FUNCTION `computer_*` tools on the text transport. The ChatGPT/Codex
-    // backend rejects hosted tool types (only function/custom/web_search accepted),
-    // so on the codex path (structuredToolTransport === false) we neutralize the
-    // capability's model binding — the SAME trick used for filesystem above — so
-    // `tools()` sees no model instance and emits the function tools the backend can
-    // call, instead of suppressing the desktop tier entirely.
+    // computer-use is transport-aware, exactly like filesystem: `tools()` emits the
+    // HOSTED `computer_use_preview` tool on the structured transport and a set of
+    // FUNCTION `computer_*` tools on the text transport. The ChatGPT/Codex backend
+    // rejects hosted tool types (only function/custom/web_search accepted).
+    //
+    // HARDENING: when the caller declares an EXPLICIT `computerToolMode` (the worker
+    // does, from its authoritative model resolution), thread it straight through —
+    // tool selection then never depends on the SDK's model-instance constructor-name
+    // sniff (which a wrapped/proxied model would defeat, silently 400ing a
+    // chat-completions provider handed the hosted tool). When ABSENT, the legacy path
+    // is preserved byte-for-byte: on the codex path (structuredToolTransport === false)
+    // we set imageFunctionResults and neutralize the capability's model binding — the
+    // SAME trick used for filesystem above — so `tools()` sees no model instance and
+    // emits the function tools the backend can call, instead of suppressing the tier.
+    const explicitMode = options.computerToolMode;
     const computerCapability = computerUse({
       dimensions: [settings.streamResolutionWidth, settings.streamResolutionHeight],
       readOnly: settings.computerUseReadOnly,
-      // On the codex path the function tools deliver screenshots as a real image the
-      // model can see. The ChatGPT/Codex backend rejects HOSTED tool types but DOES
-      // accept `input_image` content items inside a `function_call_output` (proven by
-      // openai/codex codex-rs, whose view_image tool ships exactly that shape) — so a
-      // structured image tool result is seen, where a text data-URL would be unreadable.
-      ...(options.structuredToolTransport === false ? { imageFunctionResults: true } : {}),
+      ...(explicitMode
+        ? { toolMode: explicitMode }
+        // Legacy (no explicit mode): on the codex path the function tools deliver
+        // screenshots as a real image the model can see. The ChatGPT/Codex backend
+        // rejects HOSTED tool types but DOES accept `input_image` content items inside a
+        // `function_call_output` (proven by openai/codex codex-rs, whose view_image tool
+        // ships exactly that shape) — so a structured image tool result is seen, where a
+        // text data-URL would be unreadable.
+        : options.structuredToolTransport === false ? { imageFunctionResults: true } : {}),
     });
-    if (options.structuredToolTransport === false) {
+    // Neutralize ONLY on the legacy sniff path. With an explicit toolMode the mode
+    // already forces the function tools, so the constructor-name override is moot.
+    if (!explicitMode && options.structuredToolTransport === false) {
       neutralizeStructuredToolTransport(computerCapability);
     }
     caps.push(computerCapability as unknown as ReturnType<typeof Capabilities.default>[number]);

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -761,6 +761,25 @@ export function computerFunctionTools(
 
 // ── The capability (the SDK seam) ────────────────────────────────────────────
 
+/**
+ * EXPLICIT tool-transport selection, decided by the caller that knows the
+ * provider's true wire identity (the worker's model resolution — see agent-turn.ts),
+ * NOT inferred from the bound model instance's constructor name. This is the
+ * HARDENING seam: `supportsStructuredToolOutputTransport` string-sniffs the
+ * constructor for "ChatCompletions", which a wrapped / proxied / minified model
+ * instance would defeat — silently handing a chat-completions provider the HOSTED
+ * `computer_use_preview` tool it 400s on every turn. When `toolMode` is set, tools()
+ * OBEYS it and never consults the sniff:
+ *   • "hosted"         → the single hosted `computer_use_preview` tool (Responses backends).
+ *   • "function-image" → the FUNCTION `computer_*` tools with screenshots delivered as a
+ *                        structured `{type:'image'}` output (the codex/ChatGPT backend,
+ *                        which rejects hosted tool types but SEES structured image results).
+ *   • "function-text"  → the FUNCTION tools with screenshots rendered as a text
+ *                        `data:…;base64` URL (chat-completions providers, which can't read
+ *                        structured image tool results).
+ */
+export type ComputerToolMode = "hosted" | "function-image" | "function-text";
+
 export type ComputerUseArgs = {
   dimensions?: [number, number];
   readOnly?: boolean;
@@ -771,8 +790,14 @@ export type ComputerUseArgs = {
   // `input_image` content item inside the function_call_output) instead of the text
   // data-URL string. Only the codex/ChatGPT backend can read structured image tool
   // results; chat-completions providers cannot, so this stays OFF (text rendering)
-  // by default and is turned on only on the codex path (see index.ts).
+  // by default and is turned on only on the codex path (see index.ts). Ignored when
+  // `toolMode` is set (the mode carries its own image-delivery choice).
   imageFunctionResults?: boolean;
+  // EXPLICIT transport selection (see {@link ComputerToolMode}). When present, tools()
+  // obeys it directly — the constructor-name sniff is NOT consulted. When ABSENT, the
+  // legacy sniff behaviour is preserved byte-for-byte (back-compat for any embedder
+  // that constructs the capability without threading a mode).
+  toolMode?: ComputerToolMode;
 };
 
 export function computerUse(args: ComputerUseArgs = {}): ComputerUseCapability {
@@ -820,16 +845,36 @@ export class ComputerUseCapability extends Capability {
           // The SDK base exposes the bound runAs as a protected field.
           ...(typeof this._runAs === "string" ? { runAs: this._runAs } : {}),
         });
-    // Structured transport keeps the HOSTED computer tool (unchanged); the codex /
-    // text backend gets the FUNCTION tools it can actually call.
+    // HARDENING: when the caller declares an EXPLICIT toolMode, obey it and NEVER
+    // consult `supportsStructuredToolOutputTransport` — tool selection must not
+    // depend on the model instance's constructor name (a wrapped/proxied/minified
+    // instance would defeat the "ChatCompletions" string-sniff and silently hand a
+    // chat-completions provider the hosted tool it 400s on). The mode is decided by
+    // the worker, where provider identity is authoritative (see agent-turn.ts).
+    switch (this.args.toolMode) {
+      case "hosted":
+        return [this.hostedComputerTool(computer)];
+      case "function-image":
+        return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval, true);
+      case "function-text":
+        return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval, false);
+      case undefined:
+        break; // fall through to the legacy sniff (back-compat), preserved byte-for-byte
+    }
+    // Legacy (no toolMode): structured transport keeps the HOSTED computer tool
+    // (unchanged); the codex / text backend gets the FUNCTION tools it can call.
     if (supportsStructuredToolOutputTransport(this._modelInstance)) {
-      return [
-        computerTool({
-          computer,
-          ...(this.args.needsApproval !== undefined ? { needsApproval: this.args.needsApproval as never } : {}),
-        }) as unknown as Tool<unknown>,
-      ];
+      return [this.hostedComputerTool(computer)];
     }
     return computerFunctionTools(computer, this.args.readOnly ?? false, this.args.needsApproval, this.args.imageFunctionResults ?? false);
+  }
+
+  /** The single HOSTED `computer_use_preview` tool bound to `computer` — identical
+   *  construction for the explicit "hosted" mode and the legacy structured-sniff path. */
+  private hostedComputerTool(computer: Computer): Tool<unknown> {
+    return computerTool({
+      computer,
+      ...(this.args.needsApproval !== undefined ? { needsApproval: this.args.needsApproval as never } : {}),
+    }) as unknown as Tool<unknown>;
   }
 }

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -522,6 +522,71 @@ describe("ComputerUseCapability transport-aware seam", () => {
   });
 });
 
+// ── HARDENING: EXPLICIT toolMode overrides the constructor-name sniff ─────────
+// The refactor adds `toolMode: "hosted" | "function-image" | "function-text"` so
+// tool selection is decided by the caller that knows the provider's true wire
+// identity (the worker), NOT inferred from the bound model instance's constructor
+// name (which a wrapped/proxied/minified instance would defeat). When toolMode is
+// set, tools() OBEYS it and never consults supportsStructuredToolOutputTransport;
+// when ABSENT, the legacy sniff behaviour is preserved byte-for-byte.
+describe("ComputerUseCapability explicit toolMode (hardening — sniff not consulted)", () => {
+  const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const PNG_DATA_URL = `data:image/png;base64,${Buffer.from(PNG).toString("base64")}`;
+
+  test('toolMode "hosted" → the single HOSTED tool EVEN when a ChatCompletions model is bound', () => {
+    const { session } = makeMockSession();
+    const cap = computerUse({ toolMode: "hosted" });
+    // Bind a ChatCompletions instance: the sniff would say "function tools", so a
+    // hosted result PROVES the explicit mode overrode the constructor-name sniff.
+    cap.bind(session as never).bindModel("gpt", chatCompletionsModel());
+    const tools = cap.tools();
+    expect(tools.length).toBe(1);
+    expect((tools[0] as { type?: string }).type).toBe("computer");
+  });
+
+  test('toolMode "function-image" → the 8 FUNCTION tools EVEN when a structured model is bound; screenshot is a structured image', async () => {
+    // A structured model would sniff to the hosted tool; function tools prove override.
+    const { session } = makeMockSession({ pngBytes: PNG });
+    const cap = computerUse({ toolMode: "function-image" });
+    cap.bind(session as never).bindModel("responses", structuredModel());
+    const tools = cap.tools();
+    expect(tools.map((t) => (t as { name?: string }).name)).toEqual(FUNCTION_TOOL_NAMES);
+    for (const t of tools) expect((t as { type?: string }).type).toBe("function");
+    // function-image delivers the desktop as a STRUCTURED {type:'image'} tool output
+    // (imageFunctionResults=true) — the shape the codex/ChatGPT backend can SEE.
+    const shot = toolsByName(tools).computer_screenshot;
+    const out = (await invokeTool(shot, {})) as { type?: string; image?: { mediaType?: string } };
+    expect(out.type).toBe("image");
+    expect(out.image?.mediaType).toBe("image/png");
+  });
+
+  test('toolMode "function-text" → the 8 FUNCTION tools; screenshot is a text data-URL string', async () => {
+    const { session } = makeMockSession({ pngBytes: PNG });
+    const cap = computerUse({ toolMode: "function-text" });
+    cap.bind(session as never).bindModel("responses", structuredModel());
+    const tools = cap.tools();
+    expect(tools.map((t) => (t as { name?: string }).name)).toEqual(FUNCTION_TOOL_NAMES);
+    // function-text renders the screenshot as a `data:…;base64` STRING (chat-completions
+    // providers can't read structured image tool results) — NOT a {type:'image'} object.
+    const shot = toolsByName(tools).computer_screenshot;
+    const out = await invokeTool(shot, {});
+    expect(out).toBe(PNG_DATA_URL);
+  });
+
+  test("REGRESSION: ABSENT toolMode preserves the sniff byte-for-byte (structured→hosted, chat→function)", () => {
+    const { session: s1 } = makeMockSession();
+    const structured = computerUse({}); // no toolMode
+    structured.bind(s1 as never).bindModel("responses", structuredModel());
+    expect(structured.tools().length).toBe(1);
+    expect((structured.tools()[0] as { type?: string }).type).toBe("computer");
+
+    const { session: s2 } = makeMockSession();
+    const chat = computerUse({}); // no toolMode
+    chat.bind(s2 as never).bindModel("gpt", chatCompletionsModel());
+    expect(chat.tools().map((t) => (t as { name?: string }).name)).toEqual(FUNCTION_TOOL_NAMES);
+  });
+});
+
 describe("computerFunctionTools (codex text-transport routing)", () => {
   test("emits all 8 computer_* function tools", () => {
     const { computer } = makeFakeComputer();
@@ -720,6 +785,42 @@ describe("buildAgentCapabilities computer-use gating (P4.3)", () => {
     computerCap.bind(session as never).bindModel("responses", structuredModel());
     const names = computerCap.tools().map((t) => (t as { name?: string }).name);
     expect(names).toEqual(FUNCTION_TOOL_NAMES);
+  });
+
+  test("explicit computerToolMode is threaded to the capability and OVERRIDES the bound-model sniff", async () => {
+    const desktopOn = testSettings({ sandboxBackend: "modal", sandboxDesktopEnabled: true, computerUseEnabled: true });
+
+    // "hosted" → the attached capability emits the hosted tool EVEN with a
+    // ChatCompletions model bound (the sniff alone would pick function tools).
+    const hostedCaps = buildAgentCapabilities(desktopOn, [], { computerToolMode: "hosted" });
+    const hostedCap = hostedCaps.find((c) => (c as { type?: string }).type === "computer-use") as unknown as ComputerUseCapability;
+    const { session: s1 } = makeMockSession();
+    hostedCap.bind(s1 as never).bindModel("gpt", chatCompletionsModel());
+    const hostedTools = hostedCap.tools();
+    expect(hostedTools.length).toBe(1);
+    expect((hostedTools[0] as { type?: string }).type).toBe("computer");
+
+    // "function-text" → the FUNCTION tools EVEN with a structured model bound, and the
+    // screenshot renders as a text data-URL (imageFunctionResults=false).
+    const textCaps = buildAgentCapabilities(desktopOn, [], { computerToolMode: "function-text" });
+    const textCap = textCaps.find((c) => (c as { type?: string }).type === "computer-use") as unknown as ComputerUseCapability;
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { session: s2 } = makeMockSession({ pngBytes: png });
+    textCap.bind(s2 as never).bindModel("responses", structuredModel());
+    const textTools = textCap.tools();
+    expect(textTools.map((t) => (t as { name?: string }).name)).toEqual(FUNCTION_TOOL_NAMES);
+    const shot = toolsByName(textTools).computer_screenshot;
+    expect(await invokeTool(shot, {})).toBe(`data:image/png;base64,${Buffer.from(png).toString("base64")}`);
+
+    // "function-image" → the FUNCTION tools with a STRUCTURED image screenshot.
+    const imgCaps = buildAgentCapabilities(desktopOn, [], { computerToolMode: "function-image" });
+    const imgCap = imgCaps.find((c) => (c as { type?: string }).type === "computer-use") as unknown as ComputerUseCapability;
+    const { session: s3 } = makeMockSession({ pngBytes: png });
+    imgCap.bind(s3 as never).bindModel("responses", structuredModel());
+    const imgShot = toolsByName(imgCap.tools()).computer_screenshot;
+    const imgOut = (await invokeTool(imgShot, {})) as { type?: string; image?: { mediaType?: string } };
+    expect(imgOut.type).toBe("image");
+    expect(imgOut.image?.mediaType).toBe("image/png");
   });
 
   test("codex path threads imageFunctionResults:true → the emitted computer_screenshot returns a structured image", async () => {


### PR DESCRIPTION
Computer-use tool selection (hosted `computer` tool vs function `computer_*` tools, and text-vs-image screenshot delivery) rested on string-sniffing the bound model instance's constructor name for "ChatCompletions" plus the indirect `neutralizeStructuredToolTransport` encoding of "this is codex". A wrapped/proxied/minified model instance defeats the sniff and a chat provider would silently get the hosted tool it 400s on.

Now the mode is decided where provider identity is authoritative — the worker's model resolution — as a pure, unit-testable `computerToolModeForTurn()`: codex-subscription → `function-image`; `api: "chat"` providers → `function-text`; responses providers and the legacy global-client fallback → `hosted`. Threaded as an explicit `computerToolMode` through `buildAgentCapabilities` → `computerUse({toolMode})`, obeyed directly in `tools()`.

Parity: absent `toolMode` falls through to the original sniff-based behavior byte-for-byte (embedders constructing the capability directly are unaffected), and the neutralize + `imageFunctionResults` path fires exactly as before when the option is omitted.

Tests: 3 explicit-mode tests (each overriding a mismatched bound model — the exact failure the sniff couldn't survive), absent-mode regression, buildAgentCapabilities override test, 4 worker mapping tests incl. legacy-null → hosted. Gates re-run independently: runtime+worker `tsc` clean, 502/502 runtime tests, 31/31 worker agent-turn tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which computer-use tools and screenshot shapes are sent per provider on every desktop-enabled turn; mistakes would cause provider 400s or unreadable screenshots, though behavior is pinned by tests and the legacy path is preserved when `toolMode` is omitted.
> 
> **Overview**
> **Computer-use transport is now explicit end-to-end** instead of inferring hosted vs function tools from the bound model’s constructor name (fragile for wrapped/minified instances and chat providers that would 400 on hosted `computer_use_preview`).
> 
> The worker adds **`computerToolModeForTurn()`** and passes **`computerToolMode`** into `buildAgent` for every turn (including legacy `resolveTurnModel → null` → **`hosted`**): codex-subscription → **`function-image`**, chat API → **`function-text`**, responses / built-in fallback → **`hosted`**.
> 
> The runtime threads that through **`buildAgentCapabilities` → `computerUse({ toolMode })`**, where `tools()` obeys the mode via a switch and skips **`supportsStructuredToolOutputTransport`** sniffing; legacy callers without `toolMode` keep the old neutralize + `imageFunctionResults` behavior.
> 
> Tests cover the provider→mode mapping, explicit modes overriding mismatched bound models, and regression when `toolMode` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77378bedcf411c16dc4d5d11e534c3a7c1414da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->