### PR TITLE
chore(agent): bump agent workspace version to 0.1.2

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "image",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "prost",
  "prost-build",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "blake3",
  "hex",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
Release-guard version bump: 0.1.2 ships the fast-phase reconnect backoff (#207) and graceful no-args launch (#208) to self-hosted machines via the agent-latest release. Cargo.toml + lockfile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or protocol changes in this diff.
> 
> **Overview**
> Bumps the shared **`[workspace.package]` version** in `agent/Cargo.toml` from **0.1.1** to **0.1.2**, and refreshes **`agent/Cargo.lock`** so every workspace crate (`opengeni-agent`, `opengeni-relay`, proto/platform/stream/update/macos-ffi, etc.) resolves at the new version.
> 
> This is a **release-only** change (no Rust source edits). It tags the agent workspace for distribution—e.g. **`agent-latest`** self-update—so deployed agents can pick up behavior already merged elsewhere (fast-phase reconnect backoff, graceful no-args launch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc0540cb525fac80aa8464548b681a482955aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->