### PR TITLE
feat(chart): optional self-hosted Terraform MCP server (terraformMcp.enabled)

### DIFF
--- a/deploy/helm/opengeni/templates/terraform-mcp-deployment.yaml
+++ b/deploy/helm/opengeni/templates/terraform-mcp-deployment.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.terraformMcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opengeni.fullname" . }}-terraform-mcp
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: terraform-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "opengeni.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: terraform-mcp
+  template:
+    metadata:
+      labels:
+        {{- include "opengeni.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: terraform-mcp
+    spec:
+      serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: terraform-mcp
+          image: {{ printf "%s:%s" .Values.terraformMcp.image.repository .Values.terraformMcp.image.tag | quote }}
+          imagePullPolicy: {{ .Values.terraformMcp.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: TRANSPORT_MODE
+              value: streamable-http
+            - name: TRANSPORT_HOST
+              value: 0.0.0.0
+            - name: TRANSPORT_PORT
+              value: "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            {{- include "opengeni.httpProbe" (dict "probe" (dict "path" "/health" "initialDelaySeconds" 5 "periodSeconds" 10 "timeoutSeconds" 2 "failureThreshold" 3)) | nindent 12 }}
+          livenessProbe:
+            {{- include "opengeni.httpProbe" (dict "probe" (dict "path" "/health" "initialDelaySeconds" 20 "periodSeconds" 20 "timeoutSeconds" 2 "failureThreshold" 3)) | nindent 12 }}
+          resources:
+            {{- toYaml .Values.terraformMcp.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/opengeni/templates/terraform-mcp-service.yaml
+++ b/deploy/helm/opengeni/templates/terraform-mcp-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.terraformMcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opengeni.fullname" . }}-terraform-mcp
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: terraform-mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "opengeni.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: terraform-mcp
+{{- end }}

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -722,6 +722,24 @@ selfhosted:
   natsControlUser: control
   natsCalloutUser: auth
 
+# Optional self-hosted HashiCorp Terraform MCP server. Agents reach it by adding
+# an OPENGENI_MCP_SERVERS entry that points at
+# http://<fullname>-terraform-mcp:8080/mcp, then selecting it for a session with
+# an explicit {kind:mcp,id} ToolRef. This is Terraform Registry docs only; no
+# Terraform Enterprise token is wired.
+terraformMcp:
+  enabled: false
+  image:
+    repository: hashicorp/terraform-mcp-server
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
 observability:
   structuredLogs: true
   metrics:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -300,7 +300,7 @@ A Cargo workspace building the box-side binary for the `selfhosted` backend. `ag
 
 ### 6.4 Deployment (`deploy/`)
 
-`deploy/helm/opengeni` (the chart — owns api/web/worker/relay/migrations; in-chart Postgres/Temporal/NATS/MinIO are **disposable fixtures**), `deploy/terraform/{azure,aws,gcp}` (per-cloud roots), `deploy/stacks` (wrappers for deps managed outside the chart), `deploy/nats/auth-callout.conf` (BYO-compute tenancy boundary). See §12.
+`deploy/helm/opengeni` (the chart — owns api/web/worker/relay/migrations plus the optional Terraform Registry MCP docs service; in-chart Postgres/Temporal/NATS/MinIO are **disposable fixtures**), `deploy/terraform/{azure,aws,gcp}` (per-cloud roots), `deploy/stacks` (wrappers for deps managed outside the chart), `deploy/nats/auth-callout.conf` (BYO-compute tenancy boundary). See §12.
 
 ### 6.5 Docs, scripts, test
 
@@ -463,7 +463,7 @@ The current map:
 
 A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile into validated deploy plans: required env, preflight checks, Terraform/Helm targets, and generated artifacts. **12 built-in profiles** (local-compose, local-kubernetes, kubernetes-external, {azure,aws,gcp}-{managed,existing-services}, preview-pr, preview-branch, self-contained-kubernetes) + **product overlays** (none / managed-saas-staging / managed-saas-production, which hard-override sandbox→modal and access→externalGateway).
 
-- **What OpenGeni owns vs disposable fixtures.** The chart (`deploy/helm/opengeni`) owns **api/web/worker/relay/migrations**. The in-chart **Postgres/Temporal/NATS/MinIO are disposable conformance fixtures** (default `enabled:false`) — *not production services*. Official NATS/Temporal are lifecycle-managed by the stack wrappers (`deploy/stacks`), outside the app chart; official Temporal needs an **existing** Postgres.
+- **What OpenGeni owns vs disposable fixtures.** The chart (`deploy/helm/opengeni`) owns **api/web/worker/relay/migrations**, plus optional app-adjacent integrations such as the Terraform Registry MCP docs service. The in-chart **Postgres/Temporal/NATS/MinIO are disposable conformance fixtures** (default `enabled:false`) — *not production services*. Official NATS/Temporal are lifecycle-managed by the stack wrappers (`deploy/stacks`), outside the app chart; official Temporal needs an **existing** Postgres.
 - **Secrets never reach Helm values.** `generateRuntimeArtifacts` puts sensitive Terraform outputs only into `runtime.env` (and records them in `sensitiveTerraformOutputsUsed`); generated files carry "Do not commit generated copies."
 - **Parity (not import).** `@opengeni/deployment`'s `SANDBOX_REQUIRED_ENV` and `SandboxBackend` *mirror* `@opengeni/config`/`@opengeni/contracts` — enforced by **tests, not the type system**. Edit one side without the other and it compiles but the parity test goes red.
 - **Conformance.** `scripts/deployment-conformance.ts` black-box-verifies a running deployment (health, access boundary, session run, SSE replay, MCP-tool session, scheduled task, storage round-trip). Preflight is `scripts/deployment-preflight.ts`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -246,7 +246,7 @@ Production self-hosted platform dependencies should use mature upstream projects
 - TLS: cert-manager, cloud load balancer certificate integration, or an existing ingress/TLS stack.
 - Observability: OpenTelemetry Collector/Operator plus Prometheus Operator-compatible resources, exported to a self-hosted LGTM-compatible stack or a managed cloud backend.
 
-The OpenGeni Helm chart owns OpenGeni API, web, worker, migrations, and integration resources such as `ServiceMonitor`, `PrometheusRule`, `ExternalSecret`, and workload NetworkPolicies. It must not become a replacement chart for NATS, Temporal, Postgres, cert-manager, or the observability platform.
+The OpenGeni Helm chart owns OpenGeni API, web, worker, migrations, optional Terraform Registry MCP docs service, and integration resources such as `ServiceMonitor`, `PrometheusRule`, `ExternalSecret`, and workload NetworkPolicies. It must not become a replacement chart for NATS, Temporal, Postgres, cert-manager, or the observability platform.
 
 The stack wrapper may install upstream charts as a convenience layer. That
 keeps lifecycle commands visible and reversible without making those charts
@@ -347,6 +347,39 @@ Sandbox file mount support is also backend-specific:
 | --- | --- | --- | --- | --- |
 | Docker/local in-container sandboxes | rclone mount | rclone mount | signed download materialization | signed download materialization |
 | Modal | SDK cloud bucket mount | signed download materialization | signed download materialization | signed download materialization |
+
+## Terraform Registry MCP Docs
+
+The Helm chart can deploy an optional, cluster-internal HashiCorp Terraform MCP
+server for authoritative Terraform Registry documentation:
+
+```bash
+helm upgrade --install opengeni deploy/helm/opengeni \
+  --namespace opengeni \
+  --set terraformMcp.enabled=true \
+  --set secret.existingSecret=opengeni-runtime
+```
+
+This renders a `ClusterIP` service at
+`http://<fullname>-terraform-mcp:8080/mcp`. For a release named `opengeni`, the
+default service name is `opengeni-terraform-mcp`. Register it in
+`OPENGENI_MCP_SERVERS`, for example:
+
+```json
+[
+  {
+    "id": "terraform-registry",
+    "name": "Terraform Registry Docs",
+    "url": "http://opengeni-terraform-mcp:8080/mcp",
+    "cacheToolsList": true
+  }
+]
+```
+
+Then select it per session with an explicit tool reference such as
+`{"kind":"mcp","id":"terraform-registry"}`. The chart does not wire a Terraform
+Enterprise token or other provider credential into this server; it is a
+registry-docs endpoint only.
 
 ## Connected Machines
 


### PR DESCRIPTION
## What
- Adds a default-off `terraformMcp.enabled` Helm component that deploys `hashicorp/terraform-mcp-server:1.0.0` behind a cluster-internal `ClusterIP` service.
- Documents the chart ownership change and operator wiring.

## Why
Agents can use authoritative Terraform Registry documentation through a self-hosted streamable-HTTP MCP endpoint without relying on an external service URL.

## Default-off behavior
`terraformMcp.enabled` defaults to `false`; the Deployment and Service render only when explicitly enabled. No Terraform Enterprise token or provider credential is wired into the server.

## Operator wiring
Enable the chart component, then add an `OPENGENI_MCP_SERVERS` entry such as:

```json
[{"id":"terraform-registry","name":"Terraform Registry Docs","url":"http://<fullname>-terraform-mcp:8080/mcp","cacheToolsList":true}]
```

Select it per session with an explicit ToolRef:

```json
{"kind":"mcp","id":"terraform-registry"}
```

## Validation
- `docker pull hashicorp/terraform-mcp-server:1.0.0 && docker inspect --format '{{.Config.User}}' hashicorp/terraform-mcp-server:1.0.0` returned `65532:65532`.
- `helm lint deploy/helm/opengeni`
- `helm template opengeni deploy/helm/opengeni --set terraformMcp.enabled=true` plus rendered name/port assertions
- `helm template opengeni deploy/helm/opengeni` plus default-absent assertion
- `! grep -R -nE '(:|tag:[[:space:]]*"?)latest($|")' docker-compose.yml deploy/helm/opengeni`
- `bun run check:docs-refs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only and docs changes with no runtime app code; the component is disabled by default and exposes only cluster-internal registry documentation.
> 
> **Overview**
> Adds a **default-off** `terraformMcp` Helm component that deploys HashiCorp’s `terraform-mcp-server` (streamable HTTP on port 8080) behind an in-cluster `ClusterIP` service, gated by `terraformMcp.enabled`.
> 
> The deployment follows the same hardened pod pattern as the relay (non-root uid 65532, dropped capabilities, `/health` probes). Operators enable it with `--set terraformMcp.enabled=true`, register `http://<fullname>-terraform-mcp:8080/mcp` in `OPENGENI_MCP_SERVERS`, and attach it per session via an explicit `{kind:mcp,id}` ToolRef. **No** Terraform Enterprise or other provider credentials are wired into the chart.
> 
> `docs/architecture.md` and `docs/deployment.md` now list this service among chart-owned workloads and document the operator wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1e585015333ee866001c121b646608b67f5013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->