### PR TITLE
feat(core): honor client optional MCP ToolRefs — skip-if-unconfigured, best-effort-if-down

### DIFF
--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -74,19 +74,26 @@ describe("API helpers", () => {
     ]);
   });
 
-  test("validateToolRefs strips a client-supplied optional flag (explicit tools stay strict)", () => {
+  test("validateToolRefs applies MCP optional tri-state semantics", () => {
     const runtimeSettings = {
       mcpServers: [
         { id: "opengeni", url: "https://example.com/mcp", cacheToolsList: false },
         { id: "cap-notebook", url: "https://example.com/notebook", cacheToolsList: false },
       ],
     };
-    // A client cannot smuggle optional:true onto an explicitly-requested tool to
-    // make it non-fatal; the normalized ref is a bare strict ref.
-    expect(validateToolRefs(
-      [{ kind: "mcp", id: "cap-notebook", optional: true }] as never,
-      runtimeSettings as never,
-    )).toEqual([{ kind: "mcp", id: "cap-notebook" }]);
+
+    expect(validateToolRefs([{ kind: "mcp", id: "cap-notebook" }], runtimeSettings as never))
+      .toEqual([{ kind: "mcp", id: "cap-notebook" }]);
+    expect(validateToolRefs([{ kind: "mcp", id: "cap-notebook", optional: true }], runtimeSettings as never))
+      .toEqual([{ kind: "mcp", id: "cap-notebook", optional: true }]);
+    expect(() => validateToolRefs([{ kind: "mcp", id: "missing" }], runtimeSettings as never))
+      .toThrow("unknown MCP server id: missing");
+    expect(validateToolRefs([{ kind: "mcp", id: "missing", optional: true }], runtimeSettings as never))
+      .toEqual([]);
+    expect(validateToolRefs([
+      { kind: "mcp", id: "cap-notebook", optional: true },
+      { kind: "mcp", id: "cap-notebook" },
+    ], runtimeSettings as never)).toEqual([{ kind: "mcp", id: "cap-notebook" }]);
   });
 
   test("maps scheduled task schedules into Temporal specs", () => {

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -13,6 +13,8 @@ The catalog merges:
 
 Remote MCP capabilities with a streamable HTTP endpoint are executable. Enabling a remote MCP first performs an MCP initialize/list-tools probe. If the probe succeeds, OpenGeni stores a `capability_installations` row and the API/worker merge that row into the runtime MCP server list for new sessions, follow-ups, and scheduled tasks. Sessions and scheduled tasks created without an explicit `tools` key are attached to every enabled capability MCP server by default; an explicit tools list (even an empty one) is taken verbatim. If the probe fails, the API returns `422` and the capability stays disabled, so a stale, down, or auth-only endpoint never breaks agent turns at runtime.
 
+MCP tool refs are strict by default. A bare `{ "kind": "mcp", "id": "docs" }` must name a server configured for this deployment, and a runtime connect/list failure fails the turn. A client or pack can mark a ref `{ "kind": "mcp", "id": "context7", "optional": true }` to make it portable: if the deployment does not configure that server the ref is skipped during validation, and if the server is configured but unavailable at runtime it is skipped for that turn with a warning.
+
 ### Credential headers
 
 MCP servers that require request headers (for example an `Authorization` bearer token) are enabled by passing the headers in the enable request:

--- a/docs/packs.md
+++ b/docs/packs.md
@@ -15,7 +15,7 @@ The first pack is `marketing-social-daily-analysis`. It enables a workspace to c
 
 OpenGeni keeps pack execution on the normal session and scheduled-task path. A pack does not create a second runtime. Instead, enabling a pack stores a `pack_installations` row and pack-specific flows create ordinary scheduled tasks with:
 
-- `agentConfig.tools`: first-party MCP servers such as `opengeni` and `docs`
+- `agentConfig.tools`: first-party MCP servers such as `opengeni` and `docs`; portable packs may mark deployment-specific MCP refs with `optional: true` so unconfigured servers are skipped and configured-but-unavailable servers degrade best-effort at runtime
 - `agentConfig.resources`: files or repositories when needed
 - `agentConfig.metadata`: pack ID, template ID, connector IDs, and knowledge IDs
 - `agentConfig.prompt`: role-specific instructions compiled from the pack template

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1351,15 +1351,12 @@ export type DocumentSearchRequest = z.infer<typeof DocumentSearchRequest>;
 export const ToolRef = z.object({
   kind: z.literal("mcp"),
   id: z.string().min(1),
-  // Non-fatal-on-connect marker for an AUTO-ATTACHED (workspace-default)
-  // capability MCP server: when true, a connect / tools-list failure (e.g. an
-  // expired capability credential returning 401) must SKIP that server with a
-  // logged warning and let the turn proceed, rather than failing the whole
-  // turn before the model runs. Absent/false ⇒ STRICT: an unavailable server
-  // fails the turn (the contract for EXPLICITLY-requested tools). This flag is
-  // set server-side only, at the default-capability auto-attach seam; it is
-  // stripped from client-supplied tool refs so an explicit request always
-  // stays strict.
+  // Non-fatal-on-connect marker for MCP server refs that can degrade
+  // gracefully. Absent/false is STRICT: the id must be configured and an
+  // unavailable server fails the turn. `optional:true` is preserved for known
+  // servers and makes runtime connect/list failures skip that server; if the
+  // deployment does not configure the id, validation drops the ref. The server
+  // also sets this for auto-attached workspace-default capability MCPs.
   optional: z.boolean().optional(),
 });
 export type ToolRef = z.infer<typeof ToolRef>;
@@ -1382,10 +1379,10 @@ export function mergeToolRefs(existing: ToolRef[], additions: ToolRef[]): ToolRe
       order.push(key);
       continue;
     }
-    // Strict wins: if the same server appears both auto-attached (optional) and
-    // explicitly requested (non-optional), the explicit occurrence upgrades the
-    // merged ref to strict — a later explicit request of an already-defaulted
-    // capability MCP must still fail the turn when the server is unavailable.
+    // Strict wins: if the same server appears both optional and strict, the
+    // strict occurrence upgrades the merged ref so an unavailable server fails
+    // the turn. This preserves the fail-loud default when defaults, packs, and
+    // per-turn tool selections are combined.
     if (prior.optional === true && tool.optional !== true) {
       const { optional: _dropped, ...strict } = prior;
       byKey.set(key, strict);

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -35,9 +35,9 @@ describe("contracts", () => {
   test("accepts MCP tool refs on create session", () => {
     const payload = CreateSessionRequest.parse({
       initialMessage: "inspect repo",
-      tools: [{ kind: "mcp", id: "docs" }],
+      tools: [{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "context7", optional: true }],
     });
-    expect(payload.tools).toEqual([{ kind: "mcp", id: "docs" }]);
+    expect(payload.tools).toEqual([{ kind: "mcp", id: "docs" }, { kind: "mcp", id: "context7", optional: true }]);
   });
 
   test("accepts repository and file resources on create session", () => {
@@ -300,10 +300,10 @@ describe("contracts", () => {
     expect(() => DocumentSearchRequest.parse({ query: "" })).toThrow();
   });
 
-  test("mergeToolRefs: explicit (strict) beats auto-attached (optional) for the same server", () => {
-    // A capability that is both auto-attached (optional) at create AND later
-    // explicitly requested must end up STRICT — the explicit request wins so an
-    // unavailable server fails the turn, preserving the fail-loud contract.
+  test("mergeToolRefs: strict beats optional for the same server", () => {
+    // A server that is both optional and strict must end up STRICT. This keeps
+    // explicit strict selections fail-loud when they collide with optional pack
+    // refs or auto-attached capability MCP defaults.
     expect(mergeToolRefs(
       [{ kind: "mcp", id: "cap-notebook", optional: true }],
       [{ kind: "mcp", id: "cap-notebook" }],

--- a/packages/core/src/domain/resources.ts
+++ b/packages/core/src/domain/resources.ts
@@ -17,26 +17,29 @@ import { HTTPException } from "hono/http-exception";
 
 export function validateToolRefs(tools: ToolRef[], settings: Settings): ToolRef[] {
   const mcpServerIds = new Set(settings.mcpServers.map((server) => server.id));
-  const selected = new Set<string>();
   const out: ToolRef[] = [];
   for (const tool of tools) {
     if (tool.kind !== "mcp") {
       throw new HTTPException(422, { message: `unsupported tool kind: ${(tool as { kind?: string }).kind}` });
     }
+    const optional = tool.optional === true;
     if (!mcpServerIds.has(tool.id)) {
+      if (optional) {
+        continue;
+      }
       throw new HTTPException(422, { message: `unknown MCP server id: ${tool.id}` });
     }
-    if (selected.has(tool.id)) {
-      continue;
-    }
-    selected.add(tool.id);
-    // Normalize to a bare, STRICT ref: a client-supplied `optional` flag is
-    // dropped so an EXPLICITLY-requested tool always fails the turn when its
-    // server is unavailable. `optional: true` is set only server-side, at the
-    // default-capability auto-attach seam (enabledCapabilityMcpToolRefs).
-    out.push({ kind: "mcp", id: tool.id });
+    // Tool refs are tri-state for pack portability across deployments:
+    //  - bare / optional:false is STRICT: the id must be configured here and
+    //    runtime connection failure fails the turn.
+    //  - optional:true + known id is preserved: runtime treats it like an
+    //    auto-attached capability MCP and skips connect/list failures.
+    //  - optional:true + unknown id is skipped above: the client explicitly
+    //    opted into graceful degradation for MCPs (for example docs servers
+    //    like context7) that only some deployments configure.
+    out.push(optional ? { kind: "mcp", id: tool.id, optional: true } : { kind: "mcp", id: tool.id });
   }
-  return out;
+  return mergeToolRefs([], out);
 }
 
 type McpSettings = Pick<Settings, "mcpServers">;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1117,19 +1117,19 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
     //    device-code login may lack the connector scopes, and the backend can
     //    reject the bearer at the initialize/tools-list handshake, so a 401/403
     //    (or a missing/failed token) drops the server.
-    //  - an AUTO-ATTACHED workspace-default capability MCP (ToolRef.optional):
-    //    the caller never explicitly requested it, so a broken/expired
-    //    capability credential must SKIP the server with a warning, never kill
-    //    the turn before the model runs. An EXPLICITLY-requested tool omits
-    //    `optional` and stays strict (below), preserving the fail-loud contract.
+    //  - an optional ToolRef: either an auto-attached workspace-default
+    //    capability MCP or a client/pack-selected portable ref. A
+    //    broken/expired credential or unavailable endpoint skips the server
+    //    with a warning, never killing the turn before the model runs. Bare
+    //    refs stay strict (below), preserving the fail-loud default.
     const optional = tool.optional === true;
     return { server, bestEffort: isCodexAppsMcpServer(config) || optional, optional };
   }));
   const requiredServers = servers.filter((entry) => !entry.bestEffort).map((entry) => entry.server);
   const bestEffortServers = servers.filter((entry) => entry.bestEffort).map((entry) => entry.server);
-  // Names of the OPTIONAL capability servers (not codex_apps) so a drop is
-  // surfaced as a warning; codex_apps keeps its historically-quiet drop (a
-  // not-logged-in ChatGPT plan is a normal, non-noteworthy state).
+  // Names of the OPTIONAL servers (not codex_apps) so a drop is surfaced as a
+  // warning; codex_apps keeps its historically-quiet drop (a not-logged-in
+  // ChatGPT plan is a normal, non-noteworthy state).
   const optionalServerNames = new Set(
     servers.filter((entry) => entry.optional).map((entry) => entry.server.name),
   );
@@ -1150,7 +1150,7 @@ export async function prepareAgentTools(settings: Settings, tools: ToolRef[], op
       }
       const error = connectedBestEffort.errors.get(failed);
       console.warn(
-        `[mcp] optional capability server "${failed.name}" failed to connect/list tools; skipping it for this turn`,
+        `[mcp] optional server "${failed.name}" failed to connect/list tools; skipping it for this turn`,
         error instanceof Error ? error.message : error,
       );
     }

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1392,12 +1392,12 @@ describe("runtime event normalization", () => {
     }
   });
 
-  test("optional (auto-attached) capability MCP whose connect fails is skipped, not fatal", async () => {
-    // The geni-notebook class of bug: a workspace-default capability MCP whose
-    // credential expired returns 401 at connect. Because it was AUTO-ATTACHED
-    // (ToolRef.optional), the failure must drop the server with a warning and
-    // let the turn proceed — not fail the whole turn before the model runs. The
-    // config carries NO credential header, so the required-header server 401s.
+  test("optional ToolRef whose connect fails is skipped, not fatal", async () => {
+    // Optional MCP refs cover both auto-attached capability MCPs and
+    // client/pack-selected portable refs. If the server returns 401 at connect,
+    // the failure must drop the server with a warning and let the turn proceed
+    // instead of failing before the model runs. The config carries NO
+    // credential header, so the required-header server 401s.
     const broken = startTestMcpServer({ requiredHeaders: { "x-api-key": "capability-credential" } });
     const warnings: unknown[][] = [];
     const originalWarn = console.warn;


### PR DESCRIPTION
## What changed

- Preserves client-supplied `optional: true` for known MCP ToolRefs so runtime treats them as best-effort on connect/list failure.
- Skips client-supplied `optional: true` refs when the MCP server id is not configured on this deployment.
- Keeps bare refs strict: unknown ids still return 422, and configured-but-unavailable servers still fail the turn.

## Why

This changes MCP ToolRef handling to explicit tri-state semantics. Strict remains the default because a bare tool ref means the client requires that server for the turn to run correctly. `optional: true` is now the client and pack author signal for graceful degradation.

The motivation is pack portability: a pack can reference deployment-specific documentation MCP servers, such as context7, without making installations fail on deployments that have not configured that server. Deployments that do configure it still get the tool, but runtime outages or credential failures skip only that optional server.

## Validation

- `bun test apps/api/test/app.test.ts`
- `bun test packages/contracts/test/contracts.test.ts`
- `bun test packages/runtime/test/runtime.test.ts`
- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent tool validation and MCP connect behavior for sessions, packs, and scheduled tasks; semantics are well-tested but mis-tagged optional refs could hide missing tools silently.
> 
> **Overview**
> **MCP `ToolRef` handling now uses explicit tri-state semantics** instead of stripping client-supplied `optional: true` during validation.
> 
> `validateToolRefs` **keeps** `optional: true` when the server id is configured, **silently drops** optional refs for unknown ids (so packs can reference deployment-specific MCPs like `context7` without 422), and still **422s** bare refs to missing servers. Duplicate ids in one request are merged via `mergeToolRefs` (strict still wins over optional). Runtime comments and connect behavior already treated `optional` as best-effort; the change wires client/pack refs into that same path.
> 
> Contracts, `docs/capabilities.md`, and `docs/packs.md` document the behavior; API, contracts, and runtime tests cover the matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce9072c2e67be82d2f7c158ffce97f88d6c8526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->