### PR TITLE
feat(worker-bundle): optional workflowsPath for embedded hosts

### DIFF
--- a/.changeset/worker-workflows-path-option.md
+++ b/.changeset/worker-workflows-path-option.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+`createOpenGeniWorker` accepts an optional `workflowsPath` so embedded hosts can point Temporal's workflow bundler at a relocated copy of `workflows.ts` — the in-package default under `node_modules` is not transpiled by Temporal's webpack. Standalone behavior is unchanged when unset.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -16,6 +16,11 @@ export type WorkerOptions = {
   settings?: Settings;
   activities?: ReturnType<typeof createActivities>;
   activityDependencies?: ActivityDependencies;
+  // Embedded hosts install @opengeni/worker-bundle under node_modules, where
+  // Temporal's workflow webpack refuses to transpile TS. They relocate
+  // src/workflows.ts to a host-owned path and point the worker at it here.
+  // Unset (standalone) keeps today's in-package path byte-for-byte.
+  workflowsPath?: string;
 };
 
 export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise<{
@@ -41,7 +46,7 @@ export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise
     connection,
     namespace: settings.temporalNamespace,
     taskQueue: settings.temporalTaskQueue,
-    workflowsPath: new URL("../src/workflows.ts", import.meta.url).pathname,
+    workflowsPath: options.workflowsPath ?? new URL("../src/workflows.ts", import.meta.url).pathname,
     activities,
   });
   return { worker, connection };


### PR DESCRIPTION
Embedded hosts install `@opengeni/worker-bundle` under `node_modules`, where Temporal's workflow webpack won't transpile TS (`Module parse failed: Unexpected token — type …` — hit live on the cloudgeni gecko worker). Hosts relocate `src/workflows.ts` and need to point the worker at it: `createOpenGeniWorker({ workflowsPath })`. Unset = today's in-package path, byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbPQr8kJmVXyZ2tGwCnDhE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional parameter with unchanged default; only affects workflow bundle resolution for hosts that opt in.
> 
> **Overview**
> Adds an optional **`workflowsPath`** on `createOpenGeniWorker` / `WorkerOptions` so embedded hosts can override where Temporal bundles workflow code from.
> 
> When `@opengeni/worker-bundle` lives under **`node_modules`**, Temporal’s workflow webpack often **won’t transpile TypeScript** in the package default (`workflows.ts`), which breaks worker startup. Hosts can **relocate** that file to a host-owned path and pass it in; **`Worker.create`** uses `options.workflowsPath ??` the existing in-package `../src/workflows.ts` path, so **standalone** deployments behave the same when the option is omitted.
> 
> Ships as a **patch** on `@opengeni/worker-bundle` via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009e704c171b971e154bfc8fbb501b242a86c911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->