### PR TITLE
polish: followups — home scroll/overflow, de-clutter, repo picker, computer-tool rendering

### DIFF
--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -24,9 +24,11 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MetaChip } from "@/components/ui/meta-chip";
+import { Notice } from "@/components/ui/notice";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { repoCountLabel } from "@/lib/format";
 import {
@@ -68,10 +70,51 @@ export function RepositoryContextPicker(props: {
   const selectedInstalledCount = props.selectedRepoIds.size;
   const manualCount = props.manualRepos.filter((repo) => repo.url.trim().length > 0).length;
   const selectedCount = selectedInstalledCount + manualCount;
-  const setupOpen = props.githubAppOpen;
+  const hasRepos = props.repositories.length > 0;
   // Two-step inline confirm for removing a manual repo, so a stray click in a
   // dense picker doesn't drop a repo the user typed out.
   const [confirmRemoveId, setConfirmRemoveId] = useState<number | null>(null);
+
+  // The GitHub App manifest form — org login plus the install/create actions.
+  // Rendered inline (open) in the first-run empty state so setup is never hidden
+  // behind a disclosure, and demoted into a quiet "GitHub app settings"
+  // disclosure once repositories are connected.
+  const setupForm = (
+    <div className="space-y-3">
+      <p className="text-xs leading-5 text-fg-muted">
+        {props.configured
+          ? "The app provides repository listing, scoped clone tokens, pushes, and pull requests."
+          : "Create a prefilled app, add the generated values to your .env, then restart the API and worker."}
+      </p>
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+        <div className="min-w-0">
+          <Label htmlFor="github-org-menu" className="text-2xs text-fg-subtle">Organization</Label>
+          <Input
+            id="github-org-menu"
+            value={props.org}
+            onChange={(event) => props.onOrgChange(event.target.value)}
+            placeholder="Optional org login"
+            disabled={props.githubAppBusy}
+            className="mt-1 h-8 text-xs"
+          />
+        </div>
+        <div className="flex items-end gap-1.5">
+          {props.installUrl ? (
+            <Button asChild type="button" variant="outline" size="sm" className="h-8 text-xs">
+              <a href={props.installUrl}>
+                <GitPullRequestIcon className="size-3.5" />
+                Install
+              </a>
+            </Button>
+          ) : null}
+          <Button type="button" size="sm" onClick={props.onStartGitHubApp} disabled={props.githubAppBusy} className="h-8 text-xs">
+            {props.githubAppBusy ? <Loader2Icon className="size-3.5 animate-spin" /> : <GitPullRequestIcon className="size-3.5" />}
+            {props.configured ? "Create another" : "Create app"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <DropdownMenu>
@@ -130,158 +173,152 @@ export function RepositoryContextPicker(props: {
 
           <ScrollArea className="max-h-[min(70vh,620px)]">
             <div className="space-y-3 p-3">
-              <Collapsible open={setupOpen} onOpenChange={props.onGitHubAppOpenChange}>
-                <div className="rounded-lg border border-border bg-bg/25">
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-surface-2/60"
-                    >
-                      <span className="min-w-0">
-                        <span className="block truncate text-xs font-medium text-fg">GitHub App</span>
-                        <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
-                          {props.configured ? "Configured for scoped repository tokens" : "Set up GitHub App access"}
-                        </span>
-                      </span>
-                      <span className="flex shrink-0 items-center gap-2">
-                        <MetaChip dot={props.configured ? "idle" : "waiting"} rounded="full">
-                          {props.configured ? "Configured" : "Not set up"}
-                        </MetaChip>
-                        <ChevronDownIcon className={cn("size-3.5 text-fg-subtle transition-transform", setupOpen && "rotate-180")} />
-                      </span>
-                    </button>
-                  </CollapsibleTrigger>
-
-                  <CollapsibleContent>
-                    <div className="space-y-3 border-t border-border p-3">
-                      <p className="text-xs leading-5 text-fg-muted">
-                        {props.configured
-                          ? "The app is used for repository listing, scoped clone tokens, pushes, and pull requests."
-                          : "Create a prefilled app, add the generated values to .env, then restart API and worker."}
-                      </p>
-                      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                        <div className="min-w-0">
-                          <Label htmlFor="github-org-menu" className="text-2xs text-fg-subtle">Organization</Label>
-                          <Input
-                            id="github-org-menu"
-                            value={props.org}
-                            onChange={(event) => props.onOrgChange(event.target.value)}
-                            placeholder="Optional org login"
-                            disabled={props.githubAppBusy}
-                            className="mt-1 h-8 text-xs"
-                          />
-                        </div>
-                        <div className="flex items-end gap-1.5">
-                          {props.installUrl ? (
-                            <Button asChild type="button" variant="outline" size="sm" className="h-8 text-xs">
-                              <a href={props.installUrl}>
-                                <GitPullRequestIcon className="size-3.5" />
-                                Install
-                              </a>
-                            </Button>
-                          ) : null}
-                          <Button type="button" size="sm" onClick={props.onStartGitHubApp} disabled={props.githubAppBusy} className="h-8 text-xs">
-                            {props.githubAppBusy ? <Loader2Icon className="size-3.5 animate-spin" /> : <GitPullRequestIcon className="size-3.5" />}
-                            {props.configured ? "Create another" : "Create app"}
-                          </Button>
-                        </div>
-                      </div>
+              {!props.configured ? (
+                <div className="space-y-3">
+                  <EmptyState
+                    icon={<GitBranchIcon className="size-5" />}
+                    title="No repositories connected"
+                    description="Connect the GitHub app so the sandbox can clone your repositories, push branches, and open pull requests."
+                  />
+                  <div className="rounded-lg border border-border bg-bg/25 p-3">{setupForm}</div>
+                </div>
+              ) : props.repoBusy ? (
+                <div className="flex items-center gap-2 rounded-lg border border-border bg-bg/25 p-3 text-xs text-fg-muted">
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                  Loading repositories…
+                </div>
+              ) : !hasRepos ? (
+                <div className="space-y-3">
+                  <EmptyState
+                    icon={<GitBranchIcon className="size-5" />}
+                    title="No repositories connected"
+                    description="The connected GitHub app isn't sharing any repositories with this workspace yet."
+                    action={
+                      props.installUrl ? (
+                        <Button asChild type="button" variant="outline" size="sm" className="h-8 text-xs">
+                          <a href={props.installUrl}>
+                            <GitPullRequestIcon className="size-3.5" />
+                            Reinstall on GitHub
+                          </a>
+                        </Button>
+                      ) : undefined
+                    }
+                  />
+                  <Notice tone="waiting">
+                    If repositories are missing, the app may have been removed on GitHub — reinstall it.
+                  </Notice>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-bg/25 px-3 py-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <MetaChip dot="idle" rounded="full">GitHub app</MetaChip>
+                      {props.org ? (
+                        <span className="min-w-0 truncate text-2xs text-fg-subtle" title={props.org}>{props.org}</span>
+                      ) : null}
                     </div>
-                  </CollapsibleContent>
-                </div>
-              </Collapsible>
+                    {props.installUrl ? (
+                      <a
+                        href={props.installUrl}
+                        className="shrink-0 text-2xs text-fg-subtle underline-offset-2 transition-colors hover:text-fg hover:underline"
+                      >
+                        Reconnect
+                      </a>
+                    ) : null}
+                  </div>
 
-              <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
-                <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
-                  <div className="text-xs font-medium text-fg">Installed repositories</div>
-                  <div className="text-2xs text-fg-subtle">
-                    {props.configured ? `${props.repositories.length} available` : "GitHub not configured"}
-                  </div>
-                </div>
-
-                {!props.configured ? (
-                  <div className="p-3 text-xs leading-5 text-fg-muted">
-                    Configure and install the GitHub App to select repositories.
-                  </div>
-                ) : props.repoBusy ? (
-                  <div className="flex items-center gap-2 p-3 text-xs text-fg-muted">
-                    <Loader2Icon className="size-3.5 animate-spin" />
-                    Loading repositories
-                  </div>
-                ) : props.repositories.length === 0 ? (
-                  <div className="p-3 text-xs leading-5 text-fg-muted">
-                    No installed repositories found. Install the app on a repository, then refresh.
-                  </div>
-                ) : (
-                  <div className="max-h-80 overflow-auto">
-                    {props.groups.map((group) => (
-                      <div key={group.installationId} className="border-b border-border last:border-b-0">
-                        <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
-                          <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">{group.label}</div>
-                          <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">{group.repositories.length} repos</div>
-                        </div>
-                        <div className="divide-y divide-border/70">
-                          {group.repositories.map((repo) => {
-                            const checked = props.selectedRepoIds.has(repo.id);
-                            const blocked = props.selectedInstallationId !== null && props.selectedInstallationId !== repo.installationId && !checked;
-                            return (
-                              <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-surface-2/45", blocked && "opacity-55")}>
-                                <button
-                                  type="button"
-                                  onClick={() => props.onToggleRepo(repo)}
-                                  disabled={props.pending}
-                                  aria-pressed={checked}
-                                  aria-label={`Select ${repo.fullName}`}
-                                  className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md text-left outline-none"
-                                >
-                                  <span
-                                    className={cn(
-                                      "flex size-4 items-center justify-center rounded border",
-                                      checked
-                                        ? "border-brand bg-brand-strong text-brand-fg"
-                                        : "border-border-strong bg-surface",
-                                    )}
+                  <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
+                    <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+                      <div className="min-w-0 truncate text-xs font-medium text-fg">Repositories</div>
+                      <div className="shrink-0 text-2xs text-fg-subtle">{props.repositories.length} available</div>
+                    </div>
+                    <div className="max-h-80 overflow-auto">
+                      {props.groups.map((group) => (
+                        <div key={group.installationId} className="border-b border-border last:border-b-0">
+                          <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
+                            <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">{group.label}</div>
+                            <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">{group.repositories.length} repos</div>
+                          </div>
+                          <div className="divide-y divide-border/70">
+                            {group.repositories.map((repo) => {
+                              const checked = props.selectedRepoIds.has(repo.id);
+                              const blocked = props.selectedInstallationId !== null && props.selectedInstallationId !== repo.installationId && !checked;
+                              return (
+                                <div key={`${repo.installationId}:${repo.id}`} className={cn("px-2 py-2 transition-colors hover:bg-surface-2/45", blocked && "opacity-55")}>
+                                  <button
+                                    type="button"
+                                    onClick={() => props.onToggleRepo(repo)}
+                                    disabled={props.pending}
+                                    aria-pressed={checked}
+                                    aria-label={`Select ${repo.fullName}`}
+                                    className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md text-left outline-none"
                                   >
-                                    {checked ? <CheckIcon className="size-3" /> : null}
-                                  </span>
-                                  <span className="min-w-0">
-                                    <span className="flex min-w-0 items-center gap-1.5">
-                                      <span className="truncate text-xs font-medium text-fg">{repo.fullName}</span>
-                                      {repo.private ? <LockIcon className="size-3 shrink-0 text-fg-subtle" /> : null}
+                                    <span
+                                      className={cn(
+                                        "flex size-4 items-center justify-center rounded border",
+                                        checked
+                                          ? "border-brand bg-brand-strong text-brand-fg"
+                                          : "border-border-strong bg-surface",
+                                      )}
+                                    >
+                                      {checked ? <CheckIcon className="size-3" /> : null}
                                     </span>
-                                    <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
-                                      default {repo.defaultBranch}
+                                    <span className="min-w-0">
+                                      <span className="flex min-w-0 items-center gap-1.5">
+                                        <span className="truncate text-xs font-medium text-fg">{repo.fullName}</span>
+                                        {repo.private ? <LockIcon className="size-3 shrink-0 text-fg-subtle" /> : null}
+                                      </span>
+                                      <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
+                                        default {repo.defaultBranch}
+                                      </span>
                                     </span>
-                                  </span>
-                                  {blocked ? (
-                                    <MetaChip dot="waiting" rounded="full">Other app</MetaChip>
-                                  ) : checked ? (
-                                    <MetaChip dot="idle" rounded="full">Selected</MetaChip>
+                                    {blocked ? (
+                                      <MetaChip dot="waiting" rounded="full">Other app</MetaChip>
+                                    ) : checked ? (
+                                      <MetaChip dot="idle" rounded="full">Selected</MetaChip>
+                                    ) : null}
+                                  </button>
+                                  {checked ? (
+                                    <div className="mt-2 flex items-center gap-2 pl-6">
+                                      <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
+                                      <Input
+                                        value={props.selectedRepoRefs[repo.id] ?? repo.defaultBranch}
+                                        onChange={(event) => props.onRefChange(repo.id, event.target.value)}
+                                        onClick={(event) => event.stopPropagation()}
+                                        disabled={props.pending}
+                                        placeholder={repo.defaultBranch}
+                                        aria-label={`${repo.fullName} ref`}
+                                        className="h-7 text-xs"
+                                      />
+                                    </div>
                                   ) : null}
-                                </button>
-                                {checked ? (
-                                  <div className="mt-2 flex items-center gap-2 pl-6">
-                                    <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
-                                    <Input
-                                      value={props.selectedRepoRefs[repo.id] ?? repo.defaultBranch}
-                                      onChange={(event) => props.onRefChange(repo.id, event.target.value)}
-                                      onClick={(event) => event.stopPropagation()}
-                                      disabled={props.pending}
-                                      placeholder={repo.defaultBranch}
-                                      aria-label={`${repo.fullName} ref`}
-                                      className="h-7 text-xs"
-                                    />
-                                  </div>
-                                ) : null}
-                              </div>
-                            );
-                          })}
+                                </div>
+                              );
+                            })}
+                          </div>
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </section>
+                      ))}
+                    </div>
+                  </section>
+
+                  <Collapsible open={props.githubAppOpen} onOpenChange={props.onGitHubAppOpenChange}>
+                    <div className="rounded-lg border border-border bg-bg/25">
+                      <CollapsibleTrigger asChild>
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-fg transition-colors hover:bg-surface-2/60"
+                        >
+                          <ChevronDownIcon className={cn("size-3.5 shrink-0 text-fg-subtle transition-transform", props.githubAppOpen && "rotate-180")} />
+                          <span className="truncate">GitHub app settings</span>
+                        </button>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <div className="border-t border-border p-3">{setupForm}</div>
+                      </CollapsibleContent>
+                    </div>
+                  </Collapsible>
+                </>
+              )}
 
               <Collapsible open={props.manualOpen} onOpenChange={props.onManualOpenChange}>
                 <div className="rounded-lg border border-border bg-bg/25">
@@ -289,13 +326,13 @@ export function RepositoryContextPicker(props: {
                     <CollapsibleTrigger asChild>
                       <button type="button" className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left text-xs font-medium text-fg">
                         <ChevronDownIcon className={cn("size-3.5 shrink-0 text-fg-subtle transition-transform", props.manualOpen && "rotate-180")} />
-                        <span className="truncate">Manual repositories</span>
-                        {manualCount > 0 ? <span className="rounded-full border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">{manualCount}</span> : null}
+                        <span className="truncate">Add by URL</span>
+                        {manualCount > 0 ? <MetaChip rounded="full">{manualCount}</MetaChip> : null}
                       </button>
                     </CollapsibleTrigger>
                     <Button type="button" variant="ghost" size="xs" onClick={props.onManualAdd} disabled={props.pending} className="h-7 text-xs">
                       <PlusIcon className="size-3" />
-                      Add URL
+                      Add
                     </Button>
                   </div>
 
@@ -303,7 +340,7 @@ export function RepositoryContextPicker(props: {
                     <div className="space-y-2 border-t border-border p-3">
                       {props.manualRepos.length === 0 ? (
                         <p className="text-xs leading-5 text-fg-muted">
-                          Add HTTPS Git repositories that do not use the GitHub App token.
+                          Add HTTPS Git repositories that don't use the GitHub app token.
                         </p>
                       ) : (
                         props.manualRepos.map((repo) => (

--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -116,6 +116,29 @@ export function RepositoryContextPicker(props: {
     </div>
   );
 
+  // The recovery path must stay reachable in EVERY configured state — including
+  // configured-but-zero-repos (the stale-app case), where installUrl may be
+  // absent and the settings form is the only way to reconnect or re-create.
+  const settingsDisclosure = (
+    <Collapsible open={props.githubAppOpen} onOpenChange={props.onGitHubAppOpenChange}>
+      <div className="rounded-lg border border-border bg-bg/25">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-fg transition-colors hover:bg-surface-2/60"
+          >
+            <ChevronDownIcon className={cn("size-3.5 shrink-0 text-fg-subtle transition-transform", props.githubAppOpen && "rotate-180")} />
+            <span className="truncate">GitHub app settings</span>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t border-border p-3">{setupForm}</div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -207,6 +230,7 @@ export function RepositoryContextPicker(props: {
                   <Notice tone="waiting">
                     If repositories are missing, the app may have been removed on GitHub — reinstall it.
                   </Notice>
+                  {settingsDisclosure}
                 </div>
               ) : (
                 <>
@@ -301,22 +325,7 @@ export function RepositoryContextPicker(props: {
                     </div>
                   </section>
 
-                  <Collapsible open={props.githubAppOpen} onOpenChange={props.onGitHubAppOpenChange}>
-                    <div className="rounded-lg border border-border bg-bg/25">
-                      <CollapsibleTrigger asChild>
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-fg transition-colors hover:bg-surface-2/60"
-                        >
-                          <ChevronDownIcon className={cn("size-3.5 shrink-0 text-fg-subtle transition-transform", props.githubAppOpen && "rotate-180")} />
-                          <span className="truncate">GitHub app settings</span>
-                        </button>
-                      </CollapsibleTrigger>
-                      <CollapsibleContent>
-                        <div className="border-t border-border p-3">{setupForm}</div>
-                      </CollapsibleContent>
-                    </div>
-                  </Collapsible>
+                  {settingsDisclosure}
                 </>
               )}
 

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -125,7 +125,10 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 pt-10 pb-16 sm:px-6 sm:pt-16">
+    // The canvas parent is overflow-hidden, so this route owns its scrolling —
+    // without it the page clips (recent sessions were unreachable below the fold).
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col px-4 pt-10 pb-16 sm:px-6 sm:pt-16">
       <section className="flex flex-col items-center gap-2 text-center">
         <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
           What should the agent do?
@@ -184,6 +187,7 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
       </div>
 
       <RecentSessions workspaceId={workspaceId} />
+      </div>
     </div>
   );
 }
@@ -209,7 +213,9 @@ function RecentSessions({ workspaceId }: { workspaceId: string }) {
       <h2 className="mb-2 px-0.5 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
         Recent sessions
       </h2>
-      <ul className="grid gap-1">
+      {/* flex-col, not grid: a grid auto track grows to a nowrap row's full
+          min-content width, defeating truncate and overflowing the page. */}
+      <ul className="flex min-w-0 flex-col gap-1">
         {recent.map((session) => (
           <RecentSessionRow key={session.id} workspaceId={workspaceId} session={session} />
         ))}
@@ -241,7 +247,7 @@ function RecentSessionRow({ workspaceId, session }: { workspaceId: string; sessi
   const title = session.title?.trim() || session.initialMessage?.trim() || "Untitled session";
   const meta = [session.model, sessionRepoLabel(session)].filter(Boolean).join(" · ");
   return (
-    <li>
+    <li className="min-w-0">
       <Link
         to="/workspaces/$workspaceId/sessions/$sessionId"
         params={{ workspaceId, sessionId: session.id }}
@@ -320,33 +326,6 @@ function WorkspaceRepositoryPicker({ workspaceId, disabled }: { workspaceId: str
   );
 }
 
-// Local opt-in flag for the Connected Machine path. The DEFAULT (no machines, no
-// opt-in) is the clean sandbox-only composer; this lets a user reveal the machine
-// option before/while enrolling their first machine. Mirrors the rail's
-// localStorage pattern (safe under SSR / private mode).
-// TODO(settings): promote this localStorage flag into a real persisted setting on
-// the Settings surface (workspace- or account-scoped) and surface the toggle there.
-const CONNECTED_MACHINES_OPTIN_KEY = "opengeni.composer.connectedMachines";
-
-function readConnectedMachinesOptIn(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  try {
-    return window.localStorage.getItem(CONNECTED_MACHINES_OPTIN_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function persistConnectedMachinesOptIn(value: boolean): void {
-  try {
-    window.localStorage.setItem(CONNECTED_MACHINES_OPTIN_KEY, String(value));
-  } catch {
-    // localStorage may be unavailable (private mode); keep the in-memory value.
-  }
-}
-
 // ── The promoted top-level compute target (the parent that gates the band) ────
 
 function ComputeTargetControl(props: {
@@ -380,12 +359,9 @@ function ComputeTargetControl(props: {
   // shows the clean sandbox-only flow (byte-identical submission to before this
   // redesign). Once machines exist, the control is always shown. A lightweight
   // local opt-in lets a user reveal the option before/while enrolling.
-  const [optedIn, setOptedIn] = useState<boolean>(() => readConnectedMachinesOptIn());
-  const revealConnectedMachines = () => {
-    setOptedIn(true);
-    persistConnectedMachinesOptIn(true);
-  };
-  const showComputeTarget = !fleetEmpty || optedIn;
+  // No teaser for absent hardware: the segmented control exists only when the
+  // fleet has machines. Discovery lives on the Machines page, not the composer.
+  const showComputeTarget = !fleetEmpty;
 
   // Defensive: if the segmented control is hidden (clean flow) while a stale draft
   // still points at a machine (e.g. the last machine just left the fleet), fall
@@ -428,7 +404,6 @@ function ComputeTargetControl(props: {
           disabled={props.disabled}
         />
         {fleetLoadFailed ? <FleetErrorNotice onRetry={() => void fleet.refresh()} /> : null}
-        <RevealConnectedMachinesButton onClick={revealConnectedMachines} disabled={props.disabled} />
       </section>
     );
   }
@@ -563,6 +538,9 @@ function ManagedSandboxFields(props: {
         </p>
       </div>
 
+      {/* Offer environments only when some exist — configuration UI for
+          resources you don't have is clutter (same rule as machines). */}
+      {environments.environments.length > 0 ? (
       <div className="grid gap-2 border-t border-border pt-4">
         <Label className="flex items-center gap-1.5 text-xs">
           <BoxIcon className="size-3 shrink-0 text-fg-subtle" />
@@ -584,6 +562,7 @@ function ManagedSandboxFields(props: {
           Variables are set in the sandbox at start. Their values stay write-only.
         </p>
       </div>
+      ) : null}
 
       {/* Low-level sandbox backend override — demoted into this kind's Advanced
           detail, descriptor-driven from CAPABILITY_DESCRIPTORS. */}
@@ -760,30 +739,6 @@ function CapabilityChip({ children }: { children: ReactNode }) {
     <span className="inline-flex items-center rounded-md border border-border bg-surface-2/60 px-1.5 py-0.5 text-2xs font-medium text-fg-muted">
       {children}
     </span>
-  );
-}
-
-// The opt-in affordance that reveals the Connected Machine path from the clean
-// sandbox-only flow. A quiet secondary action, tied to the compute area, with a
-// reveal-arrow on hover.
-function RevealConnectedMachinesButton(props: { onClick: () => void; disabled: boolean }) {
-  return (
-    <button
-      type="button"
-      onClick={props.onClick}
-      disabled={props.disabled}
-      className={cn(
-        "group inline-flex items-center gap-2 justify-self-start rounded-md px-1.5 py-1 text-2xs transition-colors",
-        "text-fg-subtle hover:text-fg-muted",
-        "disabled:cursor-not-allowed disabled:opacity-60",
-      )}
-    >
-      <span className="flex size-5 shrink-0 items-center justify-center rounded-md border border-border bg-surface-2/50 text-fg-subtle transition-colors group-hover:border-border-strong group-hover:text-fg-muted">
-        <ServerIcon className="size-3" />
-      </span>
-      <span>Run on your own connected machine</span>
-      <ArrowRightIcon className="size-3 -translate-x-1 opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100" />
-    </button>
   );
 }
 

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -251,3 +251,98 @@ export function unwrapMcpOutput(output: unknown): { text: string; isError: boole
   }
   return { text: typeof output === "string" ? output : output == null ? "" : JSON.stringify(output), isError: false };
 }
+
+/* --- computer-use screenshot extraction ------------------------------------- */
+
+/**
+ * Extract a renderable `data:` URL from a computer-use screenshot output,
+ * whatever transport produced it. The hosted `computer_call` and the
+ * function-text mode persist a plain `data:image/...` string; the
+ * function-image mode (codex-backed sessions) persists the STRUCTURED image
+ * output — `{type:"image", image:{data, mediaType}}` with `data` arriving as a
+ * number array / index map / Buffer-JSON / base64 string after event
+ * serialization — or the agents-core normalized `input_image` content item.
+ * Returns null when the output carries no image (so callers fall back to their
+ * text/empty presentation).
+ */
+export function screenshotDataUrl(out: unknown): string | null {
+  if (typeof out === "string") {
+    if (out.startsWith("data:image")) {
+      return out;
+    }
+    // A JSON-encoded structured output (some transports stringify tool results).
+    if (out.startsWith("{") || out.startsWith("[")) {
+      const parsed = tryParseJson(out);
+      if (parsed !== undefined && parsed !== out) {
+        return screenshotDataUrl(parsed);
+      }
+    }
+    return null;
+  }
+  if (Array.isArray(out)) {
+    for (const entry of out) {
+      const url = screenshotDataUrl(entry);
+      if (url) {
+        return url;
+      }
+    }
+    return null;
+  }
+  if (out === null || typeof out !== "object") {
+    return null;
+  }
+  const record = out as Record<string, unknown>;
+  // agents-core normalized content item: {type:"input_image", image_url: "data:…" | {url}}
+  const imageUrl = record.image_url ?? record.imageUrl;
+  if (typeof imageUrl === "string" && imageUrl.startsWith("data:image")) {
+    return imageUrl;
+  }
+  if (imageUrl && typeof imageUrl === "object") {
+    const url = (imageUrl as Record<string, unknown>).url;
+    if (typeof url === "string" && url.startsWith("data:image")) {
+      return url;
+    }
+  }
+  // Structured tool output: {type:"image", image:{data, mediaType}}
+  const image = record.image as Record<string, unknown> | undefined;
+  if (image && typeof image === "object") {
+    const mediaType = typeof image.mediaType === "string" ? image.mediaType : "image/png";
+    const base64 = bytesToBase64(image.data);
+    if (base64) {
+      return `data:${mediaType};base64,${base64}`;
+    }
+    if (typeof image.data === "string" && image.data.length > 0) {
+      // Already base64 text.
+      return `data:${mediaType};base64,${image.data}`;
+    }
+  }
+  return null;
+}
+
+/** Serialize whatever a Uint8Array became in JSON (number[], {"0":n,…} index
+ *  map, or Buffer-JSON {type:"Buffer",data:[…]}) back into base64. */
+function bytesToBase64(data: unknown): string | null {
+  let bytes: number[] | null = null;
+  if (Array.isArray(data) && data.every((n) => typeof n === "number")) {
+    bytes = data as number[];
+  } else if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    if (record.type === "Buffer" && Array.isArray(record.data)) {
+      bytes = record.data as number[];
+    } else {
+      const keys = Object.keys(record);
+      if (keys.length > 0 && keys.every((key) => /^\d+$/.test(key))) {
+        bytes = keys.sort((a, b) => Number(a) - Number(b)).map((key) => Number(record[key]));
+      }
+    }
+  }
+  if (!bytes || bytes.length === 0) {
+    return null;
+  }
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.slice(i, i + CHUNK));
+  }
+  return typeof btoa === "function" ? btoa(binary) : Buffer.from(binary, "binary").toString("base64");
+}

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -322,27 +322,36 @@ export function screenshotDataUrl(out: unknown): string | null {
 /** Serialize whatever a Uint8Array became in JSON (number[], {"0":n,…} index
  *  map, or Buffer-JSON {type:"Buffer",data:[…]}) back into base64. */
 function bytesToBase64(data: unknown): string | null {
+  const isByte = (n: unknown): n is number => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255;
   let bytes: number[] | null = null;
-  if (Array.isArray(data) && data.every((n) => typeof n === "number")) {
-    bytes = data as number[];
+  if (Array.isArray(data) && data.every(isByte)) {
+    bytes = data;
   } else if (data && typeof data === "object") {
     const record = data as Record<string, unknown>;
-    if (record.type === "Buffer" && Array.isArray(record.data)) {
-      bytes = record.data as number[];
+    if (record.type === "Buffer" && Array.isArray(record.data) && record.data.every(isByte)) {
+      bytes = record.data;
     } else {
       const keys = Object.keys(record);
       if (keys.length > 0 && keys.every((key) => /^\d+$/.test(key))) {
-        bytes = keys.sort((a, b) => Number(a) - Number(b)).map((key) => Number(record[key]));
+        const values = keys.sort((a, b) => Number(a) - Number(b)).map((key) => record[key]);
+        if (values.every(isByte)) {
+          bytes = values;
+        }
       }
     }
   }
   if (!bytes || bytes.length === 0) {
     return null;
   }
-  let binary = "";
-  const CHUNK = 0x8000;
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.slice(i, i + CHUNK));
+  try {
+    let binary = "";
+    const CHUNK = 0x8000;
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+      binary += String.fromCharCode(...bytes.slice(i, i + CHUNK));
+    }
+    return typeof btoa === "function" ? btoa(binary) : Buffer.from(binary, "binary").toString("base64");
+  } catch {
+    // A hostile/absurd payload must degrade to "no image", never crash a render.
+    return null;
   }
-  return typeof btoa === "function" ? btoa(binary) : Buffer.from(binary, "binary").toString("base64");
 }

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -15,7 +15,7 @@ import {
   WrenchIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { stringifyPayload } from "../lib/format";
+import { stringifyPayload, tryParseJson } from "../lib/format";
 import {
   applyPatchOps,
   controlCaret,
@@ -30,6 +30,7 @@ import {
   tailPeek,
   unwrapMcpOutput,
   v4aToGitFileDiff,
+  screenshotDataUrl,
   type ApplyPatchOperation,
 } from "./parsers";
 import { createToolRegistry, type ToolRegistry, type ToolRegistryEntry, type ToolRendererProps } from "./registry";
@@ -477,20 +478,49 @@ function computerVerb(action: ComputerAction | undefined): string {
   }
 }
 
+
+/** Coerce a function-tool arguments payload into the ComputerAction fields. */
+function asComputerArgs(args: unknown): Partial<ComputerAction> {
+  if (!args) {
+    return {};
+  }
+  const parsed = typeof args === "string" ? tryParseJson(args) : args;
+  if (!parsed || typeof parsed !== "object") {
+    return {};
+  }
+  const record = parsed as Record<string, unknown>;
+  return {
+    ...(typeof record.x === "number" ? { x: record.x } : {}),
+    ...(typeof record.y === "number" ? { y: record.y } : {}),
+    ...(typeof record.text === "string" ? { text: record.text } : {}),
+    ...(Array.isArray(record.keys) ? { keys: record.keys as string[] } : {}),
+    ...(typeof record.button === "string" ? { button: record.button } : {}),
+  };
+}
+
 function ComputerCallRenderer({ item }: ToolRendererProps) {
   const raw = (item.raw ?? {}) as {
     action?: ComputerAction;
     actions?: ComputerAction[];
     providerData?: { approvalStatus?: string };
   };
-  const action = raw.action;
+  // Function-mode computer tools (computer_screenshot / computer_click / …,
+  // used on codex + chat-wire providers since the explicit tool-transport
+  // change) carry the action in the tool NAME + arguments instead of raw.action.
+  // Normalize them into the same ComputerAction shape so one renderer serves
+  // every transport.
+  const functionAction: ComputerAction | undefined =
+    !raw.action && item.name.startsWith("computer_") && item.name !== "computer_call"
+      ? { type: item.name.slice("computer_".length), ...(asComputerArgs(item.arguments)) }
+      : undefined;
+  const action = raw.action ?? functionAction;
   const actions = raw.actions ?? (action ? [action] : []);
   const verb = computerVerb(action);
   const out = item.output;
   const running = item.status === "running";
   const rejected = raw.providerData?.approvalStatus === "rejected";
   const readOnly = typeof out === "string" && out.includes("read-only");
-  const isImage = typeof out === "string" && out.startsWith("data:image");
+  const shotUrl = screenshotDataUrl(out);
   const empty = out === "" || out == null;
   const batched = actions.length > 1 ? actions.map((a) => computerVerb(a)).join(" · ") : null;
   // Fold the batched-action count into the title (one media affordance per row),
@@ -542,8 +572,8 @@ function ComputerCallRenderer({ item }: ToolRendererProps) {
   const isFailed = item.status === "failed";
   const isCancelled = item.status === "cancelled";
 
-  if (isImage && typeof out === "string") {
-    const caption = `computer_call · ${verb}${actions.length > 1 ? ` (+${actions.length - 1} more)` : ""}`;
+  if (shotUrl) {
+    const caption = `${verb}${actions.length > 1 ? ` (+${actions.length - 1} more)` : ""}`;
     return (
       <ActivityDisclosure
         icon={isShot ? <CameraIcon className={ICON_SIZE} /> : <MousePointer2Icon className={ICON_SIZE} />}
@@ -551,9 +581,9 @@ function ComputerCallRenderer({ item }: ToolRendererProps) {
         title={`${verb}${countSuffix}`}
         failed={isFailed}
         cancelled={isCancelled}
-        media={<Thumbnail src={out} caption={caption} />}
+        media={<Thumbnail src={shotUrl} caption={caption} />}
       >
-        <ScreenshotFigure src={out} caption={caption} />
+        <ScreenshotFigure src={shotUrl} caption={caption} />
         {batched ? <BodyNote>batched: {batched}</BodyNote> : null}
       </ActivityDisclosure>
     );
@@ -866,6 +896,15 @@ const BASE_ENTRIES: ToolRegistryEntry[] = [
   { match: "name", name: "write_stdin", render: WriteStdinRenderer },
   { match: "name", name: "apply_patch_call", render: ApplyPatchRenderer },
   { match: "name", name: "computer_call", render: ComputerCallRenderer },
+  // Function-mode computer tools (codex / chat-wire transports).
+  { match: "name", name: "computer_screenshot", render: ComputerCallRenderer },
+  { match: "name", name: "computer_click", render: ComputerCallRenderer },
+  { match: "name", name: "computer_double_click", render: ComputerCallRenderer },
+  { match: "name", name: "computer_move", render: ComputerCallRenderer },
+  { match: "name", name: "computer_scroll", render: ComputerCallRenderer },
+  { match: "name", name: "computer_type", render: ComputerCallRenderer },
+  { match: "name", name: "computer_keypress", render: ComputerCallRenderer },
+  { match: "name", name: "computer_drag", render: ComputerCallRenderer },
   { match: "name", name: "web_search_call", render: WebSearchRenderer },
   { match: "name", name: "view_image", render: ViewImageRenderer },
   { match: "name", name: "environment_set_variable", render: SecretSetRenderer },

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Collapsible } from "radix-ui";
 import { cn } from "../lib/cn";
 import { useForcedDefaultOpen } from "./disclosure-context";
-import { applyPatchOps, isApplyPatch } from "./parsers";
+import { applyPatchOps, isApplyPatch, screenshotDataUrl } from "./parsers";
 import { rawTypeOf } from "./registry";
 import type { ActivityItem, TurnOutcome } from "./types";
 export type { TurnOutcome } from "./types";
@@ -124,8 +124,8 @@ function summarizeTurn(items: ActivityItem[], durationMs?: number): string {
       files += applyPatchOps(item.raw).length;
     } else if (item.name === "exec_command") {
       commands += 1;
-    } else if (rawTypeOf(item) === "computer_call" || item.name === "computer_call") {
-      if (typeof item.output === "string" && item.output.startsWith("data:image")) {
+    } else if (rawTypeOf(item) === "computer_call" || item.name === "computer_call" || item.name === "computer_screenshot") {
+      if (screenshotDataUrl(item.output) !== null) {
         screenshots += 1;
       }
     }

--- a/packages/react/test/screenshot-parsing.test.ts
+++ b/packages/react/test/screenshot-parsing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { screenshotDataUrl } from "../src/timeline/parsers";
+
+// A 1x1 PNG's first bytes are enough for the extractor (it never decodes).
+const BYTES = [137, 80, 78, 71, 13, 10, 26, 10];
+const B64 = Buffer.from(Uint8Array.from(BYTES)).toString("base64");
+
+describe("screenshotDataUrl — every computer-use transport shape", () => {
+  test("hosted / function-text: plain data URL passes through", () => {
+    expect(screenshotDataUrl("data:image/png;base64,AAAA")).toBe("data:image/png;base64,AAAA");
+  });
+
+  test("non-image strings return null", () => {
+    expect(screenshotDataUrl("clicked left at (3, 4)")).toBeNull();
+    expect(screenshotDataUrl("")).toBeNull();
+    expect(screenshotDataUrl(null)).toBeNull();
+  });
+
+  test("function-image: structured output with number-array bytes", () => {
+    const out = { type: "image", image: { data: BYTES, mediaType: "image/png" } };
+    expect(screenshotDataUrl(out)).toBe(`data:image/png;base64,${B64}`);
+  });
+
+  test("function-image: Buffer-JSON bytes", () => {
+    const out = { type: "image", image: { data: { type: "Buffer", data: BYTES }, mediaType: "image/png" } };
+    expect(screenshotDataUrl(out)).toBe(`data:image/png;base64,${B64}`);
+  });
+
+  test("function-image: index-map bytes (Uint8Array JSON.stringify)", () => {
+    const data = Object.fromEntries(BYTES.map((b, i) => [String(i), b]));
+    const out = { type: "image", image: { data, mediaType: "image/png" } };
+    expect(screenshotDataUrl(out)).toBe(`data:image/png;base64,${B64}`);
+  });
+
+  test("agents-core normalized input_image content item (string and {url})", () => {
+    expect(screenshotDataUrl({ type: "input_image", image_url: "data:image/png;base64,AA" })).toBe("data:image/png;base64,AA");
+    expect(screenshotDataUrl([{ type: "input_image", image_url: { url: "data:image/png;base64,BB" } }])).toBe("data:image/png;base64,BB");
+  });
+
+  test("JSON-stringified structured output", () => {
+    const out = JSON.stringify({ type: "image", image: { data: BYTES, mediaType: "image/png" } });
+    expect(screenshotDataUrl(out)).toBe(`data:image/png;base64,${B64}`);
+  });
+});


### PR DESCRIPTION
Follow-up round from user review of the merged polish (#203), plus a rendering regression fix.

- **Home page scrolls** — the route now owns its scrolling (the canvas parent is overflow-hidden; recent sessions were unreachable below the fold)
- **Recent sessions overflow fixed** — flex column + min-w-0 (a CSS grid auto track grew to the nowrap rows' min-content width, defeating truncation and pushing cards off-screen)
- **De-clutter**: the Connected-machine teaser is gone (the compute segmented control exists only when machines exist; discovery lives on the Machines page; localStorage opt-in removed); the Environment select renders only when the workspace has environments
- **Repo picker redesign**: guided "No repositories connected" state up front (no expand-to-discover-nothing), honest status chip instead of the unverifiable "Configured" (+ explicit stale-app hint: "the app may have been removed on GitHub — reinstall it"), manual repos demoted to a quiet "Add by URL" disclosure
- **Computer-use rendering regression** (from the #209 tool-transport change): function-mode tools (`computer_screenshot` / `computer_click` / …) now route to the computer renderer; screenshots are extracted from every transport shape — plain data-URL, structured image bytes (number[] / index-map / Buffer-JSON / base64), and `input_image` items — instead of dumping raw payloads into the timeline. Turn summaries count them again. 7 shape-pinning tests.

Verified: typecheck green (apps/web + packages/react), production build green, 523 tests / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/layout and client-side timeline parsing only; no auth, API, or session submission logic changes beyond hiding optional composer controls when empty.
> 
> **Overview**
> Follow-up polish on the session home and repository picker, plus a **timeline fix** for computer-use after the function-tool transport change.
> 
> **Sessions home** — The index route now scrolls inside an `overflow-y-auto` wrapper so **Recent sessions** isn’t clipped by the canvas. Recent rows use **flex + `min-w-0`** so titles truncate instead of overflowing. The composer drops the **“run on your connected machine”** localStorage teaser; the compute segmented control appears **only when machines exist**, and the **Environment** picker shows **only when the workspace has environments**.
> 
> **Repository picker** — Replaces the old collapsible “GitHub App” block with **guided empty states** (`EmptyState` + inline setup when unconfigured; reinstall hint + **Notice** when configured but zero repos). With repos, a compact **GitHub app** status row and **GitHub app settings** disclosure hold org/install/create actions; manual repos move under **“Add by URL”**.
> 
> **Timeline (`packages/react`)** — Adds **`screenshotDataUrl`** to normalize screenshot payloads (data URLs, structured image bytes, `input_image`). **`ComputerCallRenderer`** maps **`computer_*` function tools** from name/args and registers them in the tool registry; **turn summaries** count screenshots again via the same helper. **7 tests** pin parsing shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081208574d9a285b5623cbcbca6f06c93bf8752d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->