### PR TITLE
fix(react): failed turns stop painting their interrupted steps red

### DIFF
--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -319,7 +319,11 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "turn.failed": {
         const hadActivity = hasTurnActivity(items, turnId);
         const failureText = failureMessage(payload);
-        finalizeOpen(turnId, "failed");
+        // The TURN failed — the in-flight items did not. Chip doctrine: red is
+        // spent once, on the turn-level outcome. Items caught mid-flight read
+        // as calm "interrupted" (same as turn.cancelled); an item that itself
+        // failed keeps its own failed status from its output event.
+        finalizeOpen(turnId, "cancelled");
         items.push(turnEndItem(event, "failed", failureText));
         if (!hadActivity) {
           items.push({

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -549,14 +549,16 @@ describe("buildTimeline", () => {
     expect(afterUserBoundary.map((item) => item.kind)).toEqual(["tool-call", "user-message", "turn-end", "notice"]);
   });
 
-  // Fix 3: in-flight tools when turn.failed must become "failed", not "complete"
-  test("turn.failed marks in-flight tool calls as failed (not complete)", () => {
+  // Chip doctrine: the TURN failed — items caught mid-flight did not. Red is
+  // spent once (the turn-level outcome); interrupted items read as calm
+  // "cancelled"/interrupted, never as their own failure.
+  test("turn.failed marks in-flight tool calls as interrupted (not failed, not complete)", () => {
     reset();
     const items = buildTimeline([
       event("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "make build" } }),
       event("turn.failed", { error: "model provider unavailable" }),
     ]);
-    expect((items[0] as ToolCallItem).status).toBe("failed");
+    expect((items[0] as ToolCallItem).status).toBe("cancelled");
   });
 
   test("turn.cancelled marks in-flight tool calls as cancelled (not failed, not complete)", () => {
@@ -568,13 +570,13 @@ describe("buildTimeline", () => {
     expect((items[0] as ToolCallItem).status).toBe("cancelled");
   });
 
-  test("turn.failed marks in-flight sandbox operations as failed", () => {
+  test("turn.failed marks in-flight sandbox operations as interrupted", () => {
     reset();
     const items = buildTimeline([
       event("sandbox.operation.started", { name: "exec", command: "terraform apply" }),
       event("turn.failed", { error: "storage error" }),
     ]);
-    expect((items[0] as SandboxItem).status).toBe("failed");
+    expect((items[0] as SandboxItem).status).toBe("cancelled");
   });
 
   test("turn.cancelled marks in-flight sandbox operations as cancelled (not failed)", () => {


### PR DESCRIPTION
User-reported: when a turn fails, every collapsed step under the fold showed the failed affordance — even steps that ran fine and were merely in flight when the turn died. The projection finalized in-flight items with status \`failed\` on \`turn.failed\`.

Per the chip doctrine (color is spent once, on the exception): the turn-level chip carries the one red signal; interrupted items now read as calm "interrupted" (the same treatment as \`turn.cancelled\`). Items that genuinely failed keep their own failed status from their output events. Pinning tests updated to the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure timeline projection and test contract change; no auth, data, or API surface. UI semantics only for failed-turn rendering.
> 
> **Overview**
> When a turn ends with **`turn.failed`**, in-flight tool calls, workers, and sandbox rows are finalized as **`cancelled`** (interrupted) instead of **`failed`**, matching **`turn.cancelled`** and the chip doctrine: the turn-level outcome carries the single red signal; steps caught mid-flight are not blamed individually.
> 
> The **`turn-end`** item still has outcome **`failed`** with failure text unchanged. Steps that actually error still get **`failed`** from their own output or sandbox failure events.
> 
> Tests in **`timeline.test.ts`** were updated to assert **`cancelled`** for in-flight tools and sandbox ops on **`turn.failed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9e7542cbf11f19eab0961ba52cb445faf0dace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->