### PR TITLE
fix(react): sub-clusters report their own outcome, not the turn's

### DIFF
--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -617,8 +617,19 @@ function stampTurnOutcome(groups: TimelineGroup[], turnEnd: TurnEndItem): void {
 }
 
 function applyTurnOutcome(group: Extract<TimelineGroup, { kind: "activity" }>, turnEnd: TurnEndItem): void {
-  group.outcome = turnEnd.outcome;
-  if (turnEnd.failureText) {
+  // A sub-cluster reports ITS OWN outcome, not the turn's. When a turn fails
+  // at step 7, clusters 1–6 completed — painting them all red says "everything
+  // broke" when one thing did. The turn-level fold carries the turn outcome;
+  // a cluster goes red only if an item inside it actually failed, and reads
+  // "cancelled" (interrupted) only when it holds the items cut off mid-flight.
+  if (turnEnd.outcome === "complete") {
+    group.outcome = "complete";
+    return;
+  }
+  const hasFailed = group.items.some((item) => "status" in item && item.status === "failed");
+  const hasInterrupted = group.items.some((item) => "status" in item && item.status === "cancelled");
+  group.outcome = hasFailed ? "failed" : hasInterrupted ? "cancelled" : "complete";
+  if (turnEnd.failureText && hasFailed) {
     group.failureText = turnEnd.failureText;
   }
 }

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -659,8 +659,10 @@ describe("groupTimeline", () => {
       ]),
     );
     const [activity] = activityGroups(groups);
-    expect(activity?.outcome).toBe("failed");
-    expect(activity?.failureText).toBe("model provider unavailable");
+    // The in-flight call was interrupted BY the failure — the cluster reads
+    // calm interrupted; the turn-level fold carries the red + failure text.
+    expect(activity?.outcome).toBe("cancelled");
+    expect(activity?.failureText).toBeUndefined();
   });
 
   test("a settled turn folds the full span and leaves the final agent message after it", () => {
@@ -822,8 +824,10 @@ describe("groupTimeline", () => {
     const [turn] = turnGroups(groups);
     expect(turn?.groups.map((group) => group.kind)).toEqual(["activity", "item", "activity"]);
     expect(activities).toHaveLength(2);
-    expect(activities.map((group) => group.outcome)).toEqual(["failed", "failed"]);
-    expect(activities.map((group) => group.failureText)).toEqual(["compiler exploded", "compiler exploded"]);
+    // Cluster outcomes are their own: the first (reasoning, settled) reads
+    // complete; the second held the interrupted in-flight call.
+    expect(activities.map((group) => group.outcome)).toEqual(["complete", "cancelled"]);
+    expect(activities.map((group) => group.failureText)).toEqual([undefined, undefined]);
   });
 
   test("sequential settled turns stamp only their own activity groups", () => {
@@ -839,10 +843,10 @@ describe("groupTimeline", () => {
     const activities = activityGroups(groups);
     expect(groups.map((group) => group.kind)).toEqual(["turn", "turn"]);
     expect(activities).toHaveLength(2);
-    expect(activities.map((group) => group.outcome)).toEqual(["complete", "failed"]);
+    expect(activities.map((group) => group.outcome)).toEqual(["complete", "cancelled"]);
     expect(activities.map((group) => group.items.map((item) => item.turnId))).toEqual([["turn-1"], ["turn-2"]]);
     expect(activities[0]?.failureText).toBeUndefined();
-    expect(activities[1]?.failureText).toBe("deploy failed");
+    expect(activities[1]?.failureText).toBeUndefined();
   });
 
   test("a null-turn failure stamps the trailing activity group", () => {
@@ -854,7 +858,7 @@ describe("groupTimeline", () => {
       ]),
     );
     const [activity] = activityGroups(groups);
-    expect(activity?.outcome).toBe("failed");
+    expect(activity?.outcome).toBe("cancelled");
   });
 
   test("a null-turn cancellation keeps the legacy finalize path (not a queued retraction)", () => {
@@ -902,3 +906,58 @@ describe("extractSessionRef", () => {
     expect(extractSessionRef(null)).toBeNull();
   });
 });
+
+describe("cluster outcomes inside a failed turn", () => {
+  // The user-reported case: a turn fails at its LAST step; the earlier
+  // sub-clusters all completed. Only the turn-level fold may show failed —
+  // completed clusters stay calm.
+  test("completed sub-clusters keep outcome complete when the turn fails later", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", { id: "c1", name: "exec_command", arguments: { cmd: "ls" } }),
+      event("agent.toolCall.output", { id: "c1", output: "ok" }),
+      event("agent.message.completed", { text: "Narration between clusters." }),
+      event("agent.toolCall.created", { id: "c2", name: "exec_command", arguments: { cmd: "pwd" } }),
+      event("agent.toolCall.output", { id: "c2", output: "/workspace" }),
+      event("turn.failed", { error: "context overflow" }),
+    ]);
+    const groups = groupTimeline(items);
+    const turnGroup = groups.find((group) => group.kind === "turn");
+    expect(turnGroup?.outcome).toBe("failed");
+    const activity = collectActivityGroups(groups);
+    expect(activity.length).toBeGreaterThan(0);
+    for (const cluster of activity) {
+      expect(cluster.outcome).toBe("complete");
+    }
+  });
+
+  test("only the cluster containing a genuinely failed item shows failed", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", { id: "c1", name: "exec_command", arguments: { cmd: "ls" } }),
+      event("agent.toolCall.output", { id: "c1", output: "ok" }),
+      event("agent.message.completed", { text: "Narration." }),
+      event("agent.toolCall.created", { id: "c2", name: "exec_command", arguments: { cmd: "boom" } }),
+      event("agent.toolCall.output", { id: "c2", output: "exit 1", error: true }),
+      event("turn.failed", { error: "tool failed" }),
+    ]);
+    const groups = groupTimeline(items);
+    const activity = collectActivityGroups(groups);
+    const outcomes = activity.map((cluster) => cluster.outcome);
+    expect(outcomes).toContain("failed");
+    expect(outcomes.filter((outcome) => outcome === "failed").length).toBe(1);
+  });
+});
+
+function collectActivityGroups(groups: ReturnType<typeof groupTimeline>) {
+  const out: Array<Extract<ReturnType<typeof groupTimeline>[number], { kind: "activity" }>> = [];
+  for (const group of groups) {
+    if (group.kind === "activity") out.push(group);
+    if (group.kind === "turn") {
+      for (const inner of group.groups) {
+        if (inner.kind === "activity") out.push(inner);
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
User-reported (second round — the first fix addressed in-flight items, this addresses the cluster chips): inside an expanded failed turn, every sub-cluster (the per-step groupings between agent messages) showed the failed affordance even though all their tools completed; only the turn's final moment failed.

\`stampTurnOutcome\` copied the turn outcome onto every activity group in the turn. Now a sub-cluster derives its outcome from its own items: failed only if an item inside it failed; interrupted only if it holds the mid-flight items the failure cut off; otherwise complete. The turn-level fold alone carries the turn's red + failure text.

400 react tests green (4 old pinning tests updated to the new contract, 2 new cases added — including the exact reported scenario: all-complete clusters + late turn failure → clusters stay calm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure timeline projection/UI semantics change in `@opengeni/react` with broad test updates; no auth, data, or API surface changes.
> 
> **Overview**
> **Activity sub-clusters inside an expanded failed turn no longer inherit the turn’s failed chip.** `applyTurnOutcome` in `projection.ts` used to copy `turnEnd.outcome` (and often `failureText`) onto every activity group in the turn, so completed steps looked red when only the turn’s final moment failed.
> 
> **New rules:** on a completed turn, clusters still get `complete`. On failed/cancelled turns, each cluster derives **failed** only if an item inside has `status === "failed"`, **cancelled** if it holds mid-flight items marked `cancelled`, otherwise **complete**. Turn-level `failureText` is attached to a cluster only when that cluster actually has a failed item; the folded **turn** group alone carries the turn’s red outcome and failure message.
> 
> Tests were updated to match this contract and two cases were added for “all-complete clusters + late turn failure” and “single cluster with a genuinely failed tool.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd703b792d96fab81dc4f0a2898f9c662709cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->