### PR TITLE
fix(desktop): paintable-frame readiness + warm-up screenshot budget — machine→sandbox swap recovery works on the first turn

### DIFF
--- a/docker/desktop/opengeni-desktop-up.sh
+++ b/docker/desktop/opengeni-desktop-up.sh
@@ -84,9 +84,12 @@ start() { # name, cmd...
 
 # 1. Xvfb :0  (RAM framebuffer; 24-bit mandatory for Chrome; no live RANDR -> geometry fixed here)
 start xvfb Xvfb :0 -ac -screen 0 "${W}x${H}x24" -dpi "$DPI" -retro -nolisten tcp -nolisten unix
-# readiness gate: block until the display answers
-for i in $(seq 1 50); do xdpyinfo -display :0 >/dev/null 2>&1 && break; sleep 0.1; \
-  [ "$i" = "50" ] && { echo "Xvfb failed to come up" >&2; exit 11; }; done
+# readiness gate: block until the display answers. 100*0.1s=10s (was 50/5s) — on a
+# STONE-COLD gVisor box (the machine->sandbox swap-recovery turn always hits one) Xvfb's
+# first xdpyinfo answer can exceed 5s under runsc syscall overhead + cold page cache, and
+# a spurious exit 11 here degrades the whole desktop to Channel-A for the turn.
+for i in $(seq 1 100); do xdpyinfo -display :0 >/dev/null 2>&1 && break; sleep 0.1; \
+  [ "$i" = "100" ] && { echo "Xvfb failed to come up" >&2; exit 11; }; done
 
 # 1b. KEYMAP — Xvfb boots with a SPARSE default XKB map: only a handful of keysyms
 # have a keycode, so x11vnc silently drops any keysym noVNC sends that isn't in it

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -67,10 +67,16 @@ const SCROLL_NOTCH_PIXELS = 100;
 const SCROLL_MAX_CLICKS = 15;
 // screenshot() never hands the model an empty image_url (the SDK turns "" into
 // `image_url: ''`, which the model API 400s). A cold/not-yet-painting :0 can yield
-// a zero-byte frame on the first scrot; bounded retries with a short pause let a
-// momentarily-unpainted-but-live display self-heal before we FAIL LOUD.
-const SCREENSHOT_MAX_ATTEMPTS = 3;
-const SCREENSHOT_RETRY_DELAY_MS = 400;
+// zero-byte frames for the WHOLE warm-up window of a freshly cold-booted box — Xvfb
+// + XFCE + dbus + font-cache under gVisor routinely take 20s+, and the recovery path
+// after a machine→sandbox swap ALWAYS hits a stone-cold Modal box on its first turn.
+// So we retry across a bounded WALL-CLOCK budget (not a tiny fixed attempt count) with
+// a short pause between tries, so that first post-cold / post-swap screenshot self-heals
+// as the display warms — then FAIL LOUD once the budget is genuinely spent (a display
+// that is dead, not merely warming). ~800ms of retries (the prior 3×400ms) was far too
+// short to ride out a cold gVisor XFCE boot, so the turn failed loud on a transient.
+const SCREENSHOT_WARMUP_BUDGET_MS = 30_000;
+const SCREENSHOT_RETRY_DELAY_MS = 750;
 
 export type SandboxComputerOptions = {
   display?: string; // ":0"
@@ -79,6 +85,11 @@ export type SandboxComputerOptions = {
   typeDelayMs?: number; // xdotool type --delay (default 12ms)
   readOnly?: boolean; // when true, every WRITE action throws ComputerReadOnlyError
   screenshotTmpDir?: string; // "/tmp"
+  // How long screenshot() keeps retrying an empty (still-warming) frame before it
+  // FAILS LOUD, and the pause between tries. Defaults to the cold-boot warm-up budget;
+  // exposed mainly so tests can shrink it (a real caller wants the full budget).
+  screenshotWarmupBudgetMs?: number;
+  screenshotRetryDelayMs?: number;
 };
 
 // X keysym map for keypress(): model key names → xdotool keysyms.
@@ -144,6 +155,8 @@ export class SandboxComputer implements Computer {
   private readonly typeDelayMs: number;
   private readonly readOnly: boolean;
   private readonly tmp: string;
+  private readonly screenshotWarmupBudgetMs: number;
+  private readonly screenshotRetryDelayMs: number;
 
   constructor(session: SandboxSessionLike, opts: SandboxComputerOptions = {}) {
     this.session = session as unknown as ComputerSession;
@@ -155,6 +168,8 @@ export class SandboxComputer implements Computer {
     this.typeDelayMs = opts.typeDelayMs ?? 12;
     this.readOnly = opts.readOnly ?? false;
     this.tmp = opts.screenshotTmpDir ?? "/tmp";
+    this.screenshotWarmupBudgetMs = opts.screenshotWarmupBudgetMs ?? SCREENSHOT_WARMUP_BUDGET_MS;
+    this.screenshotRetryDelayMs = opts.screenshotRetryDelayMs ?? SCREENSHOT_RETRY_DELAY_MS;
   }
 
   /** Rebind to a freshly resumed-by-id session after a box rollover / re-establish. */
@@ -231,17 +246,23 @@ export class SandboxComputer implements Computer {
     // but momentarily not painting (XFCE/dbus still warming) recovers without
     // failing the turn.
     let lastError: unknown;
-    for (let attempt = 0; attempt < SCREENSHOT_MAX_ATTEMPTS; attempt++) {
+    const deadline = Date.now() + this.screenshotWarmupBudgetMs;
+    let attempt = 0;
+    // Retry across a WALL-CLOCK budget (not a fixed count): a stone-cold box on the
+    // first post-swap / post-cold turn can take 20s+ to paint, and a zero-byte frame
+    // is a KNOWN transient during that warm-up — not a reason to fail the turn.
+    while (true) {
       if (attempt > 0) {
-        await new Promise((r) => setTimeout(r, SCREENSHOT_RETRY_DELAY_MS));
+        await new Promise((r) => setTimeout(r, this.screenshotRetryDelayMs));
       }
+      attempt++;
       const f = `${this.tmp}/og-shot-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
       try {
         await this.x(`scrot --pointer --overwrite ${f}`);
         const bytes = await this.readScreenshotBytes(f);
         if (bytes.length === 0) {
           // A cold/not-yet-painting :0 yields a zero-byte frame. Retry rather than
-          // hand the model an empty image_url; throw on the final attempt.
+          // hand the model an empty image_url; throw once the budget is spent.
           throw new ComputerUnavailableError("scrot produced an empty screenshot (display not up?)");
         }
         return Buffer.from(bytes).toString("base64");
@@ -252,9 +273,15 @@ export class SandboxComputer implements Computer {
         // screenshot result.
         await this.x(`rm -f ${f}`).catch(() => undefined);
       }
+      // Stop once the warm-up budget is spent — the NEXT sleep would push us past it.
+      if (Date.now() + this.screenshotRetryDelayMs >= deadline) {
+        break;
+      }
     }
-    // Exhausted retries: FAIL LOUD. A clear throw is the only acceptable outcome —
-    // returning "" here would surface to the model as an invalid empty image_url.
+    // Exhausted the warm-up budget: FAIL LOUD. A clear throw is the only acceptable
+    // outcome — returning "" here would surface to the model as an invalid empty
+    // image_url. Reaching here means the display was still dead after ~30s, not merely
+    // warming, so a hard action failure is correct.
     if (lastError instanceof Error) {
       throw lastError;
     }

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -24,11 +24,17 @@ import { DESKTOP_STREAM_PORT } from "@opengeni/contracts";
 export { DESKTOP_STREAM_PORT };
 export const STREAM_PORT = DESKTOP_STREAM_PORT;
 
-// The whole-stack launch is bounded by the readiness gates inside the script
-// (four loops of 50 * 0.1s = ~5s each, ~20s worst case) PLUS first-boot XFCE/dbus
-// + font-cache warm-up on a cold gVisor box. 60s gives headroom over the spike's
-// observed ~5-10s warm path without masking a genuine wedge.
-export const DISPLAY_STACK_TIMEOUT_MS = 60_000;
+// The whole-stack launch is bounded by the readiness gates inside the up-script
+// (four loops of 50 * 0.1s = ~5s each, ~20s worst case) PLUS the PAINTABLE-FRAME
+// gate we append (up to ~30s of scrot probing) PLUS first-boot XFCE/dbus + font-cache
+// warm-up on a cold gVisor box. 90s gives headroom over the spike's observed ~5-10s
+// warm path AND the cold-box paint warm-up without masking a genuine wedge.
+export const DISPLAY_STACK_TIMEOUT_MS = 90_000;
+
+// PAINTABLE-FRAME gate: poll scrot up to this many times, this many seconds apart,
+// waiting for a non-empty frame before declaring the stack "up" (~30s worst case).
+const PAINT_PROBE_ATTEMPTS = 150;
+const PAINT_PROBE_INTERVAL_S = 0.2;
 
 /** Desktop geometry for the framebuffer. v1 has no live RANDR: a resolution
  *  change is a full down -> up restart (a separate op). */
@@ -41,15 +47,25 @@ export type DesktopGeometry = {
 export const DEFAULT_DESKTOP_GEOMETRY: DesktopGeometry = { width: 1280, height: 800, dpi: 96 };
 
 /** Thrown when a stage of the launch script failed. exitCode 11/12/13 map to
- *  Xvfb / x11vnc / websockify respectively (the stage that died). Degradation is
- *  surfaced as a value to viewers by the caller; this error is for diagnostics. */
+ *  Xvfb / x11vnc / websockify respectively (the stage that died); 14 is the
+ *  PAINTABLE-FRAME gate (ports listening but scrot still yields an empty frame —
+ *  the display is up but not actually painting). Degradation is surfaced as a
+ *  value to viewers by the caller; this error is for diagnostics. */
 export class DisplayStackError extends Error {
   readonly exitCode: number;
-  readonly stage: "xvfb" | "x11vnc" | "websockify" | "unknown";
+  readonly stage: "xvfb" | "x11vnc" | "websockify" | "paint" | "unknown";
 
   constructor(exitCode: number, output: string) {
     const stage =
-      exitCode === 11 ? "xvfb" : exitCode === 12 ? "x11vnc" : exitCode === 13 ? "websockify" : "unknown";
+      exitCode === 11
+        ? "xvfb"
+        : exitCode === 12
+          ? "x11vnc"
+          : exitCode === 13
+            ? "websockify"
+            : exitCode === 14
+              ? "paint"
+              : "unknown";
     super(`desktop display stack failed at stage "${stage}" (exit ${exitCode})${output ? `:\n${output}` : ""}`);
     this.name = "DisplayStackError";
     this.exitCode = exitCode;
@@ -125,15 +141,41 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
   // flock -w bounds the wait so a wedged holder can't deadlock the caller; the
   // up-script itself ALSO takes the same lock (belt + braces) so this works even
   // against an older image that predates the wrapper.
-  return (
+  //
+  // PAINTABLE-FRAME GATE (the completion criterion): the up-script's readiness gates
+  // only assert that Xvfb answers xdpyinfo and that x11vnc:5900 + websockify:PORT are
+  // LISTENING — NOT that the display actually PAINTS. On a stone-cold gVisor box (the
+  // machine→sandbox swap-recovery turn always hits one), Xvfb can answer and the VNC
+  // ports can bind seconds BEFORE the root window / XFCE compositor is drawable, so a
+  // scrot right after the `OPENGENI_DESKTOP_UP` marker yields a ZERO-BYTE frame — which
+  // is exactly the empty screenshot that 400s the model and blanks the human viewer.
+  // We therefore chain a real scrot probe as the completion gate: after the up-script
+  // reports success, poll scrot until it produces a NON-EMPTY frame (bounded ~30s), and
+  // only THEN let the command exit 0. If it never paints we exit 14 so the caller sees a
+  // typed DisplayStackError("paint") — an HONEST failure the worker can degrade + log,
+  // rather than a false "up" that hands the model an empty image. `-ac` on Xvfb disables
+  // access control so this root-side scrot reaches :0. Runs on a pre-check hit too (cheap
+  // — an already-up display paints on the first probe). Lives in the runtime-built script
+  // (not the baked image up-script) so it ships with the worker/api, no image rebuild.
+  const bringUp =
     `if nc -z 127.0.0.1 ${port} >/dev/null 2>&1 && nc -z 127.0.0.1 5900 >/dev/null 2>&1; then ` +
     `echo "OPENGENI_DESKTOP_UP port=${port} geometry=${geometry.width}x${geometry.height} dpi=${geometry.dpi} (precheck)"; ` +
     `else ` +
     `mkdir -p /tmp/opengeni-desktop && ` +
     `flock -w 45 /tmp/opengeni-desktop/up.outer.lock ` +
     `env ${env} opengeni-desktop-up; ` +
-    `fi`
-  );
+    `fi`;
+  const paintProbe =
+    `p=/tmp/opengeni-desktop/paint-probe.png; ` +
+    `for i in $(seq 1 ${PAINT_PROBE_ATTEMPTS}); do ` +
+    `if DISPLAY=:0 scrot -o "$p" >/dev/null 2>&1 && [ -s "$p" ]; then rm -f "$p"; break; fi; ` +
+    `rm -f "$p"; ` +
+    // NOTE: NOT_PAINTING goes to STDOUT (not stderr): Modal is execCommand-only, so the
+    // caller infers the outcome by string-matching the output — stdout is always captured.
+    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot empty after warmup"; exit 14; fi; ` +
+    `sleep ${PAINT_PROBE_INTERVAL_S}; ` +
+    `done`;
+  return `mkdir -p /tmp/opengeni-desktop; { ${bringUp} ; } && { ${paintProbe} ; }`;
 }
 
 function execResultOutput(result: ExecResultLike | string): string {
@@ -157,6 +199,13 @@ function execResultExitCode(result: ExecResultLike | string): number | null {
 // bare string), we infer success from the OPENGENI_DESKTOP_UP marker and infer
 // the failing stage from the stage-failure message the script prints to stderr.
 function inferExitFromOutput(output: string): number {
+  // Check the PAINTABLE-FRAME failure FIRST: on that path the up-script already
+  // printed OPENGENI_DESKTOP_UP (bring-up succeeded) and THEN the paint gate failed,
+  // so both markers are present — the NOT_PAINTING one is the authoritative outcome.
+  // (Modal is execCommand-only, so this string-inference path is the live one.)
+  if (/OPENGENI_DESKTOP_NOT_PAINTING/.test(output)) {
+    return 14;
+  }
   if (/OPENGENI_DESKTOP_UP\b/.test(output)) {
     return 0;
   }

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -29,12 +29,18 @@ import {
 // FIRST `opengeni-desktop-up` "launches" the stack (records launches), every
 // subsequent call observes it already up and is a NO-OP that re-prints the same
 // marker (exactly what flock + alive-guards yield on a real box).
-function makeFakeBox(opts: { mode?: "exec" | "execCommand"; failStage?: 11 | 12 | 13 } = {}) {
+function makeFakeBox(opts: { mode?: "exec" | "execCommand"; failStage?: 11 | 12 | 13 | 14 } = {}) {
   const calls: string[] = [];
   let launches = 0;
   let up = false;
 
   const runUp = (): { exitCode: number; output: string } => {
+    if (opts.failStage === 14) {
+      // The PAINTABLE-FRAME gate: bring-up SUCCEEDED (marker printed) but scrot never
+      // produced a non-empty frame, so both markers are present and the script exits 14.
+      const marker = `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`;
+      return { exitCode: 14, output: `${marker}\nOPENGENI_DESKTOP_NOT_PAINTING scrot empty after warmup` };
+    }
     if (opts.failStage) {
       const msg =
         opts.failStage === 11
@@ -95,6 +101,21 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(cmd).toContain("flock");
     expect(cmd).toContain("opengeni-desktop-up");
     expect(cmd).toContain("DESKTOP_W=1920 DESKTOP_H=1080 DESKTOP_DPI=120 STREAM_PORT=7090");
+  });
+
+  test("(2a) PAINTABLE-FRAME GATE: the script scrot-probes for a non-empty frame and exits 14 when it never paints", () => {
+    const cmd = buildDisplayStackScript({ port: 6080 });
+    // The completion criterion is a REAL scrot (not just ports listening). It must
+    // appear AFTER the bring-up (the up-script/precheck), chained with && so a failed
+    // bring-up short-circuits it, and it must exit 14 (the "paint" stage) on failure.
+    const scrotIdx = cmd.indexOf("scrot -o");
+    const upIdx = cmd.indexOf("opengeni-desktop-up");
+    expect(scrotIdx).toBeGreaterThan(upIdx);
+    expect(cmd).toContain("[ -s ");
+    expect(cmd).toContain("exit 14");
+    expect(cmd).toContain("OPENGENI_DESKTOP_NOT_PAINTING");
+    // chained so a failed bring-up never reaches the paint probe.
+    expect(cmd).toContain("&& {");
   });
 
   test("(2b) FAST PRE-CHECK: buildDisplayStackScript probes the exposed + VNC ports BEFORE the flock", () => {
@@ -179,6 +200,34 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     } catch (e) {
       expect((e as DisplayStackError).stage).toBe("xvfb");
     }
+  });
+
+  test("(4c) PAINTABLE-FRAME failure (exit 14) throws DisplayStackError stage 'paint' — exec path", async () => {
+    const box = makeFakeBox({ failStage: 14 });
+    let thrown: unknown;
+    try {
+      await ensureDisplayStack(box.session);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(DisplayStackError);
+    expect((thrown as DisplayStackError).exitCode).toBe(14);
+    expect((thrown as DisplayStackError).stage).toBe("paint");
+  });
+
+  test("(4d) PAINTABLE-FRAME failure via execCommand: NOT_PAINTING wins even though UP is also present", async () => {
+    // Modal is execCommand-only (no structured exitCode), so success/failure is
+    // string-inferred. On the paint-fail path the up-script ALREADY printed the UP
+    // marker, so both markers are present — NOT_PAINTING must be authoritative.
+    const box = makeFakeBox({ mode: "execCommand", failStage: 14 });
+    let thrown: unknown;
+    try {
+      await ensureDisplayStack(box.session);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(DisplayStackError);
+    expect((thrown as DisplayStackError).stage).toBe("paint");
   });
 
   test("(5) a session that cannot run commands throws DisplayStackUnsupportedError", async () => {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -178,7 +178,9 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
   // return "" — it throws (a clear action failure) or self-heals via retry.
   test("REGRESSION: a zero-byte (cold/dead :0) frame THROWS — never returns an empty string", async () => {
     const { session } = makeMockSession({ pngBytes: new Uint8Array() }); // empty PNG, every attempt
-    const c = new SandboxComputer(session as never);
+    // Shrink the warm-up budget so the "genuinely dead display" path fails fast in the
+    // test instead of burning the full 30s cold-boot budget (behavior is identical).
+    const c = new SandboxComputer(session as never, { screenshotWarmupBudgetMs: 30, screenshotRetryDelayMs: 5 });
     // Failure-sensitive: it must reject (NOT resolve to ""), so an empty image_url
     // can never reach the model.
     const result = await c.screenshot().then((s) => ({ ok: true as const, s }), (e) => ({ ok: false as const, e }));


### PR DESCRIPTION
A machine-primary session swapped to its cloud box (the RECOVERY path after a machine dies) failed its first turn's computer-use with `ComputerUnavailableError: scrot produced an empty screenshot (display not up?)`, and the human viewer saw a dead desktop. Reproduced live (fd8c20d7…); real user hit it (4ca1de69…).

**Root cause**: the display-stack up-script's readiness gates assert Xvfb answers and x11vnc/websockify **listen** — XFCE has no gate and paintability is never checked, so on a stone-cold gVisor box the script (and `ensureDisplayStack`) declare success seconds before the root window is drawable. The turn then proceeds; `screenshot()` retried only ~1.2s (3×400ms) before failing loud on what is a known 20s+ transient. `sandbox_os` ruled out (lease bookkeeping only); the viewer's transport advertisement verified correct for the swapped case (`vnc-ws`) — it was a victim of the unpainted display.

**Fix (runtime-side, effective without an image rebuild)**:
- `SandboxComputer.screenshot()`: retry empty frames across a ~30s wall-clock warm-up budget (injectable for tests), then fail loud as before.
- `ensureDisplayStack`: chain a real **paintable-frame gate** (poll scrot for a non-empty frame, ~30s) after the up-script before declaring success; a non-painting stack now degrades honestly as a typed `DisplayStackError("paint")` instead of a false "up". Best-effort/never-fail-the-turn contract preserved. `DISPLAY_STACK_TIMEOUT_MS` 60→90s.
- `opengeni-desktop-up.sh`: Xvfb gate 5s→10s (takes effect on the next desktop-image build).

Gates: runtime/worker/api `tsc` clean; `bun test packages/runtime` 511 pass / 0 fail (new paint-gate + warm-up-budget tests); `bash -n` on generated + edited scripts. Live staging verification of the exact swap repro follows the deploy and will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-turn desktop readiness and screenshot timing on cold gVisor sandboxes; longer waits (~30–90s) can delay failures but reduce false negatives on swap recovery.
> 
> **Overview**
> Fixes **machine→sandbox swap recovery** failing on the first computer-use turn with empty screenshots when the display stack reported “up” before XFCE could actually paint.
> 
> **`ensureDisplayStack`** now chains a **paintable-frame gate** after bring-up: poll `scrot` for a non-empty PNG (~30s) before success. Failure is **exit 14** / `DisplayStackError("paint")` instead of a false ready state. **`DISPLAY_STACK_TIMEOUT_MS`** goes **60s → 90s** to cover the probe. Modal **`execCommand`** paths treat **`OPENGENI_DESKTOP_NOT_PAINTING`** as authoritative when both UP and NOT_PAINTING appear in output.
> 
> **`SandboxComputer.screenshot()`** retries empty frames on a **~30s wall-clock budget** (750ms between tries), replacing the old **3×400ms** cap, with injectable budgets for tests. Still throws rather than returning `""` once the budget is spent.
> 
> **`opengeni-desktop-up.sh`**: Xvfb **`xdpyinfo`** readiness **5s → 10s** (image rebuild to take effect).
> 
> Tests cover the paint gate script shape, exit 14 / stage `paint`, and shortened warm-up in screenshot regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64db9ddd6a6a32cfbd94df7ef7af3e5ee4ef2a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->