### PR TITLE
fix(desktop): advertise the viewer transport from the ACTIVE sandbox — both swap directions

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -63,7 +63,7 @@ import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { requireAccessGrant } from "@opengeni/core";
 import type { ApiRouteDeps } from "@opengeni/core";
-import { attachViewer, detachViewer, heartbeatViewer, mintDesktopStream, mintTerminalStream, readGroupLease, viewerHeartbeatIntervalMs, type DesktopStreamMint, type TerminalStreamMint } from "../sandbox/viewer";
+import { attachViewer, detachViewer, heartbeatViewer, mintDesktopStream, mintTerminalStream, readGroupLease, resolveActiveDesktopTransport, viewerHeartbeatIntervalMs, type DesktopStreamMint, type TerminalStreamMint } from "../sandbox/viewer";
 import { settingsWithEnabledCapabilityMcpServers } from "@opengeni/core";
 import {
   normalizeResources,
@@ -584,28 +584,33 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
         : {}),
     });
 
-    // SWAP-CASE desktop transport: the negotiation keyed on the HOME backend, but
-    // the desktop/terminal plane actually runs on the ACTIVE sandbox when one is
-    // pinned. If that active sandbox is a SELFHOSTED machine, its desktop is the
-    // RELAY framebuffer (PNG-per-frame) — the "relay-frames"/"frames" client, NOT
-    // the home box's noVNC. Override the cell so the viewer selects the frame
-    // renderer (the mint already served the machine's relay url). Machine-PRIMARY
-    // sessions (home backend already selfhosted) negotiate relay-frames directly,
-    // so the `=== "vnc-ws"` guard skips the extra lookup for them.
+    // SWAP-CASE desktop transport (BOTH directions): negotiateCapabilities keyed on
+    // the HOME backend, but the pixel plane actually runs on the ACTIVE sandbox — and
+    // the two backends use DIFFERENT wire transports. The advertised transport MUST
+    // match where mintDesktopStream routed the pixels (relay IFF the active sandbox is
+    // a selfhosted machine), or the client picks the wrong renderer and the socket
+    // closes before it opens:
+    //   • modal-HOME swapped ONTO a selfhosted machine: negotiate says vnc-ws, but the
+    //     machine's desktop is the RELAY framebuffer (PNG-per-frame) → flip to
+    //     relay-frames/frames. (#171)
+    //   • selfhosted-HOME swapped AWAY to the cloud group box (activeSandboxId=null OR a
+    //     non-selfhosted active sandbox): negotiate says relay-frames (home=selfhosted),
+    //     but there is NO relay producer on the Modal box → the client hangs on a dead
+    //     relay socket ("desktop stream closed before it opened"). Flip to the Modal
+    //     noVNC/RFB tunnel (vnc-ws/novnc). This is the mirror of #171 and the missing
+    //     half that this fixes.
+    // The single invariant: advertise relay-frames IFF (activeSandboxId set AND the
+    // active sandbox kind is "selfhosted") — EXACTLY mintDesktopStream's routing. When
+    // the desktop is available we set the transport from the ACTIVE sandbox in one
+    // place (resolveActiveDesktopTransport), covering BOTH swap directions.
     let responseCapabilities = capabilities;
-    if (session.activeSandboxId && capabilities.DesktopStream.transport === "vnc-ws") {
-      const activeSandbox = await getSandbox(db, workspaceId, session.activeSandboxId);
-      if (activeSandbox?.kind === "selfhosted") {
-        responseCapabilities = {
-          ...capabilities,
-          DesktopStream: {
-            ...capabilities.DesktopStream,
-            transport: "relay-frames",
-            client: "frames",
-            mode: "read-only",
-          },
-        };
-      }
+    if (capabilities.DesktopStream.transport !== null) {
+      const activeSandbox = session.activeSandboxId ? await getSandbox(db, workspaceId, session.activeSandboxId) : null;
+      const wire = resolveActiveDesktopTransport(activeSandbox?.kind === "selfhosted", settings.sandboxDesktopInteractive !== false);
+      responseCapabilities = {
+        ...capabilities,
+        DesktopStream: { ...capabilities.DesktopStream, ...wire },
+      };
     }
     return c.json(responseCapabilities);
   });
@@ -779,8 +784,13 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
         streamToken: stream?.token ?? null,
         streamExpiresAt: stream?.expiresAt ?? null,
         resolution: stream?.resolution ?? null,
-        transport: stream ? ("vnc-ws" as const) : null,
-        client: stream ? ("novnc" as const) : null,
+        // Transport MUST match where the pixels were minted: a selfhosted-active box
+        // serves the RELAY framebuffer (relay-frames/frames), a Modal box serves noVNC
+        // (vnc-ws/novnc). Hardcoding vnc-ws here handed a machine's relay URL to the
+        // noVNC renderer (and vice-versa on the swap-away case) → "closed before it
+        // opened". Key off the SAME selfhostedActive the mint routed on.
+        transport: stream ? (selfhostedActive ? ("relay-frames" as const) : ("vnc-ws" as const)) : null,
+        client: stream ? (selfhostedActive ? ("frames" as const) : ("novnc" as const)) : null,
         // The REAL PTY terminal address (pty-ws), null when degraded.
         terminalUrl: terminal?.url ?? null,
         terminalToken: terminal?.token ?? null,

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -381,6 +381,29 @@ async function dropEstablishedHandle(established: EstablishedSandboxSession | un
 // is the out-of-band signal to the OTHER viewers of the same session.
 // ============================================================================
 
+/**
+ * The desktop WIRE transport for the session's ACTIVE sandbox — the single
+ * invariant that keeps the advertised transport in lockstep with where
+ * mintDesktopStream routed the pixels. It MUST be derived from the ACTIVE sandbox
+ * (not the session's HOME backend that negotiateCapabilities keys on): a selfhosted
+ * machine serves the RELAY framebuffer (PNG-per-frame → "relay-frames"/"frames",
+ * view-only in v1), and a Modal group box serves noVNC/RFB over the 6080 tunnel
+ * (→ "vnc-ws"/"novnc", take-control unless the deployment disabled it). Advertising
+ * relay-frames for a Modal box (the swap-away case) hands the client a dead relay
+ * socket → "desktop stream closed before it opened"; the reverse hands a machine's
+ * relay URL to the noVNC renderer. `selfhostedActive` == (activeSandboxId set AND the
+ * active sandbox kind is "selfhosted") — EXACTLY mintDesktopStream's routing predicate.
+ */
+export function resolveActiveDesktopTransport(
+  selfhostedActive: boolean,
+  interactive: boolean,
+): { transport: "relay-frames" | "vnc-ws"; client: "frames" | "novnc"; mode: "read-only" | "interactive" } {
+  if (selfhostedActive) {
+    return { transport: "relay-frames", client: "frames", mode: "read-only" };
+  }
+  return { transport: "vnc-ws", client: "novnc", mode: interactive ? "interactive" : "read-only" };
+}
+
 /** The minted pixel cell the handshake/attach folds into the DesktopStream
  *  capability. Null when degraded (no secret, headless backend, display-stack
  *  failure, provider tunnel failure) — degradation is a value, never a throw. */

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 import { resolveStreamTokenSecret } from "@opengeni/config";
 import { testSettings } from "@opengeni/testing";
 import { verifyStreamToken } from "@opengeni/runtime/sandbox";
-import { mintSelfhostedStream } from "../src/sandbox/viewer";
+import { mintSelfhostedStream, resolveActiveDesktopTransport } from "../src/sandbox/viewer";
 
 // M8b — the SELFHOSTED relay stream-mint seam (viewer.ts mintSelfhostedStream).
 //
@@ -238,5 +238,26 @@ describe("mintTerminalStream / mintDesktopStream — selfhosted-active dispatch 
       // No lease → GATE 2 returns null (Modal path, not selfhosted).
     });
     expect(cell).toBeNull();
+  });
+});
+
+// The swap-case transport advertisement invariant: the advertised wire transport MUST
+// match where mintDesktopStream routed the pixels (relay IFF the active sandbox is a
+// selfhosted machine), in BOTH swap directions. A mismatch is the "desktop stream
+// closed before it opened" bug — the client picked the wrong renderer for the URL.
+describe("resolveActiveDesktopTransport — advertisement matches active-sandbox routing (both swap directions)", () => {
+  test("selfhosted-active → RELAY framebuffer (relay-frames/frames, view-only)", () => {
+    // modal-HOME swapped onto a machine, OR a machine-primary session.
+    expect(resolveActiveDesktopTransport(true, true)).toEqual({ transport: "relay-frames", client: "frames", mode: "read-only" });
+    // interactive policy is irrelevant for the relay framebuffer (view-only in v1).
+    expect(resolveActiveDesktopTransport(true, false)).toEqual({ transport: "relay-frames", client: "frames", mode: "read-only" });
+  });
+
+  test("NOT selfhosted-active → Modal noVNC (vnc-ws/novnc); THE swap-away fix", () => {
+    // selfhosted-HOME swapped AWAY to the cloud group box (activeSandboxId=null or a
+    // non-selfhosted active sandbox): must be the Modal noVNC tunnel, NOT relay-frames.
+    expect(resolveActiveDesktopTransport(false, true)).toEqual({ transport: "vnc-ws", client: "novnc", mode: "interactive" });
+    // take-control disabled by deployment policy → read-only noVNC.
+    expect(resolveActiveDesktopTransport(false, false)).toEqual({ transport: "vnc-ws", client: "novnc", mode: "read-only" });
   });
 });


### PR DESCRIPTION
Companion to #222. A selfhosted-HOME session swapped to its cloud group box kept advertising `relay-frames`: `negotiateCapabilities` keys the desktop transport on the HOME backend, and the existing swap-case override (sessions.ts) only handled the modal-home → selfhosted-active direction. The client then speaks the relay frame protocol against a Modal noVNC tunnel with no relay producer — the socket closes before OpenAck, rendering the user-visible, never-self-healing "desktop stream closed before it opened" (confirmed by the user long after the box was up, independent of #222's cold race). POST /viewers had the mirror bug (hardcoded `vnc-ws`).

Fix: one invariant, `resolveActiveDesktopTransport` — advertise `relay-frames` iff the ACTIVE sandbox is a selfhosted machine (exactly `mintDesktopStream`'s predicate), else the Modal noVNC transport; GET /stream-capabilities and POST /viewers both derive from it, covering both swap directions in one place.

Tests: both directions asserted; api suite 278 pass / 0 fail; `tsc` clean. Live staging verification (post-swap viewer handshake reaching first frame) follows the deploy together with #222's repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live viewer handshake responses on stream-capabilities and viewer attach; behavior is narrow and covered by new tests, but wrong transport still breaks desktop viewing in production.
> 
> **Overview**
> Fixes **desktop stream transport mismatches** when a session’s **active sandbox** differs from its **home** backend (sandbox swap). Capability negotiation keyed on home could advertise `relay-frames` while pixels were minted for Modal noVNC (or the reverse), so the client used the wrong renderer and the stream failed with “closed before it opened.”
> 
> Introduces **`resolveActiveDesktopTransport`**: advertise **relay-frames / frames** only when the active sandbox is selfhosted; otherwise **vnc-ws / novnc** (respecting interactive policy). **GET `/stream-capabilities`** applies this whenever a desktop transport is available (replacing a one-direction-only override). **POST `/viewers`** stops hardcoding `vnc-ws` and keys `transport` / `client` off the same **`selfhostedActive`** predicate as **`mintDesktopStream`**.
> 
> Unit tests cover both swap directions for the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989eccb800f8163041a3986fb04e360badf16da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->