### PR TITLE
fix(runtime): route bare registry models through registry

### DIFF
--- a/.changeset/registry-bare-model-routing.md
+++ b/.changeset/registry-bare-model-routing.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Route unique bare registry model ids through their registry provider even when a run-scoped turn model matches `openaiModel`.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -426,7 +426,7 @@ export class MultiProviderModelProvider implements ModelProvider {
 
   async getModel(modelName?: string): Promise<Model> {
     if (modelName) {
-      const resolved = resolveTurnModel(this.settings, modelName);
+      const resolved = resolveTurnModel(settingsForRunScopedModelResolution(this.settings, modelName), modelName);
       if (resolved) {
         // Fail-loud floor (defense in depth): a `codex/<slug>` id must only ever
         // resolve through the synthetic codex-subscription provider (which installs
@@ -462,6 +462,27 @@ export class MultiProviderModelProvider implements ModelProvider {
     this.fallback ??= new OpenAIProvider();
     return this.fallback.getModel(modelName);
   }
+}
+
+function settingsForRunScopedModelResolution(settings: Settings, modelName: string): Settings {
+  if (modelName !== settings.openaiModel) {
+    return settings;
+  }
+  const builtinAllowed = splitOpenaiAllowedModels(settings.openaiAllowedModels);
+  const fallbackBuiltin = builtinAllowed.find((id) => id !== modelName);
+  if (!fallbackBuiltin) {
+    return settings;
+  }
+  // The worker sets runSettings.openaiModel to the turn's model. For namespaced
+  // registry ids configuredModels filters the built-in entry out, but a unique
+  // bare registry id would otherwise be claimed by the built-in only because of
+  // that per-turn override. Resolve the run-scoped router against the deployment
+  // allow-list head instead; real built-in models stay in the allow-list.
+  return builtinAllowed.includes(modelName) ? settings : { ...settings, openaiModel: fallbackBuiltin };
+}
+
+function splitOpenaiAllowedModels(value: string): string[] {
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
 }
 
 /**

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -415,6 +415,26 @@ describe("registry model shadowing is closed — the built-in never claims a nam
     expect(resolved.model).toBeInstanceOf(OpenAIChatCompletionsModel);
   });
 
+  test("the run-scoped provider routes a unique bare registry turn model to its registry provider", async () => {
+    const settings = multiProviderSettings({
+      openaiProvider: "azure",
+      azureOpenaiBaseUrl: "https://example.openai.azure.com/openai/v1",
+      azureOpenaiApiKey: "az-test-key",
+      openaiModel: "scripted-1",
+      openaiAllowedModels: "gpt-5.5,gpt-5.4",
+      modelProvidersJson: JSON.stringify([
+        {
+          id: "scripted",
+          baseUrl: "http://127.0.0.1:8399/v1",
+          apiKey: "dummy",
+          models: [{ id: "scripted-1", label: "Scripted" }],
+        },
+      ]),
+    });
+    const model = await new MultiProviderModelProvider(settings).getModel("scripted-1");
+    expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
+  });
+
   test("a BARE id a registry merely redeclares (e.g. the built-in default) still resolves to the built-in — precedence preserved", () => {
     // The registry below redeclares "gpt-5.5"; the built-in must still win it
     // (only namespaced `<provider>/<model>` ids are ceded to the registry).


### PR DESCRIPTION
## Summary
- resolve run-scoped model routing against the deployment built-in allow-list head when the turn model is a unique bare registry id
- preserve built-in precedence for real built-in model ids
- add a regression test for a bare registry id such as `scripted-1`

## Symptom -> Cause -> Fix
A unique bare registry model id could be claimed by the built-in provider during a worker turn. The worker sets `runSettings.openaiModel` to the selected turn model, so `resolveTurnModel` saw that bare id as the built-in default even when it only existed in the registry. The fix keeps real built-in ids on the built-in path, but resolves run-scoped routing against a deployment-allowed built-in fallback when the turn model is not in the built-in allow-list.

## Validation
- `bun test packages/runtime/test/model-providers.test.ts`
- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-turn model routing in a concurrency-sensitive path; scope is small and covered by a targeted regression test, but wrong routing would send turns to the wrong API client.
> 
> **Overview**
> **Fixes mis-routing of unique bare registry model IDs** when the worker sets per-turn `openaiModel` to the selected model. Namespaced registry IDs were already filtered out of the built-in list in config; a **bare** id that only exists in a custom provider could still be treated as the built-in default because `openaiModel` matched the turn name.
> 
> `MultiProviderModelProvider.getModel` now resolves through **`settingsForRunScopedModelResolution`**: if the requested name equals `openaiModel` but is **not** in `openaiAllowedModels`, resolution uses a temporary settings copy whose `openaiModel` is another deployment-allowed built-in id so `resolveTurnModel` can bind the turn to the registry provider. Ids that are genuinely in the built-in allow-list (e.g. `gpt-5.5`) keep built-in precedence.
> 
> Adds a regression test for a bare registry id (`scripted-1`) under Azure + run-scoped `openaiModel`, and a patch changeset for `@opengeni/runtime`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a440d51fceede0871579da7111933763000eb35a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->