### PR TITLE
fix(config): make .env.example boot cleanly

### DIFF
--- a/.changeset/env-example-boots.md
+++ b/.changeset/env-example-boots.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Keep the stock `.env.example` shell-sourceable and aligned with boot-time settings validation.

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ OPENGENI_AUTH_ALLOW_METRICS=false
 OPENGENI_API_HOST=0.0.0.0
 OPENGENI_API_PORT=8000
 # CORS origin allowlist regex. The API matches this as a full-string regex.
-OPENGENI_CORS_ALLOW_ORIGIN_REGEX=^https?://(localhost|127\.0\.0\.1)(:\d+)?$
+OPENGENI_CORS_ALLOW_ORIGIN_REGEX='^https?://(localhost|127\.0\.0\.1)(:\d+)?$'
 
 # Optional Docker Compose host port overrides. `bun run dev` auto-selects free
 # ports when these defaults are occupied and rewrites the runtime env in memory.
@@ -141,7 +141,8 @@ OPENGENI_DOCKER_NETWORK=opengeni_default
 
 # Modal sandbox backend.
 OPENGENI_MODAL_APP_NAME=opengeni-sandbox
-OPENGENI_MODAL_TIMEOUT_SECONDS=900
+# Keep above the default reaper+idle-grace warm window (30s + 900s).
+OPENGENI_MODAL_TIMEOUT_SECONDS=1200
 # OPENGENI_MODAL_IMAGE_REF=ghcr.io/YOUR_ORG/opengeni-sandbox:dev
 # OPENGENI_MODAL_TOKEN_ID=ak-...
 # OPENGENI_MODAL_TOKEN_SECRET=as-...

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import {
   collectGitIdentityEnvironment,
@@ -21,6 +23,37 @@ import {
   startupRetryOptions,
   streamTokenDegraded,
 } from "../src";
+
+describe(".env.example", () => {
+  test("shell-sources and validates with the stock example values", () => {
+    const envPath = fileURLToPath(new URL("../../../.env.example", import.meta.url));
+    const source = spawnSync(
+      "bash",
+      ["-c", "set -a; . \"$1\"; env -0", "bash", envPath],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "/usr/bin:/bin" },
+      },
+    );
+    if (source.status !== 0) {
+      throw new Error(`.env.example failed to source:\n${source.stderr}`);
+    }
+
+    const sourcedEnv: NodeJS.ProcessEnv = {};
+    for (const entry of source.stdout.split("\0")) {
+      if (!entry) {
+        continue;
+      }
+      const equals = entry.indexOf("=");
+      if (equals <= 0) {
+        continue;
+      }
+      sourcedEnv[entry.slice(0, equals)] = entry.slice(equals + 1);
+    }
+
+    expect(() => withEnv(sourcedEnv, () => getSettings())).not.toThrow();
+  });
+});
 
 describe("sandbox preparation profiles", () => {
   test("defaults to no sandbox environment exposure or lifecycle hooks", () => {


### PR DESCRIPTION
## Summary
- quote the active CORS allow-origin regex so `scripts/dev-stack.sh` can source `.env` without a Bash syntax error
- raise the example Modal timeout to stay above the default lease reaper plus idle-grace warm window
- add a config regression test that shell-sources the real `.env.example` and validates the resulting settings

## Symptom -> Cause -> Fix
A fresh `cp .env.example .env && bun run dev` could fail before boot because the active CORS regex contained unquoted parentheses and `scripts/dev-stack.sh` sources `.env` with Bash. Once that was fixed, the example settings still violated the sandbox timing invariant because 30s reaper + 900s idle grace was not strictly less than the 900s effective idle timeout. The fix quotes the regex and uses a 1200s example Modal timeout with a comment documenting the warm-window invariant.

## Validation
- `cp .env.example /tmp/env-check && bash -c 'set -a; . /tmp/env-check; set +a'`\n- `bun test packages/config/test/config.test.ts`\n- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-env defaults plus a config package test; no runtime behavior change for deployed services unless they copy the updated example values.
> 
> **Overview**
> Fixes fresh `cp .env.example .env` flows so Bash can source the file and `getSettings()` accepts the stock values.
> 
> **`.env.example`:** Wraps `OPENGENI_CORS_ALLOW_ORIGIN_REGEX` in single quotes so unquoted parentheses no longer break Bash when dev scripts source `.env`. Raises `OPENGENI_MODAL_TIMEOUT_SECONDS` from 900 to **1200** with a comment that it must stay above the default reaper + idle-grace warm window (30s + 900s), avoiding boot-time sandbox timing validation failures.
> 
> **Regression test:** In `packages/config/test/config.test.ts`, shell-sources the real `.env.example` via Bash and asserts `getSettings()` does not throw on the resulting env.
> 
> **Changeset:** `@opengeni/config` patch noting example env alignment with boot validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70eff75738471ee41dde545763efc0121dfc09f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->