### PR TITLE
feat(engine): overflow recovery auto-continues the turn after compaction

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -131,6 +131,14 @@ export function selectCodexCredentialForTurn(args: {
 // agent must not blindly replay side effects it cannot see in its history:
 // at most the single in-flight model step was lost, and anything it started
 // there may or may not have completed.
+// Resume notice after an in-turn context-window overflow was recovered by
+// compaction: the turn's earlier work survives (albeit summarized), so the
+// agent continues instead of the session dying or stalling idle.
+export const CONTEXT_OVERFLOW_RESUME_TEXT = [
+  "[TURN RESUMED AFTER CONTEXT COMPACTION] The conversation grew past the model's context window mid-turn; older history above was compacted into a summary.",
+  "Continue the original task from where it left off. Before repeating any action with side effects, check whether it already happened.",
+].join("\n");
+
 export const WORKER_SHUTDOWN_RESUME_TEXT = [
   "[TURN RESUMED AFTER WORKER RESTART] The platform worker running this turn restarted (deploy/rollout) before the turn finished.",
   "Your conversation history above, including this turn's earlier work, is preserved up to the last checkpoint; at most the single in-flight model step after it was lost.",
@@ -1683,6 +1691,46 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             });
           }
           if (progressPersisted) {
+            // The user's intent was live mid-turn — after a successful
+            // compaction the turn AUTO-CONTINUES via the same synthesized
+            // resume-notice requeue the worker-shutdown checkpoint uses (never
+            // the original trigger, so side effects are not replayed). Idle is
+            // the fallback, not the default; it remains for: legacy run-state
+            // history (resuming the frozen pre-compaction RunState would
+            // overflow again), a compaction that could not shrink anything,
+            // and a turn that ALREADY resumed from an overflow (loop guard —
+            // a second overflow in the same lineage stops churning).
+            const triggerPayload =
+              trigger.payload && typeof trigger.payload === "object" && !Array.isArray(trigger.payload)
+                ? trigger.payload as Record<string, unknown>
+                : {};
+            const overflowResumedTurn = triggerType === "turn.preempted" && triggerPayload.reason === "context_overflow_compacted";
+            const canAutoContinue =
+              compacted && !overflowResumedTurn && settings.sessionHistorySource === "items" && activeTurnId != null;
+            if (canAutoContinue) {
+              const [preemptedEvent] = await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [
+                {
+                  turnId: activeTurnId,
+                  type: "turn.preempted",
+                  payload: {
+                    triggerEventId: input.triggerEventId,
+                    reason: "context_overflow_compacted",
+                    resumeWithNotice: true,
+                    text: CONTEXT_OVERFLOW_RESUME_TEXT,
+                  },
+                },
+                { turnId: activeTurnId, type: "session.status.changed", payload: { status: "queued" } },
+              ]);
+              await requeuePreemptedTurn(db, input.workspaceId, activeTurnId, preemptedEvent ? preemptedEvent.id : input.triggerEventId);
+              await setSessionStatus(db, input.workspaceId, input.sessionId, "queued", null).catch(() => undefined);
+              activityStatus = "preempted";
+              observability.info("context overflow recovery succeeded by compacting and auto-continuing", {
+                sessionId: input.sessionId,
+                turnId: activeTurnId,
+                compacted,
+              });
+              return { status: "preempted" };
+            }
             await publish!([
               {
                 type: "turn.failed",

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -550,7 +550,7 @@ describe("worker activities integration", () => {
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
   });
 
-  test("context overflow after persisted progress compacts and idles without failing the session", async () => {
+  test("context overflow after persisted progress compacts and AUTO-CONTINUES via a resume-notice requeue", async () => {
     const noopWorkflowClient: SessionWorkflowClient = {
       signalUserMessage: async () => undefined,
       wakeSessionWorkflow: async () => undefined,
@@ -627,9 +627,110 @@ describe("worker activities integration", () => {
         sessionId: session.id,
         triggerEventId: trigger!.id,
         workflowId: "workflow-overflow-progress",
-      })).resolves.toEqual({ status: "idle" });
+      })).resolves.toEqual({ status: "preempted" });
 
       expect(model.calls).toBe(2);
+      const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 120);
+      // The turn auto-continues: no turn.failed — a preempted-with-notice requeue,
+      // exactly like the worker-shutdown checkpoint path.
+      expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+      const preempted = events.find((event) => event.type === "turn.preempted");
+      expect(preempted?.payload).toMatchObject({
+        reason: "context_overflow_compacted",
+        resumeWithNotice: true,
+      });
+      expect(typeof (preempted?.payload as Record<string, unknown>).text).toBe("string");
+      expect(events.some((event) => event.type === "session.context.compacted")).toBe(true);
+      expect(latestStatus(events)).toBe("queued");
+      expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("queued");
+      const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+      expect(active.some((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("an overflow on an overflow-resumed turn idles instead of requeueing again (loop guard)", async () => {
+    const noopWorkflowClient: SessionWorkflowClient = {
+      signalUserMessage: async () => undefined,
+      wakeSessionWorkflow: async () => undefined,
+      signalApprovalDecision: async () => undefined,
+      signalInterrupt: async () => undefined,
+      syncScheduledTask: async () => undefined,
+      deleteScheduledTaskSchedule: async () => undefined,
+      triggerScheduledTask: async () => undefined,
+    };
+    const grant = await testGrant(dbClient.db);
+    const apiSettings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      productAccessMode: "configured",
+      delegationSecret: "test-delegation-secret",
+    });
+    const app = createApp({ settings: apiSettings, db: dbClient.db, bus, workflowClient: noopWorkflowClient });
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: app.fetch });
+    try {
+      const settings = testSettings({
+        databaseUrl: services.databaseUrl,
+        natsUrl: services.natsUrl,
+        sessionHistorySource: "items",
+        contextCompactionMode: "client",
+        contextWindowTokens: 1_000_000,
+        contextReservedOutputTokens: 0,
+        contextCompactSoftFraction: 0.99,
+        contextKeepRecentTokens: 20,
+        mcpServers: [{
+          id: "opengeni",
+          name: "OpenGeni",
+          url: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
+          timeoutMs: undefined,
+          cacheToolsList: false,
+        }],
+      });
+      const session = await createOwnedSession(dbClient.db, grant, {
+        initialMessage: "overflow after resume",
+        resources: [],
+        tools: [{ kind: "mcp", id: "opengeni" }],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        firstPartyMcpPermissions: ["workspace:read", "sessions:read"],
+      });
+      await appendSessionHistoryItems(dbClient.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        items: [
+          { position: 0, item: { type: "message", role: "user", content: "old context" } },
+          { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "old answer" }] } },
+          { position: 2, item: { type: "message", role: "user", content: "recent context" } },
+          { position: 3, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "recent answer" }] } },
+        ],
+      });
+      // The trigger IS an overflow resume: a second overflow in this lineage
+      // must idle, not requeue forever.
+      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+        { type: "turn.preempted", payload: { reason: "context_overflow_compacted", resumeWithNotice: true, text: "[resumed after compaction]" } },
+      ]);
+      const model = new ScriptedModel([
+        { id: "overflow-loop-1", output: [functionCall("opengeni__sessions_list", { limit: 1 }, "call-overflow-loop")] },
+        { error: contextOverflowError("maximum context length exceeded") },
+      ]);
+      const activities = createActivities({
+        settings,
+        db: dbClient.db,
+        bus,
+        runtime: runtimeWithFakeCompactionSummarizer(model, "loop guard summary"),
+      });
+
+      await expect(activities.runAgentTurn({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: trigger!.id,
+        workflowId: "workflow-overflow-loop-guard",
+      })).resolves.toEqual({ status: "idle" });
+
       const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 120);
       const failed = events.find((event) => event.type === "turn.failed");
       expect(failed?.payload).toMatchObject({
@@ -637,11 +738,9 @@ describe("worker activities integration", () => {
         code: "context_window_overflow_compacted",
         recovery: "user_message",
       });
-      expect(events.some((event) => event.type === "session.context.compacted")).toBe(true);
-      expect(latestStatus(events)).toBe("idle");
+      // No SECOND requeue: the only turn.preempted event is the trigger itself.
+      expect(events.filter((event) => event.type === "turn.preempted").length).toBe(1);
       expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
-      const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-      expect(active.some((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toBe(true);
     } finally {
       server.stop(true);
     }


### PR DESCRIPTION
Follow-up to #220, from user review: after an in-turn overflow was compacted, the session went idle and waited for a user message — but the user's intent was live mid-turn. Now the turn auto-continues: compaction → \`turn.preempted\` with a synthesized resume notice (the same checkpoint/resume mechanism as worker-shutdown; the original trigger is never replayed, so side effects can't duplicate) → the workflow re-dispatches automatically.

Idle remains only as the fallback: legacy run-state history (resuming the frozen pre-compaction RunState would overflow again), a compaction that couldn't shrink anything, or a turn that already resumed from an overflow (loop guard: one auto-continue per lineage, then the honest idle message).

Integration tests updated + a new loop-guard case (overflow on an overflow-resumed trigger → idle, single requeue). Full worker+runtime suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mid-turn failure/recovery behavior for context overflows in items-mode sessions; incorrect loop-guard or requeue logic could cause duplicate side effects or infinite requeue, though it mirrors an existing worker-shutdown path.
> 
> **Overview**
> When a mid-turn **context window overflow** is recovered by compaction and the turn already had persisted model/tool progress, the worker no longer idles with `turn.failed` and waits for a user message. It **auto-continues** the same turn: emits `turn.preempted` with reason `context_overflow_compacted`, `resumeWithNotice: true`, and new **`CONTEXT_OVERFLOW_RESUME_TEXT`** (same checkpoint pattern as worker-shutdown resume; the original trigger is not replayed).
> 
> The activity returns **`preempted`** and queues the session so the workflow re-dispatches automatically. **Idle + user_message recovery** remains only when auto-continue is unsafe: non-`items` history, compaction did not shrink context, or a **loop guard** blocks a second overflow on a turn already resumed from compaction (`turn.preempted` with that reason).
> 
> Integration tests expect **preempted** + requeue instead of idle after successful overflow compaction, and add a case that a second overflow on an overflow-resumed trigger idles without a second requeue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cef6a3e4b29071dc844488b2d3a9ea606c338c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->