### PR TITLE
fix(react): eliminate timeline load flicker, animation replay, and anchor fights

### DIFF
--- a/.changeset/timeline-load-anchoring.md
+++ b/.changeset/timeline-load-anchoring.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Session load and backfill no longer flicker: the timeline stays invisible until its first bottom-anchored frame (a flash of the window top is structurally impossible), rows decide at mount whether they animate so bulk paints never replay entrance animations across the timeline, the scroller disables native browser scroll anchoring (it fought the reader-anchor corrections during backfill), and programmatic scroll echoes can no longer unpin the bottom-follow (which could strand the view just short of the bottom).

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -32,6 +32,7 @@ import {
   TurnSummary,
 } from "../timeline";
 import { SESSION_STATUS_META, StatusDot } from "./session-status";
+import { EntranceAnimationProvider, useEntranceAnimation } from "../timeline/entrance";
 
 export type MessageTimelineProps = {
   /** Raw session events (projected internally) … */
@@ -91,6 +92,15 @@ export function MessageTimeline({
   const previousBulkFirstKeyRef = useRef<string | null | undefined>(undefined);
   const [pinned, setPinned] = useState(true);
   const [bulkActive, setBulkActive] = useState(true);
+  // Content stays invisible until its first bottom-anchored frame, so a flash
+  // of the window's TOP while a large timeline lays out across commits is
+  // structurally impossible — the reader only ever sees it already at the
+  // bottom. An empty timeline reveals immediately (there is nothing to anchor).
+  const [revealed, setRevealed] = useState(false);
+  // Our own scrollTop assignments echo back as scroll events; those must never
+  // UNPIN the reader (they are not reader intent). Marked around every
+  // programmatic assignment and consumed by onScroll.
+  const programmaticScrollRef = useRef(false);
   // Mirror `pinned` into a ref so the ResizeObserver callback (a stable closure)
   // always reads the live value without re-subscribing on every scroll.
   const pinnedRef = useRef(true);
@@ -138,9 +148,21 @@ export function MessageTimeline({
   useLayoutEffect(() => {
     const node = scrollRef.current;
     if (node && autoFollow && pinned) {
+      programmaticScrollRef.current = true;
       node.scrollTop = node.scrollHeight;
     }
-  }, [resolvedItems, working, autoFollow, pinned]);
+    if (!revealed && groups.length > 0) {
+      setRevealed(true);
+    }
+  }, [resolvedItems, working, autoFollow, pinned, revealed, groups.length]);
+
+  // A cleared timeline (stream identity change) re-arms the reveal so the next
+  // session also first paints at its bottom.
+  useLayoutEffect(() => {
+    if (groups.length === 0 && revealed) {
+      setRevealed(false);
+    }
+  }, [groups.length, revealed]);
 
   // Clear the bulk-paint marker a frame after it renders, so rows appended
   // live (streams, new turns) animate exactly as before.
@@ -191,6 +213,7 @@ export function MessageTimeline({
         return;
       }
       if (autoFollow && pinnedRef.current) {
+        programmaticScrollRef.current = true;
         current.scrollTop = current.scrollHeight;
       } else {
         const anchor = anchorRef.current;
@@ -199,6 +222,7 @@ export function MessageTimeline({
           const now = anchor.el.getBoundingClientRect().top - containerTop;
           const diff = now - anchor.top;
           if (diff !== 0) {
+            programmaticScrollRef.current = true;
             current.scrollTop += diff;
           }
         }
@@ -214,16 +238,30 @@ export function MessageTimeline({
     if (!node) {
       return;
     }
+    const programmatic = programmaticScrollRef.current;
+    programmaticScrollRef.current = false;
     const nextPinned = node.scrollHeight - node.scrollTop - node.clientHeight < 48;
-    pinnedRef.current = nextPinned;
-    setPinned(nextPinned);
+    // Echoes of our own assignments may PIN but never UNPIN — only the reader
+    // scrolling away releases the bottom-follow.
+    if (nextPinned || !programmatic) {
+      pinnedRef.current = nextPinned;
+      setPinned(nextPinned);
+    }
     captureAnchor();
   };
 
   return (
     <LightboxProvider>
-    <div data-og-bulk={bulkRender ? "" : undefined} className={cn("og-root relative flex min-h-0 flex-col", className)}>
-      <div ref={scrollRef} onScroll={onScroll} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-6 sm:px-6">
+    <EntranceAnimationProvider value={!bulkRender}>
+    <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
+      {/* overflow-anchor off: the browser's native scroll anchoring would fight
+          the ResizeObserver corrections above — one authority only. */}
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-6 [overflow-anchor:none] sm:px-6"
+      >
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-5">
           {groups.length === 0 && !working
             ? (emptyState ?? <p className="py-10 text-center text-sm text-og-fg-subtle">No activity yet.</p>)
@@ -244,7 +282,7 @@ export function MessageTimeline({
             />
           ))}
           {working ? (
-            <div className="animate-og-enter flex items-center gap-2 text-sm">
+            <div className="flex items-center gap-2 text-sm">
               <span className="og-shimmer-text font-medium">Working…</span>
             </div>
           ) : null}
@@ -279,6 +317,7 @@ export function MessageTimeline({
         ) : null}
       </AnimatePresence>
     </div>
+    </EntranceAnimationProvider>
     </LightboxProvider>
   );
 }
@@ -429,8 +468,9 @@ function UserMessageRow({
   item: UserMessageItem;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
 }) {
+  const enter = useEntranceAnimation();
   return (
-    <div className="animate-og-enter flex justify-end">
+    <div className={cn(enter && "animate-og-enter", "flex justify-end")}>
       <div className="flex max-w-[85%] min-w-0 flex-col items-end gap-1">
         {item.pending ? <span className="px-1 text-og-xs text-og-fg-subtle">queued</span> : null}
         <div className="w-fit max-w-full min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-og-md leading-6 text-og-fg">
@@ -448,11 +488,12 @@ function AgentMessageRow({
   item: AgentMessageItem;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
 }) {
+  const enter = useEntranceAnimation();
   const caret = item.streaming ? (
     <span className="ml-0.5 inline-block h-[1.1em] w-[2px] translate-y-[3px] animate-og-blink rounded-full bg-og-accent" aria-hidden />
   ) : null;
   return (
-    <div className="animate-og-enter min-w-0 text-og-md leading-7 text-og-fg">
+    <div className={cn(enter && "animate-og-enter", "min-w-0 text-og-md leading-7 text-og-fg")}>
       {renderMessageText ? (
         <>
           {renderMessageText(item.text, item)}
@@ -472,9 +513,10 @@ function AgentMessageRow({
 }
 
 function SessionStatusRow({ item }: { item: { status: SessionStatus; occurredAt: string } }) {
+  const enter = useEntranceAnimation();
   const meta = SESSION_STATUS_META[item.status];
   return (
-    <div className="animate-og-enter flex items-center gap-3 text-og-xs text-og-fg-subtle" role="status">
+    <div className={cn(enter && "animate-og-enter", "flex items-center gap-3 text-og-xs text-og-fg-subtle")} role="status">
       <span className="h-px flex-1 bg-og-border" />
       <span className="inline-flex items-center gap-1.5">
         <StatusDot status={item.status} className="size-1" />
@@ -521,9 +563,10 @@ const GOAL_META: Record<GoalItem["action"], GoalMeta> = {
  * palette stays restrained — see that table for the per-action rationale.
  */
 function GoalRow({ item }: { item: GoalItem }) {
+  const enter = useEntranceAnimation();
   const { label, pill, icon: Icon } = GOAL_META[item.action];
   return (
-    <div className="animate-og-enter flex justify-center">
+    <div className={cn(enter && "animate-og-enter", "flex justify-center")}>
       <span className={cn("inline-flex max-w-full items-center gap-1.5 rounded-full border px-3 py-1 text-og-sm", pill)}>
         <Icon className="size-3.5 shrink-0" />
         <span className="truncate">
@@ -536,6 +579,7 @@ function GoalRow({ item }: { item: GoalItem }) {
 }
 
 function NoticeRow({ item }: { item: NoticeItem }) {
+  const enter = useEntranceAnimation();
   const tone =
     item.tone === "failed"
       ? "border-og-status-failed/35 bg-og-status-failed/10 text-og-status-failed"
@@ -543,7 +587,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
         ? "border-og-status-waiting/35 bg-og-status-waiting/10 text-og-status-waiting"
         : "border-og-border bg-og-surface-1 text-og-fg-muted";
   return (
-    <div className={cn("animate-og-enter flex items-start gap-2.5 rounded-og-md border px-3.5 py-2.5 text-sm", tone)} role="status">
+    <div className={cn(enter && "animate-og-enter", "flex items-start gap-2.5 rounded-og-md border px-3.5 py-2.5 text-sm", tone)} role="status">
       <TriangleAlertIcon className={cn("mt-0.5 size-4 shrink-0", item.tone === "cancelled" && "opacity-60")} />
       <span className="min-w-0 whitespace-pre-wrap break-words">{item.text}</span>
     </div>

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -2,6 +2,7 @@ import { BotIcon, BrainIcon, SquareTerminalIcon } from "lucide-react";
 import { cn } from "../lib/cn";
 import { truncate } from "../lib/format";
 import { defaultToolRegistry } from "./tool-renderers";
+import { useEntranceAnimation } from "./entrance";
 import type { ToolRegistry } from "./registry";
 import { PayloadBlock, ActivityDisclosure } from "./shared";
 import { toolDisplayName } from "./projection";
@@ -42,6 +43,7 @@ function familyOf(item: ActivityItem): string {
 }
 
 export function ActivityRail({ items, toolRegistry = defaultToolRegistry, onOpenSession, bare, className }: ActivityRailProps) {
+  const enter = useEntranceAnimation();
   return (
     <div
       className={cn(
@@ -49,7 +51,8 @@ export function ActivityRail({ items, toolRegistry = defaultToolRegistry, onOpen
         // calm cluster; a family change opens real breathing room (mt-3) below,
         // so a long rail reads as a few clusters, not a metronome of rows.
         "flex flex-col gap-0.5",
-        !bare && "animate-og-enter border-l-2 border-og-border pl-3 sm:pl-4",
+        !bare && "border-l-2 border-og-border pl-3 sm:pl-4",
+        !bare && enter && "animate-og-enter",
         className,
       )}
     >

--- a/packages/react/src/timeline/entrance.tsx
+++ b/packages/react/src/timeline/entrance.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useRef } from "react";
+
+/* ----------------------------------------------------------------------------
+   Entrance animation gating
+
+   Bulk paints (the initial tail window, a prepended older window) must not run
+   per-row entrance animations — hundreds of rows fading in at once reads as a
+   full-timeline flash. Toggling `animation: none` on and off is NOT an option:
+   removing the override restarts every animation, which is itself the flash.
+
+   Instead each animated element decides ONCE, at its own mount, whether it was
+   born in a bulk paint — and keeps that decision forever. Rows born in a bulk
+   paint never animate; rows appended live animate exactly as before. Nothing
+   is ever toggled on existing DOM, so nothing can replay.
+   -------------------------------------------------------------------------- */
+
+const EntranceAnimationContext = createContext(true);
+
+export const EntranceAnimationProvider = EntranceAnimationContext.Provider;
+
+/**
+ * Whether this element should wear the entrance animation. Captured at mount
+ * from the nearest provider (true outside any provider) and stable for the
+ * element's lifetime — see the module doctrine above.
+ */
+export function useEntranceAnimation(): boolean {
+  const enabled = useContext(EntranceAnimationContext);
+  const captured = useRef(enabled);
+  return captured.current;
+}

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Collapsible } from "radix-ui";
 import { cn } from "../lib/cn";
 import { useForcedDefaultOpen } from "./disclosure-context";
+import { useEntranceAnimation } from "./entrance";
 import { applyPatchOps, isApplyPatch, screenshotDataUrl } from "./parsers";
 import { rawTypeOf } from "./registry";
 import type { ActivityItem, TurnOutcome } from "./types";
@@ -39,10 +40,11 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
   // (screenshot instrumentation); otherwise the turn starts folded.
   const forcedDefaultOpen = useForcedDefaultOpen();
   const [open, setOpen] = useState(defaultOpen ?? forcedDefaultOpen ?? false);
+  const enter = useEntranceAnimation();
   const facets = summarizeTurn(items, durationMs);
 
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen} className="animate-og-enter">
+    <Collapsible.Root open={open} onOpenChange={setOpen} className={enter ? "animate-og-enter" : undefined}>
       <Collapsible.Trigger
         className={cn(
           "group flex w-full items-center gap-2.5 rounded-og-md border px-3 py-2 text-left text-og-base transition-colors",

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -127,10 +127,6 @@
   }
 }
 
-[data-og-bulk] .animate-og-enter {
-  animation: none;
-}
-
 /* Live/running indicators breathe; they do not flash. */
 @keyframes og-pulse {
   0%,

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -75,7 +75,7 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
-  test("bulk attribute is present on initial paint and clears after a frame", async () => {
+  test("rows born in the initial bulk paint never animate; rows appended live do", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       frames.push(cb);
@@ -83,14 +83,24 @@ describe("MessageTimeline pagination affordances", () => {
     };
     globalThis.cancelAnimationFrame = () => undefined;
 
-    const r = await renderComponent(<MessageTimeline events={[event(1)]} />);
-    expect(r.container.querySelector("[data-og-bulk]")).not.toBeNull();
+    const initial = [event(1)];
+    const r = await renderComponent(<MessageTimeline events={initial} />);
+    // Mounted during the bulk paint: no entrance animation class — and none
+    // appears later either (nothing is toggled, so nothing can replay).
+    expect(r.container.querySelector(".animate-og-enter")).toBeNull();
 
     for (const frame of frames.splice(0)) {
       frame(performance.now());
     }
     await flush();
-    expect(r.container.querySelector("[data-og-bulk]")).toBeNull();
+    expect(r.container.querySelector(".animate-og-enter")).toBeNull();
+
+    // A row appended AFTER the bulk window animates in exactly as before.
+    await r.rerender(<MessageTimeline events={[...initial, event(2)]} />);
+    await flush();
+    const animated = Array.from(r.container.querySelectorAll(".animate-og-enter"));
+    expect(animated).toHaveLength(1);
+    expect(animated[0]?.textContent).toContain("message 2");
     await r.unmount();
   });
 });


### PR DESCRIPTION
## Symptoms (user-reported after #211, all reproduced)

1. Loading a session flickers: paints at the top for a moment (seconds on slow machines/big sessions), then jumps to the bottom, sometimes twitching again.
2. The bottom anchor could land ~a line and a half short of the true bottom.
3. "Loading earlier activity" works, but the whole timeline flashes on every backfill.

## Mechanisms (probed live at 100ms resolution on staging)

- **Top flash**: large timelines lay out across multiple commits; between the first content commit and the observer's re-pin there are frames where the window top is visible at `scrollTop: 0`.
- **Whole-timeline flash**: the #211 bulk suppression set `animation: none` via a root attribute and removed it a frame later — removing the override **restarts** every `og-enter` animation (fade + 4px rise) across all rows. That's both the backfill flash and part of the load flicker.
- **Anchor fights**: the scroller never set `overflow-anchor: none`, so Chrome's native scroll anchoring and our ResizeObserver corrections both adjusted `scrollTop` during prepends — double-corrected jitter.
- **Short bottom**: scroll-event echoes of our own programmatic assignments could flip `pinned` false, after which late growth was never re-followed.

## Fixes

- **Reveal-at-bottom**: content stays `visibility: hidden` until its first bottom-anchored frame — a top flash is structurally impossible no matter how long layout takes. Empty timelines reveal immediately; a cleared timeline re-arms the reveal.
- **Capture-at-mount animation gating**: each row decides at its own mount whether it animates (context captured into a ref, stable for the element's lifetime). Rows born in bulk paints (initial window, prepends) never animate; live-appended rows animate exactly as before. Nothing toggles on existing DOM ⇒ nothing can replay. `data-og-bulk` + its CSS override are deleted.
- **`overflow-anchor: none`** on the scroller — one scroll-correction authority.
- **Programmatic-scroll guard**: our own scroll echoes may PIN but never UNPIN; only reader intent releases the bottom-follow.

## Verification

- 408 tests pass (bulk test rewritten to the capture contract: bulk-born rows never gain the class — even after the bulk window ends — and a live-appended row is the only animated element).
- `tsc --noEmit` clean; tsup + demo builds green.
- Live staging re-probe (100ms sampling + backfill flash check) follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core timeline scroll, pin, and reveal logic where regressions would be user-visible, but changes are localized to UI behavior with updated tests and no auth or data-path changes.
> 
> **Overview**
> Fixes session load and backfill flicker in **`MessageTimeline`** by hiding the scroller until the first bottom-anchored layout frame, then revealing—so users never see a flash at `scrollTop: 0` while a large timeline lays out.
> 
> **Entrance animations** no longer use `data-og-bulk` + CSS `animation: none` (removing that override replayed every row). A new **`EntranceAnimationProvider`** / **`useEntranceAnimation`** captures at mount whether the row was born in a bulk paint; bulk-born rows never get `animate-og-enter`, live-appended rows still do. Row components in the timeline, activity rail, and turn summary wire through this hook.
> 
> **Scroll behavior**: the scroller gets **`overflow-anchor: none`** so native anchoring does not fight ResizeObserver corrections during prepends. Programmatic `scrollTop` updates set a ref so scroll echoes can re-pin but not unpin bottom-follow (fixing the view landing slightly short of the bottom). The “Working…” row no longer uses entrance animation.
> 
> Tests assert the capture contract instead of the bulk attribute; changeset documents a patch for `@opengeni/react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45edf10312b6d66fd77b13081fca876d354a2937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->