### PR TITLE
fix(react): self-clear the programmatic-scroll mark on no-op assignments

### DIFF
--- a/.changeset/scroll-guard-consumption.md
+++ b/.changeset/scroll-guard-consumption.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+A no-op pinned-follow scroll assignment left the programmatic-scroll mark set (no scroll event fires to consume it), which made the reader's next real scroll-up read as programmatic and get eaten — the view snapped back to the bottom and upward backfill could never engage. The mark now self-clears when an assignment doesn't move the scroller.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -99,8 +99,18 @@ export function MessageTimeline({
   const [revealed, setRevealed] = useState(false);
   // Our own scrollTop assignments echo back as scroll events; those must never
   // UNPIN the reader (they are not reader intent). Marked around every
-  // programmatic assignment and consumed by onScroll.
+  // programmatic assignment and consumed by onScroll. When an assignment is a
+  // NO-OP (already at the target) no scroll event will fire, so the mark must
+  // self-clear — a stale mark would eat the reader's next real scroll-up.
   const programmaticScrollRef = useRef(false);
+  const assignScrollTop = useCallback((node: HTMLElement, value: number) => {
+    const previous = node.scrollTop;
+    programmaticScrollRef.current = true;
+    node.scrollTop = value;
+    if (node.scrollTop === previous) {
+      programmaticScrollRef.current = false;
+    }
+  }, []);
   // Mirror `pinned` into a ref so the ResizeObserver callback (a stable closure)
   // always reads the live value without re-subscribing on every scroll.
   const pinnedRef = useRef(true);
@@ -148,13 +158,12 @@ export function MessageTimeline({
   useLayoutEffect(() => {
     const node = scrollRef.current;
     if (node && autoFollow && pinned) {
-      programmaticScrollRef.current = true;
-      node.scrollTop = node.scrollHeight;
+      assignScrollTop(node, node.scrollHeight);
     }
     if (!revealed && groups.length > 0) {
       setRevealed(true);
     }
-  }, [resolvedItems, working, autoFollow, pinned, revealed, groups.length]);
+  }, [resolvedItems, working, autoFollow, pinned, revealed, groups.length, assignScrollTop]);
 
   // A cleared timeline (stream identity change) re-arms the reveal so the next
   // session also first paints at its bottom.
@@ -213,8 +222,7 @@ export function MessageTimeline({
         return;
       }
       if (autoFollow && pinnedRef.current) {
-        programmaticScrollRef.current = true;
-        current.scrollTop = current.scrollHeight;
+        assignScrollTop(current, current.scrollHeight);
       } else {
         const anchor = anchorRef.current;
         if (anchor && anchor.el.isConnected) {
@@ -222,8 +230,7 @@ export function MessageTimeline({
           const now = anchor.el.getBoundingClientRect().top - containerTop;
           const diff = now - anchor.top;
           if (diff !== 0) {
-            programmaticScrollRef.current = true;
-            current.scrollTop += diff;
+            assignScrollTop(current, current.scrollTop + diff);
           }
         }
       }
@@ -231,7 +238,7 @@ export function MessageTimeline({
     });
     observer.observe(inner);
     return () => observer.disconnect();
-  }, [autoFollow, captureAnchor]);
+  }, [autoFollow, captureAnchor, assignScrollTop]);
 
   const onScroll = () => {
     const node = scrollRef.current;


### PR DESCRIPTION
Follow-up to #228, caught by the post-deploy mechanism probe: the backfill never triggered because scrolling up was being eaten.

**Mechanism**: `#228`'s guard marks programmatic scrollTop assignments so their event echoes can't unpin the bottom-follow. But when the assignment is a **no-op** (already at the bottom — the common case while pinned), no scroll event fires and the mark is never consumed. The reader's next real scroll-up is then misattributed as programmatic: it can't unpin, the next observer tick snaps back to the bottom, and the backfill sentinel can never engage.

**Fix**: all programmatic assignments go through one helper that self-clears the mark when the assignment didn't move the scroller (synchronously detectable). 408 tests green; live probe re-run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized scroll-guard change in `message-timeline.tsx` with clear synchronous no-op detection; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a regression where **upward scrolling and older-history backfill** could stop working while the timeline stayed pinned to the bottom.
> 
> `MessageTimeline` now routes all programmatic `scrollTop` writes through **`assignScrollTop`**, which clears `programmaticScrollRef` immediately when the assignment does not change scroll position (already at the target, so no scroll event runs to consume the mark). The pinned-follow layout effect and `ResizeObserver` anchoring paths use this helper instead of setting `scrollTop` inline.
> 
> A patch changeset documents the `@opengeni/react` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda4fc576212f72d3630cdd6c4b51b0a61aafc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->