### PR TITLE
feat(engine): codex-parity client compaction — per-call trigger, checkpoint-summary rebuild

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -49,6 +49,8 @@ import {
   normalizeSdkEvent,
   sanitizeHistoryItemsForModel,
   summarizeForCompaction,
+  findCompactionNeededError,
+  SUMMARY_BUFFER_TOKENS,
   type SandboxFileDownload,
   type OpenGeniRuntime,
   type ComputerToolMode,
@@ -135,7 +137,7 @@ export function selectCodexCredentialForTurn(args: {
 // compaction: the turn's earlier work survives (albeit summarized), so the
 // agent continues instead of the session dying or stalling idle.
 export const CONTEXT_OVERFLOW_RESUME_TEXT = [
-  "[TURN RESUMED AFTER CONTEXT COMPACTION] The conversation grew past the model's context window mid-turn; older history above was compacted into a summary.",
+  "[TURN RESUMED AFTER CONTEXT COMPACTION] The conversation approached or exceeded the model's context window mid-turn; older history above was compacted into a summary.",
   "Continue the original task from where it left off. Before repeating any action with side effects, check whether it already happened.",
 ].join("\n");
 
@@ -167,7 +169,7 @@ export function isWorkerShutdownCancellation(error: unknown): boolean {
 }
 
 export const CONTEXT_WINDOW_OVERFLOW_RECOVERY_MESSAGE =
-  "The conversation grew past the model's context window — it has been compacted; send a message to continue.";
+  "The conversation reached the model context compaction threshold; it has been compacted. Send a message to continue.";
 
 export function classifyContextWindowOverflowError(error: unknown): { message: string; code?: string; detail?: string } | null {
   const fields = collectErrorStrings(error);
@@ -1343,18 +1345,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           : {}),
       });
       const compactSummarizer = resolvedModel
-        ? (s: Settings, m: { system: string; user: string }) => withCodex(() => summarizeForCompaction(s, m, {
+        ? (s: Settings, m: Array<Record<string, unknown>>) => withCodex(() => summarizeForCompaction(s, m, {
             client: resolvedModel.client,
             api: resolvedModel.provider.api,
             model: resolvedModel.configured.id,
-            maxOutputTokens: s.contextSummaryMaxTokens,
+            maxOutputTokens: SUMMARY_BUFFER_TOKENS,
           }))
         : undefined;
       // Pre-turn client-side context compaction (Azure path). When the
-      // resolved mode is "client" and the last turn's input tokens crossed the
-      // soft budget, this summarizes the orphan-safe old prefix into one user
-      // message and supersedes the summarized rows BEFORE the history is read
-      // for this turn, so the model sees [summary, ...recent tail] + new input.
+      // resolved mode is "client" and the single Codex-parity threshold is
+      // crossed, this summarizes the current active history and rebuilds active
+      // history as [user messages..., summary] BEFORE the model input is read.
       // Best-effort: a no-op or failure leaves the un-compacted history intact.
       // Skipped on approval/preempt resumes (no fresh user turn; the frozen
       // RunState or in-flight tail must replay verbatim).
@@ -1378,11 +1379,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             forced ? { force: true } : {},
           );
           if (outcome.compacted) {
-            // trigger precedence: an explicit operator /compact wins for the
-            // event label; otherwise a hard-forced (at/over hardFraction*B)
-            // compaction is surfaced as "hard" so the backstop firing is
-            // observable downstream, and the default soft trigger is implicit.
-            const trigger = forced ? "operator" : outcome.hardForced ? "hard" : undefined;
+            const trigger = forced ? "operator" : undefined;
             await publish([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, ...(trigger ? { trigger } : {}) } }]);
           }
         } catch (compactError) {
@@ -1447,7 +1444,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         nextHistoryPosition = await nextSessionHistoryPosition(db, input.workspaceId, input.sessionId);
       };
 
-      const forceContextOverflowCompaction = async () => {
+      const forceContextCompaction = async (triggerLabel: "overflow" | "proactive") => {
         const clientCompactionSettings: Settings = { ...runSettings, contextCompactionMode: "client" };
         const outcome = await maybeCompactContext(
           db,
@@ -1458,7 +1455,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           { force: true },
         );
         if (outcome.compacted) {
-          await publish!([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, trigger: "overflow" } }]);
+          await publish!([{ type: "session.context.compacted", payload: { summaryPosition: outcome.summaryPosition, trigger: triggerLabel } }]);
         }
         return outcome;
       };
@@ -1494,6 +1491,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               },
             }
             : {}),
+          contextCompactionSignalTokens: () => lastInputTokensObserved,
         });
         stream = await withCodex(runStreamOnce);
         batcher = createRuntimeBatcher(async (events) => {
@@ -1515,6 +1513,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               const observed = responseUsage.usage?.inputTokens;
               if (typeof observed === "number" && observed > 0) {
                 lastInputTokensObserved = observed;
+                await setSessionLastInputTokens(db, input.workspaceId, input.sessionId, observed)
+                  .catch((error) => console.error("persist last_input_tokens failed (non-fatal)", error));
               }
               await recordModelUsageAndDebitCredits(settings, db, {
                 accountId: input.accountId,
@@ -1651,13 +1651,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       };
 
       await prepareRunAttemptInput();
-      let overflowRecoveryAttempted = false;
-      let retriedAfterOverflow = false;
+      let compactionRecoveryAttempted = false;
+      let retriedAfterCompaction = false;
       while (true) {
         try {
           const result = await runStreamAttempt();
-          if (retriedAfterOverflow) {
-            observability.info("context overflow recovery succeeded after in-activity retry", {
+          if (retriedAfterCompaction) {
+            observability.info("context compaction recovery succeeded after in-activity retry", {
               sessionId: input.sessionId,
               turnId: activeTurnId,
             });
@@ -1665,26 +1665,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           return result;
         } catch (attemptError) {
           const overflow = classifyContextWindowOverflowError(attemptError);
-          if (!overflow || !publish || !turnStartedPublished || overflowRecoveryAttempted) {
+          const compactionNeeded = findCompactionNeededError(attemptError);
+          const recoveryKind = compactionNeeded ? "proactive" : overflow ? "overflow" : null;
+          if (!recoveryKind || !publish || !turnStartedPublished || compactionRecoveryAttempted) {
             throw attemptError;
           }
-          overflowRecoveryAttempted = true;
+          compactionRecoveryAttempted = true;
           await flushRuntimeBatcher();
           await reconcileConversationTruth({ skipInputOnlyRows: true });
           const progressPersisted = modelOrToolProgressPersisted;
-          observability.warn("context overflow recovery attempted", {
+          observability.warn("context compaction recovery attempted", {
             sessionId: input.sessionId,
             turnId: activeTurnId,
+            reason: recoveryKind,
             progressPersisted,
-            code: overflow.code,
-            error: overflow.message,
+            code: overflow?.code,
+            error: overflow?.message ?? compactionNeeded?.message,
+            signalTokens: compactionNeeded?.signalTokens,
+            thresholdTokens: compactionNeeded?.thresholdTokens,
           });
           let compacted = false;
           try {
-            const outcome = await forceContextOverflowCompaction();
+            const outcome = await forceContextCompaction(recoveryKind);
             compacted = outcome.compacted;
           } catch (compactError) {
-            observability.warn("context overflow recovery compaction failed", {
+            observability.warn("context compaction recovery compaction failed", {
               sessionId: input.sessionId,
               turnId: activeTurnId,
               error: compactError instanceof Error ? compactError.message : String(compactError),
@@ -1704,9 +1709,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               trigger.payload && typeof trigger.payload === "object" && !Array.isArray(trigger.payload)
                 ? trigger.payload as Record<string, unknown>
                 : {};
-            const overflowResumedTurn = triggerType === "turn.preempted" && triggerPayload.reason === "context_overflow_compacted";
+            const compactionResumedTurn = triggerType === "turn.preempted"
+              && (triggerPayload.reason === "context_compacted" || triggerPayload.reason === "context_overflow_compacted");
             const canAutoContinue =
-              compacted && !overflowResumedTurn && settings.sessionHistorySource === "items" && activeTurnId != null;
+              compacted && !compactionResumedTurn && settings.sessionHistorySource === "items" && activeTurnId != null;
             if (canAutoContinue) {
               const [preemptedEvent] = await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [
                 {
@@ -1714,7 +1720,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   type: "turn.preempted",
                   payload: {
                     triggerEventId: input.triggerEventId,
-                    reason: "context_overflow_compacted",
+                    reason: "context_compacted",
                     resumeWithNotice: true,
                     text: CONTEXT_OVERFLOW_RESUME_TEXT,
                   },
@@ -1724,9 +1730,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               await requeuePreemptedTurn(db, input.workspaceId, activeTurnId, preemptedEvent ? preemptedEvent.id : input.triggerEventId);
               await setSessionStatus(db, input.workspaceId, input.sessionId, "queued", null).catch(() => undefined);
               activityStatus = "preempted";
-              observability.info("context overflow recovery succeeded by compacting and auto-continuing", {
+              observability.info("context compaction recovery succeeded by compacting and auto-continuing", {
                 sessionId: input.sessionId,
                 turnId: activeTurnId,
+                reason: recoveryKind,
                 compacted,
               });
               return { status: "preempted" };
@@ -1736,7 +1743,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 type: "turn.failed",
                 payload: {
                   error: CONTEXT_WINDOW_OVERFLOW_RECOVERY_MESSAGE,
-                  code: "context_window_overflow_compacted",
+                  code: recoveryKind === "overflow" ? "context_window_overflow_compacted" : "context_compacted",
                   retryable: false,
                   recovery: "user_message",
                   compacted,
@@ -1748,17 +1755,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
             activityStatus = "idle";
             activityError = attemptError;
-            observability.info("context overflow recovery succeeded by compacting and idling", {
+            observability.info("context compaction recovery succeeded by compacting and idling", {
               sessionId: input.sessionId,
               turnId: activeTurnId,
+              reason: recoveryKind,
               compacted,
             });
             return { status: "idle" };
           }
-          retriedAfterOverflow = true;
-          observability.info("context overflow recovery retrying turn after compaction", {
+          retriedAfterCompaction = true;
+          observability.info("context compaction recovery retrying turn after compaction", {
             sessionId: input.sessionId,
             turnId: activeTurnId,
+            reason: recoveryKind,
             compacted,
           });
           await prepareRunAttemptInput();

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -1,48 +1,50 @@
 import {
   applyContextCompaction,
   getActiveSessionHistoryItems,
+  nextSessionHistoryPosition,
   type Database,
 } from "@opengeni/db";
 import {
-  buildCompactionMessages,
-  buildSummaryItem,
-  planCompaction,
+  SUMMARY_BUFFER_TOKENS,
+  buildCompactionPromptInput,
+  buildCompactionReplacementHistory,
+  decideClientCompaction,
+  sanitizeHistoryItemsForModel,
   summarizeForCompaction,
   type CompactionItem,
 } from "@opengeni/runtime";
-import {
-  contextInputBudgetTokens,
-  resolveContextCompactionMode,
-  type Settings,
-} from "@opengeni/config";
+import { resolveContextCompactionMode, type Settings } from "@opengeni/config";
 
 export type MaybeCompactResult =
   | { compacted: false; reason: string }
-  | { compacted: true; supersededFrom: number; summaryPosition: number; hardForced: boolean };
+  | {
+      compacted: true;
+      supersededFrom: number;
+      summaryPosition: number;
+      signalTokens: number;
+      thresholdTokens: number;
+    };
 
 /**
  * Pre-turn client-side context compaction (the Azure path).
  *
  * Runs BEFORE the model call when the resolved compaction mode is "client".
- * Reads the active history rows + the last turn's actual input tokens, asks the
- * pure planner whether/where to compact, and — when it should — summarizes the
- * orphan-safe prefix into one plain user message via a model call and writes it
- * with applyContextCompaction (supersede prefix rows, insert the summary).
+ * Reads the active history rows + the most recent provider-reported input
+ * tokens, applies the single Codex-parity threshold, and - when it should -
+ * summarizes the active history with the Codex checkpoint prompt. The write
+ * supersedes the old active rows and inserts replacement active rows:
+ * all real user messages plus one summary.
  *
  * Best-effort by design: any failure (planner says no, summarize fails, DB
  * hiccup) returns without compacting and never throws — the turn proceeds with
  * the un-compacted history. The read path's existing sanitizer keeps that safe.
  *
- * The boundary the planner picks is the start of a kept user-message turn, so
- * no tool-call pair straddles the cut. The summary row is inserted at a
- * fractional position a half-step before the kept tail (boundaryPosition - 0.5),
- * which sorts ahead of the tail without overwriting any real prefix row, so the
- * active read path returns [summary, ...recent tail] in order and the full
- * superseded prefix survives untouched as an audit trail.
+ * There is no kept assistant/tool tail in client mode now. Assistant messages,
+ * tool calls/results, reasoning, and images stay only in inactive audit rows.
  */
 export type CompactionSummarizer = (
   settings: Settings,
-  messages: { system: string; user: string },
+  input: CompactionItem[],
 ) => Promise<string | null>;
 
 export async function maybeCompactContext(
@@ -51,7 +53,7 @@ export async function maybeCompactContext(
   scope: { accountId: string; workspaceId: string; sessionId: string; turnId?: string | null },
   lastInputTokens: number | null,
   // Injectable for tests; defaults to the real provider-aware model call.
-  summarize: CompactionSummarizer = (s, m) => summarizeForCompaction(s, m, { maxOutputTokens: s.contextSummaryMaxTokens }),
+  summarize: CompactionSummarizer = (s, m) => summarizeForCompaction(s, m, { maxOutputTokens: SUMMARY_BUFFER_TOKENS }),
   // Operator-forced (the /compact command): bypass the budget trigger and
   // compact now if there is anything to summarize. Structural guards still hold.
   options: { force?: boolean } = {},
@@ -65,61 +67,52 @@ export async function maybeCompactContext(
     return { compacted: false, reason: "no_history" };
   }
 
-  const items = active.map((row) => row.item) as CompactionItem[];
-  const plan = planCompaction({
+  const items = sanitizeHistoryItemsForModel(active.map((row) => row.item) as CompactionItem[]);
+  const decision = decideClientCompaction({
     items,
     lastInputTokens,
-    inputBudgetTokens: contextInputBudgetTokens(settings),
-    softFraction: settings.contextCompactSoftFraction,
-    hardFraction: settings.contextCompactHardFraction,
-    keepRecentTokens: settings.contextKeepRecentTokens,
+    contextWindowTokens: settings.contextWindowTokens,
+    contextReservedOutputTokens: settings.contextReservedOutputTokens,
     ...(options.force ? { force: true } : {}),
   });
-  if (!plan.shouldCompact) {
-    return { compacted: false, reason: plan.reason };
-  }
-  if (plan.hardForced) {
-    // At/over the hard ceiling (hardFraction*B): the session is past the soft
-    // trigger by a wide margin (often because last_input_tokens was stale-low
-    // and the actual history overflowed). Logged distinctly so the hard-force
-    // backstop firing is observable in production.
-    console.warn(
-      `context compaction HARD-FORCED for session ${scope.sessionId}: signal ${plan.signalTokens} tokens at/over hard ceiling`,
-    );
+  if (!decision.shouldCompact) {
+    return { compacted: false, reason: decision.reason };
   }
 
-  const messages = buildCompactionMessages(plan);
-  const summaryBody = await summarize(settings, messages);
+  const promptInput = buildCompactionPromptInput(items);
+  const summaryBody = await summarize(settings, promptInput);
   if (!summaryBody) {
     return { compacted: false, reason: "summarize_failed" };
   }
 
-  // Boundary is an index into the active rows; map to absolute positions. The
-  // kept tail starts at the boundary row's position; the summary takes a
-  // FRACTIONAL position a half-step before it. Positions are whole numbers, so
-  // boundaryPosition - 0.5 sorts immediately ahead of the kept tail and behind
-  // the last superseded prefix row while colliding with NO real row — the
-  // earlier `boundaryPosition - 1` always landed on (and overwrote) the real
-  // prefix row there.
-  const boundaryRow = active[plan.boundaryIndex];
-  if (!boundaryRow) {
-    return { compacted: false, reason: "boundary_out_of_range" };
+  const replacementHistory = buildCompactionReplacementHistory(items, summaryBody);
+  const summaryItem = replacementHistory.at(-1);
+  if (!summaryItem) {
+    return { compacted: false, reason: "empty_replacement_history" };
   }
-  const boundaryPosition = boundaryRow.position;
-  if (boundaryPosition <= 0) {
-    return { compacted: false, reason: "boundary_at_origin" };
-  }
-  const summaryPosition = boundaryPosition - 0.5;
+  const nextPosition = await nextSessionHistoryPosition(db, scope.workspaceId, scope.sessionId);
+  const replacementItems = replacementHistory.slice(0, -1).map((item, index) => ({
+    position: nextPosition + index,
+    item,
+  }));
+  const summaryPosition = nextPosition + replacementItems.length;
 
   await applyContextCompaction(db, {
     accountId: scope.accountId,
     workspaceId: scope.workspaceId,
     sessionId: scope.sessionId,
     turnId: scope.turnId ?? null,
-    boundaryPosition,
+    boundaryPosition: nextPosition,
+    replacementItems,
     summaryPosition,
-    summaryItem: buildSummaryItem(summaryBody),
+    summaryItem: summaryItem as Record<string, unknown>,
   });
 
-  return { compacted: true, supersededFrom: boundaryPosition, summaryPosition, hardForced: plan.hardForced };
+  return {
+    compacted: true,
+    supersededFrom: nextPosition,
+    summaryPosition,
+    signalTokens: decision.signalTokens,
+    thresholdTokens: decision.thresholdTokens,
+  };
 }

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -234,8 +234,8 @@ async function messageInput(
   const inputBudgetTokens = readPathBudgetTokens(settings);
   if (settings?.sessionHistorySource === "items") {
     // Active rows only: after a client-side context compaction this is
-    // [active summary, ...active recent tail]; superseded (summarized-away)
-    // prefix rows stay in the table as an audit trail but never reach the model.
+    // [retained user messages..., active summary]; superseded rows stay in the
+    // table as an audit trail but never reach the model.
     const stored = await getActiveSessionHistoryItems(db, trigger.workspaceId, trigger.sessionId);
     if (stored.length > 0) {
       const envelope = await getSandboxSessionEnvelope(db, trigger.workspaceId, trigger.sessionId);

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -1,526 +1,120 @@
 # Conversation context compaction
 
-OpenGeni runs long-lived agent sessions. A per-customer "manager" can live for
-weeks, accumulating one `session_history_items` row per conversation item
-(message / reasoning / function_call / function_call_result). With no context
-management that history grows unbounded until it overflows the model's context
-window and the backend hard-fails **every** turn with
-`Your input exceeds the context window of this model`. Every long-lived session
-eventually dies. This document describes the provider-aware compaction that
-structurally fixes that.
+OpenGeni runs long-lived agent sessions whose `session_history_items` can grow
+past the model context window. Compaction is provider-aware:
 
-Code wins over this doc. The canonical sources are:
+- **OpenAI platform / server mode** keeps using the Responses API server-side
+  `context_management` path. This path is intentionally unchanged.
+- **Azure / client mode** uses OpenGeni's local compaction, now simplified to
+  **Codex CLI parity**: checkpoint summarize the current active history, then
+  rebuild active history as user messages plus one summary.
 
-- `packages/config/src/index.ts` — settings + resolution helpers
-  (`resolveContextCompactionMode`, `contextInputBudgetTokens`,
-  `contextServerCompactThreshold`).
-- `packages/runtime/src/index.ts` — `buildAgentCapabilities` (server path),
-  `summarizeForCompaction` (the summarizer model call), and the per-model-call
-  `callModelInputFilter` guard.
-- `packages/runtime/src/image-history.ts` — the pure screenshot-history elision
-  policy used before every model call.
-- `packages/runtime/src/context-compaction.ts` — the pure client-side planner
-  (`planCompaction`, `findKeepBoundary`, summary prompt + item shaping).
-- `apps/worker/src/activities/context-compaction.ts` — `maybeCompactContext`,
-  the pre-turn client-path orchestrator.
-- `apps/worker/src/activities/agent-turn.ts` — where the trigger is wired into
-  the turn, where `last_input_tokens` is recorded, and where provider context
-  overflow is classified/recovered.
-- `packages/db/src/index.ts` — `applyContextCompaction`,
-  `getActiveSessionHistoryItems`, `setSessionLastInputTokens`,
+Code wins over this document. The main files are:
+
+- `packages/config/src/index.ts` - mode and window settings.
+- `packages/runtime/src/context-compaction.ts` - client threshold, Codex prompt
+  constants, rebuild helpers, typed `CompactionNeededError`, and the read-path
+  budget guard.
+- `packages/runtime/src/index.ts` - tool-less summarizer call and per-model-call
+  input filter.
+- `apps/worker/src/activities/context-compaction.ts` - DB orchestrator for
+  client compaction.
+- `apps/worker/src/activities/agent-turn.ts` - turn-start check, manual
+  `/compact`, per-call proactive recovery, and provider overflow recovery.
+- `packages/db/src/index.ts` - `applyContextCompaction`,
+  `getActiveSessionHistoryItems`, `setSessionLastInputTokens`, and
   `nextSessionHistoryPosition`.
-- `packages/db/drizzle/0011_context_compaction.sql` and
-  `0012_compaction_summary_fractional_position.sql` — the schema.
 
-## Why provider-aware
+## Mode Resolution
 
-There are two valid ways to compact a Responses-API conversation, and which one
-is correct depends entirely on the backend:
+`contextCompactionMode` (`OPENGENI_CONTEXT_COMPACTION_MODE`) accepts:
 
-- **OpenAI platform** supports server-side compaction (GA 2026-02-11).
-  `context_management` is a top-level request field; the server compacts and
-  emits an opaque **encrypted** `compaction` item (`encrypted_content`) that
-  must not be pruned. On the platform it "just works" — we use it and run **no**
-  client-side summarization.
-- **Azure OpenAI** does **not** support it. Sending `context_management` returns
-  `400 unsupported_parameter` ("compact_threshold is not enabled"). This matches
-  the production symptom we saw on Azure: zero `compaction` items ever emitted,
-  history grew past the window, every turn 400'd. OpenGeni currently runs on
-  Azure, so on Azure we must do compaction **ourselves, client-side**.
+| mode | result |
+| --- | --- |
+| `auto` | `server` when `openaiProvider === "openai"`, otherwise `client` |
+| `server` | force server-side compaction |
+| `client` | force client-side compaction |
+| `off` | no compaction |
 
-The non-negotiable rule: detect the backend, pick exactly one path, never
-silently double-compact, and never force client-side on a backend that already
-has server-side.
+The server path still uses `contextServerCompactThresholdTokens` when set,
+otherwise `floor((contextWindowTokens - contextReservedOutputTokens) *
+contextCompactSoftFraction)`.
 
-### The SDK trap this fixes
+## Client Trigger
 
-The Agents SDK's `Capabilities.default()` **force-includes** `compaction()`,
-whose sampling params emit `context_management:[{type:'compaction', …}]` to the
-Responses transport. Attaching it unconditionally is exactly what produced the
-Azure 400 in production. So `buildAgentCapabilities` rebuilds the base capability
-set explicitly (`filesystem()`, `shell()`, `skills(...)`) and adds
-`compaction()` **only on the server path**. See
-`packages/runtime/src/index.ts:buildAgentCapabilities`.
-
-## Mode resolution
-
-`contextCompactionMode` (env `OPENGENI_CONTEXT_COMPACTION_MODE`) takes
-`auto` (default) | `server` | `client` | `off`.
-
-`resolveContextCompactionMode(settings)`:
-
-| mode     | result                                                              |
-| -------- | ------------------------------------------------------------------- |
-| `auto`   | `server` when `openaiProvider === "openai"`, else `client` (Azure)  |
-| `server` | force server-side regardless of provider                            |
-| `client` | force client-side regardless of provider                            |
-| `off`    | no compaction (escape hatch only)                                   |
-
-Detection is driven by the explicit `OPENGENI_OPENAI_PROVIDER` config
-(`openai` | `azure`) — the same flag that already selects the transport and
-client construction. It is config, not a runtime probe, so the path is
-deterministic and testable; `server`/`client` let an operator override if a
-backend ever behaves unexpectedly.
-
-## The model window (matters for BOTH paths)
-
-The model is `gpt-5.5`: real context window **1,050,000** tokens, max output
-**128,000**. `gpt-5.5` is **absent** from the SDK's hardcoded compaction
-window map (it knows up to gpt-5.4), so the SDK's `DynamicCompactionPolicy`
-would fall back to a wrong **240k** threshold and compact far too early. The SDK
-exposes no window-registration API, so the fix is to pass an explicit
-`StaticCompactionPolicy(threshold)` on the server path and to use the same
-numbers to budget the client path.
-
-Settings (all env-overridable, see `packages/config/src/index.ts`):
-
-| setting                              | env                                            | default     | meaning |
-| ------------------------------------ | ---------------------------------------------- | ----------- | ------- |
-| `contextWindowTokens`                | `OPENGENI_CONTEXT_WINDOW_TOKENS`               | `1_050_000` | the model's real context window |
-| `contextReservedOutputTokens`        | `OPENGENI_CONTEXT_RESERVED_OUTPUT_TOKENS`      | `128_000`   | tokens reserved for output |
-| `contextServerCompactThresholdTokens`| `OPENGENI_CONTEXT_SERVER_COMPACT_THRESHOLD_TOKENS` | unset   | server path: explicit `compact_threshold` override |
-| `contextCompactSoftFraction`         | `OPENGENI_CONTEXT_COMPACT_SOFT_FRACTION`       | `0.70`      | client path: compact at this fraction of budget |
-| `contextCompactHardFraction`         | `OPENGENI_CONTEXT_COMPACT_HARD_FRACTION`       | `0.85`      | client path: hard-force fraction |
-| `contextKeepRecentTokens`            | `OPENGENI_CONTEXT_KEEP_RECENT_TOKENS`          | `32_000`    | client path: recent full turns kept verbatim |
-| `contextSummaryMaxTokens`            | `OPENGENI_CONTEXT_SUMMARY_MAX_TOKENS`          | `20_000`    | client path: ceiling on generated summary body |
-
-The usable **input budget** is `B = contextWindowTokens − contextReservedOutputTokens`
-(`contextInputBudgetTokens`). With defaults, `B = 922,000`.
-
-The **server-side threshold** (`contextServerCompactThreshold`) is the explicit
-override when set, else `floor(B × softFraction)` = `floor(922,000 × 0.70)` =
-**645,400** tokens. This is the number handed to `StaticCompactionPolicy`, and
-it is what sidesteps the SDK's wrong 240k fallback.
-
-## Server-side path (OpenAI platform)
-
-When the resolved mode is `server`:
-
-1. `buildAgentCapabilities` attaches
-   `compaction({ policy: new StaticCompactionPolicy(645_400) })`. The SDK then
-   emits `context_management` on each request and the platform compacts
-   server-side, returning the encrypted `compaction` item, which the SDK's own
-   `processContext` slices around. We add nothing client-side.
-2. The request sets **`store: false`**. Server-side compaction's encrypted
-   `compaction` item round-trips in the request rather than being anchored to a
-   stored response, and `store: false` is the documented precondition. OpenGeni
-   already runs storeless (provider item ids stripped, see issue #48), so this
-   is consistent. `store: false` is set **only** on the server path —
-   see `packages/runtime/src/index.ts` (`resolveContextCompactionMode(...) === "server"`).
-
-That is the entire platform path. No DB writes, no synthetic summary, no
-`session_history_items` mutation.
-
-## Client-side path (Azure)
-
-This is the substantive new machinery. It runs **pre-turn**, before the model
-call, when the resolved mode is `client`.
-
-### Trigger (self-heal: `max(recorded, estimate)`)
-
-The trigger signal is
-**`signalTokens = max(recorded last-turn input tokens, char/4 estimate of the
-active items)`** — see `planCompaction` in `context-compaction.ts`. Compaction
-fires when `signalTokens ≥ softFraction × B` (≈ 645,400 with defaults);
-`hardFraction × B` (≈ 783,700 = `floor(922,000 × 0.85)`) is the hard-force point
-(see below — it now has distinct behavior).
-
-The **`max`** matters and is a deliberate self-heal fix. `sessions.last_input_tokens`
-is written **only** when a model response reports usage (`agent-turn.ts`,
-guarded by `lastInputTokensObserved !== null` at the end of a turn). A turn that
-**overflows on its first model call observes no usage at all**, so the column
-keeps a **stale-positive** value from the last good turn (e.g. ~600k). The old
-planner *trusted* that recorded count whenever it was positive and only
-estimated from the real history when it was null — so a stale-low 600k slipped
-under the 645k soft limit, no compaction ran, the actually-over-budget history
-(>1.05M) was sent, and the turn overflowed **again**: a permanent re-brick with
-no self-heal. Reachable in practice (e.g. a manager paging a worker's large
-event stream balloons the history in one turn). Taking the **max** of the
-recorded count and a fresh estimate of the *actual* active items means a bloated
-history triggers compaction **regardless** of a stale recorded count, so the
-session self-heals on the very next turn.
-
-A brand-new session (no recorded count, small history) simply has a small
-estimate and does not compact — same outcome as before.
-
-### Hard-force backstop (`hardFraction × B`)
-
-`hardFraction` is **no longer informational** — it drives a distinct, more
-aggressive path. When `signalTokens ≥ hardFraction × B` the plan is marked
-`hardForced` and the boundary walk runs with a **shrunk keep-recent budget**:
+Client mode has one threshold:
 
 ```
-effectiveKeepRecent = hardForced
-  ? min( floor(keepRecentTokens / 2), floor(B / 4) )
-  : keepRecentTokens
+signal > 0.9 * (contextWindowTokens - contextReservedOutputTokens - 20_000)
 ```
 
-Why: the soft path keeps the full `contextKeepRecentTokens` (32k) tail verbatim.
-But under hard pressure — especially when the recorded count was stale-low and
-the *history itself* is over the window — a history whose entire tail still
-reads as "recent" (fits within `keepRecentTokens`) would find **no prefix to
-summarize** and strand the session over budget (the everything-is-recent
-deadlock). Shrinking the tail under hard pressure forces the boundary walk to
-leave a non-empty, summarizable prefix, so an over-budget history **always**
-yields a real compaction. The structural guards still apply: a hard-force never
-invents a cut that orphans a tool-call pair or summarizes an empty prefix.
+`20_000` is `SUMMARY_BUFFER_TOKENS`, matching the output budget for the
+checkpoint summary. With the defaults (`1,050,000` window, `128,000` reserved
+output), the threshold is `811,800`.
 
-`maybeCompactContext` logs a `context compaction HARD-FORCED …` line and the
-emitted `session.context.compacted` event carries `trigger: "hard"` (vs
-`"operator"` for a `/compact`, vs unset for a normal soft compaction), so the
-hard path is observable.
+The signal prefers provider-reported input tokens:
 
-### Read-path budget guard (the airbag — last-resort backstop)
+- Turn-start compaction reads `sessions.last_input_tokens`, which is persisted
+  from provider usage.
+- Mid-turn proactive compaction reads the most recent provider usage observed in
+  the current activity.
+- `chars / 4` estimation is only the pre-first-call fallback when no provider
+  signal exists yet.
 
-Pre-turn compaction is **best-effort**: it can no-op (the summarizer model call
-fails, `client` mode is off, or a fresh user message arrives *after* a turn
-already ballooned the history) and still leave an assembled input that exceeds
-the window. The #61 orphan sanitizer is purely **structural** — it has no size
-awareness — so without a size backstop an over-budget input would be put on the
-wire and 400 every turn, re-bricking the session.
+The old client soft/hard fraction pair and `contextKeepRecentTokens` no longer
+drive client compaction. Those config keys remain parsed for environment
+back-compat and server threshold compatibility, but the client path ignores
+them. `contextSummaryMaxTokens` is also parsed for back-compat; client
+compaction uses the fixed `SUMMARY_BUFFER_TOKENS` output ceiling.
 
-`enforceInputBudget` (in `context-compaction.ts`) is that backstop. It runs at
-**input-assembly time** in `prepareRunInput` (`packages/runtime/src/index.ts`,
-via `guardAssembledInput`) and drops the **oldest** history at a clean turn
-boundary until the estimated request fits `B`, **always** keeping the most
-recent turn(s). It is:
+## Client Rebuild
 
-- **Orphan-safe by construction** — it only ever cuts at the start of a user
-  message (via `findKeepBoundary`), so no tool-call pair is split; a boundary of
-  0 (no earlier safe cut) leaves the input unchanged rather than orphaning a pair.
-- **Whole-request aware** — the trailing user/continuation message and fixed
-  system/tool overhead are counted (`trailingTokens`) so the cap is measured
-  against the *whole* request, not just the stored history.
-- **A crude data-loss fallback** — it generates **no** summary; real context
-  preservation is the summarizing pre-turn path. This is the airbag, not the
-  seatbelt. When it trims it logs
-  `read-path budget guard trimmed N oldest history item(s) … the over-budget
-  input was NOT sent`.
+The checkpoint summarizer call is tool-less and receives:
 
-It is wired **only on the Azure client path** (`readPathBudgetTokens` returns a
-budget only when `resolveContextCompactionMode(settings) === "client"`); on the
-server path the SDK enforces the window. So in production (Azure) a single
-over-budget assembled input can never reach the model.
+1. Current active history.
+2. One synthesized user message containing Codex CLI's
+   `prompts/templates/compact/prompt.md` text verbatim.
 
-### Per-call guard and screenshot elision
+The model output is wrapped with Codex CLI's `summary_prefix.md` text verbatim
+and stored as one plain user `message` item with
+`opengeni_context_summary: true`.
 
-The read-path guard above runs when the turn input is assembled. It cannot see
-history generated later in the same SDK loop, which is exactly where
-computer-use screenshots can balloon a turn. Every provider call therefore also
-runs a `callModelInputFilter` in `packages/runtime/src/index.ts`:
+The new active history is:
 
-- First, `elideStaleScreenshotImages` keeps only the last three screenshot image
-  payloads in model input and replaces older screenshots with
-  `[screenshot omitted: an older desktop frame — the full image remains in the session event log]`.
-  It recognizes hosted `computer_call_output`/`computer_call_result` images,
-  structured `input_image` tool outputs, and bare `data:image/*;base64,` strings
-  embedded in function-text tool output. It never rewrites system prompts, user
-  messages, or non-image tool output.
-- Then, only when the resolved compaction mode is `client`, the same input
-  budget `B` is enforced on the per-call input. In `server` and `off` modes the
-  image policy still applies, but the hard budget trim is skipped.
+1. All real user messages in order, excluding prior OpenGeni summary items.
+2. Each retained user message capped at 20k estimated tokens by truncating the
+   middle with a marker.
+3. One summary item appended last.
 
-These filters are request-local: they do not mutate `session_history_items` or
-the SDK `RunState`. The full screenshots remain available in the durable event
-log; only stale image bytes are omitted from subsequent model inputs.
+Assistant messages, tool calls/results, reasoning items, and images are removed
+from active history. They are not deleted: the compaction DB transaction marks
+the old active rows inactive and inserts replacement active rows, preserving the
+audit trail.
 
-### Reactive overflow recovery
+## Turn Flows
 
-If the provider still rejects a request with a context-window overflow
-(`context_length_exceeded`, `exceeds the context window`, `maximum context
-length`, and Azure/OpenAI wording variants), `runAgentTurn` handles it before the
-generic failure path:
+Turn-start client compaction runs before reading history for a fresh
+`user.message` or `goal.continuation` turn. Manual `/compact` sets the existing
+durable request flag and forces this same rebuild on the next turn.
 
-1. It flushes any batched runtime events and reconciles conversation truth only
-   when model/tool progress exists. A lone trigger message is not persisted just
-   before an in-activity retry, because rebuilding from history plus the same
-   trigger would duplicate the user's input.
-2. It forces client-side compaction for the session, independent of the configured
-   mode for that one recovery action.
-3. If no model/tool progress was persisted for the turn, it retries the run once
-   inside the same activity. This is not a Temporal retry; the activity still has
-   `maximumAttempts: 1`.
-4. If model/tool progress was already persisted, it does not replay the trigger.
-   It publishes `turn.failed` with a human-readable recovery message, leaves the
-   session `idle`, and the next user message continues from the compacted history.
-5. A second overflow in the same turn is allowed to fall through to the normal
-   failure path so recovery cannot loop forever.
+The per-model-call filter still performs screenshot elision and the existing
+input budget guard. In client mode, when the single threshold is crossed
+mid-turn, it throws `CompactionNeededError`. `agent-turn.ts` handles that error
+through the same recovery loop as provider context-window overflow:
 
-### Boundary rule (orphan safety — critical)
+- If no model/tool progress was persisted, compact and retry once inside the
+  same activity.
+- If progress was persisted, compact and requeue the turn with a resume notice
+  (`reason: "context_compacted"`).
+- If a turn already resumed from compaction immediately needs compaction again,
+  it falls back to idle instead of looping.
 
-This is the single most important correctness property. The read path already
-ships a sanitizer (#61) that drops orphaned `function_call_result` (an output
-with no matching call) and dangling `function_call` before sending to the model;
-an earlier orphan bug 400'd the model. Compaction must **never create orphans**.
+Provider context-window overflow remains a reactive safety path and reuses the
+same compaction/retry/requeue logic.
 
-`findKeepBoundary` therefore cuts **only at a clean turn boundary** — the start
-of a user `message`. The kept tail is the latest user-message boundary whose
-`[boundary, end)` tail still fits `contextKeepRecentTokens`; everything before it
-is the prefix to summarize. Because the cut lands on a user message:
+## Read-Path Guard
 
-- For every `function_call` in the dropped prefix, its
-  `function_call_result` is also in the prefix (and vice versa) — no `call_id`
-  straddles the cut.
-- `reasoning` items drop or keep with their whole turn.
-
-If no user-message boundary exists, or the only boundary is at position 0, the
-planner returns "no useful cut" and the turn proceeds un-compacted.
-
-The tail keeps **full recent turns** verbatim (recent tool results are the live
-working set), not just user messages — `contextKeepRecentTokens` defaults to 32k.
-
-### Single live summary (bounded drift)
-
-The old prefix is summarized into **one** plain `message` item, role `user`,
-carrying a `SUMMARY_PREFIX` bridge plus the model-generated summary body and a
-marker key `opengeni_context_summary: true` in the item JSON. It is a **plain
-user message, deliberately NOT the SDK `compaction` item type** — that type
-requires server-minted `encrypted_content`, and a hand-rolled one risks an
-Azure 400. (Codex's client-side compaction makes the same choice.)
-
-Exactly one live summary exists at any time. Each compaction **folds the prior
-summary forward**: it summarizes `[prior summary] + [items since]`, excludes
-prior summaries from re-collection, and replaces them with the new one. This
-bounds summary drift over a weeks-long session. If a candidate cut would leave
-**only** a prior summary in the prefix (nothing new to fold), the planner
-returns `nothing_to_summarize` and leaves the existing summary in place — this
-prevents a re-wrap loop.
-
-### Summary quality
-
-The summarizer prompt (`SUMMARY_INSTRUCTIONS`) leans on OpenGeni's durable
-structured memory: durable facts already live in the workspace notebook /
-document bases (via MCP), so the conversation summary is a **light
-working-memory bridge**, not the whole truth. It is told to capture: current
-objective + key decisions, open blockers / in-progress work, deployed/infra
-state, environment & credential facts **by reference only** (name env-var keys,
-secret names, notebook/document ids — **never copy a secret value**), and
-concrete next steps; and to state explicitly that durable facts are in the
-notebook and that it lists pointers, not contents.
-
-The summarizer is one plain, tool-less, non-streaming model call
-(`summarizeForCompaction`). On the OpenAI platform it sets `store: false`; on
-Azure it omits `store`. **Any failure returns `null` and skips compaction for
-this turn** — the turn proceeds on the un-compacted history (the read-path
-sanitizer keeps that safe). Compaction is best-effort and never throws into the
-turn.
-
-Doctrine/identity stays in the agent's resident instructions (not in history),
-so it survives every compaction for free.
-
-### Storage model (supersede, never delete)
-
-The audit trail is sacrosanct. Compaction **never deletes** rows.
-
-- `session_history_items.active` (boolean, default `true`) is the live-row flag.
-  Summarized prefix rows are set `active = false` (superseded), not removed.
-- The synthetic summary is inserted as a **new** active row at a **fractional
-  position** `boundaryPosition − 0.5`. `position` is `numeric` (widened from
-  `integer` in migration 0012). Real rows always have whole-number positions, so
-  the half-step sorts immediately ahead of the kept tail, behind the last
-  superseded prefix row, and **collides with no real row**.
-- A partial index `session_history_items_active_idx` on
-  `(workspace_id, session_id, position) WHERE active` keeps the live read fast.
-
-> **Why fractional?** The first cut of this feature (migration 0011) placed the
-> summary at the **integer** position `boundaryPosition − 1`. Because positions
-> are contiguous from 0, that slot is **always** an occupied real prefix row, and
-> the upsert overwrote that row's item JSON — destroying one real history row per
-> compaction and violating "supersede, never delete". The fractional placement
-> (migration 0012 + PR #63, folded into #62 before merge) fixes it at the source.
-> `applyContextCompaction`'s `onConflictDoUpdate` conflict target is the
-> fractional position, which can only ever collide with a **prior summary** row,
-> so a retry merely re-activates the existing summary — idempotent, and it never
-> touches a real row.
-
-### Read-path assembly
-
-`getActiveSessionHistoryItems` selects only `active` rows ordered by `position`,
-so after a compaction it returns `[summary, …recent tail]`. The worker's
-`run-input.ts` `messageInput` uses it to build the model request, then appends
-the new user message. This mirrors the SDK's "slice after boundary" behavior,
-but in our own SQL path with plain message items, so it works on Azure.
-
-New rows continue to append at fresh **whole-number** positions via
-`nextSessionHistoryPosition` (`floor(max(position)) + 1`), decoupled from the
-in-memory history length (which, after a compaction, is the short active set,
-far shorter than the total row count). See `historyRowsToAppend` and
-`nextHistoryPosition` in `agent-turn.ts`.
-
-### Events
-
-A successful client-side compaction publishes a `session.context.compacted`
-event carrying the summary position, for observability.
-
-## How to operate and tune
-
-- **Leave it on `auto`.** On Azure it resolves to `client`; if you move a
-  workspace to the OpenAI platform (`OPENGENI_OPENAI_PROVIDER=openai`) it
-  resolves to `server` automatically.
-- **If a backend behaves unexpectedly**, force the path with
-  `OPENGENI_CONTEXT_COMPACTION_MODE=server|client`. `off` disables compaction
-  entirely — only for debugging; long sessions will overflow again.
-- **If you change models**, set `OPENGENI_CONTEXT_WINDOW_TOKENS` and
-  `OPENGENI_CONTEXT_RESERVED_OUTPUT_TOKENS` to the new model's real numbers.
-  Everything else (server threshold, client soft/hard points) is derived from
-  them. Do **not** rely on the SDK's built-in window map for any model it does
-  not know.
-- **Compacting too often / too rarely** (client path): lower/raise
-  `OPENGENI_CONTEXT_COMPACT_SOFT_FRACTION`. **Tail too thin** (the agent forgets
-  recent tool output): raise `OPENGENI_CONTEXT_KEEP_RECENT_TOKENS`. **Summary
-  too long/expensive**: lower `OPENGENI_CONTEXT_SUMMARY_MAX_TOKENS`.
-- **Force the server threshold** with
-  `OPENGENI_CONTEXT_SERVER_COMPACT_THRESHOLD_TOKENS` if you want a value other
-  than `floor(B × softFraction)`.
-
-### Operator inspection
-
-To see compaction activity for a workspace DB directly:
-
-```sql
--- live summary rows (one active per compacted session)
-SELECT session_id, position
-FROM session_history_items
-WHERE item->>'opengeni_context_summary' = 'true' AND active;
-
--- superseded (audit-trail) rows per session
-SELECT session_id, count(*)
-FROM session_history_items
-WHERE active = false
-GROUP BY session_id;
-
--- the trigger signal
-SELECT id, last_input_tokens FROM sessions WHERE last_input_tokens IS NOT NULL;
-```
-
-## How it was verified
-
-- **Unit gate (re-run on `origin/main` @ `0b8f8c0`):** `bun run typecheck`
-  green (all packages, exit 0); full unit suite **511 pass / 0 fail** (37 files).
-  The compaction-specific unit tests (`packages/runtime/test/context-compaction.test.ts`,
-  `packages/config/test/context-compaction.test.ts`,
-  `packages/runtime/test/capabilities.test.ts`, `apps/worker/test/agent-turn.test.ts`)
-  contribute 39 of those and exercise: provider→mode resolution, the 645,400
-  server threshold (not 240k), boundary selection, orphan-safe cuts, prior-summary
-  fold-forward, the `nothing_to_summarize` no-loop guard, and fractional-position
-  append decoupling.
-- **Integration gate (real Postgres + NATS via testcontainers, re-run on
-  `origin/main`):** the `maybeCompactContext` tests in
-  `test/integration/worker-activity.integration.ts` — **4 pass / 0 fail** —
-  prove end-to-end against a live DB that an over-budget Azure session compacts
-  into an orphan-clean `[summary, …recent tail]` active read path, that the
-  summarized prefix is **superseded not deleted** (the audit rows remain), that
-  exactly one summary row exists, that no real row is overwritten, and that the
-  summary is recorded under the current turn so per-turn counts stay correct.
-- **Self-heal + hard-force (PR #69):** the `max(recorded, estimate)` trigger and
-  the hard-force / read-path-guard backstops were added in PR #69
-  (`cc17837`). Their unit coverage lives in
-  `packages/runtime/test/context-compaction.test.ts` and proves the two
-  regressions this doc calls out: a **stale-positive `last_input_tokens` + an
-  over-budget history MUST compact** (the `max` defeats the stale-low count), and
-  a **post-overflow session self-heals on the next turn**; plus the hard-force
-  shrunk-tail prefix guarantee and `enforceInputBudget`'s orphan-safe oldest-drop.
-- **Deploy state (re-read live 2026-06-14):** staging **and** production
-  `/healthz` both report
-  `deploymentRevision = 21315832b6cd92ec78ea6da677eb3b766a943d66`, `ok: true` —
-  the HEAD of `origin/main`, which includes PR #69 (self-heal + hard-force), #68
-  (session-read byte cap), and #70 (interrupt fix). The full ops pipeline
-  (Build Staging Artifacts → Deploy Staging → Promote Production Artifacts →
-  Deploy Production) ran green at 12:39–12:57Z on 2026-06-14, all after the
-  merges. (The staging DB is a **private** Azure endpoint not reachable from the
-  authoring environment, and no AKS/Azure credentials were available to spin up
-  an in-cluster probe pod, so a direct readback of `session_history_items`
-  column types / live summary rows was **not** re-performed in this pass — see
-  residual gaps.)
-- **Earlier live proof (point-in-time, from the shipping run):** a real Azure
-  staging session exercised the deployed client-side path and cut model input
-  ~377k → ~29k tokens (~92%), creating a summary, superseding (not deleting) the
-  prefix, with an orphan-safe read path. See the residual-gaps note below on
-  re-confirmability.
-
-## Residual gaps and caveats (read this)
-
-- **No live compaction *firing* has been re-confirmed by a current DB readback.**
-  The deployed revision is confirmed live (staging+prod `/healthz` = `21315832`),
-  the trigger column `sessions.last_input_tokens` is written by the deployed
-  worker, and the `session.context.compacted` event type is in the contract and
-  emitted by `agent-turn.ts`. But the staging DB is a **private Azure endpoint**
-  and this authoring pass had **no AKS/Azure credentials** to open an in-cluster
-  `psql` probe, so the "a real session crossed the soft threshold and produced a
-  summary row" claim still rests on the **earlier point-in-time shipping run**
-  (377k→29k), not on a fresh readback. The compaction logic is proven by the
-  real-Postgres integration test and the unit suite. The first long staging/prod
-  session to cross ~645k tokens is the live confirmation; watch for
-  `session.context.compacted` events (now carrying `trigger`) and superseded
-  (`active = false`) rows.
-- **~~`hardFraction` is currently informational.~~ FIXED (PR #69).** Hard force
-  now shrinks the keep-recent tail so an over-budget history always yields a
-  summarizable prefix, and the read-path `enforceInputBudget` guard ensures a
-  single over-budget assembled input is never sent. The stale-positive
-  `last_input_tokens` re-brick is closed by the `max(recorded, estimate)`
-  trigger. See "Hard-force backstop" and "Read-path budget guard" above.
-- **Summarizer cost/latency.** Each client-side compaction is an extra model
-  call (≤ `contextSummaryMaxTokens` output). On a busy long session this recurs;
-  it is bounded by the single-live-summary fold-forward but is not free. Monitor
-  via the compaction events if cost matters.
-- **Trigger granularity is still mostly per-turn, pre-read.** The per-call image
-  elision and budget guard now cover mid-turn growth, and classified provider
-  overflow forces compaction plus one bounded in-activity retry when no
-  model/tool progress was persisted. A pathological non-image single item can
-  still exceed the window; in that case the activity compacts, idles after
-  persisted progress, or falls through to the normal failure path on a second
-  same-turn overflow.
-- **Server-path live behavior is unexercised in our production.** We run on
-  Azure, so the `server` path (and its `store: false` + `StaticCompactionPolicy`)
-  is covered by unit tests and the SDK's own contract, but not by our own
-  production traffic. It is the correct path per the platform's GA behavior; if
-  OpenGeni moves to the OpenAI platform, validate it live then.
-
-## Executive go/no-go
-
-**GO.** Unbounded-history-overflow is now **structurally fixed** for Azure
-long-lived sessions: the Azure path no longer attaches the SDK `compaction`
-capability (so no more 400s), and a pre-turn client-side compaction summarizes
-the old prefix into a single plain user message at an orphan-safe turn boundary,
-supersedes (never deletes) the prefix, and assembles a bounded
-`[summary, …recent tail]` read path — so history can no longer grow without
-bound. **The two self-heal holes are closed (PR #69):** the
-`max(recorded, estimate)` trigger defeats the stale-positive `last_input_tokens`
-re-brick, the hard-force path shrinks the keep-recent tail so an over-budget
-  history always yields a summarizable prefix, the `enforceInputBudget`
-  read-path/per-call guards keep over-budget client-mode inputs off the wire, and
-  the image-history policy elides stale screenshot payloads before every model
-  call. Server-side compaction is **preserved and used** automatically on the
-  OpenAI platform (correct 645,400 threshold, `store: false`), with no
-client-side double-compaction. The code is merged (PR #62 + audit-trail fix #63
-+ self-heal/hard-force #69), deployed to staging **and** production
-(`/healthz` = `21315832`, re-read live 2026-06-14), and schema-migrated. The one
-honest caveat is that **the live compaction *firing* has not been re-confirmed
-by a current DB readback** this pass (the staging DB is a private endpoint and no
-in-cluster probe was available); the mechanism is proven by the real-database
-integration test, the unit suite, and the earlier point-in-time live run.
-
-> The compaction self-heal is one of four manager-session robustness fixes.
-> For the whole picture — session-read byte caps, the don't-poll doctrine, and
-> the `user.interrupt` fix — and the cross-cutting executive verdict, see
-> [`manager-session-robustness.md`](./manager-session-robustness.md).
+`enforceInputBudget` remains a request-local airbag. It can drop the oldest
+history at a clean user-message boundary so an oversized input is not sent. It
+does not create summaries and does not mutate the DB. It exists behind the
+real compaction path as a last-resort guard.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -193,14 +193,14 @@ const SettingsSchema = z.object({
   // StaticCompactionPolicy. Defaults to floor(B * contextCompactSoftFraction)
   // when unset.
   contextServerCompactThresholdTokens: z.coerce.number().int().positive().optional(),
-  // Client path: compact pre-turn when the last turn's actual input tokens
-  // reach softFraction*B; hard-force at hardFraction*B.
+  // Server path/back-compat knobs. The client compaction path ignores these:
+  // it uses Codex-parity 0.9 * (window - reserved output - 20k summary buffer).
   contextCompactSoftFraction: z.coerce.number().positive().max(1).default(0.70),
   contextCompactHardFraction: z.coerce.number().positive().max(1).default(0.85),
-  // Client path: tokens of the most recent FULL turns kept verbatim after a
-  // compaction (the live working set: recent tool results, not just messages).
+  // Deprecated for the client path; parsed for env/back-compat only.
   contextKeepRecentTokens: z.coerce.number().int().positive().default(32_000),
-  // Client path: token ceiling on the generated summary body.
+  // Parsed for back-compat. Client compaction uses the fixed 20k Codex summary
+  // buffer as its generated-summary output ceiling.
   contextSummaryMaxTokens: z.coerce.number().int().positive().default(20_000),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3431,8 +3431,8 @@ export async function getSessionHistoryItems(db: Database, workspaceId: string, 
 
 /**
  * The LIVE conversation-truth read path: only active rows, position-ordered.
- * After a client-side context compaction this returns [active summary,
- * ...active recent tail]; with no compaction yet it equals
+ * After a client-side context compaction this returns [retained user messages,
+ * active summary]; with no compaction yet it equals
  * getSessionHistoryItems. The model-facing read path uses this so superseded
  * (summarized-away) prefix rows are excluded while the full transcript stays in
  * the table as an audit trail.
@@ -3602,8 +3602,15 @@ export async function applyContextCompaction(db: Database, input: {
   turnId?: string | null;
   /** Active prefix rows with position < boundaryPosition get superseded. */
   boundaryPosition: number;
-  /** Fractional position for the new summary row (must be < boundaryPosition). */
+  /** Position for the new summary row. Old boundary mode uses a fractional half-step before the kept tail. */
   summaryPosition: number;
+  /**
+   * Optional replacement rows inserted after superseding the old active set.
+   * Used by Codex-parity client compaction to rebuild active history as retained
+   * user messages plus one summary. These rows are synthetic replay rows, so
+   * they intentionally do not inherit the current compaction turn id.
+   */
+  replacementItems?: Array<{ position: number; item: Record<string, unknown> }>;
   summaryItem: Record<string, unknown>;
 }): Promise<void> {
   await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId }, async (scopedDb) => {
@@ -3616,6 +3623,20 @@ export async function applyContextCompaction(db: Database, input: {
           eq(schema.sessionHistoryItems.active, true),
           lt(schema.sessionHistoryItems.position, input.boundaryPosition),
         ));
+      if (input.replacementItems && input.replacementItems.length > 0) {
+        await tx.insert(schema.sessionHistoryItems).values(input.replacementItems.map((entry) => ({
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          turnId: null,
+          position: entry.position,
+          item: sanitizeEventPayload(entry.item),
+          active: true,
+        }))).onConflictDoUpdate({
+          target: [schema.sessionHistoryItems.workspaceId, schema.sessionHistoryItems.sessionId, schema.sessionHistoryItems.position],
+          set: { active: true },
+        });
+      }
       // Insert the summary at its FRACTIONAL position. The supersede step above
       // also sets active=false for any rows with position < boundaryPosition —
       // which on a RETRY includes the summary itself (it sits below the

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -1,59 +1,46 @@
 /**
- * Client-side conversation context compaction (the Azure path).
+ * Client-side conversation context compaction (the Azure/client path).
  *
- * OpenGeni runs long-lived agent sessions whose conversation truth
- * (`session_history_items`) grows unbounded. On the OpenAI platform the
- * Responses API compacts server-side (the SDK's `compaction()` capability). On
- * Azure that capability 400s (`unsupported_parameter`), so the session
- * eventually overflows the model context window and hard-fails every turn.
- *
- * This module is the Azure-safe replacement. It is built from two pure pieces
- * plus one impure step the caller wires in:
- *
- *  1. `planCompaction` — given the active history items, the last turn's actual
- *     input-token count, and the token budget, decide WHETHER to compact and,
- *     if so, WHERE the orphan-safe cut boundary is (the prefix to summarize vs
- *     the recent tail to keep verbatim). Pure, exhaustively testable.
- *  2. (caller) summarize the prefix into ONE plain user `message` item via a
- *     model call — see `buildCompactionMessages` / `SUMMARY_PREFIX`.
- *  3. `applyCompaction` shape — the storage write the caller performs:
- *     supersede the prefix rows, insert the summary at the boundary position.
- *
- * Design constraints (non-negotiable):
- *  - The summary is a PLAIN user message, NOT the SDK `compaction` item type
- *    (that requires server-minted `encrypted_content`; a hand-rolled one risks
- *    an Azure 400).
- *  - ORPHAN SAFETY: the cut lands only at a clean turn boundary (start of a
- *    user message). No tool call_id may straddle the cut — for every
- *    `function_call` dropped, its `function_call_result` is also dropped, and
- *    vice versa. Reasoning items drop/keep with their whole turn.
- *  - SINGLE LIVE SUMMARY: each compaction folds the prior summary forward
- *    (summarize [prior summary] + [items since]); prior summaries are excluded
- *    from re-collection so drift stays bounded.
+ * This mirrors Codex CLI's compaction model: the checkpoint model sees the
+ * current active history plus one fixed checkpoint prompt, then the active
+ * history is rebuilt as all real user messages plus one summary message.
+ * Assistant messages, tool calls/results, reasoning, and images are removed
+ * from the active model-facing history; the database audit rows remain.
  */
 
 export type CompactionItem = Record<string, unknown>;
 
 /**
- * Marker stored on the synthetic summary item so it can be recognized on the
- * next compaction (to fold it forward) and excluded from re-summarization. It
- * lives in the item JSON, not a DB column, so it survives verbatim replay.
+ * Marker stored on the synthetic summary item so the UI can render it and the
+ * next rebuild can exclude old summaries from the retained user-message set.
  */
 export const COMPACTION_SUMMARY_MARKER = "opengeni_context_summary";
 
-/**
- * Bridge text prepended to the summary body in the synthetic user message. It
- * tells the model the preceding conversation was compacted and that durable
- * facts live in the notebook — so it treats the summary as a working-memory
- * pointer, not the whole truth.
- */
-export const SUMMARY_PREFIX = [
-  "[CONTEXT CHECKPOINT] The earlier part of this conversation was automatically compacted to stay within the model context window.",
-  "Durable facts already live in the workspace notebook / document bases (via MCP) — the summary below is a light working-memory bridge, not a full transcript.",
-  "Trust it for current objective, decisions, blockers, deployed/infra state, and next steps; re-read the notebook for anything authoritative.",
+export const SUMMARY_BUFFER_TOKENS = 20_000;
+export const COMPACT_USER_MESSAGE_MAX_TOKENS = 20_000;
+export const CLIENT_COMPACTION_TRIGGER_FRACTION = 0.9;
+
+// Verbatim from Codex CLI:
+// codex-rs/prompts/templates/compact/prompt.md
+export const COMPACTION_PROMPT = [
+  "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.",
   "",
-  "SUMMARY:",
+  "Include:",
+  "- Current progress and key decisions made",
+  "- Important context, constraints, or user preferences",
+  "- What remains to be done (clear next steps)",
+  "- Any critical data, examples, or references needed to continue",
+  "",
+  "Be concise, structured, and focused on helping the next LLM seamlessly continue the work.",
 ].join("\n");
+
+// Verbatim from Codex CLI:
+// codex-rs/prompts/templates/compact/summary_prefix.md
+export const SUMMARY_PREFIX =
+  "Another language model started to solve this problem and produced a summary of its thinking process. You also have access to the state of the tools that were used by that language model. Use this to build on the work that has already been done and avoid duplicating work. Here is the summary produced by the other language model, use the information in this summary to assist with your own analysis:";
+
+export const USER_MESSAGE_TRUNCATION_MARKER =
+  "\n[... middle truncated for context compaction ...]\n";
 
 const RESULT_TYPE_BY_CALL_TYPE: Record<string, string> = {
   function_call: "function_call_result",
@@ -87,15 +74,14 @@ export function isUserMessage(item: unknown): boolean {
 /** True for our synthetic compaction summary item. */
 export function isCompactionSummary(item: unknown): boolean {
   return (
-    isUserMessage(item) &&
-    (item as Record<string, unknown>)[COMPACTION_SUMMARY_MARKER] === true
+    isUserMessage(item)
+    && (item as Record<string, unknown>)[COMPACTION_SUMMARY_MARKER] === true
   );
 }
 
 /**
- * Rough token estimate for an item: char/4 over its serialized text. Used only
- * for the tail-budget walk; the trigger decision uses the real last-turn input
- * token count, falling back to this when that is unavailable.
+ * Rough token estimate for an item: char/4 over its serialized text. Used for
+ * the pre-first-call fallback, per-user-message cap, and read-path airbag.
  */
 export function estimateItemTokens(item: CompactionItem): number {
   let text: string;
@@ -115,19 +101,94 @@ export function estimateTokens(items: readonly CompactionItem[]): number {
   return total;
 }
 
+export function clientCompactionThresholdTokens(input: {
+  contextWindowTokens: number;
+  contextReservedOutputTokens: number;
+}): number {
+  const available = Math.max(
+    0,
+    input.contextWindowTokens - input.contextReservedOutputTokens - SUMMARY_BUFFER_TOKENS,
+  );
+  return Math.floor(available * CLIENT_COMPACTION_TRIGGER_FRACTION);
+}
+
+export type ClientCompactionDecision = {
+  shouldCompact: boolean;
+  reason: "force" | "above_threshold" | "below_threshold" | "no_history";
+  signalTokens: number;
+  thresholdTokens: number;
+};
+
+export function decideClientCompaction(input: {
+  items: readonly CompactionItem[];
+  lastInputTokens?: number | null;
+  contextWindowTokens: number;
+  contextReservedOutputTokens: number;
+  force?: boolean;
+}): ClientCompactionDecision {
+  const thresholdTokens = clientCompactionThresholdTokens(input);
+  const recorded =
+    typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
+      ? input.lastInputTokens
+      : 0;
+  const signalTokens = recorded > 0 ? recorded : estimateTokens(input.items);
+  if (input.items.length === 0) {
+    return { shouldCompact: false, reason: "no_history", signalTokens, thresholdTokens };
+  }
+  if (input.force) {
+    return { shouldCompact: true, reason: "force", signalTokens, thresholdTokens };
+  }
+  if (signalTokens > thresholdTokens) {
+    return { shouldCompact: true, reason: "above_threshold", signalTokens, thresholdTokens };
+  }
+  return { shouldCompact: false, reason: "below_threshold", signalTokens, thresholdTokens };
+}
+
+export class CompactionNeededError extends Error {
+  readonly signalTokens: number;
+  readonly thresholdTokens: number;
+  readonly signalSource: "provider" | "estimate";
+
+  constructor(input: {
+    signalTokens: number;
+    thresholdTokens: number;
+    signalSource: "provider" | "estimate";
+  }) {
+    super(
+      `Context compaction needed: signal ${input.signalTokens} tokens exceeded threshold ${input.thresholdTokens}`,
+    );
+    this.name = "CompactionNeededError";
+    this.signalTokens = input.signalTokens;
+    this.thresholdTokens = input.thresholdTokens;
+    this.signalSource = input.signalSource;
+  }
+}
+
+export function findCompactionNeededError(error: unknown, seen = new WeakSet<object>()): CompactionNeededError | null {
+  if (error instanceof CompactionNeededError) {
+    return error;
+  }
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  if (seen.has(error)) {
+    return null;
+  }
+  seen.add(error);
+  const record = error as Record<string, unknown>;
+  return (
+    findCompactionNeededError(record.cause, seen)
+    ?? findCompactionNeededError(record.error, seen)
+  );
+}
+
 /**
  * Walk backwards from the end of `items` keeping whole turns until the kept
  * tail would exceed `keepRecentTokens`, and return the index of the first kept
- * item. The returned index is always the start of a user message (a clean turn
- * boundary), so the prefix [0, index) never splits a tool-call pair.
- *
- * Returns `items.length` when nothing fits within the budget yet a boundary is
- * required (degenerate); callers treat an index of 0 or length as "no useful
- * cut".
+ * item. Retained for the read-path budget guard only; the client compaction
+ * rebuild no longer uses a keep-recent tail.
  */
 export function findKeepBoundary(items: readonly CompactionItem[], keepRecentTokens: number): number {
-  // Indices that begin a user message (candidate boundaries). The first item is
-  // a boundary even if it is not a user message, so a cut at 0 is meaningful.
   const boundaries: number[] = [];
   for (let i = 0; i < items.length; i += 1) {
     if (isUserMessage(items[i])) {
@@ -135,15 +196,8 @@ export function findKeepBoundary(items: readonly CompactionItem[], keepRecentTok
     }
   }
   if (boundaries.length === 0) {
-    // No user-message boundary at all — cannot cut safely.
     return 0;
   }
-  // keepRecentTokens is a CAP on how much recent history is kept verbatim. We
-  // keep as much as fits: the EARLIEST user-message boundary whose tail
-  // [boundary, end) is still within the cap. Walking earliest -> latest, the
-  // first boundary that fits is that earliest one (tails only shrink as the
-  // boundary moves later). If even the last boundary's tail exceeds the cap we
-  // fall back to it (keep at least the final turn).
   for (let b = 0; b < boundaries.length; b += 1) {
     const boundary = boundaries[b]!;
     if (estimateTokens(items.slice(boundary)) <= keepRecentTokens) {
@@ -156,26 +210,9 @@ export function findKeepBoundary(items: readonly CompactionItem[], keepRecentTok
 /**
  * READ-PATH BUDGET GUARD (last-resort backstop).
  *
- * Pre-turn compaction is best-effort: it can no-op (summarizer model call
- * fails, "client" mode off, a fresh user message arrives after a turn already
- * ballooned the history) and STILL leave an assembled input that exceeds the
- * model context window. The #61 orphan sanitizer is purely structural — it has
- * NO size awareness — so without this guard an over-budget input is sent and
- * 400s every turn, re-bricking the session.
- *
- * `enforceInputBudget` drops the OLDEST history at a clean turn boundary until
- * the estimated input fits `maxTokens`, ALWAYS keeping the most recent turn(s).
- * It is orphan-safe by construction: it only ever cuts at the start of a user
- * message (via `findKeepBoundary`), so no tool-call pair is split. It is a
- * crude data-loss fallback (no summary is generated) that exists solely so a
- * single over-budget assembled input is never put on the wire — real context
- * preservation is the summarizing pre-turn path; this is the airbag.
- *
- * Pure: returns a new array (same item references, in order) with an oldest
- * prefix omitted, or the input unchanged when it already fits. The provided
- * `trailingTokens` accounts for the un-stored part of the assembled input (the
- * new user/continuation message + fixed system/tool overhead) so the cap is
- * measured against the WHOLE request, not just the stored history.
+ * Drops the oldest history at a clean user-message boundary until an assembled
+ * input fits the request budget. This remains a request-local safety rail; it
+ * is not the compaction strategy.
  */
 export function enforceInputBudget<T extends CompactionItem>(
   items: readonly T[],
@@ -186,13 +223,7 @@ export function enforceInputBudget<T extends CompactionItem>(
   if (items.length === 0 || total <= maxTokens) {
     return { items: items.slice(), trimmed: false, droppedCount: 0, estimatedTokens: total };
   }
-  // Budget left for the stored history once the fixed trailing cost is paid.
   const historyBudget = Math.max(0, maxTokens - Math.max(0, trailingTokens));
-  // Find the EARLIEST user-message boundary whose tail fits historyBudget; that
-  // boundary's prefix is the oldest history we drop. findKeepBoundary already
-  // returns a clean turn boundary (start of a user message), so the cut is
-  // orphan-safe. A boundary of 0 means nothing could be dropped safely (no
-  // earlier boundary) — we leave the input as-is rather than orphan a pair.
   const boundary = findKeepBoundary(items, historyBudget);
   if (boundary <= 0) {
     return { items: items.slice(), trimmed: false, droppedCount: 0, estimatedTokens: total };
@@ -206,272 +237,96 @@ export function enforceInputBudget<T extends CompactionItem>(
   };
 }
 
-export type CompactionPlan = {
-  /** Whether a compaction should run this turn. */
-  shouldCompact: boolean;
-  /** Why not, when shouldCompact is false (for logs/tests). */
-  reason: "below_threshold" | "no_boundary" | "nothing_to_summarize" | "compact";
-  /**
-   * The signal-token count the trigger decision was made on:
-   * max(actual last-turn input tokens, char/4 estimate of the active items).
-   * Recorded for logging / metrics and so a caller can reason about pressure.
-   */
-  signalTokens: number;
-  /**
-   * True when the signal reached hardFraction*B — the session is at/over the
-   * hard ceiling and compaction was forced even if the recorded last-turn count
-   * was stale-low. The boundary walk is run with a SHRUNK keep-recent budget in
-   * this case so an over-budget history always yields a non-empty prefix to
-   * summarize (the everything-is-"recent" deadlock can't strand it un-compacted).
-   */
-  hardForced: boolean;
-  /** Index (into the active items) where the kept tail begins. */
-  boundaryIndex: number;
-  /**
-   * The prefix items to summarize: active[0, boundaryIndex), EXCLUDING any
-   * prior compaction summary (which is folded forward via `priorSummaryItem`).
-   */
-  prefixItems: CompactionItem[];
-  /** The prior live summary item folded into this compaction, if any. */
-  priorSummaryItem: CompactionItem | null;
-  /** Items kept verbatim: active[boundaryIndex, end). */
-  tailItems: CompactionItem[];
-};
-
-export type PlanCompactionInput = {
-  /** Active history items in position order (already excludes superseded rows). */
-  items: readonly CompactionItem[];
-  /**
-   * Actual input tokens reported for the last model call of the previous turn.
-   * Null/undefined falls back to a char/4 estimate over `items`.
-   */
-  lastInputTokens?: number | null;
-  /** Usable input budget B = window - reserved output. */
-  inputBudgetTokens: number;
-  softFraction: number;
-  hardFraction: number;
-  keepRecentTokens: number;
-  /**
-   * Operator-forced compaction (the /compact command): bypass the soft-limit
-   * token trigger and compact now if there is anything to summarize. The
-   * boundary / nothing-to-summarize guards still apply — force never invents a
-   * cut that would orphan a tool-call pair or summarize an empty prefix.
-   */
-  force?: boolean;
-};
+/**
+ * The exact checkpoint input shape: current active history followed by Codex's
+ * checkpoint prompt as a synthesized user message.
+ */
+export function buildCompactionPromptInput(items: readonly CompactionItem[]): CompactionItem[] {
+  return [
+    ...items,
+    {
+      type: "message",
+      role: "user",
+      content: COMPACTION_PROMPT,
+    },
+  ];
+}
 
 /**
- * Decide whether and where to compact. Pure.
- *
- * Trigger: signal tokens >= softFraction*B (soft) or hardFraction*B (hard).
- * Signal = MAX(actual last-turn input tokens, char/4 estimate of the active
- * items). The max — not "trust the recorded count, estimate only when it's
- * null" — is the self-heal fix: `sessions.last_input_tokens` is written ONLY
- * when a model response reports usage, so a turn that OVERFLOWS on its first
- * model call records NOTHING and the column keeps a STALE-POSITIVE value from
- * the last good turn (e.g. ~600k). Trusting that stale-low number let an
- * actually-over-budget history (>1.05M) slip under the soft limit and overflow
- * again, re-bricking with no self-heal. Taking the max means a bloated history
- * triggers compaction regardless of a stale recorded count.
- *
- * Hard force (hardFraction*B): at/over the hard ceiling we compact even if the
- * recorded count was stale-low, AND we run the boundary walk with a shrunk
- * keep-recent budget so an over-budget history always yields a non-empty prefix
- * — otherwise a history where the whole thing reads as "recent" (tail within
- * keepRecentTokens) would find no prefix and strand the session over budget.
- *
- * Boundary: the earliest user-message boundary whose kept tail fits the
- * (possibly shrunk) keep-recent budget. The prefix before it (minus any prior
- * summary, which is folded forward) is what gets summarized.
+ * Build the active history after compaction:
+ * all real user messages (prior summaries excluded, images removed, each
+ * message capped) plus one marked summary item.
  */
-export function planCompaction(input: PlanCompactionInput): CompactionPlan {
-  const softLimit = Math.floor(input.inputBudgetTokens * input.softFraction);
-  const hardLimit = Math.floor(input.inputBudgetTokens * input.hardFraction);
-  // Signal = MAX(recorded last-turn input tokens, estimate of the actual
-  // history). See the doc comment: the max is what defeats the stale-positive
-  // re-brick — a bloated history wins over a stale-low recorded count.
-  const recorded =
-    typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
-      ? input.lastInputTokens
-      : 0;
-  const signalTokens = Math.max(recorded, estimateTokens(input.items));
-  const hardForced = signalTokens >= hardLimit;
-
-  const empty: CompactionPlan = {
-    shouldCompact: false,
-    reason: "below_threshold",
-    signalTokens,
-    hardForced,
-    boundaryIndex: input.items.length,
-    prefixItems: [],
-    priorSummaryItem: null,
-    tailItems: [...input.items],
-  };
-
-  // force (operator /compact) bypasses the budget trigger; the structural
-  // guards below still run, so a forced compaction with nothing to summarize is
-  // still a no-op. A hard-forced compaction is, like soft, gated by those
-  // guards but additionally shrinks the keep-recent budget (below) so it can
-  // actually find a prefix when the whole history is over budget.
-  if (!input.force && signalTokens < softLimit) {
-    return empty;
-  }
-
-  // Under hard pressure, cap the verbatim tail well below B so the boundary walk
-  // is forced to leave a summarizable prefix even when last_input_tokens was
-  // stale-low and the history exceeds the window. We keep at most HALF the
-  // configured keep-recent budget (and never more than a quarter of B) — enough
-  // recent context to stay coherent, little enough that a real prefix always
-  // remains to compact. Soft compactions keep the full configured budget.
-  const effectiveKeepRecent = hardForced
-    ? Math.min(
-        Math.floor(input.keepRecentTokens / 2),
-        Math.floor(input.inputBudgetTokens / 4),
-      )
-    : input.keepRecentTokens;
-
-  const boundaryIndex = findKeepBoundary(input.items, effectiveKeepRecent);
-  if (boundaryIndex <= 0) {
-    // No prefix to summarize (cut at the very start) — nothing to do.
-    return { ...empty, reason: "no_boundary", boundaryIndex };
-  }
-
-  const prefix = input.items.slice(0, boundaryIndex);
-  const tailItems = input.items.slice(boundaryIndex);
-
-  // Fold the prior live summary forward: pull it out of the prefix so it is not
-  // re-summarized verbatim, and hand it to the summarizer as prior context.
-  let priorSummaryItem: CompactionItem | null = null;
-  const prefixItems: CompactionItem[] = [];
-  for (const item of prefix) {
-    if (isCompactionSummary(item)) {
-      priorSummaryItem = item;
+export function buildCompactionReplacementHistory(
+  items: readonly CompactionItem[],
+  summaryBody: string,
+): CompactionItem[] {
+  const history: CompactionItem[] = [];
+  for (const item of items) {
+    if (!isUserMessage(item) || isCompactionSummary(item)) {
       continue;
     }
-    prefixItems.push(item);
+    history.push(compactUserMessage(item));
   }
-
-  // Nothing real to summarize. This fires both when the prefix is genuinely
-  // empty AND when the prefix contains ONLY a prior summary (boundary landed
-  // immediately after it): folding a summary forward over zero new items would
-  // burn a summarizer call to re-wrap identical content, emit a spurious
-  // compaction event, and — if the next turn is still above the soft threshold
-  // — loop. The single live summary already sits at the boundary, so leaving it
-  // in place is correct.
-  if (prefixItems.length === 0) {
-    return { ...empty, reason: "nothing_to_summarize", boundaryIndex };
-  }
-
-  return {
-    shouldCompact: true,
-    reason: "compact",
-    signalTokens,
-    hardForced,
-    boundaryIndex,
-    prefixItems,
-    priorSummaryItem,
-    tailItems,
-  };
-}
-
-/** Extract the plain-text body of the prior summary item, if any. */
-export function compactionSummaryText(item: CompactionItem | null): string {
-  if (!item) {
-    return "";
-  }
-  const content = (item as { content?: unknown }).content;
-  if (typeof content === "string") {
-    return stripSummaryPrefix(content);
-  }
-  if (Array.isArray(content)) {
-    const text = content
-      .map((part) => {
-        if (part && typeof part === "object") {
-          const t = (part as { text?: unknown }).text;
-          return typeof t === "string" ? t : "";
-        }
-        return "";
-      })
-      .join("");
-    return stripSummaryPrefix(text);
-  }
-  return "";
-}
-
-function stripSummaryPrefix(text: string): string {
-  const marker = "SUMMARY:";
-  const idx = text.indexOf(marker);
-  return idx >= 0 ? text.slice(idx + marker.length) : text;
+  history.push(buildSummaryItem(summaryBody));
+  return history;
 }
 
 /**
- * Build the synthetic summary item (a plain user message) to insert at the
- * boundary. `summaryBody` is the model-generated working-memory bridge.
+ * Build the synthetic summary item (a plain user message) appended to the
+ * rebuilt active history.
  */
 export function buildSummaryItem(summaryBody: string): CompactionItem {
+  const trimmed = summaryBody.trim();
   return {
     type: "message",
     role: "user",
-    content: `${SUMMARY_PREFIX}${summaryBody}`,
+    content: `${SUMMARY_PREFIX}\n${trimmed}`,
     [COMPACTION_SUMMARY_MARKER]: true,
   };
 }
 
-/**
- * Instruction prompt for the summarizer model call. Leans on OpenGeni's durable
- * structured memory (the notebook) so the summary stays a light working-memory
- * bridge, never a place secret values get copied.
- */
-export const SUMMARY_INSTRUCTIONS = [
-  "You are compacting the earlier part of a long-running agent conversation into a compact working-memory checkpoint so the agent can continue past the model's context limit.",
-  "Durable facts already live in the workspace notebook and document bases (via MCP). Do NOT re-derive or copy those; summarize POINTERS, not contents.",
-  "Capture, concisely and factually:",
-  "- The current objective and the key decisions made so far.",
-  "- Open blockers and anything in-progress.",
-  "- Deployed / infrastructure state that has changed (what exists now).",
-  "- Environment and credential facts BY REFERENCE ONLY — name the env var keys, secret names, or notebook/document ids; NEVER copy a secret value, token, key, or password.",
-  "- Concrete next steps.",
-  "Say explicitly that durable facts are in the notebook and that this summary lists pointers, not contents.",
-  "Output only the summary body — no preamble, no markdown headers, plain prose or terse bullets.",
-].join("\n");
-
-/**
- * Render the prefix items into a transcript the summarizer reads. Keeps it
- * bounded by truncating individual items; the model call itself is what
- * produces the compact result.
- */
-export function renderPrefixTranscript(items: readonly CompactionItem[], priorSummaryText: string): string {
-  const lines: string[] = [];
-  if (priorSummaryText.trim().length > 0) {
-    lines.push("PRIOR CHECKPOINT SUMMARY (fold this forward; it already replaced even older history):");
-    lines.push(priorSummaryText.trim());
-    lines.push("");
-    lines.push("CONVERSATION SINCE THAT CHECKPOINT:");
-  } else {
-    lines.push("CONVERSATION TO SUMMARIZE:");
+function compactUserMessage(item: CompactionItem): CompactionItem {
+  const text = messageText(item);
+  const next = { ...item };
+  if (estimatedTextTokens(text) > COMPACT_USER_MESSAGE_MAX_TOKENS) {
+    next.content = truncateMiddleByEstimatedTokens(text, COMPACT_USER_MESSAGE_MAX_TOKENS);
+    return next;
   }
-  for (const item of items) {
-    lines.push(renderItem(item));
-  }
-  return lines.join("\n");
+  next.content = contentWithoutImages(item);
+  return next;
 }
 
-function renderItem(item: CompactionItem): string {
-  const type = itemType(item) ?? "unknown";
-  if (type === "message") {
-    const role = itemRole(item) ?? "assistant";
-    return `[${role}] ${truncate(messageText(item), 4000)}`;
+function estimatedTextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function truncateMiddleByEstimatedTokens(text: string, maxTokens: number): string {
+  const maxChars = Math.max(0, maxTokens * 4);
+  if (text.length <= maxChars) {
+    return text;
   }
-  if (type === "reasoning") {
-    return "[reasoning] (omitted)";
+  if (maxChars <= USER_MESSAGE_TRUNCATION_MARKER.length) {
+    return USER_MESSAGE_TRUNCATION_MARKER.slice(0, maxChars);
   }
-  if (RESULT_TYPES.has(type)) {
-    return `[tool_result] ${truncate(resultText(item), 2000)}`;
+  const keepChars = maxChars - USER_MESSAGE_TRUNCATION_MARKER.length;
+  const headChars = Math.ceil(keepChars / 2);
+  const tailChars = Math.floor(keepChars / 2);
+  return `${text.slice(0, headChars)}${USER_MESSAGE_TRUNCATION_MARKER}${text.slice(text.length - tailChars)}`;
+}
+
+function contentWithoutImages(item: CompactionItem): unknown {
+  const content = (item as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return content;
   }
-  if (RESULT_TYPE_BY_CALL_TYPE[type]) {
-    return `[tool_call ${type}] ${truncate(callText(item), 1000)}`;
-  }
-  return `[${type}] ${truncate(safeStringify(item), 1000)}`;
+  return content.filter((part) => {
+    if (!part || typeof part !== "object") {
+      return true;
+    }
+    const type = (part as { type?: unknown }).type;
+    return type !== "input_image" && type !== "image_url";
+  });
 }
 
 function messageText(item: CompactionItem): string {
@@ -483,14 +338,41 @@ function messageText(item: CompactionItem): string {
     return content
       .map((part) => {
         if (part && typeof part === "object") {
-          const t = (part as { text?: unknown }).text;
-          return typeof t === "string" ? t : "";
+          const record = part as { text?: unknown; content?: unknown };
+          if (typeof record.text === "string") {
+            return record.text;
+          }
+          if (typeof record.content === "string") {
+            return record.content;
+          }
         }
         return "";
       })
       .join("");
   }
   return "";
+}
+
+export function renderCompactionPromptInputForChat(input: readonly CompactionItem[]): string {
+  return input.map(renderItem).join("\n");
+}
+
+function renderItem(item: CompactionItem): string {
+  const type = itemType(item) ?? "unknown";
+  if (type === "message") {
+    const role = itemRole(item) ?? "assistant";
+    return `[${role}] ${truncateForTranscript(messageText(item), 4000)}`;
+  }
+  if (type === "reasoning") {
+    return "[reasoning] (omitted)";
+  }
+  if (RESULT_TYPES.has(type)) {
+    return `[tool_result] ${truncateForTranscript(resultText(item), 2000)}`;
+  }
+  if (RESULT_TYPE_BY_CALL_TYPE[type]) {
+    return `[tool_call ${type}] ${truncateForTranscript(callText(item), 1000)}`;
+  }
+  return `[${type}] ${truncateForTranscript(safeStringify(item), 1000)}`;
 }
 
 function resultText(item: CompactionItem): string {
@@ -517,22 +399,9 @@ function safeStringify(value: unknown): string {
   }
 }
 
-function truncate(text: string, max: number): string {
+function truncateForTranscript(text: string, max: number): string {
   if (text.length <= max) {
     return text;
   }
-  return `${text.slice(0, max)}… (${text.length - max} more chars)`;
-}
-
-/**
- * The summarizer model call payload: a system instruction plus the rendered
- * prefix transcript. The caller turns this into a single model request (no
- * tools, no streaming) and feeds the text result into `buildSummaryItem`.
- */
-export function buildCompactionMessages(plan: CompactionPlan): { system: string; user: string } {
-  const priorText = compactionSummaryText(plan.priorSummaryItem);
-  return {
-    system: SUMMARY_INSTRUCTIONS,
-    user: renderPrefixTranscript(plan.prefixItems, priorText),
-  };
+  return `${text.slice(0, max)}... (${text.length - max} more chars)`;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -84,7 +84,15 @@ import { fileURLToPath } from "node:url";
 import { computerCallNormalizingFetch, normalizeComputerCallActions, sanitizeHistoryItemsForModel } from "./history-sanitizer";
 import { elideStaleScreenshotImages } from "./image-history";
 import { installCodexToolSearch } from "./codex-tool-search";
-import { enforceInputBudget, estimateItemTokens } from "./context-compaction";
+import {
+  CompactionNeededError,
+  SUMMARY_BUFFER_TOKENS,
+  clientCompactionThresholdTokens,
+  enforceInputBudget,
+  estimateItemTokens,
+  estimateTokens,
+  renderCompactionPromptInputForChat,
+} from "./context-compaction";
 import {
   createSandboxClient,
   deserializeSandboxSessionStateEnvelope,
@@ -135,22 +143,29 @@ export type { HistoryItem } from "./history-sanitizer";
 export { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
 
 export {
-  planCompaction,
+  CompactionNeededError,
+  buildCompactionPromptInput,
+  buildCompactionReplacementHistory,
+  clientCompactionThresholdTokens,
+  decideClientCompaction,
   enforceInputBudget,
   buildSummaryItem,
-  buildCompactionMessages,
+  findCompactionNeededError,
   isCompactionSummary,
   isUserMessage,
   findKeepBoundary,
   estimateTokens,
   estimateItemTokens,
-  compactionSummaryText,
-  renderPrefixTranscript,
+  renderCompactionPromptInputForChat,
   COMPACTION_SUMMARY_MARKER,
+  COMPACTION_PROMPT,
+  COMPACT_USER_MESSAGE_MAX_TOKENS,
+  CLIENT_COMPACTION_TRIGGER_FRACTION,
+  SUMMARY_BUFFER_TOKENS,
   SUMMARY_PREFIX,
-  SUMMARY_INSTRUCTIONS,
+  USER_MESSAGE_TRUNCATION_MARKER,
 } from "./context-compaction";
-export type { CompactionItem, CompactionPlan, PlanCompactionInput } from "./context-compaction";
+export type { ClientCompactionDecision, CompactionItem } from "./context-compaction";
 export {
   elideStaleScreenshotImages,
   SCREENSHOT_OMITTED_PLACEHOLDER,
@@ -506,10 +521,10 @@ export function configureOpenAI(settings: Settings): void {
 
 /**
  * Run the compaction summarizer as one plain, tool-less, non-streaming model
- * call against the resolved provider. `system`/`user` come from
- * buildCompactionMessages. Returns the trimmed summary text, or null on any
+ * call against the resolved provider. `input` is the active history plus
+ * Codex's checkpoint prompt. Returns the trimmed summary text, or null on any
  * failure (the caller treats a failed summarize as "skip compaction this turn"
- * — never fatal). The call deliberately does NOT request reasoning encryption,
+ * - never fatal). The call deliberately does NOT request reasoning encryption,
  * tools, or server-side compaction; it is a self-contained summarize.
  *
  * Provider-aware: the summary always runs on the SAME provider that serves the
@@ -523,22 +538,19 @@ export function configureOpenAI(settings: Settings): void {
  */
 export async function summarizeForCompaction(
   settings: Settings,
-  messages: { system: string; user: string },
+  input: Array<Record<string, unknown>>,
   options: { client?: OpenAI; api?: ModelProviderApi; maxOutputTokens?: number; model?: string } = {},
 ): Promise<string | null> {
   const client = options.client ?? buildOpenAIClientFromSettings(settings);
   const api = options.api ?? "responses";
   const model = options.model ?? settings.openaiModel;
-  const maxTokens = options.maxOutputTokens ?? settings.contextSummaryMaxTokens;
+  const maxTokens = options.maxOutputTokens ?? SUMMARY_BUFFER_TOKENS;
   try {
     if (api === "chat") {
       const completion = await client.chat.completions.create({
         model,
         max_tokens: maxTokens,
-        messages: [
-          { role: "system", content: messages.system },
-          { role: "user", content: messages.user },
-        ],
+        messages: [{ role: "user", content: renderCompactionPromptInputForChat(input) }],
       } as any);
       const text = (completion as { choices?: Array<{ message?: { content?: unknown } }> }).choices?.[0]?.message?.content;
       const trimmed = typeof text === "string" ? text.trim() : "";
@@ -551,10 +563,7 @@ export async function summarizeForCompaction(
       // built-in path (api "responses"), so gate it on the built-in provider.
       ...(settings.openaiProvider === "azure" ? {} : { store: false }),
       max_output_tokens: maxTokens,
-      input: [
-        { role: "system", content: messages.system },
-        { role: "user", content: messages.user },
-      ],
+      input,
     } as any);
     const text = extractResponseOutputText(response);
     const trimmed = text.trim();
@@ -1579,6 +1588,7 @@ export type RunAgentStreamOptions = {
   sandboxClient?: unknown;
   sandboxEnvironment?: Record<string, string>;
   onRuntimeEvent?: (event: NormalizedRuntimeEvent) => Promise<void> | void;
+  contextCompactionSignalTokens?: () => number | null | undefined;
   // OWNERSHIP INVERSION (P1.2): an externally-owned, already-live sandbox
   // session resolved by the per-turn resume-by-id path. When present,
   // runAgentStream does NOT build (or resume, or discard) a client — it threads
@@ -1607,6 +1617,11 @@ export type RunAgentStreamOptions = {
   // model call and never touches `state.history`/`originalInput`, so the
   // reconcile dual-write never sees it.
   callModelInputFilter?: CallModelInputFilter;
+};
+
+export type ContextRobustnessFilterOptions = {
+  contextCompactionSignalTokens?: () => number | null | undefined;
+  throwOnCompactionNeeded?: boolean;
 };
 
 // One-shot directive appended to the agent's system prompt on the genesis turn
@@ -1662,8 +1677,13 @@ export const normalizeComputerCallsFilter: CallModelInputFilter = ({ modelData }
   ) as unknown as AgentInputItem[],
 });
 
-export function contextRobustnessFilterForSettings(settings: Settings): CallModelInputFilter {
+export function contextRobustnessFilterForSettings(
+  settings: Settings,
+  options: ContextRobustnessFilterOptions = {},
+): CallModelInputFilter {
   const inputBudgetTokens = modelCallBudgetTokens(settings);
+  const clientCompactionMode = resolveContextCompactionMode(settings) === "client";
+  const compactionThresholdTokens = clientCompactionThresholdTokens(settings);
   return ({ modelData }) => {
     const images = elideStaleScreenshotImages(modelData.input);
     if (images.elidedCount > 0) {
@@ -1682,6 +1702,20 @@ export function contextRobustnessFilterForSettings(settings: Settings): CallMode
           `per-call budget guard trimmed ${guarded.droppedCount} oldest history item(s) to fit input budget (${inputBudgetTokens} tokens); the over-budget model call was NOT sent`,
         );
         input = guarded.items as unknown as AgentInputItem[];
+      }
+    }
+    if (clientCompactionMode && options.throwOnCompactionNeeded) {
+      const reported = options.contextCompactionSignalTokens?.();
+      const hasReported = typeof reported === "number" && reported > 0;
+      const signalTokens = hasReported
+        ? reported
+        : estimateTokens(input as unknown as Array<Record<string, unknown>>);
+      if (signalTokens > compactionThresholdTokens) {
+        throw new CompactionNeededError({
+          signalTokens,
+          thresholdTokens: compactionThresholdTokens,
+          signalSource: hasReported ? "provider" : "estimate",
+        });
       }
     }
     return { ...modelData, input };
@@ -1717,12 +1751,15 @@ function composeCallModelInputFilters(filters: CallModelInputFilter[]): CallMode
  * selects it; the context-robustness guard then elides stale screenshots on
  * every mode and applies hard budget trimming only on the client-compaction path.
  */
-export function callModelInputFilterForSettings(settings: Settings): CallModelInputFilter | undefined {
+export function callModelInputFilterForSettings(
+  settings: Settings,
+  options: ContextRobustnessFilterOptions = {},
+): CallModelInputFilter | undefined {
   const filters: CallModelInputFilter[] = [normalizeComputerCallsFilter];
   if (settings.openaiProviderItemIds === "strip") {
     filters.push(stripProviderItemIdsFilter);
   }
-  filters.push(contextRobustnessFilterForSettings(settings));
+  filters.push(contextRobustnessFilterForSettings(settings, options));
   return composeCallModelInputFilters(filters);
 }
 
@@ -1801,7 +1838,15 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     // through the client during this run (it is inert for the provided session).
     const decoratedClient = withSandboxLifecycleHooks(resourceClient, ownedHooks, ownedHookContext);
     const ownedFilter = composeCallModelInputFilters(
-      [callModelInputFilterForSettings(settings), overrides.callModelInputFilter].filter(
+      [
+        callModelInputFilterForSettings(settings, {
+          throwOnCompactionNeeded: Boolean(overrides.contextCompactionSignalTokens),
+          ...(overrides.contextCompactionSignalTokens
+            ? { contextCompactionSignalTokens: overrides.contextCompactionSignalTokens }
+            : {}),
+        }),
+        overrides.callModelInputFilter,
+      ].filter(
         (f): f is CallModelInputFilter => Boolean(f),
       ),
     );
@@ -1854,7 +1899,15 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
   // model input; the SDK persists filtered clones into its session view, while
   // OpenGeni's durable conversation truth is still reconciled explicitly below.
   const callModelInputFilter = composeCallModelInputFilters(
-    [callModelInputFilterForSettings(settings), overrides.callModelInputFilter].filter(
+    [
+      callModelInputFilterForSettings(settings, {
+        throwOnCompactionNeeded: Boolean(overrides.contextCompactionSignalTokens),
+        ...(overrides.contextCompactionSignalTokens
+          ? { contextCompactionSignalTokens: overrides.contextCompactionSignalTokens }
+          : {}),
+      }),
+      overrides.callModelInputFilter,
+    ].filter(
       (f): f is CallModelInputFilter => Boolean(f),
     ),
   );

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -1,522 +1,245 @@
 import { describe, expect, test } from "bun:test";
 import {
+  COMPACT_USER_MESSAGE_MAX_TOKENS,
+  COMPACTION_PROMPT,
   COMPACTION_SUMMARY_MARKER,
+  CompactionNeededError,
+  SUMMARY_BUFFER_TOKENS,
   SUMMARY_PREFIX,
-  buildCompactionMessages,
+  USER_MESSAGE_TRUNCATION_MARKER,
+  buildCompactionPromptInput,
+  buildCompactionReplacementHistory,
   buildSummaryItem,
-  compactionSummaryText,
+  clientCompactionThresholdTokens,
+  decideClientCompaction,
   enforceInputBudget,
   estimateTokens,
+  findCompactionNeededError,
   findKeepBoundary,
   isCompactionSummary,
   isUserMessage,
-  planCompaction,
   type CompactionItem,
 } from "../src/context-compaction";
 import { extractResponseOutputText } from "../src/index";
 import { sanitizeHistoryItemsForModel } from "../src/history-sanitizer";
 
-// --- builders for readable fixtures ---
 function user(text: string): CompactionItem {
   return { type: "message", role: "user", content: text };
 }
+
+function userParts(parts: unknown[]): CompactionItem {
+  return { type: "message", role: "user", content: parts };
+}
+
 function assistant(text: string): CompactionItem {
   return { type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text }] };
 }
+
 function call(id: string, name = "shell"): CompactionItem {
   return { type: "function_call", callId: id, name, arguments: "{}" };
 }
+
 function result(id: string, output = "ok"): CompactionItem {
   return { type: "function_call_result", callId: id, status: "completed", output };
 }
-function reasoning(): CompactionItem {
-  return { type: "reasoning", content: [] };
+
+function bigUser(tokens: number, char: string): CompactionItem {
+  return user(char.repeat(tokens * 4));
 }
 
-// Pad an item so its char/4 estimate is ~`tokens`.
-function bigItem(role: "user" | "assistant", tokens: number): CompactionItem {
-  const body = "x".repeat(tokens * 4);
-  return role === "user" ? user(body) : assistant(body);
-}
+const WINDOW = 1_050_000;
+const RESERVED_OUTPUT = 128_000;
+const THRESHOLD = Math.floor((WINDOW - RESERVED_OUTPUT - SUMMARY_BUFFER_TOKENS) * 0.9);
 
-const BUDGET = 922_000;
-const SOFT = 0.7;
-const HARD = 0.85;
-
-describe("item predicates", () => {
-  test("isUserMessage only matches user-role messages", () => {
-    expect(isUserMessage(user("hi"))).toBe(true);
-    expect(isUserMessage(assistant("hi"))).toBe(false);
-    expect(isUserMessage(call("c1"))).toBe(false);
+describe("codex-parity constants and summary marker", () => {
+  test("uses Codex's checkpoint prompt and summary prefix verbatim", () => {
+    expect(COMPACTION_PROMPT).toBe([
+      "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.",
+      "",
+      "Include:",
+      "- Current progress and key decisions made",
+      "- Important context, constraints, or user preferences",
+      "- What remains to be done (clear next steps)",
+      "- Any critical data, examples, or references needed to continue",
+      "",
+      "Be concise, structured, and focused on helping the next LLM seamlessly continue the work.",
+    ].join("\n"));
+    expect(SUMMARY_PREFIX).toBe(
+      "Another language model started to solve this problem and produced a summary of its thinking process. You also have access to the state of the tools that were used by that language model. Use this to build on the work that has already been done and avoid duplicating work. Here is the summary produced by the other language model, use the information in this summary to assist with your own analysis:",
+    );
   });
 
-  test("buildSummaryItem is a marked user message recognized by isCompactionSummary", () => {
-    const item = buildSummaryItem("the summary body");
+  test("buildSummaryItem preserves the OpenGeni marker for UI rendering", () => {
+    const item = buildSummaryItem("handoff body");
     expect(isUserMessage(item)).toBe(true);
     expect(isCompactionSummary(item)).toBe(true);
     expect(item[COMPACTION_SUMMARY_MARKER]).toBe(true);
-    expect(String(item.content)).toContain(SUMMARY_PREFIX);
-    expect(String(item.content)).toContain("the summary body");
-    // A plain user message is NOT a compaction summary.
-    expect(isCompactionSummary(user("the summary body"))).toBe(false);
-  });
-
-  test("compactionSummaryText strips the bridge prefix and returns the body", () => {
-    const item = buildSummaryItem("body-X");
-    expect(compactionSummaryText(item)).toBe("body-X");
-    expect(compactionSummaryText(null)).toBe("");
+    expect(item.content).toBe(`${SUMMARY_PREFIX}\nhandoff body`);
   });
 });
 
-describe("findKeepBoundary", () => {
-  test("keeps the most recent whole turns within the budget, cutting at a user boundary", () => {
-    const items: CompactionItem[] = [
-      user("turn 1"), assistant("a1"),
-      user("turn 2"), assistant("a2"),
-      user("turn 3"), assistant("a3"),
-    ];
-    // Budget large enough for all -> boundary at first user message (index 0).
-    expect(findKeepBoundary(items, 1_000_000)).toBe(0);
-    // Tiny budget -> latest user boundary whose tail fits; the last turn alone.
-    const boundary = findKeepBoundary(items, estimateTokens(items.slice(4)) );
-    expect(boundary).toBe(4);
-    expect(isUserMessage(items[boundary]!)).toBe(true);
+describe("single client compaction threshold", () => {
+  test("computes 90 percent of window minus reserved output minus summary buffer", () => {
+    expect(clientCompactionThresholdTokens({
+      contextWindowTokens: WINDOW,
+      contextReservedOutputTokens: RESERVED_OUTPUT,
+    })).toBe(THRESHOLD);
   });
 
-  test("returns 0 when there is no user-message boundary", () => {
-    expect(findKeepBoundary([assistant("a"), call("c"), result("c")], 10)).toBe(0);
-  });
-});
-
-describe("planCompaction trigger", () => {
-  test("does not compact below the soft threshold (real last-turn tokens)", () => {
-    const items = [user("hi"), assistant("there")];
-    const plan = planCompaction({
+  test("prefers provider-reported input tokens over the estimate", () => {
+    const items = [bigUser(900_000, "x")];
+    const decision = decideClientCompaction({
       items,
-      lastInputTokens: Math.floor(BUDGET * SOFT) - 1,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: 32_000,
+      lastInputTokens: 10,
+      contextWindowTokens: WINDOW,
+      contextReservedOutputTokens: RESERVED_OUTPUT,
     });
-    expect(plan.shouldCompact).toBe(false);
-    expect(plan.reason).toBe("below_threshold");
+    expect(decision.signalTokens).toBe(10);
+    expect(decision.shouldCompact).toBe(false);
   });
 
-  test("compacts at/above the soft threshold", () => {
-    const items: CompactionItem[] = [
-      user("old 1"), assistant("a1"),
-      user("old 2"), assistant("a2"),
-      user("recent"), assistant("a3"),
-    ];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      // Keep only the last turn verbatim so a real prefix exists to summarize.
-      keepRecentTokens: estimateTokens(items.slice(4)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.reason).toBe("compact");
-    expect(plan.boundaryIndex).toBe(4);
-    expect(plan.tailItems).toEqual(items.slice(4));
-  });
-
-  test("falls back to a char/4 estimate when last-turn tokens are unknown", () => {
-    // Two big turns whose estimate crosses the soft threshold; keep only the
-    // last one so there is a prefix to summarize.
-    const items: CompactionItem[] = [
-      bigItem("user", Math.ceil(BUDGET * SOFT)), assistant("a1"),
-      user("recent"), assistant("a2"),
-    ];
-    const plan = planCompaction({
+  test("uses char/4 estimate only when there is no provider signal yet", () => {
+    const items = [bigUser(THRESHOLD + 1, "x")];
+    const decision = decideClientCompaction({
       items,
       lastInputTokens: null,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
+      contextWindowTokens: WINDOW,
+      contextReservedOutputTokens: RESERVED_OUTPUT,
     });
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.boundaryIndex).toBe(2);
+    expect(decision.signalTokens).toBeGreaterThan(THRESHOLD);
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.reason).toBe("above_threshold");
   });
 
-  test("force bypasses the budget trigger but still respects the structural guards", () => {
-    const items: CompactionItem[] = [
-      user("old 1"), assistant("a1"),
-      user("recent"), assistant("a2"),
-    ];
-    // Far below the soft threshold: without force this is a no-op.
-    const base = {
-      items,
+  test("force keeps manual /compact working below the threshold", () => {
+    const decision = decideClientCompaction({
+      items: [user("small")],
       lastInputTokens: 1,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
-    } as const;
-    expect(planCompaction(base).shouldCompact).toBe(false);
-    const forced = planCompaction({ ...base, force: true });
-    expect(forced.shouldCompact).toBe(true);
-    expect(forced.boundaryIndex).toBe(2);
-
-    // Force with nothing to summarize (whole transcript kept) is still a no-op.
-    const noPrefix = planCompaction({ ...base, force: true, keepRecentTokens: estimateTokens(items) });
-    expect(noPrefix.shouldCompact).toBe(false);
+      contextWindowTokens: WINDOW,
+      contextReservedOutputTokens: RESERVED_OUTPUT,
+      force: true,
+    });
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.reason).toBe("force");
   });
 });
 
-describe("planCompaction self-heal: trigger on max(actual, estimate)", () => {
-  // The stale-positive re-brick: `sessions.last_input_tokens` is written ONLY
-  // when usage is observed, so a turn that overflows on its first model call
-  // records nothing and the column keeps a stale-low value from the last good
-  // turn. The old trigger TRUSTED that positive number and only estimated when
-  // it was null — so an actually-over-budget history slipped under the soft
-  // limit and overflowed again, permanently. These tests pin the fix: the
-  // trigger is max(recorded, estimate), so a bloated history compacts regardless
-  // of a stale-low recorded count.
-  test("stale-positive last_input_tokens + over-budget history MUST compact (re-brick prevented)", () => {
-    // Recorded count is a stale ~600k from the last good turn — comfortably
-    // UNDER the soft limit (645,400). But the ACTUAL history estimates ABOVE the
-    // budget (the turn ballooned the history past the window). The old code
-    // trusted 600k and did NOT compact; the new code takes the max and must.
-    const STALE = 600_000;
-    expect(STALE).toBeLessThan(Math.floor(BUDGET * SOFT)); // would slip past the old trigger
-    const items: CompactionItem[] = [
-      bigItem("user", BUDGET), assistant("a-old"), // a single over-budget prefix turn
-      user("recent"), assistant("a-recent"),
-    ];
-    expect(estimateTokens(items)).toBeGreaterThan(BUDGET); // history truly exceeds B
-    const plan = planCompaction({
-      items,
-      lastInputTokens: STALE, // STALE-POSITIVE, under the soft limit
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.reason).toBe("compact");
-    // The estimate (not the stale count) drove the decision.
-    expect(plan.signalTokens).toBe(estimateTokens(items));
-    expect(plan.signalTokens).toBeGreaterThan(STALE);
+describe("codex-parity rebuild", () => {
+  test("summarizer input is current active history plus the checkpoint prompt", () => {
+    const active = [user("u1"), assistant("a1"), call("c1"), result("c1")];
+    const promptInput = buildCompactionPromptInput(active);
+    expect(promptInput.slice(0, -1)).toEqual(active);
+    expect(promptInput.at(-1)).toEqual({ type: "message", role: "user", content: COMPACTION_PROMPT });
   });
 
-  test("post-overflow session self-heals on the next turn (estimate triggers despite stale count)", () => {
-    // Model the turn AFTER an overflow: last_input_tokens is whatever the last
-    // SUCCESSFUL turn recorded (stale, under soft), and the active history is the
-    // bloated set that just 400'd. The next pre-turn check must compact so the
-    // turn after that fits — i.e. the session heals itself with no operator.
-    const STALE_FROM_LAST_GOOD_TURN = 500_000;
-    const items: CompactionItem[] = [
-      bigItem("assistant", Math.ceil(BUDGET * 0.9)), // bloated prefix from the overflow turn
-      user("turn that will retry"), assistant("a"),
-    ];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: STALE_FROM_LAST_GOOD_TURN,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(1)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    // After applying the plan the active history shrinks below the soft limit,
-    // so the FOLLOWING turn would not re-trigger — the heal converges.
-    const healed: CompactionItem[] = [buildSummaryItem("s"), ...plan.tailItems];
-    expect(estimateTokens(healed)).toBeLessThan(Math.floor(BUDGET * SOFT));
-  });
-
-  test("signalTokens never trusts a stale-low count when the real history is larger", () => {
-    const items: CompactionItem[] = [bigItem("user", 700_000), user("recent"), assistant("a")];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: 10, // absurdly stale-low
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(1)),
-    });
-    expect(plan.signalTokens).toBe(estimateTokens(items));
-    expect(plan.shouldCompact).toBe(true);
-  });
-
-  test("an accurate recorded count above the estimate still wins (system+tool overhead the items don't show)", () => {
-    // The recorded last-turn input includes system prompt + tool schemas the
-    // stored items don't contain, so it can legitimately exceed the item
-    // estimate. max() keeps trusting it — we never UNDER-count by switching to
-    // the estimate.
-    const items: CompactionItem[] = [user("old"), assistant("a"), user("recent"), assistant("b")];
-    const accurate = Math.floor(BUDGET * SOFT) + 5_000;
-    expect(accurate).toBeGreaterThan(estimateTokens(items));
-    const plan = planCompaction({
-      items,
-      lastInputTokens: accurate,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
-    });
-    expect(plan.signalTokens).toBe(accurate);
-    expect(plan.shouldCompact).toBe(true);
-  });
-});
-
-describe("planCompaction hard-force backstop (hardFraction*B)", () => {
-  test("at/over the hard ceiling, hardForced is set and the plan still compacts", () => {
-    const items: CompactionItem[] = [
-      bigItem("user", Math.ceil(BUDGET * HARD)), assistant("a-old"),
-      user("recent"), assistant("a-recent"),
-    ];
-    expect(estimateTokens(items)).toBeGreaterThanOrEqual(Math.floor(BUDGET * HARD));
-    const plan = planCompaction({
-      items,
-      lastInputTokens: null,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
-    });
-    expect(plan.hardForced).toBe(true);
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.reason).toBe("compact");
-  });
-
-  test("below the hard ceiling but above soft: compacts WITHOUT hardForced", () => {
-    const items: CompactionItem[] = [
-      bigItem("user", Math.ceil(BUDGET * SOFT) + 1_000), assistant("a"),
-      user("recent"), assistant("b"),
-    ];
-    const est = estimateTokens(items);
-    expect(est).toBeGreaterThanOrEqual(Math.floor(BUDGET * SOFT));
-    expect(est).toBeLessThan(Math.floor(BUDGET * HARD));
-    const plan = planCompaction({
-      items,
-      lastInputTokens: null,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(2)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.hardForced).toBe(false);
-  });
-
-  test("hard-force shrinks the keep-recent budget so an over-budget 'all recent' history still finds a prefix", () => {
-    // The deadlock the shrink defeats: the configured keepRecentTokens is huge
-    // (the whole history fits inside it), so a SOFT walk would keep everything
-    // verbatim and find NO prefix to summarize — stranding an over-budget
-    // session. Under hard pressure the effective keep-recent is capped, forcing
-    // a cut that leaves a non-empty prefix.
-    const items: CompactionItem[] = [
-      user("turn 0"), bigItem("assistant", 300_000),
-      user("turn 1"), bigItem("assistant", 300_000),
-      user("turn 2"), bigItem("assistant", 300_000),
-    ];
-    expect(estimateTokens(items)).toBeGreaterThanOrEqual(Math.floor(BUDGET * HARD)); // over the hard ceiling
-    const plan = planCompaction({
-      items,
-      lastInputTokens: null,
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      // keepRecentTokens is the WHOLE history — a soft walk keeps everything and
-      // would find no prefix (boundary 0). Hard-force must override that.
-      keepRecentTokens: estimateTokens(items) + 1,
-    });
-    expect(plan.hardForced).toBe(true);
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.boundaryIndex).toBeGreaterThan(0); // a real prefix WAS found
-    expect(plan.prefixItems.length).toBeGreaterThan(0);
-  });
-});
-
-describe("planCompaction orphan safety (the boundary rule)", () => {
-  test("never splits a tool-call pair: the dropped prefix keeps call+result together", () => {
-    // turn 0: user + call/result pair. turn 1 (recent): user + call/result pair.
-    const items: CompactionItem[] = [
-      user("turn 0"), reasoning(), call("c0"), result("c0"), assistant("done 0"),
-      user("turn 1"), reasoning(), call("c1"), result("c1"), assistant("done 1"),
-    ];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(5)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    // Boundary lands on the recent user message — turn 0's whole pair is in the
-    // prefix, turn 1's whole pair is in the tail. Neither straddles.
-    expect(plan.boundaryIndex).toBe(5);
-    const prefixCallIds = plan.prefixItems.filter((i) => i.callId === "c0");
-    const tailCallIds = plan.tailItems.filter((i) => i.callId === "c1");
-    expect(prefixCallIds.length).toBe(2); // call + result both in prefix
-    expect(tailCallIds.length).toBe(2); // call + result both in tail
-    expect(plan.tailItems.some((i) => i.callId === "c0")).toBe(false);
-    expect(plan.prefixItems.some((i) => i.callId === "c1")).toBe(false);
-  });
-
-  test("the post-compaction active history is orphan-clean (summary + tail survive the sanitizer)", () => {
-    const items: CompactionItem[] = [
-      user("turn 0"), call("c0"), result("c0"), assistant("done 0"),
-      user("turn 1"), call("c1"), result("c1"), assistant("done 1"),
-    ];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(4)),
-    });
-    expect(plan.shouldCompact).toBe(true);
-    const active: CompactionItem[] = [buildSummaryItem("summary"), ...plan.tailItems];
-    // The sanitizer (the read-path orphan guard) must leave it byte-identical:
-    // no orphaned result, no dangling call.
-    expect(sanitizeHistoryItemsForModel(active)).toEqual(active);
-  });
-});
-
-describe("planCompaction fold-forward (single live summary)", () => {
-  test("a prior summary in the prefix is pulled out and folded forward, not re-collected", () => {
-    const prior = buildSummaryItem("PRIOR FACTS");
-    const items: CompactionItem[] = [
+  test("replacement history keeps only real user messages plus one summary", () => {
+    const prior = buildSummaryItem("prior summary");
+    const active = [
+      user("first user"),
+      assistant("assistant dropped"),
+      call("c1"),
+      result("c1"),
       prior,
-      user("turn since"), assistant("a1"),
-      user("recent"), assistant("a2"),
+      user("second user"),
     ];
-    const plan = planCompaction({
-      items,
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: estimateTokens(items.slice(3)),
+    const rebuilt = buildCompactionReplacementHistory(active, "new summary");
+    expect(rebuilt).toHaveLength(3);
+    expect(rebuilt[0]).toMatchObject(user("first user"));
+    expect(rebuilt[1]).toMatchObject(user("second user"));
+    expect(rebuilt[2]).toMatchObject({
+      type: "message",
+      role: "user",
+      [COMPACTION_SUMMARY_MARKER]: true,
     });
-    expect(plan.shouldCompact).toBe(true);
-    expect(plan.priorSummaryItem).toBe(prior);
-    // The prior summary is NOT among the items to re-summarize.
-    expect(plan.prefixItems.some(isCompactionSummary)).toBe(false);
-    // The summarizer prompt carries the prior summary body forward.
-    const messages = buildCompactionMessages(plan);
-    expect(messages.user).toContain("PRIOR FACTS");
-    expect(messages.user).toContain("PRIOR CHECKPOINT SUMMARY");
+    expect(rebuilt.some((item) => item === prior)).toBe(false);
+    expect(rebuilt.some((item) => item.type === "function_call")).toBe(false);
   });
 
-  test("a boundary landing immediately after a prior summary does NOT compact (no empty re-wrap / loop)", () => {
-    // prefix = [prior summary only]; kept tail = the recent turn. There is
-    // nothing NEW to fold in, so re-summarizing would just re-wrap the existing
-    // summary, emit a spurious event, and risk looping turn after turn.
-    const prior = buildSummaryItem("PRIOR FACTS");
-    const items: CompactionItem[] = [
-      prior,
-      user("recent"), assistant("a-recent"),
-    ];
-    const plan = planCompaction({
-      items,
-      // Above the soft threshold so the trigger fires and we reach the boundary
-      // logic (the signal includes system/tool overhead the items don't show).
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      // Keep only the recent turn verbatim, so the boundary lands at index 1
-      // (right after the prior summary at index 0).
-      keepRecentTokens: estimateTokens(items.slice(1)),
+  test("drops images from retained user messages", () => {
+    const rebuilt = buildCompactionReplacementHistory([
+      userParts([
+        { type: "input_text", text: "look at this" },
+        { type: "input_image", image_url: "data:image/png;base64,abc" },
+      ]),
+    ], "summary");
+    expect((rebuilt[0] as { content?: unknown }).content).toEqual([{ type: "input_text", text: "look at this" }]);
+  });
+
+  test("caps each retained user message at 20k estimated tokens with a middle marker", () => {
+    const long = `${"a".repeat((COMPACT_USER_MESSAGE_MAX_TOKENS * 2) * 4)}TAIL`;
+    const rebuilt = buildCompactionReplacementHistory([user(long)], "summary");
+    const content = String(rebuilt[0]!.content);
+    expect(content).toContain(USER_MESSAGE_TRUNCATION_MARKER.trim());
+    expect(content.startsWith("aaaa")).toBe(true);
+    expect(content.endsWith("TAIL")).toBe(true);
+    expect(Math.ceil(content.length / 4)).toBeLessThanOrEqual(COMPACT_USER_MESSAGE_MAX_TOKENS);
+  });
+
+  test("rebuilt active history is orphan-clean because tool items are dropped", () => {
+    const rebuilt = buildCompactionReplacementHistory([
+      user("old"),
+      call("c0"),
+      result("c0"),
+      assistant("done"),
+      user("new"),
+    ], "summary");
+    expect(sanitizeHistoryItemsForModel(rebuilt)).toEqual(rebuilt);
+  });
+});
+
+describe("CompactionNeededError", () => {
+  test("carries signal metadata and can be found through causes", () => {
+    const error = new CompactionNeededError({
+      signalTokens: 12,
+      thresholdTokens: 10,
+      signalSource: "provider",
     });
-    expect(plan.boundaryIndex).toBe(1);
-    expect(plan.shouldCompact).toBe(false);
-    expect(plan.reason).toBe("nothing_to_summarize");
+    expect(error.signalTokens).toBe(12);
+    expect(findCompactionNeededError({ cause: error })).toBe(error);
   });
 });
 
 describe("enforceInputBudget (read-path guard backstop)", () => {
-  test("leaves an in-budget input untouched (no trim, byte-identical)", () => {
+  test("leaves an in-budget input untouched", () => {
     const items: CompactionItem[] = [user("a"), assistant("b"), user("c"), assistant("d")];
-    const out = enforceInputBudget(items, BUDGET);
+    const out = enforceInputBudget(items, 1_000_000);
     expect(out.trimmed).toBe(false);
-    expect(out.droppedCount).toBe(0);
     expect(out.items).toEqual(items);
   });
 
-  test("trims the OLDEST history at a clean boundary until it fits, keeping the recent tail", () => {
+  test("trims the oldest history at a clean boundary until it fits", () => {
     const items: CompactionItem[] = [
-      user("old turn"), bigItem("assistant", 1_000_000),
+      user("old turn"), assistant("x".repeat(1_000_000)),
       user("recent turn"), assistant("kept"),
     ];
-    expect(estimateTokens(items)).toBeGreaterThan(BUDGET);
-    const out = enforceInputBudget(items, BUDGET);
+    const out = enforceInputBudget(items, 100);
     expect(out.trimmed).toBe(true);
-    expect(out.droppedCount).toBeGreaterThan(0);
-    // The most recent turn survives; the assembled input now fits.
     expect(out.items).toContainEqual(user("recent turn"));
-    expect(out.estimatedTokens).toBeLessThanOrEqual(BUDGET);
+    expect(out.items).not.toContainEqual(user("old turn"));
   });
 
-  test("an over-budget assembled input can NOT be sent: trailingTokens counts against the cap", () => {
-    // The stored history alone fits, but the new user message (trailing) pushes
-    // the WHOLE request over budget. The guard must still trim so the request on
-    // the wire fits — the guard measures history + trailing, not history alone.
+  test("accounts for trailing tokens", () => {
     const items: CompactionItem[] = [
-      user("old"), bigItem("assistant", 600_000),
+      user("old"), assistant("x".repeat(400)),
       user("recent"), assistant("a"),
     ];
-    const historyOnly = estimateTokens(items);
-    expect(historyOnly).toBeLessThan(BUDGET); // history alone fits
-    const trailing = BUDGET - historyOnly + 50_000; // trailing blows the budget
-    const out = enforceInputBudget(items, BUDGET, trailing);
+    const out = enforceInputBudget(items, estimateTokens(items), 200);
     expect(out.trimmed).toBe(true);
-    expect(out.estimatedTokens).toBeLessThanOrEqual(BUDGET);
   });
 
-  test("the trimmed result is orphan-clean (cut only at user boundaries, no split tool pairs)", () => {
+  test("does not split tool-call pairs", () => {
     const items: CompactionItem[] = [
-      user("old"), call("c0"), result("c0"), bigItem("assistant", 1_000_000),
+      user("old"), call("c0"), result("c0"), assistant("x".repeat(1_000_000)),
       user("recent"), call("c1"), result("c1"), assistant("done"),
     ];
-    const out = enforceInputBudget(items, BUDGET);
-    expect(out.trimmed).toBe(true);
-    // The cut landed at a user-message boundary, so no call/result straddles it:
-    // the sanitizer leaves the kept tail byte-identical.
+    const out = enforceInputBudget(items, 100);
     expect(sanitizeHistoryItemsForModel(out.items)).toEqual(out.items);
-    // The old turn's pair was dropped whole; the recent turn's pair is intact.
-    expect(out.items.some((i) => i.callId === "c0")).toBe(false);
-    expect(out.items.filter((i) => i.callId === "c1").length).toBe(2);
+    expect(out.items.some((item) => item.callId === "c0")).toBe(false);
+    expect(out.items.filter((item) => item.callId === "c1")).toHaveLength(2);
   });
 
-  test("never orphans a pair: when no earlier safe boundary exists it leaves the input as-is", () => {
-    // A single over-budget turn with no earlier user boundary to cut at — the
-    // guard cannot trim without splitting the turn, so it declines (no-op).
-    const items: CompactionItem[] = [user("only turn"), bigItem("assistant", BUDGET * 2)];
-    const out = enforceInputBudget(items, BUDGET);
-    expect(out.trimmed).toBe(false);
-    expect(out.items).toEqual(items);
-  });
-
-  test("empty history is a no-op", () => {
-    const out = enforceInputBudget([], BUDGET, 1000);
-    expect(out.trimmed).toBe(false);
-    expect(out.items).toEqual([]);
-  });
-});
-
-describe("buildCompactionMessages", () => {
-  test("system prompt references the notebook (pointers not contents) and credential-by-reference", () => {
-    const plan = planCompaction({
-      items: [user("turn 0"), assistant("a0"), user("recent"), assistant("a1")],
-      lastInputTokens: Math.floor(BUDGET * SOFT),
-      inputBudgetTokens: BUDGET,
-      softFraction: SOFT,
-      hardFraction: HARD,
-      keepRecentTokens: 1,
-    });
-    const messages = buildCompactionMessages(plan);
-    expect(messages.system.toLowerCase()).toContain("notebook");
-    expect(messages.system).toContain("NEVER copy a secret value");
+  test("findKeepBoundary returns 0 when no user boundary exists", () => {
+    expect(findKeepBoundary([assistant("a"), call("c"), result("c")], 10)).toBe(0);
   });
 });
 
@@ -524,6 +247,7 @@ describe("extractResponseOutputText", () => {
   test("reads output_text directly", () => {
     expect(extractResponseOutputText({ output_text: "hello" })).toBe("hello");
   });
+
   test("reads assistant message content parts", () => {
     const response = {
       output: [
@@ -533,20 +257,17 @@ describe("extractResponseOutputText", () => {
     };
     expect(extractResponseOutputText(response)).toBe("part-A-B");
   });
-  test("skips input-echo message items (role !== assistant) so a provider that echoes the prompt back can't corrupt the summary", () => {
-    // Fireworks' beta /v1/responses echoes the user input back as an output
-    // `message` item (see docs/model-providers.md); only the assistant message
-    // is the real completion. The guard must read the assistant message and drop
-    // the echoed user/system ones.
+
+  test("skips input-echo message items", () => {
     const response = {
       output: [
         { type: "message", role: "user", content: [{ type: "input_text", text: "ECHOED PROMPT" }] },
-        { type: "message", role: "system", content: [{ type: "input_text", text: "SYSTEM ECHO" }] },
         { type: "message", role: "assistant", content: [{ type: "output_text", text: "real-summary" }] },
       ],
     };
     expect(extractResponseOutputText(response)).toBe("real-summary");
   });
+
   test("returns empty string for unknown shapes", () => {
     expect(extractResponseOutputText(null)).toBe("");
     expect(extractResponseOutputText({})).toBe("");

--- a/packages/testing/src/scripted-model.ts
+++ b/packages/testing/src/scripted-model.ts
@@ -12,6 +12,7 @@ export type ScriptedModelStep = {
   chunks?: string[];
   outputText?: string;
   output?: AgentOutputItem[];
+  inputTokens?: number;
   delayMs?: number;
   error?: unknown;
 };
@@ -98,9 +99,9 @@ function responseForStep(step: ScriptedModelStep, callNumber: number): ModelResp
   return {
     usage: new Usage({
       requests: 1,
-      inputTokens: 1,
+      inputTokens: step.inputTokens ?? 1,
       outputTokens: Math.max(1, text.length),
-      totalTokens: Math.max(2, text.length + 1),
+      totalTokens: Math.max(2, text.length + (step.inputTokens ?? 1)),
     }),
     output: step.output ?? (text ? [assistantMessage(text)] : []),
     responseId: step.id ?? `scripted-response-${callNumber}`,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -550,7 +550,63 @@ describe("worker activities integration", () => {
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
   });
 
-  test("context overflow after persisted progress compacts and AUTO-CONTINUES via a resume-notice requeue", async () => {
+  test("mid-turn proactive compaction before model progress retries once in-activity", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createOwnedSession(dbClient.db, grant, {
+      initialMessage: "proactive retry",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendSessionHistoryItems(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      items: [
+        { position: 0, item: { type: "message", role: "user", content: "x".repeat(75_000 * 4) } },
+        { position: 1, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "old answer" }] } },
+      ],
+    });
+    await setSessionLastInputTokens(dbClient.db, grant.workspaceId, session.id, 1);
+    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      { type: "user.message", payload: { text: "continue after proactive compaction" } },
+    ]);
+    const model = new ScriptedModel([
+      { outputText: "recovered", chunks: ["recovered"] },
+    ]);
+    const activities = createActivities({
+      settings: testSettings({
+        databaseUrl: services.databaseUrl,
+        natsUrl: services.natsUrl,
+        sessionHistorySource: "items",
+        contextCompactionMode: "client",
+        contextWindowTokens: 100_000,
+        contextReservedOutputTokens: 0,
+      }),
+      db: dbClient.db,
+      bus,
+      runtime: runtimeWithFakeCompactionSummarizer(model, "proactive retry summary"),
+    });
+
+    await expect(activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      workflowId: "workflow-proactive-retry",
+    })).resolves.toEqual({ status: "idle" });
+
+    expect(model.calls).toBe(1);
+    const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
+    expect(events.some((event) => event.type === "session.context.compacted")).toBe(true);
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
+    const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
+    expect(active.some((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toBe(true);
+  });
+
+  test("mid-turn proactive compaction after persisted progress AUTO-CONTINUES via a resume-notice requeue", async () => {
     const noopWorkflowClient: SessionWorkflowClient = {
       signalUserMessage: async () => undefined,
       wakeSessionWorkflow: async () => undefined,
@@ -575,10 +631,8 @@ describe("worker activities integration", () => {
         natsUrl: services.natsUrl,
         sessionHistorySource: "items",
         contextCompactionMode: "client",
-        contextWindowTokens: 1_000_000,
+        contextWindowTokens: 100_000,
         contextReservedOutputTokens: 0,
-        contextCompactSoftFraction: 0.99,
-        contextKeepRecentTokens: 20,
         mcpServers: [{
           id: "opengeni",
           name: "OpenGeni",
@@ -611,8 +665,8 @@ describe("worker activities integration", () => {
         { type: "user.message", payload: { text: "overflow after progress" } },
       ]);
       const model = new ScriptedModel([
-        { id: "overflow-progress-1", output: [functionCall("opengeni__sessions_list", { limit: 1 }, "call-overflow-progress")] },
-        { error: contextOverflowError("maximum context length exceeded") },
+        { id: "proactive-progress-1", inputTokens: 80_000, output: [functionCall("opengeni__sessions_list", { limit: 1 }, "call-overflow-progress")] },
+        { outputText: "should be requeued before this call" },
       ]);
       const activities = createActivities({
         settings,
@@ -629,14 +683,14 @@ describe("worker activities integration", () => {
         workflowId: "workflow-overflow-progress",
       })).resolves.toEqual({ status: "preempted" });
 
-      expect(model.calls).toBe(2);
+      expect(model.calls).toBe(1);
       const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 120);
       // The turn auto-continues: no turn.failed — a preempted-with-notice requeue,
       // exactly like the worker-shutdown checkpoint path.
       expect(events.some((event) => event.type === "turn.failed")).toBe(false);
       const preempted = events.find((event) => event.type === "turn.preempted");
       expect(preempted?.payload).toMatchObject({
-        reason: "context_overflow_compacted",
+        reason: "context_compacted",
         resumeWithNotice: true,
       });
       expect(typeof (preempted?.payload as Record<string, unknown>).text).toBe("string");
@@ -645,12 +699,16 @@ describe("worker activities integration", () => {
       expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("queued");
       const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
       expect(active.some((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toBe(true);
+      expect(active.every((row) => {
+        const item = row.item as Record<string, unknown>;
+        return item.type === "message" && item.role === "user";
+      })).toBe(true);
     } finally {
       server.stop(true);
     }
   });
 
-  test("an overflow on an overflow-resumed turn idles instead of requeueing again (loop guard)", async () => {
+  test("a compaction-needed error on a compaction-resumed turn idles instead of requeueing again (loop guard)", async () => {
     const noopWorkflowClient: SessionWorkflowClient = {
       signalUserMessage: async () => undefined,
       wakeSessionWorkflow: async () => undefined,
@@ -675,10 +733,8 @@ describe("worker activities integration", () => {
         natsUrl: services.natsUrl,
         sessionHistorySource: "items",
         contextCompactionMode: "client",
-        contextWindowTokens: 1_000_000,
+        contextWindowTokens: 100_000,
         contextReservedOutputTokens: 0,
-        contextCompactSoftFraction: 0.99,
-        contextKeepRecentTokens: 20,
         mcpServers: [{
           id: "opengeni",
           name: "OpenGeni",
@@ -707,14 +763,14 @@ describe("worker activities integration", () => {
           { position: 3, item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "recent answer" }] } },
         ],
       });
-      // The trigger IS an overflow resume: a second overflow in this lineage
+      // The trigger IS a compaction resume: a second compaction in this lineage
       // must idle, not requeue forever.
       const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
-        { type: "turn.preempted", payload: { reason: "context_overflow_compacted", resumeWithNotice: true, text: "[resumed after compaction]" } },
+        { type: "turn.preempted", payload: { reason: "context_compacted", resumeWithNotice: true, text: "[resumed after compaction]" } },
       ]);
       const model = new ScriptedModel([
-        { id: "overflow-loop-1", output: [functionCall("opengeni__sessions_list", { limit: 1 }, "call-overflow-loop")] },
-        { error: contextOverflowError("maximum context length exceeded") },
+        { id: "compaction-loop-1", inputTokens: 80_000, output: [functionCall("opengeni__sessions_list", { limit: 1 }, "call-overflow-loop")] },
+        { outputText: "should not run" },
       ]);
       const activities = createActivities({
         settings,
@@ -735,7 +791,7 @@ describe("worker activities integration", () => {
       const failed = events.find((event) => event.type === "turn.failed");
       expect(failed?.payload).toMatchObject({
         error: CONTEXT_WINDOW_OVERFLOW_RECOVERY_MESSAGE,
-        code: "context_window_overflow_compacted",
+        code: "context_compacted",
         recovery: "user_message",
       });
       // No SECOND requeue: the only turn.preempted event is the trigger itself.
@@ -3079,7 +3135,7 @@ describe("worker activities integration", () => {
     expect(workerEventsAfter).toBe(workerEventsBefore);
   });
 
-  test("maybeCompactContext compacts an over-budget Azure session into [summary, ...recent tail]", async () => {
+  test("maybeCompactContext compacts an over-budget Azure session into [user messages..., summary]", async () => {
     const grant = await testGrant(dbClient.db);
     const session = await createOwnedSession(dbClient.db, grant, {
       initialMessage: "long session",
@@ -3131,10 +3187,11 @@ describe("worker activities integration", () => {
       900, // last-turn input tokens, well above soft = 500
       async (_s, messages) => {
         summarizerCalls += 1;
-        // The summarizer sees the OLD prefix, not the recent tail.
-        expect(messages.user).toContain("old turn 1");
-        expect(messages.user).toContain("old turn 2");
-        expect(messages.user).not.toContain("recent turn");
+        // The summarizer sees the current active history plus Codex's checkpoint prompt.
+        expect(messages.some((item) => String((item as Record<string, unknown>).content).includes("old turn 1"))).toBe(true);
+        expect(messages.some((item) => String((item as Record<string, unknown>).content).includes("old turn 2"))).toBe(true);
+        expect(messages.some((item) => String((item as Record<string, unknown>).content).includes("recent turn"))).toBe(true);
+        expect(String((messages.at(-1) as Record<string, unknown> | undefined)?.content)).toContain("CONTEXT CHECKPOINT COMPACTION");
         return "objective: ship; blocker: none; next: continue. Durable facts are in the notebook (pointers only).";
       },
     );
@@ -3142,21 +3199,21 @@ describe("worker activities integration", () => {
     expect(summarizerCalls).toBe(1);
     expect(result.compacted).toBe(true);
 
-    // Active read path now returns [summary, recent user, recent assistant], and
-    // it is orphan-clean (no stray tool result without its call).
+    // Active read path now returns retained user messages followed by one
+    // summary; assistant/tool rows remain only in the audit trail.
     const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
     const types = active.map((row) => (row.item as Record<string, unknown>).type);
-    expect((active[0]!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
+    expect((active.at(-1)!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
     expect(active.some((row) => (row.item as Record<string, unknown>).callId === "c0")).toBe(false);
     expect(active.some((row) => (row.item as Record<string, unknown>).callId === "c1")).toBe(false);
-    expect(active.at(-1)!.item).toMatchObject({ role: "assistant" });
+    expect(active.slice(0, -1).map((row) => (row.item as Record<string, unknown>).content)).toEqual(["old turn 1", "old turn 2", "recent turn"]);
     expect(types).not.toContain("function_call_result");
+    expect(active.every((row) => (row.item as Record<string, unknown>).role === "user")).toBe(true);
 
     // Audit trail intact: ALL ten seeded rows still present (none overwritten),
-    // plus the one summary row => eleven total. The earlier integer placement
-    // overwrote one real row, leaving ten.
+    // plus three retained user-message replacement rows and one summary row.
     const all = await getSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect(all.length).toBe(11);
+    expect(all.length).toBe(14);
     expect(all.filter((row) => (row.item as Record<string, unknown>).opengeni_context_summary === true)).toHaveLength(1);
     // Every original seeded position (0..9) survives verbatim — in particular the
     // assistant 'a2' at position 7 that the half-step before the boundary used to
@@ -3343,8 +3400,8 @@ describe("worker activities integration", () => {
     const forced = await maybeCompactContext(dbClient.db, settings, scope, 10, summarize, { force: true });
     expect(forced.compacted).toBe(true);
     const active = await getActiveSessionHistoryItems(dbClient.db, grant.workspaceId, session.id);
-    expect((active[0]!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
-    expect(active.at(-1)!.item).toMatchObject({ role: "assistant" });
+    expect((active.at(-1)!.item as Record<string, unknown>).opengeni_context_summary).toBe(true);
+    expect(active.slice(0, -1).map((row) => (row.item as Record<string, unknown>).content)).toEqual(["old turn 1", "recent turn"]);
   });
 });
 


### PR DESCRIPTION
Replaces the client-mode compaction planner (soft/hard fractions, keep-recent windows, user-boundary cut planning) with codex-CLI parity, verified against the codex source (\`codex-rs/core/src/compact.rs\`, \`session/turn.rs\`, \`prompts/templates/compact/*\`):

- **Signal**: provider-reported input tokens from the previous model response (chars/4 only before the first call). One threshold: \`0.9 × (window − reservedOutput − 20k summary buffer)\`.
- **Trigger around every model call**: crossing the threshold mid-turn raises \`CompactionNeededError\`, handled by the same in-activity recovery loop as the overflow 400 (which remains as the rare reactive fallback): compact → retry in place, or requeue with the resume-notice (auto-continue) when progress was persisted. Loop guard covers both reasons.
- **Rebuild**: codex's 8-line checkpoint prompt verbatim → new active history = user messages verbatim (20k cap each) + one \`SUMMARY_PREFIX\` summary item. Assistant/tool/reasoning/image rows become inactive audit rows. UI summary marker preserved.
- Manual \`/compact\` reworked onto the same rebuild; OpenAI-platform server mode untouched; old config knobs parsed but ignored (deprecation noted in docs).

Net −682 lines. typecheck green ×3; 707 worker+runtime tests; 10 compaction/overflow integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTjpVFfiun1qdTh7XniQdG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how long sessions are trimmed and recovered mid-turn; wrong thresholds or rebuild logic could lose tool context or loop/fail turns, though integration tests cover proactive and overflow paths.
> 
> **Overview**
> **Client-mode context compaction** is rewritten to match Codex CLI: one threshold (`0.9 × (window − reserved output − 20k)`), provider usage as the signal (with char/4 only before the first call), and a rebuild of active history as **retained user messages + one checkpoint summary**—no more soft/hard fractions, keep-recent tail, or boundary-based prefix cuts. Assistant/tool/reasoning rows are superseded to the audit trail only; summarization uses Codex’s checkpoint prompt and summary prefix verbatim with a fixed `SUMMARY_BUFFER_TOKENS` output cap.
> 
> **Mid-turn behavior** adds per-model-call checks that throw `CompactionNeededError` when the threshold is crossed; `agent-turn` unifies recovery with provider overflow (force compact, single in-activity retry, or preempt with `reason: "context_compacted"`). Provider usage now **persists** `last_input_tokens` on each response. `applyContextCompaction` can insert **replacement** user rows before the summary; docs and config comments mark old client knobs as ignored (server path unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab4e7fa01fa6bbedc6a07d28376fe40703c9e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->