### PR TITLE
feat: compact event reads — server-side delta coalescing + data-based fetch caps

### DIFF
--- a/.changeset/compact-event-reads.md
+++ b/.changeset/compact-event-reads.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/sdk": minor
+"@opengeni/react": patch
+---
+
+Add compact event replay support for history windows and switch React session-event loading to capped compact pages with coalesced-delta resume cursors.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -56,7 +56,7 @@ import {
   updateQueuedSessionTurn,
   type AppendEventInput,
 } from "@opengeni/db";
-import { appendAndPublishEvents } from "@opengeni/events";
+import { appendAndPublishEvents, coalesceSessionEventDeltas } from "@opengeni/events";
 import { withChannelA } from "../sandbox/channel-a";
 import { negotiateCapabilities } from "@opengeni/runtime/sandbox";
 import type { Context, Hono } from "hono";
@@ -286,12 +286,14 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     await assertSessionExists(db, workspaceId, sessionId);
     const after = eventSequence(c.req.query("after"), 0);
     const before = optionalEventSequence(c.req.query("before"));
-    const limit = eventListLimit(c.req.query("limit"));
-    return c.json(await listSessionEvents(db, workspaceId, sessionId, {
+    const compact = compactEvents(c.req.query("compact"));
+    const limit = eventListLimit(c.req.query("limit"), compact ? 5000 : 2000);
+    const events = await listSessionEvents(db, workspaceId, sessionId, {
       after,
       ...(before !== undefined ? { before } : {}),
       limit,
-    }));
+    });
+    return c.json(compact ? coalesceSessionEventDeltas(events) : events);
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/events/stream", async (c) => {
@@ -1085,12 +1087,16 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
   });
 }
 
-function eventListLimit(raw: string | undefined): number {
+function eventListLimit(raw: string | undefined, max = 2000): number {
   const limit = Number(raw ?? 500);
   if (!Number.isFinite(limit)) {
     return 500;
   }
-  return Math.min(2000, Math.max(1, Math.floor(limit)));
+  return Math.min(max, Math.max(1, Math.floor(limit)));
+}
+
+function compactEvents(raw: string | undefined): boolean {
+  return raw === "1" || raw === "true";
 }
 
 function eventSequence(raw: string | undefined, fallback: number): number {

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -111,3 +111,5 @@ Canonical sources: `EventBus` / `createNatsEventBus` in `packages/events/src/ind
 API and worker must share the same broker-backed EventBus binding. The production implementation is `createNatsEventBus(natsUrl, auth?)`; it handles session fanout, selfhosted request/reply, and agent events over one managed NATS connection. Postgres remains the durable event log, but live SSE depends on worker publishes reaching API subscribers cross-process.
 
 Do not replace this with an in-memory bus in an embedded deployment. In-memory fanout only reaches subscribers in the same process and would make worker -> API live SSE silently disappear; clients would only recover on replay/gap backfill.
+
+For embedded UIs that page historical timelines, prefer `GET .../events?compact=1` (or SDK `listEvents(..., { compact: true })`) for windowed replay. It coalesces consecutive delta fragments in the page while preserving first-member `sequence`; use `payload.coalescedUntil` as the resume cursor for the live SSE stream. Streaming/gap backfill should keep using raw sequence replay.

--- a/packages/events/src/coalesce.ts
+++ b/packages/events/src/coalesce.ts
@@ -1,0 +1,118 @@
+import type { SessionEvent } from "@opengeni/contracts";
+
+const COALESCIBLE_DELTA_TYPES = new Set([
+  "agent.message.delta",
+  "agent.reasoning.delta",
+  "sandbox.command.output.delta",
+]);
+
+type DeltaRun = {
+  first: SessionEvent;
+  lastSequence: number;
+  text: string;
+  sandboxName: string | undefined;
+};
+
+export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent[] {
+  const coalesced: SessionEvent[] = [];
+  let run: DeltaRun | null = null;
+
+  const flush = () => {
+    if (!run) {
+      return;
+    }
+    coalesced.push({
+      ...run.first,
+      payload: {
+        text: run.text,
+        coalescedUntil: run.lastSequence,
+        ...(run.first.type === "sandbox.command.output.delta" && run.sandboxName !== undefined
+          ? { name: run.sandboxName }
+          : {}),
+      },
+    });
+    run = null;
+  };
+
+  for (const event of events) {
+    if (!isCoalescibleDelta(event)) {
+      flush();
+      coalesced.push(event);
+      continue;
+    }
+
+    const sandboxName = event.type === "sandbox.command.output.delta" ? sandboxDeltaName(event.payload) : undefined;
+    if (run && sameDeltaRun(run.first, event, run.sandboxName, sandboxName)) {
+      run.text += deltaText(event);
+      run.lastSequence = event.sequence;
+      continue;
+    }
+
+    flush();
+    run = {
+      first: event,
+      lastSequence: event.sequence,
+      text: deltaText(event),
+      sandboxName,
+    };
+  }
+
+  flush();
+  return coalesced;
+}
+
+function isCoalescibleDelta(event: SessionEvent): boolean {
+  return COALESCIBLE_DELTA_TYPES.has(event.type);
+}
+
+function sameDeltaRun(
+  first: SessionEvent,
+  next: SessionEvent,
+  firstSandboxName: string | undefined,
+  nextSandboxName: string | undefined,
+): boolean {
+  if (first.type !== next.type) {
+    return false;
+  }
+  if ((first.turnId ?? null) !== (next.turnId ?? null)) {
+    return false;
+  }
+  return first.type !== "sandbox.command.output.delta" || firstSandboxName === nextSandboxName;
+}
+
+function deltaText(event: SessionEvent): string {
+  if (event.type === "agent.reasoning.delta") {
+    return reasoningText(event.payload);
+  }
+  const payload = asRecord(event.payload);
+  if (event.type === "sandbox.command.output.delta") {
+    return typeof payload.text === "string" ? payload.text : typeof payload.output === "string" ? payload.output : "";
+  }
+  return typeof payload.text === "string" ? payload.text : "";
+}
+
+function reasoningText(payload: unknown): string {
+  const record = asRecord(payload);
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+  const content = asRecord(asRecord(record.item).rawItem).content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      const text = asRecord(part).text;
+      return typeof text === "string" ? text : "";
+    })
+    .join("");
+}
+
+function sandboxDeltaName(payload: unknown): string | undefined {
+  const name = asRecord(payload).name;
+  return typeof name === "string" ? name : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -4,6 +4,8 @@ import { connect, JSONCodec, type ConnectionOptions, type Msg, type NatsConnecti
 
 const codec = JSONCodec<SessionBusMessage | SessionEvent>();
 
+export { coalesceSessionEventDeltas } from "./coalesce";
+
 /**
  * Reconnect + keepalive defaults applied to EVERY long-lived NATS connection
  * this package opens (the event bus AND the standalone auth-callout responder).

--- a/packages/events/test/coalesce.test.ts
+++ b/packages/events/test/coalesce.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionEvent } from "@opengeni/contracts";
+import { coalesceSessionEventDeltas } from "../src/index";
+
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const SESSION_ID = "22222222-2222-4222-8222-222222222222";
+const TURN_A = "33333333-3333-4333-8333-333333333333";
+const TURN_B = "44444444-4444-4444-8444-444444444444";
+
+function event(
+  sequence: number,
+  type: SessionEvent["type"] = "agent.message.delta",
+  payload: unknown = { text: String(sequence) },
+  turnId: string | null = TURN_A,
+): SessionEvent {
+  return {
+    id: `00000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
+    workspaceId: WORKSPACE_ID,
+    sessionId: SESSION_ID,
+    sequence,
+    type,
+    payload,
+    occurredAt: new Date(1_770_000_000_000 + sequence).toISOString(),
+    clientEventId: null,
+    turnId,
+  };
+}
+
+describe("coalesceSessionEventDeltas", () => {
+  test("leaves empty and no-delta inputs untouched", () => {
+    expect(coalesceSessionEventDeltas([])).toEqual([]);
+    const events = [
+      event(1, "session.created", {}, null),
+      event(2, "user.message", { text: "hello" }, null),
+    ];
+    expect(coalesceSessionEventDeltas(events)).toEqual(events);
+  });
+
+  test("coalesces a single message delta run onto the first event cursor", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "agent.message.delta", { text: "hel" }),
+      event(2, "agent.message.delta", { text: "lo" }),
+      event(3, "agent.message.delta", { text: "!" }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "00000000-0000-4000-8000-000000000001",
+      sequence: 1,
+      occurredAt: new Date(1_770_000_000_001).toISOString(),
+      payload: { text: "hello!", coalescedUntil: 3 },
+    });
+  });
+
+  test("starts a new run when a non-delta event is interleaved", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "agent.message.delta", { text: "a" }),
+      event(2, "turn.updated", {}),
+      event(3, "agent.message.delta", { text: "b" }),
+    ]);
+
+    expect(result.map((item) => item.sequence)).toEqual([1, 2, 3]);
+    expect(result.map((item) => item.payload)).toEqual([
+      { text: "a", coalescedUntil: 1 },
+      {},
+      { text: "b", coalescedUntil: 3 },
+    ]);
+  });
+
+  test("starts a new run when type or turn changes", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "agent.message.delta", { text: "a" }, TURN_A),
+      event(2, "agent.reasoning.delta", { text: "think" }, TURN_A),
+      event(3, "agent.message.delta", { text: "b" }, TURN_A),
+      event(4, "agent.message.delta", { text: "c" }, TURN_B),
+    ]);
+
+    expect(result.map((item) => [item.type, item.turnId, item.payload])).toEqual([
+      ["agent.message.delta", TURN_A, { text: "a", coalescedUntil: 1 }],
+      ["agent.reasoning.delta", TURN_A, { text: "think", coalescedUntil: 2 }],
+      ["agent.message.delta", TURN_A, { text: "b", coalescedUntil: 3 }],
+      ["agent.message.delta", TURN_B, { text: "c", coalescedUntil: 4 }],
+    ]);
+  });
+
+  test("starts a new sandbox output run when the command name changes", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "sandbox.command.output.delta", { name: "build", text: "one\n" }),
+      event(2, "sandbox.command.output.delta", { name: "build", output: "two\n" }),
+      event(3, "sandbox.command.output.delta", { name: "test", text: "ok\n" }),
+      event(4, "sandbox.command.output.delta", { text: "unnamed\n" }),
+    ]);
+
+    expect(result.map((item) => item.payload)).toEqual([
+      { text: "one\ntwo\n", coalescedUntil: 2, name: "build" },
+      { text: "ok\n", coalescedUntil: 3, name: "test" },
+      { text: "unnamed\n", coalescedUntil: 4 },
+    ]);
+  });
+
+  test("extracts reasoning text from raw item content parts", () => {
+    const result = coalesceSessionEventDeltas([
+      event(1, "agent.reasoning.delta", { item: { rawItem: { content: [{ text: "look " }, { text: "here" }, { other: true }] } } }),
+      event(2, "agent.reasoning.delta", { text: " now" }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.payload).toEqual({ text: "look here now", coalescedUntil: 2 });
+  });
+});

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -82,12 +82,14 @@ export function App() {
 
 ## Hooks
 
-- `useSessionEvents(sessionId)` — loads a bounded tail window by default, then
-  live-streams on the SDK's exactly-once/ordered event delivery. It returns the
-  raw windowed `events`, projected `timeline`, latest `sessionStatus`,
-  connection state, and older-history controls (`hasOlder`, `loadingOlder`,
-  `loadOlder`). Pass `replay: "full"` to opt back into full replay; a nonzero
-  `after` keeps the previous resume semantics.
+- `useSessionEvents(sessionId)` — loads a compact, bounded tail window by
+  default, then live-streams on the SDK's exactly-once/ordered event delivery.
+  Initial replay is capped at three 5000-row raw pages and `loadOlder` at two;
+  timeline group density is only an early stop. It returns the raw windowed
+  `events`, projected `timeline`, latest `sessionStatus`, connection state, and
+  older-history controls (`hasOlder`, `loadingOlder`, `loadOlder`). Pass
+  `replay: "full"` to opt back into full replay; a nonzero `after` keeps the
+  previous resume semantics.
 - `useComposer(sessionId, { sendExtras, defaultMode })` — draft/send/interrupt
   state plus the compose-time **queue-vs-steer** choice (`mode`/`setMode`,
   default `"queue"`): queue stacks the message behind the running turn, steer

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -34,11 +34,11 @@ export type UseSessionEventsResult = {
   error: Error | null;
 };
 
-const TAIL_PAGE_SIZE = 1000;
+const TAIL_PAGE_SIZE = 5000;
 const INITIAL_GROUP_TARGET = 48;
-const INITIAL_EVENT_BUDGET = 10_000;
+const INITIAL_FETCH_CAP = 3;
 const OLDER_GROUP_TARGET = 32;
-const OLDER_EVENT_BUDGET = 6_000;
+const OLDER_FETCH_CAP = 2;
 const BOUNDARY_PAGE_CAP = 4;
 
 /**
@@ -102,7 +102,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
       // the next connect instead of being skipped.
       const lastInBatch = batch[batch.length - 1];
       if (lastInBatch) {
-        lastSequenceRef.current = lastInBatch.sequence;
+        lastSequenceRef.current = Math.max(lastSequenceRef.current, ...batch.map(eventResumeSequence));
       }
       setEvents((existing) => [...existing, ...batch]);
     };
@@ -118,7 +118,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
             before: Number.MAX_SAFE_INTEGER,
             pageSize: TAIL_PAGE_SIZE,
             targetGroups: INITIAL_GROUP_TARGET,
-            maxEvents: INITIAL_EVENT_BUDGET,
+            maxFetches: INITIAL_FETCH_CAP,
             signal: controller.signal,
           });
           if (controller.signal.aborted) {
@@ -182,7 +182,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
         before,
         pageSize: TAIL_PAGE_SIZE,
         targetGroups: OLDER_GROUP_TARGET,
-        maxEvents: OLDER_EVENT_BUDGET,
+        maxFetches: OLDER_FETCH_CAP,
       });
       if (generationRef.current !== generation) {
         return false;
@@ -240,20 +240,24 @@ async function loadEventWindow(
     before: number;
     pageSize: number;
     targetGroups: number;
-    maxEvents: number;
+    maxFetches: number;
     signal?: AbortSignal;
   },
 ): Promise<LoadedEventWindow> {
   let cursor = options.before;
   let buffer: SessionEvent[] = [];
   let reachedStart = false;
+  let fetches = 0;
 
-  while (buffer.length < options.maxEvents && groupCount(buffer) < options.targetGroups) {
+  while (fetches < options.maxFetches) {
+    if (buffer.length > 0 && groupCount(buffer) >= options.targetGroups) {
+      break;
+    }
     const page = await loadPreviousPage(client, workspaceId, sessionId, cursor, {
       pageSize: options.pageSize,
-      remainingEvents: options.maxEvents - buffer.length,
       ...(options.signal ? { signal: options.signal } : {}),
     });
+    fetches += 1;
     if (page.length === 0) {
       reachedStart = true;
       break;
@@ -261,7 +265,7 @@ async function loadEventWindow(
     assertAscending(page);
     buffer = [...page, ...buffer];
     cursor = page[0]!.sequence;
-    if (page.length < page.requested) {
+    if (isLogStart(page[0]!)) {
       reachedStart = true;
       break;
     }
@@ -274,12 +278,12 @@ async function loadEventWindow(
   // pages are fetched only when the buffer holds no boundary at all (one
   // monster turn); past the cap a mid-turn top is accepted.
   let snapPages = 0;
-  while (buffer.length < options.maxEvents && !reachedStart && findBoundaryIndex(buffer) === -1 && snapPages < BOUNDARY_PAGE_CAP) {
+  while (!reachedStart && findBoundaryIndex(buffer) === -1 && snapPages < BOUNDARY_PAGE_CAP && fetches < options.maxFetches) {
     const page = await loadPreviousPage(client, workspaceId, sessionId, cursor, {
       pageSize: options.pageSize,
-      remainingEvents: options.maxEvents - buffer.length,
       ...(options.signal ? { signal: options.signal } : {}),
     });
+    fetches += 1;
     snapPages += 1;
     if (page.length === 0) {
       reachedStart = true;
@@ -288,7 +292,7 @@ async function loadEventWindow(
     assertAscending(page);
     buffer = [...page, ...buffer];
     cursor = page[0]!.sequence;
-    if (page.length < page.requested) {
+    if (isLogStart(page[0]!)) {
       reachedStart = true;
       break;
     }
@@ -305,7 +309,7 @@ async function loadEventWindow(
   return {
     events: buffer,
     oldestSequence: oldest?.sequence ?? null,
-    newestSequence: newest?.sequence ?? 0,
+    newestSequence: newest ? maxResumeSequence(buffer) : 0,
     hasOlder: buffer.length > 0 && !reachedStart && oldest?.type !== "session.created",
   };
 }
@@ -330,18 +334,17 @@ async function loadPreviousPage(
   before: number,
   options: {
     pageSize: number;
-    remainingEvents: number;
     signal?: AbortSignal;
   },
 ): Promise<PreviousPage> {
   if (options.signal?.aborted) {
     throw abortError();
   }
-  const requested = Math.min(options.pageSize, Math.max(0, options.remainingEvents));
+  const requested = options.pageSize;
   if (requested === 0) {
     return Object.assign([], { requested });
   }
-  const page = await client.listEvents(workspaceId, sessionId, { before, limit: requested });
+  const page = await client.listEvents(workspaceId, sessionId, { before, limit: requested, compact: true });
   if (options.signal?.aborted) {
     throw abortError();
   }
@@ -355,6 +358,23 @@ function groupCount(events: SessionEvent[]): number {
   return groupTimeline(buildTimeline(events)).length;
 }
 
+function isLogStart(event: SessionEvent): boolean {
+  return event.type === "session.created" || event.sequence <= 1;
+}
+
+function maxResumeSequence(events: SessionEvent[]): number {
+  return events.reduce((max, event) => Math.max(max, eventResumeSequence(event)), 0);
+}
+
+function eventResumeSequence(event: SessionEvent): number {
+  const payload = asRecord(event.payload);
+  const coalescedUntil = Number(payload.coalescedUntil);
+  return Math.max(event.sequence, Number.isFinite(coalescedUntil) ? Math.floor(coalescedUntil) : 0);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
 
 function assertAscending(events: SessionEvent[]): void {
   for (let index = 1; index < events.length; index += 1) {

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -3,6 +3,7 @@ import type { SessionEvent } from "@opengeni/sdk";
 import { registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import { useSessionEvents } from "../src/hooks/use-session-events";
+import { buildTimeline, type TimelineItem } from "../src/timeline";
 
 registerDom();
 
@@ -20,7 +21,9 @@ function event(sequence: number, type: SessionEvent["type"] = "user.message", pa
   };
 }
 
-function listPage(store: SessionEvent[], options: { after?: number; before?: number; limit?: number } = {}): SessionEvent[] {
+type ListOptions = { after?: number; before?: number; limit?: number; compact?: boolean };
+
+function listPage(store: SessionEvent[], options: ListOptions = {}): SessionEvent[] {
   const after = options.after ?? 0;
   const limit = options.limit ?? 500;
   let candidates = store.filter((item) => item.sequence > after);
@@ -35,9 +38,9 @@ function listPage(store: SessionEvent[], options: { after?: number; before?: num
 function scriptedClient(input: {
   store: SessionEvent[];
   streamEvents?: SessionEvent[];
-  listEvents?: (options: { after?: number; before?: number; limit?: number }) => Promise<SessionEvent[]>;
+  listEvents?: (options: ListOptions) => Promise<SessionEvent[]>;
 }) {
-  const listCalls: Array<{ after?: number; before?: number; limit?: number }> = [];
+  const listCalls: ListOptions[] = [];
   const streamCalls: number[] = [];
   const client = fakeClient({
     listEvents: async (_workspaceId, _sessionId, options = {}) => {
@@ -61,7 +64,7 @@ function scriptedClient(input: {
 }
 
 describe("useSessionEvents", () => {
-  test("initial windowed load stops at density target and opens the stream after the newest event", async () => {
+  test("initial windowed load uses compact tail pages and opens the stream after the newest event", async () => {
     const store = Array.from({ length: 1200 }, (_, index) => event(index + 1));
     const { client, listCalls, streamCalls } = scriptedClient({ store });
     const lengths: number[] = [];
@@ -72,12 +75,12 @@ describe("useSessionEvents", () => {
     }, undefined);
     await flush(20);
 
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000 }]);
-    expect(hook.result.current.events).toHaveLength(1000);
-    expect(hook.result.current.events[0]?.sequence).toBe(201);
-    expect(hook.result.current.hasOlder).toBe(true);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(hook.result.current.events).toHaveLength(1200);
+    expect(hook.result.current.events[0]?.sequence).toBe(1);
+    expect(hook.result.current.hasOlder).toBe(false);
     expect(streamCalls).toEqual([1200]);
-    expect(lengths.filter((length) => length === 1000)).toHaveLength(1);
+    expect(lengths.filter((length) => length === 1200)).toHaveLength(1);
 
     await hook.unmount();
   });
@@ -86,31 +89,32 @@ describe("useSessionEvents", () => {
     const store = [
       event(1, "session.created", {}),
       event(2),
-      ...Array.from({ length: 498 }, (_, index) => event(index + 3, "agent.message.delta", { text: "older" })),
-      event(501),
-      ...Array.from({ length: 1000 }, (_, index) => event(index + 502, "agent.message.delta", { text: "middle" })),
-      ...Array.from({ length: 999 }, (_, index) => event(index + 1502)),
+      ...Array.from({ length: 5099 }, (_, index) => event(index + 3, "agent.message.delta", { text: "older" })),
+      event(5102),
+      ...Array.from({ length: 1000 }, (_, index) => event(index + 5103, "agent.message.delta", { text: "middle" })),
+      ...Array.from({ length: 1000 }, (_, index) => event(index + 6103)),
     ];
     const { client, listCalls } = scriptedClient({ store });
     const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
     await flush(20);
 
-    // One fetch: the tail page already contains boundaries, so the head is
-    // TRIMMED to the oldest user message (the mid-turn fragment at seq 1501 is
-    // dropped) rather than fetching further down. loadOlder's `before` cursor
-    // is the trimmed top, so the fragment is refetched with its own turn.
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000 }]);
+    // One fetch: the tail page already contains a boundary, so the head is
+    // TRIMMED to the oldest user message rather than fetching further down.
+    // loadOlder's `before` cursor is the trimmed top, so the fragment is
+    // refetched with its own turn.
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
     expect(hook.result.current.events[0]?.type).toBe("user.message");
-    expect(hook.result.current.events[0]?.sequence).toBe(1502);
+    expect(hook.result.current.events[0]?.sequence).toBe(5102);
     expect(hook.result.current.hasOlder).toBe(true);
 
     const more = await hook.result.current.loadOlder();
     await flush(20);
-    // The older window starts exactly below the kept window (before: 1502 —
-    // no overlap, no gap), recovers the trimmed fragment, and runs all the way
-    // to the log start, so nothing older remains.
+    // The older window starts exactly below the kept window (before: 5102 —
+    // no overlap, no gap), recovers the trimmed fragment, and runs to the log
+    // start within the older fetch cap, so nothing older remains.
     expect(more).toBe(false);
-    expect(listCalls[1]).toEqual({ before: 1502, limit: 1000 });
+    expect(listCalls[1]).toEqual({ before: 5102, limit: 5000, compact: true });
+    expect(listCalls[2]).toEqual({ before: 102, limit: 5000, compact: true });
     expect(hook.result.current.events[0]?.type).toBe("session.created");
     expect(hook.result.current.events[0]?.sequence).toBe(1);
     expect(hook.result.current.hasOlder).toBe(false);
@@ -124,7 +128,7 @@ describe("useSessionEvents", () => {
   test("loadOlder prepends one older window, preserves order, and guards concurrent calls", async () => {
     const store = [
       event(1, "session.created", {}),
-      ...Array.from({ length: 1199 }, (_, index) => event(index + 2)),
+      ...Array.from({ length: 5999 }, (_, index) => event(index + 2)),
     ];
     let releaseOlder: () => void = () => {
       throw new Error("older page was not requested");
@@ -132,7 +136,7 @@ describe("useSessionEvents", () => {
     const { client, listCalls } = scriptedClient({
       store,
       listEvents: async (options) => {
-        if (options.before === 201) {
+        if (options.before === 1001) {
           await new Promise<void>((resolve) => {
             releaseOlder = resolve;
           });
@@ -146,7 +150,7 @@ describe("useSessionEvents", () => {
     const first = hook.result.current.loadOlder();
     const second = hook.result.current.loadOlder();
     await flush();
-    expect(listCalls.filter((call) => call.before === 201)).toHaveLength(1);
+    expect(listCalls.filter((call) => call.before === 1001)).toHaveLength(1);
     releaseOlder();
     const [firstResult, secondResult] = await Promise.all([first, second]);
     await flush(20);
@@ -188,16 +192,110 @@ describe("useSessionEvents", () => {
     await resumedHook.unmount();
   });
 
-  test("event budget cap stops a boundary-less monster turn at the cap", async () => {
-    const store = Array.from({ length: 12_000 }, (_, index) => event(index + 1, "agent.message.delta", { text: "x" }));
+  test("few-turn many-event logs stop at the initial round-trip cap", async () => {
+    const store = Array.from({ length: 40_000 }, (_, index) => event(index + 1, "agent.message.delta", { text: "x" }));
     const { client, listCalls } = scriptedClient({ store });
     const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
     await flush(20);
 
-    expect(hook.result.current.events).toHaveLength(10_000);
-    expect(hook.result.current.events[0]?.sequence).toBe(2001);
+    expect(hook.result.current.events).toHaveLength(15_000);
+    expect(hook.result.current.events[0]?.sequence).toBe(25_001);
     expect(hook.result.current.hasOlder).toBe(true);
-    expect(listCalls).toHaveLength(10);
+    expect(listCalls).toEqual([
+      { before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true },
+      { before: 35_001, limit: 5000, compact: true },
+      { before: 30_001, limit: 5000, compact: true },
+    ]);
+
+    await hook.unmount();
+  });
+
+  test("coalesced tail opens the stream after coalescedUntil", async () => {
+    const coalescedTail = [
+      event(1, "session.created", {}),
+      event(10, "agent.message.delta", { text: "streamed", coalescedUntil: 99 }),
+    ];
+    const { client, listCalls, streamCalls } = scriptedClient({
+      store: [],
+      listEvents: async () => coalescedTail,
+    });
+    const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
+    await flush(20);
+
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(hook.result.current.events.map((item) => item.sequence)).toEqual([1, 10]);
+    expect(streamCalls).toEqual([99]);
+
+    await hook.unmount();
+  });
+
+  test("loadOlder before an oldest synthetic sequence does not duplicate projected text", async () => {
+    const calls: ListOptions[] = [];
+    const { client } = scriptedClient({
+      store: [],
+      listEvents: async (options) => {
+        calls.push(options);
+        if (options.before === Number.MAX_SAFE_INTEGER) {
+          return [event(8, "agent.message.delta", { text: "ghi", coalescedUntil: 9 })];
+        }
+        if (options.before === 8) {
+          return [event(6, "agent.message.delta", { text: "ef", coalescedUntil: 7 })];
+        }
+        if (options.before === 6) {
+          return [event(4, "agent.message.delta", { text: "cd", coalescedUntil: 5 })];
+        }
+        if (options.before === 4) {
+          return [
+            event(1, "session.created", {}),
+            event(2, "agent.message.delta", { text: "ab", coalescedUntil: 3 }),
+          ];
+        }
+        return [];
+      },
+    });
+    const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
+    await flush(20);
+
+    expect(hook.result.current.events.map((item) => item.sequence)).toEqual([4, 6, 8]);
+    expect(hook.result.current.hasOlder).toBe(true);
+    expect(hook.result.current.lastSequence).toBe(9);
+
+    const more = await hook.result.current.loadOlder();
+    await flush(20);
+
+    expect(more).toBe(false);
+    expect(calls).toEqual([
+      { before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true },
+      { before: 8, limit: 5000, compact: true },
+      { before: 6, limit: 5000, compact: true },
+      { before: 4, limit: 5000, compact: true },
+    ]);
+    const agentText = hook.result.current.timeline
+      .filter((item): item is Extract<TimelineItem, { kind: "agent-message" }> => item.kind === "agent-message")
+      .map((item) => item.text);
+    expect(agentText).toEqual(["abcdefghi"]);
+    const rawEquivalent = [
+      event(1, "session.created", {}),
+      ...Array.from("abcdefghi", (text, index) => event(index + 2, "agent.message.delta", { text })),
+    ];
+    const rawText = buildTimeline(rawEquivalent)
+      .filter((item): item is Extract<TimelineItem, { kind: "agent-message" }> => item.kind === "agent-message")
+      .map((item) => item.text);
+    expect(agentText).toEqual(rawText);
+
+    await hook.unmount();
+  });
+
+  test("group early-stop still works on many-turn logs", async () => {
+    const store = Array.from({ length: 20_000 }, (_, index) => event(index + 1, "user.message", { text: `m-${index + 1}` }));
+    const { client, listCalls } = scriptedClient({ store });
+    const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
+    await flush(20);
+
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(hook.result.current.events).toHaveLength(5000);
+    expect(hook.result.current.events[0]?.sequence).toBe(15_001);
+    expect(hook.result.current.hasOlder).toBe(true);
 
     await hook.unmount();
   });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -46,7 +46,10 @@ contiguous `sequence` number:
 
 Use `client.listEvents(workspaceId, sessionId, { before, after, limit })` for
 durable replay pages. `before` is an exclusive sequence cursor that returns the
-newest matching page, still ordered ascending in the response.
+newest matching page, still ordered ascending in the response. Pass
+`compact: true` for history windows that do not need individual delta fragments;
+delta runs may be coalesced and expose `payload.coalescedUntil` as the true last
+sequence for stream resume cursors.
 
 ```ts
 const controller = new AbortController();

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -330,16 +330,22 @@ export class OpenGeniClient {
 
   // --- Events: replay, send, stream ----------------------------------------
 
-  /** Replay durable events by sequence, ascending. `before` is exclusive and returns the newest matching window. */
+  /**
+   * Replay durable events by sequence, ascending. `before` is exclusive and
+   * returns the newest matching window. With `compact`, consecutive delta runs
+   * may be coalesced; `payload.coalescedUntil` carries the run's last sequence
+   * for resume cursors.
+   */
   async listEvents(
     workspaceId: string,
     sessionId: string,
-    options: { after?: number; before?: number; limit?: number } = {},
+    options: { after?: number; before?: number; limit?: number; compact?: boolean } = {},
   ): Promise<SessionEvent[]> {
     return await this.requestJson<SessionEvent[]>("GET", `/v1/workspaces/${workspaceId}/sessions/${sessionId}/events`, undefined, {
       ...(options.after !== undefined ? { after: String(options.after) } : {}),
       ...(options.before !== undefined ? { before: String(options.before) } : {}),
       ...(options.limit !== undefined ? { limit: String(options.limit) } : {}),
+      ...(options.compact ? { compact: "1" } : {}),
     });
   }
 

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -53,10 +53,10 @@ describe("OpenGeniClient", () => {
     const { client, requests } = makeClient((request) =>
       request.url.includes("/events") ? jsonResponse([makeEvent(3)]) : jsonResponse({ id: SESSION_ID }));
     await client.getSession(WORKSPACE_ID, SESSION_ID);
-    const events = await client.listEvents(WORKSPACE_ID, SESSION_ID, { after: 2, before: 9, limit: 10 });
+    const events = await client.listEvents(WORKSPACE_ID, SESSION_ID, { after: 2, before: 9, limit: 10, compact: true });
     expect(events.map((event) => event.sequence)).toEqual([3]);
     expect(requests[0]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}`);
-    expect(requests[1]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/events?after=2&before=9&limit=10`);
+    expect(requests[1]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/events?after=2&before=9&limit=10&compact=1`);
   });
 
   test("sendMessage wraps text in a user.message control event", async () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -2778,6 +2778,37 @@ describe("API component integration", () => {
     expect(clampedMin.status).toBe(200);
     expect((await clampedMin.json() as SessionEvent[])).toHaveLength(1);
 
+    const compact = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/events?limit=1000000000&compact=1`));
+    expect(compact.status).toBe(200);
+    const compactEvents = await compact.json() as SessionEvent[];
+    expect(compactEvents.slice(0, 4)).toEqual(initialEvents);
+    expect(compactEvents).toHaveLength(5);
+    expect(compactEvents[4]).toMatchObject({
+      sequence: 5,
+      type: "agent.message.delta",
+      payload: { coalescedUntil: latestSequence },
+    });
+    expect((compactEvents[4]?.payload as { text?: string }).text?.startsWith("bulk-0")).toBe(true);
+    expect((compactEvents[4]?.payload as { text?: string }).text?.endsWith(`bulk-${bulkEventCount - 1}`)).toBe(true);
+
+    const compactNewest = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/events?before=${Number.MAX_SAFE_INTEGER}&limit=3&compact=true`));
+    expect(compactNewest.status).toBe(200);
+    const compactNewestEvents = await compactNewest.json() as SessionEvent[];
+    expect(compactNewestEvents).toHaveLength(1);
+    expect(compactNewestEvents[0]?.sequence).toBe(latestSequence - 2);
+    expect((compactNewestEvents[0]?.payload as { coalescedUntil?: number }).coalescedUntil).toBe(latestSequence);
+
+    const compactOlder = await app.request(workspacePath(workspaceId, `/sessions/${session.id}/events?before=${compactNewestEvents[0]!.sequence}&limit=3&compact=1`));
+    expect(compactOlder.status).toBe(200);
+    const compactOlderEvents = await compactOlder.json() as SessionEvent[];
+    expect(compactOlderEvents).toHaveLength(1);
+    const compactPageChunks = [
+      ...(((compactOlderEvents[0]?.payload as { text?: string }).text ?? "").match(/bulk-\d+/g) ?? []),
+      ...(((compactNewestEvents[0]?.payload as { text?: string }).text ?? "").match(/bulk-\d+/g) ?? []),
+    ];
+    expect(compactPageChunks).toEqual(Array.from({ length: 6 }, (_, offset) => `bulk-${bulkEventCount - 6 + offset}`));
+    expect(new Set(compactPageChunks).size).toBe(compactPageChunks.length);
+
     const replayAbort = new AbortController();
     const replay = await app.request(new Request(`http://test${workspacePath(workspaceId, `/sessions/${session.id}/events/stream?after=0`)}`, {
       signal: replayAbort.signal,


### PR DESCRIPTION
## Problem (measured on real staging data)

| session | events | deltas | turns | payload |
|---|---|---|---|---|
| largest | 38,043 | 35,930 (94%) | 46 | 5.3 MB |
| second | 10,954 | 10,497 | **3** | 794 kB |
| third | 9,805 | 9,480 | **1** | 673 kB |

Two compounding defects in #211's windowed loading:
1. The initial-window loop drove fetching by **projected group count** — a semantic unit. Turns are not a unit of size (one turn can be days of autonomous work), so few-turn sessions blew through the target and fetched the **entire log** in sequential 1000-event pages — slow loads, genesis visible (user-reported).
2. 94% of the wire is delta fragments that history rendering doesn't need individually — the projection just concatenates runs.

## Design

- **Server-side delta coalescing** (`compact=1`): consecutive same-type/same-turn (and sandbox-name) delta runs collapse into one synthetic event. Cursor semantics are the load-bearing part: the synthetic keeps its **first member's sequence** (so `before`-cursor paging never refetches merged members — no duplicated text at window seams) and carries **`payload.coalescedUntil`** = last member's sequence (so SSE resume opens after the true tail — no replayed deltas doubling text). Page-boundary run splits re-merge in the projection, which needs **zero changes**.
- **Data-based fetch bounds**: hard caps of 3 round-trips (initial) / 2 (per backfill) × 5,000-row compact pages replace the group-driven loop and event budgets; group count is demoted to an early-stop. Log-start detection now uses `session.created`/sequence-1/empty-page (response length no longer means anything under compaction).

Expected effect on the 38k-event session: ~3 fast queries, ~16× fewer events on the wire, payload from 5.3MB to a few hundred KB, sub-second first paint — independent of session shape (3 turns or 300).

## Verification

519 tests pass: coalescing unit suite (run breaking on type/turn/sandbox-name, reasoning rawItem extraction, `coalescedUntil`), API integration (compact paging with no duplicated member text across consecutive pages), hook (caps bind on few-turn logs, early-stop still works, coalesced tail resume cursor, seam uniqueness). `tsc` clean; docs guard green. Live staging measurement follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session history replay semantics and React initial-load bounds; incorrect `coalescedUntil` or paging could cause duplicated/missing timeline text or wrong SSE resume, though coverage targets those paths.
> 
> **Overview**
> Adds **`compact=1` / `compact: true`** on session event list replay: the API raises the page limit to 5000 when compact is on and returns **`coalesceSessionEventDeltas`** output—consecutive agent message/reasoning and sandbox output deltas merge into one row with concatenated text, the **first** sequence kept for `before` paging, and **`payload.coalescedUntil`** for the true tail. Raw replay and SSE streaming are unchanged.
> 
> **`@opengeni/react`** `useSessionEvents` now loads history with **`compact: true`**, **5000**-row pages, and hard **fetch caps** (3 initial / 2 per `loadOlder`) instead of event budgets; timeline group count is only an early stop. Resume cursors use **`coalescedUntil`** so live SSE does not replay merged deltas. Log-end detection uses **`session.created` / sequence ≤ 1** rather than short pages.
> 
> SDK and embedding docs document the compact option; unit, hook, and API integration tests cover coalescing, paging seams, and resume behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a18f8528fb8ebe3346430379f1c7bf53529ed69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->