### PR TITLE
fix: single-fetch first paint + suppress the genesis fallback while loading

### DIFF
--- a/.changeset/first-paint-single-fetch.md
+++ b/.changeset/first-paint-single-fetch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+First paint of a session is now a single compact fetch (deeper history loads via the scroll sentinel), and the hook exposes `initialLoading` so hosts can suppress genesis fallbacks while the tail window is still fetching — on large sessions the web console painted the session's initial message at the top for the whole fetch.

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -57,7 +57,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
   // Session record + live event log via @opengeni/react. Fresh opens load a
   // bounded tail, then stream live events with resume-by-sequence.
   const { session: fetchedSession, loading, error: loadError } = useSession(sessionId);
-  const { events, sessionStatus, connectionState, hasOlder, loadingOlder, loadOlder, error: streamError } = useSessionEvents(sessionId);
+  const { events, sessionStatus, connectionState, initialLoading, hasOlder, loadingOlder, loadOlder, error: streamError } = useSessionEvents(sessionId);
   const session = useMemo(
     () => fetchedSession ? { ...fetchedSession, status: sessionStatus ?? fetchedSession.status } : null,
     [fetchedSession, sessionStatus],
@@ -88,12 +88,20 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     if (!session) {
       return [];
     }
+    // While the tail window is still being fetched, render nothing rather than
+    // projectSessionTimeline's initial-message fallback — on a large session
+    // that fallback painted the GENESIS message at the top for the whole fetch
+    // (user-reported). The fallback is only for genuinely-empty NEW sessions,
+    // i.e. after the load settles with no events.
+    if (initialLoading && visibleEvents.length === 0) {
+      return [];
+    }
     const projected = projectSessionTimeline(session, visibleEvents);
     // projectSessionTimeline falls back to the session's initial message when
     // the projection is empty; after a clear-view that fallback would resurrect
     // the very first message, so suppress it once the view has been cleared.
     return viewClearedAfter !== null && visibleEvents.length === 0 ? [] : projected;
-  }, [session, visibleEvents, viewClearedAfter]);
+  }, [session, visibleEvents, viewClearedAfter, initialLoading]);
   // Only approvals still awaiting a decision: the durable log replays every
   // historical `session.requiresAction`, so subtract decisions and finished
   // turns instead of rendering decided approvals as live buttons forever.
@@ -148,6 +156,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     <SessionChatPane
       session={session}
       timeline={timeline}
+      initialLoading={initialLoading}
       approvals={approvals}
       failure={failure}
       goal={goal}
@@ -254,6 +263,7 @@ function SessionDock(props: {
 function SessionChatPane(props: {
   session: Session;
   timeline: TimelineItem[];
+  initialLoading: boolean;
   approvals: PendingApproval[];
   failure: ReturnType<typeof summarizeSessionFailure> | null;
   goal: ReturnType<typeof useGoal>;
@@ -380,7 +390,13 @@ function SessionChatPane(props: {
               hasOlder={props.hasOlder}
               loadingOlder={props.loadingOlder}
               onLoadOlder={() => void props.onLoadOlder()}
-              emptyState={(
+              emptyState={props.initialLoading ? (
+                // History is still fetching — a quiet shimmer, not the
+                // "waiting for the first step" copy (that's for NEW sessions).
+                <div className="grid min-h-[24rem] place-items-center text-sm">
+                  <span className="og-shimmer-text font-medium">Loading conversation…</span>
+                </div>
+              ) : (
                 <EmptyState
                   className="min-h-[24rem]"
                   icon={<MessagesSquareIcon className="size-4" />}

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -25,6 +25,8 @@ export type UseSessionEventsResult = {
   connectionState: SessionEventsConnectionState;
   /** Highest sequence seen so far (0 before the first event). */
   lastSequence: number;
+  /** True until the initial tail window has been applied (windowed mode). */
+  initialLoading: boolean;
   /** Whether older durable events are available before the current window. */
   hasOlder: boolean;
   /** True while an older window is being fetched. */
@@ -35,8 +37,7 @@ export type UseSessionEventsResult = {
 };
 
 const TAIL_PAGE_SIZE = 5000;
-const INITIAL_GROUP_TARGET = 48;
-const INITIAL_FETCH_CAP = 3;
+const INITIAL_FETCH_CAP = 1;
 const OLDER_GROUP_TARGET = 32;
 const OLDER_FETCH_CAP = 2;
 const BOUNDARY_PAGE_CAP = 4;
@@ -57,6 +58,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
   const [connectionState, setConnectionState] = useState<SessionEventsConnectionState>("idle");
   const [error, setError] = useState<Error | null>(null);
   const [hasOlder, setHasOlder] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const lastSequenceRef = useRef(after);
   const oldestSequenceRef = useRef<number | null>(null);
@@ -76,6 +78,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
       setError(null);
       setHasOlder(false);
       setLoadingOlder(false);
+      setInitialLoading(true);
       lastSequenceRef.current = after;
       oldestSequenceRef.current = null;
       hasOlderRef.current = false;
@@ -114,10 +117,13 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
       try {
         if (!fullReplay) {
           setConnectionState("connecting");
+          // First paint is ONE compact fetch — the newest window, revealed at
+          // the bottom in a few hundred ms. Deeper history loads only when the
+          // reader actually scrolls up (the sentinel drives loadOlder).
           const window = await loadEventWindow(client, workspaceId, sessionId, {
             before: Number.MAX_SAFE_INTEGER,
             pageSize: TAIL_PAGE_SIZE,
-            targetGroups: INITIAL_GROUP_TARGET,
+            targetGroups: Number.POSITIVE_INFINITY,
             maxFetches: INITIAL_FETCH_CAP,
             signal: controller.signal,
           });
@@ -129,6 +135,10 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
           lastSequenceRef.current = window.newestSequence;
           setHasOlder(window.hasOlder);
           setEvents(window.events);
+          setInitialLoading(false);
+        }
+        if (fullReplay) {
+          setInitialLoading(false);
         }
         const stream = client.streamEvents(workspaceId, sessionId, {
           after: lastSequenceRef.current,
@@ -218,6 +228,7 @@ export function useSessionEvents(sessionId: string | null | undefined, options: 
     sessionStatus,
     connectionState,
     lastSequence: lastSequenceRef.current,
+    initialLoading: fullReplay ? false : initialLoading,
     hasOlder: fullReplay ? false : hasOlder,
     loadingOlder: fullReplay ? false : loadingOlder,
     loadOlder,

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -192,19 +192,18 @@ describe("useSessionEvents", () => {
     await resumedHook.unmount();
   });
 
-  test("few-turn many-event logs stop at the initial round-trip cap", async () => {
+  test("the initial window is a single fetch regardless of log size", async () => {
     const store = Array.from({ length: 40_000 }, (_, index) => event(index + 1, "agent.message.delta", { text: "x" }));
     const { client, listCalls } = scriptedClient({ store });
     const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
     await flush(20);
 
-    expect(hook.result.current.events).toHaveLength(15_000);
-    expect(hook.result.current.events[0]?.sequence).toBe(25_001);
+    // First paint is exactly ONE fetch — deeper history is the sentinel's job.
+    expect(hook.result.current.events).toHaveLength(5000);
+    expect(hook.result.current.events[0]?.sequence).toBe(35_001);
     expect(hook.result.current.hasOlder).toBe(true);
     expect(listCalls).toEqual([
       { before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true },
-      { before: 35_001, limit: 5000, compact: true },
-      { before: 30_001, limit: 5000, compact: true },
     ]);
 
     await hook.unmount();
@@ -256,9 +255,14 @@ describe("useSessionEvents", () => {
     const hook = await renderHook(() => useSessionEvents(SESSION_ID, { client, workspaceId: WORKSPACE_ID }), undefined);
     await flush(20);
 
-    expect(hook.result.current.events.map((item) => item.sequence)).toEqual([4, 6, 8]);
+    expect(hook.result.current.events.map((item) => item.sequence)).toEqual([8]);
     expect(hook.result.current.hasOlder).toBe(true);
     expect(hook.result.current.lastSequence).toBe(9);
+
+    const first = await hook.result.current.loadOlder();
+    await flush(20);
+    expect(first).toBe(true);
+    expect(hook.result.current.events.map((item) => item.sequence)).toEqual([4, 6, 8]);
 
     const more = await hook.result.current.loadOlder();
     await flush(20);


### PR DESCRIPTION
## The user-proven bug

Opening a 38k-event session showed the session's **genesis message at the top for ~1.5s** before jumping to the bottom (screenshot-verified). Reveal-at-bottom (#228) couldn't prevent it because the content was real: `projectSessionTimeline` **falls back to the session record's `initialMessage`** while the projection is empty. That fallback predates windowed loading — events used to start streaming within milliseconds, so it only ever flashed on brand-new sessions. Under windowed loading, the tail fetch takes real time on big sessions and the fallback rendered the whole while.

## Fixes

1. **`useSessionEvents` gains `initialLoading`** (true until the tail window is applied; immediately false in full-replay mode). The web route suppresses the genesis fallback and shows a quiet "Loading conversation…" shimmer while it's set — the fallback remains only for genuinely-empty new sessions after the load settles.
2. **First paint is now exactly ONE compact fetch** (was up to three sequential 5,000-row fetches before anything painted). Deeper history loads only when the reader scrolls up, via the existing 1600px sentinel — this also removes the last semantic fetch driver from the initial path. On a 38k-event session: one ~100KB request → bottom-anchored paint in a few hundred ms.

## Verification

411 tests pass (initial-window contract rewritten to single-fetch; seam-no-duplication test now exercises initial → two loadOlder rounds; coalesced-resume unchanged); `tsc` clean. Live verification against a 17k-row staging fixture + the reported session shape follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default session open behavior in `@opengeni/react` (public `initialLoading` API and fewer initial fetches), which affects any host using windowed replay; web UX is improved but timing of first paint vs. scroll-back history shifts.
> 
> **Overview**
> Fixes large-session opens where the web console showed the session **genesis / initial message** at the top for the whole tail fetch, because `projectSessionTimeline` falls back when the projection is empty during windowed loading.
> 
> **`useSessionEvents`** now exposes **`initialLoading`** (true until the first tail window is applied in windowed mode; false immediately for full replay). Initial load uses **one** compact list fetch (`INITIAL_FETCH_CAP` 1, unbounded `targetGroups` on that pass) instead of up to three sequential 5k-row fetches; older history still comes from **`loadOlder`** when the user scrolls up.
> 
> The **web session route** skips the genesis fallback while `initialLoading` and events are empty, passes loading into the chat pane, and shows a **"Loading conversation…"** shimmer instead of the new-session empty copy until the tail settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3774122b6c9f12e2fa196e3d069b1d18dddf02cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->