### PR TITLE
feat(web): /reset-password page — emailed reset links no longer dead-end

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,7 @@ import { DocumentsRoute } from "@/routes/documents";
 import { EnvironmentsRoute } from "@/routes/environments";
 import { MachinesRoute } from "@/routes/machines";
 import { OrgSettingsRoute } from "@/routes/org-settings";
+import { ResetPasswordRoute } from "@/routes/reset-password";
 import { SchedulesRoute } from "@/routes/schedules";
 import { SessionRoute } from "@/routes/session";
 import { SessionsIndexRoute } from "@/routes/sessions-index";
@@ -72,6 +73,17 @@ const deviceRoute = createRoute({
   validateSearch: (search: Record<string, unknown>): { user_code?: string } =>
     typeof search.user_code === "string" && search.user_code ? { user_code: search.user_code } : {},
   component: Device,
+});
+// Password-reset completion page. Top-level and PUBLIC: the emailed link
+// (`<PUBLIC_BASE_URL>/reset-password?token=…`) is opened by a signed-out user,
+// so `RootRouteComponent` renders this route ahead of the auth gate (see the
+// `isPublicAuthRoute` branch there). Only `token` is read from the query.
+const resetPasswordRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "reset-password",
+  validateSearch: (search: Record<string, unknown>): { token?: string } =>
+    typeof search.token === "string" && search.token ? { token: search.token } : {},
+  component: ResetPassword,
 });
 const workspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -167,6 +179,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   billingReturnRoute,
   deviceRoute,
+  resetPasswordRoute,
   workspaceRoute.addChildren([
     workspaceIndexRoute,
     workspaceAgentRoute,
@@ -289,6 +302,11 @@ function AccountRedirect() {
 function Device() {
   const { user_code } = deviceRoute.useSearch();
   return <DeviceRoute userCode={user_code} />;
+}
+
+function ResetPassword() {
+  const { token } = resetPasswordRoute.useSearch();
+  return <ResetPasswordRoute token={token} />;
 }
 
 function BillingReturnRoute() {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -148,6 +148,16 @@ export async function signOutManaged(): Promise<unknown> {
   return await authRequest<unknown>("/sign-out", { method: "POST" });
 }
 
+// Completes a password reset. `token` comes from the emailed link
+// (`<PUBLIC_BASE_URL>/reset-password?token=…`); Better Auth mounts this at
+// `/v1/auth/reset-password` and expects `{ newPassword, token }`.
+export async function resetPassword(input: { newPassword: string; token: string }): Promise<unknown> {
+  return await authRequest<unknown>("/reset-password", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
 export async function fetchClientConfig(): Promise<ClientConfig> {
   const config = await request<ClientConfig>("/v1/config/client");
   reloadIfStaleDeployment(config);

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -4,7 +4,7 @@
 // workspace shell consumes this through `useAppContext`.
 import type { OpenGeniClient } from "@opengeni/sdk";
 import type { SessionEventsConnectionState } from "@opengeni/react";
-import { Outlet, useNavigate } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { CheckIcon, Loader2Icon, LockIcon, RefreshCwIcon, UserIcon } from "lucide-react";
 import {
@@ -214,6 +214,11 @@ export function RootRouteComponent() {
   const authReady = keyAuthReady && managedAuthReady;
   const defaultWorkspaceId = accessContext?.defaultWorkspaceId ?? workspaces[0]?.id ?? accessContext?.workspaceGrants[0]?.workspaceId ?? null;
   const navigate = useNavigate();
+  // Public routes render ahead of every auth/config gate: a user completing a
+  // password reset is signed out by definition, so `/reset-password` must never
+  // be intercepted by the sign-in panel or workspace-access loading.
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const isPublicAuthRoute = pathname === "/reset-password";
   // The @opengeni/sdk client behind every console API call and hook. Auth
   // headers are read per request; a new identity per key version makes the
   // hooks re-fetch and the event streams reconnect with the new credentials.
@@ -675,7 +680,12 @@ export function RootRouteComponent() {
   return (
     <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-bg text-fg">
       <Toaster richColors theme="dark" />
-      {!clientConfig && !configError ? (
+      {isPublicAuthRoute ? (
+        // Self-contained public page (e.g. /reset-password): rendered before the
+        // config/auth gates and outside AppContext, so it works for a signed-out
+        // visitor even while client config is still loading.
+        <Outlet />
+      ) : !clientConfig && !configError ? (
         <LoadingPanel label="Loading OpenGeni" />
       ) : configError ? (
         <ProblemPanel title="Client configuration unavailable" description={configError} />

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -1,0 +1,162 @@
+// Password-reset completion page (TOP-LEVEL route, sibling of /device). The
+// managed-auth backend emails `<PUBLIC_BASE_URL>/reset-password?token=…`
+// (Better Auth `sendResetPassword`); this page reads that token, collects a new
+// password, and POSTs `{ newPassword, token }` to `/v1/auth/reset-password`.
+//
+// It is PUBLIC by construction — a user resetting a forgotten password is not
+// signed in — so `RootRouteComponent` renders this route ahead of the auth
+// gate and WITHOUT the app context provider. Nothing here may call
+// `useAppContext`; it depends only on the query string and the auth endpoint.
+import { Link } from "@tanstack/react-router";
+import { CheckIcon, KeyRoundIcon, Loader2Icon } from "lucide-react";
+import { useState } from "react";
+
+import { resetPassword } from "@/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Notice } from "@/components/ui/notice";
+
+// Minimum matches the sign-up form's `password.length < 8` rule so the two
+// screens agree on what a valid password is.
+const MIN_PASSWORD_LENGTH = 8;
+
+// `authRequest` throws `Error("Auth <status>: <body>")` where the body is the
+// Better Auth JSON error. Pull out a human-readable line; an invalid or expired
+// token is the overwhelmingly common failure, so say so plainly.
+function friendlyResetError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const body = raw.replace(/^Auth\s+\d+:\s*/, "");
+  let message = body;
+  try {
+    const parsed = JSON.parse(body) as { message?: unknown; code?: unknown };
+    if (typeof parsed.message === "string" && parsed.message.trim()) {
+      message = parsed.message;
+    } else if (typeof parsed.code === "string" && parsed.code.trim()) {
+      message = parsed.code;
+    }
+  } catch {
+    // Body was not JSON — fall back to the raw text.
+  }
+  if (/token|expire|invalid/i.test(message)) {
+    return "This reset link is invalid or has expired. Request a new one from the sign-in screen.";
+  }
+  return message.trim() || "We couldn't reset your password. Please try again.";
+}
+
+export function ResetPasswordRoute({ token }: { token?: string | undefined }) {
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const hasToken = Boolean(token);
+
+  async function submit() {
+    setError(null);
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords don't match.");
+      return;
+    }
+    if (!token) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await resetPassword({ newPassword: password, token });
+      setDone(true);
+    } catch (caught) {
+      setError(friendlyResetError(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-1 items-center justify-center px-4">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-surface p-5 shadow-sm">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="flex size-9 items-center justify-center rounded-md bg-brand-strong/20 text-brand">
+            <KeyRoundIcon className="size-4" />
+          </span>
+          <div>
+            <h1 className="text-base font-semibold">Reset password</h1>
+            <p className="text-sm text-fg-subtle">Choose a new password for your OpenGeni account.</p>
+          </div>
+        </div>
+
+        {done ? (
+          <>
+            <Notice tone="success" title="Password updated">
+              Your password has been changed. Sign in with your new password to continue.
+            </Notice>
+            <Button asChild className="mt-4 w-full">
+              <Link to="/">
+                <CheckIcon className="size-4" />
+                Continue to sign in
+              </Link>
+            </Button>
+          </>
+        ) : !hasToken ? (
+          <>
+            <Notice tone="failed" title="This link is incomplete">
+              The reset link is missing its token, so we can't verify the request. Request a new reset email and open the
+              link from your inbox.
+            </Notice>
+            <Button asChild variant="secondary" className="mt-4 w-full">
+              <Link to="/">Return to sign in</Link>
+            </Button>
+          </>
+        ) : (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submit();
+            }}
+          >
+            <div className="mb-3">
+              <Label htmlFor="reset-password-new">New password</Label>
+              <Input
+                id="reset-password-new"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="new-password"
+                className="mt-2"
+                autoFocus
+              />
+            </div>
+            <div>
+              <Label htmlFor="reset-password-confirm">Confirm password</Label>
+              <Input
+                id="reset-password-confirm"
+                type="password"
+                value={confirm}
+                onChange={(event) => setConfirm(event.target.value)}
+                autoComplete="new-password"
+                className="mt-2"
+              />
+            </div>
+            {error ? (
+              <Notice tone="failed" className="mt-4">
+                {error}
+              </Notice>
+            ) : null}
+            <Button type="submit" className="mt-4 w-full" disabled={busy}>
+              {busy ? <Loader2Icon className="size-4 animate-spin" /> : <CheckIcon className="size-4" />}
+              Reset password
+            </Button>
+            <Button asChild variant="ghost" className="mt-2 w-full">
+              <Link to="/">Back to sign in</Link>
+            </Button>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Password-reset emails link to `/reset-password?token=…` but the web app had no such route — users dead-ended on a 404 (reported today; resets had to be completed via the API by hand).

- New top-level PUBLIC route `/reset-password` rendered ahead of the auth/config gates (a resetting user is signed out by definition), sibling of `/device`
- Form matches the sign-in/sign-up visual language and the sign-up minimum-length rule; POSTs `{ newPassword, token }` to Better Auth's `/v1/auth/reset-password` via the existing `authRequest` wrapper
- States: missing token → recovery guidance; invalid/expired token → friendly error + link back; success → confirmation + sign-in link

Typechecked and render-verified headless (both token and no-token states screenshot-checked against the login screen's design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth gate ordering and adds a password-reset completion path; scope is limited to one public route and an existing Better Auth endpoint with client-side validation only.
> 
> **Overview**
> Adds a **top-level public** `/reset-password?token=…` route so password-reset emails stop 404ing. `RootRouteComponent` now treats that path as `isPublicAuthRoute` and renders `<Outlet />` **before** config loading, access-key, and managed sign-in gates—signed-out users can complete a reset without being blocked.
> 
> The new page collects a new password (8+ chars, confirm match), POSTs `{ newPassword, token }` via `resetPassword()` to Better Auth’s `/v1/auth/reset-password`, and handles **missing token**, **invalid/expired token** (friendly copy), and **success** with links back to sign-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15313fd7dd5726b308636107a4a25710e87d5473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->