### PR TITLE
feat: per-session agent instructions

### DIFF
--- a/.changeset/session-instructions.md
+++ b/.changeset/session-instructions.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/sdk": minor
+"@opengeni/db": minor
+"@opengeni/core": minor
+"@opengeni/runtime": minor
+"@opengeni/api-router": minor
+"@opengeni/worker-bundle": minor
+---
+
+Add an optional per-session `instructions` field to `CreateSessionRequest`: a first-class, system-level agent persona lever composed AFTER the per-workspace `agentInstructions` (session-specific last, non-bypassable CORE preserved). It is org-visible session metadata (returned on the session record) but is never emitted as a timeline event, so hosts can deliver per-agent-type prompts without leaking prompt content into the user-visible timeline or weakening instruction authority. Absent ⇒ byte-identical to today's composition.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -629,6 +629,11 @@ function registerWorkspaceOrchestrationTools(
       description: "Spawn a new agent session (a worker) with an initial message and optional goal, resources (e.g. repositories from github_repositories_list), tools, and workspace environment attachment. Environment attachment happens at creation only — it cannot be added to a running session — and requires the environments:use permission. When targetSandboxId names a machine, workingDir sets the working directory (cwd) the spawned session runs under on that machine.",
       inputSchema: {
         initialMessage: z4.string().min(1),
+        // Per-session agent persona/system instructions for the spawned worker
+        // (a per-agent-type prompt). Delivered system-level, composed AFTER the
+        // workspace persona; never shown in the worker's timeline. Trimmed,
+        // non-empty, max 32768 chars (re-validated by the contracts schema).
+        instructions: z4.string().min(1).max(32768).optional(),
         goal: z4.unknown().optional(),
         resources: z4.array(z4.unknown()).optional(),
         tools: z4.array(z4.unknown()).optional(),

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -166,6 +166,7 @@ const baseSession = {
   repoInstallationId: null,
   title: null,
   titleSource: null,
+  instructions: null,
   errorCode: null,
   errorMessage: null,
   queuedTurnId: null,

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -913,6 +913,7 @@ function session(patch: Partial<Session> = {}): Session {
     initialMessage: "Inspect the repo",
     title: null,
     titleSource: null,
+    instructions: null,
     resources: [],
     tools: [],
     metadata: {},

--- a/apps/web/src/lib/session-rename.test.ts
+++ b/apps/web/src/lib/session-rename.test.ts
@@ -25,6 +25,7 @@ function session(patch: Partial<Session> = {}): Session {
     initialMessage: "Inspect the repo",
     title: null,
     titleSource: null,
+    instructions: null,
     resources: [],
     tools: [],
     metadata: {},

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1335,6 +1335,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           : { computerToolMode: computerToolModeForTurn(null) }),
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(workspaceAgentInstructions ? { instructionsTemplate: workspaceAgentInstructions } : {}),
+        // Per-session persona tier (session > workspace > deployment default).
+        // Composed system-level AFTER the workspace persona so it refines it for
+        // this one session; absent ⇒ byte-identical to today's composition.
+        ...(session.instructions ? { sessionInstructions: session.instructions } : {}),
         ...(workspaceEnvironment
           ? {
             workspaceEnvironment: {

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -17,6 +17,15 @@ acceptSessionUserMessage(deps, grant, workspaceId, sessionId, input)
 
 Both live in `packages/core/src/domain/sessions.ts` and expect `ApiRouteDeps` plus an `AccessGrant`. Scheduled-task validation/sync helpers live in `packages/core/src/domain/scheduled-tasks.ts`. V2 skips Hono parsing/routing, but it does not skip Postgres, EventBus, Temporal wakeups, or worker execution.
 
+### Agent persona: two levers
+
+A host that runs multiple agent personas has two composable, system-level instruction levers. Both ride the same authoritative instructions channel the agent obeys — neither is ever rendered as a user/timeline message — and they compose in a fixed order: **deployment default template → workspace persona → per-session instructions** (session-specific last), with the non-bypassable CORE (goal-loop ownership + environment block) always substituted in.
+
+- **Workspace `agentInstructions`** (`Workspace.agentInstructions`, set at workspace create/update) — the white-label persona for *every* session in a workspace. Use it for stable, tenant-wide branding/behavior. It may embed the `{{core}}` marker to place the non-bypassable CORE; if it omits the marker, CORE is appended.
+- **Per-session `instructions`** (`CreateSessionRequest.instructions`) — an optional, per-*session* refinement layered after the workspace persona. Use it to deliver a **per-agent-type prompt** (reviewer vs. planner vs. fixer) when many personas share one workspace, without minting a workspace per persona. It is org-visible metadata (returned on the session record, exposed like `title`/`goal`), **never** a timeline event, so internal prompt content does not leak to shared-session readers and carries full system-level authority.
+
+Prefer `instructions` over stuffing persona text into `initialMessage`: `initialMessage` renders as visible timeline content, has weaker instruction authority, and is readable by anyone with the session. Reach for workspace `agentInstructions` when the persona is the same for the whole tenant; reach for session `instructions` when it varies per session. Omitting `instructions` is byte-identical to today's composition. It is trimmed, non-empty, and capped at 32768 characters.
+
 ## Ports
 
 ### Identity Resolver Chain

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2183,6 +2183,10 @@ export const Session = z.object({
   initialMessage: z.string(),
   title: z.string().nullable(),
   titleSource: z.enum(["user", "agent"]).nullable(),
+  // Per-session agent persona/system instructions supplied at create. Org-visible
+  // metadata (exposed like title/goal), never a secret and never a timeline event.
+  // null when the session carried none.
+  instructions: z.string().nullable(),
   resources: z.array(ResourceRef),
   tools: z.array(ToolRef),
   metadata: z.record(z.string(), z.unknown()),
@@ -2779,6 +2783,15 @@ export type SessionEvent = z.infer<typeof SessionEvent>;
 
 export const CreateSessionRequest = z.object({
   initialMessage: z.string().min(1),
+  // Per-session agent persona/system instructions (org-visible metadata, NOT a
+  // secret). Rides the SAME system-level instructions channel the per-workspace
+  // agentInstructions rides, composed AFTER the workspace persona so it refines
+  // it for this one session — how a host delivers per-agent-type prompts without
+  // leaking them into the user-visible timeline (it is NEVER emitted as an
+  // event, unlike goal/initialMessage). Trimmed, non-empty. The 32768-char cap
+  // matches the codebase's largest free-form string convention (workspace
+  // environment variable values). Absent ⇒ byte-identical to today.
+  instructions: z.string().trim().min(1).max(32768).optional(),
   resources: z.array(ResourceRef).default([]),
   tools: z.array(ToolRef).default([]),
   metadata: z.record(z.string(), z.unknown()).default({}),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -134,6 +134,43 @@ describe("contracts", () => {
     expect(payload.reasoningEffort).toBe("xhigh");
   });
 
+  test("accepts and trims per-session instructions", () => {
+    const payload = CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      instructions: "  You are the reviewer persona. Be terse.  ",
+    });
+    expect(payload.instructions).toBe("You are the reviewer persona. Be terse.");
+  });
+
+  test("omitting per-session instructions leaves it undefined (byte-identical to today)", () => {
+    const payload = CreateSessionRequest.parse({ initialMessage: "inspect repo" });
+    expect(payload.instructions).toBeUndefined();
+  });
+
+  test("rejects empty / whitespace-only per-session instructions", () => {
+    expect(() => CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      instructions: "",
+    })).toThrow();
+    expect(() => CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      instructions: "   ",
+    })).toThrow();
+  });
+
+  test("rejects per-session instructions over the 32768-char cap", () => {
+    expect(() => CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      instructions: "x".repeat(32769),
+    })).toThrow();
+    // Exactly at the cap is accepted.
+    const payload = CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      instructions: "x".repeat(32768),
+    });
+    expect(payload.instructions?.length).toBe(32768);
+  });
+
   test("accepts client config payloads", () => {
     const payload = ClientConfig.parse({
       deploymentRevision: "test-sha",

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -232,6 +232,11 @@ export async function createAndStartSession(input: {
   // Names/ids only; the session.created payload never carries variable values.
   environment?: { id: string; name: string } | null;
   goal?: GoalSpec | null;
+  // Per-session agent persona/system instructions (org-visible metadata, not a
+  // secret). Persisted on the session row and composed system-level AFTER the
+  // workspace agentInstructions at turn time; never emitted as a timeline event.
+  // Null/omitted ⇒ the session carries none.
+  instructions?: string | null;
   // Validated against the creating grant before this is called.
   firstPartyMcpPermissions?: Permission[] | null;
   // Encrypted DB rows plus matching safe metadata for create-time per-session
@@ -293,6 +298,7 @@ export async function createAndStartSession(input: {
       sandboxBackend: input.sandboxBackend,
       environmentId: input.environment?.id ?? null,
       firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      instructions: input.instructions ?? null,
       parentSessionId: input.parentSessionId ?? null,
       createIdempotencyKey: input.createIdempotencyKey,
       sandboxGroupId: input.sandboxGroupId ?? null,
@@ -315,6 +321,7 @@ export async function createAndStartSession(input: {
     sandboxBackend: input.sandboxBackend,
     environmentId: input.environment?.id ?? null,
     firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+    instructions: input.instructions ?? null,
     parentSessionId: input.parentSessionId ?? null,
     sandboxGroupId: input.sandboxGroupId ?? null,
     ...(input.sandboxOs ? { sandboxOs: input.sandboxOs } : {}),
@@ -855,6 +862,10 @@ export async function createSessionForRequest(
     metadata: payload.metadata,
     environment: environment ? { id: environment.id, name: environment.name } : null,
     goal: payload.goal ?? null,
+    // Per-session persona instructions (already trimmed/validated by the
+    // contracts schema). Persisted on the row; composed system-level at turn
+    // time. Not surfaced as an event.
+    instructions: payload.instructions ?? null,
     firstPartyMcpPermissions,
     mcpServers: sessionMcpServers.dbServers,
     sessionMcpServers: sessionMcpServers.metadata,

--- a/packages/db/drizzle/0037_session_instructions.sql
+++ b/packages/db/drizzle/0037_session_instructions.sql
@@ -1,0 +1,18 @@
+-- Per-session agent persona/system instructions.
+--
+-- An optional per-agent-type prompt supplied by an embedding host at session
+-- creation. It rides the SAME system-level instructions channel the
+-- per-workspace agent_instructions rides, composed AFTER the workspace persona
+-- so it refines it for this one session — never as a user-visible timeline
+-- event. NULL means the session carried none, so every existing row keeps its
+-- historical, byte-identical composed instructions after this migration without
+-- a backfill. Org-visible metadata, not a secret.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "instructions" text;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3274,6 +3274,9 @@ export async function createSession(db: Database, input: {
   sandboxBackend: SandboxBackend;
   environmentId?: string | null;
   firstPartyMcpPermissions?: Permission[] | null;
+  // Per-session agent persona/system instructions (org-visible, not a secret).
+  // Null/omitted ⇒ the session carries none (composed instructions unchanged).
+  instructions?: string | null;
   parentSessionId?: string | null;
   createIdempotencyKey?: string | null;
   // The shared-sandbox group to join. Omit (or null) for a singleton group:
@@ -3301,6 +3304,7 @@ export async function createSession(db: Database, input: {
       sandboxGroupId: input.sandboxGroupId ?? id,
       environmentId: input.environmentId ?? null,
       firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      instructions: input.instructions ?? null,
       parentSessionId: input.parentSessionId ?? null,
       createIdempotencyKey: input.createIdempotencyKey ?? null,
       status: "queued",
@@ -3339,6 +3343,8 @@ export async function createSessionWithIdempotencyKey(db: Database, input: {
   sandboxBackend: SandboxBackend;
   environmentId?: string | null;
   firstPartyMcpPermissions?: Permission[] | null;
+  // Per-session agent persona/system instructions (org-visible, not a secret).
+  instructions?: string | null;
   parentSessionId?: string | null;
   createIdempotencyKey: string;
   // The shared-sandbox group to join. Omit (or null) for a singleton group
@@ -3365,6 +3371,7 @@ export async function createSessionWithIdempotencyKey(db: Database, input: {
       sandboxGroupId: input.sandboxGroupId ?? id,
       environmentId: input.environmentId ?? null,
       firstPartyMcpPermissions: input.firstPartyMcpPermissions ?? null,
+      instructions: input.instructions ?? null,
       parentSessionId: input.parentSessionId ?? null,
       createIdempotencyKey: input.createIdempotencyKey,
       status: "queued",
@@ -7701,6 +7708,7 @@ function mapSession(row: typeof schema.sessions.$inferSelect, mcpServers: Sessio
     initialMessage: row.initialMessage,
     title: row.title ?? null,
     titleSource: (row.titleSource as "user" | "agent" | null) ?? null,
+    instructions: row.instructions ?? null,
     resources: row.resources as ResourceRef[],
     tools: row.tools as ToolRef[],
     metadata: row.metadata,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -187,6 +187,13 @@ export const sessions = pgTable("sessions", {
   initialMessage: text("initial_message").notNull(),
   title: text("title"),
   titleSource: text("title_source"),
+  // Per-session agent persona/system instructions supplied at create (the
+  // per-agent-type prompt lever for embedding hosts). NULL ⇒ the session
+  // carried none, so the composed agent instructions are byte-identical to a
+  // workspace-only persona (no backfill, no behavior change for existing rows).
+  // Composed system-level AFTER the workspace agentInstructions; never emitted
+  // as a timeline event.
+  instructions: text("instructions"),
   resources: jsonb("resources").$type<unknown[]>().notNull().default([]),
   tools: jsonb("tools").$type<unknown[]>().notNull().default([]),
   metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),

--- a/packages/db/test/session-sandbox-os.test.ts
+++ b/packages/db/test/session-sandbox-os.test.ts
@@ -20,6 +20,7 @@ function baseSession() {
     initialMessage: "hi",
     title: null,
     titleSource: null,
+    instructions: null,
     resources: [],
     tools: [],
     metadata: {},

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -743,6 +743,7 @@ export class MockOpenGeniClient implements SessionClientLike {
       initialMessage: title,
       title: null,
       titleSource: null,
+      instructions: null,
       resources: [],
       tools: [],
       metadata: { title },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -711,6 +711,14 @@ export type BuildAgentOptions = {
   // restyle the persona but never drop the goal-loop contract or environment
   // block.
   instructionsTemplate?: string;
+  // Per-SESSION persona/system instructions (the per-agent-type prompt lever an
+  // embedding host supplies at session create). Composed AFTER the workspace
+  // instructionsTemplate + the non-bypassable CORE, so it refines the workspace
+  // persona for this one session without dropping the goal-loop/environment
+  // contract. Rides the SAME instructions channel (system-level) — NEVER a user/
+  // timeline message. Omitted ⇒ the composed instructions are byte-identical to
+  // a workspace-only persona.
+  sessionInstructions?: string;
   // Skills delivered by enabled capability packs. They join the bundled
   // skills in the sandbox skill index (mounted under .agents/) so
   // skills/<name> references resolve like any other indexed skill.
@@ -793,6 +801,27 @@ export function composeAgentInstructions(template: string, workspaceEnvironment?
   return core ? `${template} ${core}` : template;
 }
 
+/**
+ * Appends the per-session persona instructions to the already-composed
+ * (workspace + CORE) instructions, joined by " " — exactly the join used
+ * throughout the persona composition. The session slice is intentionally LAST
+ * (session-specific refinement of the workspace persona). An absent/blank value
+ * is a no-op that returns the composed string byte-for-byte.
+ */
+export function appendSessionInstructions(composed: string, sessionInstructions?: string): string {
+  const trimmed = sessionInstructions?.trim();
+  return trimmed ? `${composed} ${trimmed}` : composed;
+}
+
+/**
+ * Appends the one-shot genesis title directive (genesis turn only), joined by
+ * " " and always LAST so a white-label persona template or a per-session
+ * instruction can't drop it. A no-op when the hint is absent.
+ */
+export function appendGenesisTitleDirective(instructions: string, genesisTitleHint?: boolean): string {
+  return genesisTitleHint ? `${instructions} ${GENESIS_TITLE_DIRECTIVE}` : instructions;
+}
+
 const agentFileDownloads = new WeakMap<object, SandboxFileDownload[]>();
 const agentRepositoryCloneHooks = new WeakMap<object, SandboxLifecycleHook[]>();
 // TOKEN-BROKER (B1): the per-turn git token seed, stashed alongside the agent's
@@ -837,9 +866,21 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     // ownership + workspace-environment block) at the {{core}} marker, or
     // appends it when the template omits the marker. With the default template
     // and no environment this is byte-identical to the historical preamble.
-    instructions: options.genesisTitleHint
-      ? `${composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment)} ${GENESIS_TITLE_DIRECTIVE}`
-      : composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment),
+    // Persona composition order (all one system-level instructions string):
+    //   1. workspace instructionsTemplate (or deployment default) with the
+    //      non-bypassable CORE substituted at {{core}} — composeAgentInstructions,
+    //   2. + the per-session persona instructions (session-specific, LAST so it
+    //      refines the workspace persona),
+    //   3. + the one-shot genesis title directive (genesis turn only).
+    // With no session instructions and no genesis hint this is byte-identical to
+    // the historical composed instructions.
+    instructions: appendGenesisTitleDirective(
+      appendSessionInstructions(
+        composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment),
+        options.sessionInstructions,
+      ),
+      options.genesisTitleHint,
+    ),
     modelSettings: {
       reasoning: { effort: options.reasoningEffort ?? settings.openaiReasoningEffort, summary: "detailed" },
       // Server-side compaction (OpenAI platform) requires store=false: the

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -585,6 +585,46 @@ describe("runtime event normalization", () => {
     const withOverride = buildOpenGeniAgent(settings, [], { instructionsTemplate: `WORKSPACE OVERRIDE ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER}` });
     expect(withOverride.instructions.startsWith("WORKSPACE OVERRIDE ")).toBe(true);
     expect(withOverride.instructions).not.toContain("DEPLOY DEFAULT");
+  });
+
+  test("per-session instructions compose AFTER the workspace persona + CORE (session-specific last)", () => {
+    const template = `WORKSPACE PERSONA ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER}`;
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      instructionsTemplate: template,
+      sessionInstructions: "SESSION RULE: always answer in French.",
+    });
+    // Exact ordering: workspace persona + CORE first, session instructions last.
+    expect(agent.instructions).toBe(`WORKSPACE PERSONA ${coreInstructions().join(" ")} SESSION RULE: always answer in French.`);
+    // And it rides the same instructions string (system-level), never a message.
+    expect(agent.instructions.endsWith("SESSION RULE: always answer in French.")).toBe(true);
+  });
+
+  test("per-session instructions layer onto the DEFAULT persona too (no workspace override)", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      sessionInstructions: "Be terse.",
+    });
+    expect(agent.instructions).toBe(`${HISTORICAL_DEFAULT_INSTRUCTIONS} Be terse.`);
+  });
+
+  test("absent per-session instructions are byte-identical to today's composition", () => {
+    const base = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    const withUndefined = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], { sessionInstructions: undefined });
+    // A blank/whitespace-only value is also a no-op (trimmed to nothing).
+    const withBlank = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], { sessionInstructions: "   " });
+    expect(withUndefined.instructions).toBe(base.instructions);
+    expect(withBlank.instructions).toBe(base.instructions);
+    expect(base.instructions).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+  });
+
+  test("the genesis title directive stays LAST, after per-session instructions", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), [], {
+      sessionInstructions: "Session-scoped rule.",
+      genesisTitleHint: true,
+    });
+    expect(agent.instructions).toContain("Session-scoped rule.");
+    // Genesis directive is appended after everything, including the session slice.
+    expect(agent.instructions.endsWith(GENESIS_TITLE_DIRECTIVE)).toBe(true);
+    expect(agent.instructions.indexOf("Session-scoped rule.")).toBeLessThan(agent.instructions.indexOf(GENESIS_TITLE_DIRECTIVE));
   });
 
   test("builds native S3 mount entries for file resources", () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -270,6 +270,9 @@ export type Session = {
   initialMessage: string;
   title: string | null;
   titleSource: "user" | "agent" | null;
+  // Per-session agent persona/system instructions supplied at create; null when
+  // the session carried none. Org-visible metadata, never a timeline event.
+  instructions: string | null;
   resources: ResourceRef[];
   tools: ToolRef[];
   metadata: Record<string, unknown>;
@@ -611,6 +614,11 @@ export type ScheduledTask = {
 
 export type CreateSessionRequest = {
   initialMessage: string;
+  // Per-session agent persona/system instructions (org-visible metadata, not a
+  // secret). Delivered system-level, composed AFTER the per-workspace persona —
+  // how a host supplies per-agent-type prompts without leaking them into the
+  // user-visible timeline. Trimmed, non-empty, max 32768 chars.
+  instructions?: string | undefined;
   resources?: ResourceRef[] | undefined;
   tools?: ToolRef[] | undefined;
   metadata?: Record<string, unknown> | undefined;

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -60,6 +60,57 @@ describe("API component integration", () => {
     expect(sessions.some((item) => item.id === session.id && item.workspaceId === workspaceId && item.initialMessage === "hello")).toBe(true);
   });
 
+  test("create-with-instructions persists and reads back the field without leaking a timeline event", async () => {
+    workflow = new FakeWorkflowClient();
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: workflow,
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+
+    const response = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({
+        initialMessage: "review this PR",
+        model: "scripted-model",
+        // Trailing whitespace exercises the contracts .trim() on the create path.
+        instructions: "  You are the PR-reviewer persona: be terse and cite files.  ",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(response.status).toBe(202);
+    const created = await response.json() as { id: string; instructions: string | null };
+    // Create response exposes the (trimmed) instructions.
+    expect(created.instructions).toBe("You are the PR-reviewer persona: be terse and cite files.");
+
+    // Read path (GET /sessions/:id) returns it too.
+    const read = await app.request(workspacePath(workspaceId, `/sessions/${created.id}`));
+    expect(read.status).toBe(200);
+    const fetched = await read.json() as { instructions: string | null };
+    expect(fetched.instructions).toBe("You are the PR-reviewer persona: be terse and cite files.");
+
+    // Persisted on the row (core/db roundtrip).
+    const row = await requireSession(dbClient.db, workspaceId, created.id);
+    expect(row.instructions).toBe("You are the PR-reviewer persona: be terse and cite files.");
+
+    // It must NEVER surface as a timeline event, and no payload may carry it.
+    const events = await listSessionEvents(dbClient.db, workspaceId, created.id);
+    expect(events.map((event) => event.type)).toEqual(["session.created", "user.message", "session.status.changed", "turn.queued"]);
+    const serialized = JSON.stringify(events.map((event) => event.payload));
+    expect(serialized).not.toContain("PR-reviewer persona");
+
+    // Absent instructions read back as null (byte-identical to today).
+    const plain = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "no instructions", model: "scripted-model" }),
+      headers: { "content-type": "application/json" },
+    });
+    const plainSession = await plain.json() as { id: string; instructions: string | null };
+    expect(plainSession.instructions).toBeNull();
+  });
+
   test("create idempotency key dedups double-submit and concurrent creates to one session over the API", async () => {
     workflow = new FakeWorkflowClient();
     const app = createApp({


### PR DESCRIPTION
## Motivation

OpenGeni is embedded by host products that run **multiple agent personas** in one workspace. Today the only persona lever is per-**workspace** `agentInstructions`, which can't carry per-agent-type prompts (reviewer vs. planner vs. fixer) when those personas share a workspace. Hosts have had to stuff persona instructions into the session's `initialMessage`, which:

- renders as **user-visible timeline content**,
- has **weaker instruction authority** than system-level delivery,
- **leaks** internal prompt content to shared-session readers.

This adds a first-class optional `instructions` field on session create.

## Field shape

- `CreateSessionRequest.instructions`: `z.string().trim().min(1).max(32768).optional()` — trimmed, non-empty, capped at 32768 chars (matches the codebase's largest free-form string convention, workspace env-var values).
- `Session.instructions`: `z.string().nullable()` — exposed on the session read/record the same way `title`/`goal` are (org-visible metadata, **not** a secret).

## System-level composition order

The runtime composes one system-level instructions string, session-specific last:

```
deployment/workspace template + non-bypassable CORE  →  session instructions  →  genesis title directive
```

`packages/runtime/src/index.ts` `buildOpenGeniAgent`:
`appendGenesisTitleDirective(appendSessionInstructions(composeAgentInstructions(workspaceTemplate, env), sessionInstructions), genesisTitleHint)`.
The worker (`apps/worker/src/activities/agent-turn.ts`) passes `session.instructions` on the **same system-level channel** workspace `agentInstructions` rides — never as a user/timeline message. When the field is absent, composition is **byte-identical to today** (unit-tested).

## No-timeline-event guarantee

Unlike `goal` (which emits `goal.set`), session `instructions` is **never emitted as a timeline event**. It's persisted on the session row and returned on the session record only. The integration test asserts the create event stream stays `["session.created", "user.message", "session.status.changed", "turn.queued"]` and that no event payload contains the instruction text.

## Migration

`packages/db/drizzle/0037_session_instructions.sql` — `ALTER TABLE sessions ADD COLUMN IF NOT EXISTS instructions text` + the standard `opengeni_app` GRANT block (mirrors 0015/0023). Nullable, no backfill: every existing row keeps byte-identical composed instructions.

## Wiring

- **db**: threaded through `createSession`, `createSessionWithIdempotencyKey`, and `mapSession`.
- **core**: `createAndStartSession` + `createSessionForRequest` persist `payload.instructions ?? null`.
- **api-router**: automatic — the REST route hands the raw body to `createSessionForRequest`, which parses with the contracts schema (verified by integration test, not assumed). The MCP `session_create` tool (a separate hand-written schema) also accepts `instructions`.
- **sdk**: hand-written `CreateSessionRequest` + `Session` types pick up the field.
- **docs**: `docs/embedding.md` gains a "workspace vs. per-session persona" subsection.

## Tests

- **contracts**: accept/trim, omit→undefined, reject empty/whitespace, max-length boundary.
- **runtime**: composition order, default-persona layering, absent→identical, genesis stays last.
- **api integration**: create→read→db roundtrip + no-event-leak + absent→null (71 pass against a real DB with migration 0037 applied).
- Full monorepo typecheck + `check:docs-refs` green.

## Changeset closure

`.changeset/session-instructions.md` minors `@opengeni/contracts` + its dependent closure (`sdk`, `db`, `core`, `runtime`, `api-router`, `worker-bundle`), mirroring #224. `@opengeni/react` rides `sdk` (linked); `config`/`documents`/`events`/`github`/`storage` cascade to patch via `updateInternalDependencies`. Satisfies the CONTRIBUTING §Release 0.x caret-cascade rule.

## Follow-up

The MCP `session_create` tool maintains a **duplicate hand-written zod schema** separate from the contracts `CreateSessionRequest` (it silently strips any field not mirrored — this PR adds `instructions` to both). Worth a follow-up to dedupe that schema against contracts so future create fields don't need double-maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent system-prompt composition and session create persistence; behavior is gated on optional field with explicit byte-identical fallback when absent, but incorrect composition order could affect all sessions that set `instructions`.
> 
> **Overview**
> **Optional per-session `instructions`** on `CreateSessionRequest` lets embedding hosts set per-agent-type personas (reviewer vs. planner) without putting prompts in `initialMessage`. Values are trimmed, 1–32768 chars; omitted sessions behave exactly as before.
> 
> **End-to-end wiring:** nullable `sessions.instructions` (migration `0037`), threaded through db/core/contracts/sdk; returned on session reads like `title`/`goal`. MCP `session_create` accepts the same field. The worker passes `session.instructions` as `sessionInstructions` into agent build.
> 
> **Runtime composition** chains workspace template + CORE → session slice → genesis title directive via `appendSessionInstructions` / `appendGenesisTitleDirective` in `buildOpenGeniAgent`. Session text is system-level only—**never** a timeline event (integration test asserts no leak in event payloads).
> 
> **Docs:** `docs/embedding.md` documents workspace vs. per-session persona levers. Contract, runtime, and API integration tests cover validation, ordering, and roundtrip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774e4d067c9b0655e0def99377e10b4d7c385226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->