### PR TITLE
fix(agent): bound oversized control-RPC replies — screenshots downscale to fit, everything else errors diagnosably

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "image",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "prost",
  "prost-build",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blake3",
  "hex",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"

--- a/agent/crates/opengeni-agent-platform/src/desktop.rs
+++ b/agent/crates/opengeni-agent-platform/src/desktop.rs
@@ -49,6 +49,122 @@ pub struct CapturedFrame {
     pub height: u32,
 }
 
+/// A [`CapturedFrame`] fitted under a byte budget for the control-plane reply, with
+/// the ORIGINAL capture geometry preserved so the computer-use coordinate mapping
+/// can scale model clicks (in the encoded pixel space) back to native pixels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FittedFrame {
+    /// The (possibly re-encoded/downscaled) PNG bytes to publish.
+    pub png: Vec<u8>,
+    /// The ENCODED image's width — what the model/viewer sees.
+    pub width: u32,
+    /// The ENCODED image's height.
+    pub height: u32,
+    /// The ORIGINAL (pre-downscale) capture width; equals `width` when no downscale.
+    pub native_width: u32,
+    /// The ORIGINAL (pre-downscale) capture height; equals `height` when no downscale.
+    pub native_height: u32,
+    /// Whether a downscale was applied (the PNG differs from the raw capture).
+    pub downscaled: bool,
+}
+
+/// The smallest edge we will shrink a screenshot to before giving up — below this a
+/// downscaled screen is useless for computer-use. If even this floor exceeds the
+/// budget the frame is returned anyway (the wire-seam backstop converts the
+/// un-publishable reply into a structured error).
+const MIN_FIT_EDGE: u32 = 320;
+/// Cap on re-encode attempts so a pathological compressor can never spin.
+const MAX_FIT_ITERS: usize = 8;
+
+/// Fit a captured frame's PNG under `budget` bytes so the control-plane reply can be
+/// published. A full-resolution capture of a busy or Retina display can exceed the
+/// transport's max payload (NATS defaults to 1 MiB); the reply publish then fails
+/// agent-side and the caller times out with no cause. When the PNG is over budget we
+/// DOWNSCALE the image (lossless PNG kept — JPEG artifacts hurt the model's text
+/// reading) to the largest geometry that fits, reporting both the encoded and the
+/// native geometry. A `budget` of 0 means "no known bound" → pass through untouched.
+///
+/// PNG size is content-dependent, so the first geometry guess (from the byte ratio)
+/// is verified and shrunk further if still over — bounded by [`MAX_FIT_ITERS`] and a
+/// [`MIN_FIT_EDGE`] floor.
+#[must_use]
+pub fn fit_frame_to_budget(frame: CapturedFrame, budget: usize) -> FittedFrame {
+    let native_width = frame.width;
+    let native_height = frame.height;
+    let passthrough = |png: Vec<u8>, w: u32, h: u32, downscaled: bool| FittedFrame {
+        png,
+        width: w,
+        height: h,
+        native_width,
+        native_height,
+        downscaled,
+    };
+
+    if budget == 0 || frame.png.len() <= budget {
+        return passthrough(frame.png, native_width, native_height, false);
+    }
+
+    // Decode once; if the PNG is somehow undecodable we cannot downscale — return it
+    // as-is and let the wire-seam backstop surface a structured error.
+    let decoded = match image::load_from_memory_with_format(&frame.png, image::ImageFormat::Png) {
+        Ok(img) => img,
+        Err(err) => {
+            tracing::warn!(error = %err, "screenshot over budget but PNG undecodable; cannot downscale");
+            return passthrough(frame.png, native_width, native_height, false);
+        }
+    };
+
+    // Initial geometry guess: pixel count scales ~linearly with byte size for a given
+    // image, so a linear-edge scale of sqrt(budget/len) targets the budget; 0.9 leaves
+    // headroom for PNG's non-linear compression. Shrink 0.8× per miss thereafter.
+    // The byte-length → f64 and scaled-dim → u32 casts below are inherently lossy but
+    // bounded (dims are screen-sized, scale is clamped to [0.05, 1.0], and `.max(1)`
+    // floors the result), so the precision/truncation is deliberate and harmless.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    let mut scale = (budget as f64 / frame.png.len() as f64).sqrt() * 0.9;
+    let mut best: Option<(Vec<u8>, u32, u32)> = None;
+    for _ in 0..MAX_FIT_ITERS {
+        scale = scale.clamp(0.05, 1.0);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let w = ((f64::from(native_width) * scale) as u32).max(1);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let h = ((f64::from(native_height) * scale) as u32).max(1);
+        let resized = decoded.resize_exact(w, h, image::imageops::FilterType::Triangle);
+        let mut png = Vec::new();
+        if let Err(err) =
+            resized.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+        {
+            tracing::warn!(error = %err, "re-encode of downscaled screenshot failed");
+            break;
+        }
+        let fits = png.len() <= budget;
+        best = Some((png, w, h));
+        if fits {
+            break;
+        }
+        if w <= MIN_FIT_EDGE || h <= MIN_FIT_EDGE {
+            tracing::warn!(
+                encoded_len = best.as_ref().map_or(0, |b| b.0.len()),
+                budget,
+                "screenshot still exceeds the transport budget at the minimum size; \
+                 the reply will surface as a structured error"
+            );
+            break;
+        }
+        scale *= 0.8;
+    }
+
+    match best {
+        Some((png, w, h)) => passthrough(png, w, h, true),
+        // No re-encode succeeded at all → hand back the original (backstop errors it).
+        None => passthrough(frame.png, native_width, native_height, false),
+    }
+}
+
 /// The platform's desktop capability: probe a display, capture frames, inject
 /// computer-use input. Implemented per-OS; a headless host with no backend uses
 /// [`NoDesktop`], which reports no display and refuses capture/input with a typed
@@ -159,5 +275,80 @@ mod tests {
             d.inject(&input).await,
             Err(PlatformError::Unsupported(_))
         ));
+    }
+
+    /// Encodes a `w`×`h` PNG whose pixels are pseudo-random (so it does NOT compress
+    /// to near-nothing the way a solid fill would) — a realistic stand-in for a busy
+    /// desktop capture, so the byte budget actually bites.
+    fn noisy_png(w: u32, h: u32) -> Vec<u8> {
+        let mut buf = image::RgbaImage::new(w, h);
+        let mut state: u32 = 0x1234_5678;
+        for px in buf.pixels_mut() {
+            // A cheap xorshift so adjacent pixels differ (defeats PNG filtering).
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            let b = state.to_le_bytes();
+            *px = image::Rgba([b[0], b[1], b[2], 255]);
+        }
+        let mut out = Vec::new();
+        image::DynamicImage::ImageRgba8(buf)
+            .write_to(&mut std::io::Cursor::new(&mut out), image::ImageFormat::Png)
+            .expect("encode test png");
+        out
+    }
+
+    #[test]
+    fn fit_frame_passes_through_when_under_budget_or_unbounded() {
+        let png = noisy_png(64, 48);
+        let frame = CapturedFrame {
+            png: png.clone(),
+            width: 64,
+            height: 48,
+        };
+        // budget 0 = no known bound → untouched.
+        let fitted = fit_frame_to_budget(frame.clone(), 0);
+        assert!(!fitted.downscaled);
+        assert_eq!(fitted.png, png);
+        assert_eq!((fitted.width, fitted.height), (64, 48));
+        assert_eq!((fitted.native_width, fitted.native_height), (64, 48));
+
+        // A generous budget → untouched, and native == encoded (scale factor 1.0,
+        // the no-regression guarantee).
+        let fitted = fit_frame_to_budget(frame, png.len() + 1);
+        assert!(!fitted.downscaled);
+        assert_eq!((fitted.native_width, fitted.native_height), (64, 48));
+        assert_eq!((fitted.width, fitted.height), (64, 48));
+    }
+
+    #[test]
+    fn fit_frame_downscales_to_fit_and_preserves_native_geometry() {
+        let png = noisy_png(400, 300);
+        let native_len = png.len();
+        let budget = native_len / 4;
+        let frame = CapturedFrame {
+            png,
+            width: 400,
+            height: 300,
+        };
+        let fitted = fit_frame_to_budget(frame, budget);
+        assert!(fitted.downscaled, "an over-budget frame must be downscaled");
+        // Native geometry is preserved so the server can scale clicks back.
+        assert_eq!((fitted.native_width, fitted.native_height), (400, 300));
+        // The encoded image is strictly smaller than native.
+        assert!(fitted.width < 400 && fitted.height < 300);
+        assert!(fitted.width >= 1 && fitted.height >= 1);
+        // It actually fits the budget (this geometry is well above the MIN_FIT_EDGE
+        // floor, so the loop converges rather than bottoming out).
+        assert!(
+            fitted.png.len() <= budget,
+            "downscaled png {} must fit budget {budget}",
+            fitted.png.len()
+        );
+        // And it is still a decodable PNG at the reported geometry.
+        let decoded = image::load_from_memory_with_format(&fitted.png, image::ImageFormat::Png)
+            .expect("downscaled png must decode");
+        assert_eq!(decoded.width(), fitted.width);
+        assert_eq!(decoded.height(), fitted.height);
     }
 }

--- a/agent/crates/opengeni-agent-platform/src/lib.rs
+++ b/agent/crates/opengeni-agent-platform/src/lib.rs
@@ -53,7 +53,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use opengeni_agent_proto::v1;
 
-pub use desktop::{resolve_desktop, CapturedFrame, DesktopBackend, NoDesktop};
+pub use desktop::{
+    fit_frame_to_budget, resolve_desktop, CapturedFrame, DesktopBackend, FittedFrame, NoDesktop,
+};
 pub use error::{PlatformError, PlatformResult};
 pub use native::NativePlatform;
 pub use pty::{spawn_pty, PtyProcess};

--- a/agent/crates/opengeni-agent/src/dispatch.rs
+++ b/agent/crates/opengeni-agent/src/dispatch.rs
@@ -48,7 +48,22 @@ pub struct DispatchContext {
     /// [`Op::DesktopInput`] arm refuses synthetic input with
     /// [`ErrorCode::ConsentRequired`] when this is `false`, BEFORE touching the OS.
     pub consented_screen_control: bool,
+    /// The connection's NEGOTIATED max reply payload in bytes (the NATS
+    /// `server_info().max_payload`, deployment-agnostic — never a hardcoded 1 MiB).
+    /// A reply larger than this cannot be published, so an op that produces a large
+    /// reply (a full-res screenshot) fits it under this budget agent-side. `0` means
+    /// "no known bound" (a test/sync context) → ops pass their reply through
+    /// untouched and the wire-seam backstop is the only guard.
+    pub max_reply_bytes: usize,
 }
+
+/// Headroom subtracted from [`DispatchContext::max_reply_bytes`] when an op bounds
+/// its own reply body (the screenshot), covering the `ControlResponse` envelope the
+/// body is wrapped in (`request_id`, field tags, the width/height varints) so the
+/// FULLY-encoded reply — not just the body — stays under the negotiated max. The
+/// generic wire-seam backstop checks the true encoded size regardless, so this is a
+/// best-effort first cut, not the sole guard.
+pub const REPLY_ENVELOPE_MARGIN: usize = 4 * 1024;
 
 impl DispatchContext {
     /// Milliseconds since the agent process started (the monotonic clock the
@@ -161,6 +176,13 @@ async fn dispatch_future<P: Platform>(
         }
 
         // --- platform-backed Channel-A ops -----------------------------------
+        // NOTE: `exec` (large stdout/stderr) and `fs_read` (a big file) produce
+        // UNBOUNDED replies that can exceed the transport's max payload — the same
+        // latent wall the screenshot hit. They are NOT bounded here; the generic
+        // wire-seam backstop in `supervisor::handle_message` converts any such
+        // oversized reply into a structured `PayloadTooLarge` error rather than a
+        // silent publish failure + caller timeout. If a future need arises to stream
+        // or chunk these bodies, bound them at the op like the screenshot does.
         Op::Exec(req) => result(request_id, platform.exec(&req).await, RespResult::Exec),
         Op::FsRead(req) => result(request_id, platform.fs_read(&req).await, RespResult::FsRead),
         Op::FsWrite(req) => result(
@@ -198,7 +220,7 @@ async fn dispatch_future<P: Platform>(
         // --- computer-use control ops: the AGENT drives its own desktop --------
         // Extracted to helpers so this dispatch match stays compact + readable.
         Op::DesktopInput(req) => desktop_input(request_id, req, platform, ctx).await,
-        Op::DesktopScreenshot(_req) => desktop_screenshot(request_id, platform).await,
+        Op::DesktopScreenshot(_req) => desktop_screenshot(request_id, platform, ctx).await,
         Op::PtyWrite(req) => result(
             request_id,
             platform.pty_write(&req).await,
@@ -263,18 +285,34 @@ async fn desktop_input<P: Platform>(
 /// NO consent gate: a screenshot is a VIEW op — it needs a DISPLAY, not
 /// screen-control consent (the view/control decoupling). A headless host surfaces
 /// `Unsupported` from the backend, mapped like any other error.
-async fn desktop_screenshot<P: Platform>(request_id: String, platform: &Arc<P>) -> ControlResponse {
+async fn desktop_screenshot<P: Platform>(
+    request_id: String,
+    platform: &Arc<P>,
+    ctx: &DispatchContext,
+) -> ControlResponse {
+    // Fit the captured PNG under the connection's negotiated reply budget so the
+    // reply can actually be published. A full-res capture of a busy or Retina
+    // display can exceed the transport's max payload (NATS defaults to 1 MiB); the
+    // reply publish then fails agent-side and the caller times out with no cause.
+    // `fit_frame_to_budget` downscales (lossless PNG kept) to the largest geometry
+    // that fits, reporting BOTH the encoded and the native geometry so the
+    // control-plane coordinate mapping can scale model clicks back to native pixels.
+    // A `budget` of 0 (no known bound) passes the frame through untouched. The
+    // envelope margin leaves room for the `ControlResponse` wrapper; the wire-seam
+    // backstop still catches any residual that even the minimum size cannot fit.
+    let budget = ctx.max_reply_bytes.saturating_sub(REPLY_ENVELOPE_MARGIN);
     result(
         request_id,
-        platform
-            .desktop()
-            .capture()
-            .await
-            .map(|frame| v1::DesktopScreenshotResponse {
-                png: frame.png.into(),
-                width: frame.width,
-                height: frame.height,
-            }),
+        platform.desktop().capture().await.map(|frame| {
+            let fitted = opengeni_agent_platform::fit_frame_to_budget(frame, budget);
+            v1::DesktopScreenshotResponse {
+                png: fitted.png.into(),
+                width: fitted.width,
+                height: fitted.height,
+                native_width: fitted.native_width,
+                native_height: fitted.native_height,
+            }
+        }),
         RespResult::DesktopScreenshot,
     )
 }
@@ -313,6 +351,39 @@ fn err_response(
     ControlResponse {
         request_id,
         error: Some(agent_error),
+        result: None,
+    }
+}
+
+/// Builds the structured [`ErrorCode::PayloadTooLarge`] `ControlResponse` the
+/// supervisor's wire-seam backstop publishes IN PLACE OF an oversized reply — the
+/// reply the op produced could not be published (it exceeds the connection's
+/// negotiated max payload), so rather than let the publish fail with only a WARN and
+/// leave the caller to time out opaquely, we replace it with a small, diagnosable
+/// error carrying the offending/negotiated sizes. Not retryable: the same op would
+/// produce the same oversized reply.
+#[must_use]
+pub fn oversized_reply_error(
+    request_id: String,
+    op_label: &str,
+    encoded_len: usize,
+    max_payload: usize,
+) -> ControlResponse {
+    let mut detail = std::collections::HashMap::new();
+    detail.insert("op".to_string(), op_label.to_string());
+    detail.insert("encoded_bytes".to_string(), encoded_len.to_string());
+    detail.insert("max_payload".to_string(), max_payload.to_string());
+    ControlResponse {
+        request_id,
+        error: Some(AgentError {
+            code: ErrorCode::PayloadTooLarge as i32,
+            message: format!(
+                "reply for op '{op_label}' is {encoded_len} bytes, over the transport's \
+                 negotiated max payload of {max_payload} bytes; it could not be published"
+            ),
+            retryable: false,
+            detail,
+        }),
         result: None,
     }
 }
@@ -502,6 +573,9 @@ mod tests {
             epoch: 5,
             started: std::time::Instant::now(),
             consented_screen_control,
+            // Tests exercise the dispatch logic, not the wire budget; 0 = unbounded
+            // (frames pass through untouched, matching pre-backstop behavior).
+            max_reply_bytes: 0,
         }
     }
 
@@ -702,6 +776,11 @@ mod tests {
                 assert_eq!(&s.png[..], FakeDesktop::PNG);
                 assert_eq!(s.width, FakeDesktop::WIDTH);
                 assert_eq!(s.height, FakeDesktop::HEIGHT);
+                // With no budget (max_reply_bytes = 0) the frame passes through
+                // untouched: native geometry equals the encoded geometry (no
+                // downscale), the byte-identical current behavior.
+                assert_eq!(s.native_width, FakeDesktop::WIDTH);
+                assert_eq!(s.native_height, FakeDesktop::HEIGHT);
             }
             other => panic!("expected DesktopScreenshot, got {other:?}"),
         }

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -397,21 +397,32 @@ impl<P: Platform + 'static> Supervisor<P> {
             return;
         };
 
+        // The connection's NEGOTIATED max reply payload (deployment-agnostic — NOT a
+        // hardcoded 1 MiB). Threaded into dispatch so a large-reply op (the
+        // screenshot) fits its body under the budget, and used by the wire-seam
+        // backstop below to convert any residual oversized reply into a diagnosable
+        // error instead of a silent publish failure + caller timeout.
+        let max_payload = client.server_info().max_payload;
+
         let request = match ControlRequest::decode(message.payload.as_ref()) {
             Ok(req) => req,
             Err(e) => {
                 // Reply with a protocol error rather than drop — the caller waits
                 // on the reply and would otherwise time out.
                 error!(error = %e, "undecodable ControlRequest");
-                let resp =
-                    dispatch::dispatch_bytes(message.payload.as_ref(), &self.platform, &self.ctx());
+                let resp = dispatch::dispatch_bytes(
+                    message.payload.as_ref(),
+                    &self.platform,
+                    &self.ctx(max_payload),
+                );
                 let _ = client.publish(reply, resp.into()).await;
                 return;
             }
         };
 
-        let ctx = self.ctx();
+        let ctx = self.ctx(max_payload);
         let op_label = op_label(&request);
+        let request_id = request.request_id.clone();
         let started = Instant::now();
         let response = dispatch::dispatch(request, &self.platform, &ctx).await;
         let elapsed = started.elapsed();
@@ -425,13 +436,38 @@ impl<P: Platform + 'static> Supervisor<P> {
             );
         }
 
-        if let Err(e) = client.publish(reply, response.encode_to_vec().into()).await {
+        // WIRE-SEAM BACKSTOP (generic, ALL ops): a reply larger than the connection's
+        // negotiated max payload cannot be published — the publish fails agent-side
+        // with only a WARN and the caller times out with no cause (the original
+        // screenshot bug; file reads / large exec output share the latent wall).
+        // Rather than let that happen, when the encoded reply would exceed the max we
+        // publish a small structured PAYLOAD_TOO_LARGE error IN ITS PLACE, turning
+        // every silent oversized-reply timeout into a diagnosable, typed failure.
+        let encoded = response.encode_to_vec();
+        let payload = if max_payload > 0 && encoded.len() > max_payload {
+            warn!(
+                op = op_label,
+                encoded_bytes = encoded.len(),
+                max_payload,
+                "reply exceeds the negotiated max payload; replacing it with a \
+                 structured PAYLOAD_TOO_LARGE error so the caller sees a cause"
+            );
+            dispatch::oversized_reply_error(request_id, op_label, encoded.len(), max_payload)
+                .encode_to_vec()
+        } else {
+            encoded
+        };
+
+        if let Err(e) = client.publish(reply, payload.into()).await {
             warn!(error = %e, "failed to publish rpc reply");
         }
     }
 
-    /// Builds the dispatch context snapshot for a request.
-    fn ctx(&self) -> DispatchContext {
+    /// Builds the dispatch context snapshot for a request. `max_reply_bytes` is the
+    /// connection's NEGOTIATED max payload (from `server_info()`), threaded so an op
+    /// that produces a large reply (the screenshot) can fit it under the budget
+    /// agent-side rather than emit an un-publishable reply the caller waits out.
+    fn ctx(&self, max_reply_bytes: usize) -> DispatchContext {
         DispatchContext {
             agent_id: self.creds.agent_id.clone(),
             epoch: self.epoch.load(),
@@ -439,6 +475,7 @@ impl<P: Platform + 'static> Supervisor<P> {
             // The computer-use input consent gate reads the SAME enrollment grant
             // the relay pump's `allow_input` uses.
             consented_screen_control: self.creds.consented_screen_control,
+            max_reply_bytes,
         }
     }
 

--- a/agent/proto/opengeni_agent.proto
+++ b/agent/proto/opengeni_agent.proto
@@ -76,6 +76,12 @@ enum ErrorCode {
   ERROR_CODE_AGENT_OFFLINE = 9;
   // An epoch fence rejected a stale op; caller should re-resolve and retry.
   ERROR_CODE_FENCED = 10;
+  // The op's reply would exceed the transport's negotiated max payload and could
+  // not be published (e.g. a full-res screenshot, or an unbounded file read/exec
+  // output). The agent's wire-seam backstop synthesizes THIS instead of letting
+  // the oversized publish fail silently and the caller time out opaquely.
+  // Not retryable — the same op would produce the same oversized reply.
+  ERROR_CODE_PAYLOAD_TOO_LARGE = 11;
 }
 
 // The operating system family the agent runs on.
@@ -529,8 +535,20 @@ message DesktopInputResponse {}
 message DesktopScreenshotRequest {}
 message DesktopScreenshotResponse {
   bytes png = 1;
+  // The geometry of the ENCODED image (what a viewer/model actually sees). When
+  // the raw capture is too large to fit the control-plane transport's max payload,
+  // the agent DOWNSCALES the PNG so the reply publishes (a full-res Retina/busy
+  // screen can exceed NATS's 1 MiB default); width/height then describe the
+  // downscaled image, and `native_width`/`native_height` below carry the original.
   uint32 width = 2;
   uint32 height = 3;
+  // The ORIGINAL (pre-downscale) capture geometry. Equal to width/height when no
+  // downscale was needed. The computer-use coordinate mapping scales a model click
+  // (expressed in the ENCODED pixel space it saw) back up to this native pixel
+  // space before injecting, so clicks land correctly even on a downscaled frame.
+  // 0 (unset by an older agent) MUST be read as "same as width/height" (no scale).
+  uint32 native_width = 4;
+  uint32 native_height = 5;
 }
 
 // =============================================================================

--- a/packages/agent-proto/src/gen/opengeni_agent.ts
+++ b/packages/agent-proto/src/gen/opengeni_agent.ts
@@ -31,6 +31,14 @@ export enum ErrorCode {
   ERROR_CODE_AGENT_OFFLINE = 9,
   /** ERROR_CODE_FENCED - An epoch fence rejected a stale op; caller should re-resolve and retry. */
   ERROR_CODE_FENCED = 10,
+  /**
+   * ERROR_CODE_PAYLOAD_TOO_LARGE - The op's reply would exceed the transport's negotiated max payload and could
+   * not be published (e.g. a full-res screenshot, or an unbounded file read/exec
+   * output). The agent's wire-seam backstop synthesizes THIS instead of letting
+   * the oversized publish fail silently and the caller time out opaquely.
+   * Not retryable — the same op would produce the same oversized reply.
+   */
+  ERROR_CODE_PAYLOAD_TOO_LARGE = 11,
 }
 
 export function errorCodeFromJSON(object: any): ErrorCode {
@@ -68,6 +76,9 @@ export function errorCodeFromJSON(object: any): ErrorCode {
     case 10:
     case "ERROR_CODE_FENCED":
       return ErrorCode.ERROR_CODE_FENCED;
+    case 11:
+    case "ERROR_CODE_PAYLOAD_TOO_LARGE":
+      return ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE;
     default:
       throw new globalThis.Error("Unrecognized enum value " + object + " for enum ErrorCode");
   }
@@ -97,6 +108,8 @@ export function errorCodeToJSON(object: ErrorCode): string {
       return "ERROR_CODE_AGENT_OFFLINE";
     case ErrorCode.ERROR_CODE_FENCED:
       return "ERROR_CODE_FENCED";
+    case ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE:
+      return "ERROR_CODE_PAYLOAD_TOO_LARGE";
     default:
       throw new globalThis.Error("Unrecognized enum value " + object + " for enum ErrorCode");
   }
@@ -1105,8 +1118,24 @@ export interface DesktopScreenshotRequest {
 
 export interface DesktopScreenshotResponse {
   png: Uint8Array;
+  /**
+   * The geometry of the ENCODED image (what a viewer/model actually sees). When
+   * the raw capture is too large to fit the control-plane transport's max payload,
+   * the agent DOWNSCALES the PNG so the reply publishes (a full-res Retina/busy
+   * screen can exceed NATS's 1 MiB default); width/height then describe the
+   * downscaled image, and `native_width`/`native_height` below carry the original.
+   */
   width: number;
   height: number;
+  /**
+   * The ORIGINAL (pre-downscale) capture geometry. Equal to width/height when no
+   * downscale was needed. The computer-use coordinate mapping scales a model click
+   * (expressed in the ENCODED pixel space it saw) back up to this native pixel
+   * space before injecting, so clicks land correctly even on a downscaled frame.
+   * 0 (unset by an older agent) MUST be read as "same as width/height" (no scale).
+   */
+  nativeWidth: number;
+  nativeHeight: number;
 }
 
 /**
@@ -5990,7 +6019,7 @@ export const DesktopScreenshotRequest: MessageFns<DesktopScreenshotRequest> = {
 };
 
 function createBaseDesktopScreenshotResponse(): DesktopScreenshotResponse {
-  return { png: new Uint8Array(0), width: 0, height: 0 };
+  return { png: new Uint8Array(0), width: 0, height: 0, nativeWidth: 0, nativeHeight: 0 };
 }
 
 export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = {
@@ -6003,6 +6032,12 @@ export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = 
     }
     if (message.height !== 0) {
       writer.uint32(24).uint32(message.height);
+    }
+    if (message.nativeWidth !== 0) {
+      writer.uint32(32).uint32(message.nativeWidth);
+    }
+    if (message.nativeHeight !== 0) {
+      writer.uint32(40).uint32(message.nativeHeight);
     }
     return writer;
   },
@@ -6038,6 +6073,22 @@ export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = 
           message.height = reader.uint32();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.nativeWidth = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.nativeHeight = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -6052,6 +6103,16 @@ export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = 
       png: isSet(object.png) ? bytesFromBase64(object.png) : new Uint8Array(0),
       width: isSet(object.width) ? globalThis.Number(object.width) : 0,
       height: isSet(object.height) ? globalThis.Number(object.height) : 0,
+      nativeWidth: isSet(object.nativeWidth)
+        ? globalThis.Number(object.nativeWidth)
+        : isSet(object.native_width)
+        ? globalThis.Number(object.native_width)
+        : 0,
+      nativeHeight: isSet(object.nativeHeight)
+        ? globalThis.Number(object.nativeHeight)
+        : isSet(object.native_height)
+        ? globalThis.Number(object.native_height)
+        : 0,
     };
   },
 
@@ -6066,6 +6127,12 @@ export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = 
     if (message.height !== 0) {
       obj.height = Math.round(message.height);
     }
+    if (message.nativeWidth !== 0) {
+      obj.nativeWidth = Math.round(message.nativeWidth);
+    }
+    if (message.nativeHeight !== 0) {
+      obj.nativeHeight = Math.round(message.nativeHeight);
+    }
     return obj;
   },
 
@@ -6077,6 +6144,8 @@ export const DesktopScreenshotResponse: MessageFns<DesktopScreenshotResponse> = 
     message.png = object.png ?? new Uint8Array(0);
     message.width = object.width ?? 0;
     message.height = object.height ?? 0;
+    message.nativeWidth = object.nativeWidth ?? 0;
+    message.nativeHeight = object.nativeHeight ?? 0;
     return message;
   },
 };

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -385,7 +385,11 @@ export class SandboxComputer implements Computer {
  *  leaf; the duck-typed `isNativeDesktopSession` probe (below) selects on it. */
 export type NativeDesktopSession = {
   desktopInput(event: DesktopInputRequest["event"]): Promise<void>;
-  screenshot(): Promise<{ png: Uint8Array; width: number; height: number }>;
+  // `nativeWidth`/`nativeHeight` are the PRE-DOWNSCALE capture geometry (equal to
+  // width/height when the agent did not have to shrink the PNG to fit the transport
+  // budget). NativeDesktopComputer scales model clicks from the ENCODED pixel space
+  // back to native pixels using their ratio before injecting.
+  screenshot(): Promise<{ png: Uint8Array; width: number; height: number; nativeWidth: number; nativeHeight: number }>;
 };
 
 /** Model `Button` → wire `PointerButton`. The proto has no back/forward button, so
@@ -424,6 +428,15 @@ export class NativeDesktopComputer implements Computer {
   readonly dimensions: [number, number];
   private session: NativeDesktopSession;
   private readonly readOnly: boolean;
+  // The ENCODED vs NATIVE geometry of the MOST RECENT screenshot the model saw. The
+  // model computes click coordinates in the encoded-pixel space of that screenshot;
+  // when the agent downscaled the PNG to fit the transport budget, encoded < native,
+  // so we scale coordinates back up to native pixels before injecting (the agent's
+  // native inject — macOS CGEvent / Linux XTEST — expects native-pixel coordinates,
+  // exactly as it received them pre-downscale). Null until the first screenshot;
+  // equal encoded==native (or absent) ⇒ scale factor 1.0 ⇒ byte-identical behavior.
+  private lastEncoded: [number, number] | null = null;
+  private lastNative: [number, number] | null = null;
 
   constructor(session: NativeDesktopSession, opts: NativeDesktopComputerOptions = {}) {
     this.session = session;
@@ -441,17 +454,34 @@ export class NativeDesktopComputer implements Computer {
     if (this.readOnly) throw new ComputerReadOnlyError();
   }
 
+  /** Scale a coordinate the model expressed in the MOST RECENT screenshot's
+   *  ENCODED pixel space back to NATIVE pixels. When the last frame was not
+   *  downscaled (encoded == native), or no screenshot has been taken yet, this is a
+   *  1:1 identity — the byte-identical current behavior. The agent then applies its
+   *  own platform mapping (macOS divides native pixels by the backing scale to reach
+   *  CGEvent points; Linux XTEST is 1:1) exactly as it did pre-downscale. */
+  private toNative(x: number, y: number): { x: number; y: number } {
+    const enc = this.lastEncoded;
+    const nat = this.lastNative;
+    if (!enc || !nat || enc[0] <= 0 || enc[1] <= 0) return { x, y };
+    if (enc[0] === nat[0] && enc[1] === nat[1]) return { x, y };
+    return {
+      x: Math.round((x * nat[0]) / enc[0]),
+      y: Math.round((y * nat[1]) / enc[1]),
+    };
+  }
+
   private async pointer(x: number, y: number, action: PointerAction, button: PointerButton): Promise<void> {
-    // COORDINATE SEAM — TODO(verify e2e on macOS): the model computes x/y against the
-    // pixels of the screenshot it just saw, and the agent's macOS CGEvent inject
-    // treats x/y as raw screen coordinates. On a Retina Mac, ScreenCaptureKit may
-    // capture at 2× the logical POINT space while CGEvent expects logical points — a
-    // potential 2× mismatch between the coords the model derives and the coords the
-    // inject applies. This MUST be measured on a real Retina Mac (compare the
-    // screenshot's reported width/height against the logical display bounds) before
-    // any DPR scaling is added. Do NOT add scaling speculatively. Self-hosted Linux
-    // (XTEST/x11) is 1:1 and unaffected.
-    await this.session.desktopInput({ $case: "pointer", pointer: { x, y, action, button } });
+    // COORDINATE SEAM: the model computes x/y against the pixels of the screenshot it
+    // just saw — which the agent may have DOWNSCALED to fit the transport's max
+    // payload (a full-res Retina/busy screen exceeds NATS's 1 MiB default). We scale
+    // those encoded-pixel coordinates back to native pixels here, using the native
+    // geometry the last screenshot reported, so the agent's native inject lands the
+    // click where the model intended. When no downscale occurred the factor is 1.0
+    // and the coordinates pass through unchanged. Self-hosted Linux (XTEST/x11) and
+    // any non-downscaled frame are 1:1 and unaffected.
+    const n = this.toNative(x, y);
+    await this.session.desktopInput({ $case: "pointer", pointer: { x: n.x, y: n.y, action, button } });
   }
 
   async screenshot(): Promise<string> {
@@ -461,10 +491,14 @@ export class NativeDesktopComputer implements Computer {
     // missing/empty frame is therefore a THROW, never a silent "". Native capture
     // (ScreenCaptureKit / x11) does not have the cold-scrot warm-up the xdotool path
     // retries around, so a single capture + a hard empty-guard is sufficient.
-    const { png } = await this.session.screenshot();
+    const { png, width, height, nativeWidth, nativeHeight } = await this.session.screenshot();
     if (png.length === 0) {
       throw new ComputerUnavailableError("native desktop screenshot returned an empty frame (display not up?)");
     }
+    // Record the encoded (what the model sees) vs native geometry of THIS frame so
+    // the next click/move/scroll/drag scales its coordinates back to native pixels.
+    this.lastEncoded = [width, height];
+    this.lastNative = [nativeWidth || width, nativeHeight || height];
     return Buffer.from(png).toString("base64");
   }
 
@@ -482,11 +516,12 @@ export class NativeDesktopComputer implements Computer {
   }
   async scroll(x: number, y: number, sx: number, sy: number) {
     this.guardWrite();
-    // The model's scroll deltas are PIXELS — forward them straight to the agent as a
-    // ScrollEvent{x,y,deltaX,deltaY} and let the native inject translate to wheel
-    // events per platform. No xdotool "notch" quantization here (that is an
-    // xdotool-specific artifact); the agent owns the platform-appropriate scaling.
-    await this.session.desktopInput({ $case: "scroll", scroll: { x, y, deltaX: sx, deltaY: sy } });
+    // The scroll ANCHOR (x,y) is a screenshot-pixel position → scale to native like a
+    // click. The deltas (sx,sy) are relative scroll AMOUNTS, not positions; the agent
+    // owns the platform-appropriate wheel translation, so they pass through unscaled
+    // (no xdotool "notch" quantization here — that is an xdotool-specific artifact).
+    const n = this.toNative(x, y);
+    await this.session.desktopInput({ $case: "scroll", scroll: { x: n.x, y: n.y, deltaX: sx, deltaY: sy } });
   }
   async type(text: string) {
     this.guardWrite();

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -74,7 +74,7 @@ export interface RoutableBackendSession {
   // `event` is kept `unknown` (mirroring the interface's structural style + avoiding
   // a proto import into the leaf); the SelfhostedSession takes `DesktopInputRequest["event"]`.
   desktopInput?(event: unknown): Promise<void>;
-  screenshot?(): Promise<{ png: Uint8Array; width: number; height: number }>;
+  screenshot?(): Promise<{ png: Uint8Array; width: number; height: number; nativeWidth: number; nativeHeight: number }>;
 }
 
 /** The resolved active backend for an epoch: the live session + the sandbox id it
@@ -189,7 +189,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   // that cannot serve them. So the constructor assigns them ONLY when the
   // construction-time default backend actually implements the native surface (below).
   desktopInput?: (event: unknown) => Promise<void>;
-  screenshot?: () => Promise<{ png: Uint8Array; width: number; height: number }>;
+  screenshot?: () => Promise<{ png: Uint8Array; width: number; height: number; nativeWidth: number; nativeHeight: number }>;
 
   constructor(deps: RoutingSandboxSessionDeps) {
     this.deps = deps;

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -545,16 +545,32 @@ export class SelfhostedSession {
   /** Computer-use VIEW op: capture a single PNG screenshot of the machine's desktop
    *  plus its geometry (via ScreenCaptureKit / x11). NOT consent-gated (a view op —
    *  the view/control decoupling), so it works with a display but no screen-control
-   *  consent. Returns the raw encoded bytes + width/height. */
-  async screenshot(): Promise<{ png: Uint8Array; width: number; height: number }> {
+   *  consent. Returns the raw encoded bytes + the ENCODED width/height, plus the
+   *  NATIVE (pre-downscale) geometry: when the agent had to downscale the PNG to fit
+   *  the transport's max payload, `nativeWidth`/`nativeHeight` carry the original
+   *  capture size so the computer-use layer can scale model clicks (in encoded-pixel
+   *  space) back to native pixels. An older agent leaves them 0 → read as "same as
+   *  width/height" (no downscale). */
+  async screenshot(): Promise<{
+    png: Uint8Array;
+    width: number;
+    height: number;
+    nativeWidth: number;
+    nativeHeight: number;
+  }> {
     const result = await this.call({ $case: "desktopScreenshot", desktopScreenshot: {} });
     if (result.$case !== "desktopScreenshot") {
       throw new Error(`selfhosted screenshot: unexpected result ${result.$case}`);
     }
+    const s = result.desktopScreenshot;
+    // Back-compat: an agent predating the native-geometry fields sends 0 → treat the
+    // encoded geometry AS the native geometry (scale factor 1.0, no coordinate shift).
     return {
-      png: result.desktopScreenshot.png,
-      width: result.desktopScreenshot.width,
-      height: result.desktopScreenshot.height,
+      png: s.png,
+      width: s.width,
+      height: s.height,
+      nativeWidth: s.nativeWidth || s.width,
+      nativeHeight: s.nativeHeight || s.height,
     };
   }
 

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -292,16 +292,24 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
 // A FAKE self-hosted session presenting the `{ desktopInput, screenshot }` native
 // surface. Records every injected DesktopInput event so tests can assert the exact
 // protos (event $case + fields + enum values), and returns a configurable PNG.
-function makeNativeSession(opts: { png?: Uint8Array; width?: number; height?: number } = {}) {
+function makeNativeSession(
+  opts: { png?: Uint8Array; width?: number; height?: number; nativeWidth?: number; nativeHeight?: number } = {},
+) {
   const inputs: NonNullable<DesktopInputRequest["event"]>[] = [];
+  const width = opts.width ?? 1280;
+  const height = opts.height ?? 800;
   const session: NativeDesktopSession = {
     desktopInput: async (event) => {
       if (event) inputs.push(event);
     },
     screenshot: async () => ({
       png: opts.png ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]),
-      width: opts.width ?? 1280,
-      height: opts.height ?? 800,
+      width,
+      height,
+      // Default: native == encoded (no downscale). Tests that exercise the
+      // downscale coordinate-scaling override nativeWidth/nativeHeight.
+      nativeWidth: opts.nativeWidth ?? width,
+      nativeHeight: opts.nativeHeight ?? height,
     }),
   };
   return { session, inputs };
@@ -392,6 +400,41 @@ describe("NativeDesktopComputer (self-hosted / macOS native inject+capture)", ()
     if (first.$case !== "pointer" || last.$case !== "pointer") throw new Error("expected pointers");
     expect([first.pointer.x, first.pointer.y]).toEqual([0, 0]);
     expect([last.pointer.x, last.pointer.y]).toEqual([20, 20]);
+  });
+
+  test("COORD-SCALE: after a DOWNSCALED screenshot, clicks scale from encoded→native pixels", async () => {
+    // The agent downscaled a 1280×800 native capture to a 640×400 encoded PNG to fit
+    // the transport budget. The model clicks in the ENCODED space it saw (640×400);
+    // the injected coordinates must be scaled back up 2× to native (1280×800).
+    const { session, inputs } = makeNativeSession({
+      width: 640,
+      height: 400,
+      nativeWidth: 1280,
+      nativeHeight: 800,
+    });
+    const c = new NativeDesktopComputer(session);
+    await c.screenshot(); // records encoded 640×400 / native 1280×800
+    await c.click(320, 200, "left"); // center of the encoded frame
+    const ev = inputs[0]!;
+    if (ev.$case !== "pointer") throw new Error("expected pointer");
+    // 320 * (1280/640) = 640 ; 200 * (800/400) = 400 → center of the NATIVE frame.
+    expect([ev.pointer.x, ev.pointer.y]).toEqual([640, 400]);
+
+    // Scroll anchor scales too; the deltas are amounts and pass through unscaled.
+    await c.scroll(320, 200, -3, 7);
+    const s = inputs[1]!;
+    if (s.$case !== "scroll") throw new Error("expected scroll");
+    expect(s.scroll).toEqual({ x: 640, y: 400, deltaX: -3, deltaY: 7 });
+  });
+
+  test("COORD-SCALE: with NO downscale (native == encoded), coordinates pass through byte-identical", async () => {
+    const { session, inputs } = makeNativeSession({ width: 1280, height: 800 }); // native defaults to encoded
+    const c = new NativeDesktopComputer(session);
+    await c.screenshot();
+    await c.click(640, 400, "left");
+    const ev = inputs[0]!;
+    if (ev.$case !== "pointer") throw new Error("expected pointer");
+    expect([ev.pointer.x, ev.pointer.y]).toEqual([640, 400]); // 1.0 factor, unchanged
   });
 
   test("screenshot returns the base64 of the fake PNG (non-empty, no data-URL prefix)", async () => {


### PR DESCRIPTION
The agent's `desktop_screenshot` reply (a full-res PNG) intermittently exceeded NATS's max payload; the publish failed agent-side with only a WARN and the server's op timed out with no cause — the model's screenshot tool "timed out" on busy/Retina screens (observed live: `max payload size exceeded ... 1321124`). File reads and large exec output share the latent wall.

**Fixes (deployment-agnostic — everything keys off the connection's negotiated `max_payload`, never a hardcoded limit):**
- **Generic wire-seam backstop** (supervisor): any reply that would exceed the negotiated max publishes a small structured `PAYLOAD_TOO_LARGE` error in its place — every oversized reply becomes diagnosable instead of a silent timeout, for all ops.
- **Screenshot fits itself**: the agent downscales the PNG (lossless, bounded iterations) to fit `max_payload − margin` and reports both encoded and native dimensions (proto fields, back-compat 0 ⇒ unscaled).
- **Coordinate contract preserved**: the model clicks in the encoded-pixel space of the last screenshot; `NativeDesktopComputer` scales click/scroll anchors encoded→native before injecting. No downscale ⇒ 1.0 ⇒ byte-identical behavior (regression-proof by construction); no FFI change (macOS still maps native px → points via backing scale).
- Proto regenerated on both stacks (prost + ts-proto). Agent version bumped to 0.1.3 for release.

Gates: clippy -D warnings clean; cargo tests 44+83 pass; agent-proto + runtime `tsc` clean; runtime 509 pass / 0 fail (incl. new coordinate-scaling tests).

Live verification (post-deploy + agent release): busy-screen Mac screenshot succeeds instead of timing out; the agent WARN is gone; clicks land on downscaled frames; an oversized file-read returns a structured error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-plane RPC behavior, proto compatibility, and computer-use coordinate mapping—high user impact but bounded changes with back-compat (native fields 0 ⇒ no scale) and a generic publish backstop.
> 
> **Overview**
> Fixes **silent control-RPC timeouts** when replies exceed the connection’s negotiated NATS `max_payload` (e.g. full-res desktop screenshots). Limits are taken from `server_info().max_payload`, not a hardcoded size.
> 
> **Agent:** `DispatchContext` carries `max_reply_bytes`. `desktop_screenshot` uses `fit_frame_to_budget` to losslessly downscale PNGs under budget minus envelope margin and returns **encoded** `width`/`height` plus **native** `native_width`/`native_height`. The supervisor **wire-seam backstop** replaces any reply still too large with `ERROR_CODE_PAYLOAD_TOO_LARGE` (`oversized_reply_error`) instead of a failed publish.
> 
> **Proto / TS:** New error code and screenshot native geometry fields; generated Rust/TS updated. Workspace version **0.1.3**.
> 
> **Runtime:** `NativeDesktopComputer` maps pointer/scroll anchors from the model’s encoded screenshot space to native pixels before inject; self-hosted session and routing types thread native geometry; tests cover downscale scaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 356a7bc74cec78768e0fdb13092bd87c82bdf776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->