### PR TITLE
fix(desktop): cold-box readiness means a PAINTED frame, not a non-empty one

### DIFF
--- a/docker/desktop/opengeni-desktop-up.sh
+++ b/docker/desktop/opengeni-desktop-up.sh
@@ -83,7 +83,13 @@ start() { # name, cmd...
 }
 
 # 1. Xvfb :0  (RAM framebuffer; 24-bit mandatory for Chrome; no live RANDR -> geometry fixed here)
-start xvfb Xvfb :0 -ac -screen 0 "${W}x${H}x24" -dpi "$DPI" -retro -nolisten tcp -nolisten unix
+# NO -retro: -retro paints the classic weave STIPPLE onto the unpainted root, which (a) any
+# viewer/model that catches a frame BEFORE xfdesktop's first wallpaper paint reads as noisy
+# junk rather than an honest "loading" black, and (b) encodes to a ~17 KB PNG that is close
+# enough to a painted frame to muddy a size-based paint gate. Dropping it makes the pre-paint
+# root solid BLACK (~13.5 KB PNG) — a clean, unambiguous "not painted yet" the PAINTABLE-FRAME
+# gate (ensureDisplayStack, byte-size floor) distinguishes from a real ~210 KB painted desktop.
+start xvfb Xvfb :0 -ac -screen 0 "${W}x${H}x24" -dpi "$DPI" -nolisten tcp -nolisten unix
 # readiness gate: block until the display answers. 100*0.1s=10s (was 50/5s) — on a
 # STONE-COLD gVisor box (the machine->sandbox swap-recovery turn always hits one) Xvfb's
 # first xdpyinfo answer can exceed 5s under runsc syscall overhead + cold page cache, and

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -32,9 +32,33 @@ export const STREAM_PORT = DESKTOP_STREAM_PORT;
 export const DISPLAY_STACK_TIMEOUT_MS = 90_000;
 
 // PAINTABLE-FRAME gate: poll scrot up to this many times, this many seconds apart,
-// waiting for a non-empty frame before declaring the stack "up" (~30s worst case).
+// waiting for an actually-PAINTED frame before declaring the stack "up" (~30s worst case).
 const PAINT_PROBE_ATTEMPTS = 150;
 const PAINT_PROBE_INTERVAL_S = 0.2;
+
+// The paint FLOOR (bytes): a scrot at/above this size is a real painted desktop; below
+// it, the root is still unpainted and the frame would read as "blank" to the model.
+//
+// WHY A SIZE FLOOR, NOT NON-EMPTINESS (the bug this fixes): the old gate only checked
+// `[ -s frame.png ]` (non-empty). But an UNPAINTED root is never zero-byte — a fresh
+// Xvfb draws either the `-retro` weave stipple or (with `-retro` dropped) solid black,
+// and scrot happily encodes that as a small-but-non-empty PNG. So the old gate passed
+// the instant the VNC ports bound — MEASURED at ~1.4s (fast runc host) to several
+// seconds (cold gVisor) BEFORE xfdesktop finishes its first wallpaper paint — handing
+// the model the pre-paint frame. That pre-paint frame is exactly the "blank/black"
+// screenshot that 400s the model and blanks the human viewer.
+//
+// The sizes are unambiguous and were measured on the canonical desktop image (1280x800)
+// under runc — both the current staging image and a fresh local build:
+//   painted XFCE desktop (blue-gradient wallpaper + panel + icons): ~210-222 KB
+//   `-retro` stipple root (unpainted, current image):                ~17 KB
+//   solid-black root (unpainted, after we drop `-retro`):            ~13.5 KB
+// 60 KB sits ~3.5x above every unpainted state and ~3.5x below a real paint — a wide,
+// unambiguous margin. It holds against BOTH the currently-deployed `-retro` image and
+// the `-retro`-dropped image this change ships, so the runtime gate is correct before
+// AND after the image rebuild lands. (Assumes the default ~1280x800 geometry; a larger
+// framebuffer only scales the painted frame further above the floor.)
+const PAINT_MIN_BYTES = 60_000;
 
 /** Desktop geometry for the framebuffer. v1 has no live RANDR: a resolution
  *  change is a full down -> up restart (a separate op). */
@@ -145,18 +169,25 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
   // PAINTABLE-FRAME GATE (the completion criterion): the up-script's readiness gates
   // only assert that Xvfb answers xdpyinfo and that x11vnc:5900 + websockify:PORT are
   // LISTENING — NOT that the display actually PAINTS. On a stone-cold gVisor box (the
-  // machine→sandbox swap-recovery turn always hits one), Xvfb can answer and the VNC
-  // ports can bind seconds BEFORE the root window / XFCE compositor is drawable, so a
-  // scrot right after the `OPENGENI_DESKTOP_UP` marker yields a ZERO-BYTE frame — which
-  // is exactly the empty screenshot that 400s the model and blanks the human viewer.
+  // machine→sandbox swap-recovery turn always hits one), Xvfb answers and the VNC ports
+  // bind ~1.4s (fast host) to several seconds BEFORE xfdesktop finishes its first
+  // wallpaper paint. In that window a scrot yields a small UNPAINTED frame (the -retro
+  // stipple or a solid-black root) — never zero-byte — which is exactly the "blank/black"
+  // screenshot that 400s the model and blanks the human viewer. (VERIFIED locally: the
+  // real xfdesktop backdrop window maps at full 1280x800 the whole time; the render is
+  // never structurally broken — it is purely this pre-paint capture race.)
+  //
   // We therefore chain a real scrot probe as the completion gate: after the up-script
-  // reports success, poll scrot until it produces a NON-EMPTY frame (bounded ~30s), and
-  // only THEN let the command exit 0. If it never paints we exit 14 so the caller sees a
-  // typed DisplayStackError("paint") — an HONEST failure the worker can degrade + log,
-  // rather than a false "up" that hands the model an empty image. `-ac` on Xvfb disables
+  // reports success, poll scrot until it produces an actually-PAINTED frame — a PNG at or
+  // above PAINT_MIN_BYTES, not merely NON-EMPTY (the old `[ -s ]` check passed on the
+  // ~17 KB pre-paint stipple immediately; that WAS the bug) — bounded ~30s, and only THEN
+  // let the command exit 0. If it never paints we exit 14 so the caller sees a typed
+  // DisplayStackError("paint") — an HONEST failure the worker can degrade + log, rather
+  // than a false "up" that hands the model an unpainted image. `-ac` on Xvfb disables
   // access control so this root-side scrot reaches :0. Runs on a pre-check hit too (cheap
   // — an already-up display paints on the first probe). Lives in the runtime-built script
-  // (not the baked image up-script) so it ships with the worker/api, no image rebuild.
+  // (not the baked image up-script) so it ships with the worker/api, no image rebuild —
+  // and its size floor holds against the currently-deployed image too.
   const bringUp =
     `if nc -z 127.0.0.1 ${port} >/dev/null 2>&1 && nc -z 127.0.0.1 5900 >/dev/null 2>&1; then ` +
     `echo "OPENGENI_DESKTOP_UP port=${port} geometry=${geometry.width}x${geometry.height} dpi=${geometry.dpi} (precheck)"; ` +
@@ -168,11 +199,15 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
   const paintProbe =
     `p=/tmp/opengeni-desktop/paint-probe.png; ` +
     `for i in $(seq 1 ${PAINT_PROBE_ATTEMPTS}); do ` +
-    `if DISPLAY=:0 scrot -o "$p" >/dev/null 2>&1 && [ -s "$p" ]; then rm -f "$p"; break; fi; ` +
+    // Capture, then measure the PNG byte-size. `wc -c < "$p"` yields a bare integer; a
+    // failed scrot leaves sz=0. A frame at/above PAINT_MIN_BYTES is a real painted desktop.
+    `if DISPLAY=:0 scrot -o "$p" >/dev/null 2>&1; then sz=$(wc -c < "$p" 2>/dev/null || echo 0); else sz=0; fi; ` +
     `rm -f "$p"; ` +
+    `if [ "$sz" -ge ${PAINT_MIN_BYTES} ]; then break; fi; ` +
     // NOTE: NOT_PAINTING goes to STDOUT (not stderr): Modal is execCommand-only, so the
     // caller infers the outcome by string-matching the output — stdout is always captured.
-    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot empty after warmup"; exit 14; fi; ` +
+    // ($sz is bare shell here — no ${} braces — so JS leaves it for bash to expand.)
+    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot below ${PAINT_MIN_BYTES}B after warmup (last=$sz)"; exit 14; fi; ` +
     `sleep ${PAINT_PROBE_INTERVAL_S}; ` +
     `done`;
   return `mkdir -p /tmp/opengeni-desktop; { ${bringUp} ; } && { ${paintProbe} ; }`;

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -103,15 +103,20 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(cmd).toContain("DESKTOP_W=1920 DESKTOP_H=1080 DESKTOP_DPI=120 STREAM_PORT=7090");
   });
 
-  test("(2a) PAINTABLE-FRAME GATE: the script scrot-probes for a non-empty frame and exits 14 when it never paints", () => {
+  test("(2a) PAINTABLE-FRAME GATE: the script scrot-probes for a PAINTED (size-floor) frame and exits 14 when it never paints", () => {
     const cmd = buildDisplayStackScript({ port: 6080 });
-    // The completion criterion is a REAL scrot (not just ports listening). It must
-    // appear AFTER the bring-up (the up-script/precheck), chained with && so a failed
-    // bring-up short-circuits it, and it must exit 14 (the "paint" stage) on failure.
+    // The completion criterion is a REAL PAINTED scrot (not just ports listening, and not
+    // merely NON-EMPTY). It must appear AFTER the bring-up (the up-script/precheck), chained
+    // with && so a failed bring-up short-circuits it, and it must exit 14 (the "paint" stage)
+    // on failure. The gate is a byte-size FLOOR (`wc -c` >= threshold), NOT the old `[ -s ]`
+    // non-emptiness check — an unpainted root is small-but-non-empty and would falsely pass.
     const scrotIdx = cmd.indexOf("scrot -o");
     const upIdx = cmd.indexOf("opengeni-desktop-up");
     expect(scrotIdx).toBeGreaterThan(upIdx);
-    expect(cmd).toContain("[ -s ");
+    // byte-size floor, not non-emptiness:
+    expect(cmd).toContain("wc -c < ");
+    expect(cmd).toContain("-ge 60000");
+    expect(cmd).not.toContain("[ -s ");
     expect(cmd).toContain("exit 14");
     expect(cmd).toContain("OPENGENI_DESKTOP_NOT_PAINTING");
     // chained so a failed bring-up never reaches the paint probe.


### PR DESCRIPTION
Follow-up to #222/#223 closing the last gap in the machine→sandbox swap-recovery scenario. Empirical finding (deployed image run locally under runc, byte-measured): XFCE always renders — the earlier "10x10 windows / blank desktop" readings were misdiagnoses (normal GTK group-leader windows; a 222KB scrot IS a healthy paint). The real defect is a **capture race**: a cold Xvfb root is never zero-byte (the `-retro` stipple encodes ~17KB, black ~13.5KB), so the non-empty paint gate declared "up" seconds before xfdesktop's first paint, and the turn's/viewer's first capture landed in that window as the "blank" frame.

**Fix**: the paint gate now polls for a scrot **at/above a 60KB byte floor** (painted XFCE measures 210–222KB; pre-paint ≤17KB) — effective against the currently-deployed desktop image with **no rebuild**. Offline-proven: cold deployed image blocks 1632ms until paint then returns a 222KB frame; a never-painting display exits 14 → typed degrade. Belt-and-braces: drop Xvfb `-retro` in the up-script so a pre-paint root is honest black (takes effect on the next desktop-image rebuild; the runtime gate holds either way). Deliberately NOT floor-gated: per-action `screenshot()` stays content-agnostic (a legitimately dark screen must not be rejected) — paint-readiness belongs in the one-time `ensureDisplayStack` gate, which covers both swap paths and the viewer mint.

Also verified in passing: viewer transport routing correct post-#223; `sandbox_os` ruled out; the separate multi-minute cold-establish hang did not reproduce offline (flagged for its own investigation).

Gates: bash -n + shellcheck clean, runtime tsc clean, display-stack 13/13, runtime 507/0, worker gating 9/0. Live staging verification (plain cold box + swap recovery, model-described desktop + viewer first-frame) follows the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the one-time desktop readiness gate used by viewer mint and agent turns; wrong thresholds could delay bring-up or still pass too early, but behavior is bounded (~30s probe) with explicit paint-stage failure (exit 14).
> 
> **Overview**
> Fixes a **pre-paint capture race** on cold desktop bring-up: VNC ports could be up while XFCE had not painted yet, so the old `ensureDisplayStack` gate treated small but non-empty scrot PNGs (~13–17 KB) as success and the model/viewer got blank/black frames.
> 
> **Runtime (`buildDisplayStackScript`)**: the PAINTABLE-FRAME probe now requires scrot output **≥ 60 KB** (`wc -c` + `PAINT_MIN_BYTES`), not merely `[ -s ]`. Failure still exits **14** with an updated `OPENGENI_DESKTOP_NOT_PAINTING` message (includes last size). This ships in the worker/API script without an image rebuild.
> 
> **Image (`opengeni-desktop-up.sh`)**: drops Xvfb **`-retro`** so an unpainted root is solid black (~13.5 KB) instead of the stipple (~17 KB), keeping the size floor unambiguous after the next desktop image rebuild.
> 
> Tests in `display-stack.test.ts` assert the byte-floor gate instead of non-emptiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3d4eab705c37399c7abc604c2883927c9c481d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->