### PR TITLE
fix(desktop): paint gate waits for a SETTLED frame (gVisor staged-paint)

### DIFF
--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -60,6 +60,22 @@ const PAINT_PROBE_INTERVAL_S = 0.2;
 // framebuffer only scales the painted frame further above the floor.)
 const PAINT_MIN_BYTES = 60_000;
 
+// SETTLE gate (the gVisor staged-paint fix): crossing the 60 KB floor is necessary but
+// NOT sufficient. On a fast runc host the paint is atomic (black 13.5 KB -> full 209 KB
+// in one step, panel + icons included). On a STONE-COLD gVisor Modal box it is STAGED:
+// the wallpaper gradient paints and crosses 60 KB a beat BEFORE xfdesktop draws the
+// panel / launcher icons / logo. A screenshot in that window shows a bare teal wallpaper
+// with no panel — which the model correctly reports as "graphical, but the desktop
+// hasn't fully loaded" (VERIFIED live on staging: a cold-box turn's first agent
+// screenshot caught exactly this). So the gate additionally waits for the frame to
+// SETTLE: two consecutive probes both above the floor whose byte-sizes agree within
+// PAINT_SETTLE_DELTA_BYTES. A still-painting desktop grows between probes; a fully
+// rendered, static one is byte-stable (scrot -o omits the cursor, and the clock is
+// minute-precision, so consecutive captures of a settled desktop are near-identical).
+// This makes ensureDisplayStack block until the FULL desktop is up, so the turn's first
+// screenshot — which runs AFTER this gate — sees the panel, not a bare wallpaper.
+const PAINT_SETTLE_DELTA_BYTES = 2_000;
+
 /** Desktop geometry for the framebuffer. v1 has no live RANDR: a resolution
  *  change is a full down -> up restart (a separate op). */
 export type DesktopGeometry = {
@@ -197,17 +213,22 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
     `env ${env} opengeni-desktop-up; ` +
     `fi`;
   const paintProbe =
-    `p=/tmp/opengeni-desktop/paint-probe.png; ` +
+    `p=/tmp/opengeni-desktop/paint-probe.png; prev=0; ` +
     `for i in $(seq 1 ${PAINT_PROBE_ATTEMPTS}); do ` +
     // Capture, then measure the PNG byte-size. `wc -c < "$p"` yields a bare integer; a
     // failed scrot leaves sz=0. A frame at/above PAINT_MIN_BYTES is a real painted desktop.
     `if DISPLAY=:0 scrot -o "$p" >/dev/null 2>&1; then sz=$(wc -c < "$p" 2>/dev/null || echo 0); else sz=0; fi; ` +
     `rm -f "$p"; ` +
-    `if [ "$sz" -ge ${PAINT_MIN_BYTES} ]; then break; fi; ` +
+    // SETTLE: accept only when THIS probe AND the PREVIOUS one are both above the floor
+    // and their sizes agree within PAINT_SETTLE_DELTA_BYTES — i.e., the paint has stopped
+    // growing (the full desktop, panel + icons included, is up), not merely crossed the
+    // floor mid-paint on a staged gVisor boot. ($sz/$prev/$d are bare shell — no ${}
+    // braces — so JS leaves them for bash; ${PAINT_*} ARE JS constants and interpolate.)
+    `if [ "$sz" -ge ${PAINT_MIN_BYTES} ] && [ "$prev" -ge ${PAINT_MIN_BYTES} ]; then d=$((sz-prev)); [ "$d" -lt 0 ] && d=$((0-d)); [ "$d" -le ${PAINT_SETTLE_DELTA_BYTES} ] && break; fi; ` +
+    `prev=$sz; ` +
     // NOTE: NOT_PAINTING goes to STDOUT (not stderr): Modal is execCommand-only, so the
     // caller infers the outcome by string-matching the output — stdout is always captured.
-    // ($sz is bare shell here — no ${} braces — so JS leaves it for bash to expand.)
-    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot below ${PAINT_MIN_BYTES}B after warmup (last=$sz)"; exit 14; fi; ` +
+    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot below ${PAINT_MIN_BYTES}B or unsettled after warmup (last=$sz)"; exit 14; fi; ` +
     `sleep ${PAINT_PROBE_INTERVAL_S}; ` +
     `done`;
   return `mkdir -p /tmp/opengeni-desktop; { ${bringUp} ; } && { ${paintProbe} ; }`;

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -117,6 +117,11 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(cmd).toContain("wc -c < ");
     expect(cmd).toContain("-ge 60000");
     expect(cmd).not.toContain("[ -s ");
+    // SETTLE: must also require two consecutive above-floor probes that agree within the
+    // settle delta (the gVisor staged-paint fix), not merely a single floor crossing.
+    expect(cmd).toContain("prev=0");
+    expect(cmd).toContain('"$prev" -ge 60000');
+    expect(cmd).toContain("-le 2000");
     expect(cmd).toContain("exit 14");
     expect(cmd).toContain("OPENGENI_DESKTOP_NOT_PAINTING");
     // chained so a failed bring-up never reaches the paint probe.


### PR DESCRIPTION
Follow-up to #245. Live staging verification of the 60 KB paint-floor fix surfaced a residual on stone-cold gVisor Modal boxes: the floor is necessary but not sufficient.

**Root cause.** On a fast runc host the paint is atomic (black 13.5 KB → full 209 KB in one step, panel + icons included). On a cold gVisor box it is **staged** — the wallpaper gradient paints and crosses 60 KB a beat BEFORE xfdesktop draws the panel / launcher icons. The gate released at the wallpaper stage, so a turn’s first agent screenshot caught a bare teal wallpaper with no panel. Verified live: a cold Modal turn’s screenshot saw exactly this ("graphical, but the desktop hasn’t fully loaded"), while a scrot of the same box moments later showed the full XFCE desktop.

**Fix.** The PAINTABLE-FRAME gate now also requires the frame to **settle** — two consecutive probes both above the 60 KB floor whose byte-sizes agree within 2 KB. A still-painting desktop grows between probes; a fully rendered, static one is byte-stable (scrot -o omits the cursor; the clock is minute-precision). This blocks `ensureDisplayStack` until the COMPLETE desktop is up, so the turn’s first screenshot sees the panel, not a bare wallpaper. Exit-14 (never-painting → typed `DisplayStackError("paint")` → degrade) preserved.

**Runtime-only** (`display-stack.ts`) — ships with the worker, **no image rebuild** (`desktop_image_ref` unchanged).

**Verified locally** on the -retro-dropped image: the gate returns only once post-gate `scrot`=222 KB AND `xfce4-panel` is mapped at full 1280 width; still exits 14 on a never-painting display. Gates: `bun test` 13/0, `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runtime-only timing change to the display-stack paint probe; no auth, data, or image changes, with bounded extra wait on cold gVisor boots.
> 
> **Overview**
> Extends the **PAINTABLE-FRAME** gate in `buildDisplayStackScript` so crossing the 60 KB screenshot floor is not enough on cold gVisor boxes, where wallpaper can paint before the XFCE panel and icons appear.
> 
> The probe loop now tracks the previous PNG size and only succeeds when **two consecutive** captures are both above the floor and within **2 KB** (`PAINT_SETTLE_DELTA_BYTES`), so `ensureDisplayStack` blocks until the desktop stops growing and the first post-gate screenshot is not a bare wallpaper. Exit **14** / `DisplayStackError("paint")` behavior is unchanged; the failure message mentions **unsettled** frames. Unit test **(2a)** asserts the generated shell includes `prev=0`, the previous-size floor check, and the settle delta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b890d73ab5d60aabbf3715d42f99c6949d6d399b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->