### PR TITLE
fix(computer-use): native screenshot retries a warming capture and fails loud, never a blank

### DIFF
--- a/agent/crates/opengeni-agent-platform/src/desktop.rs
+++ b/agent/crates/opengeni-agent-platform/src/desktop.rs
@@ -351,4 +351,56 @@ mod tests {
         assert_eq!(decoded.width(), fitted.width);
         assert_eq!(decoded.height(), fitted.height);
     }
+
+    /// REGRESSION GUARD (blank-screenshot incident): fitting NEVER yields empty or
+    /// blank bytes from a VALID capture — the whole "Mac screenshot came back blank"
+    /// class of failure cannot originate in `fit_frame_to_budget`. Uses the EXACT
+    /// macOS wire encoding (a tightly-packed RGBA8 buffer through `PngEncoder`, same
+    /// as `macos::encode_png`) at a Retina-ish size, forces an aggressive downscale,
+    /// and asserts the result is a non-empty, decodable, NON-degenerate image.
+    #[test]
+    fn fit_never_produces_empty_or_degenerate_bytes_from_a_valid_macos_capture() {
+        use image::ImageEncoder as _;
+
+        // Encode a 1600×1000 pseudo-random RGBA8 buffer the macOS way (PngEncoder,
+        // Rgba8) — a realistic busy-desktop stand-in that will not compress to nothing.
+        let (w, h) = (1600u32, 1000u32);
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        let mut state: u32 = 0x9E37_79B9;
+        for chunk in rgba.chunks_exact_mut(4) {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            let b = state.to_le_bytes();
+            chunk.copy_from_slice(&[b[0], b[1], b[2], 0xFF]);
+        }
+        let mut png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(&rgba, w, h, image::ExtendedColorType::Rgba8)
+            .expect("encode macOS-style png");
+        assert!(!png.is_empty());
+
+        // Force a hard downscale: budget a fraction of the native PNG size.
+        let budget = png.len() / 8;
+        let fitted = fit_frame_to_budget(
+            CapturedFrame {
+                png,
+                width: w,
+                height: h,
+            },
+            budget,
+        );
+
+        // The core regression assertions: bytes are NEVER empty, geometry NEVER
+        // collapses to a degenerate 1×1, native geometry is preserved, and the bytes
+        // decode back to a real image at the reported size.
+        assert!(!fitted.png.is_empty(), "fit must never emit empty bytes");
+        assert!(fitted.downscaled);
+        assert_eq!((fitted.native_width, fitted.native_height), (w, h));
+        assert!(fitted.width >= MIN_FIT_EDGE || fitted.height >= MIN_FIT_EDGE);
+        let decoded = image::load_from_memory_with_format(&fitted.png, image::ImageFormat::Png)
+            .expect("fitted macOS png must decode");
+        assert_eq!(decoded.width(), fitted.width);
+        assert_eq!(decoded.height(), fitted.height);
+    }
 }

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -403,11 +403,34 @@ const POINTER_BUTTON: Record<ComputerButton, PointerButton> = {
   forward: PointerButton.POINTER_BUTTON_UNSPECIFIED,
 };
 
+// Native capture (ScreenCaptureKit / x11) can hand back a null/empty FIRST frame in
+// the moments right after the agent connects — the capture stream still warming — the
+// same class of transient the scrot path retries around for a cold :0. Native capture
+// is normally sub-second, so the warm-up budget is much shorter than the scrot path's
+// 30 s cold-Modal-box budget; enough to ride a first-frame miss, not enough to hang a
+// turn on a genuinely dead capture. A TERMINAL failure (permission denied) short-
+// circuits the budget and fails immediately.
+const NATIVE_SCREENSHOT_WARMUP_BUDGET_MS = 6_000;
+const NATIVE_SCREENSHOT_RETRY_DELAY_MS = 400;
+
 export type NativeDesktopComputerOptions = {
   dimensions?: [number, number]; // the display geometry (must match the capture size)
   environment?: NonNullable<Computer["environment"]>; // "ubuntu" (default) | "mac" | ...; model uses it for OS key conventions
   readOnly?: boolean; // when true, every WRITE action throws ComputerReadOnlyError
+  screenshotWarmupBudgetMs?: number; // wall-clock budget to retry a warming/empty first frame
+  screenshotRetryDelayMs?: number; // delay between warm-up retries
 };
+
+/** A capture failure that RETRYING cannot cure — Screen Recording (TCC) has not been
+ *  granted to the agent, so every capture will deny until the user grants it. We fail
+ *  FAST on this rather than burn the warm-up budget, and surface the reason verbatim so
+ *  the operator sees "grant Screen Recording", not a blank screen. Matches the agent's
+ *  `capture_rgba` denial strings ("Screen Recording permission is not granted",
+ *  "no shareable content (Screen Recording denied?)"). */
+function isTerminalCaptureDenial(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error ?? "")).toLowerCase();
+  return msg.includes("screen recording") || msg.includes("permission is not granted") || msg.includes("consent");
+}
 
 /**
  * A `Computer` that drives a SELF-HOSTED machine's OWN desktop NATIVELY over the
@@ -428,6 +451,8 @@ export class NativeDesktopComputer implements Computer {
   readonly dimensions: [number, number];
   private session: NativeDesktopSession;
   private readonly readOnly: boolean;
+  private readonly screenshotWarmupBudgetMs: number;
+  private readonly screenshotRetryDelayMs: number;
   // The ENCODED vs NATIVE geometry of the MOST RECENT screenshot the model saw. The
   // model computes click coordinates in the encoded-pixel space of that screenshot;
   // when the agent downscaled the PNG to fit the transport budget, encoded < native,
@@ -445,6 +470,8 @@ export class NativeDesktopComputer implements Computer {
     // should pass "mac" so the model uses ⌘-based shortcuts — see the coordinate TODO.
     this.environment = opts.environment ?? "ubuntu";
     this.readOnly = opts.readOnly ?? false;
+    this.screenshotWarmupBudgetMs = opts.screenshotWarmupBudgetMs ?? NATIVE_SCREENSHOT_WARMUP_BUDGET_MS;
+    this.screenshotRetryDelayMs = opts.screenshotRetryDelayMs ?? NATIVE_SCREENSHOT_RETRY_DELAY_MS;
   }
 
   /** Rebind to a freshly resumed-by-id session after a box rollover / re-establish. */
@@ -487,19 +514,57 @@ export class NativeDesktopComputer implements Computer {
   async screenshot(): Promise<string> {
     // CRITICAL CONTRACT (mirrors SandboxComputer.screenshot): NEVER return "". The
     // Agents SDK builds the model image as `data:image/png;base64,${output}`; an
-    // empty output → `image_url: ''` → the model API 400s and kills the turn. A
-    // missing/empty frame is therefore a THROW, never a silent "". Native capture
-    // (ScreenCaptureKit / x11) does not have the cold-scrot warm-up the xdotool path
-    // retries around, so a single capture + a hard empty-guard is sufficient.
-    const { png, width, height, nativeWidth, nativeHeight } = await this.session.screenshot();
-    if (png.length === 0) {
-      throw new ComputerUnavailableError("native desktop screenshot returned an empty frame (display not up?)");
+    // empty output → `image_url: ''`. On the hosted computer_use_preview path the SDK
+    // catches a throw here, sets output='', and the wire-seam sanitizer rewrites the
+    // empty image_url to a BLANK 1×1 placeholder to dodge a 400 — so a capture MISS
+    // silently reaches the model as a "blank desktop" it then confidently reports.
+    //
+    // Native capture (ScreenCaptureKit / x11) can hand back a null/empty FIRST frame
+    // in the moments right after the agent connects (the capture stream warming) — the
+    // same transient the scrot path retries around for a cold :0. This path previously
+    // did a SINGLE capture, so one warm-up miss became a blank. We now RETRY across a
+    // bounded budget and, on a terminal failure, FAIL LOUD with the agent's actual
+    // reason (logged) — never a silent blank. A permission (TCC) denial is terminal:
+    // retrying cannot grant Screen Recording, so we break immediately.
+    let lastError: unknown;
+    const deadline = Date.now() + this.screenshotWarmupBudgetMs;
+    let attempt = 0;
+    while (true) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, this.screenshotRetryDelayMs));
+      }
+      attempt++;
+      try {
+        const { png, width, height, nativeWidth, nativeHeight } = await this.session.screenshot();
+        if (png.length === 0) {
+          // A warming capture yields an empty frame — retry rather than hand the model
+          // a blank; throw once the budget is spent.
+          throw new ComputerUnavailableError("native desktop screenshot returned an empty frame (display not up?)");
+        }
+        // Record the encoded (what the model sees) vs native geometry of THIS frame so
+        // the next click/move/scroll/drag scales its coordinates back to native pixels.
+        this.lastEncoded = [width, height];
+        this.lastNative = [nativeWidth || width, nativeHeight || height];
+        return Buffer.from(png).toString("base64");
+      } catch (error) {
+        lastError = error;
+        // A permission denial will deny on every retry — fail fast with the reason.
+        if (isTerminalCaptureDenial(error)) break;
+      }
+      // Stop once the warm-up budget is spent — the NEXT sleep would push us past it.
+      if (Date.now() + this.screenshotRetryDelayMs >= deadline) {
+        break;
+      }
     }
-    // Record the encoded (what the model sees) vs native geometry of THIS frame so
-    // the next click/move/scroll/drag scales its coordinates back to native pixels.
-    this.lastEncoded = [width, height];
-    this.lastNative = [nativeWidth || width, nativeHeight || height];
-    return Buffer.from(png).toString("base64");
+    // Exhausted the budget (or hit a terminal denial): FAIL LOUD. Log the specific
+    // reason so the failure is DIAGNOSABLE (not a silent blank the model misreads),
+    // then rethrow — never return "".
+    const reason = lastError instanceof Error ? lastError.message : String(lastError);
+    console.warn(`[NativeDesktopComputer] screenshot failed after ${attempt} attempt(s): ${reason}`);
+    if (lastError instanceof Error) {
+      throw lastError;
+    }
+    throw new ComputerUnavailableError("native desktop screenshot returned an empty frame (display not up?)");
   }
 
   async click(x: number, y: number, button: ComputerButton) {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -293,27 +293,49 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
 // surface. Records every injected DesktopInput event so tests can assert the exact
 // protos (event $case + fields + enum values), and returns a configurable PNG.
 function makeNativeSession(
-  opts: { png?: Uint8Array; width?: number; height?: number; nativeWidth?: number; nativeHeight?: number } = {},
+  opts: {
+    png?: Uint8Array;
+    width?: number;
+    height?: number;
+    nativeWidth?: number;
+    nativeHeight?: number;
+    // Per-attempt PNG sequence: attempt N returns pngPerAttempt[N] (last value sticks).
+    // Used to model a warming capture that returns an empty frame then a real one.
+    pngPerAttempt?: Uint8Array[];
+    // When set, screenshot() THROWS this per attempt (last value sticks; null = resolve).
+    // Models the agent surfacing a capture AgentError (permission denied / null image).
+    throwPerAttempt?: (Error | null)[];
+  } = {},
 ) {
   const inputs: NonNullable<DesktopInputRequest["event"]>[] = [];
   const width = opts.width ?? 1280;
   const height = opts.height ?? 800;
+  let attempt = 0;
+  const at = <T>(arr: T[] | undefined, i: number): T | undefined => (arr ? (arr[Math.min(i, arr.length - 1)]) : undefined);
   const session: NativeDesktopSession = {
     desktopInput: async (event) => {
       if (event) inputs.push(event);
     },
-    screenshot: async () => ({
-      png: opts.png ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]),
-      width,
-      height,
-      // Default: native == encoded (no downscale). Tests that exercise the
-      // downscale coordinate-scaling override nativeWidth/nativeHeight.
-      nativeWidth: opts.nativeWidth ?? width,
-      nativeHeight: opts.nativeHeight ?? height,
-    }),
+    screenshot: async () => {
+      const i = attempt++;
+      const toThrow = at(opts.throwPerAttempt, i);
+      if (toThrow) throw toThrow;
+      return {
+        png: at(opts.pngPerAttempt, i) ?? opts.png ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]),
+        width,
+        height,
+        // Default: native == encoded (no downscale). Tests that exercise the
+        // downscale coordinate-scaling override nativeWidth/nativeHeight.
+        nativeWidth: opts.nativeWidth ?? width,
+        nativeHeight: opts.nativeHeight ?? height,
+      };
+    },
   };
-  return { session, inputs };
+  return { session, inputs, attempts: () => attempt };
 }
+
+// Fast warm-up timing so the retry-loop tests don't wait the 6 s production budget.
+const FAST_WARMUP = { screenshotWarmupBudgetMs: 40, screenshotRetryDelayMs: 4 } as const;
 
 describe("NativeDesktopComputer (self-hosted / macOS native inject+capture)", () => {
   test("click emits a POINTER CLICK event with the coords + LEFT button", async () => {
@@ -447,13 +469,39 @@ describe("NativeDesktopComputer (self-hosted / macOS native inject+capture)", ()
     expect(shot.startsWith("data:")).toBe(false);
   });
 
-  test("REGRESSION: an empty PNG THROWS (never an empty image_url that would 400 the turn)", async () => {
-    const { session } = makeNativeSession({ png: new Uint8Array() });
-    const c = new NativeDesktopComputer(session);
+  test("REGRESSION: a persistently empty PNG THROWS (never an empty image_url / blank placeholder)", async () => {
+    const { session, attempts } = makeNativeSession({ png: new Uint8Array() });
+    const c = new NativeDesktopComputer(session, FAST_WARMUP);
     const result = await c.screenshot().then((s) => ({ ok: true as const, s }), (e) => ({ ok: false as const, e }));
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error(`screenshot() resolved to ${JSON.stringify(result.s)} — an empty image_url would 400 the model turn`);
     expect(result.e).toBeInstanceOf(ComputerUnavailableError);
+    // It RETRIED across the warm-up budget before failing (not a single-shot throw).
+    expect(attempts()).toBeGreaterThan(1);
+  });
+
+  test("BLANK-SCREENSHOT FIX: a warming empty FIRST frame self-heals on retry (no blank placeholder)", async () => {
+    // The agent's ScreenCaptureKit can hand back an empty first frame right after
+    // connect; the old single-shot path turned that into a blank the model misread.
+    const real = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { session, attempts } = makeNativeSession({ pngPerAttempt: [new Uint8Array(), new Uint8Array(), real] });
+    const c = new NativeDesktopComputer(session, FAST_WARMUP);
+    const shot = await c.screenshot();
+    expect(shot).toBe(Buffer.from(real).toString("base64"));
+    expect(attempts()).toBe(3); // two empty misses, then the real frame
+  });
+
+  test("BLANK-SCREENSHOT FIX: a permission (TCC) denial FAILS FAST and loud — no retry, no blank", async () => {
+    const denial = new Error("Screen Recording permission is not granted");
+    const { session, attempts } = makeNativeSession({ throwPerAttempt: [denial] });
+    const c = new NativeDesktopComputer(session, FAST_WARMUP);
+    const result = await c.screenshot().then((s) => ({ ok: true as const, s }), (e) => ({ ok: false as const, e }));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("a denied capture must throw, never resolve to a blank");
+    // The AGENT's reason is surfaced verbatim (operator sees "grant Screen Recording").
+    expect((result.e as Error).message).toContain("Screen Recording");
+    // Terminal denial short-circuits the warm-up budget — exactly ONE attempt.
+    expect(attempts()).toBe(1);
   });
 
   test("readOnly blocks every write but screenshot is always allowed", async () => {


### PR DESCRIPTION
## The regression
Live on the real Mac (agent 0.1.3, hosted gpt-5.5 path): the model's screenshots came back as a **blank desktop** it confidently reported as empty. `agent.toolCall.output` was an **empty string**, not an error.

## Root cause (NOT the payload/downscale logic)
- For a **normal (non-downscaled) frame**, the #244 wire bytes are **byte-identical to 0.1.2** — `png` is unchanged, `native_width`/`native_height` are additive (= `width`/`height`). Proven by a new agent-side regression-guard test that `fit_frame_to_budget` can never emit empty/degenerate bytes from a valid macOS-style capture.
- The real chain: the agent's ScreenCaptureKit capture can return an **empty/null first frame** right after connect (stream warming), or a hard error (`capture_rgba` returns errors for Screen Recording/TCC denied, null image, timeout). The native computer path did a **single capture with no retry** → one transient miss threw → the hosted SDK caught it, set `output=''` → the **af289e3** wire-seam sanitizer rewrote the empty `image_url` to a **1×1 transparent placeholder** to dodge a 400 → the model got a blank it treats as real.
- That is exactly **why the output was `""` and not an error**, and why the failure was silent.

## Fix (worker-side — foldable into the deploy, no agent rebuild)
- `NativeDesktopComputer.screenshot()` now **retries across a bounded warm-up budget** (mirrors the scrot path's cold-`:0` self-heal), so a warming empty first frame recovers instead of becoming a blank.
- A terminal **permission (TCC) denial short-circuits** the budget and fails **fast**.
- On definitive failure it **fails loud**: logs the agent's actual reason (Screen Recording denied / null image / timeout) at WARN and rethrows — never a silent blank. The reason is now **diagnosable in worker logs**.

## Worker-side vs agent-side
The deployable fix is **100% worker-side** (`packages/runtime`); the only agent-crate change is a **test-only** regression guard. No 0.1.4 required for the mitigation.

## Tests / gates
- Warming-empty-first-frame **self-heals**; persistent-empty **retries then throws**; TCC denial **fails fast** with the reason surfaced.
- Rust regression guard: fit never emits empty/degenerate bytes from a valid macOS-style capture.
- `bunx tsc --noEmit` TC=0; `bun test` runtime **511 pass / 0 fail**; `cargo test` platform fit_ **3 pass**; `cargo clippy -D warnings` clean.

## Follow-up (not in this PR)
A screenshot failure should reach the **model** as a legible error, not af289e3's blank placeholder — history-sanitizer must distinguish an action-timeout blank (retry OK) from a screenshot-tool failure (surface error). This PR removes the blank in the common warm-up case and makes a persistent failure loudly logged; the model-facing legibility is a larger change.

If the live logs show a **persistent** `Screen Recording permission is not granted`, that's a **TCC/bundle-grant** issue on the re-signed 0.1.3 bundle (deployment-side) — `screencapture -x` does NOT exercise the agent's ScreenCaptureKit grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native computer-use screenshot contract and retry timing on self-hosted/mac paths, which directly affects what the model sees each turn; mitigated by bounded retries, fast-fail on permission errors, and focused regression tests.
> 
> **Overview**
> Fixes **silent blank desktops** on self-hosted/native computer-use when ScreenCaptureKit returns an **empty first frame** after connect: `NativeDesktopComputer.screenshot()` now **retries** within a **~6s warm-up budget** (configurable), matching the scrot path’s cold-display behavior instead of a single capture that could throw and become an empty SDK output / 1×1 placeholder.
> 
> **Terminal Screen Recording (TCC) denials** are detected via message heuristics and **fail immediately** without burning retries. After the budget (or a terminal error), the path **warns with the agent’s reason** and **rethrows**—never returns `""`.
> 
> Adds **`screenshotWarmupBudgetMs` / `screenshotRetryDelayMs`** on `NativeDesktopComputerOptions`. Runtime tests cover warm-up self-heal, persistent-empty retry-then-throw, and fast-fail on permission errors; a **Rust-only** test asserts `fit_frame_to_budget` cannot emit empty/degenerate PNGs from a valid macOS-style capture (rules out downscale as the blank root cause).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e637f40d5284d06460f594bbc0d38567d58e274d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->