### PR TITLE
fix(computer-use): chunk the Modal screenshot read so a full frame survives the exec-output cap

### DIFF
--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -77,6 +77,19 @@ const SCROLL_MAX_CLICKS = 15;
 // short to ride out a cold gVisor XFCE boot, so the turn failed loud on a transient.
 const SCREENSHOT_WARMUP_BUDGET_MS = 30_000;
 const SCREENSHOT_RETRY_DELAY_MS = 750;
+// The screenshot PNG is read back off the box by base64-ing it over the provider's exec
+// channel. Modal's exec collects stdout into a BOUNDED buffer that silently EMPTIES a
+// single oversized read: a fully-painted 1280x800 desktop PNG (~222 KB) base64s to
+// ~296 KB, which trips the cap and returns "" — the blank-frame incident. A partly-
+// painted frame (~200 KB base64) slipped under it, which is why this only surfaced once
+// the paint gate began delivering FULLY-painted frames. (Channel-A's file read already
+// caps its own base64-over-exec output for the same reason; the screenshot read was the
+// one large read that didn't bound itself.) We therefore read the file in 3-byte-aligned
+// CHUNKS whose per-read base64 (~131 KB) stays well under the cap, then VALIDATE the
+// reconstructed byte count against the on-box file size. 98304 = 96 KiB, divisible by 3
+// so each chunk's base64 is self-contained (no cross-chunk padding) and concatenating the
+// decoded chunks reconstructs the PNG byte-exactly.
+const SCREENSHOT_READ_CHUNK_BYTES = 98_304;
 
 export type SandboxComputerOptions = {
   display?: string; // ":0"
@@ -123,6 +136,13 @@ type ComputerSession = {
 /** No exec/execCommand on the session, or the display is not up. */
 export class ComputerUnavailableError extends Error {
   constructor(message: string) { super(message); this.name = "ComputerUnavailableError"; }
+}
+/** The screenshot file read back SHORT of its on-box byte size — a chunk was truncated
+ *  by the provider's exec-output cap. This is deterministic, NOT a warm-up transient, so
+ *  it fails LOUD immediately with the byte counts (never a silent blank the model would
+ *  read as a real empty screen) and is not retried. */
+export class ScreenshotReadError extends Error {
+  constructor(message: string) { super(message); this.name = "ScreenshotReadError"; }
 }
 /** A write action attempted while readOnly. */
 export class ComputerReadOnlyError extends Error {
@@ -268,6 +288,12 @@ export class SandboxComputer implements Computer {
         return Buffer.from(bytes).toString("base64");
       } catch (error) {
         lastError = error;
+        // A short/truncated read is deterministic (the exec-output cap), not a warm-up
+        // transient — retrying only burns the budget and delays a legible failure. Fail
+        // loud NOW (the `finally` still cleans up the temp file).
+        if (error instanceof ScreenshotReadError) {
+          throw error;
+        }
       } finally {
         // Best-effort cleanup on every attempt (success OR failure); never mask the
         // screenshot result.
@@ -288,37 +314,61 @@ export class SandboxComputer implements Computer {
     throw new ComputerUnavailableError("scrot produced an empty screenshot (display not up?)");
   }
 
-  // Read the screenshot PNG bytes by base64-ing the absolute /tmp path through the
-  // SAME command primitive (exec ?? execCommand) — NOT `session.readFile` (Modal
+  // Run a read-only command over the SAME command primitive computer actions use
+  // (exec ?? execCommand) and return its RAW stdout body — NOT `session.readFile` (Modal
   // path-validates against /workspace and rejects /tmp) and NOT `this.x()` (its
-  // `sandboxCommandOutput` parser drops the execCommand STRING body, returning ""
-  // — only the exec-object path has a structured body). We capture the RAW result,
-  // strip the execCommand banner ("…Output:\n<base64>"), strip whitespace, and
-  // decode. Binary-safe: base64 of the scrot is plain ASCII over stdout, no
-  // truncation (maxOutputTokens:null), mirroring recording.ts readRecordingBytes.
-  private async readScreenshotBytes(path: string): Promise<Uint8Array> {
+  // `sandboxCommandOutput` parser drops the execCommand STRING body). exec exposes a
+  // structured stdout; execCommand returns the formatted STRING, so we strip its banner
+  // ("…Output:\n<body>") to recover the body.
+  private async readCmdRaw(cmd: string): Promise<string> {
     const args = {
-      cmd: `DISPLAY=${this.display} base64 ${path}`,
+      cmd,
       ...(this.runAs ? { runAs: this.runAs } : {}),
       yieldTimeMs: ACTION_YIELD_MS,
-      // null disables the provider's output truncation so a full-screen PNG's
-      // base64 is never clipped (the SDK's truncateOutput passes through on null).
+      // null disables the provider's TOKEN truncation; the byte cap this method chunks
+      // around is a separate, lower-level exec-stdout buffer limit.
       maxOutputTokens: null as unknown as number,
     };
-    let raw: string;
     if (typeof this.session.exec === "function") {
-      // The exec-object path exposes a structured stdout/output body.
-      raw = sandboxCommandOutput(await this.session.exec(args));
-    } else if (typeof this.session.execCommand === "function") {
-      // execCommand returns the formatted STRING — strip the banner to recover the
-      // base64 body (sandboxCommandOutput would drop it for the string form).
-      raw = stripExecBanner(await this.session.execCommand(args));
-    } else {
-      throw new ComputerUnavailableError("session cannot run commands (no exec/execCommand) — screenshots unavailable");
+      return sandboxCommandOutput(await this.session.exec(args));
     }
-    const b64 = raw.replace(/\s+/g, "");
-    if (b64.length === 0) return new Uint8Array();
-    return Uint8Array.from(Buffer.from(b64, "base64"));
+    if (typeof this.session.execCommand === "function") {
+      return stripExecBanner(await this.session.execCommand(args));
+    }
+    throw new ComputerUnavailableError("session cannot run commands (no exec/execCommand) — screenshots unavailable");
+  }
+
+  // Read the screenshot PNG bytes off the box. A SINGLE `base64 <file>` over Modal's
+  // exec silently returns "" once the base64 exceeds the exec-stdout buffer cap (a full
+  // desktop ~296 KB base64 trips it — the blank-frame incident). So we size the file
+  // first, then base64 it in SCREENSHOT_READ_CHUNK_BYTES-sized, 3-byte-aligned chunks
+  // (each read's base64 stays well under the cap) and reconstruct — validating the total
+  // against the on-box size and failing LOUD on any short read rather than handing back a
+  // truncated/blank frame. Binary-safe: base64 is plain ASCII over stdout.
+  private async readScreenshotBytes(path: string): Promise<Uint8Array> {
+    // On-box byte size (tiny output — always safe). A still-warming :0 can yield a
+    // zero-byte scrot file; report empty so the caller retries within its warm-up budget.
+    const sizeRaw = (await this.readCmdRaw(`wc -c < ${path} 2>/dev/null`)).replace(/[^0-9]/g, "");
+    const fileSize = Number.parseInt(sizeRaw, 10);
+    if (!Number.isFinite(fileSize) || fileSize <= 0) return new Uint8Array();
+
+    const chunks: Buffer[] = [];
+    const nChunks = Math.ceil(fileSize / SCREENSHOT_READ_CHUNK_BYTES);
+    for (let i = 0; i < nChunks; i++) {
+      // `dd bs=CHUNK skip=i count=1` reads bytes [i*CHUNK, (i+1)*CHUNK); CHUNK % 3 == 0
+      // so each chunk's base64 is self-contained and decoded chunks concatenate exactly.
+      const raw = await this.readCmdRaw(
+        `dd if=${path} bs=${SCREENSHOT_READ_CHUNK_BYTES} skip=${i} count=1 2>/dev/null | base64`,
+      );
+      chunks.push(Buffer.from(raw.replace(/\s+/g, ""), "base64"));
+    }
+    const bytes = Buffer.concat(chunks);
+    if (bytes.length !== fileSize) {
+      throw new ScreenshotReadError(
+        `screenshot read reconstructed ${bytes.length}B of ${fileSize}B (${nChunks} chunk(s), path=${path}) — a chunk was truncated by the exec-output cap; frame incomplete`,
+      );
+    }
+    return new Uint8Array(bytes);
   }
 
   async click(xp: number, yp: number, button: ComputerButton) {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -13,6 +13,7 @@ import {
   ComputerReadOnlyError,
   ComputerUnavailableError,
   ComputerActionError,
+  ScreenshotReadError,
   type NativeDesktopSession,
 } from "../src/sandbox-computer";
 import { KeyAction, PointerAction, PointerButton, type DesktopInputRequest } from "@opengeni/agent-proto";
@@ -74,6 +75,9 @@ function makeMockSession(opts: {
   // PNG bytes PER scrot attempt — models a cold :0 that paints on a later
   // retry (e.g. [empty, empty, valid] self-heals on attempt 3). Overrides pngBytes.
   pngBytesPerAttempt?: Uint8Array[];
+  // Simulate the Modal exec-output cap truncating EACH `dd … | base64` chunk to at most
+  // this many decoded bytes — the read then reconstructs short and must fail LOUD.
+  truncateChunkBytes?: number;
 } = {}) {
   const execCalls: string[] = [];
   // The execCommand contract: a FORMATTED STRING with a metadata preamble (F2).
@@ -81,9 +85,9 @@ function makeMockSession(opts: {
     `Chunk ID: abc123\nWall time: 0.01 seconds\nProcess exited with code ${exit}\nOutput:\n${body}`;
   const stillRunningStr = `Chunk ID: abc\nProcess running with session ID 7`;
 
-  // The bytes the NEXT `base64 <path>` screenshot read should yield, per attempt.
+  // The PNG bytes for each scrot attempt.
   let readN = 0;
-  const screenshotBytes = (): Uint8Array => {
+  const nextAttemptBytes = (): Uint8Array => {
     if (opts.pngBytesPerAttempt) {
       const i = Math.min(readN, opts.pngBytesPerAttempt.length - 1);
       readN++;
@@ -91,16 +95,31 @@ function makeMockSession(opts: {
     }
     return opts.pngBytes ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
   };
-  // `true` once a command is the screenshot byte-read (`base64 <abs-path>`, no pipe)
-  // rather than an xdotool/scrot/rm action.
-  const isScreenshotRead = (cmd: string): boolean => /\bbase64 \/tmp\/og-shot-/.test(cmd);
+  // The screenshot read is now two-phase: `wc -c < <path>` sizes the file (latching THIS
+  // attempt's bytes), then `dd if=<path> bs=B skip=i count=1 | base64` reads each 3-byte-
+  // aligned chunk. The mock models the box filesystem: wc -c advances to the next attempt
+  // and returns its length; each dd returns the base64 of that byte-range.
+  let attemptBytes: Uint8Array = new Uint8Array();
+  const readBody = (cmd: string): string | null => {
+    const sm = cmd.match(/wc -c < (\/tmp\/og-shot-\S+?\.png)/);
+    if (sm) {
+      attemptBytes = nextAttemptBytes();
+      return String(attemptBytes.length);
+    }
+    const cm = cmd.match(/dd if=(\/tmp\/og-shot-\S+?\.png) bs=(\d+) skip=(\d+)/);
+    if (cm) {
+      const bs = Number(cm[2]!), skip = Number(cm[3]!);
+      let slice = attemptBytes.slice(skip * bs, (skip + 1) * bs);
+      if (opts.truncateChunkBytes !== undefined) slice = slice.slice(0, opts.truncateChunkBytes);
+      return Buffer.from(slice).toString("base64");
+    }
+    return null;
+  };
 
   const run = (cmd: string): string => {
     execCalls.push(cmd);
-    if (isScreenshotRead(cmd)) {
-      // The screenshot read returns the PNG bytes base64'd in the banner BODY.
-      return formatted(Buffer.from(screenshotBytes()).toString("base64"));
-    }
+    const body = readBody(cmd);
+    if (body !== null) return formatted(body);
     if (opts.stillRunning) return stillRunningStr;
     return formatted("", opts.failExit ?? 0);
   };
@@ -111,9 +130,10 @@ function makeMockSession(opts: {
   if (opts.withExec) {
     session.exec = async (args: { cmd: string }) => {
       execCalls.push(args.cmd);
-      if (isScreenshotRead(args.cmd)) {
+      const body = readBody(args.cmd);
+      if (body !== null) {
         // The exec-object path exposes a structured stdout body (no banner).
-        return { output: Buffer.from(screenshotBytes()).toString("base64"), stdout: "", stderr: "", exitCode: 0 };
+        return { output: body, stdout: "", stderr: "", exitCode: 0 };
       }
       if (opts.stillRunning) return { output: "", stdout: "", stderr: "", sessionId: 7 };
       return { output: "", stdout: "", stderr: "", exitCode: opts.failExit ?? 0, wallTimeSeconds: 0.01 };
@@ -150,25 +170,58 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
     // The screenshot bytes round-trip through base64-over-exec, decoded then
     // re-encoded in JS — clean, no banner.
     expect(shot).toBe(Buffer.from(png).toString("base64"));
-    // scrot wrote the /tmp file, then the read was a `base64 <abs /tmp path>` over
-    // the command primitive — the path that ISN'T workspace-root-validated.
+    // scrot wrote the /tmp file, then the read was size-then-chunk over the command
+    // primitive — the /tmp path that ISN'T workspace-root-validated, NOT readFile.
     expect(execCalls.some((cmd) => cmd.includes("scrot --pointer --overwrite"))).toBe(true);
-    const reads = execCalls.filter((cmd) => /\bbase64 \/tmp\/og-shot-.*\.png\b/.test(cmd));
-    expect(reads.length).toBe(1);
-    // Defensive: the read is base64-direct, NOT a `base64 -w0 | …` piped form (a
-    // pipe would risk a banner-corrupted body) and NOT readFile.
-    expect(reads[0]).not.toContain("|");
+    // The read sizes the file (`wc -c`) then base64s it in `dd … | base64` chunks — the
+    // chunked form that stays under Modal's exec-output cap (a single `base64 <file>`
+    // silently empties a full-frame read).
+    expect(execCalls.some((cmd) => /wc -c < \/tmp\/og-shot-.*\.png/.test(cmd))).toBe(true);
+    const chunkReads = execCalls.filter((cmd) => /dd if=\/tmp\/og-shot-.*\.png .*\| base64/.test(cmd));
+    expect(chunkReads.length).toBe(1); // a 6-byte PNG is a single chunk
     // The temp file is cleaned up.
     expect(execCalls.some((cmd) => cmd.includes("rm -f /tmp/og-shot-"))).toBe(true);
   });
 
-  test("400-FIX: the exec-object provider path also reads the PNG via base64 (structured stdout body)", async () => {
+  test("400-FIX: the exec-object provider path also reads the PNG via the chunked read (structured stdout body)", async () => {
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     const { session, execCalls } = makeMockSession({ withExec: true, pngBytes: png });
     const c = new SandboxComputer(session as never);
     const shot = await c.screenshot();
     expect(shot).toBe(Buffer.from(png).toString("base64"));
-    expect(execCalls.some((cmd) => /\bbase64 \/tmp\/og-shot-.*\.png\b/.test(cmd))).toBe(true);
+    expect(execCalls.some((cmd) => /wc -c < \/tmp\/og-shot-.*\.png/.test(cmd))).toBe(true);
+    expect(execCalls.some((cmd) => /dd if=\/tmp\/og-shot-.*\.png .*\| base64/.test(cmd))).toBe(true);
+  });
+
+  // ── The exec-output-cap fix: a fully-painted 1280x800 desktop PNG (~222 KB) base64s
+  // to ~296 KB, which trips Modal's exec-stdout buffer cap and silently returns "" from a
+  // single `base64 <file>` — the blank-frame incident. The chunked read reconstructs the
+  // FULL frame from cap-safe pieces, and a truncated chunk fails LOUD (never a blank). ──
+  test("CAP-FIX: a large multi-chunk PNG reconstructs byte-exactly from `dd … | base64` chunks", async () => {
+    // 250 KB — larger than one 96 KiB chunk (3 chunks), and past the ~256 KB cap for a
+    // single read. Deterministic pseudo-random bytes so a mis-sliced chunk would corrupt.
+    const png = new Uint8Array(250_000);
+    for (let i = 0; i < png.length; i++) png[i] = (i * 31 + 7) & 0xff;
+    const { session, execCalls } = makeMockSession({ pngBytes: png });
+    const c = new SandboxComputer(session as never);
+    const shot = await c.screenshot();
+    expect(shot).toBe(Buffer.from(png).toString("base64"));
+    // 250000 / 98304 = 3 chunks.
+    const chunkReads = execCalls.filter((cmd) => /dd if=\/tmp\/og-shot-.*\| base64/.test(cmd));
+    expect(chunkReads.length).toBe(3);
+  });
+
+  test("CAP-FIX: a chunk truncated by the exec cap FAILS LOUD (ScreenshotReadError), never a silent blank", async () => {
+    const png = new Uint8Array(250_000).fill(0x42);
+    // Every chunk comes back truncated to 1000 bytes → the reconstruction is short.
+    const { session } = makeMockSession({ pngBytes: png, truncateChunkBytes: 1000 });
+    const c = new SandboxComputer(session as never, { screenshotWarmupBudgetMs: 30, screenshotRetryDelayMs: 5 });
+    const result = await c.screenshot().then((s) => ({ ok: true as const, s }), (e) => ({ ok: false as const, e }));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("screenshot() resolved on a truncated read — a short frame must fail loud");
+    expect(result.e).toBeInstanceOf(ScreenshotReadError);
+    // The message carries BOTH byte counts for diagnosis.
+    expect(String((result.e as Error).message)).toMatch(/of 250000B/);
   });
 
   // ── Regression: the "400 Invalid input[N].output.image_url" turn-killer ──────


### PR DESCRIPTION
Follow-up to #246 — found while live-verifying the paint gate on staging.

## Symptom
On a Modal desktop turn the model reported the screen as **blank/black**, and the worker logged `ComputerUnavailableError: scrot produced an empty screenshot` — while the display was provably **fully painted** (a direct `scrot` on the same box was a 222 KB XFCE desktop, and the noVNC/RFB viewer streamed a painted frame).

## Root cause
`SandboxComputer.screenshot()` read the PNG back with a **single `base64 <file>`** over Modal exec. Modal collects exec stdout into a bounded buffer that **silently returns `""` once the output exceeds ~256 KiB**. A fully-painted 1280×800 PNG (~222 KB) base64s to **~296 KB** → over the cap → empty read → the af289e3 wire-seam sanitizer turns the empty output into a 1×1 transparent placeholder the model reads as a blank screen.

A **partially-painted** frame (~200 KB base64) slipped under the cap — which is why this only surfaced once the paint gate (#246) started delivering fully-painted frames. **The gate exposed a latent transport bug; it did not cause one.** (Channel-A file read already caps its own base64-over-exec output for the same reason — the screenshot read was the one large read that did not bound itself. So Modal computer-use on a fully-rendered desktop was plausibly broken all along; prior e2e computer-use verification only ran on the Mac native path.)

## Fix (`readScreenshotBytes`)
- Size the file (`wc -c`), then base64 it in **96 KiB, 3-byte-aligned chunks** (`dd bs=98304 skip=i count=1 | base64`) whose per-read base64 (~131 KB) stays well under the cap; reconstruct in the worker. 3-byte alignment ⇒ each chunk base64 is self-contained ⇒ decoded chunks concatenate **byte-exactly**.
- **Validate** reconstructed bytes vs the on-box file size and **FAIL LOUD** (`ScreenshotReadError`, both counts) on any short read — never a silent blank. Deterministic (the cap), so not retried.
- Zero-byte (still-warming `:0`) path preserved: `wc -c = 0` → empty → warm-up retry budget rides it out.

## Gates
`bun test` runtime **511 pass / 0 fail** (new multi-chunk-reconstruct + truncated-chunk-fails-loud cases); `tsc` clean; dd-chunk reconstruction validated byte-exact on `ubuntu:22.04`. Runtime-only — no image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Modal computer-use screenshot transport path that feeds model `image_url` data; behavior is well-covered by new tests but affects a user-visible agent loop.
> 
> **Overview**
> Fixes **blank desktop screenshots** on Modal when a fully painted frame is large enough that a single `base64 <png>` over exec exceeds Modal’s stdout buffer (~256 KiB) and comes back empty.
> 
> **`SandboxComputer.readScreenshotBytes`** now sizes the file with `wc -c`, then reads the PNG in **96 KiB, 3-byte-aligned** `dd … | base64` chunks, reconstructs the bytes, and **compares length to the on-box size**. A short read throws **`ScreenshotReadError`** with byte counts instead of returning a truncated or empty frame. Exec plumbing is factored into **`readCmdRaw`**.
> 
> **`screenshot()`** still retries zero-byte / warming displays, but **`ScreenshotReadError` is not retried** (deterministic cap failure).
> 
> Tests mock the two-phase read and add multi-chunk reconstruction plus truncated-chunk failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8c6ea03d28c6d34ccc57449ea02f5fd4e1b20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->