### PR TITLE
feat: compatibility contract + credential/MCP/trust-model documentation

### DIFF
--- a/.changeset/compat-contract.md
+++ b/.changeset/compat-contract.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/config": patch
+---
+
+ClientConfig gains optional `serverVersion` (the release-train version baked into official server images, surfaced on /healthz and /v1/config/client); the unused `PageInfo`/`paginated()` exports are removed — list endpoints deliberately return bare arrays, and the events route's cursor scheme is the documented exception.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -167,6 +167,7 @@ export function createApp(deps: AppDependencies): Hono {
     service: deps.settings.serviceName,
     environment: deps.settings.environment,
     deploymentRevision: deps.settings.deploymentRevision,
+    ...(deps.settings.serverVersion ? { serverVersion: deps.settings.serverVersion } : {}),
     ok: true,
   }));
 
@@ -181,6 +182,7 @@ export function createApp(deps: AppDependencies): Hono {
 
   app.get("/v1/config/client", (c) => c.json(ClientConfig.parse({
     deploymentRevision: deps.settings.deploymentRevision,
+    ...(deps.settings.serverVersion ? { serverVersion: deps.settings.serverVersion } : {}),
     defaultModel: deps.settings.openaiModel,
     allowedModels: configuredAllowedModels(deps.settings),
     // Provider-grouped model list for the picker. configuredModels() carries the

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Deployment | `docs/deployment.md` | `README.md`, `AGENTS.md`, Helm/Terraform notes should link. |
 | Release/publishing | `CONTRIBUTING.md` § Release / Publishing, plus workflow files as executable truth | `README.md`, package READMEs, architecture release notes should link. |
 | Client/SDK integration | `packages/sdk/README.md` | `README.md`, `docs/embedding.md`, `@opengeni/react` docs should link. |
+| Credential taxonomy | `docs/credentials.md` | `docs/embedding.md`, `docs/capabilities.md`, route comments should link instead of re-listing token types. |
+| MCP surface selection | `docs/mcp-surfaces.md` | `docs/architecture.md`, `docs/capabilities.md`, `docs/session-mcp-servers.md` should link. |
+| Client/server compatibility policy | `docs/architecture.md` §3.10 | `packages/sdk/README.md` links; release notes should link. |
 
 ## Rules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,28 @@ A **Connected Machine** (the `selfhosted` backend) is a user's own physical mach
 - **Sandbox-access import discipline in the API:** `apps/api` accesses sandbox symbols **only** via the agent-loop-free leaf `@opengeni/runtime/sandbox`, never the bare `@opengeni/runtime` barrel (which pulls the agent loop into the API process). Enforced by a guard test.
 - **The npm publish closure is the full `@opengeni/*` runtime closure.** Stage C publishes the client packages plus the server/embed packages they need (`api-router`, `worker-bundle`, `core`, `config`, `db`, `runtime`, `events`, `storage`, `documents`, `github`, `observability`, `codex`, `agent-proto`, etc.). Leaf apps/test/deployment-only packages may stay ignored only when no publishable package depends on them. The client bundle remains stricter: `sdk` is zero-runtime-dep and `react` may only depend on `sdk` among `@opengeni/*`.
 
+### 3.10 Client/server compatibility policy
+
+The published clients (`@opengeni/sdk`, `@opengeni/react`) and a server build
+are compatible when they share a **major version**; within a major, evolution
+is **additive only** and both sides are tolerant readers:
+
+- Servers ignore unknown request params; new params must degrade gracefully
+  when absent (e.g. `compact=1` on the events route — an older server simply
+  returns uncompacted pages and the client renders identically).
+- Clients ignore unknown response fields and unknown event types; the react
+  timeline projection is a tolerant reader by construction, pinned by the
+  golden event-grammar suite in `packages/react`.
+- Removing or re-typing an existing field/param/event shape is a MAJOR bump —
+  of the whole release train (sdk and react versions are changeset-linked; the
+  server images are tagged with the same train version).
+
+Official server images carry the train version in `OPENGENI_SERVER_VERSION`,
+surfaced on `/healthz` and `/v1/config/client` as `serverVersion` (absent on
+dev/source builds). There is deliberately **no runtime version negotiation** —
+the policy above plus tolerant readers is the mechanism; a client that wants to
+assert compatibility reads `serverVersion` and compares majors.
+
 ---
 
 ## 4. System architecture

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,36 @@
+# Credential taxonomy
+
+Audience: integrators and operators. One page for every credential the system
+mints or accepts — what it is, who issues it, where it travels, and who may see
+it. If you are deciding *which* credential to use: API clients use an **API
+key**; hosts acting on behalf of their own users use a **delegated token**;
+everything else is machinery you receive from OpenGeni rather than choose.
+
+| Credential | Prefix / transport | Issued by | Verified by | Lifetime | Intended holder |
+| --- | --- | --- | --- | --- | --- |
+| Deployment access key | `x-opengeni-access-key` header | Operator (env) | API perimeter middleware | Static | Every caller of a key-gated deployment (coarse perimeter, not identity) |
+| Product API key | `ogk_…` bearer | Workspace member via `POST /v1/workspaces/:id/api-keys` | Hash lookup (stored hashed, shown once) | Until revoked | A product/backend calling the REST API for one workspace |
+| Delegated access token | `ogd_…` bearer | Host with the deployment's delegation secret (HMAC) | HMAC + embedded workspace/account/permissions | Short (embedded expiry) | An embedding host acting as one of its users; also self-minted internally for first-party MCP |
+| Managed web session | Better Auth cookie | Managed auth (email/password) | Better Auth session lookup | Session | Humans in the hosted web console |
+| Stream token | `ogs_…` (query/header) | API, on viewer/stream mint | HMAC, scope+TTL embedded | Minutes | Browsers attaching to desktop/terminal streams |
+| Machine enrollment bearer | `oge_…` | Enrollment flow (click-Grant or device flow) | Stored credential + NATS auth-callout | Until revoked | A self-hosted/connected machine agent |
+| Headless enrollment token | `oget_…` | Operator via enrollment API | One-time exchange for `oge_…` | Single use | Provisioning scripts for headless machines |
+| Relay producer token | `ogr_…` | API for self-hosted relay producers | HMAC | Short | The relay forwarding desktop frames |
+| NATS user JWT / callout | NATS credentials | API auth-callout service | NATS server (callout account) | Connection | Machine agents and internal services on the message bus |
+| Session MCP headers | Arbitrary headers, encrypted at rest | Embedding host per session (`mcpServers` on create; rotatable per user turn) | Never read back — write-only, decrypted only in the worker | Host-defined; version-bumped on rotation | Host's own MCP server called from a session |
+| Capability MCP headers | Arbitrary headers, encrypted at rest | Workspace admin when configuring a capability | Write-only, worker-side decrypt | Until reconfigured | Third-party MCP servers enabled workspace-wide |
+| Codex subscription tokens | ChatGPT access/refresh/id tokens, encrypted | Device-code login flow | OpenAI; OpenGeni stores encrypted, never returns them | Provider-defined, auto-refreshed | Workspaces using a ChatGPT/Codex subscription as a model provider |
+| GitHub installation token | GitHub App token | GitHub, minted per run | GitHub | ~1 hour, re-minted on demand | Sandbox git operations (delivered via token file + askpass, never baked into manifests) |
+| Signed storage URLs | Time-limited URL | API via object storage | Storage provider | Minutes | File upload/download without exposing storage credentials |
+
+Rules that hold across the table:
+
+- **Secrets are write-only.** Anything a caller supplies (MCP headers, Codex
+  tokens) is encrypted at rest and never echoed by any read endpoint — responses
+  expose header *names* and credential *versions* only.
+- **Rotation over longevity.** Rotating credentials (GitHub tokens, session MCP
+  bearers) are re-delivered per turn/run and never stored in long-lived
+  artifacts such as sandbox manifests.
+- **The perimeter is not identity.** The deployment access key gates who can
+  talk to a deployment at all; workspace identity and permissions always come
+  from one of the identity-bearing credentials above it.

--- a/docs/design/contract-decisions.md
+++ b/docs/design/contract-decisions.md
@@ -1,0 +1,47 @@
+# Contract decisions — reviewed and deliberately kept
+
+Record tier (2026-07-03). An architecture review of the SDK, publishing, and
+consumption surfaces flagged the items below; each was examined and **kept on
+purpose**. This record exists so future reviewers (human or agent) see the
+reasoning instead of re-flagging them. If circumstances change, overturn them
+consciously — with a doc update, not silently.
+
+1. **Event payloads stay `z.unknown()` in contracts.** Payloads carry
+   provider-native shapes; full zod typing would be brittle theater against
+   upstream drift. The real contract is the tolerant-reader projection in
+   `@opengeni/react`, pinned by its golden event-grammar test suite. Emitters
+   evolve additively; readers ignore what they don't know.
+
+2. **No runtime API version negotiation.** The compatibility mechanism is the
+   additive-within-a-major policy (architecture.md §3.10) plus tolerant readers
+   on both sides, with `serverVersion` surfaced for clients that want to check.
+   Negotiation machinery would add failure modes without adding safety at the
+   current scale.
+
+3. **API-side admission is local in embedded deployments.** The host owns the
+   perimeter (its auth fronts the mounted router) and host business admission
+   enters at the worker's entitlements port, where work actually starts. See
+   embedding.md "Trust model".
+
+4. **The engine self-mints internal tokens** (first-party MCP `ogd_`, stream
+   tokens, NATS credentials) with its own secrets — they never leave the
+   engine's trust domain, so a host token-issuer port would be coupling without
+   security. Hosts protect the engine's secrets like their own signing keys.
+
+5. **List endpoints return bare arrays.** The unfulfilled `PageInfo`/
+   `paginated()` promise was removed from contracts rather than adopted; the
+   events route's `after`/`before`/`limit`/`compact` cursor scheme is the
+   deliberate exception, designed for its access pattern.
+
+6. **Published manifests point at TypeScript source in-repo.** Workspace DX is
+   source-first (Bun); the blessed release path rewrites entrypoints to `dist`
+   and `workspace:*` to real ranges at publish, and a prepublish guard fails
+   any bypass. Do not "fix" the committed manifests to point at dist.
+
+7. **`@opengeni/core` is an engine-core, not a domain-core.** It keeps Hono's
+   `HTTPException` and the server closure; embedders who want purity should use
+   the REST API. Documented in the package README.
+
+8. **Error envelope unification is deferred.** Auth's bare `{ error }` shape
+   and route-level variance predate `ErrorEnvelope`; unifying is a breaking
+   change worth batching into the next natural major, not worth its own break.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -122,3 +122,39 @@ API and worker must share the same broker-backed EventBus binding. The productio
 Do not replace this with an in-memory bus in an embedded deployment. In-memory fanout only reaches subscribers in the same process and would make worker -> API live SSE silently disappear; clients would only recover on replay/gap backfill.
 
 For embedded UIs that page historical timelines, prefer `GET .../events?compact=1` (or SDK `listEvents(..., { compact: true })`) for windowed replay. It coalesces consecutive delta fragments in the page while preserving first-member `sequence`; use `payload.coalescedUntil` as the resume cursor for the live SSE stream. Streaming/gap backfill should keep using raw sequence replay.
+
+## Trust model
+
+The embed boundary has a deliberate split of authority. Getting this wrong in
+either direction creates real vulnerabilities (too little host gating) or
+pointless coupling (host ownership of engine internals), so it is a contract:
+
+**The host owns the perimeter and external identity.**
+
+- Every request reaching the mounted api-router has already passed the HOST's
+  authentication. OpenGeni's own checks (delegated tokens, API keys) are the
+  second gate, not the first — an embedded deployment must never be reachable
+  except through the host's front door.
+- The host decides which of its principals maps to which OpenGeni
+  account/workspace, and mints `ogd_` delegated tokens (with the deployment's
+  delegation secret) to act as them. Admission policy that depends on the
+  host's business state (plans, quotas, feature gates) enters through the
+  entitlements port on the worker side.
+
+**The engine owns its internal plumbing tokens.**
+
+- First-party MCP delegated tokens, stream tokens, and NATS credentials are
+  self-minted by the engine with its own secrets. They never leave the engine's
+  trust domain (the host's process and infrastructure), so routing them through
+  a host token issuer would add coupling without adding security. Do not expect
+  a port for these; there isn't one on purpose.
+- Corollary for hosts: protect the engine's secrets (delegation secret,
+  encryption keys) exactly like your own signing keys — inside the engine's
+  trust domain they are root authority.
+
+**API-side admission is local by design.** The API validates structure,
+permissions, and workspace scoping; host-specific admission (may this tenant
+run another turn?) is enforced where the work actually starts — the worker's
+entitlements port. A request can therefore be *accepted* by the API and still
+be *declined* at run admission; hosts that want earlier rejection should gate
+at their own perimeter, which they control.

--- a/docs/mcp-surfaces.md
+++ b/docs/mcp-surfaces.md
@@ -1,0 +1,27 @@
+# MCP surfaces — which one do you want?
+
+Audience: integrators. OpenGeni touches the Model Context Protocol in five
+places. They are different products with different owners and lifecycles; this
+page exists so you pick the right one in one read.
+
+| Surface | Who configures it | Scope / lifecycle | Credentials | Use it when |
+| --- | --- | --- | --- | --- |
+| **First-party OpenGeni MCP** (`/v1/workspaces/:id/mcp`) | Nobody — built in | Always available; tools mirror the REST API (session create/send/interrupt, packs, environments…) capped by the caller's grant | The caller's own bearer; internally delegated `ogd_` tokens per session | An AGENT (often a manager session) should orchestrate OpenGeni itself — spawn workers, steer sessions |
+| **Docs MCP** (`/mcp/docs`) | Nobody — built in | Always available | Caller's bearer | An agent should search the workspace's documents store |
+| **Capability MCP servers** | Workspace admin (capabilities settings) | Workspace-wide; on for every session while enabled | Admin-supplied headers, encrypted, write-only | A third-party tool (e.g. a SaaS MCP) should be available to *all* sessions in a workspace |
+| **Per-session MCP servers** (`mcpServers` on session create) | The embedding host, per session | One session; credentials rotatable on every user turn | Host-supplied headers, encrypted, write-only, `credentialVersion`-bumped | An embedding host injects its OWN tool server with per-session, short-lived bearers |
+| **Codex Apps MCP** | Automatic for Codex-subscription runs | Per turn, only on the ChatGPT/Codex model path | Workspace's Codex tokens | You don't — it rides along with the Codex subscription provider |
+
+Rules of thumb:
+
+- Building a product **on top of** OpenGeni (embed or API)? Per-session MCP is
+  your integration point for host tools; the first-party MCP is your agents'
+  steering wheel.
+- Giving **every** session in a workspace a tool? Capability MCP.
+- Never proxy one MCP surface through another — each is already reachable where
+  it is needed (API-side for callers, worker-side for the running agent).
+
+Details: first-party tools and grants in [architecture.md](architecture.md),
+per-session servers in [session-mcp-servers.md](session-mcp-servers.md),
+workspace capabilities in [capabilities.md](capabilities.md), credential
+handling in [credentials.md](credentials.md).

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -105,6 +105,9 @@ const SettingsSchema = z.object({
   serviceName: z.string().default("opengeni"),
   environment: z.string().default("local"),
   deploymentRevision: z.string().default("dev"),
+  // The release-train version baked into official images (OPENGENI_SERVER_VERSION).
+  // Absent on dev/source builds — consumers must treat it as optional.
+  serverVersion: z.string().optional(),
   databaseUrl: z.string().default("postgres://opengeni:opengeni@127.0.0.1:5432/opengeni"),
   // Step I (§7.8 runtime half). Dedicated Postgres schema for the EMBEDDED
   // topology. Default "" → standalone: no search_path scoping, server default
@@ -835,6 +838,7 @@ export function getSettings(): Settings {
     serviceName: optional("OPENGENI_SERVICE_NAME"),
     environment: optional("OPENGENI_ENVIRONMENT"),
     deploymentRevision: optional("OPENGENI_DEPLOYMENT_REVISION") ?? optional("SOURCE_VERSION") ?? optional("GITHUB_SHA"),
+    serverVersion: optional("OPENGENI_SERVER_VERSION"),
     databaseUrl: optional("OPENGENI_DATABASE_URL"),
     dbSchema: optional("OPENGENI_DB_SCHEMA"),
     rlsStrategy: optional("OPENGENI_RLS_STRATEGY"),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -429,20 +429,6 @@ export const ErrorEnvelope = z.object({
 });
 export type ErrorEnvelope = z.infer<typeof ErrorEnvelope>;
 
-export const PageInfo = z.object({
-  limit: z.number().int().positive(),
-  nextCursor: z.string().nullable(),
-  hasMore: z.boolean(),
-});
-export type PageInfo = z.infer<typeof PageInfo>;
-
-export function paginated<T extends z.ZodTypeAny>(item: T) {
-  return z.object({
-    data: z.array(item),
-    page: PageInfo,
-  });
-}
-
 export const Permission = z.enum([
   "account:read",
   "account:admin",
@@ -3493,6 +3479,10 @@ export type ClientModel = z.infer<typeof ClientModel>;
 
 export const ClientConfig = z.object({
   deploymentRevision: z.string(),
+  // Release-train version of the server (absent on dev/source builds). The
+  // compatibility policy lives in docs/architecture.md — clients within the
+  // same major are supported; evolution is additive within a major.
+  serverVersion: z.string().optional(),
   defaultModel: z.string(),
   allowedModels: z.array(z.string()).min(1),
   // Richer model list (provider-grouped) for the picker. Defaults to [] for

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,3 +12,12 @@ It owns code that is not intrinsically HTTP or Temporal process bootstrapping:
 `@opengeni/api-router` owns the Hono app, middleware, HTTP route adapters, MCP HTTP transport, and API-direct sandbox endpoints. `@opengeni/worker-bundle` owns Temporal worker construction, workflows, activities, and process lifecycle. Both consume `@opengeni/core`; core does not import either app.
 
 The package is used by standalone OpenGeni through those app runners and by embedded hosts that call core directly or mount the API router.
+
+## Scope honesty: engine-core, not domain-core
+
+This package is the **engine core** — the transport-mostly-neutral heart of the
+server, extracted so embedders can mount it. It still carries server-flavored
+dependencies (notably Hono's `HTTPException` as the domain error type and the
+full persistence/runtime closure). It is NOT a pure domain library and does not
+try to be one; if you need OpenGeni without any server runtime, you want the
+REST API + `@opengeni/sdk` instead.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -163,6 +163,23 @@ Every public endpoint group has typed methods:
 | API keys | `listApiKeys`, `createApiKey`, `deleteApiKey` |
 | Billing | `getBilling`, `getBillingUsage`, `getBillingEntitlements`, `createBillingCheckout` |
 
+### Protocol routes (deliberately not in the SDK)
+
+Some endpoints are wire protocols for specific counterparts, not client
+surface, and are intentionally absent from the SDK: machine-agent enrollment
+device flow and NATS auth-callout, viewer/stream internals beyond minting,
+OAuth/GitHub browser callbacks, Stripe webhooks, the MCP transports themselves
+(`/v1/workspaces/:id/mcp`, `/mcp/docs` — speak MCP to those), and the install
+script routes. If you find yourself calling one of these raw from a product,
+reconsider — they can change with their counterpart, not with the SDK.
+
+## Compatibility
+
+Clients and servers are compatible within the same **major** release-train
+version; evolution is additive within a major and both sides are tolerant
+readers. Official server builds expose `serverVersion` on `/healthz` and
+`/v1/config/client`. Full policy: `docs/architecture.md` §3.10.
+
 ## Proxy through your own API
 
 Keep your OpenGeni API key on your server and re-emit the stream to your own


### PR DESCRIPTION
Part of the architecture-review hardening pass (with the release-train hygiene and golden event-grammar PRs). This one turns the system's **implicit contracts into explicit ones** — almost entirely additive.

- **Compatibility policy** (architecture.md §3.10): same-major client/server compatibility, additive-only evolution within a major, tolerant readers both ways. Official images will carry the train version (`OPENGENI_SERVER_VERSION`, wired in the release-hygiene PR), surfaced as `serverVersion` on `/healthz` and `/v1/config/client` (optional field — dev builds omit it). Deliberately **no** runtime negotiation machinery.
- **contracts**: remove the unused `PageInfo`/`paginated()` exports (used nowhere; bare-array lists are the deliberate design — recorded).
- **docs/credentials.md**: all 14 credential types — prefix, issuer, verifier, lifetime, holder — in one page, with the three cross-cutting rules (write-only secrets, rotation over longevity, perimeter ≠ identity).
- **docs/mcp-surfaces.md**: the five MCP surfaces as a decision guide.
- **embedding.md § Trust model**: host owns perimeter + external identity; engine self-mints internal plumbing tokens (no host-issuer port, on purpose); API-side admission local by design with worker-side entitlements as the host's business-admission hook.
- **docs/design/contract-decisions.md**: eight reviewed-and-kept decisions recorded (record tier) so future reviews don't re-flag deliberate design.
- SDK README: protocol-routes list + compatibility section; core README: engine-core scope honesty; docs map registrations.

Verification: monorepo `tsc` clean, contracts/config tests green, docs-refs guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive optional fields and documentation; the contracts removal of unused pagination helpers is a minor semver surface change for any external importer of those symbols.
> 
> **Overview**
> This PR **codifies client/server compatibility** and surfaces the release-train version on the wire, alongside integrator-focused documentation.
> 
> **Wire & config:** Optional `serverVersion` is added to `ClientConfig` and settings (`OPENGENI_SERVER_VERSION`), and included on **`/healthz`** and **`/v1/config/client`** when set (official images; dev builds omit it). **`PageInfo`** and **`paginated()`** are **removed** from `@opengeni/contracts` as unused; list APIs stay **bare arrays**, with the events cursor as the documented exception.
> 
> **Docs:** New **`docs/credentials.md`**, **`docs/mcp-surfaces.md`**, and **`docs/design/contract-decisions.md`** (record tier); **`docs/architecture.md` §3.10** (same-major, additive-within-major, tolerant readers, no runtime negotiation); **`embedding.md` § Trust model**; docs map updates; SDK README (compatibility + protocol routes not in SDK); core README (engine-core scope).
> 
> Changeset: `@opengeni/contracts` minor, `@opengeni/config` patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78cba69b33bb783aa1e7a3754445a09a8776bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->