### PR TITLE
fix(computer-use): banner-strip routing-proxy string exec so Modal screenshots survive

### DIFF
--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -129,7 +129,9 @@ const BUTTON_NUM: Record<ComputerButton, number> = { left: 1, wheel: 2, right: 3
 // exec/execCommand (readFile path-validates against /workspace and rejects /tmp).
 type ExecResultLike = { output?: string; stdout?: string; stderr?: string; exitCode?: number | null; sessionId?: number };
 type ComputerSession = {
-  exec?: (args: { cmd: string; runAs?: string; yieldTimeMs?: number; maxOutputTokens?: number }) => Promise<ExecResultLike>;
+  // A native provider exec returns a structured `ExecResultLike`; the routing proxy
+  // fronting a Modal box returns the execCommand banner STRING. Both are handled.
+  exec?: (args: { cmd: string; runAs?: string; yieldTimeMs?: number; maxOutputTokens?: number }) => Promise<ExecResultLike | string>;
   execCommand?: (args: { cmd: string; runAs?: string; yieldTimeMs?: number; maxOutputTokens?: number }) => Promise<string>;
 };
 
@@ -320,6 +322,16 @@ export class SandboxComputer implements Computer {
   // `sandboxCommandOutput` parser drops the execCommand STRING body). exec exposes a
   // structured stdout; execCommand returns the formatted STRING, so we strip its banner
   // ("…Output:\n<body>") to recover the body.
+  //
+  // ROUTING-PROXY SEAM: when the selfhosted feature is on, the turn's box is wrapped in a
+  // `RoutingSandboxSession`, which ALWAYS exposes an `exec` method — but for a Modal-backed
+  // box (no native `exec`) that method internally falls back to `execCommand` and returns
+  // the formatted STRING, not a `{output}` object. `sandboxCommandOutput` returns "" for a
+  // string, so a naive `sandboxCommandOutput(await session.exec())` silently dropped the
+  // whole screenshot body → empty read → "display not up" error card on EVERY Modal
+  // computer-use turn once routing was enabled. So a STRING exec result is banner-stripped
+  // exactly like the direct execCommand path; only a structured object goes to
+  // sandboxCommandOutput.
   private async readCmdRaw(cmd: string): Promise<string> {
     const args = {
       cmd,
@@ -330,7 +342,11 @@ export class SandboxComputer implements Computer {
       maxOutputTokens: null as unknown as number,
     };
     if (typeof this.session.exec === "function") {
-      return sandboxCommandOutput(await this.session.exec(args));
+      const result = await this.session.exec(args);
+      // A routing proxy fronting a Modal box returns the execCommand banner STRING;
+      // a native structured exec returns an object. Handle both so neither silently
+      // yields an empty body.
+      return typeof result === "string" ? stripExecBanner(result) : sandboxCommandOutput(result);
     }
     if (typeof this.session.execCommand === "function") {
       return stripExecBanner(await this.session.execCommand(args));

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -78,6 +78,10 @@ function makeMockSession(opts: {
   // Simulate the Modal exec-output cap truncating EACH `dd … | base64` chunk to at most
   // this many decoded bytes — the read then reconstructs short and must fail LOUD.
   truncateChunkBytes?: number;
+  // Model the RoutingSandboxSession fronting a Modal box: it EXPOSES an `exec` method
+  // (so typeof session.exec === "function"), but for a Modal backend that method falls
+  // back to execCommand and returns the formatted banner STRING — NOT a {output} object.
+  proxyExecString?: boolean;
 } = {}) {
   const execCalls: string[] = [];
   // The execCommand contract: a FORMATTED STRING with a metadata preamble (F2).
@@ -127,7 +131,12 @@ function makeMockSession(opts: {
   const session: Record<string, unknown> = {
     execCommand: async (args: { cmd: string }) => run(args.cmd),
   };
-  if (opts.withExec) {
+  if (opts.proxyExecString) {
+    // The routing proxy's exec() resolves to the execCommand banner STRING (Modal has
+    // no native exec). readCmdRaw must banner-strip it, NOT feed it to
+    // sandboxCommandOutput (which returns "" for a string).
+    session.exec = async (args: { cmd: string }) => run(args.cmd);
+  } else if (opts.withExec) {
     session.exec = async (args: { cmd: string }) => {
       execCalls.push(args.cmd);
       const body = readBody(args.cmd);
@@ -191,6 +200,23 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
     expect(shot).toBe(Buffer.from(png).toString("base64"));
     expect(execCalls.some((cmd) => /wc -c < \/tmp\/og-shot-.*\.png/.test(cmd))).toBe(true);
     expect(execCalls.some((cmd) => /dd if=\/tmp\/og-shot-.*\.png .*\| base64/.test(cmd))).toBe(true);
+  });
+
+  test("ROUTING-PROXY-FIX: a proxy exec() that returns the execCommand banner STRING is banner-stripped, not dropped to ''", async () => {
+    // The RoutingSandboxSession (selfhosted enabled) fronting a Modal box exposes `exec`,
+    // but it resolves to the formatted execCommand STRING. A naive
+    // sandboxCommandOutput(string) === "" made `wc -c` read as 0 → empty frame → the
+    // "display not up" error card on EVERY Modal computer-use turn. Multi-chunk so the
+    // chunked dd|base64 reads also flow through the string path.
+    const png = new Uint8Array(250_000);
+    for (let i = 0; i < png.length; i++) png[i] = (i * 2654435761) & 0xff;
+    const { session, execCalls } = makeMockSession({ proxyExecString: true, pngBytes: png });
+    const c = new SandboxComputer(session as never);
+    const shot = await c.screenshot();
+    expect(shot).toBe(Buffer.from(png).toString("base64")); // full frame, byte-exact — NOT empty
+    // Drove the read through the exec() (proxy string) path, not execCommand directly.
+    expect(execCalls.some((cmd) => /wc -c < \/tmp\/og-shot-.*\.png/.test(cmd))).toBe(true);
+    expect(execCalls.filter((cmd) => /dd if=\/tmp\/og-shot-.*\| base64/.test(cmd)).length).toBeGreaterThanOrEqual(3);
   });
 
   // ── The exec-output-cap fix: a fully-painted 1280x800 desktop PNG (~222 KB) base64s


### PR DESCRIPTION
Follow-up to #252 — the ACTUAL fix for the blank/error-card desktop on Modal computer-use turns, root-caused by reproducing the exact turn path live on staging.

## Symptom
Every cold Modal desktop turn returned the #249 error card ("SCREEN CAPTURE FAILED"), even though the box was provably rendering a full XFCE desktop (direct `scrot` = 222 KB) **and the turn's own scrot wrote a valid 222 KB PNG**. So render is fine and #246 works; the **read** of that PNG was failing.

## Root cause
When the selfhosted feature is enabled (it is — `OPENGENI_SANDBOX_SELFHOSTED_ENABLED=true` on staging + prod), the turn's box session is wrapped in `RoutingSandboxSession`. That proxy **always** exposes an `exec` method — but for a Modal-backed box (no native `exec`) its `exec()` falls back to `execCommand` and resolves to the formatted banner **STRING** (`Chunk ID …\nOutput:\n<body>`), not a `{output}` object.

`readScreenshotBytes → readCmdRaw` did `sandboxCommandOutput(await session.exec(args))`, and `sandboxCommandOutput` returns `""` for a string (it only reads `{output,stdout,stderr}`). So `wc -c` → `""` → `fileSize ≤ 0` → empty frame → `ComputerUnavailableError("…display not up?")` → #249 card — on **every** Modal computer-use turn once routing was on. #252's chunked read was correct but never got a size to chunk.

The **raw** Modal session (no proxy) has no `exec`, so it used `execCommand`+`stripExecBanner` and worked — which is why prior direct repros passed while real turns failed.

## Fix
`readCmdRaw` now banner-strips a STRING exec result (proxy-over-Modal) instead of feeding it to `sandboxCommandOutput`; only a structured object goes to `sandboxCommandOutput`. `ComputerSession.exec` is widened to `ExecResultLike | string`. `this.x` already tolerated the string (reads only the exit code, which parses from the banner), so actions were unaffected — only the screenshot READ was broken.

## Verification — live, staging Modal, real execCommand channel
- **Render:** fresh cold gVisor box paints a full 222 KB desktop (Xvfb + xfce4-session + xfce4-panel + x11vnc + websockify, ports 5900/6080 up).
- **Bug, deployed code + proxy-mimic** (exec returns the execCommand string) → `screenshot()` THROWS `…display not up?` (reproduces the exact turn failure).
- **Fix, same box + patched file injected** → `screenshot() OK, base64Len=296272` (full 222 KB frame).
- Raw session (no proxy) worked before and after.

## Gates
runtime `bun test` **515 pass / 0 fail** (new `ROUTING-PROXY-FIX` multi-chunk test); `tsc` clean. Runtime-only — no image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets screenshot read plumbing on a known routing/Modal seam; behavior for native structured exec and direct execCommand is unchanged, but incorrect banner handling would still break all routed Modal computer-use turns.
> 
> **Overview**
> With **selfhosted routing** enabled, turns use a `RoutingSandboxSession` that always exposes `exec`, but on Modal that call returns the same **formatted execCommand string** as `execCommand`—not a structured `{ output }` object. Screenshot PNG reads go through `readCmdRaw`; feeding that string into `sandboxCommandOutput` yielded **empty output**, so `wc -c` looked like zero bytes and every Modal computer-use turn showed the **screen capture failed** card even when `scrot` wrote a valid PNG.
> 
> **`readCmdRaw`** now branches on the exec result: **strings** are handled with `stripExecBanner` (same as the direct `execCommand` path); **objects** still use `sandboxCommandOutput`. `ComputerSession.exec` is typed as `Promise<ExecResultLike | string>`. A new **`ROUTING-PROXY-FIX`** test models proxy `exec` returning the banner string over a large multi-chunk PNG read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b507b5f520f99ea57967dabaee8a5f680d1663d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->