### PR TITLE
fix(chart): nil-guard worker.service for --reuse-values upgrades

### DIFF
--- a/deploy/helm/opengeni/templates/worker-service.yaml
+++ b/deploy/helm/opengeni/templates/worker-service.yaml
@@ -10,12 +10,12 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: {{ .Values.observability.metrics.path | quote }}
-    prometheus.io/port: {{ .Values.worker.service.port | quote }}
+    prometheus.io/port: {{ (.Values.worker.service).port | default 8001 | quote }}
   {{- end }}
 spec:
-  type: {{ .Values.worker.service.type }}
+  type: {{ (.Values.worker.service).type | default "ClusterIP" }}
   ports:
-    - port: {{ .Values.worker.service.port }}
+    - port: {{ (.Values.worker.service).port | default 8001 }}
       targetPort: http
       protocol: TCP
       name: http


### PR DESCRIPTION
The worker Service template (#251) dereferences .Values.worker.service.* which is nil when 'helm upgrade --reuse-values' runs against a release installed before #251 (stored values lack the key). Parenthesized lookups with defaults matching values.yaml (8001/ClusterIP). Verified: helm template with defaults and with worker.service=null both render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm template-only change with behavior-preserving defaults; no runtime app or auth/data path changes.
> 
> **Overview**
> **Fixes Helm render failures** when upgrading with `--reuse-values` on releases that predate the worker Service template and therefore have no `worker.service` in stored values.
> 
> The worker Service template now uses **parenthesized lookups** on `(.Values.worker.service)` with **defaults** (`8001` for port, `ClusterIP` for type) for Prometheus annotations, `spec.type`, and `ports[].port`, instead of dereferencing `.Values.worker.service.*` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee56bed29290c5dc2fac4b9035e8657b9ce8cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->