### PR TITLE
fix(chart): reuse-values-safe guards for all #251 keys

### DIFF
--- a/deploy/helm/opengeni/templates/api-networkpolicy.yaml
+++ b/deploy/helm/opengeni/templates/api-networkpolicy.yaml
@@ -22,7 +22,7 @@ spec:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: web
-        {{- if and .Values.observability.collector.enabled .Values.observability.metrics.enabled }}
+        {{- if and ((.Values.observability).collector).enabled ((.Values.observability).metrics).enabled }}
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}

--- a/deploy/helm/opengeni/templates/api-service.yaml
+++ b/deploy/helm/opengeni/templates/api-service.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
-  {{- if .Values.observability.metrics.enabled }}
+  {{- if ((.Values.observability).metrics).enabled }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/path: {{ .Values.observability.metrics.path | quote }}
+    prometheus.io/path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
     prometheus.io/port: {{ .Values.api.service.port | quote }}
   {{- end }}
 spec:

--- a/deploy/helm/opengeni/templates/configmap.yaml
+++ b/deploy/helm/opengeni/templates/configmap.yaml
@@ -16,8 +16,8 @@ data:
   {{- else if .Values.nats.url }}
   OPENGENI_NATS_URL: {{ .Values.nats.url | quote }}
   {{- end }}
-  {{- if .Values.observability.otel.enabled }}
-  OPENGENI_OTEL_EXPORTER_OTLP_ENDPOINT: {{ default (printf "http://%s-otel-collector:4318" (include "opengeni.fullname" .)) .Values.observability.otel.endpoint | quote }}
+  {{- if ((.Values.observability).otel).enabled }}
+  OPENGENI_OTEL_EXPORTER_OTLP_ENDPOINT: {{ default (printf "http://%s-otel-collector:4318" (include "opengeni.fullname" .)) ((.Values.observability).otel).endpoint | quote }}
   {{- end }}
   {{- if .Values.selfhosted.enabled }}
   # Bring-your-own-compute (selfhosted SandboxBackend) NON-SECRET wiring. The
@@ -46,4 +46,4 @@ data:
   {{- end }}
   {{- end }}
   OPENGENI_OBSERVABILITY_STRUCTURED_LOGS: {{ .Values.observability.structuredLogs | quote }}
-  OPENGENI_OBSERVABILITY_METRICS_ENABLED: {{ .Values.observability.metrics.enabled | quote }}
+  OPENGENI_OBSERVABILITY_METRICS_ENABLED: {{ ((.Values.observability).metrics).enabled | quote }}

--- a/deploy/helm/opengeni/templates/otel-collector-configmap.yaml
+++ b/deploy/helm/opengeni/templates/otel-collector-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.observability.collector.enabled }}
+{{- if ((.Values.observability).collector).enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/component: otel-collector
 data:
   collector.yaml: |
-    {{- if .Values.observability.collector.config }}
-    {{- tpl .Values.observability.collector.config . | nindent 4 }}
+    {{- if ((.Values.observability).collector).config }}
+    {{- tpl ((.Values.observability).collector).config . | nindent 4 }}
     {{- else }}
     receivers:
       otlp:
@@ -20,7 +20,7 @@ data:
         config:
           scrape_configs:
             - job_name: opengeni-api
-              metrics_path: {{ .Values.observability.metrics.path }}
+              metrics_path: {{ ((.Values.observability).metrics).path }}
               static_configs:
                 - targets:
                     - {{ include "opengeni.fullname" . }}-api:{{ .Values.api.service.port }}

--- a/deploy/helm/opengeni/templates/otel-collector-deployment.yaml
+++ b/deploy/helm/opengeni/templates/otel-collector-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.observability.collector.enabled }}
+{{- if ((.Values.observability).collector).enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,8 +23,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       containers:
         - name: otel-collector
-          image: {{ printf "%s:%s" .Values.observability.collector.image.repository .Values.observability.collector.image.tag | quote }}
-          imagePullPolicy: {{ .Values.observability.collector.image.pullPolicy }}
+          image: {{ printf "%s:%s" (((.Values.observability).collector).image).repository (((.Values.observability).collector).image).tag | quote }}
+          imagePullPolicy: {{ (((.Values.observability).collector).image).pullPolicy }}
           args:
             - --config=/conf/collector.yaml
           ports:
@@ -37,7 +37,7 @@ spec:
               mountPath: /conf
               readOnly: true
           resources:
-            {{- toYaml .Values.observability.collector.resources | nindent 12 }}
+            {{- toYaml ((.Values.observability).collector).resources | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/deploy/helm/opengeni/templates/otel-collector-service.yaml
+++ b/deploy/helm/opengeni/templates/otel-collector-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.observability.collector.enabled }}
+{{- if ((.Values.observability).collector).enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/opengeni/templates/poddisruptionbudgets.yaml
+++ b/deploy/helm/opengeni/templates/poddisruptionbudgets.yaml
@@ -13,7 +13,7 @@ spec:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: api
 {{- end }}
-{{- if and .Values.worker.enabled .Values.worker.podDisruptionBudget.enabled }}
+{{- if and .Values.worker.enabled ((.Values.worker).podDisruptionBudget).enabled }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -23,7 +23,7 @@ metadata:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
-  minAvailable: {{ .Values.worker.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ ((.Values.worker).podDisruptionBudget).minAvailable }}
   selector:
     matchLabels:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -1,14 +1,14 @@
-{{- if and .Values.observability.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and ((.Values.observability).prometheusRule).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "opengeni.fullname" . }}
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
-    {{- with .Values.observability.prometheusRule.labels }}
+    {{- with ((.Values.observability).prometheusRule).labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.observability.prometheusRule.annotations }}
+  {{- with ((.Values.observability).prometheusRule).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -16,8 +16,8 @@ spec:
   groups:
     - name: opengeni.rules
       rules:
-        {{- if .Values.observability.prometheusRule.rules }}
-        {{- toYaml .Values.observability.prometheusRule.rules | nindent 8 }}
+        {{- if ((.Values.observability).prometheusRule).rules }}
+        {{- toYaml ((.Values.observability).prometheusRule).rules | nindent 8 }}
         {{- else }}
         - alert: OpenGeniTurnStuck
           expr: opengeni_turn_oldest_inflight_age_seconds > 900

--- a/deploy/helm/opengeni/templates/relay-service.yaml
+++ b/deploy/helm/opengeni/templates/relay-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
-  {{- if .Values.observability.metrics.enabled }}
+  {{- if ((.Values.observability).metrics).enabled }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"

--- a/deploy/helm/opengeni/templates/servicemonitor.yaml
+++ b/deploy/helm/opengeni/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.api.enabled .Values.observability.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and .Values.api.enabled ((.Values.observability).serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
-    {{- with .Values.observability.serviceMonitor.labels }}
+    {{- with ((.Values.observability).serviceMonitor).labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.observability.serviceMonitor.annotations }}
+  {{- with ((.Values.observability).serviceMonitor).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -20,11 +20,11 @@ spec:
       app.kubernetes.io/component: api
   endpoints:
     - port: http
-      path: {{ .Values.observability.metrics.path | quote }}
-      interval: {{ .Values.observability.serviceMonitor.interval | quote }}
-      scrapeTimeout: {{ .Values.observability.serviceMonitor.scrapeTimeout | quote }}
+      path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
+      interval: {{ ((.Values.observability).serviceMonitor).interval | default "30s" | quote }}
+      scrapeTimeout: {{ ((.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
 {{- end }}
-{{- if and .Values.worker.enabled .Values.observability.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and .Values.worker.enabled ((.Values.observability).serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -33,10 +33,10 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
-    {{- with .Values.observability.serviceMonitor.labels }}
+    {{- with ((.Values.observability).serviceMonitor).labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.observability.serviceMonitor.annotations }}
+  {{- with ((.Values.observability).serviceMonitor).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -47,11 +47,11 @@ spec:
       app.kubernetes.io/component: worker
   endpoints:
     - port: http
-      path: {{ .Values.observability.metrics.path | quote }}
-      interval: {{ .Values.observability.serviceMonitor.interval | quote }}
-      scrapeTimeout: {{ .Values.observability.serviceMonitor.scrapeTimeout | quote }}
+      path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
+      interval: {{ ((.Values.observability).serviceMonitor).interval | default "30s" | quote }}
+      scrapeTimeout: {{ ((.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
 {{- end }}
-{{- if and .Values.relay.enabled .Values.observability.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and .Values.relay.enabled ((.Values.observability).serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -60,10 +60,10 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
-    {{- with .Values.observability.serviceMonitor.labels }}
+    {{- with ((.Values.observability).serviceMonitor).labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.observability.serviceMonitor.annotations }}
+  {{- with ((.Values.observability).serviceMonitor).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -76,6 +76,6 @@ spec:
     # The relay exposes a Prometheus exposition at GET /metrics on the wss port.
     - port: wss
       path: /metrics
-      interval: {{ .Values.observability.serviceMonitor.interval | quote }}
-      scrapeTimeout: {{ .Values.observability.serviceMonitor.scrapeTimeout | quote }}
+      interval: {{ ((.Values.observability).serviceMonitor).interval | default "30s" | quote }}
+      scrapeTimeout: {{ ((.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/worker-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
         - name: worker
           image: {{ include "opengeni.image" (dict "root" . "image" .Values.worker.image) | quote }}
-          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          imagePullPolicy: {{ ((.Values.worker).image).pullPolicy }}
           securityContext:
             {{- toYaml .Values.worker.securityContext | nindent 12 }}
           {{- if .Values.worker.command }}
@@ -79,17 +79,17 @@ spec:
               value: {{ include "opengeni.minioInternalEndpoint" . | quote }}
             {{- end }}
             {{- end }}
-          {{- if .Values.worker.probes.readiness.enabled }}
+          {{- if (((.Values.worker).probes).readiness).enabled }}
           readinessProbe:
-            {{- include "opengeni.httpProbe" (dict "probe" .Values.worker.probes.readiness) | nindent 12 }}
+            {{- include "opengeni.httpProbe" (dict "probe" ((.Values.worker).probes).readiness) | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.probes.liveness.enabled }}
+          {{- if (((.Values.worker).probes).liveness).enabled }}
           livenessProbe:
-            {{- include "opengeni.httpProbe" (dict "probe" .Values.worker.probes.liveness) | nindent 12 }}
+            {{- include "opengeni.httpProbe" (dict "probe" ((.Values.worker).probes).liveness) | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
-      {{- if .Values.worker.topologySpreadConstraints.enabled }}
+      {{- if ((.Values.worker).topologySpreadConstraints).enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "worker" "values" .Values.worker) | nindent 8 }}
       {{- end }}

--- a/deploy/helm/opengeni/templates/worker-hpa.yaml
+++ b/deploy/helm/opengeni/templates/worker-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled }}
+{{- if and .Values.worker.enabled ((.Values.worker).autoscaling).enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -11,13 +11,13 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "opengeni.fullname" . }}-worker
-  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  minReplicas: {{ ((.Values.worker).autoscaling).minReplicas }}
+  maxReplicas: {{ ((.Values.worker).autoscaling).maxReplicas }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ ((.Values.worker).autoscaling).targetCPUUtilizationPercentage }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/worker-service.yaml
+++ b/deploy/helm/opengeni/templates/worker-service.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
-  {{- if .Values.observability.metrics.enabled }}
+  {{- if ((.Values.observability).metrics).enabled }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/path: {{ .Values.observability.metrics.path | quote }}
+    prometheus.io/path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
     prometheus.io/port: {{ (.Values.worker.service).port | default 8001 | quote }}
   {{- end }}
 spec:


### PR DESCRIPTION
helm upgrade --reuse-values renders new templates with the OLD stored values, ignoring new chart defaults — so every key introduced in #251 (observability.*, worker.probes.*, worker.service.*, etc.) nil-derefs one by one (#256 fixed one instance; the staging observability bootstrap then hit the next). This sweeps the whole chart with parenthesized nil-chains + scalar defaults, verified by rendering the new templates against the actual pre-#251 values.yaml with and without the observability flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upgrade-time rendering for observability and worker Kubernetes resources; mis-guarded paths could silently disable features or apply wrong defaults, but scope is template-only with no runtime app logic changes.
> 
> **Overview**
> Makes the **opengeni** Helm chart render when `helm upgrade --reuse-values` leaves out keys added in #251 (`observability.*`, `worker.probes.*`, `worker.service.*`, etc.), which previously caused template nil-dereference failures during upgrades.
> 
> Templates now use **parenthesized nil-chains** (e.g. `((.Values.observability).metrics).enabled`, `((.Values.worker).probes).readiness`) for conditionals and field access across observability (collector, OTEL, metrics, ServiceMonitor, PrometheusRule), worker (PDB, HPA, probes, topology spread, image pull policy), and related network policy / scrape annotations. **Scalar `default` filters** were added where missing values would produce bad manifests—e.g. metrics path `/metrics`, ServiceMonitor interval `30s` and scrape timeout `10s`, worker service port `8001`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8d44d07154f72a7f6932093c09478701d972d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->