### PR TITLE
docs/tests: use a neutral example MCP server id

### DIFF
--- a/docs/session-mcp-servers.md
+++ b/docs/session-mcp-servers.md
@@ -54,7 +54,7 @@ Credentials rotate through a `user.message` payload:
   "payload": {
     "text": "continue",
     "mcpCredentialUpdates": [
-      { "id": "peloton", "headers": { "Authorization": "Bearer ..." } }
+      { "id": "crm", "headers": { "Authorization": "Bearer ..." } }
     ]
   }
 }

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -44,11 +44,11 @@ describe("contracts", () => {
   test("accepts per-session MCP servers and credential rotations without response value echo", () => {
     const payload = CreateSessionRequest.parse({
       initialMessage: "inspect repo",
-      tools: [{ kind: "mcp", id: "peloton" }],
+      tools: [{ kind: "mcp", id: "crm" }],
       mcpServers: [{
-        id: "peloton",
-        name: "Peloton MCP",
-        url: "https://peloton.example/mcp",
+        id: "crm",
+        name: "CRM MCP",
+        url: "https://crm.example/mcp",
         allowedTools: ["workouts.list"],
         timeoutMs: 1500,
         cacheToolsList: false,
@@ -65,7 +65,7 @@ describe("contracts", () => {
       type: "user.message",
       payload: {
         text: "rotate",
-        mcpCredentialUpdates: [{ id: "peloton", headers: { Authorization: "Bearer rotated-secret" } }],
+        mcpCredentialUpdates: [{ id: "crm", headers: { Authorization: "Bearer rotated-secret" } }],
       },
     });
     expect(event.type).toBe("user.message");
@@ -75,16 +75,16 @@ describe("contracts", () => {
     expect(event.payload.mcpCredentialUpdates?.[0]?.headers.Authorization).toBe("Bearer rotated-secret");
 
     const metadata = SessionMcpServerMetadata.parse({
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization"],
       credentialVersion: 2,
     });
     expect(metadata).toEqual({
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization"],
       credentialVersion: 2,
     });

--- a/packages/db/test/event-payload-sanitizer.test.ts
+++ b/packages/db/test/event-payload-sanitizer.test.ts
@@ -116,12 +116,12 @@ describe("sanitizeEventPayload (deep walk)", () => {
   test("redacts session MCP credential header values to names", () => {
     const cleaned = sanitizeEventPayload({
       mcpServers: [{
-        id: "peloton",
-        url: "https://peloton.example/mcp",
+        id: "crm",
+        url: "https://crm.example/mcp",
         headers: { Authorization: "Bearer create-secret" },
       }],
       mcpCredentialUpdates: [{
-        id: "peloton",
+        id: "crm",
         headers: { Authorization: "Bearer rotated-secret", "X-Session": "turn-2" },
       }],
     }) as unknown as {
@@ -133,12 +133,12 @@ describe("sanitizeEventPayload (deep walk)", () => {
     expect(serialized).not.toContain("create-secret");
     expect(serialized).not.toContain("rotated-secret");
     expect(cleaned.mcpServers[0]).toEqual({
-      id: "peloton",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization"],
     });
     expect(cleaned.mcpCredentialUpdates[0]).toEqual({
-      id: "peloton",
+      id: "crm",
       headerNames: ["Authorization", "X-Session"],
     });
   });

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3902,13 +3902,13 @@ describe("API component integration", () => {
     const created = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
       method: "POST",
       body: JSON.stringify({
-        initialMessage: "use the peloton server",
+        initialMessage: "use the crm server",
         model: "scripted-model",
-        tools: [{ kind: "mcp", id: "peloton" }],
+        tools: [{ kind: "mcp", id: "crm" }],
         mcpServers: [{
-          id: "peloton",
-          name: "Peloton MCP",
-          url: "https://peloton.example/mcp",
+          id: "crm",
+          name: "CRM MCP",
+          url: "https://crm.example/mcp",
           allowedTools: ["workouts.list"],
           timeoutMs: 2500,
           cacheToolsList: false,
@@ -3925,11 +3925,11 @@ describe("API component integration", () => {
       tools: Array<{ kind: string; id: string }>;
       mcpServers: Array<{ id: string; name: string | null; url: string; headerNames: string[]; credentialVersion: number; headers?: unknown }>;
     };
-    expect(session.tools).toContainEqual({ kind: "mcp", id: "peloton" });
+    expect(session.tools).toContainEqual({ kind: "mcp", id: "crm" });
     expect(session.mcpServers).toEqual([{
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization"],
       credentialVersion: 1,
     }]);
@@ -3958,7 +3958,7 @@ describe("API component integration", () => {
         type: "user.message",
         payload: {
           text: "rotate then continue",
-          mcpCredentialUpdates: [{ id: "peloton", headers: { Authorization: rotatedSecret, "X-Turn": "2" } }],
+          mcpCredentialUpdates: [{ id: "crm", headers: { Authorization: rotatedSecret, "X-Turn": "2" } }],
         },
       }),
       headers: { "content-type": "application/json", authorization: attachAuth },
@@ -3968,9 +3968,9 @@ describe("API component integration", () => {
     expect(rotatedText).not.toContain(rotatedSecret);
     const accepted = JSON.parse(rotatedText) as { payload: { mcpCredentialUpdates?: Array<{ id: string; headerNames: string[]; credentialVersion: number; headers?: unknown }> } };
     expect(accepted.payload.mcpCredentialUpdates).toEqual([{
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization", "X-Turn"],
       credentialVersion: 2,
     }]);
@@ -4002,7 +4002,7 @@ describe("API component integration", () => {
       method: "POST",
       body: JSON.stringify({
         type: "user.message",
-        payload: { text: "denied rotate", mcpCredentialUpdates: [{ id: "peloton", headers: { Authorization: "Bearer denied" } }] },
+        payload: { text: "denied rotate", mcpCredentialUpdates: [{ id: "crm", headers: { Authorization: "Bearer denied" } }] },
       }),
       headers: { "content-type": "application/json", authorization: limitedAuth },
     });
@@ -4083,13 +4083,13 @@ describe("API component integration", () => {
     const created = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
       method: "POST",
       body: JSON.stringify({
-        initialMessage: "use the peloton server",
+        initialMessage: "use the crm server",
         model: "scripted-model",
-        tools: [{ kind: "mcp", id: "peloton" }],
+        tools: [{ kind: "mcp", id: "crm" }],
         mcpServers: [{
-          id: "peloton",
-          name: "Peloton MCP",
-          url: "https://peloton.example/mcp",
+          id: "crm",
+          name: "CRM MCP",
+          url: "https://crm.example/mcp",
           headers: { Authorization: createSecret, "X-Initial": "1" },
         }],
       }),
@@ -4114,7 +4114,7 @@ describe("API component integration", () => {
         type: "user.message",
         payload: {
           text: "rotate after cancellation",
-          mcpCredentialUpdates: [{ id: "peloton", headers: { Authorization: "Bearer rejected", "X-Initial": "2" } }],
+          mcpCredentialUpdates: [{ id: "crm", headers: { Authorization: "Bearer rejected", "X-Initial": "2" } }],
         },
       }),
       headers: { "content-type": "application/json", authorization: attachAuth },

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -107,9 +107,9 @@ describe("DB integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
       mcpServers: [{
-        id: "peloton",
-        name: "Peloton MCP",
-        url: "https://peloton.example/mcp",
+        id: "crm",
+        name: "CRM MCP",
+        url: "https://crm.example/mcp",
         allowedTools: ["workouts.list"],
         timeoutMs: 2500,
         cacheToolsList: true,
@@ -120,9 +120,9 @@ describe("DB integration", () => {
     });
 
     expect(session.mcpServers).toEqual([{
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization"],
       credentialVersion: 1,
     }]);
@@ -139,9 +139,9 @@ describe("DB integration", () => {
 
     const forRun = await listSessionMcpServersForRun(dbClient.db, grant.workspaceId, session.id, encryptionKey);
     expect(forRun).toEqual([{
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       allowedTools: ["workouts.list"],
       timeoutMs: 2500,
       cacheToolsList: true,
@@ -154,7 +154,7 @@ describe("DB integration", () => {
       workspaceId: grant.workspaceId,
       sessionId: session.id,
       updates: [{
-        id: "peloton",
+        id: "crm",
         headersEncrypted: {
           Authorization: encryptEnvironmentValue(encryptionKey, "Bearer rotated-secret"),
           "X-Session": encryptEnvironmentValue(encryptionKey, "turn-2"),
@@ -163,9 +163,9 @@ describe("DB integration", () => {
     });
     expect(rotated.missingIds).toEqual([]);
     expect(rotated.servers).toEqual([{
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       headerNames: ["Authorization", "X-Session"],
       credentialVersion: 2,
     }]);

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -122,14 +122,14 @@ describe("worker activities integration", () => {
     const session = await createOwnedSession(dbClient.db, grant, {
       initialMessage: "use session mcp",
       resources: [],
-      tools: [{ kind: "mcp", id: "peloton" }],
+      tools: [{ kind: "mcp", id: "crm" }],
       metadata: {},
       model: "scripted-model",
       sandboxBackend: "none",
       mcpServers: [{
-        id: "peloton",
-        name: "Peloton MCP",
-        url: "https://peloton.example/mcp",
+        id: "crm",
+        name: "CRM MCP",
+        url: "https://crm.example/mcp",
         allowedTools: ["workouts.list"],
         timeoutMs: 3000,
         cacheToolsList: false,
@@ -157,10 +157,10 @@ describe("worker activities integration", () => {
 
     await runtime.prepareTools(runSettings);
 
-    expect(preparedSettings?.mcpServers.find((server) => server.id === "peloton")).toEqual({
-      id: "peloton",
-      name: "Peloton MCP",
-      url: "https://peloton.example/mcp",
+    expect(preparedSettings?.mcpServers.find((server) => server.id === "crm")).toEqual({
+      id: "crm",
+      name: "CRM MCP",
+      url: "https://crm.example/mcp",
       allowedTools: ["workouts.list"],
       timeoutMs: 3000,
       cacheToolsList: false,


### PR DESCRIPTION
## Summary

- replace a project-specific MCP test fixture with a neutral example identifier
- preserve the existing contract, database, API, and worker coverage

## Verification

- focused contract and integration tests