### PR TITLE
fix(runtime): flag failed MCP tool calls with isError instead of a flat error string

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -43,6 +43,7 @@ import {
   type AgentInputItem,
   type CallModelInputFilter,
   type MCPServer,
+  type MCPToolErrorFunction,
   type Model,
   type ModelProvider,
   type RunStreamEvent,
@@ -918,6 +919,42 @@ const agentGitTokenSeed = new WeakMap<object, string>();
 // connected machines (a user's real computer).
 const agentActiveSandboxBackend = new WeakMap<object, Settings["sandboxBackend"]>();
 
+/**
+ * The tool output emitted for an MCP tool call that FAILED with a THROWN error
+ * — a JSON-RPC protocol error (e.g. -32602 invalid params), an auth 401/403, a
+ * transport failure, a timeout, or tool-not-found. Shaped as an MCP
+ * `{ isError: true, content }` result so the failure is CARRIED on the tool
+ * output rather than erased.
+ *
+ * The SDK's `defaultToolErrorFunction` would instead turn a thrown tool error
+ * into a plain STRING ("An error occurred while running the tool…") returned as
+ * a NORMAL, successful-looking result — so `agent.toolCall.output` carried no
+ * error signal and the timeline rendered the failure as success. `normalizeSdkEvent`
+ * captures `RunToolCallOutputItem.output` (the raw function return) verbatim, so
+ * returning this object makes the emitted payload's `output.isError === true`,
+ * which the timeline projection's `isErrorOutput` (packages/react/src/timeline/
+ * projection.ts) settles to "failed" and downstream client normalizers read the same field.
+ *
+ * SCOPE: this only covers THROWN MCP failures (the ones that reach an
+ * errorFunction). An MCP tool result carrying `isError: true` INLINE alongside
+ * content is stripped to its `content` by @openai/agents-core's streamable-http
+ * shim (dist/shims/mcp-server/node.js `callTool` returns `parsed.content`,
+ * dropping `parsed.isError`) BEFORE the runtime ever sees it. Covering that mode
+ * requires an SDK-level change (preserve `isError`) or reading the raw
+ * CallToolResult — tracked separately.
+ */
+export function mcpToolErrorOutput(error: unknown): { isError: true; content: [{ type: "text"; text: string }] } {
+  const details = error instanceof Error ? error.message : String(error);
+  return { isError: true, content: [{ type: "text", text: `An error occurred while running the tool. Please try again. Error: ${details}` }] };
+}
+
+// Applied to EVERY MCP server via the agent's `mcpConfig.errorFunction`
+// (server-level errorFunctions would win, but PrefixedMcpServer sets none). The
+// SDK types the return as `string`; the runtime actually stores the raw return
+// as the tool output, so we return the MCP-shaped error object and cast — this
+// is the only way to attach an `isError` flag to a failed MCP tool call's output.
+const mcpToolErrorFunction: MCPToolErrorFunction = ({ error }) => mcpToolErrorOutput(error) as unknown as string;
+
 export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[], options: BuildAgentOptions = {}): Agent<any, any> {
   // Resolved per-turn gating. Each override defaults to today's settings-derived
   // behaviour, so the legacy global-client callers (no resolved model) build the
@@ -993,6 +1030,13 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     // spread; the SDK concatenates these with MCP and sandbox capability tools.
     ...(hostedTools.length ? { tools: hostedTools } : {}),
     ...(options.mcpServers?.length ? { mcpServers: options.mcpServers } : {}),
+    // Surface FAILED MCP tool calls as `{ isError: true }` tool output (see
+    // mcpToolErrorFunction / mcpToolErrorOutput) instead of the SDK's default
+    // flat error string, so a thrown MCP failure (protocol error, auth, timeout,
+    // tool-not-found) settles the timeline tool to "failed" rather than rendering
+    // as success. Applies to every MCP server on this agent (session, first-party,
+    // capability, codex_apps) since none set a server-level errorFunction.
+    mcpConfig: { errorFunction: mcpToolErrorFunction },
   } as const;
 
   if (settings.sandboxBackend === "none") {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -253,6 +253,49 @@ describe("runtime event normalization", () => {
     test("MCP isError object output is unchanged", () => {
       const mcp = { isError: true, content: [{ type: "text", text: "delivery failed" }] };
       expect(normalizeToolOutputForEvent(mcp)).toEqual(mcp);
+    });
+  });
+
+  describe("failed MCP tool calls carry an isError flag", () => {
+    test("mcpToolErrorOutput shapes a thrown error as an MCP isError result", () => {
+      const out = mcpToolErrorOutput(new Error("MCP error -32602: Invalid params"));
+      expect(out.isError).toBe(true);
+      expect(out.content[0]?.text).toContain("-32602");
+      // Non-Error values stringify rather than throwing.
+      expect(mcpToolErrorOutput("boom").content[0]?.text).toContain("boom");
+    });
+
+    test("every agent gets an mcpConfig.errorFunction that produces isError output", () => {
+      // Both agent paths share baseConfig, so both carry the errorFunction.
+      for (const backend of ["none", "docker"] as const) {
+        const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: backend }), []);
+        const errorFunction = (agent as any).mcpConfig?.errorFunction as
+          | ((args: { context: unknown; error: unknown }) => unknown)
+          | undefined;
+        expect(typeof errorFunction).toBe("function");
+        // The runtime stores the raw return as the tool output; it must be an
+        // isError object (not the SDK's flat default string) so the timeline
+        // projection settles the tool to "failed".
+        const produced = errorFunction!({ context: {}, error: new Error("boom") });
+        expect((produced as { isError?: unknown }).isError).toBe(true);
+      }
+    });
+
+    test("an isError tool output survives normalizeSdkEvent as the event output", () => {
+      const errored = mcpToolErrorOutput(new Error("MCP error -32602: Invalid params"));
+      const [event] = normalizeSdkEvent({
+        type: "run_item_stream_event",
+        item: {
+          id: "item-err",
+          type: "tool_call_output_item",
+          rawItem: { callId: "call-err", type: "function_call_result" },
+          output: errored,
+        },
+      } as any);
+      expect(event?.type).toBe("agent.toolCall.output");
+      const payload = event?.payload as { id: string; output: { isError?: unknown } };
+      expect(payload.id).toBe("call-err");
+      expect(payload.output.isError).toBe(true);
     });
   });
 


### PR DESCRIPTION
A thrown MCP tool failure (JSON-RPC protocol error such as -32602 invalid params, auth 401/403, transport failure, timeout, tool-not-found) was converted by the SDK's `defaultToolErrorFunction` into a plain string returned as a normal-looking result, so `agent.toolCall.output` carried no error signal and timelines rendered the failure as success.

Sets the agent's `mcpConfig.errorFunction` (covers every MCP server on the agent — none set a server-level one) to return an MCP-shaped `{ isError: true, content }` result, which the timeline projection's `isErrorOutput` already understands.

Scope: thrown failures only. An MCP result carrying `isError: true` inline is stripped by the SDK's streamable-http shim before the runtime sees it; that needs an SDK-level fix and is out of scope here.

Tests: error-shape unit test, both agent build paths carry the errorFunction, and normalization pass-through.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized runtime/agent wiring and event-shape change with tests; no auth or data-model changes. Inline MCP `isError` stripping remains a known SDK gap.
> 
> **Overview**
> **Thrown MCP tool failures** (protocol errors, auth, transport, timeouts) were surfaced as a plain success-looking string via the SDK default `errorFunction`, so timelines treated them as successful tool calls.
> 
> The runtime adds **`mcpToolErrorOutput`** and wires **`mcpConfig.errorFunction`** on every agent built through `buildOpenGeniAgent` (sandbox and non-sandbox paths). Failed calls now return MCP-shaped **`{ isError: true, content }`**, which `normalizeSdkEvent` passes through and the timeline **`isErrorOutput`** logic already maps to **failed** status.
> 
> **Out of scope:** inline MCP results that already carry `isError` but are stripped by the SDK streamable-http shim before the runtime sees them.
> 
> Tests cover the error shape, both agent build backends, and event normalization pass-through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f912040f5bc67d4aebe663014818dcd0deba049b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->