### PR TITLE
feat(sessions): per-session-MCP-server human-approval policy (requireApproval)

### DIFF
--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -58,6 +58,7 @@ export function settingsWithSessionMcpServers(settings: Settings, servers: Sessi
         ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
         ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
         cacheToolsList: server.cacheToolsList ?? false,
+        ...(server.requireApproval !== undefined ? { requireApproval: server.requireApproval } : {}),
         headers: server.headers,
       })),
     ],

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -585,6 +585,14 @@ const SettingsSchema = z.object({
     timeoutMs: z.number().int().positive().optional(),
     cacheToolsList: z.boolean().default(false),
     /**
+     * Human-approval policy for this server's tools, overlaid per-run from a
+     * session MCP server row (never from OPENGENI_MCP_SERVERS). `true` = all
+     * tools require approval; a string[] = only the listed UNPREFIXED tool
+     * names do; absent = auto-run (the historical default). Enforced in the
+     * runtime by attaching `needsApproval` to the matching MCP tools.
+     */
+    requireApproval: z.union([z.boolean(), z.array(z.string().min(1))]).optional(),
+    /**
      * Extra request headers sent to this MCP server (credential injection
      * for workspace-enabled capability MCPs). Populated at runtime from
      * encrypted capability-installation credentials; do not put secrets in

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1367,6 +1367,12 @@ export const SessionMcpServerInput = z.object({
   allowedTools: z.array(z.string().min(1)).optional(),
   timeoutMs: z.number().int().positive().optional(),
   cacheToolsList: z.boolean().optional(),
+  // Human-approval policy for this server's tools. `true` = every tool of this
+  // server requires approval before it runs (a `session.requiresAction` pause
+  // the caller resolves with `user.approvalDecision`); a string[] = ONLY the
+  // listed UNPREFIXED tool names require approval (e.g. reads auto-run, writes
+  // ask); absent / `false` = auto-run everything (the historical default).
+  requireApproval: z.union([z.boolean(), z.array(z.string().min(1))]).optional(),
   // Write-only credential headers. Values are encrypted at rest and never
   // returned in session responses or events; response metadata exposes names.
   headers: z.record(z.string(), z.string()).optional(),

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -105,6 +105,7 @@ function mcpServerConfigFromInput(server: SessionMcpServerInput): Settings["mcpS
     ...(server.allowedTools ? { allowedTools: server.allowedTools } : {}),
     ...(server.timeoutMs ? { timeoutMs: server.timeoutMs } : {}),
     cacheToolsList: server.cacheToolsList ?? false,
+    ...(server.requireApproval !== undefined ? { requireApproval: server.requireApproval } : {}),
   };
 }
 
@@ -170,6 +171,7 @@ function validateSessionMcpServersForCreate(
       allowedTools: server.allowedTools ?? null,
       timeoutMs: server.timeoutMs ?? null,
       cacheToolsList: server.cacheToolsList ?? false,
+      requireApproval: server.requireApproval ?? null,
       headersEncrypted,
     });
     metadata.push({

--- a/packages/db/drizzle/0039_session_mcp_require_approval.sql
+++ b/packages/db/drizzle/0039_session_mcp_require_approval.sql
@@ -1,0 +1,7 @@
+-- 0039_session_mcp_require_approval.sql
+-- Per-session-MCP-server human-approval policy. jsonb holds either `true`
+-- (every tool of the server requires approval) or a JSON array of UNPREFIXED
+-- tool names (only those require it). NULL / absent = auto-run (the historical
+-- default), so this is additive and backfill-free.
+
+ALTER TABLE "session_mcp_servers" ADD COLUMN IF NOT EXISTS "require_approval" jsonb;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1209,6 +1209,7 @@ export type CreateSessionMcpServerInput = {
   allowedTools?: string[] | null;
   timeoutMs?: number | null;
   cacheToolsList?: boolean | null;
+  requireApproval?: boolean | string[] | null;
   headersEncrypted?: Record<string, string>;
 };
 
@@ -1226,6 +1227,7 @@ export type SessionMcpServerForRun = SessionMcpServerMetadata & {
   allowedTools?: string[];
   timeoutMs?: number;
   cacheToolsList?: boolean;
+  requireApproval?: boolean | string[];
   headers: Record<string, string>;
 };
 
@@ -3166,6 +3168,7 @@ async function insertSessionMcpServers(db: Database, input: {
     allowedTools: server.allowedTools ?? null,
     timeoutMs: server.timeoutMs ?? null,
     cacheToolsList: server.cacheToolsList ?? false,
+    requireApproval: server.requireApproval ?? null,
     headersEncrypted: server.headersEncrypted ?? {},
   }))).returning();
   return rows.map(mapSessionMcpServerMetadata);
@@ -3257,6 +3260,7 @@ export async function listSessionMcpServersForRun(
         ...(row.allowedTools ? { allowedTools: row.allowedTools } : {}),
         ...(row.timeoutMs ? { timeoutMs: row.timeoutMs } : {}),
         ...(row.cacheToolsList ? { cacheToolsList: row.cacheToolsList } : {}),
+        ...(row.requireApproval != null ? { requireApproval: row.requireApproval } : {}),
         headers,
       };
     });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -301,6 +301,9 @@ export const sessionMcpServers = pgTable("session_mcp_servers", {
   allowedTools: jsonb("allowed_tools").$type<string[]>(),
   timeoutMs: integer("timeout_ms"),
   cacheToolsList: boolean("cache_tools_list").notNull().default(false),
+  // Human-approval policy: `true` = every tool requires approval, a string[] of
+  // UNPREFIXED tool names = only those require it, null/absent = auto-run.
+  requireApproval: jsonb("require_approval").$type<boolean | string[]>(),
   // Map of header name -> AES-GCM ciphertext. Values are decrypted only by the
   // worker's run-preparation path and never returned by API helpers.
   headersEncrypted: jsonb("headers_encrypted").$type<Record<string, string>>().notNull().default({}),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -47,6 +47,7 @@ import {
   type Model,
   type ModelProvider,
   type RunStreamEvent,
+  type Tool,
 } from "@openai/agents";
 import {
   localDirLazySkillSource,
@@ -1101,29 +1102,35 @@ function mcpToolRequiresApproval(policy: boolean | string[], unprefixedName: str
   return policy === true || (Array.isArray(policy) && policy.includes(unprefixedName));
 }
 
+/** A per-server approval policy keyed by the server's `<id>__` tool prefix. */
+type McpApprovalPolicy = { prefix: string; requireApproval: boolean | string[] };
+
+/** The subset of the agent surface the approval wrap needs — including `clone`. */
+type ApprovalCapableAgent = {
+  getMcpTools: (runContext: unknown) => Promise<Tool<any>[]>;
+  clone?: (config: unknown) => ApprovalCapableAgent;
+};
+
 /**
- * Enforce per-MCP-server human approval. `settings.mcpServers[].requireApproval`
- * is `true` (every tool of that server requires approval) or a string[] of
- * UNPREFIXED tool names (only those do); absent = auto-run. The SDK converts MCP
- * tools to function tools with `needsApproval` unset (defaults false) and exposes
- * no per-server/agent approval knob, so we wrap the agent's `getMcpTools` to
- * attach a `needsApproval: () => true` predicate to the matching tools — matched
- * by the server's `<id>__` prefix, then the unprefixed tool name. A tool that
- * needs approval raises a run INTERRUPTION, which the worker turns into
- * `session.requiresAction` and resolves via `user.approvalDecision`
- * (resumeApproval) — the same generic path shell/computer-use approvals use, so
- * no extra plumbing. No-op when no server requests approval, so the default
- * (auto-run everything) is byte-for-byte unchanged.
+ * Install the approval wrap on a single agent instance: replace `getMcpTools`
+ * with one that stamps `needsApproval: () => true` on every MCP tool whose
+ * server policy demands it. Tools are matched by the server's `<id>__` prefix
+ * (LONGEST prefix first — see {@link applyMcpApprovalPolicy}), then the
+ * unprefixed tool name.
+ *
+ * CLONE SURVIVAL (mirrors {@link installCodexToolSearch}): the sandbox runtime
+ * resolves tools not on the agent we build here but on a FRESH clone —
+ * `prepareSandboxAgent` calls `agent.clone(...)`, and `SandboxAgent.clone`
+ * reconstructs from a FIXED field list (name/tools/mcpServers/…), so an
+ * instance-own `getMcpTools` override is dropped and approval would silently
+ * bypass on every sandbox turn. We therefore also wrap `clone` to RE-INSTALL the
+ * policy onto every clone, recursively — covering clone-of-clone and the resume
+ * paths. The base (non-sandbox) `Agent.clone` spreads `...this` and would carry
+ * the override, but re-installing is idempotent there and keeps one code path.
  */
-function applyMcpApprovalPolicy(agent: Agent<any, any>, settings: Settings): void {
-  const policies = settings.mcpServers
-    .filter((server) => server.requireApproval === true || (Array.isArray(server.requireApproval) && server.requireApproval.length > 0))
-    .map((server) => ({ prefix: prefixedMcpToolName(server.id, ""), requireApproval: server.requireApproval as boolean | string[] }));
-  if (policies.length === 0) {
-    return;
-  }
+function installMcpApprovalPolicy(agent: ApprovalCapableAgent, policies: McpApprovalPolicy[]): void {
   const listMcpTools = agent.getMcpTools.bind(agent);
-  agent.getMcpTools = async (runContext) => {
+  agent.getMcpTools = async (runContext: unknown) => {
     const tools = await listMcpTools(runContext);
     return tools.map((tool) => {
       if (tool.type !== "function") {
@@ -1139,6 +1146,50 @@ function applyMcpApprovalPolicy(agent: Agent<any, any>, settings: Settings): voi
         : tool;
     });
   };
+  const originalClone = agent.clone?.bind(agent);
+  if (originalClone) {
+    agent.clone = (config: unknown) => {
+      const cloned = originalClone(config);
+      installMcpApprovalPolicy(cloned, policies);
+      return cloned;
+    };
+  }
+}
+
+/**
+ * Enforce per-MCP-server human approval. `settings.mcpServers[].requireApproval`
+ * is `true` (every tool of that server requires approval) or a string[] of
+ * UNPREFIXED tool names (only those do); absent = auto-run. The SDK converts MCP
+ * tools to function tools with `needsApproval` unset (defaults false) and exposes
+ * no per-server/agent approval knob, so we wrap the agent's `getMcpTools` to
+ * attach a `needsApproval: () => true` predicate to the matching tools — matched
+ * by the server's `<id>__` prefix, then the unprefixed tool name. A tool that
+ * needs approval raises a run INTERRUPTION, which the worker turns into
+ * `session.requiresAction` and resolves via `user.approvalDecision`
+ * (resumeApproval) — the same generic path shell/computer-use approvals use, so
+ * no extra plumbing. No-op when no server requests approval, so the default
+ * (auto-run everything) is byte-for-byte unchanged.
+ *
+ * Two robustness properties the wrap must hold:
+ *  - LONGEST-PREFIX-FIRST. Server ids can be prefixes of one another (`my` vs
+ *    `my_`), so their tool prefixes collide (`my__` vs `my___`): a tool like
+ *    `my___run` (from server `my_`) also `startsWith` `my__` (server `my`). A
+ *    first-match `find` over unsorted policies could bind it to the WRONG
+ *    server's policy and bypass gating. Sorting policies by DESCENDING prefix
+ *    length makes the most-specific (longest) prefix win, so each tool resolves
+ *    to its own server.
+ *  - CLONE SURVIVAL. The wrap is re-installed onto every clone; see
+ *    {@link installMcpApprovalPolicy}.
+ */
+function applyMcpApprovalPolicy(agent: Agent<any, any>, settings: Settings): void {
+  const policies: McpApprovalPolicy[] = settings.mcpServers
+    .filter((server) => server.requireApproval === true || (Array.isArray(server.requireApproval) && server.requireApproval.length > 0))
+    .map((server) => ({ prefix: prefixedMcpToolName(server.id, ""), requireApproval: server.requireApproval as boolean | string[] }))
+    .sort((a, b) => b.prefix.length - a.prefix.length);
+  if (policies.length === 0) {
+    return;
+  }
+  installMcpApprovalPolicy(agent as unknown as ApprovalCapableAgent, policies);
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1042,6 +1042,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   if (settings.sandboxBackend === "none") {
     const agent = new Agent(baseConfig);
     maybeInstallCodexToolSearch(agent, settings, options);
+    applyMcpApprovalPolicy(agent, settings);
     return agent;
   }
 
@@ -1073,6 +1074,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     agentGitTokenSeed.set(agent, options.gitTokenSeed);
   }
   maybeInstallCodexToolSearch(agent, settings, options);
+  applyMcpApprovalPolicy(agent, settings);
   return agent;
 }
 
@@ -1092,6 +1094,51 @@ function maybeInstallCodexToolSearch(agent: Agent<any, any>, settings: Settings,
       options.codexConnectorNamespaces ?? new Set<string>(),
     );
   }
+}
+
+/** True when the unprefixed tool `name` requires approval under `policy`. */
+function mcpToolRequiresApproval(policy: boolean | string[], unprefixedName: string): boolean {
+  return policy === true || (Array.isArray(policy) && policy.includes(unprefixedName));
+}
+
+/**
+ * Enforce per-MCP-server human approval. `settings.mcpServers[].requireApproval`
+ * is `true` (every tool of that server requires approval) or a string[] of
+ * UNPREFIXED tool names (only those do); absent = auto-run. The SDK converts MCP
+ * tools to function tools with `needsApproval` unset (defaults false) and exposes
+ * no per-server/agent approval knob, so we wrap the agent's `getMcpTools` to
+ * attach a `needsApproval: () => true` predicate to the matching tools — matched
+ * by the server's `<id>__` prefix, then the unprefixed tool name. A tool that
+ * needs approval raises a run INTERRUPTION, which the worker turns into
+ * `session.requiresAction` and resolves via `user.approvalDecision`
+ * (resumeApproval) — the same generic path shell/computer-use approvals use, so
+ * no extra plumbing. No-op when no server requests approval, so the default
+ * (auto-run everything) is byte-for-byte unchanged.
+ */
+function applyMcpApprovalPolicy(agent: Agent<any, any>, settings: Settings): void {
+  const policies = settings.mcpServers
+    .filter((server) => server.requireApproval === true || (Array.isArray(server.requireApproval) && server.requireApproval.length > 0))
+    .map((server) => ({ prefix: prefixedMcpToolName(server.id, ""), requireApproval: server.requireApproval as boolean | string[] }));
+  if (policies.length === 0) {
+    return;
+  }
+  const listMcpTools = agent.getMcpTools.bind(agent);
+  agent.getMcpTools = async (runContext) => {
+    const tools = await listMcpTools(runContext);
+    return tools.map((tool) => {
+      if (tool.type !== "function") {
+        return tool;
+      }
+      const policy = policies.find((entry) => tool.name.startsWith(entry.prefix));
+      if (!policy) {
+        return tool;
+      }
+      const unprefixed = tool.name.slice(policy.prefix.length);
+      return mcpToolRequiresApproval(policy.requireApproval, unprefixed)
+        ? { ...tool, needsApproval: async () => true }
+        : tool;
+    });
+  };
 }
 
 /**

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -300,6 +300,21 @@ describe("runtime event normalization", () => {
   });
 
   describe("per-MCP-server tool approval policy", () => {
+    type ApprovalAgent = { getMcpTools: (runContext: RunContext) => Promise<Awaited<ReturnType<typeof getAllMcpTools>>> };
+
+    // Resolves an agent's MCP tools and reports which prefixed tool names need
+    // approval (invoking each tool's needsApproval predicate).
+    async function approvalMapForAgent(agent: ApprovalAgent): Promise<Record<string, boolean>> {
+      const tools = await agent.getMcpTools(new RunContext());
+      const entries = await Promise.all(tools.map(async (tool) => {
+        const needs = tool.type === "function"
+          ? Boolean(await (tool.needsApproval as (rc: unknown, input: unknown, details: unknown) => boolean | Promise<boolean>)(new RunContext(), "{}", {}))
+          : false;
+        return [tool.name, needs] as const;
+      }));
+      return Object.fromEntries(entries);
+    }
+
     // Builds an agent with a real test MCP server ("docs": search_documents +
     // fetch_document) under the given requireApproval policy, then resolves the
     // agent's MCP tools and reports which prefixed tool names need approval.
@@ -319,14 +334,7 @@ describe("runtime event normalization", () => {
           [],
           { mcpServers: prepared.mcpServers },
         );
-        const tools = await agent.getMcpTools(new RunContext());
-        const entries = await Promise.all(tools.map(async (tool) => {
-          const needs = tool.type === "function"
-            ? Boolean(await (tool.needsApproval as (rc: unknown, input: unknown, details: unknown) => boolean | Promise<boolean>)(new RunContext(), "{}", {}))
-            : false;
-          return [tool.name, needs] as const;
-        }));
-        return Object.fromEntries(entries);
+        return await approvalMapForAgent(agent);
       } finally {
         await prepared.close();
         mcp.close();
@@ -346,6 +354,64 @@ describe("runtime event normalization", () => {
     test("requireApproval absent → nothing needs approval (historical default)", async () => {
       const map = await mcpToolApprovalMap(undefined);
       expect(map).toEqual({ docs__search_documents: false, docs__fetch_document: false });
+    });
+
+    test("requireApproval survives the sandbox clone() tool-resolution path", async () => {
+      const mcp = startTestMcpServer();
+      const serverConfig = { id: "docs", name: "Document Search", url: mcp.url, cacheToolsList: false, requireApproval: true as const };
+      const prepared = await prepareAgentTools(testSettings({ mcpServers: [serverConfig] }), [{ kind: "mcp", id: "docs" }]);
+      try {
+        const agent = buildOpenGeniAgent(
+          // Sandbox backend → a SandboxAgent, whose tools are resolved on a fresh
+          // clone (prepareSandboxAgent), NOT on this instance.
+          testSettings({ sandboxBackend: "modal", mcpServers: [serverConfig] }),
+          [],
+          { mcpServers: prepared.mcpServers },
+        );
+        // Mirror the sandbox runtime: it calls agent.clone(...) and resolves tools
+        // on the CLONE. SandboxAgent.clone reconstructs from a fixed field list, so
+        // an instance-own getMcpTools override is dropped — approval must be
+        // re-installed onto the clone or it silently bypasses on every sandbox turn.
+        const clone = (agent as unknown as { clone: (config: unknown) => ApprovalAgent }).clone({});
+        expect(await approvalMapForAgent(clone)).toEqual({ docs__search_documents: true, docs__fetch_document: true });
+        // clone-of-clone (resume paths) must keep the policy too.
+        const grandchild = (clone as unknown as { clone: (config: unknown) => ApprovalAgent }).clone({});
+        expect(await approvalMapForAgent(grandchild)).toEqual({ docs__search_documents: true, docs__fetch_document: true });
+      } finally {
+        await prepared.close();
+        mcp.close();
+      }
+    });
+
+    test("prefix-colliding server ids resolve each tool to ITS OWN server's policy", async () => {
+      const outer = startTestMcpServer();
+      const inner = startTestMcpServer();
+      // Server ids where one is a prefix of the other, so their tool prefixes
+      // collide: `my__` (outer) is a prefix of `my___` (inner). A tool like
+      // `my___fetch_document` (inner) also startsWith `my__` (outer).
+      const outerConfig = { id: "my", name: "Outer", url: outer.url, cacheToolsList: false, requireApproval: ["search_documents"] };
+      const innerConfig = { id: "my_", name: "Inner", url: inner.url, cacheToolsList: false, requireApproval: true as const };
+      // Order [outer, inner] puts the SHORTER (colliding) prefix first, so a
+      // first-match find over UNSORTED policies would mis-bind inner's tools to
+      // outer's narrower policy and bypass gating on my___fetch_document.
+      const settings = testSettings({ sandboxBackend: "none", mcpServers: [outerConfig, innerConfig] });
+      const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "my" }, { kind: "mcp", id: "my_" }]);
+      try {
+        const agent = buildOpenGeniAgent(settings, [], { mcpServers: prepared.mcpServers });
+        expect(await approvalMapForAgent(agent)).toEqual({
+          // outer ("my"): only search_documents is gated.
+          my__search_documents: true,
+          my__fetch_document: false,
+          // inner ("my_"): ALL tools gated — must NOT inherit outer's narrower
+          // policy via the colliding prefix.
+          my___search_documents: true,
+          my___fetch_document: true,
+        });
+      } finally {
+        await prepared.close();
+        outer.close();
+        inner.close();
+      }
     });
   });
 

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
+import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunContext, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
 import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER } from "../src/index";
@@ -296,6 +296,56 @@ describe("runtime event normalization", () => {
       const payload = event?.payload as { id: string; output: { isError?: unknown } };
       expect(payload.id).toBe("call-err");
       expect(payload.output.isError).toBe(true);
+    });
+  });
+
+  describe("per-MCP-server tool approval policy", () => {
+    // Builds an agent with a real test MCP server ("docs": search_documents +
+    // fetch_document) under the given requireApproval policy, then resolves the
+    // agent's MCP tools and reports which prefixed tool names need approval.
+    async function mcpToolApprovalMap(requireApproval: boolean | string[] | undefined): Promise<Record<string, boolean>> {
+      const mcp = startTestMcpServer();
+      const serverConfig = {
+        id: "docs",
+        name: "Document Search",
+        url: mcp.url,
+        cacheToolsList: false,
+        ...(requireApproval !== undefined ? { requireApproval } : {}),
+      };
+      const prepared = await prepareAgentTools(testSettings({ mcpServers: [serverConfig] }), [{ kind: "mcp", id: "docs" }]);
+      try {
+        const agent = buildOpenGeniAgent(
+          testSettings({ sandboxBackend: "none", mcpServers: [serverConfig] }),
+          [],
+          { mcpServers: prepared.mcpServers },
+        );
+        const tools = await agent.getMcpTools(new RunContext());
+        const entries = await Promise.all(tools.map(async (tool) => {
+          const needs = tool.type === "function"
+            ? Boolean(await (tool.needsApproval as (rc: unknown, input: unknown, details: unknown) => boolean | Promise<boolean>)(new RunContext(), "{}", {}))
+            : false;
+          return [tool.name, needs] as const;
+        }));
+        return Object.fromEntries(entries);
+      } finally {
+        await prepared.close();
+        mcp.close();
+      }
+    }
+
+    test("requireApproval: true → every tool of the server needs approval", async () => {
+      const map = await mcpToolApprovalMap(true);
+      expect(map).toEqual({ docs__search_documents: true, docs__fetch_document: true });
+    });
+
+    test("requireApproval: string[] → only the listed unprefixed tool needs approval", async () => {
+      const map = await mcpToolApprovalMap(["fetch_document"]);
+      expect(map).toEqual({ docs__search_documents: false, docs__fetch_document: true });
+    });
+
+    test("requireApproval absent → nothing needs approval (historical default)", async () => {
+      const map = await mcpToolApprovalMap(undefined);
+      expect(map).toEqual({ docs__search_documents: false, docs__fetch_document: false });
     });
   });
 

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -168,6 +168,94 @@ describe("worker activities integration", () => {
     });
   });
 
+  test("a requireApproval session MCP tool pauses for approval and resumes on approve", async () => {
+    // End-to-end through the GENERIC interruption loop: a session MCP server with
+    // requireApproval:true makes its tool raise a run interruption, which the
+    // worker turns into session.requiresAction (tool NOT yet executed); a
+    // user.approvalDecision:approve then resumes the saved run state and the tool
+    // finally runs.
+    const encryptionKey = Buffer.alloc(32, 5);
+    const mcp = startTestMcpServer();
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      natsUrl: services.natsUrl,
+      environmentsEncryptionKey: encryptionKey.toString("base64"),
+    });
+    try {
+      const grant = await testGrant(dbClient.db);
+      const session = await createOwnedSession(dbClient.db, grant, {
+        initialMessage: "search please",
+        resources: [],
+        tools: [{ kind: "mcp", id: "crm" }],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        mcpServers: [{
+          id: "crm",
+          name: "CRM",
+          url: mcp.url,
+          cacheToolsList: false,
+          requireApproval: true,
+          headersEncrypted: {},
+        }],
+      });
+      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+        { type: "user.message", payload: { text: "search please" } },
+      ]);
+      const model = new ScriptedModel([
+        { id: "approval-call-1", output: [functionCall("crm__search_documents", { query: "network policy" }, "call-appr-1")] },
+        { id: "approval-call-2", outputText: "found it", chunks: ["found ", "it"] },
+      ]);
+      const activities = createActivities({
+        settings,
+        db: dbClient.db,
+        bus,
+        runtime: createProductionAgentRuntime({ model }),
+      });
+
+      // Turn 1: the tool call is gated — the turn pauses instead of running it.
+      const first = await activities.runAgentTurn({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: trigger!.id,
+        workflowId: "workflow-mcp-approval",
+      });
+      expect(first.status).toBe("requires_action");
+      const afterFirst = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
+      expect(afterFirst.some((event) => event.type === "session.requiresAction")).toBe(true);
+      expect(latestStatus(afterFirst)).toBe("requires_action");
+      // The MCP tool did NOT execute while approval is pending.
+      expect(mcp.calls).toEqual([]);
+
+      const activeTurnId = (await getSession(dbClient.db, grant.workspaceId, session.id))?.activeTurnId;
+      expect(activeTurnId).toBeTruthy();
+
+      // Turn 2: approve → the saved run resumes and the tool finally runs.
+      const [approvalTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+        { type: "user.approvalDecision", payload: { approvalId: "call-appr-1", decision: "approve" } },
+      ]);
+      const second = await activities.runAgentTurn({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        sessionId: session.id,
+        triggerEventId: approvalTrigger!.id,
+        // Distinct workflowId so the resume's event producerId
+        // (`${workflowId}:${turnId}`) does not collide with turn 1's — the real
+        // system disambiguates via the Temporal activityId, which is absent here.
+        workflowId: "workflow-mcp-approval-resume",
+        turnId: activeTurnId!,
+      });
+      expect(second.status).toBe("idle");
+      expect(mcp.calls).toEqual([{ tool: "search_documents", args: { query: "network policy" } }]);
+      const afterSecond = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
+      expect(afterSecond.some((event) => event.type === "turn.completed")).toBe(true);
+      expect(latestStatus(afterSecond)).toBe("idle");
+    } finally {
+      mcp.close();
+    }
+  });
+
   test("manager session's first-party MCP token carries its granted permissions end to end", async () => {
     // A manager-style session (created with firstPartyMcpPermissions) calls
     // the workspace-orchestration tools through its own first-party MCP


### PR DESCRIPTION
Session MCP servers currently auto-execute every tool. This adds an opt-in human-in-the-loop approval policy per server: `requireApproval?: boolean | string[]` on `SessionMcpServerInput` — `true` gates every tool of that server; a string[] gates only the listed (unprefixed) tool names; absent/false keeps today's auto-run behavior byte-for-byte.

Wiring: contracts (zod union) → nullable jsonb `session_mcp_servers.require_approval` (additive migration 0039) → `SessionMcpServerForRun` → worker settings overlay → runtime: `buildOpenGeniAgent` wraps `getMcpTools` to attach `needsApproval: () => true` to matching tools (matched by the server's `<id>__` prefix, then unprefixed name), on both agent paths. Approval-required tools raise the existing run interruption, flowing through the established `session.requiresAction` → `user.approvalDecision` → resume loop — zero new plumbing. The field is not exposed in `SessionMcpServerMetadata`, so it never leaks into session events.

Independent of #<error-flag-PR>. Tests: policy unit tests (boolean → all, list → only listed, absent → none) and an integration test proving pause → approve → resume with the tool executing only after approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent turn behavior for sessions that set the flag (tool execution timing and interruption handling); default sessions are unchanged, but misconfigured policies or prefix collisions could gate the wrong tools until caught by tests.
> 
> **Overview**
> **Per-session MCP servers can opt into human approval before tools run** via new `requireApproval?: boolean | string[]` on session MCP input (`true` = all tools; string[] = listed unprefixed names only; unset = unchanged auto-run).
> 
> The field is validated in contracts/config, stored as nullable `require_approval` jsonb (migration 0039), loaded on runs, and overlaid into worker `mcpServers` settings. **Runtime** `buildOpenGeniAgent` wraps `getMcpTools` to set `needsApproval` on gated tools (longest `<id>__` prefix wins; policy survives `clone()` for sandbox turns), reusing **`session.requiresAction` → `user.approvalDecision`** with no new worker plumbing.
> 
> Unit and integration tests cover policy mapping, prefix collisions, clone survival, and pause → approve → execute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8b94777409e97b7a5bd19fd6e2371083cd5e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->