### PR TITLE
feat(react): fold completed clusters of a running turn behind neutral chips

### DIFF
--- a/.changeset/live-turn-cluster-fold.md
+++ b/.changeset/live-turn-cluster-fold.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Completed activity clusters of a still-running turn now fold behind neutral chips (facets + a quiet pulse dot; no verdict glyph — the turn has none yet), keeping only the live tail expanded. This bounds the DOM of very long autonomous turns the same way settled folding bounds history; on settle, everything collapses into the single turn fold as before. TurnSummary's `outcome` prop is now optional (absent = in-progress cluster).

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -279,13 +279,14 @@ export function MessageTimeline({
               <span className="og-shimmer-text font-medium">Loading earlier activity…</span>
             </div>
           ) : null}
-          {groups.map((group) => (
+          {groups.map((group, index) => (
             <TimelineGroupView
               key={timelineGroupKey(group)}
               group={group}
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
               toolRegistry={toolRegistry}
+              foldLiveCluster={index < groups.length - 1}
             />
           ))}
           {working ? (
@@ -350,11 +351,16 @@ function TimelineGroupView({
   onOpenSession,
   toolRegistry,
   insideTurn = false,
+  foldLiveCluster = false,
 }: {
   group: TimelineGroup;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
   toolRegistry: ToolRegistry;
+  /** A completed cluster of a still-RUNNING turn (not the live tail) folds
+      behind a neutral chip — the one place activity without an outcome still
+      folds, bounding the DOM of days-long autonomous turns. */
+  foldLiveCluster?: boolean;
   /** Rendering inside an expanded turn group: the outer chip already owns the
       failure surface, so nested chips stay tinted but quiet (no repeated
       failure text, no auto-open) — one loud error, N calm sub-expands. */
@@ -362,7 +368,7 @@ function TimelineGroupView({
 }) {
   switch (group.kind) {
     case "activity":
-      return group.outcome ? (
+      return group.outcome || foldLiveCluster ? (
         <TurnSummary
           items={group.items}
           outcome={group.outcome}

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -24,7 +24,12 @@ export type { TurnOutcome } from "./types";
 export type TurnSummaryProps = {
   /** The activity items in the turn (used only to compute the facet counts). */
   items: ActivityItem[];
-  outcome: TurnOutcome;
+  /**
+   * The settled verdict — or absent for a completed CLUSTER of a still-running
+   * turn, which folds neutrally: no verdict glyph (the turn has none yet), a
+   * quiet pulse dot in its place so alignment and the running feel both hold.
+   */
+  outcome?: TurnOutcome | undefined;
   /** A short failure reason shown inline on a failed chip (never hidden). */
   failureText?: string | undefined;
   /** Elapsed turn duration; shown as a trailing facet when at least 1s. */
@@ -78,8 +83,10 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
             <TriangleAlertIcon className="size-3" />
           ) : outcome === "cancelled" ? (
             <CircleSlashIcon className="size-3" />
-          ) : (
+          ) : outcome === "complete" ? (
             <CheckIcon className="size-3.5" />
+          ) : (
+            <span className="size-1.5 animate-og-pulse rounded-full bg-og-fg-subtle" />
           )}
         </span>
         <span className="min-w-0 flex-1 truncate text-og-fg-muted">

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -204,6 +204,59 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
+  test("completed clusters of a RUNNING turn fold behind neutral chips; the live tail stays bare", async () => {
+    resetTimelineEvents();
+    const events = [
+      timelineEvent("user.message", { text: "Do a long job" }),
+      timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "step one" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      timelineEvent("agent.message.delta", { text: "Step one done, moving on." }),
+      timelineEvent("agent.message.completed", { text: "Step one done, moving on." }),
+      timelineEvent("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "step two" } }),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} status="running" />);
+    await flush();
+
+    const triggers = turnSummaryTriggers(r.container);
+    // Exactly ONE chip: the completed first cluster. It is NEUTRAL — no verdict
+    // glyph (chevron is the only svg; the slot holds the pulse dot span).
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.querySelectorAll("svg")).toHaveLength(1);
+    expect(triggers[0]?.querySelector(".animate-og-pulse")).not.toBeNull();
+    // The live tail cluster renders bare: its command is visible without expanding.
+    expect(r.container.textContent).toContain("step two");
+    // The folded cluster's contents are NOT in the DOM until expanded.
+    expect(r.container.textContent).not.toContain("step one");
+
+    await r.unmount();
+  });
+
+  test("when the running turn settles, live-cluster chips give way to the single turn fold", async () => {
+    resetTimelineEvents();
+    const events = [
+      timelineEvent("user.message", { text: "Do a long job" }),
+      timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "step one" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      timelineEvent("agent.message.delta", { text: "Step one done, moving on." }),
+      timelineEvent("agent.message.completed", { text: "Step one done, moving on." }),
+      timelineEvent("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "step two" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-2", output: "ok" }),
+      timelineEvent("agent.message.completed", { text: "All finished." }),
+      timelineEvent("turn.completed", {}),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+
+    const triggers = turnSummaryTriggers(r.container);
+    // One settled OUTER chip (check glyph present: chevron + check = 2 svgs);
+    // the final answer sits outside it.
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.querySelectorAll("svg")).toHaveLength(2);
+    expect(r.container.textContent).toContain("All finished.");
+
+    await r.unmount();
+  });
+
   test("nested chips inside a failed turn stay quiet — the outer chip owns the failure", async () => {
     resetTimelineEvents();
     const events = [


### PR DESCRIPTION
The last unbounded-DOM path: live turns never fold, so a **days-long autonomous turn** rendered every past cluster unfolded (turns aren't a unit of size — one turn can be a week of work). Now:

- Every **completed** activity cluster of a running turn folds behind a **neutral** chip — facet counts plus a quiet pulse dot in the verdict slot (no check/fail glyph: the turn has no verdict yet). Same disclosure grammar, same alignment as settled chips.
- The **live tail** cluster stays expanded — the streaming action remains visible exactly as today.
- On settle, everything collapses into the single turn fold as before; nested behavior inside turn groups is unchanged.

Mechanics: `TurnSummary.outcome` becomes optional (absent = in-progress cluster); the fold rule lives at the render layer — an outcome-less activity group folds unless it is the timeline's last group. The projection is untouched (**golden suite passes unchanged**), and folded clusters unmount their contents, so a very long running turn's DOM stays bounded the same way history does.

422 tests green (new coverage: neutral glyph assertions, folded-contents-out-of-DOM, live tail bare, settle→single fold); tsc + build clean. Live mid-turn verification on staging follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-layer timeline folding only; timeline projection is unchanged and behavior is covered by new tests.
> 
> **Overview**
> **Long-running turns** no longer keep every past activity cluster expanded in the DOM. `MessageTimeline` passes `foldLiveCluster` for every timeline group except the **last** (the live tail), and `TimelineGroupView` wraps those outcome-less activity clusters in `TurnSummary` the same way settled turns do—so older steps collapse behind chips while the current cluster stays bare.
> 
> `TurnSummary` now accepts an **optional** `outcome`. When it is missing (in-progress cluster chip), the verdict slot shows a **pulse dot** instead of check/fail/cancel icons; facet text and disclosure behavior stay the same. On `turn.completed`, the existing single outer turn fold is unchanged.
> 
> New integration tests cover neutral chips, folded content unmounted until expand, live tail visibility, and settle → one chip with check glyph. Minor `@opengeni/react` changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27818314c67eaaa43afb89727a07c0e7d05225c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->