### PR TITLE
chore(agent): bump agent workspace version to 0.1.4

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "image",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "prost-build",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "blake3",
  "hex",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the 0.1.4 agent release: capability preflight (#250) + macOS capture retry; first Developer-ID-signed + notarized release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or logic changes in the diff.
> 
> **Overview**
> Bumps the agent Rust workspace release from **0.1.3** to **0.1.4** by updating `[workspace.package].version` in `agent/Cargo.toml` and the matching `opengeni-*` crate entries in `agent/Cargo.lock` (agent, platform, proto, stream, update, macOS FFI).
> 
> There are no source or behavior changes in this diff—only version metadata for the 0.1.4 release cut described in the PR (capability preflight, macOS capture retry, signed/notarized builds landed elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481b60ae19ae04e4764e8eb79bdff38920a3335f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->