### PR TITLE
fix: fresh-eyes review — sandbox chunk payloads end-to-end + live-fold invariants

### DIFF
--- a/.changeset/never-fold-running-cluster.md
+++ b/.changeset/never-fold-running-cluster.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+A cluster containing a running or streaming item can never fold — the live-cluster fold rule was position-based ("not the last group"), which wrongly folded the actively-streaming cluster when a pending queued message rendered at the timeline tail.

--- a/.changeset/never-fold-running-cluster.md
+++ b/.changeset/never-fold-running-cluster.md
@@ -1,5 +1,6 @@
 ---
 "@opengeni/react": patch
+"@opengeni/events": patch
 ---
 
-A cluster containing a running or streaming item can never fold — the live-cluster fold rule was position-based ("not the last group"), which wrongly folded the actively-streaming cluster when a pending queued message rendered at the timeline tail.
+Fresh-eyes review fixes: sandbox command output uses its canonical `chunk` wire field end-to-end — the projection and the compact coalescer previously read only legacy `text`/`output`, so compact history windows dropped terminal output entirely (and the resume cursor skipped the raw events that carried it); coalesced sandbox runs now also break on stream and commandId so stdout/stderr never merge. Live-cluster folding is re-based on the true invariants: a cluster with running/streaming items never folds, and folding happens only when the NEXT group is agent progress (activity/turn/narration) — so a pending queued message or an approval pause no longer folds the work the reader needs in view.

--- a/packages/events/src/coalesce.ts
+++ b/packages/events/src/coalesce.ts
@@ -11,6 +11,8 @@ type DeltaRun = {
   lastSequence: number;
   text: string;
   sandboxName: string | undefined;
+  sandboxStream: string | undefined;
+  sandboxCommandId: string | undefined;
 };
 
 export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent[] {
@@ -23,13 +25,20 @@ export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent
     }
     coalesced.push({
       ...run.first,
-      payload: {
-        text: run.text,
-        coalescedUntil: run.lastSequence,
-        ...(run.first.type === "sandbox.command.output.delta" && run.sandboxName !== undefined
-          ? { name: run.sandboxName }
-          : {}),
-      },
+      payload: run.first.type === "sandbox.command.output.delta"
+        // Sandbox output keeps its CANONICAL field (`chunk` — the terminal and
+        // projection read it) plus the stream/commandId identity of the run.
+        ? {
+            chunk: run.text,
+            coalescedUntil: run.lastSequence,
+            ...(run.sandboxStream !== undefined ? { stream: run.sandboxStream } : {}),
+            ...(run.sandboxCommandId !== undefined ? { commandId: run.sandboxCommandId } : {}),
+            ...(run.sandboxName !== undefined ? { name: run.sandboxName } : {}),
+          }
+        : {
+            text: run.text,
+            coalescedUntil: run.lastSequence,
+          },
     });
     run = null;
   };
@@ -41,8 +50,16 @@ export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent
       continue;
     }
 
-    const sandboxName = event.type === "sandbox.command.output.delta" ? sandboxDeltaName(event.payload) : undefined;
-    if (run && sameDeltaRun(run.first, event, run.sandboxName, sandboxName)) {
+    const isSandbox = event.type === "sandbox.command.output.delta";
+    const sandboxName = isSandbox ? sandboxDeltaName(event.payload) : undefined;
+    const sandboxStream = isSandbox ? sandboxDeltaString(event.payload, "stream") : undefined;
+    const sandboxCommandId = isSandbox ? sandboxDeltaString(event.payload, "commandId") : undefined;
+    if (
+      run
+      && sameDeltaRun(run.first, event, run.sandboxName, sandboxName)
+      && run.sandboxStream === sandboxStream
+      && run.sandboxCommandId === sandboxCommandId
+    ) {
       run.text += deltaText(event);
       run.lastSequence = event.sequence;
       continue;
@@ -54,6 +71,8 @@ export function coalesceSessionEventDeltas(events: SessionEvent[]): SessionEvent
       lastSequence: event.sequence,
       text: deltaText(event),
       sandboxName,
+      sandboxStream,
+      sandboxCommandId,
     };
   }
 
@@ -86,7 +105,14 @@ function deltaText(event: SessionEvent): string {
   }
   const payload = asRecord(event.payload);
   if (event.type === "sandbox.command.output.delta") {
-    return typeof payload.text === "string" ? payload.text : typeof payload.output === "string" ? payload.output : "";
+    // `chunk` is the canonical wire field (contracts SandboxCommandOutputDeltaPayload);
+    // text/output are tolerated legacy shapes.
+    for (const key of ["chunk", "text", "output"] as const) {
+      if (typeof payload[key] === "string") {
+        return payload[key] as string;
+      }
+    }
+    return "";
   }
   return typeof payload.text === "string" ? payload.text : "";
 }
@@ -111,6 +137,11 @@ function reasoningText(payload: unknown): string {
 function sandboxDeltaName(payload: unknown): string | undefined {
   const name = asRecord(payload).name;
   return typeof name === "string" ? name : undefined;
+}
+
+function sandboxDeltaString(payload: unknown, key: "stream" | "commandId"): string | undefined {
+  const value = asRecord(payload)[key];
+  return typeof value === "string" ? value : undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/packages/events/test/coalesce.test.ts
+++ b/packages/events/test/coalesce.test.ts
@@ -83,18 +83,26 @@ describe("coalesceSessionEventDeltas", () => {
     ]);
   });
 
-  test("starts a new sandbox output run when the command name changes", () => {
+  test("coalesces sandbox chunk runs and breaks on name, stream, and commandId", () => {
+    // The CANONICAL wire shape (contracts SandboxCommandOutputDeltaPayload):
+    // { stream, chunk, commandId?, seq? }. text/output are legacy-tolerated.
     const result = coalesceSessionEventDeltas([
-      event(1, "sandbox.command.output.delta", { name: "build", text: "one\n" }),
-      event(2, "sandbox.command.output.delta", { name: "build", output: "two\n" }),
-      event(3, "sandbox.command.output.delta", { name: "test", text: "ok\n" }),
-      event(4, "sandbox.command.output.delta", { text: "unnamed\n" }),
+      event(1, "sandbox.command.output.delta", { stream: "stdout", chunk: "one\n", commandId: "cmd-1" }),
+      event(2, "sandbox.command.output.delta", { stream: "stdout", chunk: "two\n", commandId: "cmd-1" }),
+      // stderr of the SAME command must not merge into the stdout run.
+      event(3, "sandbox.command.output.delta", { stream: "stderr", chunk: "warn\n", commandId: "cmd-1" }),
+      // A new command starts a new run even on the same stream.
+      event(4, "sandbox.command.output.delta", { stream: "stdout", chunk: "next\n", commandId: "cmd-2" }),
+      // Legacy shapes still coalesce (text/output fallbacks).
+      event(5, "sandbox.command.output.delta", { name: "build", text: "legacy\n" }),
+      event(6, "sandbox.command.output.delta", { name: "build", output: "older\n" }),
     ]);
 
     expect(result.map((item) => item.payload)).toEqual([
-      { text: "one\ntwo\n", coalescedUntil: 2, name: "build" },
-      { text: "ok\n", coalescedUntil: 3, name: "test" },
-      { text: "unnamed\n", coalescedUntil: 4 },
+      { chunk: "one\ntwo\n", coalescedUntil: 2, stream: "stdout", commandId: "cmd-1" },
+      { chunk: "warn\n", coalescedUntil: 3, stream: "stderr", commandId: "cmd-1" },
+      { chunk: "next\n", coalescedUntil: 4, stream: "stdout", commandId: "cmd-2" },
+      { chunk: "legacy\nolder\n", coalescedUntil: 6, name: "build" },
     ]);
   });
 

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -286,7 +286,7 @@ export function MessageTimeline({
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
               toolRegistry={toolRegistry}
-              foldLiveCluster={index < groups.length - 1}
+              foldLiveCluster={isAgentProgress(groups[index + 1])}
             />
           ))}
           {working ? (
@@ -421,6 +421,18 @@ function timelineGroupKey(group: TimelineGroup): string {
     case "turn":
       return group.id;
   }
+}
+
+/** The agent has moved PAST a cluster only when what follows is more agent
+    progress — new activity, a settled turn, or narration. A waiting notice
+    (approval pause), a pending queued message, a goal pill, or nothing at all
+    do NOT advance the story, and folding on them would hide exactly the work
+    the reader needs in view. */
+function isAgentProgress(next: TimelineGroup | undefined): boolean {
+  if (!next) {
+    return false;
+  }
+  return next.kind === "activity" || next.kind === "turn" || (next.kind === "item" && next.item.kind === "agent-message");
 }
 
 /** No item still running or streaming — the only state safe to fold live.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -368,7 +368,7 @@ function TimelineGroupView({
 }) {
   switch (group.kind) {
     case "activity":
-      return group.outcome || foldLiveCluster ? (
+      return group.outcome || (foldLiveCluster && clusterIsSettled(group)) ? (
         <TurnSummary
           items={group.items}
           outcome={group.outcome}
@@ -421,6 +421,18 @@ function timelineGroupKey(group: TimelineGroup): string {
     case "turn":
       return group.id;
   }
+}
+
+/** No item still running or streaming — the only state safe to fold live.
+    Position alone is a broken proxy: a pending queued message (or any trailing
+    item) can sit after the ACTIVE cluster, which must never fold mid-work. */
+function clusterIsSettled(group: Extract<TimelineGroup, { kind: "activity" }>): boolean {
+  return group.items.every((item) => {
+    if (item.kind === "reasoning") {
+      return !item.streaming;
+    }
+    return item.status !== "running";
+  });
 }
 
 function flattenActivityItems(groups: TimelineGroup[]): ActivityItem[] {

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -262,7 +262,10 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "sandbox.command.output.delta": {
-        const text = typeof payload.text === "string" ? payload.text : typeof payload.output === "string" ? payload.output : "";
+        // `chunk` is the canonical wire field; text/output are legacy shapes.
+        const text = typeof payload.chunk === "string"
+          ? payload.chunk
+          : typeof payload.text === "string" ? payload.text : typeof payload.output === "string" ? payload.output : "";
         if (!text) {
           break;
         }

--- a/packages/react/test/golden/fixtures/05-coalesced-compact.json
+++ b/packages/react/test/golden/fixtures/05-coalesced-compact.json
@@ -71,8 +71,9 @@
     "type": "sandbox.command.output.delta",
     "payload": {
       "name": "build",
-      "text": "Step 1\nStep 2\n",
-      "coalescedUntil": 9
+      "coalescedUntil": 9,
+      "chunk": "Step 1\nStep 2\n",
+      "stream": "stdout"
     },
     "occurredAt": "2026-01-02T14:00:08.000Z",
     "turnId": "aaaaaaaa-0000-4000-8000-000000000010"

--- a/packages/react/test/golden/fixtures/05-coalesced-raw.json
+++ b/packages/react/test/golden/fixtures/05-coalesced-raw.json
@@ -94,7 +94,8 @@
     "type": "sandbox.command.output.delta",
     "payload": {
       "name": "build",
-      "text": "Step 1\n"
+      "chunk": "Step 1\n",
+      "stream": "stdout"
     },
     "occurredAt": "2026-01-02T14:00:08.000Z",
     "turnId": "aaaaaaaa-0000-4000-8000-000000000010"

--- a/packages/react/test/golden/snapshots/07-legacy-malformed-tolerance.json
+++ b/packages/react/test/golden/snapshots/07-legacy-malformed-tolerance.json
@@ -29,7 +29,7 @@
       "name": "sandbox",
       "command": null,
       "status": "failed",
-      "output": "legacy-output\n\ndisk full"
+      "output": "ignored chunk field\ndisk full"
     },
     {
       "kind": "session-status",
@@ -96,7 +96,7 @@
               "name": "sandbox",
               "command": null,
               "status": "failed",
-              "output": "legacy-output\n\ndisk full"
+              "output": "ignored chunk field\ndisk full"
             }
           ]
         },

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -231,6 +231,25 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
+  test("a cluster paused for approval does NOT fold — the reader needs the context in view", async () => {
+    resetTimelineEvents();
+    const events = [
+      timelineEvent("user.message", { text: "Deploy it" }),
+      timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "terraform apply" } }),
+      timelineEvent("session.requiresAction", {}),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} status="requires_action" />);
+    await flush();
+
+    // The waiting notice follows the cluster, but a notice is not agent
+    // PROGRESS — the paused work stays expanded next to the approval ask.
+    expect(turnSummaryTriggers(r.container)).toHaveLength(0);
+    expect(r.container.textContent).toContain("terraform apply");
+    expect(r.container.textContent).toContain("Approval needed");
+
+    await r.unmount();
+  });
+
   test("a STREAMING cluster never folds, even when a pending queued message sits after it", async () => {
     resetTimelineEvents();
     const events = [

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -231,6 +231,33 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
+  test("a STREAMING cluster never folds, even when a pending queued message sits after it", async () => {
+    resetTimelineEvents();
+    const events = [
+      timelineEvent("user.message", { text: "Do a long job" }),
+      timelineEvent("agent.toolCall.created", { id: "call-1", name: "exec_command", arguments: { cmd: "step one" } }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      timelineEvent("agent.message.delta", { text: "Step one done, moving on." }),
+      timelineEvent("agent.message.completed", { text: "Step one done, moving on." }),
+      // The ACTIVE cluster: tool call still running (no output yet).
+      timelineEvent("agent.toolCall.created", { id: "call-2", name: "exec_command", arguments: { cmd: "step two running" } }),
+      // A queued follow-up renders at the tail (#197 pending anchoring) —
+      // making the running cluster second-to-last. It must STILL not fold.
+      timelineEvent("user.message", { text: "queued follow-up" }, null),
+      timelineEvent("turn.queued", { turnId: "turn-b", triggerEventId: "timeline-evt-7", source: "user" }, "turn-b"),
+    ];
+    const r = await renderComponent(<MessageTimeline events={events} status="running" />);
+    await flush();
+
+    // The settled first cluster folds; the RUNNING second cluster stays bare.
+    const triggers = turnSummaryTriggers(r.container);
+    expect(triggers).toHaveLength(1);
+    expect(r.container.textContent).toContain("step two running");
+    expect(r.container.textContent).toContain("queued follow-up");
+
+    await r.unmount();
+  });
+
   test("when the running turn settles, live-cluster chips give way to the single turn fold", async () => {
     resetTimelineEvents();
     const events = [


### PR DESCRIPTION
Adversarial fresh-eyes review of the whole timeline/loading stack (my pass + an independent high-effort review), all findings verified against contracts and the real producer before fixing.

## High: compact mode destroyed sandbox terminal history
`sandbox.command.output.delta`'s canonical payload is `{stream, chunk, commandId, seq}` (contracts says so explicitly; channel-a emits it). The projection and the #236 coalescer read only legacy `text`/`output`:
- `SandboxItem.output` stayed **empty** on real events (pre-existing bug, inherited);
- compact windows collapsed chunk runs into `{text: "", coalescedUntil}` **and** the resume cursor then skipped the raw events that carried the output — history silently destroyed.

Fixed end-to-end: both readers take `chunk` first (legacy tolerated); coalesced sandbox synthetics carry `{chunk, stream, commandId, name?}`; runs additionally break on `stream`/`commandId` so stdout/stderr never merge and the terminal's per-command grouping survives compaction. The golden suite had **pinned the bug as the contract** (fixture 07's sandbox delta literally contained "ignored chunk field") — regenerated with the diff in this PR, which is the golden-review flow working as designed.

## Medium: live-fold rule folded work the reader needs in view
Two same-class failures of the #264 position-based rule ("fold if not last group"):
- a **pending queued message** at the tail folded the *actively-streaming* cluster;
- an **approval pause** (waiting notice at tail) folded the paused work right when the reader must inspect it to decide.

Replaced with the true invariants: a cluster containing running/streaming items **never** folds, and folding happens only when the **next group is agent progress** (activity/turn/narration) — notices, pending messages, and goal pills don't advance the story.

## Verification
430 tests green: rewritten coalesce suite with real wire shapes (stream/commandId run-breaking, legacy fallbacks), streaming-cluster + approval-pause regressions, golden fixtures converted to canonical shape with reviewed snapshot diffs. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9hLekKycvHLhj3teKScPg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event compaction and timeline projection/UI folding on the main session activity path; fixes prior data-loss and UX bugs but alters how compact windows and live clusters render.
> 
> **Overview**
> Fixes **silent loss of sandbox terminal output** in compact/history paths and **incorrect folding** of in-progress timeline clusters.
> 
> **Sandbox `sandbox.command.output.delta`:** Projection and delta coalescing now treat **`chunk` as the canonical field** (with legacy `text`/`output` fallbacks). Coalesced synthetics emit **`chunk`** plus **`stream`** / **`commandId`** / optional **`name`**, and coalescing **splits runs** when stream or commandId changes so stdout/stderr and distinct commands do not merge.
> 
> **Live activity folding:** Replaces “fold if not the last group” with **`foldLiveCluster` only when the next group is agent progress** (activity, turn, or agent message) **and** the cluster **`clusterIsSettled`** (no running tools/sandbox or streaming reasoning). Approval pauses, queued user messages, and similar tail items no longer collapse the work the reader needs visible.
> 
> Tests and golden fixtures are updated for canonical wire shapes and the new fold behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c440099a45198e85e535c70c0dcec976e9e514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->