### PR TITLE
fix(agent-release): rcodesign flag is --binary-identifier, not --identifier

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -260,7 +260,7 @@ jobs:
           echo "$APPLE_CERT_P12" | base64 -d > /tmp/cert.p12
           # Sign the WHOLE bundle with the hardened runtime + the stable identifier.
           rcodesign sign --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
-            --code-signature-flags runtime --identifier ai.opengeni.agent "$APP"
+            --code-signature-flags runtime --binary-identifier ai.opengeni.agent "$APP"
           # Zip with the .app dir as the archive root (install.sh extracts into
           # ~/Applications and expects exactly that layout).
           ditto -c -k --keepParent "$APP" "OpenGeni-Agent.app.zip"


### PR DESCRIPTION
Latent in the creds-guarded bundle-sign step — only executes now that the Apple Developer ID secrets exist. apple-codesign 0.29 renamed the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow flag rename for macOS codesign; no runtime or application code changes.
> 
> **Overview**
> Updates the **macOS `.app` bundle** signing step in `agent-release.yml` so `rcodesign sign` uses **`--binary-identifier ai.opengeni.agent`** instead of **`--identifier`**, matching **apple-codesign 0.29** CLI naming.
> 
> Without this change, the creds-guarded bundle sign step would fail once Apple Developer ID secrets are present and that step actually runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33cb2ce9b3664e8df8ed2285729a7c4da9aba45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->