### PR TITLE
fix(agent-release): sign with --for-notarization

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -200,7 +200,7 @@ jobs:
           # key without a Mac keychain. Authored as the creds-drop-in.
           cargo install --locked apple-codesign || true
           echo "$APPLE_CERT_P12" | base64 -d > /tmp/cert.p12
-          rcodesign sign --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
+          rcodesign sign --for-notarization --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
             --code-signature-flags runtime "${{ matrix.asset }}"
           echo "$APPLE_ASC_KEY" > /tmp/asc.json
           rcodesign notary-submit --api-key-path /tmp/asc.json --wait "${{ matrix.asset }}" || \
@@ -259,7 +259,7 @@ jobs:
           cargo install --locked apple-codesign || true
           echo "$APPLE_CERT_P12" | base64 -d > /tmp/cert.p12
           # Sign the WHOLE bundle with the hardened runtime + the stable identifier.
-          rcodesign sign --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
+          rcodesign sign --for-notarization --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
             --code-signature-flags runtime --binary-identifier ai.opengeni.agent "$APP"
           # Zip with the .app dir as the archive root (install.sh extracts into
           # ~/Applications and expects exactly that layout).


### PR DESCRIPTION
Apple's notary rejected the 0.1.4 bundle ('signature of the binary is invalid' + 'no secure timestamp'). `--for-notarization` makes rcodesign emit the notarization-grade signature (secure timestamp token, full chain, hardened runtime on all signed paths) and fail fast if settings are incompatible. Verified the flag exists in apple-codesign 0.29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to macOS signing flags when Apple creds are present; no runtime or application code affected.
> 
> **Overview**
> Fixes Apple notarization failures on agent releases (e.g. 0.1.4) by adding **`--for-notarization`** to both `rcodesign sign` calls in **`agent-release.yml`**: the standalone macOS binary and the **OpenGeni Agent.app** bundle.
> 
> That flag makes `rcodesign` produce a notarization-grade signature (secure timestamp, full chain, hardened-runtime expectations) instead of a basic Developer ID sign that notary was rejecting as invalid / missing a secure timestamp. No other workflow steps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f483526614a94e17abc0140667ee5ce378d1ef7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->