### PR TITLE
fix(db): schema-agnostic opengeni_app grants + default privileges

### DIFF
--- a/.changeset/schema-agnostic-opengeni-app-grants.md
+++ b/.changeset/schema-agnostic-opengeni-app-grants.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Repair embedded-schema database migrations by re-granting `opengeni_app` table and sequence privileges in the active schema and setting schema-scoped default privileges for future objects.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,4 @@ Two publish-coherence rules learned the hard way (all versions are 0.x):
 ## Migration Authoring
 
 - Migrations must be schema-agnostic: they run under a caller-selected schema/search path. Use `current_schema()` in policy/guard queries, and never pin OpenGeni tables to `public` or issue `SET search_path` inside a migration.
+- `opengeni_app` grant blocks must also be schema-agnostic: use `current_schema()` with dynamic SQL (`EXECUTE format(... %I ...)`) instead of `IN SCHEMA public`, and include default privileges when future tables or sequences must inherit app-role access.

--- a/packages/db/drizzle/0040_schema_agnostic_opengeni_app_grants.sql
+++ b/packages/db/drizzle/0040_schema_agnostic_opengeni_app_grants.sql
@@ -1,0 +1,36 @@
+-- Correct historical opengeni_app grant blocks that hardcoded `public`.
+-- Embedded hosts run migrations with search_path pointed at their dedicated
+-- data schema, so grants must target current_schema().
+
+DO $$
+DECLARE
+  target_schema text := current_schema();
+  owner_role text := current_user;
+  app_role text := 'opengeni_app';
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = app_role) THEN
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', target_schema, app_role);
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I',
+      target_schema,
+      app_role
+    );
+    EXECUTE format(
+      'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I',
+      target_schema,
+      app_role
+    );
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+      owner_role,
+      target_schema,
+      app_role
+    );
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO %I',
+      owner_role,
+      target_schema,
+      app_role
+    );
+  END IF;
+END $$;

--- a/packages/db/test/schema-isolation.test.ts
+++ b/packages/db/test/schema-isolation.test.ts
@@ -21,13 +21,16 @@ import { migrate, runMigrations } from "../src/migrate";
 //      the two paths don't interfere.
 //
 // One throwaway pgvector container, torn down with the test (NEVER a persistent
-// default-port stack). Non-default port. Assertions run as superuser (the
-// opengeni_app GRANTs are IF EXISTS-guarded, so no role provisioning needed).
+// default-port stack). Non-default port. Most assertions run as superuser; the
+// embedded leg also pre-creates opengeni_app so the migration grant blocks run
+// and a non-owner insert can prove dedicated-schema app-role privileges.
 
 const CONTAINER = "ogbuild-pg-schema-iso";
 const PORT = 55471;
 const PASSWORD = "x";
+const APP_PASSWORD = "apppw";
 const ADMIN_URL = `postgres://postgres:${PASSWORD}@127.0.0.1:${PORT}/postgres`;
+const APP_URL = `postgres://opengeni_app:${APP_PASSWORD}@127.0.0.1:${PORT}/postgres`;
 const IMAGE = "pgvector/pgvector:pg17";
 
 function docker(args: string[]): string {
@@ -81,6 +84,14 @@ beforeAll(async () => {
   const admin = postgres(ADMIN_URL, { max: 1 });
   try {
     await admin.unsafe(`CREATE DATABASE standalone_public`);
+    await admin.unsafe(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+          CREATE ROLE opengeni_app LOGIN PASSWORD '${APP_PASSWORD}';
+        END IF;
+      END $$;
+    `);
   } finally {
     await admin.end();
   }
@@ -143,6 +154,46 @@ describe("Step I — embedded dedicated-schema isolation (SPIKE-1 F1, productize
         WHERE n.nspname = 'opengeni' AND c.relname = 'sessions'`)[0]!;
       expect(rls.relrowsecurity).toBe(true);
       expect(rls.relforcerowsecurity).toBe(true);
+
+      const [account] = await sql<{ id: string }[]>`
+        INSERT INTO opengeni.managed_accounts (name) VALUES ('grant acct') RETURNING id`;
+      const [workspace] = await sql<{ id: string }[]>`
+        INSERT INTO opengeni.workspaces (account_id, name) VALUES (${account!.id}, 'grant ws') RETURNING id`;
+      const [session] = await sql<{ id: string }[]>`
+        WITH ids AS (SELECT gen_random_uuid() AS id)
+        INSERT INTO opengeni.sessions (
+          id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
+        )
+        SELECT id, ${account!.id}, ${workspace!.id}, 'hello', 'gpt-4.1', 'none', id FROM ids
+        RETURNING id`;
+      await sql.unsafe(`
+        CREATE TABLE opengeni.default_privilege_probe (
+          id bigserial PRIMARY KEY,
+          note text NOT NULL
+        )
+      `);
+
+      const app = postgres(APP_URL, { max: 1 });
+      try {
+        await app.unsafe(`SET search_path = "opengeni", "opengeni_private", "public"`);
+        await app`SELECT set_config('opengeni.account_id', ${account!.id}, false)`;
+        await app`SELECT set_config('opengeni.workspace_id', ${workspace!.id}, false)`;
+        const inserted = await app<{ id: string }[]>`
+          INSERT INTO session_mcp_servers (
+            account_id, workspace_id, session_id, server_id, name, url, headers_encrypted
+          )
+          VALUES (
+            ${account!.id}, ${workspace!.id}, ${session!.id}, 'grant-test', 'Grant test',
+            'https://mcp.example.test', '{}'::jsonb
+          )
+          RETURNING id`;
+        expect(inserted).toHaveLength(1);
+        const defaultGrantInserted = await app<{ id: string }[]>`
+          INSERT INTO default_privilege_probe (note) VALUES ('default grants include sequences') RETURNING id`;
+        expect(defaultGrantInserted).toHaveLength(1);
+      } finally {
+        await app.end();
+      }
     } finally {
       await sql.end();
     }


### PR DESCRIPTION
## Bug
Migration grant blocks hardcode `IN SCHEMA public` (28 historical lines). OpenGeni's own deployments run in `public`, so grants work there — but **embedded deployments** run the same migrations with `search_path` pointed at a dedicated schema, where every one of those grants is a silent no-op. Any table created by migration after the host's provision-time grants never becomes accessible to `opengeni_app`. Live failure on a cloudgeni embedded deployment: `permission denied for table session_mcp_servers` on session create with per-session MCP servers.

## Fix
- Corrective migration `0040`: grants tables/sequences in `current_schema()` to `opengeni_app` **and** sets `ALTER DEFAULT PRIVILEGES` for the migration-runner role, so all future migration-created tables are granted automatically in whatever schema the deployment uses. Idempotent; a re-grant no-op on public-schema deployments.
- Convention documented in CONTRIBUTING: migration grants must use `current_schema()`, never hardcode `public`.
- Changeset: patch `@opengeni/db`.

## Test
The dedicated-schema isolation test now pre-creates `opengeni_app`, migrates into a non-public schema, inserts into `session_mcp_servers` as `opengeni_app`, and proves default privileges with a post-migration probe table (5 tests / 22 assertions, real DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database privilege grants applied on every migration run; incorrect logic could over-grant or leave embedded deployments broken, but the migration is guarded, idempotent, and covered by integration tests.
> 
> **Overview**
> Repairs **embedded-schema** deployments where historical migrations granted `opengeni_app` only on `public`, so tables in a dedicated schema (e.g. `session_mcp_servers`) stayed inaccessible to the app role.
> 
> Adds migration **`0040`**: idempotent `DO` block that grants schema usage, DML on all tables, sequence rights, and **`ALTER DEFAULT PRIVILEGES`** for the migration runner in **`current_schema()`** when `opengeni_app` exists—safe no-op on existing `public` installs.
> 
> **CONTRIBUTING** now requires schema-agnostic grant blocks (`format` + `%I`, not `IN SCHEMA public`). **`@opengeni/db`** patch changeset. **`schema-isolation.test.ts`** pre-creates `opengeni_app` and asserts inserts as that role into `session_mcp_servers` and a post-migration probe table (default privileges on sequences).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f509780477e5868b28b2b2b007f57bc94d5b14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->