### PR TITLE
feat(toolspace): selfhosted parity + generic programmatic-calling instructions

### DIFF
--- a/.changeset/toolspace-instructions.md
+++ b/.changeset/toolspace-instructions.md
@@ -1,0 +1,12 @@
+---
+"@opengeni/runtime": minor
+"@opengeni/worker-bundle": minor
+"@opengeni/core": patch
+"@opengeni/api-router": patch
+---
+
+Toolspace: selfhosted parity + generic programmatic-calling agent instructions.
+
+Connected-machine (selfhosted) turns now receive the toolspace token like every other backend. The git-token skip does not transfer: the platform GitHub token is inert on a user machine, but the toolspace token is the machine's only path to programmatic tool calling. It is safe to deliver because it grants no more than the machine owner's own authority — `toolspace:call` only, bound to its own session, turn TTL, budgeted, approval-tools excluded. Delivery mirrors the docker path: the token is seeded to `$OPENGENI_TOOLSPACE_TOKEN_FILE` over the machine's exec channel, off-manifest, targeting the public sandbox-routable API URL; the platform setup hooks (repository clone, az login) still never run against the user's machine.
+
+When a toolspace token is minted for a turn (feature enabled, any backend), the agent's composed instructions carry a short, generic substrate note: every MCP tool is also callable programmatically from the sandbox via `ogtool` (or MCP JSON-RPC to `$OPENGENI_TOOLSPACE_URL` with the bearer from `$OPENGENI_TOOLSPACE_TOKEN_FILE`), prefer programmatic calls for loops/polling/bulk filtering because those results do not consume model context, and approval-required tools must still be invoked normally. The note composes after the workspace persona + CORE but before the per-session instructions. The `@opengeni/core` and `@opengeni/api-router` bumps are the dependent-closure patch for the runtime minor.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1027,7 +1027,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         workspaceEnvironment?.values ?? {},
         {
           skipGitHubToken: activeSandboxBackend === "selfhosted",
-          skipToolspaceToken: activeSandboxBackend === "selfhosted",
           scope: connectionScope,
           gitCredentials: connectionCredentials?.gitCredentials,
           sessionId: input.sessionId,
@@ -1312,7 +1311,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // seeds it to the box's token file before the repository-clone runs; it never
         // touches the box/agent manifest env.
         ...(activeSandboxBackend !== "selfhosted" && sandboxGitToken ? { gitTokenSeed: sandboxGitToken } : {}),
-        ...(activeSandboxBackend !== "selfhosted" && sandboxToolspaceToken ? { toolspaceTokenSeed: sandboxToolspaceToken } : {}),
+        // Toolspace is delivered on EVERY backend including selfhosted. The git-
+        // token skip does NOT transfer: that token is inert on a connected
+        // machine (it uses its own git creds), but the toolspace token is the
+        // machine's ONLY path to programmatic tool calling and grants no more
+        // than toolspace:call for its own session (own-session-bound, turn TTL,
+        // budgeted, approval-tools excluded). The runtime seeds it to the box's
+        // token file over the same exec channel, off-manifest, on every backend.
+        ...(sandboxToolspaceToken ? { toolspaceTokenSeed: sandboxToolspaceToken } : {}),
         ...(activeSandboxBackend ? { activeSandboxBackend } : {}),
         fileResourceDownloads,
         mcpServers: preparedTools.mcpServers,

--- a/apps/worker/src/activities/environment.ts
+++ b/apps/worker/src/activities/environment.ts
@@ -108,7 +108,6 @@ export async function sandboxEnvironmentForRun(
     gitCredentials?: ConnectionCredentialsPort["gitCredentials"];
     sessionId?: string;
     runId?: string;
-    skipToolspaceToken?: boolean;
   } = {},
 ): Promise<{ environment: Record<string, string>; gitToken?: string; toolspaceToken?: string }> {
   // Precedence: deployment allowlist < git identity < workspace environment
@@ -129,10 +128,17 @@ export async function sandboxEnvironmentForRun(
   // rotates. The agent can refresh the token mid-turn via the `github_token` MCP tool.
   const stableOptions = options.scope ? { workspaceId: options.scope.workspaceId } : {};
   const environment = stableSandboxEnvironmentForRun(settings, workspaceEnvironment, stableOptions);
+  // TOOLSPACE (selfhosted parity): the toolspace token is minted for EVERY
+  // backend, including a connected machine. Unlike the platform GitHub token
+  // (inert on selfhosted → skipped above), the toolspace token is the machine's
+  // only path to programmatic tool calling, and it grants no more than the
+  // machine owner's own authority (toolspace:call, own-session-bound, turn TTL,
+  // budgeted, approval-tools excluded). Delivery mirrors the docker path: the
+  // caller threads it OFF-MANIFEST as the seed the runtime writes to
+  // $OPENGENI_TOOLSPACE_TOKEN_FILE over the box's exec channel.
   let toolspaceToken: string | undefined;
   if (
     settings.toolspaceEnabled
-    && !options.skipToolspaceToken
     && settings.delegationSecret
     && options.scope
     && options.sessionId

--- a/apps/worker/test/toolspace-token.test.ts
+++ b/apps/worker/test/toolspace-token.test.ts
@@ -59,26 +59,50 @@ describe("toolspace token mint and sandbox delivery pointers", () => {
     });
   });
 
-  test("skipToolspaceToken suppresses the credential mint for connected-machine turns", async () => {
-    const result = await sandboxEnvironmentForRun(
-      testSettings({
-        sandboxBackend: "modal",
-        delegationSecret: "toolspace-secret",
-        toolspaceEnabled: true,
-        apiPort: 8000,
-      }),
-      [],
-      {},
-      {
-        scope: { accountId, workspaceId },
-        sessionId,
-        runId: "run-1",
-        skipToolspaceToken: true,
-      },
-    );
+  test("connected-machine (selfhosted) turns mint the token too — there is no skip path", async () => {
+    // Selfhosted parity: the toolspace token is minted on every backend. Unlike
+    // the platform GitHub token (inert on a connected machine), the toolspace
+    // token is the machine's only path to programmatic tool calling and grants no
+    // more than the owner's own authority, so the previous skip is gone entirely.
+    // `sandboxEnvironmentForRun` is backend-agnostic; the removed option means a
+    // connected-machine turn mints exactly like a modal turn.
+    const settings = testSettings({
+      sandboxBackend: "modal",
+      delegationSecret: "toolspace-secret",
+      toolspaceEnabled: true,
+      apiPort: 8000,
+    });
+    const result = await sandboxEnvironmentForRun(settings, [], {}, {
+      scope: { accountId, workspaceId },
+      sessionId,
+      runId: "run-1",
+    });
 
-    expect(result.toolspaceToken).toBeUndefined();
+    expect(result.toolspaceToken).toMatch(/^ogd_/);
     expect(result.environment.OPENGENI_TOOLSPACE_TOKEN_FILE).toBe("/workspace/.opengeni/toolspace-token");
-    expect(result.environment.OPENGENI_TOOLSPACE_URL).toBe(`http://127.0.0.1:8000/v1/workspaces/${workspaceId}/mcp`);
+    // The token VALUE stays off-manifest (delivered via the exec-channel seed).
+    expect(Object.values(result.environment)).not.toContain(result.toolspaceToken);
+  });
+
+  test("the token targets the PUBLIC, machine-routable API URL, never a cluster-internal one", async () => {
+    // A connected machine enrolled against the public base and reaches OpenGeni
+    // over the internet, so OPENGENI_TOOLSPACE_URL must resolve to the same
+    // sandbox-routable base every remote backend uses (OPENGENI_MCP_URL), not the
+    // loopback default that only works for a co-located box.
+    const settings = testSettings({
+      sandboxBackend: "modal",
+      delegationSecret: "toolspace-secret",
+      toolspaceEnabled: true,
+      apiPort: 8000,
+      opengeniMcpUrl: "https://app.opengeni.example/v1/workspaces/{workspaceId}/mcp",
+    });
+    const result = await sandboxEnvironmentForRun(settings, [], {}, {
+      scope: { accountId, workspaceId },
+      sessionId,
+      runId: "run-1",
+    });
+
+    expect(result.environment.OPENGENI_TOOLSPACE_URL).toBe(`https://app.opengeni.example/v1/workspaces/${workspaceId}/mcp`);
+    expect(result.environment.OPENGENI_TOOLSPACE_URL).not.toContain("127.0.0.1");
   });
 });

--- a/docs/design/toolspace.md
+++ b/docs/design/toolspace.md
@@ -121,6 +121,37 @@ written into a sandbox file and the environment exposes only
 must not appear in the sandbox manifest, env delta, event log, run state, or
 logs.
 
+### Every backend, including selfhosted
+
+The token is minted and delivered on **every** compute backend, including a
+connected machine (selfhosted). This is a deliberate departure from the platform
+GitHub token, which is skipped on selfhosted because it is inert there — the
+machine uses its own git credentials. That reasoning does not transfer to the
+toolspace token: it is the machine's *only* path to programmatic tool calling,
+and refusing to deliver it would silently downgrade selfhosted agents.
+
+On a selfhosted turn the token seed is written to `OPENGENI_TOOLSPACE_TOKEN_FILE`
+over the machine's existing exec channel (the same NATS-backed `exec` the agent
+runs commands through), reusing the identical off-manifest seed hook the docker
+path uses — the value never rides the manifest. The other platform setup hooks
+(repository clone, `az login`) and file materialization still do **not** run
+against the user's real computer; the toolspace token seed is the single piece of
+per-turn material that crosses to it.
+
+There is one accepted delta from the docker path. On docker the manifest
+environment is exported into the box shell, so `ogtool` reads
+`OPENGENI_TOOLSPACE_URL` / `OPENGENI_TOOLSPACE_TOKEN_FILE` straight from `env`. A
+selfhosted machine owns its own shell and does **not** consume the manifest env
+wholesale (pushing `HOME`, `GIT_*`, etc. onto a real computer would clobber it),
+so selfhosted `exec` exports a strict two-key allowlist — exactly
+`OPENGENI_TOOLSPACE_URL` and `OPENGENI_TOOLSPACE_TOKEN_FILE`, both non-secret
+pointers — into every command's environment. That is enough for `ogtool` (and the
+seed hook) to find the tool surface and the token file; the token VALUE is never
+in that env. `OPENGENI_TOOLSPACE_URL` resolves to the public, sandbox-routable API
+base (`OPENGENI_MCP_URL`) the machine enrolled against — the same URL every remote
+backend uses — never a loopback or cluster-internal address the machine could not
+reach.
+
 When the flag is off, behavior is byte-identical to the current tree: no
 permission is minted, no file path appears, no URL appears, and no toolspace
 surface is added.
@@ -161,6 +192,14 @@ cannot re-enter `/mcp` as a toolspace principal.
 - No credential exposure to the sandbox: third-party MCP headers are decrypted
   or broker-resolved only inside the API proxy path and are never returned to the
   sandbox.
+- No over-authority on a user machine: **no credential crosses to a connected
+  (selfhosted) machine that grants more than the machine owner's own authority.**
+  The toolspace token satisfies this — it carries `toolspace:call` only, is bound
+  to its own session, expires at turn TTL, is per-turn budgeted, and cannot invoke
+  approval-required tools — so it is safe to deliver to the machine, whereas the
+  platform GitHub installation token (which would grant repo access beyond the
+  owner) is not, and stays off it. This invariant, not the git-token precedent, is
+  what decides which per-turn credentials may reach a selfhosted box.
 - SSRF posture: proxy targets come only from validated persisted rows and
   enabled pack/capability refs, not from sandbox-supplied URLs.
 - Human approval is not bypassed: approval-required tools are excluded or return
@@ -182,6 +221,30 @@ The sandbox image carries a small dependency-light CLI, `ogtool`, that reads
 `OPENGENI_TOOLSPACE_TOKEN_FILE` and `OPENGENI_TOOLSPACE_URL` and performs
 `tools/list` and `tools/call` with JSON input/output. It is a convenience shim,
 not a new API surface.
+
+## Agent Awareness
+
+For the capability to be used, the agent has to know it exists. This is done
+with **generic substrate prompting**, not per-host prompt text: a single fixed
+directive (`TOOLSPACE_PROGRAMMATIC_DIRECTIVE` in `packages/runtime`) is appended
+to the composed agent instructions by `appendToolspaceInstructions`. It tells the
+agent that every tool on its MCP surface is also callable programmatically from
+the sandbox (`ogtool list` / `ogtool call <name> '<json>'`, or MCP JSON-RPC to
+`$OPENGENI_TOOLSPACE_URL` with the bearer from `$OPENGENI_TOOLSPACE_TOKEN_FILE`),
+that input schemas come from `tools/list`, that programmatic calls are preferred
+for loops, polling, and bulk filtering because their results do not consume model
+context, and that approval-required tools must still be invoked normally (they
+return a typed error programmatically).
+
+The directive is appended **only when a toolspace token was minted for this turn**
+— the exact condition that gates the sandbox mint (feature enabled), surfaced to
+the runtime as the per-turn toolspace token seed. The mint happens on every
+backend including selfhosted, so the directive appears on a connected machine too;
+a turn with no minted token has no `ogtool`/URL in its sandbox, so it never
+advertises a capability that is not there. In the instruction composition order
+the directive sits **after** the workspace persona + non-bypassable CORE and
+**before** the per-session instructions, so host- and session-specific guidance
+still refines it.
 
 ## Follow-Ups
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -938,6 +938,25 @@ export function appendSessionInstructions(composed: string, sessionInstructions?
 }
 
 /**
+ * Appends the generic programmatic-tool-calling (toolspace) directive to the
+ * composed workspace + CORE instructions, joined by " ". This is GENERIC
+ * substrate prompting — the same text for every host, never per-host copy.
+ *
+ * Included ONLY when `toolspaceAvailable` is true, which the caller sets from the
+ * exact condition that gates the sandbox token mint: the toolspace feature is
+ * enabled AND a toolspace token was minted for THIS turn. That mint now happens
+ * on every backend including selfhosted (connected machines get the token too),
+ * so the block appears there as well; a turn with no minted token (feature off)
+ * has no toolspace URL/token in its sandbox and must not advertise a capability
+ * that is not there — the gate is false and this is a no-op. Placed BEFORE the
+ * per-session instructions so host/session specificity still wins over this
+ * substrate note.
+ */
+export function appendToolspaceInstructions(composed: string, toolspaceAvailable: boolean): string {
+  return toolspaceAvailable ? `${composed} ${TOOLSPACE_PROGRAMMATIC_DIRECTIVE}` : composed;
+}
+
+/**
  * Appends the one-shot genesis title directive (genesis turn only), joined by
  * " " and always LAST so a white-label persona template or a per-session
  * instruction can't drop it. A no-op when the hint is absent.
@@ -1030,14 +1049,21 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
     // Persona composition order (all one system-level instructions string):
     //   1. workspace instructionsTemplate (or deployment default) with the
     //      non-bypassable CORE substituted at {{core}} — composeAgentInstructions,
-    //   2. + the per-session persona instructions (session-specific, LAST so it
-    //      refines the workspace persona),
-    //   3. + the one-shot genesis title directive (genesis turn only).
-    // With no session instructions and no genesis hint this is byte-identical to
-    // the historical composed instructions.
+    //   2. + the generic programmatic-tool-calling (toolspace) directive, ONLY
+    //      when a toolspace token was minted for this turn (feature enabled + a
+    //      per-turn seed — the mint gate, which includes selfhosted turns since
+    //      they now receive the token too) — appendToolspaceInstructions,
+    //   3. + the per-session persona instructions (session-specific, so it
+    //      refines both the workspace persona and the substrate note),
+    //   4. + the one-shot genesis title directive (genesis turn only).
+    // With no toolspace token, no session instructions, and no genesis hint this
+    // is byte-identical to the historical composed instructions.
     instructions: appendGenesisTitleDirective(
       appendSessionInstructions(
-        composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment),
+        appendToolspaceInstructions(
+          composeAgentInstructions(options.instructionsTemplate ?? settings.agentInstructionsTemplate, options.workspaceEnvironment),
+          settings.toolspaceEnabled && Boolean(options.toolspaceTokenSeed),
+        ),
         options.sessionInstructions,
       ),
       options.genesisTitleHint,
@@ -2194,6 +2220,13 @@ export type ContextRobustnessFilterOptions = {
 export const GENESIS_TITLE_DIRECTIVE =
   "This is the first turn of a new session. Before responding to the user, call the opengeni__set_session_title tool with a concise 3-7 word title that summarizes what this session is about, then address the user's request normally.";
 
+// Generic substrate prompting for programmatic tool calling (toolspace). Same
+// text for every host; gated per-turn by appendToolspaceInstructions on the
+// presence of a minted toolspace token, so it only appears when the sandbox
+// actually exposes the ogtool CLI + $OPENGENI_TOOLSPACE_URL/_TOKEN_FILE.
+export const TOOLSPACE_PROGRAMMATIC_DIRECTIVE =
+  "Every tool on your MCP surface is also callable programmatically from the sandbox shell, so scripts can invoke tools without a model round trip per call. Run `ogtool list` to see the available tools and their input schemas (from tools/list), then `ogtool call <tool-name> '<json-args>'`; equivalently, POST MCP JSON-RPC to $OPENGENI_TOOLSPACE_URL with the bearer token read from $OPENGENI_TOOLSPACE_TOKEN_FILE. Prefer programmatic calls for loops, polling, and bulk filtering: their results stay in the sandbox and do not consume your context window. Tools that require human approval must still be invoked normally — called programmatically they return a typed error.";
+
 /**
  * callModelInputFilter that removes provider-assigned item ids (rs_/msg_/fc_…)
  * from every input item immediately before each model call. Responses-API
@@ -2397,6 +2430,22 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
           ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
           ...(runAs ? { runAs } : {}),
         });
+      }
+    } else {
+      // SELFHOSTED TOOLSPACE (parity): the platform setup hooks (repository clone,
+      // az login) and file materialization stay OFF the user's real machine — but
+      // the toolspace token seed is the ONE piece of per-turn material that must
+      // reach it. It writes a scoped, own-session-bound token to
+      // $OPENGENI_TOOLSPACE_TOKEN_FILE over the SAME exec channel the clone-seed
+      // uses (off-manifest, value never on the manifest), and it grants no more
+      // than the machine owner's own authority (toolspace:call, this session, turn
+      // TTL, budgeted, approval-tools excluded) — the invariant that makes it safe
+      // to cross to a user machine when the git token is not. It is also the
+      // machine's only path to programmatic tool calling. Seed it (only) here; the
+      // hook list is empty when no toolspace token was minted for this turn.
+      const toolspaceHooks = sandboxToolspaceTokenHooksForAgent(agent);
+      if (toolspaceHooks.length > 0) {
+        await runBeforeAgentStartHooks(setupSession, toolspaceHooks, ownedHookContext);
       }
     }
     // Keep the decoration as a safety net for any session the SDK does create/resume

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -144,6 +144,28 @@ export interface SelfhostedImageOutput {
  *  (the turn pauses + retries); it is NOT a hard failure. */
 export const SELFHOSTED_DEFAULT_TIMEOUT_MS = 30_000;
 
+/**
+ * The ONLY manifest-environment keys exported into a selfhosted machine's exec
+ * shell. The manifest env is otherwise NOT consumed by selfhosted exec — the
+ * machine owns its own environment, and pushing HOME, GIT_ vars, and the like
+ * onto a real computer would clobber it. The toolspace pointers are the exception:
+ * `ogtool` (and the token-seed hook) need the non-secret programmatic-calling URL
+ * and the token-FILE PATH to reach the tool surface. The token VALUE never rides
+ * here — it is seeded to that file off-manifest over the same exec channel.
+ */
+const SELFHOSTED_EXEC_ENV_ALLOWLIST = ["OPENGENI_TOOLSPACE_URL", "OPENGENI_TOOLSPACE_TOKEN_FILE"] as const;
+
+function selfhostedExecEnv(environment: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of SELFHOSTED_EXEC_ENV_ALLOWLIST) {
+    const value = environment[key];
+    if (value) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
 /** The relay-URL shape config the session needs to build a stream endpoint. M8b
  *  wires the real relay deployment behind THIS seam so `buildStreamUrl` works
  *  unchanged behind `resolveExposedPort`. */
@@ -181,9 +203,11 @@ export interface SelfhostedSessionDeps {
    * session delta; `validateNoEnvironmentDelta` throws "Live sandbox sessions cannot
    * change manifest environment variables" on ANY env mismatch. So `state.manifest`'s
    * `environment` MUST EQUAL the turn's environment for the delta to be empty. The
-   * selfhosted exec routes over NATS and does NOT consume the env, but the manifest
-   * must carry it for parity. Omitted → `{}` (the negotiation-only / test path,
-   * which never applies a turn manifest, so there is no delta to validate).
+   * selfhosted exec routes over NATS and does NOT consume this env wholesale (the
+   * machine owns its own shell), EXCEPT the allowlisted toolspace pointers it
+   * exports per exec so `ogtool` works — see SELFHOSTED_EXEC_ENV_ALLOWLIST. The
+   * manifest carries the full env for parity. Omitted → `{}` (the negotiation-only
+   * / test path, which never applies a turn manifest, so there is no delta).
    */
   environment?: Record<string, string>;
   /**
@@ -340,7 +364,11 @@ export class SelfhostedSession {
       // SELFHOSTED_VIRTUAL_ROOT). Empty → the session workingDir (itself "" by
       // default ⇒ the agent runs in its workspace_root).
       cwd: toMachinePath(args.workdir, this.workingDir),
-      env: {},
+      // The machine owns its own shell environment; the manifest env is NOT
+      // exported here. The ONE exception is the non-secret toolspace pointers
+      // (URL + token-file path), so a programmatic `ogtool` call and the token-
+      // seed hook can find the tool surface. See SELFHOSTED_EXEC_ENV_ALLOWLIST.
+      env: selfhostedExecEnv(this.state.environment),
       stdin: new Uint8Array(0),
       timeoutMs: 0,
     };

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunContext, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, runToolspaceTokenSeedHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, toolspaceTokenSeedCommand, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER, type ResolveConnectionCredentialInput, type ResolveConnectionCredentialResult } from "../src/index";
+import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, appendToolspaceInstructions, TOOLSPACE_PROGRAMMATIC_DIRECTIVE, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, runToolspaceTokenSeedHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, toolspaceTokenSeedCommand, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER, type ResolveConnectionCredentialInput, type ResolveConnectionCredentialResult } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -784,6 +784,85 @@ describe("runtime event normalization", () => {
     // Genesis directive is appended after everything, including the session slice.
     expect(agent.instructions.endsWith(GENESIS_TITLE_DIRECTIVE)).toBe(true);
     expect(agent.instructions.indexOf("Session-scoped rule.")).toBeLessThan(agent.instructions.indexOf(GENESIS_TITLE_DIRECTIVE));
+  });
+
+  // ── generic programmatic-tool-calling (toolspace) substrate directive ──────
+  // The block is GENERIC substrate prompting, gated by the SAME condition that
+  // gates the sandbox token mint: toolspaceEnabled AND a toolspace token minted
+  // for this turn (surfaced to the runtime as options.toolspaceTokenSeed, which
+  // the worker passes only for a non-selfhosted, non-skipped turn).
+  const toolspaceOn = { sandboxBackend: "none", toolspaceEnabled: true } as const;
+
+  test("the toolspace directive is present exactly when the feature is on AND a token was minted", () => {
+    const agent = buildOpenGeniAgent(testSettings(toolspaceOn), [], { toolspaceTokenSeed: "ogd_seed" });
+    expect(agent.instructions).toContain(TOOLSPACE_PROGRAMMATIC_DIRECTIVE);
+    // Default (feature off, no seed) never carries it — the historical preamble.
+    const off = buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []);
+    expect(off.instructions).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+    expect(off.instructions).not.toContain(TOOLSPACE_PROGRAMMATIC_DIRECTIVE);
+  });
+
+  test("NEGATIVE: feature flag off (even with a token seed) omits the directive", () => {
+    const agent = buildOpenGeniAgent(testSettings({ sandboxBackend: "none", toolspaceEnabled: false }), [], {
+      toolspaceTokenSeed: "ogd_seed",
+    });
+    expect(agent.instructions).not.toContain(TOOLSPACE_PROGRAMMATIC_DIRECTIVE);
+    expect(agent.instructions).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+  });
+
+  test("NEGATIVE: feature on but no token minted for the turn omits the directive", () => {
+    // The block gates on the per-turn seed, not the flag alone: a turn with no
+    // minted toolspace token (the worker passed no seed) has no ogtool/URL in its
+    // sandbox, so the block must not advertise it. The mint now happens on every
+    // backend including selfhosted, so this is the genuine no-token case, not a
+    // backend distinction.
+    const agent = buildOpenGeniAgent(testSettings(toolspaceOn), []);
+    expect(agent.instructions).not.toContain(TOOLSPACE_PROGRAMMATIC_DIRECTIVE);
+    expect(agent.instructions).toBe(HISTORICAL_DEFAULT_INSTRUCTIONS);
+  });
+
+  test("the toolspace directive composes AFTER the workspace persona + CORE but BEFORE the per-session slice", () => {
+    const template = `WORKSPACE PERSONA ${AGENT_INSTRUCTIONS_CORE_PLACEHOLDER}`;
+    const agent = buildOpenGeniAgent(testSettings(toolspaceOn), [], {
+      instructionsTemplate: template,
+      sessionInstructions: "SESSION RULE: always answer in French.",
+      toolspaceTokenSeed: "ogd_seed",
+    });
+    // Exact ordering: workspace persona + CORE, then the toolspace directive,
+    // then the session slice last (host/session specificity wins).
+    expect(agent.instructions).toBe(
+      `WORKSPACE PERSONA ${coreInstructions().join(" ")} ${TOOLSPACE_PROGRAMMATIC_DIRECTIVE} SESSION RULE: always answer in French.`,
+    );
+    expect(agent.instructions.indexOf(TOOLSPACE_PROGRAMMATIC_DIRECTIVE))
+      .toBeLessThan(agent.instructions.indexOf("SESSION RULE"));
+  });
+
+  test("the toolspace directive stays before the genesis directive, which remains LAST", () => {
+    const agent = buildOpenGeniAgent(testSettings(toolspaceOn), [], {
+      sessionInstructions: "Session-scoped rule.",
+      genesisTitleHint: true,
+      toolspaceTokenSeed: "ogd_seed",
+    });
+    expect(agent.instructions).toContain(TOOLSPACE_PROGRAMMATIC_DIRECTIVE);
+    expect(agent.instructions.endsWith(GENESIS_TITLE_DIRECTIVE)).toBe(true);
+    expect(agent.instructions.indexOf(TOOLSPACE_PROGRAMMATIC_DIRECTIVE))
+      .toBeLessThan(agent.instructions.indexOf("Session-scoped rule."));
+    expect(agent.instructions.indexOf("Session-scoped rule."))
+      .toBeLessThan(agent.instructions.indexOf(GENESIS_TITLE_DIRECTIVE));
+  });
+
+  test("appendToolspaceInstructions joins by space and no-ops when unavailable", () => {
+    expect(appendToolspaceInstructions("BASE", true)).toBe(`BASE ${TOOLSPACE_PROGRAMMATIC_DIRECTIVE}`);
+    expect(appendToolspaceInstructions("BASE", false)).toBe("BASE");
+  });
+
+  test("the toolspace directive text is a stable, generic, host-agnostic snapshot", () => {
+    // Pinned verbatim so an unintended edit to the substrate prompt fails here.
+    // It must name only generic substrate handles (ogtool, $OPENGENI_TOOLSPACE_*),
+    // never a host/product name.
+    expect(TOOLSPACE_PROGRAMMATIC_DIRECTIVE).toBe(
+      "Every tool on your MCP surface is also callable programmatically from the sandbox shell, so scripts can invoke tools without a model round trip per call. Run `ogtool list` to see the available tools and their input schemas (from tools/list), then `ogtool call <tool-name> '<json-args>'`; equivalently, POST MCP JSON-RPC to $OPENGENI_TOOLSPACE_URL with the bearer token read from $OPENGENI_TOOLSPACE_TOKEN_FILE. Prefer programmatic calls for loops, polling, and bulk filtering: their results stay in the sandbox and do not consume your context window. Tools that require human approval must still be invoked normally — called programmatically they return a typed error.",
+    );
   });
 
   test("builds native S3 mount entries for file resources", () => {

--- a/packages/runtime/test/selfhosted-turn.integration.test.ts
+++ b/packages/runtime/test/selfhosted-turn.integration.test.ts
@@ -44,7 +44,11 @@ const liveSessions: Array<{ close?: () => Promise<void> }> = [];
  *  a SelfhostedSession pinned active. Returns the serialized RunState string (the
  *  worker's `state.toString()` — the call that triggers the cross-backend serialize
  *  that used to crash). A contract gap or a serialize crash throws before return. */
-async function runPinnedToVmTurn(model: ScriptedModel): Promise<string> {
+async function runPinnedToVmTurn(model: ScriptedModel, opts: {
+  toolspaceTokenSeed?: string;
+  responder?: MockAgentResponder;
+  activeSandboxBackend?: "selfhosted";
+} = {}): Promise<string> {
   const settings = testSettings({ sandboxBackend: "local", webSearchEnabled: false, gitAuthorName: "OpenGeni Bot" });
   // A real local session seeds the proxy DEFAULT (group) backend (createEditor /
   // viewImage bearing), but its manifest is forced to the empty-entries shape the
@@ -65,7 +69,7 @@ async function runPinnedToVmTurn(model: ScriptedModel): Promise<string> {
   const self = new SelfhostedSession({
     workspaceId: WS,
     agentId: "enroll-1",
-    controlRpc: new MockAgentResponder({ hostname: "vm2" }),
+    controlRpc: opts.responder ?? new MockAgentResponder({ hostname: "vm2" }),
     relay: RELAY,
     environment: ENV,
   });
@@ -79,7 +83,12 @@ async function runPinnedToVmTurn(model: ScriptedModel): Promise<string> {
     resolveActiveBackend: async () => ({ session: self as never, sandboxId: "sbx-self", kind: "selfhosted" }),
   });
 
-  const agent = buildOpenGeniAgent(settings, [], { model, sandboxEnvironment: ENV });
+  const agent = buildOpenGeniAgent(settings, [], {
+    model,
+    sandboxEnvironment: ENV,
+    ...(opts.toolspaceTokenSeed ? { toolspaceTokenSeed: opts.toolspaceTokenSeed } : {}),
+    ...(opts.activeSandboxBackend ? { activeSandboxBackend: opts.activeSandboxBackend } : {}),
+  });
   const result = await runAgentStream(agent, "run echo on the vm", settings, {
     ownedSandbox: { client: client as never, session: proxy as never },
   });
@@ -114,6 +123,79 @@ describe("selfhosted agent-turn contract — full run loop over a pinned selfhos
       { output: [assistantMessage("done on vm2")] },
     ]));
     expect(typeof s).toBe("string");
+  });
+
+  test("TOOLSPACE DELIVERY: the token seed is written to the machine over the exec channel, with NO platform setup", async () => {
+    // Selfhosted parity: a connected-machine turn now receives the toolspace token
+    // (activeSandboxBackend "selfhosted" + a per-turn seed). The runtime seeds it
+    // over the SAME exec channel the docker path uses — off-manifest — while the
+    // platform setup hooks (repository clone, az login) stay OFF the user's real
+    // machine. Record every exec the machine received and assert both halves.
+    const execLog: string[] = [];
+    const responder = new MockAgentResponder({
+      hostname: "vm2",
+      exec: (req) => {
+        execLog.push(req.command.join(" "));
+        return { exitCode: 0, stdout: new TextEncoder().encode(""), stderr: new Uint8Array(0), timedOut: false, durationMs: "1" };
+      },
+    });
+    await runPinnedToVmTurn(new ScriptedModel([{ output: [assistantMessage("ok")] }]), {
+      toolspaceTokenSeed: "ogd_selfhosted_seed",
+      responder,
+      activeSandboxBackend: "selfhosted",
+    });
+    // The seed hook ran over the machine's exec channel and carried the token value.
+    expect(execLog.some((c) => c.includes("OPENGENI_TOOLSPACE_TOKEN_SEED") && c.includes("ogd_selfhosted_seed"))).toBe(true);
+    // But NO platform setup ran against the user's real computer.
+    expect(execLog.some((c) => c.includes("git clone"))).toBe(false);
+    expect(execLog.some((c) => c.includes("az login") || c.includes("az account"))).toBe(false);
+  });
+
+  test("NO-TOOLSPACE selfhosted turn seeds nothing (the hook list is empty without a token)", async () => {
+    const execLog: string[] = [];
+    const responder = new MockAgentResponder({
+      hostname: "vm2",
+      exec: (req) => {
+        execLog.push(req.command.join(" "));
+        return { exitCode: 0, stdout: new TextEncoder().encode(""), stderr: new Uint8Array(0), timedOut: false, durationMs: "1" };
+      },
+    });
+    await runPinnedToVmTurn(new ScriptedModel([{ output: [assistantMessage("ok")] }]), {
+      responder,
+      activeSandboxBackend: "selfhosted",
+    });
+    expect(execLog.some((c) => c.includes("OPENGENI_TOOLSPACE_TOKEN_SEED"))).toBe(false);
+  });
+
+  test("selfhosted exec exports ONLY the allowlisted toolspace pointers to the machine (not HOME/GIT_*)", async () => {
+    // ogtool on the machine reads $OPENGENI_TOOLSPACE_URL/_TOKEN_FILE from its
+    // shell env, but selfhosted exec does not consume the manifest env wholesale
+    // (pushing HOME=/workspace onto a real computer would break it). Prove the
+    // exec carries exactly the two non-secret toolspace pointers and nothing else.
+    let capturedEnv: Record<string, string> = {};
+    const responder = new MockAgentResponder({
+      exec: (req) => {
+        capturedEnv = req.env;
+        return { exitCode: 0, stdout: new TextEncoder().encode(""), stderr: new Uint8Array(0), timedOut: false, durationMs: "1" };
+      },
+    });
+    const self = new SelfhostedSession({
+      workspaceId: WS,
+      agentId: "enroll-1",
+      controlRpc: responder,
+      relay: RELAY,
+      environment: {
+        OPENGENI_TOOLSPACE_URL: "https://app.opengeni.example/v1/workspaces/ws/mcp",
+        OPENGENI_TOOLSPACE_TOKEN_FILE: "/workspace/.opengeni/toolspace-token",
+        HOME: "/workspace",
+        GIT_AUTHOR_NAME: "OpenGeni Bot",
+      },
+    });
+    await self.exec({ cmd: "ogtool list" });
+    expect(capturedEnv.OPENGENI_TOOLSPACE_URL).toBe("https://app.opengeni.example/v1/workspaces/ws/mcp");
+    expect(capturedEnv.OPENGENI_TOOLSPACE_TOKEN_FILE).toBe("/workspace/.opengeni/toolspace-token");
+    expect(capturedEnv.HOME).toBeUndefined();
+    expect(capturedEnv.GIT_AUTHOR_NAME).toBeUndefined();
   });
 
   test("REGRESSION (focused): the selfhosted state carries the `environment` field the GROUP client's serialize reads", () => {


### PR DESCRIPTION
## What

Two folded-together changes for the `toolspace:call` substrate (follow-up to #277).

### 1. Generic programmatic-calling agent instructions
When a toolspace token is minted for a turn (feature enabled), the composed agent instructions carry one **generic, host-agnostic** substrate directive (`TOOLSPACE_PROGRAMMATIC_DIRECTIVE`): every MCP tool is also callable from the sandbox via `ogtool` (or MCP JSON-RPC to `$OPENGENI_TOOLSPACE_URL` with the bearer from `$OPENGENI_TOOLSPACE_TOKEN_FILE`), prefer programmatic calls for loops/polling/bulk filtering because those results don't consume model context, and approval-required tools must still be invoked normally. It composes **after** the workspace persona + non-bypassable CORE but **before** the per-session instructions, so host/session specificity still wins. Gated on the per-turn token seed, not the flag alone.

### 2. Selfhosted parity
The prior selfhosted mint-skip was wrong. The git-token skip does **not** transfer: that token is inert on a connected machine, but the toolspace token is the machine's *only* path to programmatic tool calling. The governing invariant is now:

> **No credential crosses to a user machine that grants more than the machine owner's own authority.**

The toolspace token (`toolspace:call` only, own-session-bound, turn TTL, budgeted, approval-tools excluded) satisfies it. So:
- removed the `skipToolspaceToken` path — selfhosted mints like any backend;
- the runtime seeds the token to `$OPENGENI_TOOLSPACE_TOKEN_FILE` over the machine's exec channel (off-manifest), while repository clone / `az login` / file materialization still never run against the user's computer;
- selfhosted `exec` exports a strict two-key allowlist (`OPENGENI_TOOLSPACE_URL`, `OPENGENI_TOOLSPACE_TOKEN_FILE` — non-secret pointers only) so `ogtool` can find the surface; the token value never rides that env. This is the one **accepted delta** from the docker path (where the manifest env is consumed wholesale), documented in `docs/design/toolspace.md`;
- the URL resolves to the public sandbox-routable base (`OPENGENI_MCP_URL`) the machine enrolled against, never a loopback/cluster-internal address.

## Tests
- **Runtime composition** (`runtime.test.ts`): directive present/absent by flag+seed, composition order (after CORE, before session, genesis last), stable content snapshot.
- **Worker mint** (`toolspace-token.test.ts`): selfhosted-positive mint (replaces the old skip test) + the public-URL assertion.
- **Selfhosted integration** (`selfhosted-turn.integration.test.ts`): the real run loop delivers the seed over exec; nothing is seeded without a token; only the allowlisted pointers reach the machine.

Full unit suite (2179 pass / 0 fail), typecheck, and `check:docs-refs` all green. Changeset: `@opengeni/runtime` + `@opengeni/worker-bundle` minor, `@opengeni/core` + `@opengeni/api-router` patch (dependent closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which credentials reach user-owned machines and what agents are told about programmatic tool calling; mitigated by narrow `toolspace:call` tokens, off-manifest delivery, and selfhosted exec env allowlisting, but still security- and behavior-sensitive.
> 
> **Overview**
> **Selfhosted toolspace parity:** Connected-machine turns no longer skip toolspace token minting or seed delivery. The worker removes `skipToolspaceToken` and always forwards `toolspaceTokenSeed` when a token exists (GitHub platform tokens still skip on selfhosted). The runtime seeds the token off-manifest on selfhosted over exec only—clone/`az login`/file setup still stay off the user machine—and **selfhosted `exec` exports only** `OPENGENI_TOOLSPACE_URL` and `OPENGENI_TOOLSPACE_TOKEN_FILE` so `ogtool` works without clobbering the host shell.
> 
> **Agent substrate prompting:** When toolspace is enabled and a per-turn token was minted, composed instructions gain a fixed **`TOOLSPACE_PROGRAMMATIC_DIRECTIVE`** via `appendToolspaceInstructions`—after workspace persona + CORE, before per-session instructions—describing `ogtool` / MCP JSON-RPC and when to prefer programmatic calls.
> 
> Design doc and tests cover mint on selfhosted, public MCP URL routing, instruction gating/order, and integration behavior for seeding vs platform setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ac31fa6fd4a0eb482a00e850a5c8475889cab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->