### PR TITLE
fix(release): invoke prepublish-guard with bash, not bun

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,7 @@
     "start": "bun src/index.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1044.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -35,7 +35,7 @@
     "start": "bun src/index.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/codex": "workspace:*",

--- a/packages/agent-proto/package.json
+++ b/packages/agent-proto/package.json
@@ -35,7 +35,7 @@
     "build": "tsup",
     "codegen": "bash scripts/codegen.sh",
     "test": "bun test ./test",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0"

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "zod": "^4.2.1"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/codex": "workspace:*",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "zod": "^4.2.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -49,7 +49,7 @@
     "provision-roles": "bun src/provision-roles.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/codex": "workspace:*",

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/config": "workspace:*",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/contracts": "workspace:*",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/config": "workspace:*",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
     "build": "tsup",
     "demo": "vite dev demo --port 3100",
     "demo:build": "vite build demo",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@opengeni/agent-proto": "workspace:*",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "devDependencies": {
     "@opengeni/contracts": "workspace:*",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun ../../scripts/prepublish-guard"
+    "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1044.0",

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -53,7 +53,7 @@ const publishable = topologicallySortedPackages(publishableWorkspacePackages());
 const publishableNames = new Set(publishable.map((pkg) => pkg.name));
 const ignored = changesetIgnoreSet();
 const workspaceNames = workspacePackageByName();
-const PREPUBLISH_GUARD_SCRIPT = "bun ../../scripts/prepublish-guard";
+const PREPUBLISH_GUARD_SCRIPT = "bash ../../scripts/prepublish-guard";
 
 function readPkg(pkgDir: string): PackageJson {
   return JSON.parse(readFileSync(join(repoRoot, pkgDir, "package.json"), "utf8")) as PackageJson;


### PR DESCRIPTION
The prepublish guard became a bash script in #275 while all 16 `prepublishOnly` hooks still invoked it via `bun`, which parses bash as JavaScript (`error: Expected ";" but found "pipefail"`) — breaking every package publish. The Release run after Version PR #279 failed exactly there, leaving the 0.9.0-closure versions bumped on main but unpublished; merging this lets the next Release run publish the pending set.

Verified locally: the guard blocks correctly under `bash` without `OPENGENI_RELEASE=1` and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script wiring only; no runtime or application logic changes.
> 
> **Overview**
> **Fixes npm publish** by running `scripts/prepublish-guard` with `bash` instead of `bun` in every publishable package’s `prepublishOnly` hook and in `scripts/publish-closure-guard.ts`.
> 
> After the guard became a bash script, `bun` tried to parse it as JavaScript and failed (e.g. on `pipefail`), which blocked the whole release publish path. Using `bash` matches the shebang and restores the intended behavior: block ad-hoc `npm publish` unless `OPENGENI_RELEASE=1` is set by the blessed release script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b343fe9f71a2423d5a2df446a6ee06d8fa2a28fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->