### PR TITLE
feat(observability): opengeni_credit_balance_micros gauge — see the wallet before it hits zero

### DIFF
--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -37,6 +37,7 @@ import {
   countSandboxLeasesByLiveness,
   forceDrainOverLimitViewerOnlyBoxes,
   getBillingBalance,
+  listCreditBalancesByAccount,
   listLiveModalSandboxLeaseAttributions,
   listMeterableWarmLeases,
   persistDrainSnapshot,
@@ -63,6 +64,7 @@ import {
 } from "@opengeni/runtime";
 import type { ActivityServices } from "./types";
 import {
+  recordCreditBalanceGauges,
   recordCreditMicros,
   recordSandboxLeaseGauges,
   recordSandboxOrphansTerminated,
@@ -174,7 +176,7 @@ export function createSandboxLeaseActivities(
     if (!settings.sandboxOwnershipEnabled) {
       return { examined: 0, terminated: 0, skipped: 0, metered: 0, forceDrained: 0, modalOrphansTerminated: 0 };
     }
-    await refreshQueueAndLeaseGauges(db, observability);
+    await refreshQueueLeaseAndCreditGauges(db, observability);
 
     // (0) Warm-meter tick (P2.1) — accrue warm-seconds for every WARM viewer-only
     // box (turn-held boxes meter on the turn heartbeat, so the list fn excludes
@@ -229,7 +231,7 @@ export function createSandboxLeaseActivities(
       });
     }
 
-    await refreshQueueAndLeaseGauges(db, observability);
+    await refreshQueueLeaseAndCreditGauges(db, observability);
 
     if (drainable.length > 0 || metered.accrued > 0 || forceDrained > 0 || modalOrphansTerminated > 0) {
       observability.info("sandbox reaper swept", {
@@ -299,7 +301,7 @@ async function accrueWarmTick(
   return { accrued, workspaceIds };
 }
 
-async function refreshQueueAndLeaseGauges(
+async function refreshQueueLeaseAndCreditGauges(
   db: ActivityServices["db"],
   observability: ActivityServices["observability"],
 ): Promise<void> {
@@ -314,6 +316,13 @@ async function refreshQueueAndLeaseGauges(
     recordSandboxLeaseGauges(observability, await countSandboxLeasesByLiveness(db));
   } catch (error) {
     observability.warn("sandbox reaper: sandbox-lease gauge refresh failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  try {
+    recordCreditBalanceGauges(observability, await listCreditBalancesByAccount(db));
+  } catch (error) {
+    observability.warn("sandbox reaper: credit-balance gauge refresh failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -5,8 +5,10 @@ import type { RuntimeMetricsHooks } from "@opengeni/runtime";
 export type TurnOutcome = "completed" | "failed" | "cancelled" | "preempted";
 export type CreditMicrosKind = "usage" | "grant" | "topup" | "refund";
 export type SandboxLeaseLiveness = "cold" | "warming" | "warm" | "draining";
+export type CreditBalanceGauge = { accountId: string; balanceMicros: number };
 
 const turnTrackers = new WeakMap<Observability, TurnLifecycleMetrics>();
+const creditBalanceGaugeAccounts = new WeakMap<Observability, Set<string>>();
 
 export function observabilityEventLogger(observability: Observability): EventLogger {
   return {
@@ -192,6 +194,31 @@ export function recordSandboxLeaseGauges(observability: Observability, counts: P
       value: counts[liveness] ?? 0,
     });
   }
+}
+
+export function recordCreditBalanceGauges(observability: Observability, balances: CreditBalanceGauge[]): void {
+  const previous = creditBalanceGaugeAccounts.get(observability) ?? new Set<string>();
+  const current = new Set<string>();
+  for (const balance of balances) {
+    current.add(balance.accountId);
+    observability.setGauge({
+      name: "opengeni_credit_balance_micros",
+      help: "Current credit balance in micros by account.",
+      labels: { account_id: balance.accountId },
+      value: balance.balanceMicros,
+    });
+  }
+  for (const accountId of previous) {
+    if (!current.has(accountId)) {
+      observability.setGauge({
+        name: "opengeni_credit_balance_micros",
+        help: "Current credit balance in micros by account.",
+        labels: { account_id: accountId },
+        value: 0,
+      });
+    }
+  }
+  creditBalanceGaugeAccounts.set(observability, current);
 }
 
 export function recordSandboxOrphansTerminated(observability: Observability, count: number): void {

--- a/apps/worker/test/turn-lifecycle-metrics.test.ts
+++ b/apps/worker/test/turn-lifecycle-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createObservability } from "@opengeni/observability";
 import { testSettings } from "@opengeni/testing";
-import { TurnLifecycleMetrics } from "../src/observability-metrics";
+import { recordCreditBalanceGauges, TurnLifecycleMetrics } from "../src/observability-metrics";
 
 describe("turn lifecycle metrics", () => {
   test("start and finish update inflight gauges and terminal totals", async () => {
@@ -30,5 +30,28 @@ describe("turn lifecycle metrics", () => {
     expect(metrics).toContain("opengeni_turns_total");
     expect(metrics).toContain('outcome="completed"');
     expect(metrics).toContain("opengeni_turn_duration_seconds_bucket");
+  });
+
+  test("records credit balance gauges by account", async () => {
+    const observability = createObservability(testSettings(), { component: "worker" });
+    const accountA = "11111111-1111-4111-8111-111111111111";
+    const accountB = "22222222-2222-4222-8222-222222222222";
+
+    recordCreditBalanceGauges(observability, [
+      { accountId: accountA, balanceMicros: 25_000 },
+      { accountId: accountB, balanceMicros: -500 },
+    ]);
+
+    let metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(new RegExp(`opengeni_credit_balance_micros\\{[^}]*account_id="${accountA}"[^}]*\\} 25000`));
+    expect(metrics).toMatch(new RegExp(`opengeni_credit_balance_micros\\{[^}]*account_id="${accountB}"[^}]*\\} -500`));
+
+    recordCreditBalanceGauges(observability, [
+      { accountId: accountA, balanceMicros: 10_000 },
+    ]);
+
+    metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(new RegExp(`opengeni_credit_balance_micros\\{[^}]*account_id="${accountA}"[^}]*\\} 10000`));
+    expect(metrics).toMatch(new RegExp(`opengeni_credit_balance_micros\\{[^}]*account_id="${accountB}"[^}]*\\} 0`));
   });
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -593,7 +593,7 @@ Minimum production dashboards should cover:
 - Worker execution: activity run rate, failure rate, and p50/p95/p99 `runAgentTurn` duration by `activity`, `status`, `environment`, and `component`.
 - Turn lifecycle: `opengeni_turns_total{outcome}`, `opengeni_turn_duration_seconds`, `opengeni_turns_inflight`, and `opengeni_turn_oldest_inflight_age_seconds`.
 - Model and sandbox SLIs: `opengeni_model_calls_total{provider,outcome}`, `opengeni_model_call_duration_seconds{provider}`, `opengeni_sandbox_creates_total{backend,outcome}`, `opengeni_sandbox_create_duration_seconds{backend}`, `opengeni_sandbox_leases{liveness}`, `opengeni_sandbox_warming_timeouts_total`, and `opengeni_sandbox_orphans_terminated_total`.
-- Queue and billing: `opengeni_turns_queued`, `opengeni_credit_micros_total{kind}`, and `opengeni_build_info{version,revision}`.
+- Queue and billing: `opengeni_turns_queued`, `opengeni_credit_balance_micros{account_id}`, `opengeni_credit_micros_total{kind}`, and `opengeni_build_info{version,revision}`.
 - Dependency health: Postgres connection health, Temporal worker poll health, NATS connectivity, object-storage write/read conformance, and sandbox backend readiness.
 - Runtime health: API/worker restarts, CPU/memory saturation, pod pending time, collector scrape/export errors, and OTLP export failures.
 

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -56,14 +56,16 @@ work. The domain metric set (all `opengeni_` prefixed, bounded label values only
 
 **Queue & billing:**
 - `opengeni_turns_queued` gauge
+- `opengeni_credit_balance_micros{account_id}` gauge
 - `opengeni_credit_micros_total{kind}` counter (usage | grant | topup | refund)
 
 **Deploy marker:** `opengeni_build_info{version, revision}` gauge=1 — dashboards
 join against it instead of hard-coding SHAs.
 
 Cardinality rule: no user ids, session ids, workspace ids, or free-form strings as
-label values, ever. Session-scoped detail already has a home (the durable
-`session_events` log); metrics are aggregates.
+label values, ever. `account_id` is allowed only for managed-account billing
+gauges where cardinality is intentionally small. Session-scoped detail already
+has a home (the durable `session_events` log); metrics are aggregates.
 
 ## Log hygiene
 

--- a/packages/db/drizzle/0043_credit_balance_observability.sql
+++ b/packages/db/drizzle/0043_credit_balance_observability.sql
@@ -1,0 +1,22 @@
+-- 0043_credit_balance_observability.sql
+-- Cross-account billing balance reads for Prometheus gauges. This mirrors the
+-- observability count SECURITY DEFINER functions so workers can refresh global
+-- process metrics without disabling FORCE RLS on account-scoped tables.
+
+CREATE OR REPLACE FUNCTION opengeni_private.credit_balance_by_account()
+RETURNS TABLE (account_id uuid, balance_micros bigint)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT L.account_id, coalesce(sum(L.amount_micros), 0)::bigint AS balance_micros
+  FROM credit_ledger_entries L
+  GROUP BY L.account_id
+  ORDER BY L.account_id;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.credit_balance_by_account() TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5713,6 +5713,22 @@ export async function countSandboxLeasesByLiveness(db: Database): Promise<Record
   return counts;
 }
 
+export type CreditBalanceByAccount = {
+  accountId: string;
+  balanceMicros: number;
+};
+
+export async function listCreditBalancesByAccount(db: Database): Promise<CreditBalanceByAccount[]> {
+  const rows = await rawRows<{ account_id: string; balance_micros: number | string }>(db, sql`
+    select account_id, balance_micros
+    from opengeni_private.credit_balance_by_account()
+  `);
+  return rows.map((row) => ({
+    accountId: row.account_id,
+    balanceMicros: Number(row.balance_micros),
+  }));
+}
+
 // Cross-workspace live Modal lease read for the provider-side orphan sweep. The
 // SECURITY DEFINER function is the sanctioned RLS bypass; see migration 0036.
 export async function listLiveModalSandboxLeaseAttributions(db: Database): Promise<LiveModalSandboxLeaseAttribution[]> {

--- a/packages/db/test/observability-counts.test.ts
+++ b/packages/db/test/observability-counts.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import {
+  createDb,
+  listCreditBalancesByAccount,
+  type Database,
+  type DbClient,
+} from "../src/index";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("db-observability-counts");
+  if (!shared) {
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[db-observability-counts] docker unavailable, skipping");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  try {
+    await client?.close();
+  } catch { /* noop */ }
+  await shared?.release();
+});
+
+describe("observability count helpers", () => {
+  test("credit balances are readable cross-account through the SECURITY DEFINER function", async () => {
+    if (!available) return;
+    const [accountA] = await admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('acct-a') returning id`;
+    const [accountB] = await admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('acct-b') returning id`;
+    const [accountC] = await admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('acct-c') returning id`;
+
+    await admin`
+      insert into credit_ledger_entries (account_id, type, amount_micros, idempotency_key)
+      values
+        (${accountA!.id}, 'grant', 1000, ${"obs:a:grant:" + crypto.randomUUID()}),
+        (${accountA!.id}, 'usage', -250, ${"obs:a:usage:" + crypto.randomUUID()}),
+        (${accountB!.id}, 'grant', 500, ${"obs:b:grant:" + crypto.randomUUID()}),
+        (${accountB!.id}, 'usage', -750, ${"obs:b:usage:" + crypto.randomUUID()})
+    `;
+
+    const balances = await listCreditBalancesByAccount(db);
+    const byAccount = new Map(balances.map((balance) => [balance.accountId, balance.balanceMicros]));
+
+    expect(byAccount.get(accountA!.id)).toBe(750);
+    expect(byAccount.get(accountB!.id)).toBe(-250);
+    expect(byAccount.has(accountC!.id)).toBe(false);
+  }, 60_000);
+});


### PR DESCRIPTION
Credit exhaustion currently announces itself only by parking the program (3× in 3 days on the managed flywheel account). This adds a per-account balance gauge (`opengeni_credit_balance_micros{account_id}`) refreshed on the worker metrics poll, via a SECURITY DEFINER `credit_balance_by_account()` mirroring the 0038 observability-count pattern (FORCE RLS stays on).

Alert rule (CreditBalanceLow → incident session) follows in the ops repo once this deploys.

Tests: db integration + worker metrics suites green; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQHtjHKi5CwRx42fXwbtUE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only observability path with bounded `account_id` label cardinality; no changes to billing enforcement or ledger writes.
> 
> **Overview**
> Adds **per-account credit balance visibility** before exhaustion shows up only as parked programs.
> 
> A new migration introduces `opengeni_private.credit_balance_by_account()` (SECURITY DEFINER, same pattern as existing observability count functions) so workers can aggregate ledger balances without turning off FORCE RLS. The DB layer exposes `listCreditBalancesByAccount`, and the worker publishes **`opengeni_credit_balance_micros{account_id}`** through `recordCreditBalanceGauges`, which also **zeros gauges for accounts that drop out of the snapshot** so Prometheus does not keep stale series.
> 
> The sandbox reaper’s gauge refresh path is extended (renamed to `refreshQueueLeaseAndCreditGauges`) to load credit balances at the **start and end** of each `reapSandboxLeases` sweep, alongside queued turns and lease liveness. Deployment and observability docs list the new metric and document **`account_id` as an intentional low-cardinality billing label exception**.
> 
> Coverage includes a DB integration test for the SECURITY DEFINER read and a worker metrics test for gauge emission and account removal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8be15327ab2145be40b9e33133e221f1229866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->