### PR TITLE
feat(react,web): credit exhaustion surfaces as a first-class failure with top-up CTA

### DIFF
--- a/.changeset/credit-exhaustion-surfacing.md
+++ b/.changeset/credit-exhaustion-surfacing.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Credit exhaustion renders as a first-class failure with a top-up CTA (was: silent idle). A budget-exhausted `turn.completed` (`segmentLimit: "budget_exhausted"` / `detail: "insufficient OpenGeni credits"`) now projects as a failed turn-end plus a failed notice instead of a clean completed turn, and `turn.failed` credit errors collapse to one canonical sentence via `humanizeFailureReason`. New exports: `isCreditExhaustion`, `creditExhaustedFromEvents`, and `CREDIT_EXHAUSTION_MESSAGE`. The web console (unversioned app) rides along: a credit-specific banner with an "Add credits" link to organization settings — shown also on idle sessions whose last turn died of budget exhaustion — replacing the "send a message to revive" copy that cannot work without credits.

--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -1,5 +1,6 @@
-import { AlertTriangleIcon, ArrowLeftIcon, DownloadIcon, FileJsonIcon, GitBranchIcon, ImageIcon, TerminalIcon, WrenchIcon } from "lucide-react";
+import { AlertTriangleIcon, ArrowLeftIcon, CreditCardIcon, DownloadIcon, FileJsonIcon, GitBranchIcon, ImageIcon, TerminalIcon, WrenchIcon } from "lucide-react";
 import type { UserMessageItem } from "@opengeni/react";
+import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -37,8 +38,41 @@ export function TerminalSessionBanner(props: { session: Session; onNewSession: (
  * Failure honesty: the reason the session failed, how many turns timed out and
  * were retried automatically before it, and the fact that the composer stays
  * usable — sending a message revives the session.
+ *
+ * Credit exhaustion gets its own copy: "send a message to revive" is a lie
+ * when the workspace has no credits (the revive turn dies the same death), so
+ * the banner points at the actual fix — the organization's Credits section.
  */
-export function FailedSessionBanner({ failure }: { failure: SessionFailureSummary }) {
+export function FailedSessionBanner({ failure, creditExhausted, workspaceId }: {
+  failure: SessionFailureSummary;
+  creditExhausted?: boolean;
+  workspaceId?: string;
+}) {
+  if (creditExhausted) {
+    return (
+      <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
+        <div data-testid="failed-session-banner" className="flex flex-col gap-3 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 gap-2.5">
+            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-status-failed" />
+            <div className="min-w-0 text-sm">
+              <span className="font-medium">This workspace is out of OpenGeni credits{failure.failedAt ? ` (since ${formatTimestamp(failure.failedAt)})` : ""}.</span>
+              <div className="mt-1 text-xs text-fg-muted">
+                The conversation history is preserved. Add credits to the organization, then keep working from right here.
+              </div>
+            </div>
+          </div>
+          {workspaceId ? (
+            <Button asChild type="button" size="sm" variant="secondary" className="shrink-0">
+              <Link to="/workspaces/$workspaceId/organization" params={{ workspaceId }}>
+                <CreditCardIcon className="size-3.5" />
+                Add credits
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="mx-auto mb-2 w-full max-w-3xl px-4 pt-4 sm:px-6">
       <div data-testid="failed-session-banner" className="flex gap-2.5 rounded-lg border border-status-failed/30 bg-status-failed/10 p-3 text-status-failed">

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -3,6 +3,7 @@
 // The composer is queue-by-default with explicit steer; failed sessions stay
 // honest (reason + retry history) and revivable from the same composer.
 import {
+  creditExhaustedFromEvents,
   MessageTimeline,
   projectPendingApprovals,
   useComposer,
@@ -106,9 +107,16 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
   // historical `session.requiresAction`, so subtract decisions and finished
   // turns instead of rendering decided approvals as live buttons forever.
   const approvals = useMemo(() => projectPendingApprovals(events), [events]);
+  // Credit death is sneaky: the engine can end the turn as a NOMINALLY
+  // completed one (segmentLimit budget_exhausted), leaving the session idle and
+  // healthy-looking. Track the terminal credit state from the last turn-end so
+  // the banner shows for idle-but-broke sessions too, not only failed ones.
+  const creditExhausted = useMemo(() => creditExhaustedFromEvents(events), [events]);
   const failure = useMemo(
-    () => session?.status === "failed" ? summarizeSessionFailure(events, session.status) : null,
-    [events, session?.status],
+    () => session && (session.status === "failed" || creditExhausted)
+      ? summarizeSessionFailure(events, session.status)
+      : null,
+    [events, session?.status, creditExhausted],
   );
 
   // Keep the workspace header (title, status badge, connection pill) in sync.
@@ -159,6 +167,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       initialLoading={initialLoading}
       approvals={approvals}
       failure={failure}
+      creditExhausted={creditExhausted}
       goal={goal}
       hasOlder={hasOlder}
       loadingOlder={loadingOlder}
@@ -266,6 +275,8 @@ function SessionChatPane(props: {
   initialLoading: boolean;
   approvals: PendingApproval[];
   failure: ReturnType<typeof summarizeSessionFailure> | null;
+  /** The last turn ended budget_exhausted — the workspace is out of credits. */
+  creditExhausted: boolean;
   goal: ReturnType<typeof useGoal>;
   hasOlder: boolean;
   loadingOlder: boolean;
@@ -379,7 +390,14 @@ function SessionChatPane(props: {
         </div>
       ) : (
         <>
-          {props.session.status === "failed" && props.failure ? <FailedSessionBanner failure={props.failure} /> : null}
+          {/* Credit death also surfaces on an IDLE session: a budget_exhausted
+              turn completes "cleanly", so waiting for status === "failed" would
+              hide the one banner that explains why nothing works anymore. It
+              hides again while a turn is actually running (someone topped up
+              and is trying), so the recovery turn isn't shadowed by it. */}
+          {props.failure && (props.session.status === "failed" || (props.creditExhausted && props.session.status === "idle")) ? (
+            <FailedSessionBanner failure={props.failure} creditExhausted={props.creditExhausted} workspaceId={props.session.workspaceId} />
+          ) : null}
           <div data-testid="session-timeline" className="min-h-0 min-w-0 flex-1">
             <MessageTimeline
               className="h-full"
@@ -455,9 +473,13 @@ function SessionChatPane(props: {
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
             placeholder={props.session.status === "cancelled"
               ? "This session was cancelled."
-              : props.session.status === "failed"
-                ? "This session failed — send a message to revive it."
-                : "Send a follow-up…"}
+              : props.creditExhausted && (props.session.status === "failed" || props.session.status === "idle")
+                // "Send a message to revive" is a dead end without credits —
+                // the reply turn dies the same budget death.
+                ? "Out of OpenGeni credits — add credits to continue."
+                : props.session.status === "failed"
+                  ? "This session failed — send a message to revive it."
+                  : "Send a follow-up…"}
             controls={(
               <div className="flex min-w-0 items-center gap-1.5">
                 <ModelPicker

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -91,6 +91,7 @@ export type { PendingApproval } from "./approvals";
 // Timeline projection
 export {
   buildTimeline,
+  creditExhaustedFromEvents,
   extractSessionRef,
   groupTimeline,
   sessionStatusFromEvents,
@@ -242,4 +243,4 @@ export { xtermThemeFromTokens } from "./lib/xterm-theme";
 
 // Utilities
 export { cn } from "./lib/cn";
-export { formatBytes, formatRelativeTime, humanizeFailureReason, stringifyPayload, truncate, tryParseJson } from "./lib/format";
+export { CREDIT_EXHAUSTION_MESSAGE, formatBytes, formatRelativeTime, humanizeFailureReason, isCreditExhaustion, stringifyPayload, truncate, tryParseJson } from "./lib/format";

--- a/packages/react/src/lib/format.ts
+++ b/packages/react/src/lib/format.ts
@@ -84,17 +84,55 @@ export function tryParseJson(text: string): unknown {
 }
 
 /**
+ * The canonical credit-death sentence. Credit exhaustion is the one failure a
+ * user can fix themselves — the copy must say what happened (empty balance),
+ * what to do (add credits), and what is safe (nothing was lost). Crucially it
+ * must NOT say "send a message to revive": a revive turn burns credits the
+ * workspace no longer has.
+ */
+export const CREDIT_EXHAUSTION_MESSAGE =
+  "Out of OpenGeni credits — this workspace's balance is empty. Add credits to continue; the conversation is preserved.";
+
+/**
+ * Does this failure/completion payload (or raw error string) mean the
+ * workspace ran out of OpenGeni credits? Matches the engine's
+ * "insufficient OpenGeni credits" text (case-insensitive, substring — it
+ * arrives both bare and wrapped in "Activity task failed: …") and the
+ * budget-exhausted segment limit the engine stamps on a turn it ended early.
+ */
+export function isCreditExhaustion(
+  input: { error?: string | null; detail?: string | null; segmentLimit?: string | null } | string,
+): boolean {
+  if (typeof input === "string") {
+    return input.toLowerCase().includes("insufficient opengeni credits");
+  }
+  if (input.segmentLimit === "budget_exhausted") {
+    return true;
+  }
+  for (const text of [input.error, input.detail]) {
+    if (typeof text === "string" && text.toLowerCase().includes("insufficient opengeni credits")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Humanize engine/provider failure text before it reaches the timeline or a
  * failure banner. Raw provider errors leak the wrong audience's instructions —
  * "Incorrect API key … find your API key at platform.openai.com" tells a
  * managed-deployment USER to fix credentials only an OPERATOR controls (and is
- * flatly wrong for Azure or subscription-backed engines). Auth and quota
- * failures collapse to one neutral, honest sentence; every other reason passes
- * through untouched. Raw payloads stay available in the debug surfaces.
+ * flatly wrong for Azure or subscription-backed engines). Auth, quota, and
+ * credit-exhaustion failures collapse to one neutral, honest sentence; every
+ * other reason passes through untouched. Raw payloads stay available in the
+ * debug surfaces.
  */
 export function humanizeFailureReason(reason: string | null): string | null {
   if (!reason) {
     return reason;
+  }
+  if (isCreditExhaustion(reason)) {
+    return CREDIT_EXHAUSTION_MESSAGE;
   }
   const normalized = reason.toLowerCase();
   const authFailure =

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -16,7 +16,7 @@
    -------------------------------------------------------------------------- */
 
 // projection
-export { buildTimeline, extractSessionRef, groupTimeline, sessionStatusFromEvents, toolDisplayName } from "./projection";
+export { buildTimeline, creditExhaustedFromEvents, extractSessionRef, groupTimeline, sessionStatusFromEvents, toolDisplayName } from "./projection";
 
 // item types
 export type {

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1,5 +1,5 @@
 import type { SessionEvent, SessionStatus } from "@opengeni/sdk";
-import { humanizeFailureReason, tryParseJson } from "../lib/format";
+import { CREDIT_EXHAUSTION_MESSAGE, humanizeFailureReason, isCreditExhaustion, tryParseJson } from "../lib/format";
 import type {
   AgentMessageItem,
   ActivityItem,
@@ -328,6 +328,24 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "turn.completed": {
+        // Credit exhaustion arrives as a NOMINALLY completed turn (`detail:
+        // "insufficient OpenGeni credits"`, `segmentLimit: "budget_exhausted"`)
+        // — the engine ended the segment early, it did not finish the work.
+        // Rendering it as a clean "complete" turn is a lie that leaves the
+        // session looking healthy while every future turn silently dies, so it
+        // projects exactly like a failed turn plus an explicit notice.
+        if (isCreditExhaustionPayload(payload)) {
+          finalizeOpen(turnId);
+          items.push(turnEndItem(event, "failed", CREDIT_EXHAUSTION_MESSAGE));
+          items.push({
+            kind: "notice",
+            id: event.id,
+            tone: "failed",
+            text: CREDIT_EXHAUSTION_MESSAGE,
+            occurredAt: event.occurredAt,
+          });
+          break;
+        }
         finalizeOpen(turnId);
         items.push(turnEndItem(event, "complete", null));
         break;
@@ -335,7 +353,10 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
 
       case "turn.failed": {
         const hadActivity = hasTurnActivity(items, turnId);
-        const failureText = failureMessage(payload);
+        // Credit death can hide behind fields `failureMessage` doesn't read
+        // (detail/segmentLimit), so classify the whole payload before falling
+        // back to the generic error/message extraction.
+        const failureText = isCreditExhaustionPayload(payload) ? CREDIT_EXHAUSTION_MESSAGE : failureMessage(payload);
         // The TURN failed — the in-flight items did not. Chip doctrine: red is
         // spent once, on the turn-level outcome. Items caught mid-flight read
         // as calm "interrupted" (same as turn.cancelled); an item that itself
@@ -398,6 +419,33 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   }
 
   return items;
+}
+
+/** The turn-end payload shape, as `isCreditExhaustion` wants it. */
+function isCreditExhaustionPayload(payload: Record<string, unknown>): boolean {
+  return isCreditExhaustion({
+    error: typeof payload.error === "string" ? payload.error : null,
+    detail: typeof payload.detail === "string" ? payload.detail : null,
+    segmentLimit: typeof payload.segmentLimit === "string" ? payload.segmentLimit : null,
+  });
+}
+
+/**
+ * Whether the session's most recent turn ended in credit exhaustion — the
+ * terminal credit state apps key their "add credits" affordances on. Derived
+ * from the LAST turn-end event (completed/failed/cancelled): a later turn that
+ * settles any other way (someone topped up and kept working) clears it.
+ */
+export function creditExhaustedFromEvents(events: SessionEvent[]): boolean {
+  const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const event = ordered[index];
+    if (event?.type !== "turn.completed" && event?.type !== "turn.failed" && event?.type !== "turn.cancelled") {
+      continue;
+    }
+    return isCreditExhaustionPayload(asRecord(event.payload));
+  }
+  return false;
 }
 
 /** The latest session status carried in the event log, if any. */

--- a/packages/react/test/format.test.ts
+++ b/packages/react/test/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { formatRelativeTime, stringifyPayload, truncate, tryParseJson } from "../src/lib/format";
+import {
+  CREDIT_EXHAUSTION_MESSAGE,
+  formatRelativeTime,
+  humanizeFailureReason,
+  isCreditExhaustion,
+  stringifyPayload,
+  truncate,
+  tryParseJson,
+} from "../src/lib/format";
 
 describe("formatRelativeTime", () => {
   const now = new Date("2026-06-12T12:00:00Z");
@@ -40,5 +48,41 @@ describe("tryParseJson", () => {
     expect(tryParseJson("[1,2]")).toEqual([1, 2]);
     expect(tryParseJson("nope")).toBeUndefined();
     expect(tryParseJson("{broken")).toBeUndefined();
+  });
+});
+
+describe("isCreditExhaustion", () => {
+  test("matches the engine error text, bare and wrapped, case-insensitively", () => {
+    expect(isCreditExhaustion("insufficient OpenGeni credits")).toBe(true);
+    expect(isCreditExhaustion("Activity task failed: insufficient OpenGeni credits")).toBe(true);
+    expect(isCreditExhaustion("INSUFFICIENT OPENGENI CREDITS")).toBe(true);
+    expect(isCreditExhaustion({ error: "Activity task failed: insufficient OpenGeni credits" })).toBe(true);
+    expect(isCreditExhaustion({ detail: "insufficient OpenGeni credits" })).toBe(true);
+  });
+
+  test("matches the budget_exhausted segment limit on its own", () => {
+    expect(isCreditExhaustion({ segmentLimit: "budget_exhausted" })).toBe(true);
+    expect(isCreditExhaustion({ detail: "insufficient OpenGeni credits", segmentLimit: "budget_exhausted" })).toBe(true);
+  });
+
+  test("rejects unrelated failures and limits", () => {
+    expect(isCreditExhaustion("insufficient_quota")).toBe(false);
+    expect(isCreditExhaustion({ error: "connection reset by peer" })).toBe(false);
+    expect(isCreditExhaustion({ segmentLimit: "max_turns" })).toBe(false);
+    expect(isCreditExhaustion({ error: null, detail: null, segmentLimit: null })).toBe(false);
+  });
+});
+
+describe("humanizeFailureReason", () => {
+  test("maps credit exhaustion to the canonical sentence", () => {
+    expect(humanizeFailureReason("insufficient OpenGeni credits")).toBe(CREDIT_EXHAUSTION_MESSAGE);
+    expect(humanizeFailureReason("Activity task failed: insufficient OpenGeni credits")).toBe(CREDIT_EXHAUSTION_MESSAGE);
+  });
+
+  test("keeps auth/quota mappings and passes other reasons through", () => {
+    expect(humanizeFailureReason("Incorrect API key provided")).toContain("engine credentials");
+    expect(humanizeFailureReason("insufficient_quota")).toContain("provider quota");
+    expect(humanizeFailureReason("something else broke")).toBe("something else broke");
+    expect(humanizeFailureReason(null)).toBeNull();
   });
 });

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
+import { CREDIT_EXHAUSTION_MESSAGE } from "../src/lib/format";
 import {
   buildTimeline,
+  creditExhaustedFromEvents,
   extractSessionRef,
   groupTimeline,
   sessionStatusFromEvents,
@@ -965,6 +967,100 @@ describe("cluster outcomes inside a failed turn", () => {
     const outcomes = activity.map((cluster) => cluster.outcome);
     expect(outcomes).toContain("failed");
     expect(outcomes.filter((outcome) => outcome === "failed").length).toBe(1);
+  });
+});
+
+describe("credit exhaustion", () => {
+  // Case (b), the worst one: the engine ends a budget-exhausted turn as a
+  // NOMINALLY completed turn. It must project as a failure, never as a clean
+  // "complete" chip on an otherwise healthy-looking idle session.
+  test("turn.completed with budget_exhausted projects as a failed turn-end plus a failed notice", () => {
+    reset();
+    const items = buildTimeline([
+      event("user.message", { text: "keep going" }),
+      event("agent.message.delta", { text: "Working…" }),
+      event("turn.completed", { detail: "insufficient OpenGeni credits", segmentLimit: "budget_exhausted" }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["user-message", "agent-message", "turn-end", "notice"]);
+    expect(items[2]).toMatchObject({ kind: "turn-end", outcome: "failed", failureText: CREDIT_EXHAUSTION_MESSAGE });
+    expect(items[3]).toMatchObject({ kind: "notice", tone: "failed", text: CREDIT_EXHAUSTION_MESSAGE });
+  });
+
+  test("turn.completed with only the detail text (no segmentLimit) still projects as failed", () => {
+    reset();
+    const items = buildTimeline([
+      event("turn.completed", { detail: "insufficient OpenGeni credits" }),
+    ]);
+    expect(items[0]).toMatchObject({ kind: "turn-end", outcome: "failed", failureText: CREDIT_EXHAUSTION_MESSAGE });
+    expect(items[1]).toMatchObject({ kind: "notice", tone: "failed" });
+  });
+
+  test("ordinary turn.completed is untouched — complete turn-end, no notice", () => {
+    reset();
+    const items = buildTimeline([
+      event("turn.completed", { detail: "all good", segmentLimit: "max_turns" }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["turn-end"]);
+    expect(items[0]).toMatchObject({ outcome: "complete", failureText: null });
+  });
+
+  // Case (a): turn.failed carrying the raw engine error (bare or wrapped in
+  // "Activity task failed") maps to the same canonical sentence.
+  test("turn.failed with the credit error renders the canonical message", () => {
+    reset();
+    const items = buildTimeline([
+      event("turn.failed", { error: "Activity task failed: insufficient OpenGeni credits" }),
+    ]);
+    expect(items[0]).toMatchObject({ kind: "turn-end", outcome: "failed", failureText: CREDIT_EXHAUSTION_MESSAGE });
+    expect(items[1]).toMatchObject({ kind: "notice", tone: "failed", text: CREDIT_EXHAUSTION_MESSAGE });
+  });
+
+  test("groupTimeline folds a credit-exhausted turn as failed", () => {
+    reset();
+    const groups = groupTimeline(buildTimeline([
+      event("agent.toolCall.created", { id: "c1", name: "exec_command", arguments: { cmd: "ls" } }),
+      event("agent.toolCall.output", { id: "c1", output: "ok" }),
+      event("turn.completed", { detail: "insufficient OpenGeni credits", segmentLimit: "budget_exhausted" }),
+    ]));
+    const turnGroup = groups.find((group) => group.kind === "turn");
+    expect(turnGroup?.outcome).toBe("failed");
+    expect(turnGroup?.failureText).toBe(CREDIT_EXHAUSTION_MESSAGE);
+  });
+});
+
+describe("creditExhaustedFromEvents", () => {
+  test("true when the LAST turn-end is credit exhaustion (either payload shape)", () => {
+    reset();
+    expect(creditExhaustedFromEvents([
+      event("turn.completed", {}, { turnId: "turn-1" }),
+      event("turn.completed", { detail: "insufficient OpenGeni credits", segmentLimit: "budget_exhausted" }, { turnId: "turn-2" }),
+    ])).toBe(true);
+    reset();
+    expect(creditExhaustedFromEvents([
+      event("turn.failed", { error: "Activity task failed: insufficient OpenGeni credits" }),
+    ])).toBe(true);
+  });
+
+  test("false when a later turn settles any other way, or with no turn ends", () => {
+    reset();
+    expect(creditExhaustedFromEvents([
+      event("turn.completed", { detail: "insufficient OpenGeni credits", segmentLimit: "budget_exhausted" }, { turnId: "turn-1" }),
+      event("turn.completed", {}, { turnId: "turn-2" }),
+    ])).toBe(false);
+    reset();
+    expect(creditExhaustedFromEvents([
+      event("user.message", { text: "hello" }),
+      event("agent.message.delta", { text: "hi" }),
+    ])).toBe(false);
+    expect(creditExhaustedFromEvents([])).toBe(false);
+  });
+
+  test("orders by sequence, not array order", () => {
+    reset();
+    expect(creditExhaustedFromEvents([
+      eventAt(20, "turn.completed", { segmentLimit: "budget_exhausted" }, { turnId: "turn-2" }),
+      eventAt(10, "turn.completed", {}, { turnId: "turn-1" }),
+    ])).toBe(true);
   });
 });
 


### PR DESCRIPTION
Credit death was invisible: the `budget_exhausted` `turn.completed` shape rendered as a clean finish (session looked healthy while starving), and the `turn.failed` shape told users to 'send a message to revive' — a dead end without credits. Now: shared `isCreditExhaustion` classifier + canonical message in @opengeni/react, budget_exhausted projects as a failed turn-end + failed-tone notice, and the app banner switches to credit-specific copy with an Add-credits CTA (also firing on idle-but-exhausted sessions). Changeset: react minor, web patch. 438 SDK tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQHtjHKi5CwRx42fXwbtUE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side UX and event projection only; no auth, billing, or server behavior changes. Risk is mainly wrong detection copy if engine payload shapes drift.
> 
> **Overview**
> **OpenGeni credit exhaustion** is treated as a first-class, user-fixable failure instead of a silent or healthy-looking idle session.
> 
> In **`@opengeni/react`**, new helpers (`isCreditExhaustion`, `CREDIT_EXHAUSTION_MESSAGE`, `creditExhaustedFromEvents`) recognize engine signals (`budget_exhausted` / “insufficient OpenGeni credits”). **`humanizeFailureReason`** maps those errors to one canonical message. Timeline projection rewrites budget-exhausted **`turn.completed`** into a **failed** turn-end plus a failed notice (same handling for credit **`turn.failed`** payloads that hide in `detail`/`segmentLimit`).
> 
> The **web session route** derives `creditExhausted` from events, shows **`FailedSessionBanner`** credit copy with an **Add credits** link to organization settings on **failed or idle** sessions (not while a turn is running), and replaces composer **“send a message to revive”** placeholder text when credits are empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e6a342d6b02913f6b95048ce5293c943661e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->