### PR TITLE
fix(web): capabilities page scroll + clean MCP tool labels

### DIFF
--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -561,7 +561,13 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
   const packBusyId = busyId?.startsWith("pack:") ? busyId.slice("pack:".length) : null;
 
   return (
-    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">
+    // The app shell (RailShell) hands each route a fixed-height overflow-hidden
+    // flex column, so the PAGE never body-scrolls — the route must own its own
+    // vertical scroll. This root IS that scroll viewport (min-h-0 so it can
+    // shrink inside the flex parent, overflow-y-auto so the tall catalog grid
+    // scrolls); the centered max-width column lives inside it.
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       <PageHeader
         icon={<PlugIcon className="size-4" />}
         title="Capabilities"
@@ -691,6 +697,7 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
             )}
           </section>
         ) : null}
+      </div>
       </div>
 
       <CapabilityDetailSheet

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -977,7 +977,18 @@ function looksLikeId(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }
 
-/** Readable label for a tool call ("session_create" -> "session create"). */
+/**
+ * Readable label for a tool call ("session_create" -> "session create").
+ *
+ * MCP tools are namespaced `<serverId>__<toolName>` (see prefixedMcpToolName),
+ * and for catalog-imported servers that serverId is an opaque slug+hash
+ * ("mcp-integrations-sh-supabase-com-34ed9dcf1390-0i6tcf8"). De-slugging the
+ * whole thing leaked that id into the timeline; strip the server prefix and show
+ * just the tool ("list organizations"). Names without the `__` boundary (plain
+ * built-ins like "session_create") are unaffected.
+ */
 export function toolDisplayName(name: string): string {
-  return name.replace(/[_-]+/g, " ").trim();
+  const boundary = name.lastIndexOf("__");
+  const toolPart = boundary >= 0 ? name.slice(boundary + 2) : name;
+  return toolPart.replace(/[_-]+/g, " ").trim();
 }

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -988,7 +988,9 @@ function looksLikeId(value: string): boolean {
  * built-ins like "session_create") are unaffected.
  */
 export function toolDisplayName(name: string): string {
-  const boundary = name.lastIndexOf("__");
+  // The prefix is a single LEFT boundary (`registryId__toolName`), so split on
+  // the FIRST `__` — the tool name itself may contain `__` and must survive whole.
+  const boundary = name.indexOf("__");
   const toolPart = boundary >= 0 ? name.slice(boundary + 2) : name;
   return toolPart.replace(/[_-]+/g, " ").trim();
 }

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -28,6 +28,10 @@ describe("toolDisplayName", () => {
     expect(toolDisplayName("session_create")).toBe("session create");
     expect(toolDisplayName("bash")).toBe("bash");
   });
+
+  test("splits on the FIRST __ so a tool name containing __ survives whole", () => {
+    expect(toolDisplayName("mcp-supabase-abc123__do__thing")).toBe("do thing");
+  });
 });
 
 let sequence = 0;

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -7,6 +7,7 @@ import {
   extractSessionRef,
   groupTimeline,
   sessionStatusFromEvents,
+  toolDisplayName,
   type AgentMessageItem,
   type SandboxItem,
   type TimelineGroup,
@@ -15,6 +16,19 @@ import {
   type UserMessageItem,
   type WorkerItem,
 } from "../src/timeline";
+
+describe("toolDisplayName", () => {
+  test("strips the MCP server-id prefix and shows only the tool", () => {
+    // Catalog-imported MCP server: <opaque slug+hash>__<tool>.
+    expect(toolDisplayName("mcp-integrations-sh-supabase-com-34ed9dcf1390-0i6tcf8__list_organizations")).toBe("list organizations");
+    expect(toolDisplayName("opengeni__set_session_title")).toBe("set session title");
+  });
+
+  test("plain built-in tool names (no __ boundary) are just de-slugged", () => {
+    expect(toolDisplayName("session_create")).toBe("session create");
+    expect(toolDisplayName("bash")).toBe("bash");
+  });
+});
 
 let sequence = 0;
 


### PR DESCRIPTION
Two post-merge fixes to the I3 capabilities redesign, caught on live staging:

**1. Scrollability (real bug).** The redesigned page's root was `flex-1` with no overflow container, but the app shell (`RailShell`) hands each route a fixed-height `overflow-hidden` flex column and delegates scrolling to the route. The tall catalog grid was clipped and the page wouldn't scroll. Root is now the scroll viewport (`min-h-0 flex-1 overflow-y-auto`) with the centered content inside.

**2. Clean MCP tool labels.** `toolDisplayName` de-slugged the whole namespaced tool name, leaking the opaque catalog MCP server id (`mcp-integrations-sh-supabase-com-<hash>-<hash>`) into the session timeline. Now strips the `<serverId>__` prefix and shows just the tool ("list organizations"); plain built-ins unaffected. Covered by a unit test.

Verified: web + react typecheck clean; react timeline tests 70 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout and display-string formatting with tests; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **Capabilities** scrolling under `RailShell` by making the route root the scroll viewport (`min-h-0 flex-1 overflow-y-auto`) and nesting the centered `max-w-6xl` content inside it, so the tall catalog grid is no longer clipped.
> 
> Updates **`toolDisplayName`** so MCP namespaced tools (`serverId__toolName`) show only the tool segment after the first `__` (e.g. “list organizations”), while plain built-ins still get underscore/hyphen humanization. Adds unit tests for prefix stripping, built-ins, and tool names that contain `__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0e22a2db7b802b2a40bfa6fb2a10715101bac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->