### PR TITLE
Surface MCP OAuth callback failures

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -4,6 +4,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { parseIntegrationsOauthClientsJson, type Settings } from "@opengeni/config";
 import { OAuthStartResponse, type OAuthStartRequest } from "@opengeni/contracts";
 import { requireEnvironmentEncryption } from "@opengeni/core";
+import type { Observability } from "@opengeni/observability";
 import {
   consumeIntegrationOAuthStateNonce,
   createConnection,
@@ -29,6 +30,7 @@ export const oauthStateTtlMs = 10 * 60 * 1000;
 type OAuthClientDeps = {
   db: Database;
   settings: Settings;
+  observability?: Observability | undefined;
 };
 
 export type OAuthStartContext = {
@@ -107,6 +109,19 @@ type TokenResponse = {
   raw: Record<string, unknown>;
 };
 
+type OAuthCallbackStage = "state_verify" | "token_exchange" | "tools_list" | "persist";
+
+class OAuthCallbackStageError extends Error {
+  constructor(
+    readonly stage: OAuthCallbackStage,
+    readonly reason: string,
+    readonly cause: unknown,
+  ) {
+    super(errorMessage(cause));
+    this.name = "OAuthCallbackStageError";
+  }
+}
+
 export async function startMcpOAuth(
   deps: OAuthClientDeps,
   context: OAuthStartContext,
@@ -168,24 +183,33 @@ export async function completeMcpOAuthCallback(
   deps: OAuthClientDeps,
   input: { code?: string | undefined; state?: string | undefined; requestUrl: string },
 ): Promise<OAuthCallbackResult> {
-  const { db, settings } = deps;
+  const { db, settings, observability } = deps;
+  let state: OAuthStatePayload | null = null;
   if (!input.state) {
-    throw new HTTPException(400, { message: "missing OAuth state" });
+    const error = new OAuthCallbackStageError("state_verify", "state_invalid", new Error("missing OAuth state"));
+    logOAuthCallbackFailure(observability, error, state);
+    return { redirectTo: callbackReturnPath("/integrations", "error", { reason: error.reason }) };
   }
-  const state = readOAuthState(input.state, settings);
-  if (!input.code) {
-    return { redirectTo: callbackReturnPath(state.returnPath, "error", { reason: "missing_code" }) };
-  }
-  const consumed = await consumeIntegrationOAuthStateNonce(db, {
-    accountId: state.accountId,
-    workspaceId: state.workspaceId,
-    subjectId: state.subjectId,
-    nonce: state.nonce,
-    expiresAt: new Date(state.iat * 1000 + oauthStateTtlMs),
-    now: new Date(),
-  });
-  if (!consumed) {
-    throw new HTTPException(400, { message: "OAuth state has already been used" });
+  try {
+    state = readOAuthState(input.state, settings);
+    if (!input.code) {
+      return { redirectTo: callbackReturnPath(state.returnPath, "error", { reason: "missing_code" }) };
+    }
+    const consumed = await consumeIntegrationOAuthStateNonce(db, {
+      accountId: state.accountId,
+      workspaceId: state.workspaceId,
+      subjectId: state.subjectId,
+      nonce: state.nonce,
+      expiresAt: new Date(state.iat * 1000 + oauthStateTtlMs),
+      now: new Date(),
+    });
+    if (!consumed) {
+      throw new HTTPException(400, { message: "OAuth state has already been used" });
+    }
+  } catch (error) {
+    const staged = new OAuthCallbackStageError("state_verify", "state_invalid", error);
+    logOAuthCallbackFailure(observability, staged, state);
+    return { redirectTo: callbackReturnPath(state?.returnPath ?? "/integrations", "error", { reason: staged.reason }) };
   }
 
   try {
@@ -194,15 +218,15 @@ export async function completeMcpOAuthCallback(
     const key = requireEnvironmentEncryption(settings);
     const verifier = decryptEnvironmentValue(key, state.encryptedPkceVerifier);
     const client = await clientForState(db, settings, state);
-    const token = await exchangeAuthorizationCode(settings, {
-      code: input.code,
+    const token = await stage("token_exchange", "token_exchange_failed", () => exchangeAuthorizationCode(settings, {
+      code: input.code!,
       verifier,
       redirectUri,
       resource: state.resource,
       tokenEndpoint: state.tokenEndpoint,
       client,
-    });
-    const tools = await verifyMcpToolsList(settings, state.resource, token);
+    }));
+    const tools = await stage("tools_list", "tools_list_failed", () => verifyMcpToolsList(settings, state.resource, token));
     const scopes = grantedScopes(token.scopeText, state.authorizeScopes);
     const credential = credentialBundle(token, state, client);
     const metadata = {
@@ -215,8 +239,8 @@ export async function completeMcpOAuthCallback(
       mcpTools: tools,
     };
     const credentialEncrypted = encryptEnvironmentValue(key, JSON.stringify(credential));
-    const connection = state.connectionId
-      ? await updateConnection(db, {
+    const connection = await stage("persist", "persist_failed", () => state.connectionId
+      ? updateConnection(db, {
         workspaceId: state.workspaceId,
         connectionId: state.connectionId,
         visibleToSubjectId: state.subjectId,
@@ -230,7 +254,7 @@ export async function completeMcpOAuthCallback(
         metadata,
         updatedBySubjectId: state.subjectId,
       })
-      : await createConnection(db, {
+      : createConnection(db, {
         accountId: state.accountId,
         workspaceId: state.workspaceId,
         subjectId: null,
@@ -241,7 +265,7 @@ export async function completeMcpOAuthCallback(
         expiresAt: token.expiresAt,
         metadata,
         createdBySubjectId: state.subjectId,
-      });
+      }));
     if (!connection) {
       throw new HTTPException(409, { message: "connection changed during OAuth reconnect; start again" });
     }
@@ -251,10 +275,11 @@ export async function completeMcpOAuthCallback(
     // and leave the connection created but the capability un-enabled.
     return { redirectTo: callbackReturnPath(state.returnPath, "success", { connectionId: connection.id, providerDomain: connection.providerDomain }) };
   } catch (error) {
-    if (error instanceof HTTPException && error.status >= 400 && error.status < 500) {
-      throw error;
-    }
-    return { redirectTo: callbackReturnPath(state.returnPath, "error", { reason: "oauth_callback_failed" }) };
+    const staged = error instanceof OAuthCallbackStageError
+      ? error
+      : new OAuthCallbackStageError("persist", "persist_failed", error);
+    logOAuthCallbackFailure(observability, staged, state);
+    return { redirectTo: callbackReturnPath(state.returnPath, "error", { reason: staged.reason }) };
   }
 }
 
@@ -648,7 +673,8 @@ async function exchangeAuthorizationCode(
   }
   const response = await fetchOAuth(input.tokenEndpoint, settings, { method: "POST", headers, body });
   if (!response.ok) {
-    throw new Error(`OAuth token endpoint returned HTTP ${response.status}`);
+    const oauthError = await oauthErrorFromResponse(response);
+    throw new OAuthCallbackStageError("token_exchange", oauthError ?? "token_exchange_failed", new Error(`OAuth token endpoint returned HTTP ${response.status}`));
   }
   const payload = await response.json() as Record<string, unknown>;
   const accessToken = stringValue(payload.access_token);
@@ -663,6 +689,73 @@ async function exchangeAuthorizationCode(
     ...(stringValue(payload.refresh_token) ? { refreshToken: stringValue(payload.refresh_token)! } : {}),
     ...(stringValue(payload.scope) ? { scopeText: stringValue(payload.scope)! } : {}),
   };
+}
+
+async function stage<T>(
+  stage: OAuthCallbackStage,
+  fallbackReason: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error instanceof OAuthCallbackStageError) {
+      throw error;
+    }
+    throw new OAuthCallbackStageError(stage, fallbackReason, error);
+  }
+}
+
+function logOAuthCallbackFailure(
+  observability: Observability | undefined,
+  error: OAuthCallbackStageError,
+  state: OAuthStatePayload | null,
+): void {
+  observability?.error("MCP OAuth callback failed", {
+    "opengeni.oauth.stage": error.stage,
+    "opengeni.oauth.reason": error.reason,
+    "opengeni.oauth.provider_domain": state?.providerDomain,
+    "opengeni.oauth.resource_host": state ? safeHost(state.resource) : undefined,
+    "opengeni.oauth.authorization_server": state?.authorizationServer,
+    "opengeni.oauth.issuer": state?.issuer,
+    "opengeni.oauth.client_registration_method": state?.clientRegistrationMethod,
+    error: sanitizedError(error.cause),
+  });
+}
+
+function sanitizedError(error: unknown): string {
+  if (error instanceof HTTPException) {
+    return `HTTPException ${error.status}: ${error.message}`;
+  }
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function safeHost(rawUrl: string): string | undefined {
+  try {
+    return new URL(rawUrl).host;
+  } catch {
+    return undefined;
+  }
+}
+
+async function oauthErrorFromResponse(response: Response): Promise<string | null> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return null;
+  }
+  const payload = await response.clone().json().catch(() => null) as Record<string, unknown> | null;
+  const error = stringValue(payload?.error);
+  if (!error || !/^[a-zA-Z0-9_.-]{1,80}$/.test(error)) {
+    return null;
+  }
+  return error;
 }
 
 async function verifyMcpToolsList(settings: Settings, resource: string, token: TokenResponse): Promise<Array<{ name: string; description?: string }>> {

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -27,7 +27,7 @@ import {
 import { canonicalProviderDomain } from "../integrations/provider-domain";
 
 export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
-  const { db, settings } = deps;
+  const { db, settings, observability } = deps;
 
   function assertIntegrationsEnabled(): void {
     if (!settings.integrationsEnabled) {
@@ -131,7 +131,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(400, { message: parsed.error.issues[0]?.message ?? "invalid OAuth start request" });
     }
     const payload = parsed.data;
-    const result = await startMcpOAuth({ db, settings }, {
+    const result = await startMcpOAuth({ db, settings, observability }, {
       accountId: grant.accountId,
       workspaceId,
       subjectId: grant.subjectId,
@@ -143,7 +143,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
 
   app.get("/v1/integrations/oauth/callback", async (c) => {
     assertIntegrationsEnabled();
-    const result = await completeMcpOAuthCallback({ db, settings }, {
+    const result = await completeMcpOAuthCallback({ db, settings, observability }, {
       code: c.req.query("code"),
       state: c.req.query("state"),
       requestUrl: c.req.url,

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -82,6 +82,28 @@ function publicApp(dbOverride: unknown = client?.db ?? {}, overrides: Partial<Se
   } as never);
 }
 
+function publicAppWithDeps(dbOverride: unknown, overrides: Partial<Settings>, extraDeps: Record<string, unknown>) {
+  const publicSettings = testSettings({
+    authRequired: true,
+    accessKey: "deployment-key",
+    productAccessMode: "managed",
+    delegationSecret: DELEGATION_SECRET,
+    environmentsEncryptionKey: encryptionKey,
+    integrationsEnabled: true,
+    integrationsStateSecret: STATE_SECRET,
+    publicBaseUrl: "https://api.opengeni.test",
+    ...overrides,
+  }) as Settings;
+  return createApp({
+    settings: publicSettings,
+    db: dbOverride as never,
+    bus: {} as never,
+    workflowClient: {} as never,
+    managedAuth: null,
+    ...extraDeps,
+  } as never);
+}
+
 async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
   const [account] = await shared!.admin<{ id: string }[]>`
     insert into managed_accounts (name) values ('acct') returning id`;
@@ -133,6 +155,8 @@ function startFakeAuthorizationServer(options: {
   clientIdMetadataDocumentSupported?: boolean;
   dcr?: boolean;
   tokenAccessToken?: string;
+  tokenStatus?: number;
+  tokenError?: string;
 } = {}): FakeAuthorizationServer {
   const tokenRequests: URLSearchParams[] = [];
   const registrations: Record<string, unknown>[] = [];
@@ -169,6 +193,12 @@ function startFakeAuthorizationServer(options: {
       if (url.pathname === "/token") {
         const body = new URLSearchParams(await request.text());
         tokenRequests.push(body);
+        if (options.tokenStatus && options.tokenStatus >= 400) {
+          return Response.json({
+            error: options.tokenError ?? "invalid_client",
+            error_description: "fake token failure",
+          }, { status: options.tokenStatus });
+        }
         return Response.json({
           access_token: options.tokenAccessToken ?? "mcp-access-token",
           refresh_token: "mcp-refresh-token",
@@ -469,6 +499,70 @@ describe("connections routes", () => {
     }
   });
 
+  test("oauth callback logs token exchange failures and redirects with a machine-readable reason", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      clientIdMetadataDocumentSupported: true,
+      scopesSupported: ["documents:read"],
+      tokenStatus: 401,
+      tokenError: "invalid_client",
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource", scope="documents:read"`,
+    });
+    const errors: Array<Record<string, unknown>> = [];
+    const observability = {
+      startSpan: () => ({ end: () => undefined }),
+      recordHttpRequest: () => undefined,
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: (message: string, attributes: Record<string, unknown>) => errors.push({ message, ...attributes }),
+    };
+    const response = await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+      method: "POST",
+      headers: {
+        authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        providerDomain: "mcp.example.com",
+        mcpUrl: mcp.url,
+        returnPath: "/integrations?connect_item=linear",
+      }),
+    });
+    try {
+      expect(response.status).toBe(200);
+      const body = await response.json() as { state: string };
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown>;
+      const verifier = decryptEnvironmentValue(rawKey, state.encryptedPkceVerifier as string);
+
+      const callback = await publicAppWithDeps(client.db, {}, { observability })
+        .request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
+      expect(callback.status).toBe(302);
+      const location = callback.headers.get("location")!;
+      expect(location).toContain("integration_oauth=error");
+      expect(location).toContain("reason=invalid_client");
+      expect(location).toContain("connect_item=linear");
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        message: "MCP OAuth callback failed",
+        "opengeni.oauth.stage": "token_exchange",
+        "opengeni.oauth.reason": "invalid_client",
+        "opengeni.oauth.provider_domain": "mcp.example.com",
+        "opengeni.oauth.client_registration_method": "cimd",
+      });
+      expect(JSON.stringify(errors)).not.toContain(verifier);
+      expect(JSON.stringify(errors)).not.toContain("abc");
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
   test("oauth reconnect preserves a subject-owned connection subject", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
@@ -655,8 +749,8 @@ describe("connections routes", () => {
     try {
       const response = await publicApp(client.db, { environment: "production" })
         .request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(state)}`);
-      expect(response.status).toBe(422);
-      expect(await response.text()).toContain("private network");
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toContain("reason=tools_list_failed");
       expect(hits).toEqual(["https://1.1.1.1/token", "https://1.1.1.1/mcp"]);
       expect(privateHopHits).toBe(0);
     } finally {
@@ -804,7 +898,8 @@ describe("connections routes", () => {
       const first = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
       expect(first.status).toBe(302);
       const replay = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
-      expect(replay.status).toBe(400);
+      expect(replay.status).toBe(302);
+      expect(replay.headers.get("location")).toContain("reason=state_invalid");
 
       const expiredState = createSignedState(STATE_SECRET, {
         accountId: workspace.accountId,
@@ -824,7 +919,8 @@ describe("connections routes", () => {
         returnPath: "/integrations",
       }, Math.floor(Date.now() / 1000) - 601);
       const expired = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(expiredState)}`);
-      expect(expired.status).toBe(400);
+      expect(expired.status).toBe(302);
+      expect(expired.headers.get("location")).toContain("reason=state_invalid");
     } finally {
       mcp.close();
       as.close();


### PR DESCRIPTION
## Summary
- log MCP OAuth callback failures with explicit stages: state_verify, token_exchange, tools_list, persist
- redirect OAuth callback failures with machine-readable reasons instead of the generic oauth_callback_failed
- preserve provider OAuth error codes such as invalid_client without logging secrets, codes, tokens, or PKCE verifiers
- update callback tests for redirect-based failure handling and add a token-exchange regression test

## Linear diagnosis
Linear's official MCP endpoint is https://mcp.linear.app/mcp. Its protected-resource metadata advertises https://mcp.linear.app as the authorization server, and the AS metadata advertises PKCE S256, token_endpoint_auth_methods_supported including none, registration_endpoint, and client_id_metadata_document_supported=true. Linear's public docs also state that the Streamable HTTP transport uses OAuth 2.1 with dynamic client registration. That means the current evidence does not support the registered-confidential-app-only hypothesis for Linear. The production failure is still opaque until this logging deploys; the next failed attempt should identify token_exchange vs tools_list and the specific provider reason where available.

## Verification
- bun run typecheck
- bun test apps/api/test/connections-routes.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth callback error paths and redirect contracts (including state replay/expired and tools-list guard failures), which affects integration UX and production debugging for credential flows.
> 
> **Overview**
> MCP OAuth callback handling now **fails consistently via SPA redirects** instead of mixing HTTP 4xx/422 responses with a generic `oauth_callback_failed` reason.
> 
> **Staged errors and observability:** Callback work is wrapped in stages (`state_verify`, `token_exchange`, `tools_list`, `persist`). Failures emit structured `observability.error` logs with stage, reason, provider metadata, and **sanitized** cause text—no auth codes, tokens, or PKCE verifiers. Token endpoint JSON errors (e.g. `invalid_client`) are parsed and passed through as redirect `reason` when safe.
> 
> **Routes:** Connection OAuth start/callback pass optional `observability` from API deps into the OAuth client.
> 
> **Tests:** Callback cases expect 302 + `reason=…`; new coverage for token-exchange failure logging and redirect reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df8aca2d1ba9799a95951455aca5daee9794e6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->