### PR TITLE
Add repeatable integrations catalog pipeline

### DIFF
--- a/data/catalog/integrations-snapshot.json
+++ b/data/catalog/integrations-snapshot.json
@@ -1,0 +1,16494 @@
+{
+  "generatedAt": "2026-07-03T23:41:44.132Z",
+  "source": "integrations.sh",
+  "cleanedAt": "2026-07-07T08:59:30.524Z",
+  "cleaning": {
+    "inputRows": 1081,
+    "outputRows": 935,
+    "skippedRows": 141,
+    "quarantinedRows": 5,
+    "duplicateDomainNameRows": 128,
+    "controlCharacterFields": 0
+  },
+  "importRows": [
+    {
+      "domain": "12andus.com",
+      "name": "12andus Astrology",
+      "mcpUrl": "https://mcp.12andus.com/mcp/?v=10",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.12andus.com/oauth/register",
+          "setup": "Register an OAuth client against the MCP server's [registration endpoint](https://mcp.12andus.com/oauth/register), then send the user through the authorization flow using the server's [authorization metadata](https://mcp.12andus.com/.well-known/oauth-authorization-server). The server advertises `authorization_code` and `refresh_token` grants with PKCE `S256`; resource scopes are `openid`, `email`, and `profile`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/12andus.com"
+    },
+    {
+      "domain": "2u.com",
+      "name": "edX",
+      "mcpUrl": "https://xpert-chatgpt-app.prod.ai.2u.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/2u.com"
+    },
+    {
+      "domain": "3minapi.com",
+      "name": "3Min API",
+      "mcpUrl": "https://3minapi.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/3minapi.com"
+    },
+    {
+      "domain": "4ygmimr3yj.us-east-2.awsapprunner.com",
+      "name": "4ygmimr3yj.us-east-2.awsapprunner.com",
+      "mcpUrl": "https://4ygmimr3yj.us-east-2.awsapprunner.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cardchain_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://4ygmimr3yj.us-east-2.awsapprunner.com/mcp/oauth2/register",
+          "setup": "Register an OAuth client against the server's dynamic client registration endpoint at [CardChain OAuth registration](https://4ygmimr3yj.us-east-2.awsapprunner.com/mcp/oauth2/register). The server advertises OAuth metadata at [OAuth Authorization Server Metadata](https://4ygmimr3yj.us-east-2.awsapprunner.com/.well-known/oauth-authorization-server) and [OpenID Connect Discovery](https://4ygmimr3yj.us-east-2.awsapprunner.com/.well-known/openid-configuration). It supports the authorization code flow with PKCE (`S256`), scope `openid`, and `token_endpoint_auth_methods_supported` = `none`, so the registered client uses the standard browser-based OAuth flow to obtain bearer tokens for the MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/4ygmimr3yj.us-east-2.awsapprunner.com"
+    },
+    {
+      "domain": "abhibus-com-s-account.workers.dev",
+      "name": "AbhiBus",
+      "mcpUrl": "https://abhibus-mcp-production.abhibus-com-s-account.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/abhibus-com-s-account.workers.dev"
+    },
+    {
+      "domain": "accessapproval.googleapis.com",
+      "name": "accessapproval.googleapis.com",
+      "mcpUrl": "https://accessapproval.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/accessapproval.googleapis.com"
+    },
+    {
+      "domain": "accessowl.com",
+      "name": "AccessOwl",
+      "mcpUrl": "https://mcp.accessowl.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "accessowl_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/accessowl.com"
+    },
+    {
+      "domain": "account.read",
+      "name": "account.read",
+      "mcpUrl": "https://api.read.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "read_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/account.read"
+    },
+    {
+      "domain": "acko.com",
+      "name": "ACKO",
+      "mcpUrl": "https://atlas.live.acko.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/acko.com"
+    },
+    {
+      "domain": "adalo.com",
+      "name": "Adalo",
+      "mcpUrl": "https://mcp.adalo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "adalo_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.adalo.com/mcp",
+          "setup": "Connect an MCP client to `https://mcp.adalo.com/mcp` and complete the OAuth flow offered by the server. The curated registry identifies this MCP server as using OAuth, but public Adalo docs describing client registration or scopes were not found in the pages reviewed.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/adalo.com"
+    },
+    {
+      "domain": "adobe.io",
+      "name": "Adobe Acrobat",
+      "mcpUrl": "https://ajo-mcp.adobe.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "adobe_oauth_user",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/adobe.io"
+    },
+    {
+      "domain": "advancedwebranking.com",
+      "name": "Advanced Web Ranking",
+      "mcpUrl": "https://api.advancedwebranking.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "awr_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "In an MCP-capable client, connect to the remote MCP server at `https://api.advancedwebranking.com/mcp`. The help doc says you'll see an authorization consent screen, and after approval the connection appears in [Connectors & API](https://app.advancedwebranking.com/account/api) under the MCP section. This is the easiest path for ChatGPT/Claude-style remote MCP connections.",
+          "fields": null
+        },
+        {
+          "id": "awr_api_token",
+          "type": "api_key",
+          "generateUrl": "https://app.advancedwebranking.com/account/api",
+          "setup": "Sign in to your AWR account, open [Settings → Connectors & API](https://app.advancedwebranking.com/account/api), and copy your Developer API token. The docs state API access is available on yearly plans and on monthly plans starting at Agency.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/advancedwebranking.com"
+    },
+    {
+      "domain": "agentichoteldistribution.com",
+      "name": "The Houstonian",
+      "mcpUrl": "https://agentichoteldistribution.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/agentichoteldistribution.com"
+    },
+    {
+      "domain": "agiflow.io",
+      "name": "Agiflow",
+      "mcpUrl": "https://agiflow.io/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "agiflow_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/agiflow.io"
+    },
+    {
+      "domain": "agilitycms.com",
+      "name": "agilitycms.com",
+      "mcpUrl": "https://mcp.agilitycms.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_user",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/agilitycms.com"
+    },
+    {
+      "domain": "agreezone.replit.app",
+      "name": "Agree Zone",
+      "mcpUrl": "https://agreezone.replit.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/agreezone.replit.app"
+    },
+    {
+      "domain": "ahrefs.com",
+      "name": "Ahrefs",
+      "mcpUrl": "https://api.ahrefs.com/mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ahrefs_connect_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/ahrefs.com"
+    },
+    {
+      "domain": "ai-stats.phaseo.app",
+      "name": "ai-stats.phaseo.app",
+      "mcpUrl": "https://ai-stats.phaseo.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/phaseo.app"
+    },
+    {
+      "domain": "aiera.com",
+      "name": "Aiera",
+      "mcpUrl": "https://mcp-pub.aiera.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "aiera_oauth_login",
+          "type": "oauth2",
+          "generateUrl": "https://rest.aiera.com/docs/mcp-platforms",
+          "setup": "For hosted MCP connectors, start from the connector marketplace in a supported client and click **Connect** for Aiera. The docs say this opens an Aiera login form where you sign in with your existing Aiera dashboard credentials and authorize access. See [MCP platform setup](https://rest.aiera.com/docs/mcp-platforms).",
+          "fields": null
+        },
+        {
+          "id": "aiera_api_key",
+          "type": "api_key",
+          "generateUrl": "https://rest.aiera.com/docs/authentication",
+          "setup": "Sign up for the service to receive a unique API key; the docs state you are provided one when you first sign up. See [Getting started](https://rest.aiera.com/) and [Authentication](https://rest.aiera.com/docs/authentication). Use it in requests as `X-API-Key`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/aiera.com"
+    },
+    {
+      "domain": "airbyte.com",
+      "name": "airbyte.com",
+      "mcpUrl": "https://mcp.airbyte.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "airbyte_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/airbyte.com"
+    },
+    {
+      "domain": "airops.com",
+      "name": "AirOps",
+      "mcpUrl": "https://app.airops.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "airops_oauth_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/airops.com"
+    },
+    {
+      "domain": "airtable.com",
+      "name": "Airtable",
+      "mcpUrl": "https://mcp.airtable.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "airtable_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.airtable.com/.well-known/oauth-authorization-server",
+          "setup": "For the Airtable MCP server, use an MCP client that supports OAuth. The client can discover Airtable's authorization server from [the MCP server metadata](https://mcp.airtable.com/.well-known/oauth-authorization-server) and register dynamically at `https://airtable.com/oauth2/v1/register`; the user then approves access in the browser. No pre-created developer app is documented as required for MCP clients.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/airtable.com"
+    },
+    {
+      "domain": "airwallex.com",
+      "name": "Airwallex Developer",
+      "mcpUrl": "https://mcp-demo.airwallex.com/developer",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sandbox_oauth_user",
+          "type": "oauth2",
+          "generateUrl": "https://demo.airwallex.com/signup/sandbox",
+          "setup": "Create a sandbox account at [Airwallex Sandbox signup](https://demo.airwallex.com/signup/sandbox), then connect from your MCP client or the Airwallex CLI and complete the browser-based OAuth flow. For CLI access use `airwallex auth login`; for the Developer MCP, point your MCP client at `https://mcp-demo.airwallex.com/developer` and approve the Airwallex OAuth consent flow.",
+          "fields": null
+        },
+        {
+          "id": "api_key_client",
+          "type": "compound",
+          "generateUrl": "https://www.airwallex.com/docs/developer-tools/api/manage-api-keys",
+          "setup": "In the [Airwallex web app](https://airwallex.com/app/), go to **Settings > Developer > API keys**. Generate either an admin API key or a scoped API key for your organization/account, then copy the API key and note the associated `Client ID` shown in the Developer app. Airwallex uses this pair to obtain an access token via the Authentication API. Only users with Owner, Admin, or Developer access to the Developer app can manage API keys.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/airwallex.com"
+    },
+    {
+      "domain": "akqa-emea-starbucks-chatgpt-app.vercel.app",
+      "name": "Starbucks",
+      "mcpUrl": "https://akqa-emea-starbucks-chatgpt-app.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/akqa-emea-starbucks-chatgpt-app.vercel.app"
+    },
+    {
+      "domain": "algolia.com",
+      "name": "algolia.com",
+      "mcpUrl": "https://mcp.algolia.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "algolia_cli_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/algolia.com"
+    },
+    {
+      "domain": "all-ten-chat-gpt-app.replit.app",
+      "name": "Beast Academy - All Ten",
+      "mcpUrl": "https://all-ten-chat-gpt-app.replit.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/all-ten-chat-gpt-app.replit.app"
+    },
+    {
+      "domain": "allapp.net",
+      "name": "AccurateScribe.ai – Transcribe",
+      "mcpUrl": "https://notify.allapp.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "accuratescribe_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://accuratescribe.ai/api/oidc/reg",
+          "setup": "Register an OAuth client with AccurateScribe's OIDC server at [`/api/oidc/reg`](https://accuratescribe.ai/api/oidc/reg), then run the authorization-code flow against [`/api/oidc/auth`](https://accuratescribe.ai/api/oidc/auth) and [`/api/oidc/token`](https://accuratescribe.ai/api/oidc/token) to obtain an access token for scopes like `read:notify`, `write:notify`, and optionally `offline_access`. The OIDC discovery document is at [`/api/oidc/.well-known/openid-configuration`](https://accuratescribe.ai/api/oidc/.well-known/openid-configuration).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/allapp.net"
+    },
+    {
+      "domain": "alltrails.com",
+      "name": "AllTrails",
+      "mcpUrl": "https://www.alltrails.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/alltrails.com"
+    },
+    {
+      "domain": "almosafer.com",
+      "name": "Almosafer.com",
+      "mcpUrl": "https://chatgpt.almosafer.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/almosafer.com"
+    },
+    {
+      "domain": "alpaca.markets",
+      "name": "Alpaca",
+      "mcpUrl": "https://mcp.alpaca.markets/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/alpaca.markets"
+    },
+    {
+      "domain": "alpic.ai",
+      "name": "Alpic",
+      "mcpUrl": "https://mcp.alpic.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "alpic_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/alpic.ai"
+    },
+    {
+      "domain": "alpic.live",
+      "name": "Noodle Seed",
+      "mcpUrl": "https://mcp.alpic.ai/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "alpic_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/alpic.live"
+    },
+    {
+      "domain": "alpy.com",
+      "name": "Alpy.com",
+      "mcpUrl": "https://mcp.alpy.com/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/alpy.com"
+    },
+    {
+      "domain": "amapas353.com",
+      "name": "Amapas Vacation Rental",
+      "mcpUrl": "https://booking.amapas353.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/amapas353.com"
+    },
+    {
+      "domain": "americanexpress.com",
+      "name": "Resy",
+      "mcpUrl": "https://apigw.americanexpress.com/dining/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/americanexpress.com"
+    },
+    {
+      "domain": "amplifyr.me",
+      "name": "Amplifyr",
+      "mcpUrl": "https://mcp.amplifyr.me/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "amplifyr_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/amplifyr.me"
+    },
+    {
+      "domain": "amplitude.com",
+      "name": "Amplitude",
+      "mcpUrl": "https://mcp.amplitude.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "amplitude_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/amplitude.com"
+    },
+    {
+      "domain": "analyticsadmin.googleapis.com",
+      "name": "analyticsadmin.googleapis.com",
+      "mcpUrl": "https://analyticsadmin.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/analyticsadmin.googleapis.com"
+    },
+    {
+      "domain": "androidmanagement.googleapis.com",
+      "name": "androidmanagement.googleapis.com",
+      "mcpUrl": "https://androidmanagement.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/androidmanagement.googleapis.com"
+    },
+    {
+      "domain": "apartmentlist.io",
+      "name": "Apartment List",
+      "mcpUrl": "https://search-mcp.production.apartmentlist.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/apartmentlist.io"
+    },
+    {
+      "domain": "api-and-you.com",
+      "name": "SecretBox",
+      "mcpUrl": "https://mcp.api-and-you.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/api-and-you.com"
+    },
+    {
+      "domain": "api.aws",
+      "name": "AWS Marketplace",
+      "mcpUrl": "https://aws-mcp.us-east-1.api.aws/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "aws_iam_creds",
+          "type": "signature",
+          "generateUrl": "https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html",
+          "setup": "Install the AWS CLI and sign in with [Setting up the AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html). The easiest path is to run `aws login`, which obtains short-lived AWS credentials that auto-rotate; verify with `aws sts get-caller-identity`. Other AWS-issued credential methods are also supported through the normal AWS CLI credential chain, as noted in [Sign in with the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/api.aws"
+    },
+    {
+      "domain": "api.driftless.icu",
+      "name": "api.driftless.icu",
+      "mcpUrl": "https://api.driftless.icu/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "driftless_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.driftless.icu",
+          "setup": "Open the Driftless dashboard at [app.driftless.icu](https://app.driftless.icu), go to **Settings → API Keys**, and create a key for your workspace. The raw key is shown only once and has a `drift_` prefix. For the CLI, the easiest path is to run `driftless login` and copy the key from the dashboard when prompted. For CI/non-interactive use, supply it via `DRIFTLESS_API_KEY` or `driftless login --key <key>`.",
+          "fields": null
+        },
+        {
+          "id": "driftless_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://api.driftless.icu/api/v1/oauth/register",
+          "setup": "For MCP clients, Driftless supports self-service OAuth 2.0 with Dynamic Client Registration. An MCP-capable client can register itself automatically against [the registration endpoint](https://api.driftless.icu/api/v1/oauth/register), send the user to the Driftless consent screen, and exchange the authorization code for tokens. The user just approves access in the browser; supported scopes documented by Driftless are `context:read`, `topics:create`, `topics:write`, `work:write`, `context:diff`, and `offline_access`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu"
+    },
+    {
+      "domain": "api.openbudget.sh",
+      "name": "api.openbudget.sh",
+      "mcpUrl": "https://api.openbudget.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "openbudget_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/openbudget.sh"
+    },
+    {
+      "domain": "api.opencapital.sh",
+      "name": "api.opencapital.sh",
+      "mcpUrl": "https://api.opencapital.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "opencapital_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/opencapital.sh"
+    },
+    {
+      "domain": "api7.ai",
+      "name": "api7.ai",
+      "mcpUrl": "http://127.0.0.1:3000/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "aisix_caller_api_key",
+          "type": "api_key",
+          "generateUrl": "https://docs.api7.ai/ai-gateway/build-traffic-path/manage-gateway-resources/caller-api-keys.md",
+          "setup": "Create a caller API key through AISIX management. For self-hosted AISIX, choose a plaintext key, hash it with SHA-256, then create the API key resource via the Admin API as shown in [Caller API Keys](https://docs.api7.ai/ai-gateway/build-traffic-path/manage-gateway-resources/caller-api-keys.md). For managed deployments, the same doc says you create it in the managed control plane and can supply the plaintext `key` field there when custom key import is enabled. Applications send the plaintext key to the proxy as `Authorization: Bearer <caller-key>` or `x-api-key: <caller-key>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/api7.ai"
+    },
+    {
+      "domain": "apify.com",
+      "name": "apify.com",
+      "mcpUrl": "https://mcp.apify.com/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "apify_api_token",
+          "type": "bearer",
+          "generateUrl": "https://console.apify.com/settings/integrations",
+          "setup": "Sign in to [Apify Console](https://console.apify.com/) and open [API & Integrations](https://console.apify.com/settings/integrations) to copy or create your API token. The docs identify this token as the credential for the REST API and MCP server; the CLI can also use it as an alternative to browser login via `apify login`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/apify.com"
+    },
+    {
+      "domain": "apigee.googleapis.com",
+      "name": "apigee.googleapis.com",
+      "mcpUrl": "https://apigee.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/apigee.googleapis.com"
+    },
+    {
+      "domain": "apitoolkit.io",
+      "name": "Monoscope MCP Server",
+      "mcpUrl": "https://api.monoscope.tech/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "monoscope_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.monoscope.tech",
+          "setup": "Sign in to the [Monoscope dashboard](https://app.monoscope.tech), open [Settings → API Keys](https://monoscope.tech/docs/dashboard/settings-pages/api-keys/), and click `Create an API key`. Monoscope also says a default project gets an API key on first load, and you can create additional keys per environment or per project. Keys are project-scoped and shown only once, so copy and store the key securely.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/apitoolkit.io"
+    },
+    {
+      "domain": "apollo.io",
+      "name": "Apollo.io",
+      "mcpUrl": "https://mcp.apollo.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "apollo_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/apollo.io"
+    },
+    {
+      "domain": "apollographql.com",
+      "name": "GraphOS MCP Tools",
+      "mcpUrl": "https://mcp.apollographql.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/apollographql.com"
+    },
+    {
+      "domain": "app.fullstackgtm.com",
+      "name": "app.fullstackgtm.com",
+      "mcpUrl": "https://app.fullstackgtm.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fsgtm_pairing_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fullstackgtm.com"
+    },
+    {
+      "domain": "appdeploy.ai",
+      "name": "AppDeploy",
+      "mcpUrl": "https://api-v2.appdeploy.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "appdeploy_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/appdeploy.ai"
+    },
+    {
+      "domain": "apple.com",
+      "name": "apple.com – sirikit-cloud-media",
+      "mcpUrl": "https://mcp.music.apple.com/v1/longandcomplexstring294/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/apple.com"
+    },
+    {
+      "domain": "arcjet.com",
+      "name": "arcjet.com",
+      "mcpUrl": "https://api.arcjet.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "arcjet_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/arcjet.com"
+    },
+    {
+      "domain": "artue.io",
+      "name": "artue.io",
+      "mcpUrl": "https://artue.io/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/artue.io"
+    },
+    {
+      "domain": "asana.com",
+      "name": "Asana",
+      "mcpUrl": "https://mcp.asana.com/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "asana_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://app.asana.com/0/my-apps",
+          "setup": "Create an app in the Asana [developer console](https://app.asana.com/0/my-apps). Use the app's client ID and client secret with Asana's OAuth 2.0 authorization code flow. The docs list the authorize endpoint as `GET https://app.asana.com/-/oauth_authorize`, token endpoint as `POST https://app.asana.com/-/oauth_token`, and revoke endpoint as `POST https://app.asana.com/-/oauth_revoke`. The resulting access token is sent as `Authorization: Bearer <token>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/asana.com"
+    },
+    {
+      "domain": "assetvision.com.au",
+      "name": "Asset Vision",
+      "mcpUrl": "https://mcp.assetvision.com.au/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "assetvision_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.assetvision.com.au/connect/register",
+          "setup": "For the MCP server at [mcp.assetvision.com.au](https://mcp.assetvision.com.au), register an OAuth client via the advertised OAuth metadata at [authorization server metadata](https://mcp.assetvision.com.au/.well-known/oauth-authorization-server). The metadata exposes a dynamic client registration endpoint at [connect/register](https://mcp.assetvision.com.au/connect/register), then use the authorization-code flow with PKCE against `https://mcp.assetvision.com.au/connect/authorize` and `https://mcp.assetvision.com.au/connect/token` to obtain a bearer access token for scopes such as `mcp:read` or `mcp:write`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/assetvision.com.au"
+    },
+    {
+      "domain": "atlassian.net",
+      "name": "Atlassian Rovo MCP Server",
+      "mcpUrl": "https://mcp.atlassian.com/v1/mcp/authv2",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "atlassian_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/atlassian.net"
+    },
+    {
+      "domain": "attio.com",
+      "name": "Attio",
+      "mcpUrl": "https://mcp.attio.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "attio_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/attio.com"
+    },
+    {
+      "domain": "audible.com",
+      "name": "Audible",
+      "mcpUrl": "https://mcp.audible.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/audible.com"
+    },
+    {
+      "domain": "auraintelligence.com",
+      "name": "Aura",
+      "mcpUrl": "https://mcp.auraintelligence.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/auraintelligence.com"
+    },
+    {
+      "domain": "authzed.com",
+      "name": "authzed.com",
+      "mcpUrl": "https://mcp.authzed.com",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/authzed.com"
+    },
+    {
+      "domain": "autodesk.com",
+      "name": "Autodesk Product Help",
+      "mcpUrl": "https://developer.api.autodesk.com/knowledge/public/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/autodesk.com"
+    },
+    {
+      "domain": "automotion-mcp-production-6f08e98a6e4b.herokuapp.com",
+      "name": "AutoMotion",
+      "mcpUrl": "https://automotion-mcp-production-6f08e98a6e4b.herokuapp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/automotion-mcp-production-6f08e98a6e4b.herokuapp.com"
+    },
+    {
+      "domain": "autoverzekering.nl",
+      "name": "Autoverzekering.nl",
+      "mcpUrl": "https://mcp.autoverzekering.nl/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/autoverzekering.nl"
+    },
+    {
+      "domain": "autovit.ro",
+      "name": "Autovit.ro",
+      "mcpUrl": "https://www.autovit.ro/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/autovit.ro"
+    },
+    {
+      "domain": "avito.ma",
+      "name": "Avito.ma",
+      "mcpUrl": "https://services.avito.ma/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/avito.ma"
+    },
+    {
+      "domain": "avo.app",
+      "name": "avo.app",
+      "mcpUrl": "https://mcp.avo.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "avo_user_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/avo.app"
+    },
+    {
+      "domain": "aweber.com",
+      "name": "AWeber",
+      "mcpUrl": "https://mcp.aweber.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "aweber_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://labs.aweber.com/apps",
+          "setup": "Create a free developer account at [AWeber Labs](https://labs.aweber.com), sign in at [Labs login](https://labs.aweber.com/auth/login), then create an app at [My Apps](https://labs.aweber.com/apps). Use that app's client credentials with AWeber's OAuth 2.0 flow documented in the [API docs](https://api.aweber.com/) to obtain user access tokens. For MCP, follow the product setup guide at [Connecting and using the AWeber MCP server](https://docs.aweber.com/api/api/connecting-and-using-the-aweber-mcp-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/aweber.com"
+    },
+    {
+      "domain": "awesomize.ai",
+      "name": "Apixel",
+      "mcpUrl": "https://bananagen.awesomize.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "awesomize_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://talkgen.awesomize.ai/oidc/oauth/register",
+          "setup": "Register an OAuth client with the MCP service's dynamic client registration endpoint, for example [TalkGen client registration](https://talkgen.awesomize.ai/oidc/oauth/register), [MangaBoom client registration](https://mangaboom.awesomize.ai/oidc/oauth/register), or [Apixel/BananaGen client registration](https://bananagen.awesomize.ai/oidc/oauth/register). Then run the OAuth 2.0 authorization-code flow against that service's issuer to obtain an access token for MCP access. The well-known metadata advertises `authorization_code` and `refresh_token` grants, PKCE support, and token endpoint auth methods `client_secret_basic` and `client_secret_post`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/awesomize.ai"
+    },
+    {
+      "domain": "axiom.co",
+      "name": "axiom.co",
+      "mcpUrl": "https://mcp.axiom.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "axiom_api_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/axiom.co"
+    },
+    {
+      "domain": "azurecontainerapps.io",
+      "name": "Soul Family AI",
+      "mcpUrl": "https://soulfamily-gpt-api.purplegrass-5a3c53cc.eastus2.azurecontainerapps.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/azurecontainerapps.io"
+    },
+    {
+      "domain": "b12.io",
+      "name": "B12 Website Generator",
+      "mcpUrl": "https://b12.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/b12.io"
+    },
+    {
+      "domain": "backstage.com",
+      "name": "Backstage",
+      "mcpUrl": "https://mcp.backstage.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/backstage.com"
+    },
+    {
+      "domain": "ballparkhq.com",
+      "name": "Ballpark",
+      "mcpUrl": "https://edge.ballparkhq.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ballpark_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://dugout.ballparkhq.com/oauth/applications/",
+          "setup": "Register an application at [Ballpark OAuth applications](https://dugout.ballparkhq.com/oauth/applications/). Ballpark supports OAuth 2.0 with optional PKCE for native/client-side apps. Use the `authorization_code` flow for confidential clients, or `authorization_code` + PKCE for public/native apps that need refresh tokens. Tokens are then used as `Authorization: Bearer <access_token>` when calling the API.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ballparkhq.com"
+    },
+    {
+      "domain": "bandsintown.com",
+      "name": "Bandsintown API",
+      "mcpUrl": "https://prod-chatgpt-app.prod.bandsintown.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bandsintown.com"
+    },
+    {
+      "domain": "bankrate.com",
+      "name": "Bankrate",
+      "mcpUrl": "https://bankrate-openai-mcp.bankrate.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bankrate.com"
+    },
+    {
+      "domain": "barcelo-mcp.com",
+      "name": "Barceló Hotel Group",
+      "mcpUrl": "https://barcelo-mcp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "barcelo_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/barcelo-mcp.com"
+    },
+    {
+      "domain": "base44.com",
+      "name": "Base44",
+      "mcpUrl": "https://app.base44.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "base44_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/base44.com"
+    },
+    {
+      "domain": "beautiful.ai",
+      "name": "beautiful.ai",
+      "mcpUrl": "https://openai-mcp-696419881849.us-central1.run.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "beautiful_oauth_user",
+          "type": "oauth2",
+          "generateUrl": "https://www.beautiful.ai/provisioning/oauth2",
+          "setup": "Start the OAuth flow from the MCP client using [Beautiful.ai OAuth provisioning](https://www.beautiful.ai/provisioning/oauth2). Sign in with your Beautiful.ai account and grant the connector access. The support docs state the MCP connector uses OAuth 2.0 and the client receives a secure token rather than your password.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/beautiful.ai"
+    },
+    {
+      "domain": "bed-and-breakfast.it",
+      "name": "Bed-and-Breakfast.it",
+      "mcpUrl": "https://tools.bed-and-breakfast.it/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bed-and-breakfast.it"
+    },
+    {
+      "domain": "beerfinder.workers.dev",
+      "name": "NA Drink Finder",
+      "mcpUrl": "https://na-beer-finder.beerfinder.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/beerfinder.workers.dev"
+    },
+    {
+      "domain": "berlin-group.org",
+      "name": "berlin-group.org",
+      "mcpUrl": "https://www.berlin-group.org/_api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/berlin-group.org"
+    },
+    {
+      "domain": "bestcolleges.com",
+      "name": "BestColleges.com",
+      "mcpUrl": "https://gpt.bestcolleges.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bestcolleges.com"
+    },
+    {
+      "domain": "bestlawyers.com",
+      "name": "Best Lawyers",
+      "mcpUrl": "https://mcp.bestlawyers.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bestlawyers.com"
+    },
+    {
+      "domain": "bettermg.com",
+      "name": "Tinman AI",
+      "mcpUrl": "https://prod.bettermg.com/api/mortgage/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tinman_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/bettermg.com"
+    },
+    {
+      "domain": "betterstack.com",
+      "name": "betterstack.com",
+      "mcpUrl": "https://betterstack.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/betterstack.com"
+    },
+    {
+      "domain": "bigdata.com",
+      "name": "Bigdata.com",
+      "mcpUrl": "https://mcp.bigdata.com/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "bigdata_api_key",
+          "type": "api_key",
+          "generateUrl": "https://platform.bigdata.com/api-keys?utm_source=docs",
+          "setup": "Create an API key in the [Developer Platform > API Keys](https://platform.bigdata.com/api-keys?utm_source=docs). The docs describe this as the credential for the REST API, custom MCP integrations, and CLI configuration. You can also store it in `BIGDATA_API_KEY` for CLI/SDK use.",
+          "fields": null
+        },
+        {
+          "id": "bigdata_app_login",
+          "type": "compound",
+          "generateUrl": null,
+          "setup": "For official hosted MCP connectors, sign in with your Bigdata App account when redirected from the client. New organizations use the Bigdata Identity Provider by default; Bigdata says users log in with their Bigdata App email and password. Enterprise teams can request SSO setup by contacting [support@bigdata.com](mailto:support@bigdata.com); the docs list SAML support for Microsoft Entra ID, Google, and Okta. User access is managed by Bigdata support.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bigdata.com"
+    },
+    {
+      "domain": "biggeo.com",
+      "name": "BigGeo AI",
+      "mcpUrl": "https://mcp.biggeo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "biggeo_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/biggeo.com"
+    },
+    {
+      "domain": "bigquery.googleapis.com",
+      "name": "Google Cloud BigQuery",
+      "mcpUrl": "https://bigquery.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/bigquery.googleapis.com"
+    },
+    {
+      "domain": "bigquerydatatransfer.googleapis.com",
+      "name": "bigquerydatatransfer.googleapis.com",
+      "mcpUrl": "https://bigquerydatatransfer.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/bigquerydatatransfer.googleapis.com"
+    },
+    {
+      "domain": "bigtableadmin.googleapis.com",
+      "name": "bigtableadmin.googleapis.com",
+      "mcpUrl": "https://bigtableadmin.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/bigtableadmin.googleapis.com"
+    },
+    {
+      "domain": "billingbudgets.googleapis.com",
+      "name": "billingbudgets.googleapis.com",
+      "mcpUrl": "https://billingbudgets.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/billingbudgets.googleapis.com"
+    },
+    {
+      "domain": "biorender.com",
+      "name": "BioRender",
+      "mcpUrl": "https://mcp.services.biorender.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "biorender_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://chatgpt.com/apps/biorender/connector_691e3de0d2708191a6476a7b36e38779",
+          "setup": "Connect BioRender from a supported AI assistant such as [ChatGPT](https://chatgpt.com/apps/biorender/connector_691e3de0d2708191a6476a7b36e38779) or the [Claude connector directory](https://claude.ai/directory/connectors/81cc5080-a204-4aa1-a694-fa868a3c8720). Click **Connect**, sign in with your BioRender account, and approve the requested permissions. BioRender's help article describes this as logging in with your BioRender credentials and approving permissions for the MCP connector.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/biorender.com"
+    },
+    {
+      "domain": "bitdj.com",
+      "name": "Binance",
+      "mcpUrl": "https://mcp-prod.bitdj.com/mcp_server/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bitdj.com"
+    },
+    {
+      "domain": "bitly.com",
+      "name": "Bitly",
+      "mcpUrl": "https://api-ssl.bitly.com/v4/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "bitly_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://app.bitly.com/settings/api/",
+          "setup": "Log in to Bitly, open [Developer settings](https://app.bitly.com/settings/api/), click **Register new app**, complete the emailed registration flow, and Bitly assigns a `client_id` and `client_secret`. Use those in Bitly's OAuth web flow via `https://bitly.com/oauth/authorize`, then exchange the returned code at `https://api-ssl.bitly.com/v4/oauth/access_token` for a bearer access token. Bitly documents this flow in [Authentication](https://dev.bitly.com/docs/getting-started/authentication/).",
+          "fields": null
+        },
+        {
+          "id": "bitly_api_token",
+          "type": "bearer",
+          "generateUrl": "https://app.bitly.com/settings/api/",
+          "setup": "Log in to Bitly, open [API settings](https://app.bitly.com/settings/api/), enter your Bitly account password, and click **Generate token**. Copy the token and send it as `Authorization: Bearer {token}`. Bitly's support article with step-by-step instructions is [here](https://support.bitly.com/hc/en-us/articles/230647907-How-do-I-generate-an-OAuth-access-token-for-the-Bitly-API).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bitly.com"
+    },
+    {
+      "domain": "bizcover.com.au",
+      "name": "BizCover AU",
+      "mcpUrl": "https://bizify-mcp.bizcover.com.au/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bizcover.com.au"
+    },
+    {
+      "domain": "blackbaud.com",
+      "name": "Blackbaud",
+      "mcpUrl": "https://mcp.sky.blackbaud.com/",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/blackbaud.com"
+    },
+    {
+      "domain": "blazesql.com",
+      "name": "BlazeSQL",
+      "mcpUrl": "https://mcp.blazesql.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "blaze_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/blazesql.com"
+    },
+    {
+      "domain": "blockscout.com",
+      "name": "Blockscout",
+      "mcpUrl": "https://mcp.blockscout.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/blockscout.com"
+    },
+    {
+      "domain": "bluente.com",
+      "name": "BluTranslate",
+      "mcpUrl": "https://translate.bluente.com/api/gpt-app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "bluente_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://translate.bluente.com/",
+          "setup": "Start from [BluTranslate](https://translate.bluente.com/) / [Get Started](https://translate.bluente.com/). The curated OpenAI registry marks the MCP server as `authTypes: OAUTH`, but Bluente's public MCP page does not document the authorize/token flow or client registration steps. Use Bluente's hosted sign-in/onboarding path for the MCP server and follow the MCP client's OAuth prompt.",
+          "fields": null
+        },
+        {
+          "id": "bluente_api_key",
+          "type": "api_key",
+          "generateUrl": "https://translate.bluente.com/settings/?type=apiKeys",
+          "setup": "Open the [Bluente Dashboard API key settings](https://translate.bluente.com/settings/?type=apiKeys) and create/copy an API key. Bluente's docs say to send it as `Authorization: Bearer $BLUENTE_API_KEY`. The same dashboard area is also where Bluente says webhook settings are configured.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bluente.com"
+    },
+    {
+      "domain": "blueskyapi.com",
+      "name": "MT Newswires",
+      "mcpUrl": "https://vast-mcp.blueskyapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vianexus_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/blueskyapi.com"
+    },
+    {
+      "domain": "bluesuite.app",
+      "name": "BlueSuite",
+      "mcpUrl": "https://my.bluesuite.app/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "bluesuite_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/bluesuite.app"
+    },
+    {
+      "domain": "bodi.com",
+      "name": "BODi",
+      "mcpUrl": "https://api.edge.content-mcp-server.prod.bodi.com/gpt-app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bodi.com"
+    },
+    {
+      "domain": "boleron.bg",
+      "name": "Boleron AI",
+      "mcpUrl": "https://ai.boleron.bg/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/boleron.bg"
+    },
+    {
+      "domain": "bon-coin.net",
+      "name": "leboncoin",
+      "mcpUrl": "https://openaiapp.bon-coin.net/api/openaiapp/v1/mcp/http",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "boncoin_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Register an OAuth client/application with Leboncoin for the OpenAI app/MCP integration flow, then use that client to obtain OAuth access tokens for the MCP server. The automated registry indicates OAuth is required for the MCP endpoint at `https://openaiapp.bon-coin.net/api/openaiapp/v1/mcp/http`, but publicly accessible developer registration or authorization documentation on `bon-coin.net` could not be located during this scan.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bon-coin.net"
+    },
+    {
+      "domain": "book-direct.co",
+      "name": "Book Direct",
+      "mcpUrl": "https://app.book-direct.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/book-direct.co"
+    },
+    {
+      "domain": "botpress.sh",
+      "name": "Botpress",
+      "mcpUrl": "https://botgpt.botpress.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "botpress_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/botpress.sh"
+    },
+    {
+      "domain": "box.com",
+      "name": "Box Platform API",
+      "mcpUrl": "https://mcp.box.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "box_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://cloud.app.box.com/developers/console",
+          "setup": "Create or open an app in the [Box Developer Console](https://cloud.app.box.com/developers/console). Choose a Platform App using **Standard OAuth 2.0**, set your redirect URI, choose scopes, save changes, then copy the `Client ID` and `Client Secret`. Users then authorize via Box OAuth in the browser. For MCP, Box Admin Console can also generate integration credentials with a `Client ID` and `Client Secret` for the Box MCP server as documented in [Set up the MCP server](https://developer.box.com/guides/box-mcp/setup).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/box.com"
+    },
+    {
+      "domain": "box.dev",
+      "name": "box.dev",
+      "mcpUrl": "https://box.main-kill-isr.mintlify.me/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/box.dev"
+    },
+    {
+      "domain": "boxoffice.com",
+      "name": "Regal",
+      "mcpUrl": "https://chatgpt-mcp.boxoffice.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/boxoffice.com"
+    },
+    {
+      "domain": "boyner.com.tr",
+      "name": "Yapay Zeka'nın Boyner'i",
+      "mcpUrl": "https://mcp-backend.boyner.com.tr/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/boyner.com.tr"
+    },
+    {
+      "domain": "bpcs-ad-broker.de",
+      "name": "ADAC Mietwagen",
+      "mcpUrl": "https://bpcs-gptapp.bpcs-ad-broker.de/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bpcs-ad-broker.de"
+    },
+    {
+      "domain": "braintrust.dev",
+      "name": "braintrust.dev",
+      "mcpUrl": "https://api.braintrust.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "braintrust_api_key",
+          "type": "bearer",
+          "generateUrl": "https://www.braintrust.dev/app/settings?subroute=api-keys",
+          "setup": "Create an API key in [Settings > API keys](https://www.braintrust.dev/app/settings?subroute=api-keys). The API reference shows using it as `Authorization: Bearer $BRAINTRUST_API_KEY`. If you prefer the CLI flow, [`bt setup`](https://www.braintrust.dev/docs/reference/cli/setup) can create a new key interactively and prints an `export BRAINTRUST_API_KEY=<key>` command.",
+          "fields": null
+        },
+        {
+          "id": "braintrust_cli_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use [`bt auth login`](https://www.braintrust.dev/docs/reference/cli/quickstart) to open the browser-based Braintrust sign-in flow and save credentials to your keychain, or run [`bt auth login --no-browser`](https://www.braintrust.dev/docs/reference/cli/setup) on a headless server. For remote MCP clients, the [Braintrust MCP docs](https://www.braintrust.dev/docs/integrations/developer-tools/mcp) state that OAuth is supported when you add the server without an `Authorization` header, and clients like Claude Desktop authenticate when you first use the server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/braintrust.dev"
+    },
+    {
+      "domain": "brand24.com",
+      "name": "Brand24",
+      "mcpUrl": "https://mcp.brand24.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "brand24_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/brand24.com"
+    },
+    {
+      "domain": "breethe.com",
+      "name": "Breethe Meditations Made 4 You",
+      "mcpUrl": "https://mcp-prod.breethe.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/breethe.com"
+    },
+    {
+      "domain": "brevo.com",
+      "name": "brevo.com",
+      "mcpUrl": "https://mcp.brevo.com/v1/brevo/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "brevo_mcp_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/brevo.com"
+    },
+    {
+      "domain": "brex.com",
+      "name": "Brex",
+      "mcpUrl": "https://api.brex.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "brex_partner_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/brex.com"
+    },
+    {
+      "domain": "brexapis.com",
+      "name": "brexapis.com",
+      "mcpUrl": "https://api.brex.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "brex_partner_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/brexapis.com"
+    },
+    {
+      "domain": "browser-use.com",
+      "name": "browser-use.com",
+      "mcpUrl": "https://api.browser-use.com/v3/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "browser_use_api_key",
+          "type": "api_key",
+          "generateUrl": "https://cloud.browser-use.com/settings?tab=api-keys&new=1",
+          "setup": "In the [Browser Use dashboard](https://cloud.browser-use.com/settings?tab=api-keys&new=1), create an API key. Docs say keys start with `bu_`. You can also set it in your environment as `BROWSER_USE_API_KEY` for SDKs and some CLI flows.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/browser-use.com"
+    },
+    {
+      "domain": "browserbase.com",
+      "name": "browserbase.com",
+      "mcpUrl": "https://mcp.browserbase.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "browserbase_api_key",
+          "type": "api_key",
+          "generateUrl": "https://www.browserbase.com/overview",
+          "setup": "Sign in to the [Browserbase dashboard](https://www.browserbase.com/overview), then copy your API key from the dashboard/settings UI. The docs say to get your Browserbase credentials from the [Browserbase Dashboard](https://www.browserbase.com/overview); API reference pages also describe this as your Browserbase API key and link to [Settings](https://www.browserbase.com/settings).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/browserbase.com"
+    },
+    {
+      "domain": "buf.build",
+      "name": "buf.build",
+      "mcpUrl": "https://buf.build/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "buf_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/buf.build"
+    },
+    {
+      "domain": "builder.io",
+      "name": "builder.io",
+      "mcpUrl": "https://mcp.builder.io/mcp/publish",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "builder_mcp_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.builder.io/oauth/register",
+          "setup": "Register an OAuth client with Builder's MCP authorization server at [dynamic client registration](https://mcp.builder.io/oauth/register). Then send the user through the authorization flow at `https://mcp.builder.io/oauth/authorize` and exchange the code at `https://mcp.builder.io/oauth/token`. Supported scopes published by Builder are `mcp:publish:read` and `mcp:publish:write`. The authorization server metadata is published at [oauth-authorization-server](https://mcp.builder.io/.well-known/oauth-authorization-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/builder.io"
+    },
+    {
+      "domain": "buildwithfern.com",
+      "name": "buildwithfern.com",
+      "mcpUrl": "https://buildwithfern.com/learn/_mcp/server",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/buildwithfern.com"
+    },
+    {
+      "domain": "bump.sh",
+      "name": "bump.sh",
+      "mcpUrl": "https://developers.bump.sh/doc/portal/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bump.sh"
+    },
+    {
+      "domain": "busbud-int.com",
+      "name": "Busbud",
+      "mcpUrl": "https://trips-mcp-production-us.busbud-int.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/busbud-int.com"
+    },
+    {
+      "domain": "buser.com.br",
+      "name": "Buser",
+      "mcpUrl": "https://mcp.buser.com.br/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/buser.com.br"
+    },
+    {
+      "domain": "bygravity.com",
+      "name": "bygravity.com",
+      "mcpUrl": "https://g.runorion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "orion_account",
+          "type": "compound",
+          "generateUrl": "https://www.bygravity.com/contact",
+          "setup": "Request access to Orion from Gravity, typically by contacting sales via [Contact Sales](https://www.bygravity.com/contact). After your organization has an Orion workspace, sign in at your organization’s Orion URL with your Orion login credentials; the MCP setup flow then opens a browser sign-in and uses that account.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/bygravity.com"
+    },
+    {
+      "domain": "cal.com",
+      "name": "cal.com",
+      "mcpUrl": "https://mcp.cal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cal_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cal.com"
+    },
+    {
+      "domain": "calendly.com",
+      "name": "Calendly",
+      "mcpUrl": "https://mcp.calendly.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "calendly_mcp_dcr",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/calendly.com"
+    },
+    {
+      "domain": "calorieappguidemcp-production.up.railway.app",
+      "name": "Calorie Tracker Guide",
+      "mcpUrl": "https://calorieappguidemcp-production.up.railway.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/calorieappguidemcp-production.up.railway.app"
+    },
+    {
+      "domain": "campfire.ai",
+      "name": "campfire.ai",
+      "mcpUrl": "https://api.meetcampfire.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "campfire_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/campfire.ai"
+    },
+    {
+      "domain": "candid.org",
+      "name": "Candid",
+      "mcpUrl": "https://mcp.candid.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "candid_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/candid.org"
+    },
+    {
+      "domain": "canny.io",
+      "name": "Canny",
+      "mcpUrl": "https://canny.io/api/mcp/v1",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "canny_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://api.canny.io/api/mcp/oauth/authorize",
+          "setup": "Connect an MCP client to Canny's MCP server and complete the OAuth flow against Canny's authorization endpoint at [authorize](https://api.canny.io/api/mcp/oauth/authorize) and token endpoint at [token](https://api.canny.io/api/mcp/oauth/token). The curated registry marks this MCP server's auth type as OAuth. Canny does not expose developer-facing client registration docs in the pages reviewed, so use your MCP client's built-in connect flow.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/canny.io"
+    },
+    {
+      "domain": "canva.com",
+      "name": "Canva",
+      "mcpUrl": "https://mcp.canva.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "canva_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/canva.com"
+    },
+    {
+      "domain": "capacities.io",
+      "name": "Capacities",
+      "mcpUrl": "https://api.capacities.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "capacities_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/capacities.io"
+    },
+    {
+      "domain": "carbonarc.ai",
+      "name": "carbonarc.ai",
+      "mcpUrl": "https://mcp.carbonarc.ai",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "carbonarc_platform_login",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.ai"
+    },
+    {
+      "domain": "carbonarc.co",
+      "name": "Carbon Arc",
+      "mcpUrl": "https://mcp.carbonarc.co",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "carbonarc_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.co"
+    },
+    {
+      "domain": "cardchain.ai",
+      "name": "CardChain AI",
+      "mcpUrl": "https://api.cardchain.ai/mcp/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cardchain_account_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://cardchain.ai/mcp/docs",
+          "setup": "Use the [CardChain AI MCP setup guide](https://cardchain.ai/mcp/docs). In your MCP client, add the CardChain connector URL, then follow the OAuth sign-in prompt and log in with your CardChain AI account (or create one) on the CardChain AI login page. The guide explicitly says Claude redirects you to CardChain AI to sign in and then back to the client; the server details list auth as `OAuth 2.0`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cardchain.ai"
+    },
+    {
+      "domain": "carfax.com",
+      "name": "CARFAX",
+      "mcpUrl": "https://ai.carfax.com/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carfax.com"
+    },
+    {
+      "domain": "cargurus.com",
+      "name": "CarGurus",
+      "mcpUrl": "https://chat-gpt-app.api.cargurus.com/chat-mcp/v1/stream",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cargurus.com"
+    },
+    {
+      "domain": "carmax.com",
+      "name": "CarMax",
+      "mcpUrl": "https://apim.carmax.com/chatgpt-connector/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carmax.com"
+    },
+    {
+      "domain": "carrefour.fr",
+      "name": "Carrefour",
+      "mcpUrl": "https://mcp-openai.carrefour.fr/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carrefour.fr"
+    },
+    {
+      "domain": "cars24.com",
+      "name": "CARS24",
+      "mcpUrl": "https://mcp.cars24.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cars24.com"
+    },
+    {
+      "domain": "carsguide.com.au",
+      "name": "CarsGuide",
+      "mcpUrl": "https://mcp.carsguide.com.au/mcp/wHXYY2hgbt3AiUCpc4LfwxBqflDvZ4JOkyTnJDNfXbWwXDPAtlInfIpH4OO7FgR1e",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carsguide.com.au"
+    },
+    {
+      "domain": "carta.com",
+      "name": "carta.com",
+      "mcpUrl": "https://mcp.listalpha.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carta.com"
+    },
+    {
+      "domain": "cartesia.ai",
+      "name": "cartesia.ai",
+      "mcpUrl": "https://mcp.cartesia.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cartesia_access_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cartesia.ai"
+    },
+    {
+      "domain": "carwale.com",
+      "name": "CarWale",
+      "mcpUrl": "https://mcp.carwale.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/carwale.com"
+    },
+    {
+      "domain": "cazoo.co.uk",
+      "name": "Cazoo",
+      "mcpUrl": "https://apimanagement.cazoo.co.uk/chat-gpt-app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cazoo.co.uk"
+    },
+    {
+      "domain": "cbinsights.com",
+      "name": "CB Insights",
+      "mcpUrl": "https://mcp.cbinsights.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cbi_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cbinsights.com"
+    },
+    {
+      "domain": "cdata.com",
+      "name": "CData Connect AI",
+      "mcpUrl": "https://mcp.cloud.cdata.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "connect_ai_pat",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cdata.com"
+    },
+    {
+      "domain": "cdiscount.com",
+      "name": "Cdiscount",
+      "mcpUrl": "https://mcpapps.cdiscount.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cdiscount.com"
+    },
+    {
+      "domain": "cfdomains.com",
+      "name": "broadbandnow.com",
+      "mcpUrl": "https://bbnmcp.cfdomains.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cfdomains.com"
+    },
+    {
+      "domain": "channel99.com",
+      "name": "Channel99",
+      "mcpUrl": "https://mcp.channel99.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "channel99_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.channel99.com/oauth/authorize",
+          "setup": "Use an MCP client that supports OAuth 2.0 Authorization Code with PKCE against Channel99's advertised authorization server metadata at [mcp.channel99.com/.well-known/oauth-authorization-server](https://mcp.channel99.com/.well-known/oauth-authorization-server). The metadata lists `authorization_endpoint` at `https://app.channel99.com/oauth/authorize`, `token_endpoint` at `https://api.stytch.app.channel99.com/v1/oauth2/token`, `registration_endpoint` at `https://api.stytch.app.channel99.com/v1/oauth2/register`, grant types `authorization_code` and `refresh_token`, and PKCE `S256`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/channel99.com"
+    },
+    {
+      "domain": "chartmogul.com",
+      "name": "chartmogul.com",
+      "mcpUrl": "https://mcp.chartmogul.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "chartmogul_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://help.chartmogul.com/article/348-chartmogul-mcp-server",
+          "setup": "An admin or owner must first enable MCP access in **Settings & Data** > **Admin** > [Security](https://app.chartmogul.com/#/settings/security) by turning **Allow MCP server access** on. Then add the remote MCP server URL `https://mcp.chartmogul.com` in your MCP-compatible AI assistant and sign in to your ChartMogul account when prompted. ChartMogul states the MCP server uses OAuth 2.0 and authorization is handled automatically by the assistant. See [ChartMogul MCP server](https://help.chartmogul.com/article/348-chartmogul-mcp-server) and [Connecting ChartMogul to an AI assistant using MCP](https://dev.chartmogul.com/docs/chartmogul-mcp-server/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/chartmogul.com"
+    },
+    {
+      "domain": "chatgpt-app-with-next-js-t66k.vercel.app",
+      "name": "artue",
+      "mcpUrl": "https://chatgpt-app-with-next-js-t66k.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/chatgpt-app-with-next-js-t66k.vercel.app"
+    },
+    {
+      "domain": "check24.de",
+      "name": "CHECK24",
+      "mcpUrl": "https://chatgpt.bot.check24.de/v4.0/mcp/stream",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/check24.de"
+    },
+    {
+      "domain": "checklyhq.com",
+      "name": "checklyhq.com",
+      "mcpUrl": "https://api.checklyhq.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "checkly_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/checklyhq.com"
+    },
+    {
+      "domain": "checkr.com",
+      "name": "checkr.com",
+      "mcpUrl": "https://mcp.checkr.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "partner_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/checkr.com"
+    },
+    {
+      "domain": "chessvia.ai",
+      "name": "Chessvia Openings",
+      "mcpUrl": "https://openings.chessvia.ai/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/chessvia.ai"
+    },
+    {
+      "domain": "chroma.com",
+      "name": "chroma.com",
+      "mcpUrl": "https://mcp.trychroma.com/package-search/v1",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "chroma_api_key",
+          "type": "api_key",
+          "generateUrl": "https://trychroma.com/package-search",
+          "setup": "Create a Chroma Cloud account via [sign up](https://trychroma.com/signup?utm_source=docs-getting-started) or [log in](https://trychroma.com/login). For CLI headless login, the docs say to first create an API key in the Chroma Cloud dashboard, then use it with `chroma login --profile my_profile_name --api-key ck-...` as described on [CLI Login](https://docs.trychroma.com/docs/cli/login). For Package Search specifically, the docs say to visit [Package Search](http://trychroma.com/package-search), click **Get API Key**, and copy the key from the **Other** tab on the MCP page docs [Package Search MCP Server](https://docs.trychroma.com/cloud/package-search/mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/chroma.com"
+    },
+    {
+      "domain": "chronograph.pe",
+      "name": "Chronograph",
+      "mcpUrl": "https://ai.chronograph.pe/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/chronograph.pe"
+    },
+    {
+      "domain": "cinemo.fun",
+      "name": "Cinemô",
+      "mcpUrl": "https://mcp.cinemo.fun/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cinemo.fun"
+    },
+    {
+      "domain": "circleback.ai",
+      "name": "Circleback",
+      "mcpUrl": "https://app.circleback.ai/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "circleback_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/circleback.ai"
+    },
+    {
+      "domain": "clarify.ai",
+      "name": "Clarify",
+      "mcpUrl": "https://api.clarify.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "clarify_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/clarify.ai"
+    },
+    {
+      "domain": "clarity.ai",
+      "name": "Clarity AI",
+      "mcpUrl": "https://clarity-sfdr20-mcp.pro.clarity.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/clarity.ai"
+    },
+    {
+      "domain": "clarivate.com",
+      "name": "Cortellis Regulatory Intelligence",
+      "mcpUrl": "https://api.clarivate.com/lifesciences/mcp-regulatory/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/clarivate.com"
+    },
+    {
+      "domain": "clay.com",
+      "name": "Clay",
+      "mcpUrl": "https://api.clay.com/v3/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "clay_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/clay.com"
+    },
+    {
+      "domain": "clerk.com",
+      "name": "Clerk",
+      "mcpUrl": "https://mcp.clerk.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/clerk.com"
+    },
+    {
+      "domain": "clickup.com",
+      "name": "clickup20",
+      "mcpUrl": "https://mcp.clickup.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "clickup_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/clickup.com"
+    },
+    {
+      "domain": "closai.io",
+      "name": "Closai",
+      "mcpUrl": "https://app.closai.io/mcp/v2",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "closai_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://app.closai.io/mcp/v2/register/",
+          "setup": "Register an OAuth client against Closai's dynamic client registration endpoint at [MCP register](https://app.closai.io/mcp/v2/register/). The authorization server metadata is published at [OAuth authorization server metadata](https://app.closai.io/.well-known/oauth-authorization-server), which lists the `registration_endpoint`, `authorization_endpoint`, and `token_endpoint`. For the easiest path, add Closai from a compatible MCP client marketplace/integrations UI and complete the browser sign-in/authorize flow there; clients can also register programmatically and then use OAuth 2.0 authorization code with PKCE. The metadata says token endpoint auth uses `client_secret_post`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/closai.io"
+    },
+    {
+      "domain": "close.com",
+      "name": "Close",
+      "mcpUrl": "https://mcp.close.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "close_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/close.com"
+    },
+    {
+      "domain": "cloudasset.googleapis.com",
+      "name": "cloudasset.googleapis.com",
+      "mcpUrl": "https://cloudasset.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cloudasset.googleapis.com"
+    },
+    {
+      "domain": "clouderrorreporting.googleapis.com",
+      "name": "clouderrorreporting.googleapis.com",
+      "mcpUrl": "https://clouderrorreporting.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/clouderrorreporting.googleapis.com"
+    },
+    {
+      "domain": "cloudflare.com",
+      "name": "wrangler",
+      "mcpUrl": "https://bindings.mcp.cloudflare.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cf_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cloudflare.com"
+    },
+    {
+      "domain": "cloudresourcemanager.googleapis.com",
+      "name": "cloudresourcemanager.googleapis.com",
+      "mcpUrl": "https://cloudresourcemanager.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cloudresourcemanager.googleapis.com"
+    },
+    {
+      "domain": "cloudsupport.googleapis.com",
+      "name": "cloudsupport.googleapis.com",
+      "mcpUrl": "https://cloudsupport.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cloudsupport.googleapis.com"
+    },
+    {
+      "domain": "cloudtrace.googleapis.com",
+      "name": "cloudtrace.googleapis.com",
+      "mcpUrl": "https://cloudtrace.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cloudtrace.googleapis.com"
+    },
+    {
+      "domain": "clutch.ca",
+      "name": "Clutch",
+      "mcpUrl": "https://mcp.api.clutch.ca/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "clutch_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.api.clutch.ca/.well-known/oauth-authorization-server",
+          "setup": "Clutch's MCP server advertises OAuth 2.0 metadata at [OAuth authorization server metadata](https://mcp.api.clutch.ca/.well-known/oauth-authorization-server). Register or obtain a Clutch OAuth client from Clutch, then use the advertised `authorization_endpoint` and `token_endpoint` to get an access token. The metadata shows support for the `authorization_code`, `client_credentials`, and `refresh_token` grants, `client_secret_post` client authentication, and scopes including `tools:read` and `offline_access`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/clutch.ca"
+    },
+    {
+      "domain": "clutch.co",
+      "name": "Clutch.co",
+      "mcpUrl": "https://bot.clutch.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/clutch.co"
+    },
+    {
+      "domain": "cmcp.shop",
+      "name": "C.FLIP",
+      "mcpUrl": "https://cmcp.shop/mcp/e4b5ec4f-6e83-4292-b7c5-32272974d287",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cmcp.shop"
+    },
+    {
+      "domain": "cobaltpf.com",
+      "name": "cobaltpf.com",
+      "mcpUrl": "https://api.cobaltpf.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cobalt_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://docs.cobaltpf.com/docs/mcp",
+          "setup": "For the hosted MCP server, add `https://api.cobaltpf.com/api/mcp` in your MCP client (for example Claude, Cursor, VS Code, Codex, Gemini, or OpenCode). On first connect, the client registers as an OAuth application with Cobalt automatically and opens a browser sign-in/consent flow. After you sign in with your Cobalt account, the client caches the OAuth token. See [MCP Server](https://docs.cobaltpf.com/docs/mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cobaltpf.com"
+    },
+    {
+      "domain": "coches.net",
+      "name": "Milanuncios",
+      "mcpUrl": "https://llms-apps.gw.coches.net/coches/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/coches.net"
+    },
+    {
+      "domain": "cockroachlabs.com",
+      "name": "cockroachlabs.com",
+      "mcpUrl": "https://cockroachlabs.cloud/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cloud_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cockroachlabs.com"
+    },
+    {
+      "domain": "cogedim.com",
+      "name": "Cogedim",
+      "mcpUrl": "https://www.cogedim.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cogedim.com"
+    },
+    {
+      "domain": "collegenation.com",
+      "name": "collegenation.com",
+      "mcpUrl": "https://5guxfz-1n.myshopify.com/api/ucp/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/collegenation.com"
+    },
+    {
+      "domain": "columnapi.com",
+      "name": "Aiwyn Tax (formerly Column Tax)",
+      "mcpUrl": "https://mcp.columnapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/columnapi.com"
+    },
+    {
+      "domain": "commonroom.io",
+      "name": "Common Room",
+      "mcpUrl": "https://mcp.commonroom.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/commonroom.io"
+    },
+    {
+      "domain": "compute.googleapis.com",
+      "name": "Google Compute Engine",
+      "mcpUrl": "https://compute.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/compute.googleapis.com"
+    },
+    {
+      "domain": "computrabajo.com",
+      "name": "Computrabajo",
+      "mcpUrl": "https://api-mcp.computrabajo.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/computrabajo.com"
+    },
+    {
+      "domain": "conductor.com",
+      "name": "Conductor",
+      "mcpUrl": "https://mcp-universal.conductor.com/mcp/v2",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "conductor_user_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use a Conductor account that has access to the MCP early access program. Start from a supported client such as [ChatGPT setup](https://www.conductor.com/docs/mcp/chatgpt), [Claude setup](https://www.conductor.com/docs/mcp/claude), [Copilot setup](https://www.conductor.com/docs/mcp/copilot), or [Perplexity setup](https://www.conductor.com/docs/mcp/perplexity), then choose the Conductor connector/app and sign in on the redirected Conductor authentication screen with your Conductor credentials. If your organization is not enabled for MCP, contact your Conductor team.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/conductor.com"
+    },
+    {
+      "domain": "confident-ai.com",
+      "name": "confident-ai.com",
+      "mcpUrl": "https://mcp.confident-ai.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "confident_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.confident-ai.com",
+          "setup": "Sign in to [Confident AI](https://app.confident-ai.com) or create an account from [Sign Up](https://app.confident-ai.com/auth/signup). In the platform Settings page, copy the **Project API Key**. The DeepEval setup guide says you can also run `deepeval login` and paste the key when prompted, or pass it directly with `deepeval login --confident-api-key \"<your-confident-api-key>\"`. The key is commonly stored as `CONFIDENT_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/confident-ai.com"
+    },
+    {
+      "domain": "confirmtkt.com",
+      "name": "ConfirmTkt",
+      "mcpUrl": "https://mcp.confirmtkt.com/trains-ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/confirmtkt.com"
+    },
+    {
+      "domain": "connectedpdf.com",
+      "name": "Foxit PDF Editor",
+      "mcpUrl": "https://mcp-ai-assistant-azk8s.connectedpdf.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/connectedpdf.com"
+    },
+    {
+      "domain": "consensus.app",
+      "name": "Consensus",
+      "mcpUrl": "https://mcp.consensus.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "consensus_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/consensus.app"
+    },
+    {
+      "domain": "contactcenterinsights.googleapis.com",
+      "name": "contactcenterinsights.googleapis.com",
+      "mcpUrl": "https://contactcenterinsights.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/contactcenterinsights.googleapis.com"
+    },
+    {
+      "domain": "container.googleapis.com",
+      "name": "container.googleapis.com",
+      "mcpUrl": "https://container.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/container.googleapis.com"
+    },
+    {
+      "domain": "contentful.com",
+      "name": "contentful.com",
+      "mcpUrl": "https://mcp.contentful.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "contentful_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use an MCP client that supports OAuth and connect it to the hosted endpoint. The client will redirect you to sign in with your Contentful account (`be.contentful.com` for global or `be.eu.contentful.com` for EU) and authorize the session. The remote server also requires the Contentful MCP app to be installed in each target space/environment. See [Model Context Protocol (MCP) server](https://www.contentful.com/developers/docs/tools/mcp-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/contentful.com"
+    },
+    {
+      "domain": "contentsquare.com",
+      "name": "Contentsquare",
+      "mcpUrl": "https://api.contentsquare.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cs_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/contentsquare.com"
+    },
+    {
+      "domain": "context.dev",
+      "name": "context.dev",
+      "mcpUrl": "https://context-dev.stlmcp.com",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "context_api_key",
+          "type": "bearer",
+          "generateUrl": "https://context.dev/signup",
+          "setup": "Sign up at [context.dev/signup](https://context.dev/signup), then open the [dashboard](https://context.dev/dashboard) and copy the API key from the **API Keys** section. It starts with `ctxt_secret_`. For autonomous agent setup, Context.dev also supports the agentic registration flow documented in [auth.md](https://www.context.dev/auth.md), which ultimately issues the same long-lived API key after the user completes the browser claim step.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/context.dev"
+    },
+    {
+      "domain": "context7.com",
+      "name": "Context7",
+      "mcpUrl": "https://mcp.context7.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "context7_api_key",
+          "type": "bearer",
+          "generateUrl": "https://context7.com/dashboard",
+          "setup": "Go to the [Context7 dashboard](https://context7.com/dashboard), open the API Keys card, click **Create API Key**, optionally name it, and copy the key immediately. Keys are shown only once and have the format `ctx7sk-...`. Use it as a bearer token in `Authorization: Bearer ...`, or for the hosted MCP server send it in the `CONTEXT7_API_KEY` header.",
+          "fields": null
+        },
+        {
+          "id": "context7_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://context7.com/api/oauth/authorize",
+          "setup": "For the hosted MCP server's OAuth mode, your MCP client self-registers with Context7 using Dynamic Client Registration and then opens the browser for you to sign in and approve access. Configure the MCP server at `https://mcp.context7.com/mcp/oauth` in an MCP client that supports the MCP OAuth spec; then use the client's **Authenticate** action. Context7 publishes OAuth endpoints at [authorize](https://context7.com/api/oauth/authorize), [token](https://context7.com/api/oauth/token), and [dynamic client registration](https://context7.com/api/oauth/register). Documented scopes are `profile` and `email`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/context7.com"
+    },
+    {
+      "domain": "corrently.de",
+      "name": "corrently.de",
+      "mcpUrl": "https://api.corrently.io/v2.0/mcp/tools",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "corrently_api_token",
+          "type": "bearer",
+          "generateUrl": "https://console.corrently.io/",
+          "setup": "Go to the [Corrently Developer Console](https://console.corrently.io/). Under **Your Access Token**, request either the **Anonymous Access Token** (browser-issued, short expiration) or the **Email Secured Access Token** (email verification flow). The console says the token can be used either as query parameter `token` or as an `Authorization: Bearer` header.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/corrently.de"
+    },
+    {
+      "domain": "cosmicjs.com",
+      "name": "cosmicjs.com",
+      "mcpUrl": "https://mcp.cosmicjs.com/v1/agent",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "agent_key",
+          "type": "bearer",
+          "generateUrl": "https://www.cosmicjs.com/docs/api/agents",
+          "setup": "Create an agent-scoped signup session by calling [`POST /v3/agents/sign-up`](https://www.cosmicjs.com/docs/api/agents#sign-up) on `https://dapi.cosmicjs.com`. The response includes an `agent_key` with the `agk_` prefix. Store it securely; it authenticates only the agent-flow endpoints and MCP agent scope.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cosmicjs.com"
+    },
+    {
+      "domain": "coupler.io",
+      "name": "Coupler.io",
+      "mcpUrl": "https://mcp.coupler.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "coupler_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/coupler.io"
+    },
+    {
+      "domain": "courier.com",
+      "name": "courier.com",
+      "mcpUrl": "https://mcp.courier.com",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "courier_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.courier.com/settings/api-keys",
+          "setup": "Sign up or log in to [Courier](https://app.courier.com), then open [Settings > API Keys](https://app.courier.com/settings/api-keys) and create or copy an API key. Courier documents that Test and Production use separate keys. Use the key as `Authorization: Bearer <API_KEY>` for the REST API, set `COURIER_API_KEY` for the CLI, or pass it to MCP clients in the `api_key` header.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/courier.com"
+    },
+    {
+      "domain": "coursera.org",
+      "name": "Coursera",
+      "mcpUrl": "https://www.coursera.org/chatgpt-widgets/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/coursera.org"
+    },
+    {
+      "domain": "coveo.com",
+      "name": "Coveo",
+      "mcpUrl": "https://mcp.cloud.coveo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "coveo_oauth_access_token",
+          "type": "oauth2",
+          "generateUrl": "https://platform.cloud.coveo.com/",
+          "setup": "Sign in to the [Coveo platform](https://platform.cloud.coveo.com/). In pages such as the REST API source tutorial, Coveo instructs users to open **Authentication** and click **Generate Access Token** or **Authenticated (you) → Generate** to mint an access token for API calls. Use the token as a `Bearer` token in API requests.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/coveo.com"
+    },
+    {
+      "domain": "cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com",
+      "name": "Cowboy Model Finder",
+      "mcpUrl": "https://cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com"
+    },
+    {
+      "domain": "craft.do",
+      "name": "Craft",
+      "mcpUrl": "https://mcp.craft.do/my/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "craft_mcp_approval",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/craft.do"
+    },
+    {
+      "domain": "creditkarma.com",
+      "name": "Intuit Credit Karma",
+      "mcpUrl": "https://anthropic.mcp.creditkarma.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "creditkarma_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Open the MCP endpoint in an MCP client and complete the provider's OAuth sign-in/consent flow when prompted. The curated registry identifies this server as using OAuth, but Credit Karma does not appear to publish separate public developer registration docs for this MCP server. Start from the MCP endpoint `https://anthropic.mcp.creditkarma.com/mcp` and the Credit Karma sign-in pages such as [Log in](https://www.creditkarma.com/auth/logon).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/creditkarma.com"
+    },
+    {
+      "domain": "creed.md",
+      "name": "creed.md",
+      "mcpUrl": "https://creed.md/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "creed_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/creed.md"
+    },
+    {
+      "domain": "crewai.com",
+      "name": "crewai.com",
+      "mcpUrl": "https://crewai.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/crewai.com"
+    },
+    {
+      "domain": "crossbeam.com",
+      "name": "Crossbeam",
+      "mcpUrl": "https://mcp.crossbeam.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "crossbeam_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/crossbeam.com"
+    },
+    {
+      "domain": "crowdstrike.com",
+      "name": "crowdstrike.com",
+      "mcpUrl": "http://127.0.0.1:8000",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "falcon_mcp_http_key",
+          "type": "api_key",
+          "generateUrl": null,
+          "setup": "When self-hosting `falcon-mcp` over an HTTP transport, set the server's API key value and configure clients to send it in the `x-api-key` header. The server source documents this as `api_key` for HTTP transport authentication and validates the `x-api-key` header. This is a server-local credential you choose when deploying the MCP server, not a CrowdStrike-issued Falcon platform credential.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/crowdstrike.com"
+    },
+    {
+      "domain": "cruisecritic.com",
+      "name": "Cruise Critic",
+      "mcpUrl": "https://chatgpt.cruisecritic.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/cruisecritic.com"
+    },
+    {
+      "domain": "crypto.com",
+      "name": "Crypto.com",
+      "mcpUrl": "https://mcp.crypto.com/market-data/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/crypto.com"
+    },
+    {
+      "domain": "ctmers.io",
+      "name": "Compare the Market",
+      "mcpUrl": "https://external-agent-mcp.ctmers.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ctmers.io"
+    },
+    {
+      "domain": "cubesoftware.com",
+      "name": "Cube",
+      "mcpUrl": "https://mcp.cubesoftware.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cube_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/cubesoftware.com"
+    },
+    {
+      "domain": "daloopa.com",
+      "name": "Daloopa",
+      "mcpUrl": "https://mcp.daloopa.com/server/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "daloopa_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/daloopa.com"
+    },
+    {
+      "domain": "dataflow.googleapis.com",
+      "name": "dataflow.googleapis.com",
+      "mcpUrl": "https://dataflow.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dataflow.googleapis.com"
+    },
+    {
+      "domain": "dataforseo.com",
+      "name": "dataforseo.com",
+      "mcpUrl": "https://mcp.dataforseo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dfs_api_basic",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dataforseo.com"
+    },
+    {
+      "domain": "dataplex.googleapis.com",
+      "name": "dataplex.googleapis.com",
+      "mcpUrl": "https://dataplex.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dataplex.googleapis.com"
+    },
+    {
+      "domain": "dataproc.googleapis.com",
+      "name": "dataproc.googleapis.com",
+      "mcpUrl": "https://dataproc.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dataproc.googleapis.com"
+    },
+    {
+      "domain": "datasite.com",
+      "name": "Datasite",
+      "mcpUrl": "https://mcp.global.datasite.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "datasite_user_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.global.datasite.com/dev-portal/guides/mcp-server",
+          "setup": "Connect the Datasite MCP server from a supported AI client (for example Claude or ChatGPT) as described in the [MCP Server guide](https://app.global.datasite.com/dev-portal/guides/mcp-server). On first use, Datasite starts an OAuth 2.0 Authorization Code + PKCE login in the browser; sign in with your Datasite account and approve access. Datasite then issues a time-limited bearer token for MCP calls.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/datasite.com"
+    },
+    {
+      "domain": "datastream.googleapis.com",
+      "name": "datastream.googleapis.com",
+      "mcpUrl": "https://datastream.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/datastream.googleapis.com"
+    },
+    {
+      "domain": "datocms.com",
+      "name": "datocms.com",
+      "mcpUrl": "https://mcp.datocms.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cli_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.datocms.com/docs/cli",
+          "setup": "Install the CLI, then run `npx datocms login`. Your browser opens for DatoCMS account authorization, and the CLI stores credentials locally in `~/.config/datocms/credentials.json` as described in [CLI Overview](https://www.datocms.com/docs/cli).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/datocms.com"
+    },
+    {
+      "domain": "day.ai",
+      "name": "Day AI",
+      "mcpUrl": "https://day.ai/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "day_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/day.ai"
+    },
+    {
+      "domain": "dazzly.co",
+      "name": "Dazzly",
+      "mcpUrl": "https://prod.mcp.dazzly.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dazzly_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dazzly.co"
+    },
+    {
+      "domain": "decolar.com",
+      "name": "decolar.com",
+      "mcpUrl": "https://apis.despegar.com/api-b2b-flights-mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "despegar_mcp_client",
+          "type": "oauth2_cc",
+          "generateUrl": "https://api-docs.despegar.com/docs/mcp-support",
+          "setup": "For MCP access, reach out to your account manager to obtain sandbox credentials for the MCP proof of concept. The docs say MCP uses OAuth 2.0 `client_credentials` and that Despegar supports integration from start to finish. See [MCP Support](https://api-docs.despegar.com/docs/mcp-support).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/decolar.com"
+    },
+    {
+      "domain": "deepgram.com",
+      "name": "deepgram.com",
+      "mcpUrl": "https://developers.deepgram.com/_mcp/server",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/deepgram.com"
+    },
+    {
+      "domain": "demandbase.com",
+      "name": "Demandbase",
+      "mcpUrl": "https://gateway.demandbase.com/mcp/servers/db-mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "db_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/demandbase.com"
+    },
+    {
+      "domain": "descope.com",
+      "name": "descope.com",
+      "mcpUrl": "https://mcp.descope.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "descope_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/descope.com"
+    },
+    {
+      "domain": "devcycle.com",
+      "name": "devcycle.com",
+      "mcpUrl": "https://mcp.devcycle.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "cli_access_token",
+          "type": "bearer",
+          "generateUrl": null,
+          "setup": "Install the CLI from [CLI docs](https://docs.devcycle.com/cli/) and run `dvc login sso` (or `dvc repo init`). The CLI opens the DevCycle universal login in a browser, stores an access token valid for 24 hours, and can refresh it with `dvc login again`, per the [CLI authentication docs](https://docs.devcycle.com/cli/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/devcycle.com"
+    },
+    {
+      "domain": "devrev.ai",
+      "name": "DevRev",
+      "mcpUrl": "https://api.devrev.ai/mcp/v1",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/devrev.ai"
+    },
+    {
+      "domain": "dialogflow.googleapis.com",
+      "name": "dialogflow.googleapis.com",
+      "mcpUrl": "https://dialogflow.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dialogflow.googleapis.com"
+    },
+    {
+      "domain": "dice.com",
+      "name": "Dice",
+      "mcpUrl": "https://mcp.dice.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/dice.com"
+    },
+    {
+      "domain": "digits.com",
+      "name": "Digits",
+      "mcpUrl": "https://api.digits.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "digits_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/digits.com"
+    },
+    {
+      "domain": "directbooker.ai",
+      "name": "DirectBooker",
+      "mcpUrl": "https://www.directbooker.ai/claude",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/directbooker.ai"
+    },
+    {
+      "domain": "district.in",
+      "name": "District",
+      "mcpUrl": "https://mcp-server.district.in/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "district_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp-server.district.in/register",
+          "setup": "For the District MCP server, register an OAuth client at [District MCP client registration](https://mcp-server.district.in/register), then complete the authorization-code flow against the server's OAuth metadata at [authorization server metadata](https://mcp-server.district.in/.well-known/oauth-authorization-server). The metadata advertises `authorization_endpoint` `https://mcp-server.district.in/authorize`, `token_endpoint` `https://mcp-server.district.in/token`, and supports `authorization_code` plus `refresh_token` with PKCE `S256`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/district.in"
+    },
+    {
+      "domain": "docketai.com",
+      "name": "Docket",
+      "mcpUrl": "https://mcp.app.docketai.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "docket_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.app.docketai.com",
+          "setup": "In your MCP client, add Docket's remote MCP server at `https://mcp.app.docketai.com` and start the connect flow. The server is listed as OAuth-based in the MCP registry, and the server itself responds with an `invalid_token` error asking the client to reconnect so it can automatically re-register and obtain new tokens. If you need access, request a Docket workspace/demo through [Docket](https://www.docket.io/) or [book a demo](https://www.docket.io/request-for-demo).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/docketai.com"
+    },
+    {
+      "domain": "docsie.io",
+      "name": "docsie.io",
+      "mcpUrl": "https://app.docsie.io/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "docsie_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/docsie.io"
+    },
+    {
+      "domain": "documents.craft.me",
+      "name": "documents.craft.me",
+      "mcpUrl": "https://mcp.craft.do/my/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "craft_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/documents.craft.me"
+    },
+    {
+      "domain": "docuseal.com",
+      "name": "DocuSeal",
+      "mcpUrl": "https://docuseal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "docuseal_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://docuseal.com/oauth/authorize",
+          "setup": "DocuSeal exposes OAuth 2.0 authorization and token endpoints at [authorize](https://docuseal.com/oauth/authorize) and [token](https://docuseal.com/oauth/token). The provided public docs I found do not describe where developers register OAuth clients or obtain client credentials, but the MCP endpoint is cataloged as using OAuth 2.0 against these endpoints.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/docuseal.com"
+    },
+    {
+      "domain": "docusign.com",
+      "name": "Docusign",
+      "mcpUrl": "https://mcp.docusign.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/docusign.com"
+    },
+    {
+      "domain": "domotz.app",
+      "name": "Domotz (Preview)",
+      "mcpUrl": "https://mcp.domotz.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "domotz_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/domotz.app"
+    },
+    {
+      "domain": "domotz.com",
+      "name": "domotz.com",
+      "mcpUrl": "https://mcp.domotz.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "domotz_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/domotz.com"
+    },
+    {
+      "domain": "dovetail.com",
+      "name": "Dovetail",
+      "mcpUrl": "https://dovetail.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dovetail_api_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dovetail.com"
+    },
+    {
+      "domain": "dowjones.io",
+      "name": "Dow Jones Factiva",
+      "mcpUrl": "https://factiva.mcp.shared-data.dowjones.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dj_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://developer.dowjones.com/documents/site-docs-getting_started-quick_start-getting_credentials",
+          "setup": "Request access or a trial from the [Dow Jones Developer Platform](https://developer.dowjones.com/) and follow the [Getting Credentials](https://developer.dowjones.com/documents/site-docs-getting_started-quick_start-getting_credentials) and [Authenticating into Dow Jones](https://developer.dowjones.com/documents/site-docs-getting_started-quick_start-authenticating_into_dowjones) guides. Dow Jones states its identity service is based on OAuth 2.0 / OpenID Connect; after your product access is provisioned, obtain your application credentials from the developer platform or via Dow Jones support.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/dowjones.io"
+    },
+    {
+      "domain": "draftkings.com",
+      "name": "DraftKings",
+      "mcpUrl": "https://mcp.draftkings.com/sports/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/draftkings.com"
+    },
+    {
+      "domain": "driftless.icu",
+      "name": "driftless.icu",
+      "mcpUrl": "https://api.driftless.icu/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "driftless_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.driftless.icu",
+          "setup": "Primary path: run `driftless login` from the [CLI setup docs](https://docs.driftless.icu/cli/setup), which opens the Driftless dashboard so you can copy an API key. You can also create or revoke keys in the dashboard under **Settings → API Keys** at [app.driftless.icu](https://app.driftless.icu). Keys are shown once at creation time and use the `drift_` prefix.",
+          "fields": null
+        },
+        {
+          "id": "driftless_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://api.driftless.icu/api/v1/oauth/authorize",
+          "setup": "For MCP clients, Driftless supports self-onboarding OAuth 2.0 with dynamic client registration: the MCP client registers itself at `POST /oauth/register`, sends you to Driftless consent, and then exchanges the code for a token. The easiest path is simply to connect Driftless from an MCP-capable client such as Claude or ChatGPT and approve access in the browser. Relevant docs: [MCP & OAuth](https://docs.driftless.icu/mcp/overview) and [Security](https://docs.driftless.icu/security/overview).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu"
+    },
+    {
+      "domain": "dropbox.com",
+      "name": "Dropbox Dash",
+      "mcpUrl": "https://mcp.dropbox.com/chatgpt_app_mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dropbox_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dropbox.com"
+    },
+    {
+      "domain": "dub.co",
+      "name": "dub.co",
+      "mcpUrl": "https://mcp.dub.sh/mcp/dub-links",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dub_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.dub.co/settings/tokens",
+          "setup": "In your Dub workspace, open **Settings** → [API Keys](https://app.dub.co/settings/tokens), click **Create**, choose the permissions and whether the key is associated with **You** or a **Machine** user, then create and copy the key. Dub API keys are secret server-side credentials in the form `dub_xxxxxxxx` and are used as `Authorization: Bearer <key>` for the REST API. The same key is also used for Dub's MCP servers by sending it in the `Mcp-Dub-Token` header. For partner-program MCP access, create the key with access to your partner program.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/dub.co"
+    },
+    {
+      "domain": "e2b.dev",
+      "name": "e2b.dev",
+      "mcpUrl": "https://e2b.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/e2b.dev"
+    },
+    {
+      "domain": "easemytrip.com",
+      "name": "EaseMyTrip",
+      "mcpUrl": "https://emt-mcp-server.easemytrip.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/easemytrip.com"
+    },
+    {
+      "domain": "ecsbr.net",
+      "name": "Serasa",
+      "mcpUrl": "https://ia-openai-prd.ecsbr.net/mcp/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ecsbr.net"
+    },
+    {
+      "domain": "edmunds.com",
+      "name": "Edmunds",
+      "mcpUrl": "https://www.edmunds.com/mcp/map/emo/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/edmunds.com"
+    },
+    {
+      "domain": "edreams.com",
+      "name": "eDreams",
+      "mcpUrl": "https://www.edreams.com/ai-travel-assistant/chatgpt/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/edreams.com"
+    },
+    {
+      "domain": "egnyte.com",
+      "name": "Egnyte",
+      "mcpUrl": "https://mcp-server.egnyte.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "egnyte_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/egnyte.com"
+    },
+    {
+      "domain": "email-creation-mcp-node-production.up.railway.app",
+      "name": "Kopi - Shopify Email Creator",
+      "mcpUrl": "https://email-creation-mcp-node-production.up.railway.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/email-creation-mcp-node-production.up.railway.app"
+    },
+    {
+      "domain": "employers.com",
+      "name": "EMPLOYERS",
+      "mcpUrl": "https://mcp.employers.com/direct/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/employers.com"
+    },
+    {
+      "domain": "enechange.jp",
+      "name": "エネチェンジ Home 電気・ガス比較",
+      "mcpUrl": "https://enechange.jp/api/apps_in_chatgpt/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "enechange_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/enechange.jp"
+    },
+    {
+      "domain": "enhancv.com",
+      "name": "Enhancv",
+      "mcpUrl": "https://agent.enhancv.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/enhancv.com"
+    },
+    {
+      "domain": "enterpret.com",
+      "name": "Enterpret",
+      "mcpUrl": "https://wisdom-api.enterpret.com/server/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "enterpret_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/enterpret.com"
+    },
+    {
+      "domain": "envoy.com",
+      "name": "envoy.com",
+      "mcpUrl": "https://mcp.envoy.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "envoy_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.envoy.com/",
+          "setup": "Use an MCP client that supports OAuth and connect it to `https://mcp.envoy.com/mcp`. Envoy documents that you add the server URL in the client and complete the OAuth authentication flow when prompted. The MCP client handles the OAuth registration/discovery flow automatically; you just approve access in the browser.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/envoy.com"
+    },
+    {
+      "domain": "enzoreader.com",
+      "name": "Enzo Reader for RSS",
+      "mcpUrl": "https://chatgpt.enzoreader.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "enzo_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://chatgpt.enzoreader.com/oauth/registration",
+          "setup": "Register an OAuth client at Enzo Reader's dynamic client registration endpoint [`/oauth/registration`](https://chatgpt.enzoreader.com/oauth/registration), then run the standard OAuth 2.0 authorization flow against the authorization server advertised at [`.well-known/oauth-authorization-server`](https://chatgpt.enzoreader.com/.well-known/oauth-authorization-server). The metadata lists `authorization_code` and `refresh_token` grants, scopes including `read` and `write`, and token endpoint auth methods `client_secret_basic` and `client_secret_post`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/enzoreader.com"
+    },
+    {
+      "domain": "eodhd.com",
+      "name": "eodhd.com",
+      "mcpUrl": "https://mcp.eodhd.com/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/eodhd.com"
+    },
+    {
+      "domain": "esky.com",
+      "name": "ThomasCook",
+      "mcpUrl": "https://mcp.esky.com/mcpgpttc",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/esky.com"
+    },
+    {
+      "domain": "ethoslife.com",
+      "name": "Ethos",
+      "mcpUrl": "https://eg.ethoslife.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ethoslife.com"
+    },
+    {
+      "domain": "etraveligroup.com",
+      "name": "Flight Network",
+      "mcpUrl": "https://mcp-ultrasearch.etraveligroup.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/etraveligroup.com"
+    },
+    {
+      "domain": "evaneos.com",
+      "name": "Evaneos",
+      "mcpUrl": "https://chatgpt-app.evaneos.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/evaneos.com"
+    },
+    {
+      "domain": "every.ai",
+      "name": "Every AI",
+      "mcpUrl": "https://admin-mcp.every.ai/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "every_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/every.ai"
+    },
+    {
+      "domain": "exa.ai",
+      "name": "Exa",
+      "mcpUrl": "https://mcp.exa.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/exa.ai"
+    },
+    {
+      "domain": "excalidraw.com",
+      "name": "Excalidraw",
+      "mcpUrl": "https://mcp.excalidraw.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/excalidraw.com"
+    },
+    {
+      "domain": "executor.sh",
+      "name": "Executor Dev",
+      "mcpUrl": "https://executor.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "executor_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/executor.sh"
+    },
+    {
+      "domain": "expedia.com",
+      "name": "Expedia",
+      "mcpUrl": "https://www.expedia.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/expedia.com"
+    },
+    {
+      "domain": "experian.com",
+      "name": "Experian Insurance",
+      "mcpUrl": "https://usa.experian.com/api/mcp-insurance-app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/experian.com"
+    },
+    {
+      "domain": "experiancs.co.uk",
+      "name": "Experian UK",
+      "mcpUrl": "https://openai-app.experiancs.co.uk/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/experiancs.co.uk"
+    },
+    {
+      "domain": "experteer.com",
+      "name": "Experteer",
+      "mcpUrl": "https://mcp.jca.experteer.com/mcp/4688951b6d7da4fa5a66399f31944d4ba15c5078ef88d82f56bf7515d3711f7d",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/experteer.com"
+    },
+    {
+      "domain": "explorium.ai",
+      "name": "Vibe Prospecting",
+      "mcpUrl": "https://mcp.explorium.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "explorium_api_key",
+          "type": "api_key",
+          "generateUrl": "https://developers.explorium.ai/reference/setup/getting_your_api_key",
+          "setup": "Log in to the [Explorium Admin Portal](https://admin.explorium.ai/) and go to [Getting Your API Key](https://developers.explorium.ai/reference/setup/getting_your_api_key). Under **Access & Authentication**, reveal the company API key with **Show Key** and copy it. Explorium states each company gets a single shared API key after purchasing a subscription package.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/explorium.ai"
+    },
+    {
+      "domain": "facebook.com",
+      "name": "facebook.com",
+      "mcpUrl": "https://mcp.facebook.com/devtools",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "meta_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://developers.facebook.com/documentation/mcp/devtools-mcp",
+          "setup": "Add the MCP server endpoint from [Developer Tools MCP](https://developers.facebook.com/documentation/mcp/devtools-mcp) to a supported MCP client, then authenticate by signing in with your Meta account and granting access to the apps you want the server to access. You can manage or revoke access later in Facebook **Settings** > **Business Integrations**, as described in [Connect AI Agents to Meta with MCP](https://developers.facebook.com/documentation/mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/facebook.com"
+    },
+    {
+      "domain": "faces.app",
+      "name": "faces.app",
+      "mcpUrl": "https://mcp.faces.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "faces_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/faces.app"
+    },
+    {
+      "domain": "factagora.com",
+      "name": "Agora",
+      "mcpUrl": "https://api.factagora.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "factagora_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/factagora.com"
+    },
+    {
+      "domain": "factset.io",
+      "name": "FactSet AI-Ready Data MCP",
+      "mcpUrl": "https://mcp.factset.com/content/v1",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/factset.io"
+    },
+    {
+      "domain": "faire.com",
+      "name": "Faire Wholesale",
+      "mcpUrl": "https://www.faire.com/chatgpt/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/faire.com"
+    },
+    {
+      "domain": "fal.ai",
+      "name": "fal.ai",
+      "mcpUrl": "https://mcp.fal.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fal_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fal.ai"
+    },
+    {
+      "domain": "fareharbor.com",
+      "name": "FareHarbor",
+      "mcpUrl": "https://partner-mcp.fareharbor.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/fareharbor.com"
+    },
+    {
+      "domain": "fastmcp.cloud",
+      "name": "fastmcp.cloud",
+      "mcpUrl": "https://my-tools.horizon.prefect.io",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/fastmcp.cloud"
+    },
+    {
+      "domain": "fathom.ai",
+      "name": "Fathom",
+      "mcpUrl": "https://api.fathom.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fathom_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fathom.ai"
+    },
+    {
+      "domain": "feedclaw.io",
+      "name": "FeedClaw",
+      "mcpUrl": "https://www.feedclaw.io/api/chatgpt-app",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "feedclaw_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/feedclaw.io"
+    },
+    {
+      "domain": "fellow.ai",
+      "name": "fellow.ai",
+      "mcpUrl": "https://fellow.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fellow_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://help.fellow.ai/en/articles/12622641-fellow-s-mcp-server",
+          "setup": "Have a workspace admin enable **Workspace Settings → Security → Allow users to create MCP connections**. Then connect an MCP client such as Claude, ChatGPT, Cursor, or Copilot to `https://fellow.app/mcp` and sign into Fellow when redirected to authorize the connection. ChatGPT docs explicitly say to leave OAuth client ID and secret blank and complete authorization on Fellow’s side. See [Fellow's MCP Server](https://help.fellow.ai/en/articles/12622641-fellow-s-mcp-server) and [MCP Server](https://developers.fellow.ai/reference/mcp-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/fellow.ai"
+    },
+    {
+      "domain": "ferryhopper.com",
+      "name": "Ferryhopper",
+      "mcpUrl": "https://mcp.ferryhopper.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ferryhopper.com"
+    },
+    {
+      "domain": "feverup.com",
+      "name": "Fever Event Discovery",
+      "mcpUrl": "https://data-search.apigw.feverup.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fever_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/feverup.com"
+    },
+    {
+      "domain": "fgdsp698b0.execute-api.eu-west-1.amazonaws.com",
+      "name": "Taxdown",
+      "mcpUrl": "https://fgdsp698b0.execute-api.eu-west-1.amazonaws.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fgdsp698b0.execute-api.eu-west-1.amazonaws.com"
+    },
+    {
+      "domain": "figma.com",
+      "name": "Figma",
+      "mcpUrl": "https://mcp.figma.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "figma_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/figma.com"
+    },
+    {
+      "domain": "file.googleapis.com",
+      "name": "file.googleapis.com",
+      "mcpUrl": "https://file.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/file.googleapis.com"
+    },
+    {
+      "domain": "financialmodelingprep.com",
+      "name": "financialmodelingprep.com",
+      "mcpUrl": "https://financialmodelingprep.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fmp_api_key",
+          "type": "api_key",
+          "generateUrl": "https://financialmodelingprep.com/developer/docs/dashboard",
+          "setup": "Create an account or sign in on the [FMP dashboard](https://financialmodelingprep.com/developer/docs/dashboard). The Quickstart says your API key is available in the dashboard under **API Keys**. Use it in requests as either the `apikey` header or the `apikey` query parameter.",
+          "fields": null
+        },
+        {
+          "id": "fmp_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://financialmodelingprep.com/oauth/authorize",
+          "setup": "FMP exposes OAuth endpoints at [`https://financialmodelingprep.com/oauth/authorize`](https://financialmodelingprep.com/oauth/authorize) and [`https://financialmodelingprep.com/oauth/token`](https://financialmodelingprep.com/oauth/token). Register or configure an FMP OAuth client in your FMP account/app flow, then obtain user tokens for the MCP server with scopes such as `openid`, `email`, and `profile`. The automated probes confirmed the OAuth authorization endpoint, token endpoint, and scopes.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/financialmodelingprep.com"
+    },
+    {
+      "domain": "fintables.com",
+      "name": "Fintables",
+      "mcpUrl": "https://evo.fintables.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fintables_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fintables.com"
+    },
+    {
+      "domain": "fireflies.ai",
+      "name": "Fireflies",
+      "mcpUrl": "https://api.fireflies.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fireflies.ai"
+    },
+    {
+      "domain": "firestore.googleapis.com",
+      "name": "firestore.googleapis.com",
+      "mcpUrl": "https://firestore.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/firestore.googleapis.com"
+    },
+    {
+      "domain": "fiscal.ai",
+      "name": "Fiscal.ai",
+      "mcpUrl": "https://api.fiscal.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fiscal_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fiscal.ai"
+    },
+    {
+      "domain": "flaerobotics.ai",
+      "name": "BE-A",
+      "mcpUrl": "https://beamcpserverprod.flaerobotics.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/flaerobotics.ai"
+    },
+    {
+      "domain": "flagsmith.com",
+      "name": "flagsmith.com",
+      "mcpUrl": "https://mcp.flagsmith.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/flagsmith.com"
+    },
+    {
+      "domain": "flarehawk.com",
+      "name": "flarehawk.com",
+      "mcpUrl": "https://app.flarehawk.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/flarehawk.com"
+    },
+    {
+      "domain": "flowerdiary.xyz",
+      "name": "Blossom",
+      "mcpUrl": "https://openai.flowerdiary.xyz/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "blossom_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://openai.flowerdiary.xyz/oauth/register",
+          "setup": "Register an OAuth client with Blossom's MCP server at [OAuth client registration](https://openai.flowerdiary.xyz/oauth/register). Then run the MCP client's OAuth login flow against Blossom's authorization server discovered from [the OAuth metadata document](https://openai.flowerdiary.xyz/.well-known/oauth-authorization-server). The metadata advertises `authorization_code` with PKCE (`S256`) and scopes including `diary:read` and `diary:write`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/flowerdiary.xyz"
+    },
+    {
+      "domain": "formbyte.ai",
+      "name": "Formbyte",
+      "mcpUrl": "https://formbyte.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "formbyte_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://formbyte.ai/api/oidc/oauth/register",
+          "setup": "Register an OAuth client with Formbyte via the dynamic client registration endpoint at [OAuth client registration](https://formbyte.ai/api/oidc/oauth/register). The server advertises `client_secret_basic` and `client_secret_post` as supported token-endpoint client authentication methods in its discovery document at [OAuth authorization server metadata](https://formbyte.ai/.well-known/oauth-authorization-server). Use the resulting client credentials to complete the authorization-code flow against `https://formbyte.ai/api/oidc/oauth/authorize` and `https://formbyte.ai/api/oidc/oauth/token`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/formbyte.ai"
+    },
+    {
+      "domain": "formulagenius.co",
+      "name": "Formula Genius",
+      "mcpUrl": "https://formulagenius.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fg_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/formulagenius.co"
+    },
+    {
+      "domain": "fos.tui",
+      "name": "TUI",
+      "mcpUrl": "https://openai-app-mcp-apps.prod.fos.tui/fos-mcp-app-openai-prod/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/fos.tui"
+    },
+    {
+      "domain": "fotocasa.es",
+      "name": "Fotocasa",
+      "mcpUrl": "https://www.fotocasa.es/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/fotocasa.es"
+    },
+    {
+      "domain": "framagit.org",
+      "name": "framagit.org",
+      "mcpUrl": "https://framagit.org/api/v4/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://framagit.org/oauth/applications",
+          "setup": "Sign in to [Framagit OAuth Applications](https://framagit.org/oauth/applications), create a new application, set its redirect URI, and note the client ID and client secret. OAuth endpoints are `https://framagit.org/oauth/authorize`, `https://framagit.org/oauth/token`, and dynamic client registration is available at `https://framagit.org/oauth/register`. Request scopes appropriate to your integration, such as `api`, `read_api`, or the detected MCP scopes `mcp` / `mcp_orbit`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/framagit.org"
+    },
+    {
+      "domain": "frankfurter.dev",
+      "name": "frankfurter.dev",
+      "mcpUrl": "https://mcp.frankfurter.dev/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/frankfurter.dev"
+    },
+    {
+      "domain": "freediver.club",
+      "name": "Freediver",
+      "mcpUrl": "https://integrations.freediver.club/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "freediver_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/freediver.club"
+    },
+    {
+      "domain": "freee.co.jp",
+      "name": "freee確定申告",
+      "mcpUrl": "https://tax-advisors-qa-chatgpt-app.secure.freee.co.jp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/freee.co.jp"
+    },
+    {
+      "domain": "freshdesk.com",
+      "name": "freshdesk.com",
+      "mcpUrl": "https://mcp.freshworks.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "freshworks_dev_api_key",
+          "type": "bearer",
+          "generateUrl": "https://developers.freshworks.com/docs/agentic-dev-tools/mcp-server/",
+          "setup": "Sign in to the [Application Management Portal](https://developers.freshworks.com/login/), open **Settings**, then under **API key for Freddy AI Copilot VS Code plugin & Agentic Developer Toolkit** click **Generate API Key** or **View API Key**. Copy the key shown there, as documented on the [Developer MCP server page](https://developers.freshworks.com/docs/agentic-dev-tools/mcp-server/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/freshdesk.com"
+    },
+    {
+      "domain": "front.com",
+      "name": "front.com",
+      "mcpUrl": "https://mcp.frontapp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "front_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://dev.frontapp.com/docs/create-and-manage-apps",
+          "setup": "Create a Front developer app in **Settings** → **Company** → **Developers** → **Create app**, then add the **OAuth** feature and obtain the app's `client_id` and `client_secret` as described in [Create, manage, and publish apps](https://dev.frontapp.com/docs/create-and-manage-apps) and [OAuth](https://dev.frontapp.com/docs/oauth). Configure redirect URLs and the needed scopes/resources for your integration. The resulting OAuth flow yields Bearer access tokens for Front APIs.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/front.com"
+    },
+    {
+      "domain": "fugle.ai",
+      "name": "fugle.ai",
+      "mcpUrl": "https://www.fugle.tw/api/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fugle_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fugle.ai"
+    },
+    {
+      "domain": "fugle.tw",
+      "name": "Fugle-Stock",
+      "mcpUrl": "https://www.fugle.tw/api/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fugle_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fugle.tw"
+    },
+    {
+      "domain": "fullstory.com",
+      "name": "fullstory.com",
+      "mcpUrl": "https://api.fullstory.com/mcp/fullstory",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fullstory_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fullstory.com"
+    },
+    {
+      "domain": "functionhealth.com",
+      "name": "Function Health",
+      "mcpUrl": "https://services.functionhealth.com/ai-chat/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fh_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://claude.ai/settings/connectors",
+          "setup": "In Claude, go to [Settings → Connectors](https://claude.ai/settings/connectors), choose **Function Health**, and click **Connect**. Claude redirects you to Function Health to sign in and authorize access, then stores and refreshes the access token automatically. The connector docs say the granted scopes are `read:health_summary`, `read:biomarkers`, and `read:action_plan`, and that the flow uses OAuth 2.0 with PKCE.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/functionhealth.com"
+    },
+    {
+      "domain": "fyxer.com",
+      "name": "Fyxer",
+      "mcpUrl": "https://mcp.fyxer.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "fyxer_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/fyxer.com"
+    },
+    {
+      "domain": "g2.com",
+      "name": "G2",
+      "mcpUrl": "https://mcp.g2.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "g2_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://my.g2.com/developers",
+          "setup": "Create or log into your organization in the [G2 Developer Portal](https://my.g2.com/developers). In **OAuth Apps**, select **New OAuth App**, enter the app name, privacy-policy URL, terms-of-service URL, and redirect URL, optionally mark it **Confidential** if it can store a secret, choose endpoint **Permissions**, and save. Open the app's **Details** view to copy the `Client ID` and `Secret`. Use those with G2's OAuth flow (`https://www.g2.com/oauth/authorize` and `https://www.g2.com/oauth/token`) and request only scopes matching the permissions enabled for the app. Example documented scopes include `openid`, `profile`, `products.read`, and `products.reviews.read`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/g2.com"
+    },
+    {
+      "domain": "galileo.ai",
+      "name": "galileo.ai",
+      "mcpUrl": "https://api.galileo.ai/mcp/http/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "galileo_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.galileo.ai/settings/api-keys",
+          "setup": "In the Galileo app, open the user menu in the bottom-left, choose **API Keys**, click **+Create new key**, name the key, optionally set an expiry date, then copy it and store it safely. The docs note you won't be able to view the full key again. See [Where Do I Find My Project Keys?](https://docs.galileo.ai/references/faqs/find-keys) and the [API keys page](https://app.galileo.ai/settings/api-keys).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/galileo.ai"
+    },
+    {
+      "domain": "gamma.app",
+      "name": "Gamma",
+      "mcpUrl": "https://mcp.gamma.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gamma.app"
+    },
+    {
+      "domain": "garchi.co.uk",
+      "name": "Garchi CMS",
+      "mcpUrl": "https://garchi.co.uk/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "garchi_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://garchi.co.uk/oauth/register",
+          "setup": "Register an OAuth client with Garchi at [dynamic client registration](https://garchi.co.uk/oauth/register). Use the MCP OAuth flow against Garchi's authorization server, requesting the `mcp:use` scope, then authorize via [authorize](https://garchi.co.uk/oauth/authorize) and exchange at [token](https://garchi.co.uk/oauth/token).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/garchi.co.uk"
+    },
+    {
+      "domain": "gathrd.uk",
+      "name": "Gathrd",
+      "mcpUrl": "https://gathrd.uk/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "gathrd_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gathrd.uk"
+    },
+    {
+      "domain": "getagent.co.uk",
+      "name": "GetAgent",
+      "mcpUrl": "https://mcp.api.getagent.co.uk/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/getagent.co.uk"
+    },
+    {
+      "domain": "getguru.com",
+      "name": "Guru",
+      "mcpUrl": "https://mcp.api.getguru.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "guru_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://developer.getguru.com/docs/oauth2-clients",
+          "setup": "To use Guru OAuth2 on behalf of users, first request access by emailing [support@getguru.com](mailto:support@getguru.com) as described in [OAuth2 Clients](https://developer.getguru.com/docs/oauth2-clients). Once enabled, create a client via Guru's OAuth2 client maintenance flow; Guru returns a `clientId` and `clientSecret`, and you configure your `redirectUris` and scopes such as `read:*` or `*:*`.",
+          "fields": null
+        },
+        {
+          "id": "guru_api_token",
+          "type": "compound",
+          "generateUrl": "https://help.getguru.com/s/article/how-to-obtain-your-api-credentials",
+          "setup": "In Guru, generate API credentials from the product/admin UI as described in [How to Obtain Your API Credentials](https://help.getguru.com/s/article/how-to-obtain-your-api-credentials). For the REST API and API-token-based MCP auth, Guru uses HTTP Basic auth with an identifier plus token: either `USER_EMAIL:TOKEN` for a user token, or `COLLECTION_ID:TOKEN` for a collection token. See [Guru API Overview](https://developer.getguru.com/docs/getting-started) and [User Tokens vs Collection Tokens](https://developer.getguru.com/docs/user-tokens-vs-collection-tokens) for the two token types and their permissions.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/getguru.com"
+    },
+    {
+      "domain": "getmedesign.com",
+      "name": "GetMeDesign",
+      "mcpUrl": "https://backend.getmedesign.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/getmedesign.com"
+    },
+    {
+      "domain": "getperseuss.com",
+      "name": "getperseuss.com",
+      "mcpUrl": "https://www.getperseuss.com/_api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/getperseuss.com"
+    },
+    {
+      "domain": "glama.ai",
+      "name": "glama.ai",
+      "mcpUrl": "https://mcp-test.glama.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/glama.ai"
+    },
+    {
+      "domain": "glean.com",
+      "name": "glean.com",
+      "mcpUrl": "https://developers.glean.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/glean.com"
+    },
+    {
+      "domain": "glinded.com",
+      "name": "glinded.com",
+      "mcpUrl": "https://mcp-detprm6tzq-uc.a.run.app",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "glinded_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Open the [ChatGPT Glinded app](https://chatgpt.com/apps/glinded-for-memorial-videos/asdk_app_69a937558b8081918b8b5d01ae1572c1) or another MCP-compatible chat app that supports Glinded, then connect Glinded and sign in or sign up when prompted. Glinded's docs state the MCP server is OAuth-protected and that a free Glinded account is required; sign-in is initiated by the connecting chat app.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/glinded.com"
+    },
+    {
+      "domain": "gmail.googleapis.com",
+      "name": "gmail.googleapis.com",
+      "mcpUrl": "https://gmail.googleapis.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "google_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://console.cloud.google.com/apis/credentials",
+          "setup": "In [Google Cloud Console](https://console.cloud.google.com/apis/credentials), create or select a project, enable the Gmail API, configure the OAuth consent screen as described in [Configure OAuth consent](https://developers.google.com/workspace/guides/configure-oauth-consent), then create OAuth client credentials and authorize for the Gmail scopes listed in [Choose scopes](https://developers.google.com/workspace/gmail/api/auth/scopes). The quickstart flow stores a user access/refresh token after the user completes consent.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/gmail.googleapis.com"
+    },
+    {
+      "domain": "gocardless.com",
+      "name": "GoCardless",
+      "mcpUrl": "https://mcp.gocardless.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "gc_cli_session",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gocardless.com"
+    },
+    {
+      "domain": "godaddy.com",
+      "name": "GoDaddy",
+      "mcpUrl": "https://api.godaddy.com/v1/domains/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/godaddy.com"
+    },
+    {
+      "domain": "gogs.io",
+      "name": "gogs.io",
+      "mcpUrl": "https://gogs.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gogs.io"
+    },
+    {
+      "domain": "gohighlevel.com",
+      "name": "gohighlevel.com",
+      "mcpUrl": "https://services.leadconnectorhq.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pit",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gohighlevel.com"
+    },
+    {
+      "domain": "gojinko.com",
+      "name": "Jinko",
+      "mcpUrl": "https://mcp.builders.gojinko.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jinko_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gojinko.com"
+    },
+    {
+      "domain": "goodnotes.com",
+      "name": "Goodnotes",
+      "mcpUrl": "https://claude-mcp-api.ml.goodnotes.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/goodnotes.com"
+    },
+    {
+      "domain": "gorgias.com",
+      "name": "gorgias.com",
+      "mcpUrl": "https://mcp.gorgias.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gorgias.com"
+    },
+    {
+      "domain": "gosure.ai",
+      "name": "Insurance GPT",
+      "mcpUrl": "https://dev.gosure.ai/core-mcp/api",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/gosure.ai"
+    },
+    {
+      "domain": "goupword.com",
+      "name": "upword",
+      "mcpUrl": "https://www.goupword.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "upword_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://www.goupword.com/api/oauth/register",
+          "setup": "Register an OAuth client with upword at [dynamic client registration](https://www.goupword.com/api/oauth/register), then run the authorization-code flow against [the authorization server metadata](https://www.goupword.com/.well-known/oauth-authorization-server). The server supports `authorization_code` with PKCE `S256`, scope `read`, and `token_endpoint_auth_methods_supported` of `client_secret_post` and `none` (public client).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/goupword.com"
+    },
+    {
+      "domain": "govcon.dev",
+      "name": "Tango",
+      "mcpUrl": "https://govcon.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tango_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/govcon.dev"
+    },
+    {
+      "domain": "govtribe.com",
+      "name": "GovTribe",
+      "mcpUrl": "https://govtribe.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "govtribe_mcp_api_key",
+          "type": "bearer",
+          "generateUrl": "https://govtribe.com/account-mcp",
+          "setup": "In [GovTribe MCP](https://govtribe.com/account-mcp), enable credits if prompted, then choose **Create Key**, enter a name, and save the key when GovTribe shows it. GovTribe's developer guides say MCP access requires a GovTribe account with MCP access and credits enabled; if exposed, revoke the key from [GovTribe MCP](https://govtribe.com/account-mcp).",
+          "fields": null
+        },
+        {
+          "id": "govtribe_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://govtribe.com/oauth/register",
+          "setup": "Register an OAuth client with GovTribe at [dynamic client registration](https://govtribe.com/oauth/register). Then send the user through the authorization flow at `https://govtribe.com/oauth/authorize` and exchange the code at `https://govtribe.com/oauth/token`. Seed facts indicate the `mcp:use` scope is available for MCP access.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/govtribe.com"
+    },
+    {
+      "domain": "grain.com",
+      "name": "Grain",
+      "mcpUrl": "https://api.grain.com/_/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "grain_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/grain.com"
+    },
+    {
+      "domain": "granola.ai",
+      "name": "Granola",
+      "mcpUrl": "https://mcp.granola.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/granola.ai"
+    },
+    {
+      "domain": "grantedai.com",
+      "name": "Granted",
+      "mcpUrl": "https://grantedai.com/api/mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/grantedai.com"
+    },
+    {
+      "domain": "grep.app",
+      "name": "grep.app",
+      "mcpUrl": "https://mcp.grep.app",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/grep.app"
+    },
+    {
+      "domain": "greptile.com",
+      "name": "greptile.com",
+      "mcpUrl": "https://api.greptile.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "greptile_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.greptile.com/settings/organization/api",
+          "setup": "Sign in to [Greptile](https://app.greptile.com/login), then open [Organization API Keys](https://app.greptile.com/settings/organization/api) under Settings → Organization → API Keys and copy the key. Use it as a bearer token in the `Authorization` header or store it in `GREPTILE_API_KEY` for MCP clients that support env-based configuration.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/greptile.com"
+    },
+    {
+      "domain": "greystar.com",
+      "name": "Greystar Apartment Scout",
+      "mcpUrl": "https://apt-scout.greystar.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/greystar.com"
+    },
+    {
+      "domain": "groundcover.com",
+      "name": "groundcover.com",
+      "mcpUrl": "https://mcp.groundcover.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "gc_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/groundcover.com"
+    },
+    {
+      "domain": "gsplantfoods.com",
+      "name": "gsplantfoods.com",
+      "mcpUrl": "https://gsplantfoods.com/api/ucp/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/gsplantfoods.com"
+    },
+    {
+      "domain": "gumtree.com.au",
+      "name": "Gumtree",
+      "mcpUrl": "https://gt-api.gumtree.com.au/partner/mcp/39cc77d5c8ae755375b92dfaf4d9ce072fe5a8692f1ea1804e254a88945d225c/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/gumtree.com.au"
+    },
+    {
+      "domain": "gusto.com",
+      "name": "Gusto",
+      "mcpUrl": "https://mcp.api.gusto.com/anthropic",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "gusto_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/gusto.com"
+    },
+    {
+      "domain": "habitify.me",
+      "name": "Habitify",
+      "mcpUrl": "https://mcp.habitify.me/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "habitify_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/habitify.me"
+    },
+    {
+      "domain": "happenstance.ai",
+      "name": "Happenstance",
+      "mcpUrl": "https://happenstance.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hpn_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/happenstance.ai"
+    },
+    {
+      "domain": "harmonic.ai",
+      "name": "Harmonic",
+      "mcpUrl": "https://mcp.api.harmonic.ai",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "harmonic_oauth_user",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/harmonic.ai"
+    },
+    {
+      "domain": "harvey.ai",
+      "name": "Harvey",
+      "mcpUrl": "https://api.harvey.ai/hosted_mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "harvey_account_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.harvey.ai",
+          "setup": "Use an MCP client that supports remote MCP servers over Streamable HTTP with OAuth, then connect the Harvey connector/server and sign in with your Harvey account in the browser when prompted. Harvey documents this flow for Claude, Gemini, and Microsoft 365 Copilot; access to the hosted MCP feature must be enabled for your user/account. Docs: [Harvey MCP](https://developers.harvey.ai/guides/harvey_mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/harvey.ai"
+    },
+    {
+      "domain": "hauptsache.net",
+      "name": "hauptsache.net",
+      "mcpUrl": "https://hauptsache.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hauptsache_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/hauptsache.net"
+    },
+    {
+      "domain": "healthex.io",
+      "name": "HealthEx",
+      "mcpUrl": "https://api.healthex.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/healthex.io"
+    },
+    {
+      "domain": "heepsy.com",
+      "name": "Heepsy Influencer Search",
+      "mcpUrl": "https://mcp.heepsy.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/heepsy.com"
+    },
+    {
+      "domain": "heffl.com",
+      "name": "heffl.com",
+      "mcpUrl": "https://api.heffl.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "heffl_oauth_user",
+          "type": "oauth2",
+          "generateUrl": "https://heffl.com/login",
+          "setup": "For the Heffl MCP server, you typically do not pre-create developer credentials. Add the MCP server URL in your MCP client, and the client should initiate OAuth automatically; you then sign in on Heffl’s own login page and approve access for a team. Docs for Claude/ChatGPT/Cursor instruct pasting `https://api.heffl.com/api/mcp`, signing in with your usual Heffl account, choosing a team, and clicking **Authorize**. The service advertises OAuth endpoints at [login](https://heffl.com/login) and [token](https://heffl.com/api/auth/token).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/heffl.com"
+    },
+    {
+      "domain": "hellosign.com",
+      "name": "hellosign.com",
+      "mcpUrl": "https://developers.hellosign.com/_mcp/server",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hellosign.com"
+    },
+    {
+      "domain": "hemlak.com",
+      "name": "hepsiemlak",
+      "mcpUrl": "https://mcp.hemlak.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hemlak.com"
+    },
+    {
+      "domain": "hercules.app",
+      "name": "hercules.app",
+      "mcpUrl": "https://hercules.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hercules_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://hercules.app/api/v1/auth/oauth2/register",
+          "setup": "Register an OAuth client against Hercules at [dynamic client registration](https://hercules.app/api/v1/auth/oauth2/register). After registration, use the returned client credentials with Hercules OAuth endpoints: authorize at `https://hercules.app/api/v1/auth/oauth2/authorize` and token at `https://hercules.app/api/v1/auth/oauth2/token`. Documented scopes include `read:app`, `write:app`, `read:chat`, and `write:chat`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hercules.app"
+    },
+    {
+      "domain": "hex.tech",
+      "name": "Hex",
+      "mcpUrl": "https://app.hex.tech/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hex_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/hex.tech"
+    },
+    {
+      "domain": "hipages.com.au",
+      "name": "hipages",
+      "mcpUrl": "https://mcp.hipages.com.au/v1",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hipages.com.au"
+    },
+    {
+      "domain": "hjarni.com",
+      "name": "Hjarni",
+      "mcpUrl": "https://hjarni.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hjarni_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://hjarni.com/register",
+          "setup": "For MCP clients that support OAuth, use Hjarni's OAuth 2.0 Authorization Code flow with PKCE discovered from [OAuth authorization server metadata](https://hjarni.com/.well-known/oauth-authorization-server). Hjarni supports dynamic client registration at [register](https://hjarni.com/register); hosted clients may also use pre-approved redirect URIs documented in the [MCP reference](https://hjarni.com/docs/mcp). Authorize the user via [authorize](https://hjarni.com/authorize) and exchange the code at [token](https://hjarni.com/token).",
+          "fields": null
+        },
+        {
+          "id": "hjarni_api_token",
+          "type": "bearer",
+          "generateUrl": "https://hjarni.com/docs/api",
+          "setup": "In Hjarni, go to **Settings > Connections**, create a token for your integration, and copy it. The REST API docs say to send it as `Authorization: Bearer YOUR_API_TOKEN`. The same personal API token can also be used against the MCP endpoint for clients that do not support OAuth. Start from the [REST API reference](https://hjarni.com/docs/api).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/hjarni.com"
+    },
+    {
+      "domain": "homegraph.googleapis.com",
+      "name": "homegraph.googleapis.com",
+      "mcpUrl": "https://homegraph.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/homegraph.googleapis.com"
+    },
+    {
+      "domain": "honeycomb.io",
+      "name": "Honeycomb",
+      "mcpUrl": "https://mcp.honeycomb.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hc_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/honeycomb.io"
+    },
+    {
+      "domain": "hostinger.com",
+      "name": "Hostinger",
+      "mcpUrl": "https://hmcp.hostinger.com/chatgpt/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hostinger_api_token",
+          "type": "bearer",
+          "generateUrl": "https://hpanel.hostinger.com/profile/api",
+          "setup": "In the [Hostinger Account API page](https://hpanel.hostinger.com/profile/api) (the developer docs also link to the [Account page](https://hpanel.hostinger.com/profile/api)), create an API token for your user. The docs say tokens have the same permissions as the owning user and can optionally expire. Use it as a bearer token in `Authorization: Bearer YOUR_API_TOKEN`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hostinger.com"
+    },
+    {
+      "domain": "hubspot.com",
+      "name": "HubSpot",
+      "mcpUrl": "https://mcp.hubspot.com/anthropic",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/hubspot.com"
+    },
+    {
+      "domain": "huggingface.co",
+      "name": "Hugging Face",
+      "mcpUrl": "https://huggingface.co/mcp?login&gradio=none",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/huggingface.co"
+    },
+    {
+      "domain": "hyatt.com",
+      "name": "Hyatt",
+      "mcpUrl": "https://www.hyatt.com/mcp/browse",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hyatt.com"
+    },
+    {
+      "domain": "hyperping.com",
+      "name": "hyperping.com",
+      "mcpUrl": "https://api.hyperping.io/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hyperping_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.hyperping.io/project/developers",
+          "setup": "In the Hyperping app, open [Developers](https://app.hyperping.io/project/developers) in your project settings, click **Create key**, choose a name, permission level (`Read & Write` or `Read-only`), and optional expiration, then copy the key when it is shown. The docs note the key is shown only once, so store it securely.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/hyperping.com"
+    },
+    {
+      "domain": "ibm.com",
+      "name": "ibm.com",
+      "mcpUrl": "https://api.dataplatform.cloud.ibm.com/wxbi/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ibm_cloud_api_key",
+          "type": "api_key",
+          "generateUrl": "https://cloud.ibm.com/docs/iam?topic=iam-userapikey&interface=ui",
+          "setup": "In the IBM Cloud console, go to [Manage user API keys](https://cloud.ibm.com/docs/iam?topic=iam-userapikey&interface=ui), then open **Manage** > **Access (IAM)** > **API keys** and click **Create an IBM Cloud API key**. Save the key when it is shown; IBM notes it is only available to copy or download at creation time. You can also create one with the CLI using `ibmcloud iam api-key-create NAME` after logging in.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ibm.com"
+    },
+    {
+      "domain": "ice.com",
+      "name": "ICE Data Services",
+      "mcpUrl": "https://fids-mcp.ice.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ice.com"
+    },
+    {
+      "domain": "idealista.com",
+      "name": "idealista",
+      "mcpUrl": "https://app-chatgpt.idealista.com/idealista/chatgpt/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/idealista.com"
+    },
+    {
+      "domain": "idealo.tools",
+      "name": "idealo",
+      "mcpUrl": "https://idealo-app-in-chatgpt.idealo.tools/v5/mcp/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/idealo.tools"
+    },
+    {
+      "domain": "idoctor.md",
+      "name": "Kokiko",
+      "mcpUrl": "https://kokiko.idoctor.md/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/idoctor.md"
+    },
+    {
+      "domain": "ifttt.com",
+      "name": "IFTTT",
+      "mcpUrl": "https://ifttt.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ifttt_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/ifttt.com"
+    },
+    {
+      "domain": "imedidata.com",
+      "name": "Medidata",
+      "mcpUrl": "https://mcp.imedidata.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "medidata_jwt",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/imedidata.com"
+    },
+    {
+      "domain": "incident.io",
+      "name": "incident.io",
+      "mcpUrl": "https://mcp.incident.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/incident.io"
+    },
+    {
+      "domain": "indeed.com",
+      "name": "Indeed",
+      "mcpUrl": "https://mcp.indeed.com/claude/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/indeed.com"
+    },
+    {
+      "domain": "inline.chat",
+      "name": "inline.chat",
+      "mcpUrl": "https://mcp.inline.chat/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "inline_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/inline.chat"
+    },
+    {
+      "domain": "inngest.com",
+      "name": "inngest.com",
+      "mcpUrl": "http://127.0.0.1:8288/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/inngest.com"
+    },
+    {
+      "domain": "inpost-group.com",
+      "name": "InPost",
+      "mcpUrl": "https://mcp.inpost-group.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/inpost-group.com"
+    },
+    {
+      "domain": "insighttimer-api.net",
+      "name": "Insight Timer",
+      "mcpUrl": "https://chatgpt-api.insighttimer-api.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/insighttimer-api.net"
+    },
+    {
+      "domain": "instacart.com",
+      "name": "Instacart",
+      "mcpUrl": "https://fig-mcp.instacart.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "instacart_dev_api_key",
+          "type": "api_key",
+          "generateUrl": "https://docs.instacart.com/developer_platform_api/get_started/api-keys",
+          "setup": "Log in to the [Instacart Developer Dashboard](http://dashboard.instacart.com/), open **API Keys**, click **Create New API Key**, choose Development or Production, and copy the generated key. The docs say the key is only shown once and looks like `keys.<hex>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/instacart.com"
+    },
+    {
+      "domain": "integrations.sh",
+      "name": "integrations.sh",
+      "mcpUrl": "https://integrations.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/integrations.sh"
+    },
+    {
+      "domain": "intercom.io",
+      "name": "Fin Agent API MCP Server",
+      "mcpUrl": "https://api.intercom.io/fin/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "intercom_access_token",
+          "type": "bearer",
+          "generateUrl": "https://app.intercom.io/a/apps/_/developer-hub/app-packages",
+          "setup": "Create an app in your workspace, then open the app in the [Developer Hub](https://app.intercom.io/a/apps/_/developer-hub/app-packages). Intercom says it provides an access token as soon as you create an app; you can find it under `Configure > Authentication`, and it is also visible on `Test & Publish > Your Workspaces`. The authentication guide links app creation at [create an app](https://app.intercom.com/admins/sign_up/developer).",
+          "fields": null
+        },
+        {
+          "id": "intercom_messenger_jwt",
+          "type": "jwt",
+          "generateUrl": "https://app.intercom.com/a/apps/_/settings/workspace/security?tab=messenger-security",
+          "setup": "Enable Messenger identity verification for your workspace and get the Messenger secret from [Settings > Workspace > Security > Messenger](https://app.intercom.com/a/apps/_/settings/workspace/security?tab=messenger-security). Generate an `HS256` JWT server-side for a single verified end user with the required claims described in [Fin Agent API: MCP Server](https://www.intercom.com/help/en/articles/15481203-fin-agent-api-mcp-server): `aud` must be `fin-agent-api-mcp`, `exp` is required and must be within 30 days, and the token identifies the user for Fin.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/intercom.io"
+    },
+    {
+      "domain": "intercom.io",
+      "name": "Intercom MCP Server",
+      "mcpUrl": "https://mcp.intercom.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/intercom.io"
+    },
+    {
+      "domain": "introvoke.com",
+      "name": "Sequel.io",
+      "mcpUrl": "https://api.introvoke.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "introvoke_jwt",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/introvoke.com"
+    },
+    {
+      "domain": "intuit.com",
+      "name": "Intuit TurboTax",
+      "mcpUrl": "https://ai-inc.quickbooks.intuit.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/intuit.com"
+    },
+    {
+      "domain": "ipinfo.io",
+      "name": "ipinfo.io",
+      "mcpUrl": "https://mcp.ipinfo.io/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ipinfo_token",
+          "type": "api_key",
+          "generateUrl": "https://ipinfo.io/signup",
+          "setup": "Create an account or sign in via [IPinfo signup](https://ipinfo.io/signup) / [IPinfo dashboard](https://ipinfo.io/dashboard). Generate or copy your API token there; IPinfo docs state a free token is available from [signup](https://ipinfo.io/signup). This same token is used for the REST API, MCP server, and CLI. On HTTP surfaces it can be sent as `Authorization: Bearer <TOKEN>`, as HTTP Basic username with an empty password, or as the `token` query parameter.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ipinfo.io"
+    },
+    {
+      "domain": "isango.com",
+      "name": "isango!",
+      "mcpUrl": "https://mcp.isango.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/isango.com"
+    },
+    {
+      "domain": "itsdunzo.com",
+      "name": "Dunzo - Task Assistant",
+      "mcpUrl": "https://api.itsdunzo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "dunzo_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.itsdunzo.com/oauth/register",
+          "setup": "Register an OAuth client with Dunzo at [`/oauth/register`](https://api.itsdunzo.com/oauth/register). The authorization server metadata at [api.itsdunzo.com/.well-known/oauth-authorization-server](https://api.itsdunzo.com/.well-known/oauth-authorization-server) shows support for `authorization_code` and `refresh_token`, with client authentication methods `client_secret_post` or `client_secret_basic`. Request scopes such as `tasks:read` and `tasks:write`, then send the user through the authorization flow using the listed authorize and token endpoints.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/itsdunzo.com"
+    },
+    {
+      "domain": "jam.dev",
+      "name": "Jam",
+      "mcpUrl": "https://mcp.jam.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jam_oauth_user",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/jam.dev"
+    },
+    {
+      "domain": "jars.lt",
+      "name": "JARS LT",
+      "mcpUrl": "https://api.jars.lt/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jars_api_key",
+          "type": "api_key",
+          "generateUrl": "https://jars.lt/en/signup",
+          "setup": "Create an account or sign in on [JARS.LT](https://jars.lt/en/), choose a plan from [Pricing](https://jars.lt/en/pricing), then obtain your API key from your account to use in the `x-api-key` header. The docs and official SDK both instruct developers to use an API key from JARS.LT.",
+          "fields": null
+        },
+        {
+          "id": "jars_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.jars.lt/register",
+          "setup": "For MCP clients that support OAuth, use JARS's OAuth 2.0 discovery metadata at [authorization server metadata](https://api.jars.lt/.well-known/oauth-authorization-server) and [protected resource metadata](https://api.jars.lt/.well-known/oauth-protected-resource). JARS supports Dynamic Client Registration, so an AI client can register itself at `https://api.jars.lt/register`, then complete the authorization-code flow to obtain a bearer access token for scopes like `mcp:read`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jars.lt"
+    },
+    {
+      "domain": "jaz.ai",
+      "name": "jaz.ai",
+      "mcpUrl": "https://mcp.jaz.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jaz_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/jaz.ai"
+    },
+    {
+      "domain": "jebbit.com",
+      "name": "BlueConic Solutions Finder",
+      "mcpUrl": "https://api2.jebbit.com/mcp/open_ai",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jebbit.com"
+    },
+    {
+      "domain": "jentic.com",
+      "name": "Jentic",
+      "mcpUrl": "https://api.jentic.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jentic_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "For the remote MCP server, use an MCP client that supports OAuth. The client self-registers automatically with Jentic's MCP OAuth metadata and opens a browser for you to approve access; no manual developer-app creation is documented. Jentic documents OAuth as the recommended authentication method for the remote MCP connection.",
+          "fields": null
+        },
+        {
+          "id": "jentic_agent_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.jentic.com/sign-up",
+          "setup": "Sign up in the Jentic app via [register](https://jentic.com/register) or [app sign-up](https://app.jentic.com/sign-up). In the app, add any upstream API credentials you want the agent to use, then create an Agent and generate its API key. Export it as `JENTIC_AGENT_API_KEY` for SDK/MCP/CLI use.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/jentic.com"
+    },
+    {
+      "domain": "jerry.ai",
+      "name": "Jerry.ai Car Insurance & Care",
+      "mcpUrl": "https://jerry.ai/api/chatgpt-apps-jerry/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jerry.ai"
+    },
+    {
+      "domain": "jimdo.com",
+      "name": "Jimdo",
+      "mcpUrl": "https://website-creation-mcp.e.jimdo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jimdo_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/jimdo.com"
+    },
+    {
+      "domain": "jina.ai",
+      "name": "jina.ai",
+      "mcpUrl": "https://mcp.jina.ai/v1",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jina_api_key",
+          "type": "bearer",
+          "generateUrl": "https://jina.ai/api-dashboard/key-manager",
+          "setup": "Sign in at [Jina AI](https://jina.ai) or go directly to the [API dashboard key manager](https://jina.ai/api-dashboard/key-manager) to create an API key. The API docs state new users receive free tokens, and the key is then sent as `Authorization: Bearer jina_YOUR_API_KEY`. The CLI docs also note you can set it in `JINA_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jina.ai"
+    },
+    {
+      "domain": "jiqiren.ai",
+      "name": "PocketMind: Texas Hold'em",
+      "mcpUrl": "https://poker-api.jiqiren.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jiqiren.ai"
+    },
+    {
+      "domain": "jira.com",
+      "name": "jira.com",
+      "mcpUrl": "https://mcp.atlassian.com/v1/mcp/authv2",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "atlassian_oauth_3lo_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/jira.com"
+    },
+    {
+      "domain": "jora.com",
+      "name": "Jora",
+      "mcpUrl": "https://api.jora.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jora_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.jora.com/.well-known/oauth-authorization-server",
+          "setup": "Jora publishes an OAuth 2.0 authorization server at [api.jora.com well-known metadata](https://api.jora.com/.well-known/oauth-authorization-server), including a `registration_endpoint` at `https://api.jora.com/oauth/registration`. The easiest documented acquisition path I could verify is to register an OAuth client against that server, then use the issued client credentials in the OAuth flow for the scopes your integration needs (for example `chatgpt`). I could not verify a human-facing developer console page.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jora.com"
+    },
+    {
+      "domain": "jotform.com",
+      "name": "Jotform",
+      "mcpUrl": "https://mcp.jotform.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "jotform_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use an MCP-capable client and add the Jotform MCP server URL. On first connection, the client opens a Jotform OAuth consent screen via the Jotform MCP app; sign in and approve access. The docs say OAuth is required for every user, and authorized clients can be viewed or revoked in [My Account → Connected Apps](https://www.jotform.com/myaccount/connectedapps).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/jotform.com"
+    },
+    {
+      "domain": "justfix.app",
+      "name": "JustFix",
+      "mcpUrl": "https://estimator-mcp.justfix.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/justfix.app"
+    },
+    {
+      "domain": "kactus.com",
+      "name": "Kactus",
+      "mcpUrl": "https://www.kactus.com/apis/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kactus.com"
+    },
+    {
+      "domain": "kaggle.com",
+      "name": "kaggle.com",
+      "mcpUrl": "https://www.kaggle.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kaggle_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://www.kaggle.com/api/v1/oauth2/register",
+          "setup": "Register or obtain a Kaggle OAuth client to use the Authorization Code flow. The [OAuth 2.0 Provider API docs](https://www.kaggle.com/docs/oauth-provider-api) say public clients should request a pre-configured client ID from the Kaggle team, and organization clients should register as `org:<organization-slug>`. Use the authorization endpoint `https://www.kaggle.com/api/v1/oauth2/authorize` and token endpoint `https://www.kaggle.com/api/v1/oauth2/token`. Public clients use PKCE; organization clients authenticate token exchange with HTTP Basic using the org owner's API key.",
+          "fields": null
+        },
+        {
+          "id": "kaggle_mcp_bearer",
+          "type": "bearer",
+          "generateUrl": "https://www.kaggle.com/settings",
+          "setup": "In [Kaggle Settings](https://www.kaggle.com/settings), generate a new token and copy it. The [MCP docs](https://www.kaggle.com/docs/mcp) say the token should begin with `KGAT`. Send it as `Authorization: Bearer <token>` when your MCP client cannot do OAuth 2.0.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kaggle.com"
+    },
+    {
+      "domain": "kakao.com",
+      "name": "PlayMCP",
+      "mcpUrl": "https://playmcp.kakao.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kakao.com"
+    },
+    {
+      "domain": "kartikay-dhar.workers.dev",
+      "name": "Sprouts Data Intelligence",
+      "mcpUrl": "https://sprouts-mcp-server.kartikay-dhar.workers.dev",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kartikay-dhar.workers.dev"
+    },
+    {
+      "domain": "kensho.com",
+      "name": "S&P Global",
+      "mcpUrl": "https://grounding.kensho.com/integrations/v2/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "spg_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/kensho.com"
+    },
+    {
+      "domain": "kernel.sh",
+      "name": "kernel.sh",
+      "mcpUrl": "https://mcp.onkernel.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kernel_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://kernel.sh/docs/reference/mcp-server/authentication",
+          "setup": "Connect an MCP client to the Kernel server at [`https://mcp.onkernel.com/mcp`](https://mcp.onkernel.com/mcp). Kernel documents OAuth 2.1 with dynamic client registration, so a compatible MCP client should self-register automatically and prompt you to approve access in your browser; you do not need to pre-create a developer app. As a fallback for non-interactive access, Kernel also accepts a regular API key instead of OAuth.",
+          "fields": null
+        },
+        {
+          "id": "kernel_api_key",
+          "type": "bearer",
+          "generateUrl": "https://kernel.sh/docs/info/api-keys",
+          "setup": "Create a key from the [API Keys guide](https://kernel.sh/docs/info/api-keys). You can mint keys in the Kernel dashboard or with the [`kernel api-keys`](https://kernel.sh/docs/reference/cli/api-keys) command group after authenticating once. Save the plaintext key immediately; Kernel only shows it once. For non-interactive use, provide it as `KERNEL_API_KEY` or send it as `Authorization: Bearer <key>`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/kernel.sh"
+    },
+    {
+      "domain": "kestra.io",
+      "name": "kestra.io",
+      "mcpUrl": "https://api.kestra.io/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kestra.io"
+    },
+    {
+      "domain": "ketryx.com",
+      "name": "Ketryx",
+      "mcpUrl": "https://app.ketryx.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/ketryx.com"
+    },
+    {
+      "domain": "keybid.eu",
+      "name": "KeyBid Puls",
+      "mcpUrl": "https://keybid.eu/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/keybid.eu"
+    },
+    {
+      "domain": "kindora.co",
+      "name": "kindora.co",
+      "mcpUrl": "https://kindora-mcp.azurewebsites.net/mcp/premium",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kindora_service_key",
+          "type": "bearer",
+          "generateUrl": "https://www.kindora.co/dashboard/integrations/claude",
+          "setup": "Sign in to [Kindora Claude integrations](https://www.kindora.co/dashboard/integrations/claude) and generate a scoped service key for headless agents. The MCP docs say keys are issued from the dashboard and used as `Authorization: Bearer kdra_…` against the Pro endpoint.",
+          "fields": null
+        },
+        {
+          "id": "kindora_account_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.kindora.co/dashboard/integrations/claude",
+          "setup": "Sign in to [Kindora Claude integrations](https://www.kindora.co/dashboard/integrations/claude) and use the OAuth connector flow offered there to connect your Kindora account to Claude. The public docs mention this flow for the Pro MCP tier but do not publish the authorization/token endpoint details.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kindora.co"
+    },
+    {
+      "domain": "kit.com",
+      "name": "kit.com",
+      "mcpUrl": "https://app.kit.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kit_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/kit.com"
+    },
+    {
+      "domain": "kiwi.com",
+      "name": "Kiwi.com",
+      "mcpUrl": "https://mcp.kiwi.com",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kiwi.com"
+    },
+    {
+      "domain": "klaviyo.com",
+      "name": "Klaviyo",
+      "mcpUrl": "https://mcp.klaviyo.com/mcp?include-mcp-app=true",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developers.klaviyo.com/en/docs/create_a_public_oauth_app",
+          "setup": "Create a public OAuth app using Klaviyo's partner/app flow described in [Create a public OAuth app](https://developers.klaviyo.com/en/docs/create_a_public_oauth_app). After registering the app, configure scopes and redirect URIs, then have users install/connect it to obtain OAuth access tokens as described in [Make API calls using OAuth](https://developers.klaviyo.com/en/docs/set_up_oauth) and [Handle your app's OAuth flow](https://developers.klaviyo.com/en/docs/handle_your_apps_oauth_flow).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/klaviyo.com"
+    },
+    {
+      "domain": "kleinanzeigen.de",
+      "name": "Kleinanzeigen",
+      "mcpUrl": "https://gateway.kleinanzeigen.de/openai-app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kleinanzeigen.de"
+    },
+    {
+      "domain": "klook.com",
+      "name": "Klook",
+      "mcpUrl": "https://mcp.klook.com/v2/aiappsbff/public/openai/apps-mcp-server",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/klook.com"
+    },
+    {
+      "domain": "komoot.net",
+      "name": "komoot",
+      "mcpUrl": "https://gpt.main.komoot.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/komoot.net"
+    },
+    {
+      "domain": "kone.vc",
+      "name": "Business Helper",
+      "mcpUrl": "https://go.kone.vc/business",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kone.vc"
+    },
+    {
+      "domain": "kosik.cz",
+      "name": "Košík.cz",
+      "mcpUrl": "https://mcp.kosik.cz/mcp-openai/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kosik_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/kosik.cz"
+    },
+    {
+      "domain": "kraken.com",
+      "name": "Kraken",
+      "mcpUrl": "https://ai-analytics-mcp.kraken.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kraken.com"
+    },
+    {
+      "domain": "krisp.ai",
+      "name": "Krisp",
+      "mcpUrl": "https://mcp.krisp.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "krisp_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/krisp.ai"
+    },
+    {
+      "domain": "kronan.is",
+      "name": "Krónan",
+      "mcpUrl": "https://kronan.is/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kronan.is"
+    },
+    {
+      "domain": "kubera.com",
+      "name": "Kubera",
+      "mcpUrl": "https://api.kubera.com/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kubera_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/kubera.com"
+    },
+    {
+      "domain": "kynapp.ca",
+      "name": "KYN AI Fitness Planner",
+      "mcpUrl": "https://mcp.kynapp.ca/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kyn_member_key",
+          "type": "compound",
+          "generateUrl": "https://www.kynapp.ca/",
+          "setup": "Connect the KYN AI app from ChatGPT as described on the [KYN AI home page](https://www.kynapp.ca/) under “How to use KYN AI in ChatGPT”, then sign in with your KYN AI member credentials. The MCP endpoint itself indicates it accepts either `?key=<auth_key>` or `?token=<firebase_token>`. KYN says accounts/sign-in use Firebase Authentication in its [Privacy Policy](https://www.kynapp.ca/privacy-policy).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/kynapp.ca"
+    },
+    {
+      "domain": "lambus.ai",
+      "name": "Tourlane",
+      "mcpUrl": "https://mcp.lambus.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lambus_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.lambus.ai/register",
+          "setup": "Register an OAuth client against the Lambus MCP authorization server. The OAuth metadata advertises a client registration endpoint at [register](https://mcp.lambus.ai/register), with authorization at [authorize](https://mcp.lambus.ai/authorize) and token exchange at [token](https://mcp.lambus.ai/token). Use the registered client with the authorization-code flow; the server supports PKCE `S256`, `refresh_token`, and token endpoint auth methods `client_secret_post` or `none` for public clients.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lambus.ai"
+    },
+    {
+      "domain": "langfuse.com",
+      "name": "langfuse.com",
+      "mcpUrl": "https://cloud.langfuse.com/api/public/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "project_api_keys",
+          "type": "basic",
+          "generateUrl": "https://langfuse.com/docs/api-and-data-platform/features/public-api",
+          "setup": "In the Langfuse UI, open your project's settings and create or copy the API keys under **Project settings → API Keys**. Langfuse issues a public key and a secret key, used together as HTTP Basic Auth username/password or exported for the CLI as `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY`. See [Public API](https://langfuse.com/docs/api-and-data-platform/features/public-api) and [CLI](https://langfuse.com/docs/api-and-data-platform/features/cli).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/langfuse.com"
+    },
+    {
+      "domain": "lastminute.com",
+      "name": "lastminute.com",
+      "mcpUrl": "https://mcp.lastminute.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lastminute.com"
+    },
+    {
+      "domain": "lckqhyftgouenpercpjk.supabase.co",
+      "name": "lckqhyftgouenpercpjk.supabase.co",
+      "mcpUrl": "http://127.0.0.1:54321/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lckqhyftgouenpercpjk.supabase.co"
+    },
+    {
+      "domain": "leadconnectorhq.com",
+      "name": "HighLevel",
+      "mcpUrl": "https://services.leadconnectorhq.com/mcp/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "private_integration_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/leadconnectorhq.com"
+    },
+    {
+      "domain": "leapscholar.com",
+      "name": "LeapScholar",
+      "mcpUrl": "https://abroadly-ls.leapscholar.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/leapscholar.com"
+    },
+    {
+      "domain": "learningcommons.org",
+      "name": "Learning Commons Knowledge Graph",
+      "mcpUrl": "https://kg.mcp.learningcommons.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lc_api_key",
+          "type": "api_key",
+          "generateUrl": "https://platform.learningcommons.org/",
+          "setup": "Sign up or sign in to the [Learning Commons Platform](https://platform.learningcommons.org/), then create/manage an API key there. The docs explicitly say you can create and manage API keys in the platform and use the key as `x-api-key: YOUR_API_KEY`; the MCP docs also allow `Authorization: Bearer YOUR_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/learningcommons.org"
+    },
+    {
+      "domain": "legalzoom.com",
+      "name": "LegalZoom",
+      "mcpUrl": "https://www.legalzoom.com/mcp/claude/v1",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lz_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/legalzoom.com"
+    },
+    {
+      "domain": "lemlist.com",
+      "name": "lemlist.com",
+      "mcpUrl": "https://app.lemlist.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lemlist_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lemlist.com"
+    },
+    {
+      "domain": "leparisien.fr",
+      "name": "Le Parisien",
+      "mcpUrl": "https://app-mcp-mobile.leparisien.fr/_mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/leparisien.fr"
+    },
+    {
+      "domain": "lesfurets.com",
+      "name": "lesfurets",
+      "mcpUrl": "https://mcp.lesfurets.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lesfurets.com"
+    },
+    {
+      "domain": "leyware-mcp.vercel.app",
+      "name": "Leyware",
+      "mcpUrl": "https://leyware-mcp.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/leyware-mcp.vercel.app"
+    },
+    {
+      "domain": "liblab.com",
+      "name": "liblab.com",
+      "mcpUrl": "https://mcp.liblab.io/liblab",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/liblab.com"
+    },
+    {
+      "domain": "lifttrackapp.com",
+      "name": "LiftTrack",
+      "mcpUrl": "https://mcp.lifttrackapp.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lifttrack_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://lifttrackapp.com/how-to-connect-lifttrack-to-your-ai-assistant/",
+          "setup": "Add the LiftTrack MCP server URL `https://mcp.lifttrackapp.com` in an MCP-capable client such as ChatGPT, Claude, Cursor, Claude Code, or Gemini CLI, then sign in with your LiftTrack account when prompted, as described in [How To Connect LiftTrack to Your AI Assistant](https://lifttrackapp.com/how-to-connect-lifttrack-to-your-ai-assistant/). The client opens a browser window for LiftTrack sign-in on first use and stores the resulting session/token until it expires.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lifttrackapp.com"
+    },
+    {
+      "domain": "lilt.com",
+      "name": "LILT",
+      "mcpUrl": "https://mcp.lilt.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lilt_mcp_account",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.lilt.com/",
+          "setup": "Create an account specifically for the MCP app at [mcp.lilt.com](https://mcp.lilt.com/). In Claude, add the remote MCP server `https://mcp.lilt.com/mcp`, click **Connect**, sign up or sign in on the LILT page, and approve access. The MCP docs state these MCP accounts are separate from `lilt.com` accounts.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lilt.com"
+    },
+    {
+      "domain": "linear.app",
+      "name": "linear",
+      "mcpUrl": "https://mcp.linear.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "linear_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/linear.app"
+    },
+    {
+      "domain": "linklyhq.com",
+      "name": "Linkly URL Shortener",
+      "mcpUrl": "https://mcp.linklyhq.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "linkly_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.linklyhq.com/.well-known/oauth-authorization-server",
+          "setup": "Connect your MCP client to `https://mcp.linklyhq.com` and complete the browser sign-in flow to Linkly. The MCP server publishes OAuth metadata at [authorization server metadata](https://mcp.linklyhq.com/.well-known/oauth-authorization-server) and [protected resource metadata](https://mcp.linklyhq.com/.well-known/oauth-protected-resource); release notes say the flow uses OAuth `authorization_code` with PKCE and dynamic client registration. If your MCP client supports remote OAuth MCP servers, it should discover these endpoints automatically.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/linklyhq.com"
+    },
+    {
+      "domain": "list-manage.com",
+      "name": "list-manage.com",
+      "mcpUrl": "https://mandrillapp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mc_transactional_api_key",
+          "type": "api_key",
+          "generateUrl": "https://mandrillapp.com/settings",
+          "setup": "Sign in to your Mailchimp Transactional account, open [Settings](https://mandrillapp.com/settings), find **API Keys**, and click **Create New Key**. Copy the generated key immediately and store it securely; the docs note you will not be able to see or copy it again after generation. See the [Transactional API quick start](https://mailchimp.com/developer/transactional/guides/quick-start/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/list-manage.com"
+    },
+    {
+      "domain": "listalpha.com",
+      "name": "Carta CRM",
+      "mcpUrl": "https://mcp.listalpha.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "carta_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://login.app.carta.com/credentials/login",
+          "setup": "Use an MCP client that supports OAuth and connect to the Carta CRM MCP server at `https://mcp.listalpha.com/mcp`. The docs identify the MCP as OAuth-protected and the MCP endpoint returns `Unauthorized` without auth. Start from the [Carta login](https://login.app.carta.com/credentials/login) flow when your client prompts you to sign in.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/listalpha.com"
+    },
+    {
+      "domain": "listingforgeai.it",
+      "name": "ListingForgeAI",
+      "mcpUrl": "https://services.listingforgeai.it/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lf_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/listingforgeai.it"
+    },
+    {
+      "domain": "listoai.co",
+      "name": "Remedy Legal",
+      "mcpUrl": "https://valpas-mcp-3b7e1c9d-5a42-4f8e-b6d1-9c2a7e4f1b8a.listoai.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/listoai.co"
+    },
+    {
+      "domain": "litellm.ai",
+      "name": "litellm.ai",
+      "mcpUrl": "https://litellm-api.up.railway.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "litellm_virtual_key",
+          "type": "api_key",
+          "generateUrl": "https://litellm-api.up.railway.app/ui",
+          "setup": "Create a virtual key from the LiteLLM proxy admin UI linked from the [Swagger UI](https://litellm-api.up.railway.app/) (`/ui`), or use the [LiteLLM Proxy CLI](https://docs.litellm.ai/docs/proxy/management_cli) key-management commands against your proxy. The CLI docs show the client authenticating with `LITELLM_PROXY_URL` and `LITELLM_PROXY_API_KEY`, and the gateway auth docs describe sending the key as `Authorization: Bearer sk-...` or `x-litellm-api-key: Bearer sk-...`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/litellm.ai"
+    },
+    {
+      "domain": "ll-mcp.replit.app",
+      "name": "API Lessons",
+      "mcpUrl": "https://ll-mcp.replit.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ll-mcp.replit.app"
+    },
+    {
+      "domain": "llamaindex.ai",
+      "name": "llamaindex.ai",
+      "mcpUrl": "https://developers.llamaindex.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/llamaindex.ai"
+    },
+    {
+      "domain": "lmnr.ai",
+      "name": "lmnr.ai",
+      "mcpUrl": "https://api.lmnr.ai/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lmnr_project_api_key",
+          "type": "api_key",
+          "generateUrl": "https://www.lmnr.ai/projects",
+          "setup": "Open the [Laminar dashboard](https://www.lmnr.ai/projects), select your project, then create or view a key under `Settings → Project API Keys`. The docs also note that [`lmnr-cli setup`](https://laminar.sh/docs/platform/cli) can mint a project API key for the linked project and write it to `LMNR_PROJECT_API_KEY` for your app or MCP client.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lmnr.ai"
+    },
+    {
+      "domain": "lobehub.com",
+      "name": "lobehub.com",
+      "mcpUrl": "https://lobehub.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lobehub.com"
+    },
+    {
+      "domain": "localfalcon.com",
+      "name": "Local Falcon",
+      "mcpUrl": "https://mcp.localfalcon.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lf_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/localfalcon.com"
+    },
+    {
+      "domain": "localiza.com",
+      "name": "Localiza",
+      "mcpUrl": "https://api-hub.localiza.com/genaichatapp-mcp/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/localiza.com"
+    },
+    {
+      "domain": "logging.googleapis.com",
+      "name": "logging.googleapis.com",
+      "mcpUrl": "https://logging.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/logging.googleapis.com"
+    },
+    {
+      "domain": "logrocket.com",
+      "name": "logrocket.com",
+      "mcpUrl": "https://mcp.logrocket.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "logrocket_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/logrocket.com"
+    },
+    {
+      "domain": "logto.io",
+      "name": "logto.io",
+      "mcpUrl": "https://mcp.logto.io",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "m2m_app",
+          "type": "basic",
+          "generateUrl": "https://cloud.logto.io/to/applications",
+          "setup": "In [Logto Console Applications](https://cloud.logto.io/to/applications), create an application of type `Machine-to-machine`. Assign M2M roles that include the needed Management API permissions (for the built-in Management API, include the `all` permission). Copy the app's `App ID` and `App Secret` from the application details. These are sent to the tenant token endpoint using HTTP Basic auth to obtain an access token.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/logto.io"
+    },
+    {
+      "domain": "lona.agency",
+      "name": "LONA Trading Assistant",
+      "mcpUrl": "https://mcp.lona.agency/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lona_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.lona.agency/.well-known/oauth-authorization-server",
+          "setup": "Use an MCP client that supports OAuth discovery against the LONA remote MCP server at `https://mcp.lona.agency/mcp`. The authorization server metadata is published at [OAuth authorization server metadata](https://mcp.lona.agency/.well-known/oauth-authorization-server), which advertises authorization, token, and dynamic client registration endpoints and the `lona:full` scope. For a human-friendly setup path, see [Partners](https://www.lona.agency/en/partners) and [MCP Tools Reference](https://docs.lona.agency/agents/mcp-tools-reference).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lona.agency"
+    },
+    {
+      "domain": "loomalabs.ai",
+      "name": "Selah - Bible stories",
+      "mcpUrl": "https://mcp.loomalabs.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/loomalabs.ai"
+    },
+    {
+      "domain": "lorikeetcx.ai",
+      "name": "Lorikeet",
+      "mcpUrl": "https://api.lorikeetcx.ai/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lorikeet_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lorikeetcx.ai"
+    },
+    {
+      "domain": "lovable.dev",
+      "name": "Lovable",
+      "mcpUrl": "https://api.lovable.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lovable_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lovable.dev"
+    },
+    {
+      "domain": "loveholidays.com",
+      "name": "loveholidays",
+      "mcpUrl": "https://www.loveholidays.com/ai/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/loveholidays.com"
+    },
+    {
+      "domain": "lovelymango-zzaim-mcp.hf.space",
+      "name": "ZZAIM",
+      "mcpUrl": "https://lovelymango-zzaim-mcp.hf.space/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "zzaim_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://ybdmskwkowiiblfuzzyp.supabase.co/auth/v1/oauth/clients/register",
+          "setup": "Register an OAuth client against the Supabase Auth server at [dynamic client registration](https://ybdmskwkowiiblfuzzyp.supabase.co/auth/v1/oauth/clients/register), then run the MCP client's OAuth login flow against the authorization server advertised by the resource. The protected resource advertises scopes `openid`, `email`, and `profile` at [oauth-protected-resource](https://lovelymango-zzaim-mcp.hf.space/.well-known/oauth-protected-resource).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lovelymango-zzaim-mcp.hf.space"
+    },
+    {
+      "domain": "lowes.com",
+      "name": "Lowe’s",
+      "mcpUrl": "https://mcp.lowes.com/lowes-oai-mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lowes.com"
+    },
+    {
+      "domain": "lseg.com",
+      "name": "LSEG",
+      "mcpUrl": "https://api.analytics.lseg.com/lfa/mcp/server-cl",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lseg_platform_oauth_cc",
+          "type": "oauth2_cc",
+          "generateUrl": "https://developers.lseg.com/en/api-catalog/lseg-data-platform/lseg-data-library-for-python/quick-start/access-credentials",
+          "setup": "For direct cloud access to LSEG Data Platform, obtain a `Client ID` (Service ID) and `Client Secret` from LSEG. The [Access Credentials guide](https://developers.lseg.com/en/api-catalog/lseg-data-platform/lseg-data-library-for-python/quick-start/access-credentials) says these are provided in a welcome email and that you should contact your LSEG Account Manager to acquire platform credentials. The same guide also describes the older OAuth 2.0 password-grant variant and notes that version 2 uses service IDs/client secrets.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lseg.com"
+    },
+    {
+      "domain": "lucid.app",
+      "name": "Lucid",
+      "mcpUrl": "https://mcp.lucid.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lucid_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://developer.lucid.co/docs/oauth-20-client-creation",
+          "setup": "Create an OAuth 2.0 client in the Lucid developer portal as described in [OAuth 2.0 client creation](https://developer.lucid.co/docs/oauth-20-client-creation). Lucid's REST API uses the authorization code flow; after creating the client, direct users to `https://lucid.app/oauth2/authorizeUser` and exchange the code at `https://api.lucid.co/oauth2/token`. Request only the needed scopes, such as `user.profile`, document scopes, or `offline_access` for refresh tokens.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lucid.app"
+    },
+    {
+      "domain": "lucid.co",
+      "name": "lucid.co",
+      "mcpUrl": "https://lucid-developer-docs.readme.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lucid.co"
+    },
+    {
+      "domain": "lugg.com",
+      "name": "Lugg",
+      "mcpUrl": "https://api.lugg.com/mcp/public",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lugg.com"
+    },
+    {
+      "domain": "luminpdf.com",
+      "name": "Lumin",
+      "mcpUrl": "https://mcp.luminpdf.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lumin_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developers.luminpdf.com/tabs/guides/authentication/oauth2",
+          "setup": "Log in to Lumin and go to **Settings → Developer settings → Integration apps**, then click **Create app**. Enter an application name, choose **Public Application** (PKCE, no client secret) or **Private Application** (server-side, includes client secret), select scopes, add redirect URIs, configure the consent screen, and save. Lumin issues a `Client ID` for all apps and a `Client Secret` for private apps. You must be a **Workspace Owner** to register apps. See [OAuth 2.0](https://developers.luminpdf.com/tabs/guides/authentication/oauth2).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/luminpdf.com"
+    },
+    {
+      "domain": "lunarcrush.ai",
+      "name": "LunarCrush",
+      "mcpUrl": "https://lunarcrush.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.ai"
+    },
+    {
+      "domain": "lunarcrush.com",
+      "name": "lunarcrush.com",
+      "mcpUrl": "https://lunarcrush.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lunarcrush_api_key",
+          "type": "bearer",
+          "generateUrl": "https://lunarcrush.com/developers/api",
+          "setup": "Sign in to the [LunarCrush Developer Hub](https://lunarcrush.com/en/developers) or [API reference](https://lunarcrush.com/developers/api/introduction). The docs state you can manage keys on the API Keys page and that the same key powers the API, CLI, and MCP server. Use the [Get API Key](https://lunarcrush.com/developers/api) / [Get Free API Key](https://lunarcrush.com/developers/api) flow from the developer pages, then use the issued key as `Authorization: Bearer <API_KEY>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.com"
+    },
+    {
+      "domain": "lusha.com",
+      "name": "Lusha",
+      "mcpUrl": "https://mcp.lusha.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lusha_mcp_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lusha.com"
+    },
+    {
+      "domain": "luxuryescapes.com",
+      "name": "Luxury Escapes",
+      "mcpUrl": "https://api.luxuryescapes.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/luxuryescapes.com"
+    },
+    {
+      "domain": "lytical.ai",
+      "name": "Lytical",
+      "mcpUrl": "https://mcp.lytical.ai",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lytical_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lytical.ai"
+    },
+    {
+      "domain": "m6.fr",
+      "name": "M6plus",
+      "mcpUrl": "https://prod-v1.mcp.m6.fr/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/m6.fr"
+    },
+    {
+      "domain": "magicpatterns.com",
+      "name": "Magic Patterns",
+      "mcpUrl": "https://mcp.magicpatterns.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mp_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/magicpatterns.com"
+    },
+    {
+      "domain": "magneto365.com",
+      "name": "Magneto Empleos",
+      "mcpUrl": "https://api.magneto365.com/agents/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/magneto365.com"
+    },
+    {
+      "domain": "mailchimp.com",
+      "name": "Intuit Mailchimp",
+      "mcpUrl": "https://ai-inc.mailchimp.com/claude/mcp/v2",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mailchimp.com"
+    },
+    {
+      "domain": "mailerlite.com",
+      "name": "MailerLite",
+      "mcpUrl": "https://mcp.mailerlite.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mailerlite_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mailerlite.com"
+    },
+    {
+      "domain": "mailersend.com",
+      "name": "mailersend.com",
+      "mcpUrl": "https://mcp.mailersend.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mailersend_cli_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mailersend.com"
+    },
+    {
+      "domain": "make.com",
+      "name": "Make",
+      "mcpUrl": "https://mcp.make.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "make_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://f.make.com/oauth",
+          "setup": "Request OAuth client credentials through Make’s [OAuth client registration form](https://f.make.com/oauth) as described in [Requesting an OAuth 2.0 client](https://developers.make.com/api-documentation/authentication/requesting-an-oauth-2.0-client). Choose the API scopes your app needs and wait for Make to approve the request; on approval, Make issues a `client_id` and, for confidential clients, a `client_secret`. Authorization uses `https://www.make.com/oauth/v2/authorize` and token exchange uses `https://www.make.com/oauth/v2/token`.",
+          "fields": null
+        },
+        {
+          "id": "make_mcp_token",
+          "type": "bearer",
+          "generateUrl": "https://developers.make.com/mcp-server/connect-using-mcp-token",
+          "setup": "In your Make account, open **Profile** → **API access** → **Tokens** → **Add token**, then create a token with the scopes you need; include `mcp:use` if you want scenarios exposed as MCP tools. The [Connect using MCP token](https://developers.make.com/mcp-server/connect-using-mcp-token) guide explains the steps and notes that the token is used either directly in the MCP URL or as an `Authorization: Bearer` header.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/make.com"
+    },
+    {
+      "domain": "makeaviz.com",
+      "name": "Make A Viz",
+      "mcpUrl": "https://mcp.makeaviz.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "makeaviz_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/makeaviz.com"
+    },
+    {
+      "domain": "makegov.com",
+      "name": "makegov.com",
+      "mcpUrl": "https://tango.makegov.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tango_api_key",
+          "type": "api_key",
+          "generateUrl": "https://tango.makegov.com/accounts/login/",
+          "setup": "Sign in at [Get API access](https://tango.makegov.com/accounts/login/) using a supported provider or email sign-in code. After signing in, use the Tango account portal to create/view your API key; the portal exposes your API key(s) and usage dashboard. The docs' quick start and auth guide describe using the key in the `X-API-KEY` header, and the SDKs also accept it directly or via `TANGO_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/makegov.com"
+    },
+    {
+      "domain": "makemytrip.com",
+      "name": "MakeMyTrip",
+      "mcpUrl": "https://www.makemytrip.com/ai/mcp?src=cm",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/makemytrip.com"
+    },
+    {
+      "domain": "makenotion.com",
+      "name": "makenotion.com",
+      "mcpUrl": "https://mcp.notion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "public_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/makenotion.com"
+    },
+    {
+      "domain": "malwarebytes.com",
+      "name": "Malwarebytes",
+      "mcpUrl": "https://scamguard.malwarebytes.com/claude/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/malwarebytes.com"
+    },
+    {
+      "domain": "manus.im",
+      "name": "Manus",
+      "mcpUrl": "https://mcp.manus.im/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "manus_open_app",
+          "type": "oauth2",
+          "generateUrl": "https://manus.im/app#settings/integrations/api",
+          "setup": "Create an Open App from [Manus Integrations settings](https://manus.im/app#settings/integrations/api). Enter the app name, description, redirect URI(s), and homepage URL, then save the shown `client_id` and one-time `client_secret`. Use the app to obtain user access tokens via the documented OAuth authorization-code flow with optional PKCE; team accounts are required for app creation and authorization.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/manus.im"
+    },
+    {
+      "domain": "mapify.so",
+      "name": "Mapify",
+      "mcpUrl": "https://mapify.so/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mapify_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mapify.so"
+    },
+    {
+      "domain": "marcopolo.dev",
+      "name": "MarcoPolo",
+      "mcpUrl": "https://mcp.marcopolo.dev",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "marcopolo_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://docs.marcopolo.dev/getting-started",
+          "setup": "Add the MarcoPolo MCP server URL `https://mcp.marcopolo.dev` in your MCP-capable client, then choose **Connect** in the client to start sign-in. The docs say you can establish identity with **Google**, **Microsoft**, **GitHub**, or your **Email address**; the first authentication also provisions your workspace automatically. See [Getting Started](https://docs.marcopolo.dev/getting-started) and the [homepage connection instructions](https://marcopolo.dev/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/marcopolo.dev"
+    },
+    {
+      "domain": "masbasbas.com",
+      "name": "masbasbas.com",
+      "mcpUrl": "https://masbasbas.com/api/ucp/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "shopify_customer_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://account.masbasbas.com/authentication/oauth/authorize",
+          "setup": "This store exposes customer-account OAuth endpoints on `account.masbasbas.com`. To obtain client credentials, a developer would need to register or provision a BASBAS/Shopify customer account app that is authorized for this store's customer APIs and request scopes such as `openid`, `email`, `customer-account-api:full`, or `customer-account-mcp-api:full`. The automated probe confirmed the authorization endpoint at [account.masbasbas.com/authentication/oauth/authorize](https://account.masbasbas.com/authentication/oauth/authorize) and token endpoint `https://account.masbasbas.com/authentication/oauth/token`, but the public BASBAS site did not expose developer-facing app registration steps.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/masbasbas.com"
+    },
+    {
+      "domain": "massive.com",
+      "name": "massive.com",
+      "mcpUrl": "https://mcp.massive.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "massive_oauth_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Create a Massive account via [sign up](https://massive.com/dashboard/signup) or sign in at [Massive login](https://massive.com/dashboard/login). Then add the remote MCP server `https://mcp.massive.com/` in your MCP client and complete the browser-based OAuth sign-in when prompted. Massive's client setup guides state there is no API key to copy for the hosted MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/massive.com"
+    },
+    {
+      "domain": "masteringthezodiac.com",
+      "name": "True Sky",
+      "mcpUrl": "https://truesky.masteringthezodiac.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/masteringthezodiac.com"
+    },
+    {
+      "domain": "mavriq.com",
+      "name": "MutuiOnline.it",
+      "mcpUrl": "https://molaimcp.mavriq.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mavriq.com"
+    },
+    {
+      "domain": "mcafee.com",
+      "name": "McAfee",
+      "mcpUrl": "https://chatgptcompanion.gateway.api.mcafee.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mcafee.com"
+    },
+    {
+      "domain": "mcp-detprm6tzq-uc.a.run.app",
+      "name": "Glinded for Memorial Videos",
+      "mcpUrl": "https://mcp-detprm6tzq-uc.a.run.app",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "glinded_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://clerk.glinded.com/oauth/register",
+          "setup": "Register an OAuth client at [Clerk OAuth dynamic client registration](https://clerk.glinded.com/oauth/register). The authorization server metadata at [oauth-authorization-server](https://clerk.glinded.com/.well-known/oauth-authorization-server) shows support for `authorization_code` and `refresh_token`, PKCE `S256`, and scopes including `openid`, `profile`, `email`, `public_metadata`, `private_metadata`, and `offline_access`. Use the resulting client registration with the authorization endpoint `https://clerk.glinded.com/oauth/authorize` and token endpoint `https://clerk.glinded.com/oauth/token`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mcp-detprm6tzq-uc.a.run.app"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "name": "Adobe Experience Manager",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/aem",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "adobe_ims_user",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.adobeaemcloud.com"
+    },
+    {
+      "domain": "mcp.com.ai",
+      "name": "HAPI MCP Registry",
+      "mcpUrl": "https://registry.run.mcp.com.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.com.ai"
+    },
+    {
+      "domain": "mcp.lapyme.com.ar",
+      "name": "mcp.lapyme.com.ar",
+      "mcpUrl": "https://mcp.lapyme.com.ar/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "lapyme_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://qesnypidkptygqfupife.supabase.co/auth/v1/oauth/clients/register",
+          "setup": "Use the MCP client's built-in OAuth flow against La Pyme's authorization server. The server advertises dynamic client registration at [OAuth client registration](https://qesnypidkptygqfupife.supabase.co/auth/v1/oauth/clients/register), then sends the user through [Authorize](https://qesnypidkptygqfupife.supabase.co/auth/v1/oauth/authorize) to sign in and consent, and exchanges the code at [Token](https://qesnypidkptygqfupife.supabase.co/auth/v1/oauth/token). Supported scopes advertised by the authorization server are `openid`, `profile`, `email`, and `phone`. La Pyme's help docs say to add the MCP URL in a compatible client and then authorize when prompted.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/lapyme.com.ar"
+    },
+    {
+      "domain": "mcp.read",
+      "name": "mcp.read",
+      "mcpUrl": "https://api.read.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "read_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.read"
+    },
+    {
+      "domain": "mcptotal.io",
+      "name": "mcptotal.io",
+      "mcpUrl": "https://mcptotal.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcptotal_access_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mcptotal.io"
+    },
+    {
+      "domain": "medeloop.ai",
+      "name": "Medeloop Grants",
+      "mcpUrl": "https://medeloop-mcp.medeloop.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "medeloop_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/medeloop.ai"
+    },
+    {
+      "domain": "meetgeek.ai",
+      "name": "meetgeek.ai",
+      "mcpUrl": "https://mcp.meetgeek.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "meetgeek_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/meetgeek.ai"
+    },
+    {
+      "domain": "melon.com",
+      "name": "Melon",
+      "mcpUrl": "https://mcp.melon.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/melon.com"
+    },
+    {
+      "domain": "mem.ai",
+      "name": "Mem",
+      "mcpUrl": "https://mcp.mem.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mem_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mem.ai"
+    },
+    {
+      "domain": "mem0.ai",
+      "name": "mem0.ai",
+      "mcpUrl": "https://mcp.mem0.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mem0_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mem0.ai"
+    },
+    {
+      "domain": "mentirosa.vercel.app",
+      "name": "Mentirosa",
+      "mcpUrl": "https://mentirosa.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mentirosa.vercel.app"
+    },
+    {
+      "domain": "mercury.com",
+      "name": "Mercury",
+      "mcpUrl": "https://mcp.mercury.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mercury_mcp_dcr_client",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.mercury.com/register",
+          "setup": "For Mercury's hosted MCP server, register your client with OAuth 2.0 Dynamic Client Registration by POSTing to [https://mcp.mercury.com/register](https://mcp.mercury.com/register) with your `redirect_uris` and `client_name`. Mercury returns a `client_id` and `client_secret` for use in the OAuth authorization code flow against Mercury MCP.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mercury.com"
+    },
+    {
+      "domain": "merge.dev",
+      "name": "merge.dev",
+      "mcpUrl": "https://ah-api.merge.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "merge_ah_access_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/merge.dev"
+    },
+    {
+      "domain": "mermaid.ai",
+      "name": "Mermaid Chart",
+      "mcpUrl": "https://mcp.mermaid.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mermaid_chart_api_token",
+          "type": "bearer",
+          "generateUrl": "https://mermaid.ai/app/login",
+          "setup": "Sign in to your [Mermaid Chart account](https://mermaid.ai/app/login), then open your account settings and generate an API token as described in the [MCP Server docs](https://mermaid.ai/docs/ai/mcp-server). Use it in an `Authorization: Bearer <token>` header for Mermaid Chart integration tools exposed by the MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mermaid.ai"
+    },
+    {
+      "domain": "mervia.ai",
+      "name": "Ovios Home",
+      "mcpUrl": "https://mcp.mervia.ai/mcp/s/ovios-furn-b85c0919",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mervia.ai"
+    },
+    {
+      "domain": "messagebird.com",
+      "name": "messagebird.com",
+      "mcpUrl": "https://mcp.platform.bird.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "bird_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/messagebird.com"
+    },
+    {
+      "domain": "metaview.ai",
+      "name": "Metaview",
+      "mcpUrl": "https://mcp.metaview.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "metaview_account_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://my.metaview.app/settings/mcp",
+          "setup": "In Metaview, open [MCP settings](https://my.metaview.app/settings/mcp) or connect from a supported client such as Claude or ChatGPT. For generic MCP clients, add `https://mcp.metaview.ai/mcp` to the client; when it connects, Metaview opens a browser window and prompts you to sign in with your Metaview account. The support docs describe this as the simplest path and note that no API key is needed for OAuth-capable MCP clients.",
+          "fields": null
+        },
+        {
+          "id": "metaview_mcp_api_key",
+          "type": "api_key",
+          "generateUrl": "https://my.metaview.app/settings/mcp",
+          "setup": "Open [MCP settings](https://my.metaview.app/settings/mcp) in the Metaview app, toggle on `Use API Key instead of OAuth?`, then click `Generate API Key`. Give the key a descriptive name and copy it immediately, because the full key is only shown once. The docs say this path is for MCP clients that do not support OAuth.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/metaview.ai"
+    },
+    {
+      "domain": "meterplan.com",
+      "name": "Texas Electricity Plans",
+      "mcpUrl": "https://meterplan.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/meterplan.com"
+    },
+    {
+      "domain": "microsoft.com",
+      "name": "microsoft.com – graph-beta",
+      "mcpUrl": "https://learn.microsoft.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "learn_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://learn.microsoft.com/en-us/api/mcp",
+          "setup": "The MCP server is self-onboarding for MCP clients: connect your client to [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) and let the client perform the standard MCP OAuth flow automatically. The user completes consent in the browser if prompted; no manual developer app registration was found in the Learn MCP entrypoint docs.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/microsoft.com"
+    },
+    {
+      "domain": "middesk.com",
+      "name": "middesk.com",
+      "mcpUrl": "https://mcp.middesk.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "middesk_api_key",
+          "type": "api_key",
+          "generateUrl": "https://docs.middesk.com/build/api-keys",
+          "setup": "In the Middesk docs, go to [Get your API keys](https://docs.middesk.com/build/api-keys). Middesk uses API credentials for its developer APIs; the GraphQL guide and product release note say GraphQL uses your existing Middesk API credentials as a Bearer token. If you do not already have access, request access through [Contact sales](https://www.middesk.com/contact-sales) or [Contact](https://www.middesk.com/contact).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/middesk.com"
+    },
+    {
+      "domain": "midpage.ai",
+      "name": "Midpage Legal Research",
+      "mcpUrl": "https://app.midpage.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "midpage_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/midpage.ai"
+    },
+    {
+      "domain": "migma.ai",
+      "name": "migma.ai",
+      "mcpUrl": "https://migma.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "migma_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.migma.ai/.well-known/oauth-authorization-server",
+          "setup": "For OAuth-capable MCP clients, point the client at `https://migma.ai/mcp` or discover auth from [authorization-server metadata](https://api.migma.ai/.well-known/oauth-authorization-server). The client self-registers with Migma using Dynamic Client Registration at `POST /oauth2/register`, then sends the user through Migma consent; the user only reviews scopes and approves access. No manual client creation in a developer portal is documented; the resulting `access_token` is a scoped Migma API key.",
+          "fields": null
+        },
+        {
+          "id": "migma_api_key",
+          "type": "bearer",
+          "generateUrl": "https://migma.ai/settings/api-keys",
+          "setup": "Create a key in [Settings → Developers → API Keys](https://migma.ai/settings/api-keys): click **Create API Key**, choose a name and only the scopes you need, then copy the key immediately because it is shown once. Use it as a bearer token in `Authorization`, or set `MIGMA_API_KEY` for tools like the SDK, CLI, or local MCP. Test keys start with `sk_test_`; production keys start with `sk_live_`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/migma.ai"
+    },
+    {
+      "domain": "migrosone.com",
+      "name": "Migros",
+      "mcpUrl": "https://mcp.migrosone.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "migros_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/migrosone.com"
+    },
+    {
+      "domain": "mintlify.com",
+      "name": "mintlify.com",
+      "mcpUrl": "https://mintlify.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mint_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mintlify.com"
+    },
+    {
+      "domain": "minty.com",
+      "name": "Minty",
+      "mcpUrl": "https://mcp.minty.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/minty.com"
+    },
+    {
+      "domain": "mirai.com",
+      "name": "Hotel Moderno",
+      "mcpUrl": "https://api.mirai.com/synapse/mcp?hotelId=10030559",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mirai.com"
+    },
+    {
+      "domain": "miro.com",
+      "name": "Miro",
+      "mcpUrl": "https://mcp.miro.com/",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/miro.com"
+    },
+    {
+      "domain": "mixedbread.com",
+      "name": "mixedbread.com",
+      "mcpUrl": "https://www.mcp.mixedbread.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mxb_api_key",
+          "type": "api_key",
+          "generateUrl": "https://platform.mixedbread.com/platform?next=api-keys",
+          "setup": "Go to the [API Keys page](https://platform.mixedbread.com/platform?next=api-keys), create a new key, and copy it. Use it as a bearer token in the `Authorization` header for API and MCP requests, or store it for the CLI with `mxbai config keys add YOUR_API_KEY default` or `export MXBAI_API_KEY=YOUR_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mixedbread.com"
+    },
+    {
+      "domain": "mixmax.com",
+      "name": "Mixmax",
+      "mcpUrl": "https://mcp.mixmax.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mixmax_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://success.mixmax.com/en/articles/14298142-mixmax-mcp-server",
+          "setup": "Connect an MCP client to `https://mcp.mixmax.com/mcp` and complete the Mixmax sign-in and consent flow when prompted. The [Mixmax MCP Server](https://success.mixmax.com/en/articles/14298142-mixmax-mcp-server) article documents OAuth 2.0 authorization code flow and shows setup in Claude Desktop, Claude Code, ChatGPT, and other MCP clients.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mixmax.com"
+    },
+    {
+      "domain": "mixpanel.com",
+      "name": "Mixpanel",
+      "mcpUrl": "https://mcp.mixpanel.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mixpanel.com"
+    },
+    {
+      "domain": "mobile.de",
+      "name": "mobile.de",
+      "mcpUrl": "https://www.mobile.de/integration/consumer-chatgpt-app/mcp?c=6a3929ea-9f78-4d44-af4e-e345cf3f9920",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mobile.de"
+    },
+    {
+      "domain": "modelcontextprotocol.io",
+      "name": "Play Sheet Music",
+      "mcpUrl": "https://mcp.main-kill-isr.mintlify.me/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/modelcontextprotocol.io"
+    },
+    {
+      "domain": "mollie.com",
+      "name": "mollie.com",
+      "mcpUrl": "https://mcp.mollie.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mollie_org_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mollie.com"
+    },
+    {
+      "domain": "monday.com",
+      "name": "monday.com",
+      "mcpUrl": "https://mcp.monday.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "monday_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/monday.com"
+    },
+    {
+      "domain": "mondoir.art",
+      "name": "Mondoir.art",
+      "mcpUrl": "https://mondoir.art/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mondoir_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mondoir.art"
+    },
+    {
+      "domain": "moneysupermarket.com",
+      "name": "MoneySuperMarket",
+      "mcpUrl": "https://www.moneysupermarket.com/labs/v2/mcp/",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/moneysupermarket.com"
+    },
+    {
+      "domain": "monito.com",
+      "name": "Monito",
+      "mcpUrl": "https://ai.monito.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/monito.com"
+    },
+    {
+      "domain": "monotype.com",
+      "name": "MyFonts",
+      "mcpUrl": "https://fontgpt-chatgpt.monotype.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/monotype.com"
+    },
+    {
+      "domain": "moodtrip.ai",
+      "name": "MoodTrip.Ai",
+      "mcpUrl": "https://api.moodtrip.ai/api/mcp-http",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "moodtrip_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.moodtrip.ai/api/oauth-register",
+          "setup": "Register an OAuth client at [`/api/oauth-register`](https://api.moodtrip.ai/api/oauth-register) using MoodTrip's dynamic client registration. Then run the authorization-code flow against [`/api/oauth-authorize`](https://api.moodtrip.ai/api/oauth-authorize) and [`/api/oauth-token`](https://api.moodtrip.ai/api/oauth-token). Supported scopes published by MoodTrip are `mcp:tools`, `mcp:resources`, and `mcp:prompts`; PKCE `S256` is supported, and token endpoint auth methods include `none`, `client_secret_post`, and `client_secret_basic`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/moodtrip.ai"
+    },
+    {
+      "domain": "moodys.com",
+      "name": "Moody's",
+      "mcpUrl": "https://api.moodys.com/genai-ready-data/m1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "moodys_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/moodys.com"
+    },
+    {
+      "domain": "morningstar.com",
+      "name": "Morningstar",
+      "mcpUrl": "https://mcp.morningstar.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ms_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/morningstar.com"
+    },
+    {
+      "domain": "mospi.gov.in",
+      "name": "MoSPI",
+      "mcpUrl": "https://mcp.mospi.gov.in/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mospi.gov.in"
+    },
+    {
+      "domain": "motherduck.com",
+      "name": "MotherDuck",
+      "mcpUrl": "https://api.motherduck.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "md_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.motherduck.com/?auth_flow=signup",
+          "setup": "Create or sign in to a MotherDuck account via [MotherDuck](https://app.motherduck.com/?auth_flow=signup). Then add the remote MCP server `https://api.motherduck.com/mcp` in your MCP client; MotherDuck documents that clients like Claude, ChatGPT, Cursor, Claude Code, and GitHub Copilot open a browser and authenticate automatically through OAuth during connection setup in [Connect to the MotherDuck MCP Server](https://motherduck.com/docs/key-tasks/ai-and-motherduck/mcp-setup/).",
+          "fields": null
+        },
+        {
+          "id": "md_access_token",
+          "type": "bearer",
+          "generateUrl": "https://app.motherduck.com",
+          "setup": "In the [MotherDuck UI](https://app.motherduck.com), open your organization menu, go to `Settings`, click `+ Create token`, choose a token type (`Read/Write` or `Read Scaling`), optionally set an expiry, then copy the token. For service accounts, an org Admin can create the service account in `Settings` → `Service Accounts` and then create a token there; the walkthrough is in [Create and configure service accounts](https://motherduck.com/docs/key-tasks/service-accounts-guide/create-and-configure-service-accounts/). Store the token securely; for DuckDB clients MotherDuck recommends setting `motherduck_token` in your environment.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/motherduck.com"
+    },
+    {
+      "domain": "motionapp.com",
+      "name": "Motion Creative Analytics",
+      "mcpUrl": "https://projects.motionapp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "motion_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/motionapp.com"
+    },
+    {
+      "domain": "motionhub.ai",
+      "name": "MotionHub MCP",
+      "mcpUrl": "https://api.motionhub.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "motionhub_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://api.motionhub.ai/register",
+          "setup": "For an MCP client that connects to MotionHub, register or let the client dynamically register an OAuth client at [MotionHub OAuth registration](https://api.motionhub.ai/register). Then connect to the MotionHub MCP server; the user authorizes in the browser at MotionHub's consent screen and signs in with their MotionHub account. MotionHub's OAuth authorization server metadata is published at [oauth-authorization-server](https://api.motionhub.ai/.well-known/oauth-authorization-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/motionhub.ai"
+    },
+    {
+      "domain": "motra.com",
+      "name": "Motra",
+      "mcpUrl": "https://mcp.motra.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "motra_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Connect an MCP client to `https://mcp.motra.com/mcp` and complete the Motra OAuth sign-in/consent flow when prompted. The OpenAI MCP registry identifies this server as using OAuth; the server itself returns `invalid_token` when called without authorization. No public Motra developer page describing manual client registration was found.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/motra.com"
+    },
+    {
+      "domain": "mountaingoatsoftware.com",
+      "name": "MGS Agile Toolkit",
+      "mcpUrl": "https://ai-toolkit.mountaingoatsoftware.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mgs_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/mountaingoatsoftware.com"
+    },
+    {
+      "domain": "moviepick.app",
+      "name": "Movie Pick",
+      "mcpUrl": "https://moviepick.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "moviepick_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://moviepick.app/oauth2/v1/register",
+          "setup": "Register an OAuth client with MoviePick at the dynamic client registration endpoint `https://moviepick.app/oauth2/v1/register`. The authorization server metadata is published at [OAuth Authorization Server Metadata](https://moviepick.app/.well-known/oauth-authorization-server), which lists the registration endpoint, authorization endpoint, and token endpoint. Request the scopes you need from [OAuth Protected Resource Metadata](https://moviepick.app/.well-known/oauth-protected-resource): `movies:read` and/or `movies:write`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/moviepick.app"
+    },
+    {
+      "domain": "mozilla.org",
+      "name": "mozilla.org",
+      "mcpUrl": "https://developer.mozilla.org/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mozilla.org"
+    },
+    {
+      "domain": "msci.com",
+      "name": "MSCI",
+      "mcpUrl": "https://mcp.msci.com/mcp/v1.0/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "msci_oauth_access_token",
+          "type": "oauth2",
+          "generateUrl": "https://developer.msci.com/apis/esg-data-api-v3-0",
+          "setup": "For MSCI surfaces that use OAuth 2.0, first obtain access to the relevant API through the [MSCI Developer Community](https://developer.msci.com/apis) / your MSCI representative. The ESG Data API documentation explicitly states it uses OAuth 2.0 token-based authorization, but the public docs we found do not expose the token acquisition steps or endpoints. After access is provisioned, follow the authenticated API documentation or MSCI support instructions to obtain an access token.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/msci.com"
+    },
+    {
+      "domain": "mux.com",
+      "name": "mux.com",
+      "mcpUrl": "https://mcp.mux.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mux_dashboard_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://dashboard.mux.com",
+          "setup": "Configure the hosted MCP server at `https://mcp.mux.com` in your MCP client. The client will start authentication automatically, prompting you to sign in at [Mux Dashboard](https://dashboard.mux.com) and choose which environment to authorize for the connection. This is the documented auth path for the hosted MCP server; no dashboard access token needs to be copied manually.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mux.com"
+    },
+    {
+      "domain": "my-mcp-server-flame.vercel.app",
+      "name": "RadioFM",
+      "mcpUrl": "https://my-mcp-server-flame.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/my-mcp-server-flame.vercel.app"
+    },
+    {
+      "domain": "mychoice.ca",
+      "name": "MyChoice Insurance",
+      "mcpUrl": "https://mcp-new.mychoice.ca/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mychoice.ca"
+    },
+    {
+      "domain": "mydeetz.ai",
+      "name": "mydeetz",
+      "mcpUrl": "https://app.mydeetz.ai/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/mydeetz.ai"
+    },
+    {
+      "domain": "myfitnesspal.com",
+      "name": "MyFitnessPal",
+      "mcpUrl": "https://mcp.myfitnesspal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/myfitnesspal.com"
+    },
+    {
+      "domain": "myregistry.com",
+      "name": "MyRegistry.com",
+      "mcpUrl": "https://mcp.myregistry.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/myregistry.com"
+    },
+    {
+      "domain": "naked.insure",
+      "name": "Naked Insurance",
+      "mcpUrl": "https://svc.naked.insure/quote/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "naked_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://svc.naked.insure/oauth2/register",
+          "setup": "Register an OAuth client at [`/oauth2/register`](https://svc.naked.insure/oauth2/register). The authorization server metadata is published at [oauth-authorization-server](https://svc.naked.insure/.well-known/oauth-authorization-server), which shows `authorization_code`, `client_credentials`, and `refresh_token` support, with token endpoint auth methods `client_secret_basic` and `client_secret_post`. Request an access token for scopes such as `mcp-api/read`, `mcp-api/write`, or `mcp-api/quote.run`, then send it as a bearer token to the MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/naked.insure"
+    },
+    {
+      "domain": "natural.co",
+      "name": "natural.co",
+      "mcpUrl": "https://mcp.natural.co",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "natural_cli_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/natural.co"
+    },
+    {
+      "domain": "naturalint.com",
+      "name": "BestMoney - Car Insurance",
+      "mcpUrl": "https://mcp-apps-platform.naturalint.com/openai/bestmoney_car_insurance_app/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/naturalint.com"
+    },
+    {
+      "domain": "neartail.com",
+      "name": "Neartail",
+      "mcpUrl": "https://neartail.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "neartail_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://neartail.com/api/oauth/register",
+          "setup": "Register an OAuth client at [Neartail OAuth dynamic client registration](https://neartail.com/api/oauth/register). Then complete user authorization against [authorize](https://neartail.com/api/oauth/authorize) and exchange the code at [token](https://neartail.com/api/oauth/token). The catalog indicates supported scopes `readOnly` and `full`. The MCP docs say each user needs a Neartail account and a one-time OAuth approval.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/neartail.com"
+    },
+    {
+      "domain": "neighbor.com",
+      "name": "Neighbor",
+      "mcpUrl": "https://api.production.neighbor.com/mcp-server/discovery/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/neighbor.com"
+    },
+    {
+      "domain": "neon.com",
+      "name": "neon.com",
+      "mcpUrl": "https://mcp.neon.tech/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "neon_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/neon.com"
+    },
+    {
+      "domain": "neptuneflood.com",
+      "name": "Neptune Flood",
+      "mcpUrl": "https://mcp.neptuneflood.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/neptuneflood.com"
+    },
+    {
+      "domain": "netlify-mcp.netlify.app",
+      "name": "Netlify",
+      "mcpUrl": "https://netlify-mcp.netlify.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "netlify_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/netlify-mcp.netlify.app"
+    },
+    {
+      "domain": "networkmanagement.googleapis.com",
+      "name": "networkmanagement.googleapis.com",
+      "mcpUrl": "https://networkmanagement.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/networkmanagement.googleapis.com"
+    },
+    {
+      "domain": "networksolutions.com",
+      "name": "Network Solutions",
+      "mcpUrl": "https://mcp.networksolutions.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/networksolutions.com"
+    },
+    {
+      "domain": "neurnav.com",
+      "name": "Neurnav",
+      "mcpUrl": "https://neurnav.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "neurnav_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/neurnav.com"
+    },
+    {
+      "domain": "newegg.com",
+      "name": "Newegg",
+      "mcpUrl": "https://commerce-api.newegg.com/openai/mcp/chatgpt-newegg-app",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/newegg.com"
+    },
+    {
+      "domain": "newrelic.com",
+      "name": "newrelic.com",
+      "mcpUrl": "https://mcp.newrelic.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "nr_user_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/newrelic.com"
+    },
+    {
+      "domain": "newsifytrends.com",
+      "name": "Newsify",
+      "mcpUrl": "https://mcp.newsifytrends.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/newsifytrends.com"
+    },
+    {
+      "domain": "newt.net",
+      "name": "NEWT（ニュート）",
+      "mcpUrl": "https://chatgpt.newt.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/newt.net"
+    },
+    {
+      "domain": "nexafin.com",
+      "name": "Nexafin",
+      "mcpUrl": "https://nexafin.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/nexafin.com"
+    },
+    {
+      "domain": "notion.com",
+      "name": "Notion API",
+      "mcpUrl": "https://mcp.notion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "notion_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/notion.com"
+    },
+    {
+      "domain": "notion.notion.site",
+      "name": "notion.notion.site",
+      "mcpUrl": "https://mcp.notion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "notion_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/notion.notion.site"
+    },
+    {
+      "domain": "notion.so",
+      "name": "notion.so",
+      "mcpUrl": "https://mcp.notion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "notion_public_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/notion.so"
+    },
+    {
+      "domain": "notiondevs.notion.site",
+      "name": "notiondevs.notion.site",
+      "mcpUrl": "https://mcp.notion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "notion_public_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/notiondevs.notion.site"
+    },
+    {
+      "domain": "novu.co",
+      "name": "novu.co",
+      "mcpUrl": "https://mcp.novu.co/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "novu_secret_key",
+          "type": "bearer",
+          "generateUrl": "https://dashboard.novu.co/settings/api-keys",
+          "setup": "Sign in to the [Novu dashboard](https://dashboard.novu.co), open [API Keys](https://dashboard.novu.co/settings/api-keys), and copy a key from **Secret Keys**. The docs describe the secret key as the private token used to authenticate and authorize API requests, and note that keys are environment-specific.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/novu.co"
+    },
+    {
+      "domain": "nuwapen.com",
+      "name": "Nuwa",
+      "mcpUrl": "https://mcp.nuwapen.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "nuwa_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/nuwapen.com"
+    },
+    {
+      "domain": "nuxt.com",
+      "name": "nuxt.com",
+      "mcpUrl": "https://nuxt.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com"
+    },
+    {
+      "domain": "nyquistai.com",
+      "name": "NyquistAI",
+      "mcpUrl": "https://mcp.nyquistai.com/agent/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "nyquist_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/nyquistai.com"
+    },
+    {
+      "domain": "oaimcp-production.up.railway.app",
+      "name": "CalorieCam",
+      "mcpUrl": "https://oaimcp-production.up.railway.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/oaimcp-production.up.railway.app"
+    },
+    {
+      "domain": "okkanji.com",
+      "name": "OK幹事",
+      "mcpUrl": "https://okkanji.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/okkanji.com"
+    },
+    {
+      "domain": "okx.com",
+      "name": "OKX",
+      "mcpUrl": "https://www.okx.com/api/v1/mcp/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/okx.com"
+    },
+    {
+      "domain": "olutely.com",
+      "name": "ABC Word Search",
+      "mcpUrl": "https://affirmations.widgets.widget.olutely.com/affirmations/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/olutely.com"
+    },
+    {
+      "domain": "olx.io",
+      "name": "Imovirtual",
+      "mcpUrl": "https://chatgpt-imovirtual.genai.olx.io/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/olx.io"
+    },
+    {
+      "domain": "omni.co",
+      "name": "omni.co",
+      "mcpUrl": "https://callbacks.omniapp.co/callback/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "omni_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/omni.co"
+    },
+    {
+      "domain": "omniapp.co",
+      "name": "Omni Analytics",
+      "mcpUrl": "https://callbacks.omniapp.co/callback/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "omni_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/omniapp.co"
+    },
+    {
+      "domain": "omnisend.com",
+      "name": "Omnisend",
+      "mcpUrl": "https://mcp.omnisend.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "omnisend_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/omnisend.com"
+    },
+    {
+      "domain": "ondata.github.io",
+      "name": "ondata.github.io",
+      "mcpUrl": "https://ckan-mcp-server.andy-pr.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ondata.github.io"
+    },
+    {
+      "domain": "onepeloton.com",
+      "name": "Peloton",
+      "mcpUrl": "https://mcp.onepeloton.com",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/onepeloton.com"
+    },
+    {
+      "domain": "oneuptime.com",
+      "name": "oneuptime.com",
+      "mcpUrl": "https://oneuptime.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/oneuptime.com"
+    },
+    {
+      "domain": "onthebeach.co.uk",
+      "name": "On the Beach Holidays",
+      "mcpUrl": "https://mcp.onthebeach.co.uk/chatgpt/v2",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/onthebeach.co.uk"
+    },
+    {
+      "domain": "openai-mcp-696419881849.us-central1.run.app",
+      "name": "Beautiful.ai",
+      "mcpUrl": "https://openai-mcp-696419881849.us-central1.run.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "beautiful_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.beautiful.ai/provisioning/oauth2",
+          "setup": "Connect through the [Beautiful.ai OAuth provisioning flow](https://www.beautiful.ai/provisioning/oauth2) when your MCP client prompts for authorization. Sign in with your Beautiful.ai account and grant the connector access; the client receives tokens via OAuth 2.0 and the MCP server acts within that user's existing Beautiful.ai permissions.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/openai-mcp-696419881849.us-central1.run.app"
+    },
+    {
+      "domain": "openlens.com",
+      "name": "openlens.com",
+      "mcpUrl": "https://openlens.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "openlens_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/openlens.com"
+    },
+    {
+      "domain": "openobserve.ai",
+      "name": "openobserve.ai",
+      "mcpUrl": "https://api.openobserve.ai/api/default/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oo_basic",
+          "type": "basic",
+          "generateUrl": "https://cloud.openobserve.ai",
+          "setup": "Sign in to your OpenObserve Cloud or self-hosted OpenObserve instance and use your account's user ID/email plus password to build an HTTP Basic `Authorization` header. The API reference says all APIs require an authorization header created from base64-encoded user ID and password using HTTP Basic auth. For hosted Cloud, start from [OpenObserve Cloud login](https://cloud.openobserve.ai).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/openobserve.ai"
+    },
+    {
+      "domain": "openrouter.ai",
+      "name": "openrouter.ai",
+      "mcpUrl": "https://mcp.openrouter.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "openrouter_oauth_pkce_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/openrouter.ai"
+    },
+    {
+      "domain": "openstatus.dev",
+      "name": "openstatus.dev",
+      "mcpUrl": "https://api.openstatus.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "openstatus_api_token",
+          "type": "api_key",
+          "generateUrl": "https://app.openstatus.dev/login",
+          "setup": "Sign in to the [OpenStatus dashboard](https://app.openstatus.dev/login), then create a token from **Settings → API Tokens** as described in the [API tooling page](https://www.openstatus.dev/tooling/api) and [MCP server reference](https://www.openstatus.dev/docs/reference/mcp-server/). Use the resulting token value in the `x-openstatus-key` header for API/MCP calls, or provide it to CLI auth via `openstatus login` or the `OPENSTATUS_API_TOKEN` environment variable.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/openstatus.dev"
+    },
+    {
+      "domain": "opentargets.org",
+      "name": "Open Targets",
+      "mcpUrl": "https://mcp.platform.opentargets.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/opentargets.org"
+    },
+    {
+      "domain": "optionscalc.app",
+      "name": "OptionsCalc",
+      "mcpUrl": "https://api.optionscalc.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/optionscalc.app"
+    },
+    {
+      "domain": "optiversal.com",
+      "name": "Tillys",
+      "mcpUrl": "https://hibbett.mcp.optiversal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/optiversal.com"
+    },
+    {
+      "domain": "orgpolicy.googleapis.com",
+      "name": "orgpolicy.googleapis.com",
+      "mcpUrl": "https://orgpolicy.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/orgpolicy.googleapis.com"
+    },
+    {
+      "domain": "originalvoices.ai",
+      "name": "OriginalVoices",
+      "mcpUrl": "https://api.originalvoices.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ov_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/originalvoices.ai"
+    },
+    {
+      "domain": "ory.sh",
+      "name": "ory.sh",
+      "mcpUrl": "https://ory-docs.mcp.kapa.ai",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ory.sh"
+    },
+    {
+      "domain": "otomoto.pl",
+      "name": "Otomoto",
+      "mcpUrl": "https://www.otomoto.pl/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/otomoto.pl"
+    },
+    {
+      "domain": "otseek.com",
+      "name": "OTseek",
+      "mcpUrl": "https://backend.otseek.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/otseek.com"
+    },
+    {
+      "domain": "otter.ai",
+      "name": "Otter.ai",
+      "mcpUrl": "https://mcp.otter.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "otter_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/otter.ai"
+    },
+    {
+      "domain": "outreach.io",
+      "name": "Outreach",
+      "mcpUrl": "https://api.outreach.io/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/outreach.io"
+    },
+    {
+      "domain": "overstappen.nl",
+      "name": "Overstappen.nl",
+      "mcpUrl": "https://mcp.overstappen.nl/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/overstappen.nl"
+    },
+    {
+      "domain": "ovios-home.com",
+      "name": "ovios-home.com",
+      "mcpUrl": "https://www.ovios-home.com/api/ucp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ovios-home.com"
+    },
+    {
+      "domain": "owkin.com",
+      "name": "Owkin",
+      "mcpUrl": "https://mcp.k.owkin.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/owkin.com"
+    },
+    {
+      "domain": "pacvue.com",
+      "name": "Helium 10",
+      "mcpUrl": "https://h10-mcp-chatgptapps.pacvue.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pacvue.com"
+    },
+    {
+      "domain": "paddle.com",
+      "name": "paddle.com",
+      "mcpUrl": "https://mcp.paddle.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "paddle_api_key",
+          "type": "bearer",
+          "generateUrl": "https://developer.paddle.com/api-reference/about/authentication",
+          "setup": "In your Paddle dashboard, go to [Authentication](https://developer.paddle.com/api-reference/about/authentication) at **Paddle > Developer Tools > Authentication**. Open the **API keys** tab, click **New API key**, choose permissions and an expiry date, save, then copy the key once and store it securely. Use sandbox keys (prefixed `pdl_sdbx_`) for sandbox surfaces and live keys for live surfaces.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/paddle.com"
+    },
+    {
+      "domain": "pagerduty.com",
+      "name": "PagerDuty",
+      "mcpUrl": "https://mcp.pagerduty.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pd_api_token",
+          "type": "api_key",
+          "generateUrl": "https://support.pagerduty.com/docs/using-the-api#section-generating-a-general-access-rest-api-key",
+          "setup": "Create a PagerDuty API token in your account. For account-wide REST access, follow the support guide to generate a general access REST API key at [Generating a General Access REST API Key](https://support.pagerduty.com/docs/using-the-api#section-generating-a-general-access-rest-api-key). The developer auth docs also describe account and user API tokens at [Authentication](https://developer.pagerduty.com/docs/authentication). Send it in the `Authorization` header as `Token token=<API_KEY>` where supported.",
+          "fields": null
+        },
+        {
+          "id": "pd_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developer.pagerduty.com/docs/register-an-app",
+          "setup": "Register a PagerDuty app from [Register an App](https://developer.pagerduty.com/docs/register-an-app). On **Integrations → App Registration**, create a new app and add OAuth functionality. For Classic User OAuth, use the authorization code or PKCE flow described in [OAuth Functionality](https://developer.pagerduty.com/docs/oauth-functionality) and [User OAuth Token via Code Grant](https://developer.pagerduty.com/docs/user-oauth-token-via-code-grant). For Scoped OAuth app-to-account access, use the client credentials flow in [Obtaining an App OAuth Token](https://developer.pagerduty.com/docs/app-oauth-token). This gives you a `client_id` and, for confidential apps, a `client_secret`, which you exchange for bearer access tokens from `https://identity.pagerduty.com/oauth/token`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pagerduty.com"
+    },
+    {
+      "domain": "pandadoc.com",
+      "name": "pandadoc.com",
+      "mcpUrl": "https://mcp.pandadoc.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pd_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/pandadoc.com"
+    },
+    {
+      "domain": "pane.money",
+      "name": "Pane",
+      "mcpUrl": "https://mcp.pane.money",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pane_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.pane.money/register",
+          "setup": "Use an MCP client that supports OAuth 2.0 with dynamic client registration, or register a client at [Pane OAuth registration](https://mcp.pane.money/register) if your client needs its own app credentials. For normal setup, create a Pane account at [Pane signup](https://pane.money/signup), link at least one institution, then connect your MCP client to `https://mcp.pane.money` and complete the OAuth authorization flow when prompted. Supported scopes shown by the authorization server are `mcp:read` and `mcp:write`.",
+          "fields": null
+        },
+        {
+          "id": "pane_api_key",
+          "type": "bearer",
+          "generateUrl": "https://pane.money/",
+          "setup": "Sign in to your [Pane dashboard](https://pane.money/) after creating an account via [Pane signup](https://pane.money/signup). Generate an API key from the dashboard, then use it as a Bearer token with MCP clients that support direct token authentication.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pane.money"
+    },
+    {
+      "domain": "parqet.com",
+      "name": "Parqet",
+      "mcpUrl": "https://mcp.parqet.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "parqet_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://developer.parqet.com/console/integrations",
+          "setup": "Sign in to the [Parqet Developer Console](https://developer.parqet.com/console), open [Integrations](https://developer.parqet.com/console/integrations), and create a new integration. Choose the scopes you need (`portfolio:read` and/or `portfolio:write`) and add your OAuth redirect URLs. Use the resulting `Client ID` in your OAuth 2 authorization code with PKCE flow against `https://connect.parqet.com`. The implementation guide shows the authorize endpoint at `https://connect.parqet.com/oauth2/authorize` and token endpoint at `https://connect.parqet.com/oauth2/token`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/parqet.com"
+    },
+    {
+      "domain": "particl.com",
+      "name": "Particl Market Research",
+      "mcpUrl": "https://mcp.particl.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "particl_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/particl.com"
+    },
+    {
+      "domain": "passby.com",
+      "name": "Almanac by PassBy",
+      "mcpUrl": "https://openai-app.passby.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "passby_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/passby.com"
+    },
+    {
+      "domain": "payabli.com",
+      "name": "payabli.com",
+      "mcpUrl": "https://mcp.inkeep.com/payabli/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/payabli.com"
+    },
+    {
+      "domain": "paypal.com",
+      "name": "PayPal",
+      "mcpUrl": "https://mcp.paypal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "paypal_app_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/paypal.com"
+    },
+    {
+      "domain": "pcexpress.ca",
+      "name": "PC Express",
+      "mcpUrl": "https://api.pcexpress.ca/v1/agents/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pcexpress.ca"
+    },
+    {
+      "domain": "pdfmaker.to",
+      "name": "AnyPDF - Your PDF Converter",
+      "mcpUrl": "https://api.pdfmaker.to/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pdfmaker_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://api.pdfmaker.to/.well-known/oauth-authorization-server",
+          "setup": "Use the service's OAuth 2.0 authorization flow exposed via its authorization server metadata at [OAuth Authorization Server Metadata](https://api.pdfmaker.to/.well-known/oauth-authorization-server). The metadata advertises `authorization_code` with PKCE (`S256`) and a token endpoint. Register or obtain an OAuth client through PDFMaker/AnyPDF's developer flow if provided to you by the service, then authorize against the advertised endpoints to mint access tokens for the MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pdfmaker.to"
+    },
+    {
+      "domain": "peec.ai",
+      "name": "Peec AI",
+      "mcpUrl": "https://api.peec.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "peec_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/peec.ai"
+    },
+    {
+      "domain": "pendo.io",
+      "name": "Pendo Feedback API",
+      "mcpUrl": "https://app.pendo.io/mcp/v0/shttp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pendo_user_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/pendo.io"
+    },
+    {
+      "domain": "people.googleapis.com",
+      "name": "people.googleapis.com",
+      "mcpUrl": "https://people.googleapis.com/mcp/v1",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "google_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://console.cloud.google.com/apis/credentials",
+          "setup": "Create or select a Google Cloud project, enable People API, then configure the OAuth consent screen as described in [Get Ready to Use the People API](https://developers.google.com/people/v1/getting-started) and [Configure OAuth consent](https://developers.google.com/workspace/guides/configure-oauth-consent). In [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials), create an OAuth client ID for your app type, run the user OAuth flow requesting the People API scopes you need, and send the resulting access token to `people.googleapis.com`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/people.googleapis.com"
+    },
+    {
+      "domain": "perplexity.ai",
+      "name": "perplexity.ai",
+      "mcpUrl": "https://www.perplexity.ai/rest/computer/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pplx_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/perplexity.ai"
+    },
+    {
+      "domain": "pga.com",
+      "name": "PGA – Play Golf",
+      "mcpUrl": "https://mcp.pga.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pga.com"
+    },
+    {
+      "domain": "phantombuster.com",
+      "name": "phantombuster.com",
+      "mcpUrl": "https://mcp.phantombuster.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pb_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.phantombuster.com",
+          "setup": "Connect an MCP client to [https://mcp.phantombuster.com](https://mcp.phantombuster.com). On first connection, PhantomBuster redirects you to sign in to your PhantomBuster account and authorize the MCP server, then you choose the workspace to use. The connection is reused by the MCP client afterward: [MCP server docs](https://hub.phantombuster.com/docs/mcp-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/phantombuster.com"
+    },
+    {
+      "domain": "phish.in",
+      "name": "Phish.in",
+      "mcpUrl": "https://phish.in/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/phish.in"
+    },
+    {
+      "domain": "pier-luma.vercel.app",
+      "name": "Pier Seguradora",
+      "mcpUrl": "https://pier-luma.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pier-luma.vercel.app"
+    },
+    {
+      "domain": "pinelabsonline.com",
+      "name": "Pine Labs",
+      "mcpUrl": "https://agentic-commerce.pinelabsonline.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pinelabsonline.com"
+    },
+    {
+      "domain": "pipedream.com",
+      "name": "pipedream.com",
+      "mcpUrl": "https://remote.mcp.pipedream.net/v3",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pd_oauth_client",
+          "type": "oauth2_cc",
+          "generateUrl": "https://pipedream.com/settings/api",
+          "setup": "In your Pipedream workspace, open [API settings](https://pipedream.com/settings/api), click **New OAuth Client**, name the client, and click **Create**. Copy the `client_secret` immediately because it is shown only once, then copy the `client_id` from the client list. The Connect quickstart also provisions these credentials for you when you run [`pd init connect`](https://pipedream.com/docs/connect/quickstart).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pipedream.com"
+    },
+    {
+      "domain": "pitchbook.com",
+      "name": "PitchBook Premium",
+      "mcpUrl": "https://premium.mcp.pitchbook.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/pitchbook.com"
+    },
+    {
+      "domain": "pixelesq.com",
+      "name": "pixelesq.com",
+      "mcpUrl": "https://pixelesq-mcp.pixelesq.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.com"
+    },
+    {
+      "domain": "pixelesq.workers.dev",
+      "name": "Pixelesq",
+      "mcpUrl": "https://pixelesq-mcp.pixelesq.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pixelesq_account_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.pixelesq.ai/",
+          "setup": "Create a Pixelesq account at [Pixelesq app](https://app.pixelesq.ai/). Then in your MCP client (for example Claude), add the connector URL `https://pixelesq-mcp.pixelesq.workers.dev/mcp` and sign in using either Google with the same account linked to Pixelesq, or your Pixelesq email address and the 6-digit verification code sent to your inbox, as described in the [Claude integration docs](https://www.pixelesq.com/docs/integrations/claude).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.workers.dev"
+    },
+    {
+      "domain": "plain.com",
+      "name": "plain.com",
+      "mcpUrl": "https://mcp.plain.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "plain_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/plain.com"
+    },
+    {
+      "domain": "plane.so",
+      "name": "plane.so",
+      "mcpUrl": "https://mcp.plane.so",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "plane_oauth_app",
+          "type": "app",
+          "generateUrl": "https://app.plane.so/<workspace>/settings/integrations/",
+          "setup": "Register an OAuth app in Plane at [Workspace Settings → Integrations](https://app.plane.so/<workspace>/settings/integrations/) by clicking **Build your own**, then fill in your `Setup URL`, `Redirect URI`, `Webhook URL`, and scopes as shown in [Create an OAuth Application](https://developers.plane.so/dev-tools/build-plane-app/create-oauth-application). Save the app and copy the `Client ID` and `Client Secret`. Use this app for either the bot-token (`client_credentials`) flow or the user-token (`authorization_code`) flow described in [Choose token flow](https://developers.plane.so/dev-tools/build-plane-app/choose-token-flow).",
+          "fields": null
+        },
+        {
+          "id": "plane_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.plane.so/<workspace>/settings/integrations/",
+          "setup": "In Plane, go to [Workspace Settings → Integrations](https://app.plane.so/<workspace>/settings/integrations/) and create or manage an API token for the workspace/user as described in the [API authentication docs](https://developers.plane.so/api-reference/introduction) and [MCP server docs](https://developers.plane.so/dev-tools/mcp-server). For MCP header auth or stdio mode, provide the token as `x-api-key` or `PLANE_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/plane.so"
+    },
+    {
+      "domain": "playdeveloperreporting.googleapis.com",
+      "name": "playdeveloperreporting.googleapis.com",
+      "mcpUrl": "https://playdeveloperreporting.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/playdeveloperreporting.googleapis.com"
+    },
+    {
+      "domain": "playdigital.com.ar",
+      "name": "MODO",
+      "mcpUrl": "https://benefits-mcp.playdigital.com.ar/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/playdigital.com.ar"
+    },
+    {
+      "domain": "polar.sh",
+      "name": "polar.sh",
+      "mcpUrl": "https://mcp.polar.sh/mcp/polar-mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "polar_oauth_access_token",
+          "type": "bearer",
+          "generateUrl": "https://polar.sh/docs/integrate/oauth2/connect",
+          "setup": "First create an [OAuth 2.0 client](https://polar.sh/docs/integrate/oauth2/setup). Then send users through the [OAuth 2.0 Connect](https://polar.sh/docs/integrate/oauth2/connect) authorization code flow using `https://polar.sh/oauth2/authorize`, and exchange the returned code at `https://api.polar.sh/v1/oauth2/token`. Polar returns an `access_token` (and usually a `refresh_token`). Use the access token as `Authorization: Bearer <token>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/polar.sh"
+    },
+    {
+      "domain": "policynote.com",
+      "name": "PolicyNote",
+      "mcpUrl": "https://data.policynote.com/v0/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "policynote_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/policynote.com"
+    },
+    {
+      "domain": "policytroubleshooter.googleapis.com",
+      "name": "policytroubleshooter.googleapis.com",
+      "mcpUrl": "https://policytroubleshooter.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/policytroubleshooter.googleapis.com"
+    },
+    {
+      "domain": "port.io",
+      "name": "port.io",
+      "mcpUrl": "https://mcp.port.io",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "port_access_token",
+          "type": "bearer",
+          "generateUrl": "https://app.port.io",
+          "setup": "Generate a short-lived API token from the [Port application](https://app.port.io) via `Credentials` → `Generate API token`, or mint it programmatically by calling `POST https://api.port.io/v1/auth/access_token` (EU) or the US-region equivalent with your `clientId` and `clientSecret` from the same credentials page. The docs state the token is valid for 3 hours.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/port.io"
+    },
+    {
+      "domain": "posthog.com",
+      "name": "PostHog",
+      "mcpUrl": "https://mcp.posthog.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "posthog_oauth_access_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/posthog.com"
+    },
+    {
+      "domain": "postman.co",
+      "name": "postman.co",
+      "mcpUrl": "https://mcp.postman.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "postman_api_key",
+          "type": "api_key",
+          "generateUrl": "https://web.postman.co/settings/me/api-keys",
+          "setup": "Sign in to Postman, open [API Keys](https://web.postman.co/settings/me/api-keys), and create a key. Postman documents this as the credential for the Postman API and for non-interactive Postman CLI login. Store it in a secret or environment variable such as `POSTMAN_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/postman.co"
+    },
+    {
+      "domain": "postman.com",
+      "name": "Postman",
+      "mcpUrl": "https://mcp.postman.com/minimal",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/postman.com"
+    },
+    {
+      "domain": "preply.com",
+      "name": "Preply Language Tutor Finder",
+      "mcpUrl": "https://preply.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/preply.com"
+    },
+    {
+      "domain": "priceline.com",
+      "name": "Priceline",
+      "mcpUrl": "https://mcp.priceline.com/penny-mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/priceline.com"
+    },
+    {
+      "domain": "primitive.dev",
+      "name": "primitive.dev",
+      "mcpUrl": "https://www.primitive.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "primitive_api_key",
+          "type": "api_key",
+          "generateUrl": "https://www.primitive.dev/app/settings/api-keys",
+          "setup": "Create an API key in [Settings → API Keys](https://www.primitive.dev/app/settings/api-keys). For headless agents, you can also mint one with the unauthenticated `POST https://api.primitive.dev/v1/agent/accounts` flow described in [auth.md](https://www.primitive.dev/auth.md). Use the returned `prim_...` value as a Bearer token.",
+          "fields": null
+        },
+        {
+          "id": "primitive_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://www.primitive.dev/oauth/register",
+          "setup": "Register a public client with [OAuth dynamic client registration](https://www.primitive.dev/oauth/register) as described in [Authentication & API Keys](https://docs.primitive.dev/docs/auth). Then run the Authorization Code + PKCE flow against [`/oauth/authorize`](https://www.primitive.dev/oauth/authorize) and [`/oauth/token`](https://www.primitive.dev/oauth/token), or let the CLI do it via `primitive login`. This yields a `prim_oat_...` access token and a refresh token for the authorized organization.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/primitive.dev"
+    },
+    {
+      "domain": "printhiv3d.com",
+      "name": "printhiv3d.com",
+      "mcpUrl": "https://api.printhiv3d.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com"
+    },
+    {
+      "domain": "priority-guard.com",
+      "name": "Priority Guardian",
+      "mcpUrl": "https://pg.priority-guard.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pg_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/priority-guard.com"
+    },
+    {
+      "domain": "prisma.io",
+      "name": "prisma.io",
+      "mcpUrl": "https://mcp.prisma.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "prisma_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://console.prisma.io/",
+          "setup": "In [Prisma Console](https://console.prisma.io/), open **Integrations**, under **Published Applications** click **New Application**, enter the app details and redirect URI, then copy the `Client ID` and `Client Secret`. Prisma's auth server is documented at [Authentication](https://www.prisma.io/docs/management-api/authentication); request scopes such as `workspace:admin` and optionally `offline_access`, then use the resulting bearer access token against the API.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/prisma.io"
+    },
+    {
+      "domain": "prismic.io",
+      "name": "prismic.io",
+      "mcpUrl": "https://mcp.prismic.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "prismic_account_login",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/prismic.io"
+    },
+    {
+      "domain": "privatemdlabs.com",
+      "name": "Private MD Labs",
+      "mcpUrl": "https://chatgpt.privatemdlabs.com/mcp/privatemdlabs/c3e4b1a9-7f2a-4d8e-b6c9-91f4e0a2d5b7",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/privatemdlabs.com"
+    },
+    {
+      "domain": "process.st",
+      "name": "Process Street",
+      "mcpUrl": "https://mcp.process.st",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ps_account_login",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/process.st"
+    },
+    {
+      "domain": "productboard.com",
+      "name": "productboard.com",
+      "mcpUrl": "https://mcp.productboard.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pb_mcp_public_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/productboard.com"
+    },
+    {
+      "domain": "profit.co",
+      "name": "Profit.co",
+      "mcpUrl": "https://integrations.profit.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "profit_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/profit.co"
+    },
+    {
+      "domain": "promptperfect.xyz",
+      "name": "Prompt Perfect",
+      "mcpUrl": "https://chatgpt.promptperfect.xyz/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/promptperfect.xyz"
+    },
+    {
+      "domain": "proofx-mcp.fly.dev",
+      "name": "ProofX",
+      "mcpUrl": "https://proofx-mcp.fly.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "proofx_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://proofx-mcp.fly.dev/oauth/register",
+          "setup": "Register an OAuth client at [dynamic client registration](https://proofx-mcp.fly.dev/oauth/register). The authorization server metadata at [`.well-known/oauth-authorization-server`](https://proofx-mcp.fly.dev/.well-known/oauth-authorization-server) shows `registration_endpoint`, `authorization_endpoint`, and `token_endpoint`. Use the authorization code flow with PKCE (`S256`); the server advertises `token_endpoint_auth_methods_supported` as `none`, so the token exchange is a public-client flow. Request the scopes you need, such as `protect` and/or `verify`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/proofx-mcp.fly.dev"
+    },
+    {
+      "domain": "property24.com",
+      "name": "Property24.com",
+      "mcpUrl": "https://pcm.property24.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "property24_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://www.property24.com/connect/authorize",
+          "setup": "Property24 exposes OAuth/OpenID Connect endpoints at [`/connect/authorize`](https://www.property24.com/connect/authorize) and [`/connect/token`](https://www.property24.com/connect/token). To integrate, obtain/register a client with Property24 so you have a `client_id` (and, for confidential clients, a client secret) and request the needed scopes such as `openid`, `offline_access`, `profile`, `email`, `roles`, `api`, or `phone`. The public docs/search results did not reveal a self-service developer registration page, so client issuance appears to require Property24-provided access.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/property24.com"
+    },
+    {
+      "domain": "pscale.dev",
+      "name": "PlanetScale",
+      "mcpUrl": "https://mcp.pscale.dev/mcp/planetscale",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ps_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "To create an OAuth app, log into your PlanetScale organization and open **Settings → OAuth applications** as described in the [OAuth docs](https://planetscale.com/docs/api/reference/oauth). Click **Create new application**, fill in the app name, domain, and redirect URI, then save it. Copy the app **ID**, **Client ID**, **Redirect URL**, and **Client secret** when shown; the client secret is only shown once. Select the access scopes your integration needs.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pscale.dev"
+    },
+    {
+      "domain": "pubnub.com",
+      "name": "pubnub.com",
+      "mcpUrl": "https://mcp.pubnub.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pubnub_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.pubnub.com",
+          "setup": "Use an MCP client that supports remote MCP OAuth and add the hosted server at `https://mcp.pubnub.com`. During setup, the client opens PubNub's authorization flow, where you select the organization to authorize, review permissions, and click **Allow access**. PubNub documents this flow on the [PubNub MCP server page](https://www.pubnub.com/docs/ai/pubnub-mcp-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pubnub.com"
+    },
+    {
+      "domain": "pubsub.googleapis.com",
+      "name": "pubsub.googleapis.com",
+      "mcpUrl": "https://pubsub.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/pubsub.googleapis.com"
+    },
+    {
+      "domain": "pulumi.com",
+      "name": "pulumi.com",
+      "mcpUrl": "https://mcp.ai.pulumi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pulumi_access_token",
+          "type": "bearer",
+          "generateUrl": "https://app.pulumi.com/account/tokens",
+          "setup": "Create an access token in the Pulumi Cloud account settings at [Access Tokens](https://app.pulumi.com/account/tokens) or follow the admin guide at [Pulumi Cloud: Access Tokens](https://www.pulumi.com/docs/administration/access-identity/access-tokens/). You can then provide it to tools as `PULUMI_ACCESS_TOKEN`, use `pulumi login` to store it for the CLI, or send it to HTTP APIs in the `Authorization` header as `token <value>` where documented.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pulumi.com"
+    },
+    {
+      "domain": "pumadb.ai",
+      "name": "pumadb.ai",
+      "mcpUrl": "https://api.pumadb.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pumadb_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://api.pumadb.ai/oauth/register",
+          "setup": "For hosted MCP, use a client that supports OAuth discovery and dynamic client registration against the pumaDB MCP server, such as the flows described in the [install guide](https://api.pumadb.ai/install) and [how-to-use guide](https://api.pumadb.ai/how-to-use). The server advertises OAuth discovery and supports dynamic client registration at [OAuth client registration](https://api.pumadb.ai/oauth/register); MCP clients can leave client fields blank and choose dynamic OAuth. The documented scope is `pumadb`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pumadb.ai"
+    },
+    {
+      "domain": "pyxl.pro",
+      "name": "Code Tytor: Python",
+      "mcpUrl": "https://www.pyxl.pro/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pyxl_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://www.pyxl.pro/api/mcp/oauth/register",
+          "setup": "Register an OAuth client against Pyxl's dynamic client registration endpoint `https://www.pyxl.pro/api/mcp/oauth/register`, then run the OAuth authorization-code flow against `https://www.pyxl.pro/api/mcp/oauth/authorize` and `https://www.pyxl.pro/api/mcp/oauth/token`. Pyxl's authorization server metadata at [oauth-authorization-server](https://www.pyxl.pro/api/mcp/.well-known/oauth-authorization-server) shows `token_endpoint_auth_methods_supported` is `none`, so clients use PKCE (`S256`) and do not need a client secret. Supported scopes there include `images:read`, `images:write`, and `user:read`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/pyxl.pro"
+    },
+    {
+      "domain": "qovery.com",
+      "name": "qovery.com",
+      "mcpUrl": "https://mcp.qovery.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "qovery_cli_login",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/qovery.com"
+    },
+    {
+      "domain": "quartr.com",
+      "name": "Quartr",
+      "mcpUrl": "https://mcp.quartr.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "quartr_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/quartr.com"
+    },
+    {
+      "domain": "quicknode.com",
+      "name": "Quicknode",
+      "mcpUrl": "https://mcp.quicknode.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "qn_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.quicknode.com/signup",
+          "setup": "Create a Quicknode account at [Sign up](https://www.quicknode.com/signup), then connect from an MCP client such as Claude, ChatGPT, Codex, Cursor, or VS Code as described in [Quicknode MCP](https://www.quicknode.com/docs/build-with-ai/quicknode-mcp). On first connection, the MCP client opens a browser to log in to Quicknode and approve access.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/quicknode.com"
+    },
+    {
+      "domain": "quintoandar.com.br",
+      "name": "QuintoAndar",
+      "mcpUrl": "https://external-mcp-service.quintoandar.com.br/mcp-server/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/quintoandar.com.br"
+    },
+    {
+      "domain": "quiver.ai",
+      "name": "quiver.ai",
+      "mcpUrl": "https://app.quiver.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "quiver_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use an MCP client that supports remote MCP servers and OAuth, add the QuiverAI MCP endpoint `https://app.quiver.ai/mcp`, then start the client’s login flow. The client begins the OAuth flow, you sign in with your QuiverAI account and approve access, and the client receives a token scoped to your account automatically. Examples in the docs include `codex mcp login quiverai`, Claude Code’s `/mcp`, and Cursor’s MCP UI after adding the server from [MCP server docs](https://docs.quiver.ai/app/mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/quiver.ai"
+    },
+    {
+      "domain": "quizlet.com",
+      "name": "Quizlet",
+      "mcpUrl": "https://api.quizlet.com/v4/partner/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "quizlet_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://quizlet.com/oauth/authorize",
+          "setup": "Quizlet exposes OAuth endpoints at [authorize](https://quizlet.com/oauth/authorize) and token endpoint `https://quizlet.com/oauth/token`. The authorize page confirms a `client_id` is required. Public docs for self-service app registration were not found, so acquisition details beyond using a Quizlet-issued OAuth client are not documented in the pages reviewed. The catalog indicates the `write_set` scope exists.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/quizlet.com"
+    },
+    {
+      "domain": "quo.com",
+      "name": "Quo",
+      "mcpUrl": "https://mcp.quo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "quo_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/quo.com"
+    },
+    {
+      "domain": "quotecraft-ai-zeta.vercel.app",
+      "name": "QuoteCraft AI",
+      "mcpUrl": "https://quotecraft-ai-zeta.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/quotecraft-ai-zeta.vercel.app"
+    },
+    {
+      "domain": "ramp.com",
+      "name": "Ramp",
+      "mcpUrl": "https://ramp-mcp-remote.ramp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ramp_user_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/ramp.com"
+    },
+    {
+      "domain": "raptive.com",
+      "name": "Raptive Food",
+      "mcpUrl": "https://chatgpt-recipe-app.production.raptive.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/raptive.com"
+    },
+    {
+      "domain": "ray-arceneaux-ai-agentic.replit.app",
+      "name": "Ray Arceneaux",
+      "mcpUrl": "https://ray-arceneaux-ai-agentic.replit.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ray-arceneaux-ai-agentic.replit.app"
+    },
+    {
+      "domain": "razorpay.com",
+      "name": "Razorpay",
+      "mcpUrl": "https://mcp.razorpay.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "rzp_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.razorpay.com/register",
+          "setup": "Register an OAuth client for the Razorpay MCP server using Dynamic Client Registration at [`/register`](https://mcp.razorpay.com/register), or request manual registration from the [Razorpay Support Team](mailto:n8n-node-support@razorpay.com). The MCP OAuth server advertises `authorization_code`, `client_credentials`, and `refresh_token` grants with scope `read_only` at the [well-known authorization server metadata](https://mcp.razorpay.com/.well-known/oauth-authorization-server).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/razorpay.com"
+    },
+    {
+      "domain": "rbi.digital",
+      "name": "Tim Hortons",
+      "mcpUrl": "https://th-chatgpt.rbi.digital/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/rbi.digital"
+    },
+    {
+      "domain": "rbictg.com",
+      "name": "Popeyes",
+      "mcpUrl": "https://use1-prod-bk-chatgpt-app.rbictg.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/rbictg.com"
+    },
+    {
+      "domain": "read.ai",
+      "name": "Read AI",
+      "mcpUrl": "https://api.read.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "read_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/read.ai"
+    },
+    {
+      "domain": "readwise.io",
+      "name": "Readwise",
+      "mcpUrl": "https://mcp2.readwise.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "readwise_oauth_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/readwise.io"
+    },
+    {
+      "domain": "reagent.travel",
+      "name": "Reagent Travel",
+      "mcpUrl": "https://app.reagent.travel/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/reagent.travel"
+    },
+    {
+      "domain": "realestate.com.au",
+      "name": "realestate.com.au",
+      "mcpUrl": "https://chatestate.realestate.com.au/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/realestate.com.au"
+    },
+    {
+      "domain": "reclaim.ai",
+      "name": "Reclaim.ai",
+      "mcpUrl": "https://mcp.reclaim.ai/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "reclaim_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.reclaim.ai/login",
+          "setup": "Open Reclaim from the client that supports it and complete the Reclaim sign-in and consent flow. For ChatGPT, the public instructions are on [Manage Your Calendar from ChatGPT](https://reclaim.ai/integrations/chatgpt): in ChatGPT go to **Settings → Apps**, search for Reclaim.ai, click **Connect**, then complete the Reclaim OAuth flow and approve access. For MCP clients, connect to the server URL and follow the server's OAuth flow.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/reclaim.ai"
+    },
+    {
+      "domain": "recommender.googleapis.com",
+      "name": "recommender.googleapis.com",
+      "mcpUrl": "https://recommender.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/recommender.googleapis.com"
+    },
+    {
+      "domain": "redbus.com",
+      "name": "redBus",
+      "mcpUrl": "https://www.redbus.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/redbus.com"
+    },
+    {
+      "domain": "redis.googleapis.com",
+      "name": "redis.googleapis.com",
+      "mcpUrl": "https://redis.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/redis.googleapis.com"
+    },
+    {
+      "domain": "redocly.com",
+      "name": "redocly.com",
+      "mcpUrl": "https://redocly.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/redocly.com"
+    },
+    {
+      "domain": "redoxengine.com",
+      "name": "redoxengine.com",
+      "mcpUrl": "https://api.redoxengine.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/redoxengine.com"
+    },
+    {
+      "domain": "reducto.ai",
+      "name": "reducto.ai",
+      "mcpUrl": "https://mcp.reducto.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "reducto_api_key",
+          "type": "bearer",
+          "generateUrl": "https://studio.reducto.ai/api-keys",
+          "setup": "Create an account in [Reducto Studio](https://studio.reducto.ai/), then open [API Keys](https://studio.reducto.ai/api-keys) in the Studio sidebar and click **Create new API key**. Copy the key and store it in `REDUCTO_API_KEY` for SDKs, CLI/MCP env-based auth, or send it as `Authorization: Bearer <token>` for direct HTTP or hosted MCP requests.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/reducto.ai"
+    },
+    {
+      "domain": "refiner.io",
+      "name": "Refiner",
+      "mcpUrl": "https://app.refiner.io/v001/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "refiner_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.refiner.io/",
+          "setup": "Connect from an MCP client that supports OAuth against Refiner's MCP endpoint `https://app.refiner.io/v001/mcp`. Refiner's integration guides for [ChatGPT](https://refiner.io/docs/kb/integrations/chatgpt-integration/) and [Claude](https://refiner.io/docs/kb/integrations/claude-integration/) describe connecting Refiner via its MCP server, and the catalog fact for the MCP endpoint indicates `OAUTH`. Use the client's built-in OAuth connect flow to authorize your Refiner account.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/refiner.io"
+    },
+    {
+      "domain": "releases.sh",
+      "name": "releases.sh",
+      "mcpUrl": "https://mcp.releases.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/releases.sh"
+    },
+    {
+      "domain": "remote.com",
+      "name": "remote.com",
+      "mcpUrl": "https://mcp.remote.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "remote_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/remote.com"
+    },
+    {
+      "domain": "render.com",
+      "name": "render.com",
+      "mcpUrl": "https://mcp.render.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "render_api_key",
+          "type": "bearer",
+          "generateUrl": "https://dashboard.render.com/u/settings?add-api-key",
+          "setup": "Create an API key from the [Render Dashboard Account Settings](https://dashboard.render.com/u/settings?add-api-key). The API docs state that all Render API requests use an `Authorization: Bearer <API_KEY>` header, and the CLI docs note the CLI can authenticate via API key. Treat the key as a secret and revoke/regenerate it from the same settings page if needed.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/render.com"
+    },
+    {
+      "domain": "rentcast.io",
+      "name": "rentcast.io",
+      "mcpUrl": "https://developers.rentcast.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "rentcast_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.rentcast.io/app/api",
+          "setup": "Sign in or create an account from the [RentCast API dashboard](https://app.rentcast.io/app/api), choose an API billing plan, then click **Create API Key** on the dashboard. RentCast says API keys are created, viewed, and deleted from that dashboard and are used to authenticate all API requests.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/rentcast.io"
+    },
+    {
+      "domain": "replit-mcp.com",
+      "name": "Replit",
+      "mcpUrl": "https://replit-mcp.com/server/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "replit_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/replit-mcp.com"
+    },
+    {
+      "domain": "replit.com",
+      "name": "replit.com",
+      "mcpUrl": "https://replit-mcp.com/server/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "replit_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/replit.com"
+    },
+    {
+      "domain": "researchsolutions.com",
+      "name": "researchsolutions.com",
+      "mcpUrl": "https://mcp.articlegalaxy.com/ag/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ag_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/researchsolutions.com"
+    },
+    {
+      "domain": "resend.com",
+      "name": "resend.com",
+      "mcpUrl": "https://mcp.resend.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "resend_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/resend.com"
+    },
+    {
+      "domain": "retellai.com",
+      "name": "Retell AI",
+      "mcpUrl": "https://chatgpt-app.retellai.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "retell_api_key",
+          "type": "api_key",
+          "generateUrl": "https://dashboard.retellai.com",
+          "setup": "In the [Retell dashboard](https://dashboard.retellai.com), open the **API Keys** tab to create or copy a workspace API key. The docs say API keys authenticate Retell REST API requests, SDK integrations, and MCP usage, and REST requests send it as `Authorization: Bearer YOUR_API_KEY`. Manage scopes from [Manage API keys and permission scopes](https://docs.retellai.com/accounts/manage-api-keys).",
+          "fields": null
+        },
+        {
+          "id": "retell_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://chatgpt-app.retellai.com/mcp",
+          "setup": "Connect your MCP client to Retell's hosted MCP server at [Retell MCP server docs](https://docs.retellai.com/get-started/mcp-server). The curated registry marks the MCP endpoint as OAuth-enabled. In OAuth-capable MCP clients, add the server endpoint and complete the Retell sign-in/consent flow when prompted. Retell's docs also describe API-key-based MCP auth for other clients.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/retellai.com"
+    },
+    {
+      "domain": "rillet.com",
+      "name": "Rillet",
+      "mcpUrl": "https://api.rillet.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "rillet_oauth_user",
+          "type": "oauth2",
+          "generateUrl": "https://api.rillet.com/mcp",
+          "setup": "In an MCP client such as Claude Desktop, open the connector directory, add `Rillet`, and complete the browser authorization flow where you select your organization and click `Allow access`, as described in the [MCP setup guide](https://docs.api.rillet.com/docs/mcp). The client obtains and stores the OAuth tokens for the remote MCP connection.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/rillet.com"
+    },
+    {
+      "domain": "roadops.app",
+      "name": "RoadOps",
+      "mcpUrl": "https://api.roadops.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "roadops_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://support.roadops.app",
+          "setup": "RoadOps exposes an MCP server at `https://api.roadops.app/mcp` and registry metadata says it uses OAuth. RoadOps does not publish public developer setup docs that we could find, so the acquisition path is not documented publicly. Start from [RoadOps support](https://support.roadops.app) or contact `support@roadops.app` to request developer/OAuth access for the MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/roadops.app"
+    },
+    {
+      "domain": "rome2rio.com",
+      "name": "Rome2Rio",
+      "mcpUrl": "https://chatgpt-app.rome2rio.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/rome2rio.com"
+    },
+    {
+      "domain": "rootly.com",
+      "name": "rootly.com",
+      "mcpUrl": "https://mcp.rootly.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "rootly_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/rootly.com"
+    },
+    {
+      "domain": "run.googleapis.com",
+      "name": "run.googleapis.com",
+      "mcpUrl": "https://run.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/run.googleapis.com"
+    },
+    {
+      "domain": "runorion.com",
+      "name": "Orion by Gravity",
+      "mcpUrl": "https://g.runorion.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "orion_account",
+          "type": "oauth2",
+          "generateUrl": "https://docs.runorion.com/mcp/setup",
+          "setup": "Have an Orion account, then connect from your MCP client and choose **Authenticate**. The docs show the easiest path in [MCP Setup](https://docs.runorion.com/mcp/setup): for Claude Code, run `claude mcp add orion --transport http https://g.runorion.com/mcp`, open `/mcp`, select **orion**, choose **Authenticate**, and sign in with your Orion credentials in the browser. Claude Desktop and Cursor similarly prompt you to authenticate with Orion after adding the connector/server. If you do not yet have access, you need an Orion account for your organization.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/runorion.com"
+    },
+    {
+      "domain": "runready.dev",
+      "name": "RunReady",
+      "mcpUrl": "https://runready.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/runready.dev"
+    },
+    {
+      "domain": "sadhguru.org",
+      "name": "Miracle Of Mind",
+      "mcpUrl": "https://miracle-mcp.sadhguru.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sadhguru.org"
+    },
+    {
+      "domain": "saleor.io",
+      "name": "saleor.io",
+      "mcpUrl": "https://mcp.saleor.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "saleor_app_token",
+          "type": "bearer",
+          "generateUrl": "https://docs.saleor.io/quickstart/api",
+          "setup": "In your Saleor Dashboard, go to **Extensions → Add extension → Provide details manually**, give the app a name, assign the required permissions, and copy the generated token. The [API Walkthrough](https://docs.saleor.io/quickstart/api) and [Saleor MCP blog post](https://saleor.io/blog/saleor-mcp) describe this flow.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/saleor.io"
+    },
+    {
+      "domain": "saleseq.ai",
+      "name": "SalesEQ",
+      "mcpUrl": "https://mcp.saleseq.ai",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "saleseq_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/saleseq.ai"
+    },
+    {
+      "domain": "samrum.io",
+      "name": "SAMRUM",
+      "mcpUrl": "https://mcp.samrum.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "samrum_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/samrum.io"
+    },
+    {
+      "domain": "sanity.io",
+      "name": "Sanity",
+      "mcpUrl": "https://mcp.sanity.io",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sanity_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sanity.io"
+    },
+    {
+      "domain": "savecraft.gg",
+      "name": "Savecraft",
+      "mcpUrl": "https://mcp.savecraft.gg",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "savecraft_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/savecraft.gg"
+    },
+    {
+      "domain": "scalar.com",
+      "name": "scalar.com",
+      "mcpUrl": "https://scalar.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/scalar.com"
+    },
+    {
+      "domain": "scholargateway.ai",
+      "name": "Scholar Gateway",
+      "mcpUrl": "https://connector.scholargateway.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sg_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/scholargateway.ai"
+    },
+    {
+      "domain": "scholarxiv.com",
+      "name": "scholarxiv.com",
+      "mcpUrl": "https://www.scholarxiv.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "scholarxiv_api_key",
+          "type": "api_key",
+          "generateUrl": "https://scholarxiv.com/developers/dashboard/apikeys",
+          "setup": "Log in at [ScholarXIV](https://scholarxiv.com/), open the [Developer Dashboard](https://scholarxiv.com/developers/dashboard), then go to [API Keys](https://scholarxiv.com/developers/dashboard/apikeys) and click **Create API Key**. Name the key, choose an expiration, create it, and copy it immediately; the raw key is shown only once. Keys start with `sxv_`. Store it in an environment variable such as `SCHOLARXIV_API_KEY`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/scholarxiv.com"
+    },
+    {
+      "domain": "scite.ai",
+      "name": "Scite",
+      "mcpUrl": "https://api.scite.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "scite_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/scite.ai"
+    },
+    {
+      "domain": "scrapfly.io",
+      "name": "scrapfly.io",
+      "mcpUrl": "https://mcp.scrapfly.io",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "scrapfly_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.scrapfly.io/oauth/mcp/register",
+          "setup": "For MCP clients that use OAuth, register or let the client dynamically register against Scrapfly's MCP OAuth server at [dynamic client registration](https://mcp.scrapfly.io/oauth/mcp/register), then complete the OAuth flow against [authorize](https://mcp.scrapfly.io/oauth/mcp/authorize) and [token](https://mcp.scrapfly.io/oauth/mcp/token). The detected scope is `scrapfly-mcp`. Many MCP clients can do this automatically from the server's well-known metadata.",
+          "fields": null
+        },
+        {
+          "id": "scrapfly_api_key",
+          "type": "api_key",
+          "generateUrl": "https://scrapfly.io/dashboard",
+          "setup": "Sign up or sign in at [Scrapfly](https://scrapfly.io/register), then open the [dashboard](https://scrapfly.io/dashboard) and copy your project API key. The public `llms.txt` says keys are project-scoped and can be sent either as the canonical `key` query parameter or the `X-Scrapfly-Api-Key` header.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/scrapfly.io"
+    },
+    {
+      "domain": "scrapingbee.com",
+      "name": "scrapingbee.com",
+      "mcpUrl": "https://mcp.scrapingbee.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "scrapingbee_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.scrapingbee.com/account/manage/api_key",
+          "setup": "Sign in to the [ScrapingBee dashboard](https://dashboard.scrapingbee.com/account/login), then open the [API key page](https://app.scrapingbee.com/account/manage/api_key) to copy your key. You can also create an account from [Sign Up](https://dashboard.scrapingbee.com/account/register) if you do not have one yet.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/scrapingbee.com"
+    },
+    {
+      "domain": "scrimba.com",
+      "name": "Scrimba",
+      "mcpUrl": "https://scrimba.com/mcp/v2",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/scrimba.com"
+    },
+    {
+      "domain": "searchconsole.googleapis.com",
+      "name": "searchconsole.googleapis.com",
+      "mcpUrl": "https://searchconsole.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/searchconsole.googleapis.com"
+    },
+    {
+      "domain": "seatpin.com",
+      "name": "Seatpin",
+      "mcpUrl": "https://www.seatpin.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/seatpin.com"
+    },
+    {
+      "domain": "seatunique.com",
+      "name": "Seat Unique",
+      "mcpUrl": "https://chatgpt-app.seatunique.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/seatunique.com"
+    },
+    {
+      "domain": "securelend.ai",
+      "name": "SecureLend",
+      "mcpUrl": "https://agents.securelend.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "agents_human_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://agents.securelend.ai",
+          "setup": "Create or sign in to your SecureLend account at [agents.securelend.ai](https://agents.securelend.ai). For MCP clients like Claude or ChatGPT developer mode, add the MCP endpoint and let the client complete the browser OAuth flow using the discovery document at [agents.securelend.ai OAuth discovery](https://agents.securelend.ai/.well-known/oauth-authorization-server).",
+          "fields": null
+        },
+        {
+          "id": "agents_m2m_client",
+          "type": "oauth2_cc",
+          "generateUrl": "https://agents.securelend.ai/oauth/m2m/register",
+          "setup": "Register an M2M client by POSTing to [SecureLend Agents M2M registration](https://agents.securelend.ai/oauth/m2m/register) (the docs show the same flow on the dev host as well). The response returns a permanent `client_id` and `client_secret`; exchange them at `https://agents.securelend.ai/oauth/token` for a bearer token with the MCP access scope before calling the MCP server. See [AI Agents Authentication](https://docs.securelend.ai/agents/authentication).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/securelend.ai"
+    },
+    {
+      "domain": "seekist.ai",
+      "name": "Zen Shopping",
+      "mcpUrl": "https://seekist.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/seekist.ai"
+    },
+    {
+      "domain": "semaphoreci.com",
+      "name": "semaphoreci.com",
+      "mcpUrl": "https://mcp.semaphoreci.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://docs.semaphore.io/using-semaphore/ai/mcp-server",
+          "setup": "For MCP clients that support remote MCP OAuth, add the MCP server URL `https://mcp.semaphoreci.com/mcp` in your client and start the sign-in flow. Semaphore says OAuth-capable clients use discovery and dynamic client registration automatically; browser sign-in and consent grant access. If the feature is not enabled for your org, request MCP access per the [MCP Server docs](https://docs.semaphore.io/using-semaphore/ai/mcp-server).",
+          "fields": null
+        },
+        {
+          "id": "api_token",
+          "type": "bearer",
+          "generateUrl": "https://me.semaphoreci.com/account",
+          "setup": "Get your token from your Semaphore account profile. In the web app, open your user menu, choose **Profile settings**, and under **API Token** use **Reset API Token** to mint a new one, or visit your [Semaphore account page](https://me.semaphoreci.com/account). The same token is used for the REST API, `sem`, `sem-ai`, and MCP token auth.",
+          "fields": null
+        },
+        {
+          "id": "service_account_token",
+          "type": "bearer",
+          "generateUrl": "https://docs.semaphore.io/using-semaphore/service-accounts",
+          "setup": "Service accounts must be enabled for your organization; request access via [Service Accounts](https://docs.semaphore.io/using-semaphore/service-accounts). Then in Semaphore open the organization **People** page, choose **Create Service Account**, assign a role, create it, and copy the token when shown. Service account tokens can only be viewed once and are used the same way as user API tokens.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/semaphoreci.com"
+    },
+    {
+      "domain": "semrush.com",
+      "name": "Semrush",
+      "mcpUrl": "https://mcp.semrush.com/openai/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "semrush_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/semrush.com"
+    },
+    {
+      "domain": "send.co",
+      "name": "Send",
+      "mcpUrl": "https://www.send.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "send_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/send.co"
+    },
+    {
+      "domain": "sentry.io",
+      "name": "sentry-cli",
+      "mcpUrl": "https://mcp.sentry.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sentry_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sentry.io"
+    },
+    {
+      "domain": "sephora.com",
+      "name": "SEPHORA",
+      "mcpUrl": "https://www.sephora.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sephora_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.sephora.com/mcp",
+          "setup": "Connect an MCP client to `https://www.sephora.com/mcp` and complete the server's OAuth flow when prompted. The OpenAI registry reports this MCP server uses OAuth; the token is then used by the MCP client for subsequent calls to the server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sephora.com"
+    },
+    {
+      "domain": "serpapi.com",
+      "name": "serpapi.com",
+      "mcpUrl": "https://mcp.serpapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "serpapi_api_key",
+          "type": "api_key",
+          "generateUrl": "https://serpapi.com/manage-api-key",
+          "setup": "Create an account via [Sign up](https://serpapi.com/users/sign_up), then get your key from the [API key page](https://serpapi.com/manage-api-key) or [dashboard](https://serpapi.com/dashboard). SerpApi docs explicitly say you can find your API key on the dashboard and use it with the API, MCP server, or CLI.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/serpapi.com"
+    },
+    {
+      "domain": "serpstat.com",
+      "name": "Serpstat",
+      "mcpUrl": "https://mcp.serpstat.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "serpstat_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/serpstat.com"
+    },
+    {
+      "domain": "setu.co",
+      "name": "Setu Bharat Connect BillPay",
+      "mcpUrl": "https://billpay-mcp.setu.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "setu_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/setu.co"
+    },
+    {
+      "domain": "sftapi.com",
+      "name": "Softonic",
+      "mcpUrl": "https://softonic-mcp-server-v1.sft.product-europe.sftapi.com/mcp/demo",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sftapi.com"
+    },
+    {
+      "domain": "share.eu",
+      "name": "share.eu",
+      "mcpUrl": "https://share-gmbh.myshopify.com/api/ucp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/share.eu"
+    },
+    {
+      "domain": "shazam.com",
+      "name": "Shazam",
+      "mcpUrl": "https://www.shazam.com/mcp?auth=92807691",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shazam.com"
+    },
+    {
+      "domain": "shippo.com",
+      "name": "Shippo hosted MCP server",
+      "mcpUrl": "https://mcp.shippo.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "shippo_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://goshippo.com/oauth/clients",
+          "setup": "Register an OAuth client with Shippo at the dynamic client registration endpoint [Shippo OAuth client registration](https://goshippo.com/oauth/clients). Then connect an MCP-compatible client to `https://mcp.shippo.com`; on first use the client opens Shippo sign-in/consent using the OAuth endpoints documented by automated probes: authorize at `https://goshippo.com/oauth/authorize` and token at `https://goshippo.com/oauth/access_token`. For simple end-user setup, Shippo's MCP docs say to add the hosted server and sign in with your Shippo account; no API key is configured for the hosted server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shippo.com"
+    },
+    {
+      "domain": "shipt.com",
+      "name": "Shipt",
+      "mcpUrl": "https://member-api.shipt.com/marketplace-mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shipt.com"
+    },
+    {
+      "domain": "shop.app",
+      "name": "Shop",
+      "mcpUrl": "https://shop.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/shop.app"
+    },
+    {
+      "domain": "shopback.com",
+      "name": "ShopBack",
+      "mcpUrl": "https://connect.shopback.com/shopbackgpt/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shopback.com"
+    },
+    {
+      "domain": "shopee.com",
+      "name": "Shopee",
+      "mcpUrl": "https://mcp.shopee.com/openai/v1",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "shopee_shop_access_token",
+          "type": "oauth2",
+          "generateUrl": "https://open.shopee.com/developer-guide/20",
+          "setup": "After creating a Partner App in the [Shopee Open Platform](https://open.shopee.com/), send the seller through Shopee's authorization flow described in [The authorization process](https://open.shopee.com/developer-guide/20). Then exchange the returned authorization `code` with the documented token API in [v2.public.get_access_token](https://open.shopee.com/documents/v2/v2.public.get_access_token?module=104&type=1). Refresh it with [v2.public.refresh_access_token](https://open.shopee.com/documents/v2/v2.public.refresh_access_token?module=104&type=1) when needed.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shopee.com"
+    },
+    {
+      "domain": "shoppingcontent.googleapis.com",
+      "name": "shoppingcontent.googleapis.com",
+      "mcpUrl": "https://shoppingcontent.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/shoppingcontent.googleapis.com"
+    },
+    {
+      "domain": "shortcut.com",
+      "name": "shortcut.com",
+      "mcpUrl": "https://mcp.shortcut.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "shortcut_oauth_account",
+          "type": "oauth2",
+          "generateUrl": "https://help.shortcut.com/hc/en-us/articles/36443434285844-MCP-Server",
+          "setup": "Use an MCP client that supports remote MCP OAuth, then add the hosted Shortcut MCP server URL `https://mcp.shortcut.com/mcp` as described in the [MCP Server](https://help.shortcut.com/hc/en-us/articles/36443434285844-MCP-Server) help article. On first use, the client prompts you to authorize with your Shortcut account; no API token or local setup is required for the hosted server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shortcut.com"
+    },
+    {
+      "domain": "shuftipro.com",
+      "name": "shuftipro.com",
+      "mcpUrl": "https://shuftipro.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "shufti_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/shuftipro.com"
+    },
+    {
+      "domain": "shutterstock.com",
+      "name": "Shutterstock API Explorer",
+      "mcpUrl": "https://www.shutterstock.com/gciq/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/shutterstock.com"
+    },
+    {
+      "domain": "sider.ai",
+      "name": "Sider Recorder & Transcriber",
+      "mcpUrl": "https://knowledge-graph.chatgptapps.sider.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sider_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Open one of Sider's MCP apps in ChatGPT or another MCP client that supports OAuth and follow the Sider sign-in/consent flow when prompted. The MCP endpoints are on `*.chatgptapps.sider.ai`; OAuth discovery is expected from the server's standard MCP/OAuth metadata for that host. I could not find a standalone developer console or app-registration page on [sider.ai](https://sider.ai/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sider.ai"
+    },
+    {
+      "domain": "sierra.chat",
+      "name": "Remitly",
+      "mcpUrl": "https://api.sierra.chat/chat/EjQq6tcBmBR3J0kBmyP2dwIhGdGDuOpdcINADkeE94Q/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sierra.chat"
+    },
+    {
+      "domain": "sigmacomputing.com",
+      "name": "sigmacomputing.com",
+      "mcpUrl": "https://help.sigmacomputing.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sigmacomputing.com"
+    },
+    {
+      "domain": "signnow.com",
+      "name": "SignNow",
+      "mcpUrl": "https://mcp-server.signnow.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "signnow_oauth_access_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/signnow.com"
+    },
+    {
+      "domain": "similarweb.com",
+      "name": "Similarweb",
+      "mcpUrl": "https://mcp.similarweb.com",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/similarweb.com"
+    },
+    {
+      "domain": "simply-family-budget.com",
+      "name": "Simply Family Budget",
+      "mcpUrl": "https://mcp.simply-family-budget.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/simply-family-budget.com"
+    },
+    {
+      "domain": "simplybusiness.com",
+      "name": "Simply Business",
+      "mcpUrl": "https://ts-mcp.simplybusiness.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/simplybusiness.com"
+    },
+    {
+      "domain": "simsurf.com",
+      "name": "Simsurf",
+      "mcpUrl": "https://ai.simsurf.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/simsurf.com"
+    },
+    {
+      "domain": "sketchup.com",
+      "name": "Trimble SketchUp",
+      "mcpUrl": "https://api.sketchup.com/mcp/v1/sketchup/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "trimble_bearer",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sketchup.com"
+    },
+    {
+      "domain": "skipcalls.com",
+      "name": "skipcalls.com",
+      "mcpUrl": "https://be.skipcalls.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "skipcalls_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.skipcalls.com",
+          "setup": "Create a SkipCalls account in the [web app](https://app.skipcalls.com) or mobile app and complete onboarding. For MCP clients, add the SkipCalls MCP server URL `https://be.skipcalls.com/mcp`; on first use the client opens a browser for SkipCalls OAuth consent, after which the MCP tools are connected automatically.",
+          "fields": null
+        },
+        {
+          "id": "skipcalls_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.skipcalls.com/integration",
+          "setup": "Sign in to the [SkipCalls web dashboard](https://app.skipcalls.com) or mobile app, then go to Integrations / API Keys (the AI agents guide says **Settings → Integrations → Copy API key**; the agent API guide says **Integrations → API Keys**). Copy the generated key and use it as a Bearer token in `Authorization` headers.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/skipcalls.com"
+    },
+    {
+      "domain": "skyscanner.net",
+      "name": "Skyscanner",
+      "mcpUrl": "https://partners.api.skyscanner.net/b2b-mcp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/skyscanner.net"
+    },
+    {
+      "domain": "skywatch.ai",
+      "name": "SkyWatch.ai",
+      "mcpUrl": "https://api.skywatch.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.ai"
+    },
+    {
+      "domain": "skywatch.co",
+      "name": "SkyWatch",
+      "mcpUrl": "https://api.skywatch.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.co"
+    },
+    {
+      "domain": "skywatch.com",
+      "name": "skywatch.com",
+      "mcpUrl": "https://api.skywatch.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.com"
+    },
+    {
+      "domain": "slack.com",
+      "name": "slack.com – openai",
+      "mcpUrl": "https://mcp.slack.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "slack_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://api.slack.com/apps",
+          "setup": "Create an app in [Your Apps](https://api.slack.com/apps), configure the scopes your integration needs under OAuth & Permissions, then install the app to a workspace or Enterprise org to obtain Slack access tokens. For Slack's standard install flow, follow [Installing with OAuth](https://api.slack.com/authentication/oauth-v2); the authorize URL is `https://slack.com/oauth/v2/authorize` and the app's `client_id` comes from your app settings.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/slack.com"
+    },
+    {
+      "domain": "slidesgpt-server-uojeu24xoq-uc.a.run.app",
+      "name": "SlidesGPT",
+      "mcpUrl": "https://slidesgpt-server-uojeu24xoq-uc.a.run.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt-server-uojeu24xoq-uc.a.run.app"
+    },
+    {
+      "domain": "slidesgpt.com",
+      "name": "slidesgpt.com",
+      "mcpUrl": "https://mcp.slidesgpt.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt.com"
+    },
+    {
+      "domain": "smartbear.com",
+      "name": "smartbear.com",
+      "mcpUrl": "https://bugsnag.mcp.smartbear.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "smartbear_id_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/smartbear.com"
+    },
+    {
+      "domain": "smartcustomer.com",
+      "name": "SmartCustomer",
+      "mcpUrl": "https://chatgpt.smartcustomer.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/smartcustomer.com"
+    },
+    {
+      "domain": "smartsheet.com",
+      "name": "smartsheet.com",
+      "mcpUrl": "https://mcp.smartsheet.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "smartsheet_api_token",
+          "type": "bearer",
+          "generateUrl": "https://developers.smartsheet.com/api/smartsheet/guides/getting-started",
+          "setup": "In the Smartsheet app, open **Account** → **Personal Settings** → **API Access**, then click **Generate new access token**. Store the token securely. Smartsheet notes tokens are environment-specific; generate separate tokens for commercial, Gov, or regional environments as needed. See [Get Started](https://developers.smartsheet.com/api/smartsheet/guides/getting-started) and the linked [generate API key help article](https://help.smartsheet.com/articles/2482389-generate-API-key).",
+          "fields": null
+        },
+        {
+          "id": "smartsheet_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developers.smartsheet.com/register",
+          "setup": "Register a licensed Business-plan-or-higher Smartsheet user for Developer Tools at [Developer Tools Registration](https://developers.smartsheet.com/register). Then use Developer Tools to register your client application for OAuth, as described in the [OAuth guide](https://developers.smartsheet.com/api/smartsheet/guides/advanced-topics/oauth). This is only needed for apps that request user authorization to access Smartsheet data.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/smartsheet.com"
+    },
+    {
+      "domain": "smarty.com",
+      "name": "smarty.com",
+      "mcpUrl": "https://mcp.api.smarty.com/",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "smarty_secret_key_pair",
+          "type": "compound",
+          "generateUrl": "https://www.smarty.com/docs/account/key-management-step-by-step",
+          "setup": "Sign in to your Smarty account, open the API keys / key management area described in [Key management step by step](https://www.smarty.com/docs/account/key-management-step-by-step), and create or copy a server-side secret key pair: `auth-id` and `auth-token`. The [Authentication](https://www.smarty.com/docs/account/authentication) page says secret key pairs are used to authenticate API requests and can be sent either as query parameters or as HTTP headers.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/smarty.com"
+    },
+    {
+      "domain": "smtp2go.com",
+      "name": "smtp2go.com",
+      "mcpUrl": "https://developers.smtp2go.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "smtp2go_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.smtp2go.com/sending/apikeys/",
+          "setup": "Log in to the [SMTP2GO App](https://app.smtp2go.com) and go to [Sending > API Keys](https://app.smtp2go.com/sending/apikeys/). Click **Add API Key** to create a key, then copy it. SMTP2GO docs note keys have an `api-` prefix and can be permission-scoped per endpoint.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/smtp2go.com"
+    },
+    {
+      "domain": "sonicapply.com",
+      "name": "U.S. Secret Service Careers",
+      "mcpUrl": "https://gptapp.sonicapply.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sonicapply.com"
+    },
+    {
+      "domain": "soulfamily.ai",
+      "name": "soulfamily.ai",
+      "mcpUrl": "https://soulfamily.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/soulfamily.ai"
+    },
+    {
+      "domain": "sourcegraph.com",
+      "name": "sourcegraph.com",
+      "mcpUrl": "https://sourcegraph.com/.api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sg_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sourcegraph.com"
+    },
+    {
+      "domain": "southeasthre.com",
+      "name": "southeasthre.com",
+      "mcpUrl": "https://www.southeasthre.com/_api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/southeasthre.com"
+    },
+    {
+      "domain": "spaceship.com",
+      "name": "Spaceship",
+      "mcpUrl": "https://gpt-mcp.service.spaceship.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/spaceship.com"
+    },
+    {
+      "domain": "spanner.googleapis.com",
+      "name": "spanner.googleapis.com",
+      "mcpUrl": "https://spanner.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/spanner.googleapis.com"
+    },
+    {
+      "domain": "sparkspot.be",
+      "name": "SparkSpot",
+      "mcpUrl": "https://api.sparkspot.be/mcp/public/parkingspots",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sparkspot.be"
+    },
+    {
+      "domain": "speechify.com",
+      "name": "Speechify",
+      "mcpUrl": "https://openai.speechify.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/speechify.com"
+    },
+    {
+      "domain": "spinify.com",
+      "name": "Spinify",
+      "mcpUrl": "https://mcp.spinify.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "spinify_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/spinify.com"
+    },
+    {
+      "domain": "splice.com",
+      "name": "Splice",
+      "mcpUrl": "https://mcp.splice.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/splice.com"
+    },
+    {
+      "domain": "spotify.net",
+      "name": "Spotify",
+      "mcpUrl": "https://mcp-gateway-external-pilot.spotify.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "spotify_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developer.spotify.com/dashboard",
+          "setup": "Sign in to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), create an app, and use that app's `client_id`. For confidential-server flows, also use the app's `client_secret`; for PKCE/public-client flows you use only the `client_id`. Configure your app's redirect URI(s) in the dashboard before running the authorization flow, as described in the [Apps concept](https://developer.spotify.com/documentation/web-api/concepts/apps) and the [Authorization Code tutorial](https://developer.spotify.com/documentation/web-api/tutorials/code-flow).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/spotify.net"
+    },
+    {
+      "domain": "spreedly.com",
+      "name": "spreedly.com",
+      "mcpUrl": "https://developer.spreedly.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/spreedly.com"
+    },
+    {
+      "domain": "springer.com",
+      "name": "AdisInsight",
+      "mcpUrl": "https://adisinsight-mcp.springer.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "adis_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/springer.com"
+    },
+    {
+      "domain": "sqladmin.googleapis.com",
+      "name": "sqladmin.googleapis.com",
+      "mcpUrl": "https://sqladmin.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sqladmin.googleapis.com"
+    },
+    {
+      "domain": "squareup.com",
+      "name": "Square Connect API",
+      "mcpUrl": "https://connect.squareup.com/v2/mcp/cash-app",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "square_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/squareup.com"
+    },
+    {
+      "domain": "stablebaseline.io",
+      "name": "Stable Baseline",
+      "mcpUrl": "https://api.stablebaseline.io/functions/v1/cloud-serve/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sb_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://stablebaseline.io/.well-known/mcp.json",
+          "setup": "Use an MCP client that supports OAuth 2.1 with Dynamic Client Registration and point it at the Stable Baseline MCP server. The machine-readable manifest is [mcp.json](https://stablebaseline.io/.well-known/mcp.json), which advertises the OAuth endpoints and supported scopes. End users can also initiate this through hosts like ChatGPT by clicking **Connect** for Stable Baseline and authorizing at [app.stablebaseline.io](https://app.stablebaseline.io). Docs: [Setup & auth](https://stablebaseline.io/docs/mcp/setup), [ChatGPT recipe](https://stablebaseline.io/docs/recipes/chatgpt).",
+          "fields": null
+        },
+        {
+          "id": "sb_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.stablebaseline.io/settings/mcp-keys",
+          "setup": "In the Stable Baseline web app, go to **Settings → MCP keys** (project-scoped from **Project settings → MCP keys**, or personal/global from **Account settings → MCP keys**) and click **Generate new key**. Scope it to the needed workspaces/projects and capabilities, then copy the `sta_…` key when shown; it is shown once. Docs: [MCP setup](https://stablebaseline.io/docs/mcp/setup), [Quickstart](https://stablebaseline.io/docs/quickstart).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/stablebaseline.io"
+    },
+    {
+      "domain": "staircase.ai",
+      "name": "Gainsight (Staircase AI)",
+      "mcpUrl": "https://mcp.staircase.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "staircase_mcp_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/staircase.ai"
+    },
+    {
+      "domain": "standvirtual.com",
+      "name": "Standvirtual",
+      "mcpUrl": "https://www.standvirtual.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/standvirtual.com"
+    },
+    {
+      "domain": "statsig.com",
+      "name": "Statsig",
+      "mcpUrl": "https://api.statsig.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "personal_console_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/statsig.com"
+    },
+    {
+      "domain": "steer.coach",
+      "name": "Steer Astro",
+      "mcpUrl": "https://mcp.steer.coach/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "steer_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://sso.steer.coach/realms/steer/clients-registrations/openid-connect",
+          "setup": "Register an OAuth/OpenID Connect client against Steer's authorization server. The authorization server metadata for the MCP resource is published at [`https://mcp.steer.coach/.well-known/oauth-authorization-server`](https://mcp.steer.coach/.well-known/oauth-authorization-server), which exposes the `registration_endpoint` at [`https://sso.steer.coach/realms/steer/clients-registrations/openid-connect`](https://sso.steer.coach/realms/steer/clients-registrations/openid-connect). Create a client there, then use the issued `client_id` and your chosen client authentication method to obtain OAuth access tokens for the MCP resource `https://mcp.steer.coach/mcp`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/steer.coach"
+    },
+    {
+      "domain": "sticklight.com",
+      "name": "Sticklight",
+      "mcpUrl": "https://mcp.sticklight.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sticklight_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sticklight.com"
+    },
+    {
+      "domain": "storage.googleapis.com",
+      "name": "storage.googleapis.com",
+      "mcpUrl": "https://storage.googleapis.com",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/storage.googleapis.com"
+    },
+    {
+      "domain": "storyblok.com",
+      "name": "storyblok.com",
+      "mcpUrl": "https://mcp.labs.storyblok.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "personal_access_token",
+          "type": "bearer",
+          "generateUrl": "https://app.storyblok.com/#/me/account?tab=token",
+          "setup": "Sign in to the Storyblok app and open [My Account → Personal access tokens](https://app.storyblok.com/#/me/account?tab=token) to create a Personal Access Token. Storyblok's docs and MCP setup identify this as the management token used for the Management API and MCP server; the MCP docs recommend using a scoped personal access token to limit access. See [Field plugin development](https://www.storyblok.com/docs/plugins/field-plugins/development) and [MCP Server](https://mcp.labs.storyblok.com/).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/storyblok.com"
+    },
+    {
+      "domain": "straighterline.com",
+      "name": "StraighterLine Degree Planner",
+      "mcpUrl": "https://degreeplanner.straighterline.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/straighterline.com"
+    },
+    {
+      "domain": "strapi.io",
+      "name": "strapi.io",
+      "mcpUrl": "https://strapi-docs.mcp.kapa.ai",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/strapi.io"
+    },
+    {
+      "domain": "streak.com",
+      "name": "Streak",
+      "mcpUrl": "https://api.streak.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "streak_oauth_account",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "To connect an MCP client, add Streak's MCP server URL `https://api.streak.com/mcp` in the client, then sign in to your Streak account and authorize access when prompted. Streak's MCP setup docs say it uses OAuth and that no API keys are required for MCP; see the [MCP setup guide](https://support.streak.com/en/articles/13931874-integrating-streak-with-gemini-claude-chatgpt-and-other-ai-tools) and the [MCP product page](https://www.streak.com/integrations/mcp).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/streak.com"
+    },
+    {
+      "domain": "stripe.com",
+      "name": "stripe",
+      "mcpUrl": "https://mcp.stripe.com",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "stripe_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Configure your MCP client to connect to `https://mcp.stripe.com`. Per Stripe’s [MCP docs](https://docs.stripe.com/mcp), the server uses OAuth to connect MCP clients according to the MCP spec; the MCP client handles the OAuth flow and the user approves access in the browser. After installation, you can manage MCP client sessions in your Stripe Dashboard settings.",
+          "fields": null
+        },
+        {
+          "id": "stripe_api_key",
+          "type": "api_key",
+          "generateUrl": "https://dashboard.stripe.com/test/apikeys",
+          "setup": "Create or sign in to your Stripe account, then open the [API keys page](https://dashboard.stripe.com/test/apikeys) in the Developers Dashboard to create, reveal, rotate, or delete keys. Stripe documents account-level secret keys (`sk_...`), restricted keys (`rk_...`), publishable keys (`pk_...`), and organization keys (`sk_org_...`) on the [API keys guide](https://docs.stripe.com/keys). For server-side integrations, use a restricted or secret key; for Connect requests on behalf of a connected account, also send the `Stripe-Account` header when needed.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/stripe.com"
+    },
+    {
+      "domain": "strivemaths.com",
+      "name": "Strive PDF Generator",
+      "mcpUrl": "https://mcp.strivemaths.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/strivemaths.com"
+    },
+    {
+      "domain": "stubhub.net",
+      "name": "StubHub",
+      "mcpUrl": "https://open-ai-app.stubhub.net/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/stubhub.net"
+    },
+    {
+      "domain": "stytch.com",
+      "name": "stytch.com",
+      "mcpUrl": "https://mcp.stytch.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "stytch_project_secret",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/stytch.com"
+    },
+    {
+      "domain": "stytch.dev",
+      "name": "Stytch",
+      "mcpUrl": "https://mcp.stytch.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/stytch.dev"
+    },
+    {
+      "domain": "subdivide.app",
+      "name": "Subdivide",
+      "mcpUrl": "https://mcp.subdivide.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/subdivide.app"
+    },
+    {
+      "domain": "subscriptionflow.com",
+      "name": "SubscriptionFlow",
+      "mcpUrl": "https://gpt.subscriptionflow.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/subscriptionflow.com"
+    },
+    {
+      "domain": "substack.com",
+      "name": "substack.com",
+      "mcpUrl": "https://mcp.substack.com/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "substack_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/substack.com"
+    },
+    {
+      "domain": "success.co",
+      "name": "Success.co",
+      "mcpUrl": "https://www.success.co/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "success_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/success.co"
+    },
+    {
+      "domain": "sumsub.com",
+      "name": "sumsub.com",
+      "mcpUrl": "https://api.sumsub.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sumsub_account_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Use a Sumsub account that has the **Use MCP server** permission enabled for its role, as described in [MCP server](https://docs.sumsub.com/docs/mcp-server.md). Then connect from your MCP client and choose **Sign in with Sumsub** or the client's MCP login flow against `https://api.sumsub.com/mcp/`. The docs describe authenticating interactively from ChatGPT, Claude, Codex, and other MCP clients rather than manually registering an OAuth app.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sumsub.com"
+    },
+    {
+      "domain": "supabase.com",
+      "name": "supabase",
+      "mcpUrl": "https://mcp.supabase.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "supabase_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/supabase.com"
+    },
+    {
+      "domain": "superhuman.com",
+      "name": "Superhuman Mail",
+      "mcpUrl": "https://mcp.mail.superhuman.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "superhuman_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/superhuman.com"
+    },
+    {
+      "domain": "supermetrics.com",
+      "name": "Supermetrics Marketing Analytics",
+      "mcpUrl": "https://mcp.supermetrics.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sm_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/supermetrics.com"
+    },
+    {
+      "domain": "superserve.ai",
+      "name": "superserve.ai",
+      "mcpUrl": "https://mcp.superserve.ai",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "superserve_api_key",
+          "type": "api_key",
+          "generateUrl": "https://console.superserve.ai",
+          "setup": "In the [Superserve API key guide](https://docs.superserve.ai/api-key), go to [console.superserve.ai](https://console.superserve.ai), open **Settings → API keys**, click **Create key**, and copy the key value once. Superserve says keys are prefixed with `ss_live_` and are scoped to a single team. For SDKs and local MCP setups, set it as `SUPERSERVE_API_KEY`; for hosted MCP, send it as a bearer token.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/superserve.ai"
+    },
+    {
+      "domain": "suri.cz",
+      "name": "SURI.CZ",
+      "mcpUrl": "https://carb.suri.cz/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "carb_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/suri.cz"
+    },
+    {
+      "domain": "surrealdb.com",
+      "name": "surrealdb.com",
+      "mcpUrl": "http://127.0.0.1:8000/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "surreal_userpass",
+          "type": "basic",
+          "generateUrl": null,
+          "setup": "Create credentials when you start or configure a SurrealDB instance. For self-hosted instances, start the server with `surreal start --user <username> --pass <password>` as shown in the [HTTP protocol setup](https://surrealdb.com/docs/reference/rest-api/http-protocol) and [CLI overview](https://surrealdb.com/docs/reference/cli/surrealdb-cli/overview). For SurrealDB Cloud, create an instance in [Create an instance](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/getting-started/create-an-instance), then connect to that instance as described in [Connecting to Cloud](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/connecting). Namespace- and database-scoped users can also be used where supported via the `--auth-level` flow documented on [`surreal sql`](https://surrealdb.com/docs/reference/cli/surrealdb-cli/commands/sql).",
+          "fields": null
+        },
+        {
+          "id": "surreal_jwt",
+          "type": "bearer",
+          "generateUrl": null,
+          "setup": "Mint a token by signing in to a SurrealDB instance through the documented auth flow. The REST API exposes [`POST /signin`](https://surrealdb.com/docs/reference/rest-api/http-protocol), and the CLI can also connect with an existing token via [`surreal sql --token`](https://surrealdb.com/docs/reference/cli/surrealdb-cli/commands/sql). For Cloud, first create an account and instance via [Cloud management](https://surrealdb.com/docs/manage/cloud) and [Create an instance](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/getting-started/create-an-instance), then sign in to that instance and reuse the returned JWT as a Bearer token.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/surrealdb.com"
+    },
+    {
+      "domain": "surveymonkey.com",
+      "name": "SurveyMonkey",
+      "mcpUrl": "https://mcp.surveymonkey.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "sm_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/surveymonkey.com"
+    },
+    {
+      "domain": "sweetspotgov.workers.dev",
+      "name": "Sweetspot",
+      "mcpUrl": "https://app-sdk.sweetspotgov.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/sweetspotgov.workers.dev"
+    },
+    {
+      "domain": "sybill.ai",
+      "name": "Sybill",
+      "mcpUrl": "https://mcp.sybill.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/sybill.ai"
+    },
+    {
+      "domain": "synapse.org",
+      "name": "Synapse.org",
+      "mcpUrl": "https://mcp.synapse.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "synapse_access_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/synapse.org"
+    },
+    {
+      "domain": "systembolaget.se",
+      "name": "Systembolaget",
+      "mcpUrl": "https://ag.sip.systembolaget.se/marcipan-chapp/mcp?subscription-key=7ed84209e2f44c8b83471712049c98f0",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/systembolaget.se"
+    },
+    {
+      "domain": "talktoglow.com",
+      "name": "Glow",
+      "mcpUrl": "https://agents.talktoglow.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "glow_oauth_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/talktoglow.com"
+    },
+    {
+      "domain": "tally.so",
+      "name": "tally.so",
+      "mcpUrl": "https://api.tally.so/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tally_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "For the Tally MCP server, use an MCP client that supports OAuth and add the server at `https://api.tally.so/mcp`. The client handles registration automatically; when prompted, sign in to Tally and approve access. Tally documents this as the recommended way to connect in the [MCP server docs](https://developers.tally.so/api-reference/mcp).",
+          "fields": null
+        },
+        {
+          "id": "tally_api_key",
+          "type": "bearer",
+          "generateUrl": "https://tally.so/settings/api-keys",
+          "setup": "In Tally, go to [Settings → API keys](https://tally.so/settings/api-keys), click **Create API key**, then copy the key and store it safely; Tally only shows it once. Use it as a bearer token in `Authorization: Bearer tly-xxxx`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tally.so"
+    },
+    {
+      "domain": "tamg.cloud",
+      "name": "Tripadvisor",
+      "mcpUrl": "https://production.ai-mcp-extensibility-prd.tamg.cloud/ogMvjY4De1G7CiHanMOAgddl/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tamg.cloud"
+    },
+    {
+      "domain": "tapteach.org",
+      "name": "Angler Adventures: Lure Guide",
+      "mcpUrl": "https://angleradventures.tapteach.org/mcpServer",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tapteach.org"
+    },
+    {
+      "domain": "target.com",
+      "name": "Target",
+      "mcpUrl": "https://rmcp.target.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/target.com"
+    },
+    {
+      "domain": "targetvalidation.org",
+      "name": "targetvalidation.org",
+      "mcpUrl": "https://mcp.platform.opentargets.org/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/targetvalidation.org"
+    },
+    {
+      "domain": "taskrabbit.com",
+      "name": "Taskrabbit Booking Assistance",
+      "mcpUrl": "https://mcp.taskrabbit.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/taskrabbit.com"
+    },
+    {
+      "domain": "tavily.com",
+      "name": "Tavily",
+      "mcpUrl": "https://mcp.tavily.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tavily_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tavily.com"
+    },
+    {
+      "domain": "taxheaven-chatgpt-app.vercel.app",
+      "name": "TaxHeaven",
+      "mcpUrl": "https://taxheaven-chatgpt-app.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/taxheaven-chatgpt-app.vercel.app"
+    },
+    {
+      "domain": "teklifimgelsin.com",
+      "name": "TeklifimGelsin",
+      "mcpUrl": "https://chat.teklifimgelsin.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/teklifimgelsin.com"
+    },
+    {
+      "domain": "theknot.com",
+      "name": "The Knot",
+      "mcpUrl": "https://singularity-chatgpt-mcp.guestservices.theknot.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/theknot.com"
+    },
+    {
+      "domain": "thetrainline.com",
+      "name": "Trainline",
+      "mcpUrl": "https://chatgpt.mcp.thetrainline.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/thetrainline.com"
+    },
+    {
+      "domain": "thumbtack.com",
+      "name": "Thumbtack",
+      "mcpUrl": "https://mcp.thumbtack.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/thumbtack.com"
+    },
+    {
+      "domain": "ticketmaster.com",
+      "name": "ticketmaster.com – publish",
+      "mcpUrl": "https://partner-mcp.ticketmaster.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ticketmaster.com"
+    },
+    {
+      "domain": "tickettailor.ai",
+      "name": "Ticket Tailor",
+      "mcpUrl": "https://mcp.tickettailor.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tt_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.tickettailor.com/box-office/api",
+          "setup": "Sign in to your Ticket Tailor account, open your box office API settings at [Box office API settings](https://app.tickettailor.com/box-office/api), and generate a new API key. If you do not yet have an account, first [create a Ticket Tailor account](https://www.tickettailor.com/sign-up) and create a box office; API keys are associated with the box office that issued them.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.ai"
+    },
+    {
+      "domain": "tickettailor.com",
+      "name": "tickettailor.com",
+      "mcpUrl": "https://mcp.tickettailor.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tt_api_key",
+          "type": "api_key",
+          "generateUrl": "https://app.tickettailor.com/box-office/api",
+          "setup": "Sign in to your Ticket Tailor account, open [Box office API settings](https://app.tickettailor.com/box-office/api), and generate a new API key for your box office. The API docs note keys are box-office scoped, and the MCP docs say you enter this same key during the MCP authentication prompt. If offered, Ticket Tailor recommends keeping `Hide personal data from responses` enabled when using AI connectors.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.com"
+    },
+    {
+      "domain": "tigerdata.com",
+      "name": "pg-aiguide",
+      "mcpUrl": "https://mcp.tigerdata.com/docs",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tigerdata.com"
+    },
+    {
+      "domain": "tigrisdata.com",
+      "name": "tigrisdata.com",
+      "mcpUrl": "https://mcp.storage.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tigris_cli_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tigrisdata.com"
+    },
+    {
+      "domain": "tldraw.workers.dev",
+      "name": "tldraw",
+      "mcpUrl": "https://tldraw-mcp-app.tldraw.workers.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tldraw.workers.dev"
+    },
+    {
+      "domain": "tokenterminal.com",
+      "name": "Token Terminal",
+      "mcpUrl": "https://mcp.tokenterminal.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tt_oauth_user",
+          "type": "oauth2",
+          "generateUrl": "https://tokenterminal.com/docs/mcp/introduction",
+          "setup": "Connect an MCP-compatible client to [Token Terminal MCP docs](https://tokenterminal.com/docs/mcp/introduction) at `https://mcp.tokenterminal.com/mcp`. On first connection, the client opens a browser window where you sign in to Token Terminal and select the user account and organization the session should operate under. The client stores the resulting access token and refreshes it transparently. For a concrete example, see the [Codex CLI setup](https://tokenterminal.com/docs/mcp/codex).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tokenterminal.com"
+    },
+    {
+      "domain": "tomorrow.io",
+      "name": "Tomorrow.io Weather",
+      "mcpUrl": "https://api.tomorrow.io/v4/weather-apps/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tomorrow.io"
+    },
+    {
+      "domain": "tourradar.com",
+      "name": "TourRadar",
+      "mcpUrl": "https://ai.tourradar.com/mcp/chatgpt",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tourradar.com"
+    },
+    {
+      "domain": "transloadit.com",
+      "name": "transloadit.com",
+      "mcpUrl": "https://api2.transloadit.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "transloadit_bearer_token",
+          "type": "bearer",
+          "generateUrl": "https://transloadit.com/docs/api/token-post/",
+          "setup": "Mint a short-lived access token from [`POST /token`](https://transloadit.com/docs/api/token-post/) using HTTP Basic Auth with your `Auth Key` and `Auth Secret`, or run `npx -y @transloadit/node auth token` (use `--aud mcp` for the hosted MCP endpoint). Tokens are valid for 6 hours and are then sent as `Authorization: Bearer <access_token>`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/transloadit.com"
+    },
+    {
+      "domain": "travelenie.com",
+      "name": "Travelenie",
+      "mcpUrl": "https://mcp.travelenie.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/travelenie.com"
+    },
+    {
+      "domain": "travelimpactmodel.googleapis.com",
+      "name": "travelimpactmodel.googleapis.com",
+      "mcpUrl": "https://travelimpactmodel.googleapis.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "gcp_api_key",
+          "type": "api_key",
+          "generateUrl": "https://console.cloud.google.com/apis/credentials",
+          "setup": "In [Google Cloud Console credentials](https://console.cloud.google.com/apis/credentials), create an API key in your Google Cloud project. Make sure the [Travel Impact Model API docs](https://developers.google.com/travel/impact-model) note that the API is enabled for the project; the MCP guide says you must provide a valid API key from your Google Cloud project with the \"Travel Impact Model API\" enabled. Google’s API key docs are linked from the product docs at [API keys](https://cloud.google.com/docs/authentication/api-keys).",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/travelimpactmodel.googleapis.com"
+    },
+    {
+      "domain": "tray.ai",
+      "name": "tray.ai",
+      "mcpUrl": "https://api.tray.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tray_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tray.ai"
+    },
+    {
+      "domain": "tredict.com",
+      "name": "Tredict",
+      "mcpUrl": "https://www.tredict.com/api/mcp/v2/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://www.tredict.com/blog/oauth_docs/",
+          "setup": "Email [support@tredict.com](mailto:support@tredict.com) with your app name, short description, logo, one or more OAuth callback URLs, privacy-policy link, required scopes, and whether you need PKCE-only or server flow. Tredict issues a `client_id`, and for confidential/server flow also a `client_secret`, as described in the [OAuth2 documentation](https://www.tredict.com/blog/oauth_docs/).",
+          "fields": null
+        },
+        {
+          "id": "personal_token",
+          "type": "bearer",
+          "generateUrl": null,
+          "setup": "Sign in to the Tredict web app, open Settings → `Personal API`, create a token, select scopes, and store the token securely. The setup and scopes are described in [Setup and Getting Started](https://www.tredict.com/skills/setup.md).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tredict.com"
+    },
+    {
+      "domain": "tripbtoz.com",
+      "name": "Tripbtoz",
+      "mcpUrl": "https://tripbtoz-mcp-gateway.tripbtoz.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tripbtoz.com"
+    },
+    {
+      "domain": "trivago.com",
+      "name": "Trivago",
+      "mcpUrl": "https://mcp.trivago.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/trivago.com"
+    },
+    {
+      "domain": "tropicapp.io",
+      "name": "Tropic",
+      "mcpUrl": "https://app.tropicapp.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tropic_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tropicapp.io"
+    },
+    {
+      "domain": "trufflejournal.com",
+      "name": "Truffle Journal",
+      "mcpUrl": "https://mcp.trufflejournal.com/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "truffle_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://www.trufflejournal.com/setup",
+          "setup": "Create a Truffle Journal account in the iPhone app via [Setup Guide](https://www.trufflejournal.com/setup), then in ChatGPT Developer mode create an app pointing at `https://mcp.trufflejournal.com/api/v1/mcp` with Authentication set to `OAuth`. After app creation, ChatGPT redirects you to a Truffle Journal login page; sign in with the same email and password you created for your Truffle Journal account. The docs say to leave OAuth client ID and secret blank in ChatGPT.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/trufflejournal.com"
+    },
+    {
+      "domain": "trustrebound.com",
+      "name": "Rebound Scam Assistant",
+      "mcpUrl": "https://trustrebound.com/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/trustrebound.com"
+    },
+    {
+      "domain": "trychannel3.com",
+      "name": "Penny",
+      "mcpUrl": "https://penny.apps.trychannel3.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/trychannel3.com"
+    },
+    {
+      "domain": "trychroma.com",
+      "name": "trychroma.com",
+      "mcpUrl": "https://mcp.trychroma.com/package-search/v1",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "chroma_api_key",
+          "type": "api_key",
+          "generateUrl": "https://trychroma.com/package-search",
+          "setup": "Create or log into your Chroma Cloud account via the [dashboard signup/login](https://trychroma.com/signup) or the [Package Search page](https://trychroma.com/package-search). For headless/CLI use, create an API key in the Chroma Cloud dashboard, then use it directly or pass it to `chroma login --api-key ...`. The docs state the CLI stores the API key with the selected profile.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/trychroma.com"
+    },
+    {
+      "domain": "trykopi.ai",
+      "name": "trykopi.ai",
+      "mcpUrl": "https://www.trykopi.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "kopi_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/trykopi.ai"
+    },
+    {
+      "domain": "trymalcolm.com",
+      "name": "Aviva",
+      "mcpUrl": "https://mcp.trymalcolm.com/sse",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "marrow_api_key",
+          "type": "bearer",
+          "generateUrl": "https://www.onmarrow.com/contact",
+          "setup": "To get Sandbox credentials, email Marrow via [contact@onmarrow.com](mailto:contact@onmarrow.com) or use the [contact page](https://www.onmarrow.com/contact). The partner quickstart says Marrow will set you up with test credentials. Use the issued key as a bearer token in `Authorization: Bearer <key>`. The docs show production-style keys prefixed `mk_live_` and sandbox/test keys prefixed `mk_test_`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/trymalcolm.com"
+    },
+    {
+      "domain": "tubi.io",
+      "name": "Tubi",
+      "mcpUrl": "https://openai-app-mcp.main-production-custom.production.k8s.tubi.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/tubi.io"
+    },
+    {
+      "domain": "tuio-mcp-demo.vercel.app",
+      "name": "Tuio",
+      "mcpUrl": "https://tuio-mcp-demo.vercel.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tuio-mcp-demo.vercel.app"
+    },
+    {
+      "domain": "tuist.dev",
+      "name": "tuist.dev",
+      "mcpUrl": "https://tuist.dev/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "tuist_user_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tuist.dev"
+    },
+    {
+      "domain": "turkishtechlab.com",
+      "name": "Turkish Airlines",
+      "mcpUrl": "https://mcp-app.turkishtechlab.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/turkishtechlab.com"
+    },
+    {
+      "domain": "turo.com",
+      "name": "Turo",
+      "mcpUrl": "https://mcp.turo.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/turo.com"
+    },
+    {
+      "domain": "turso.tech",
+      "name": "turso.tech",
+      "mcpUrl": "https://mcp.turso.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/turso.tech"
+    },
+    {
+      "domain": "tusalario.app",
+      "name": "SueldoNeto",
+      "mcpUrl": "https://tusalario.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/tusalario.app"
+    },
+    {
+      "domain": "uber.com",
+      "name": "Uber",
+      "mcpUrl": "https://mcp.uber.com/claude/rides-3p/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/uber.com"
+    },
+    {
+      "domain": "ubereats.com",
+      "name": "Uber Eats",
+      "mcpUrl": "https://mcp.ubereats.com/eats-claude/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ubereats.com"
+    },
+    {
+      "domain": "ubersuggest.com",
+      "name": "ubersuggest.com",
+      "mcpUrl": "https://ubersuggest-mcp.neilpatelapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ubersuggest_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/ubersuggest.com"
+    },
+    {
+      "domain": "udemy.com",
+      "name": "Udemy",
+      "mcpUrl": "https://api.udemy.com/mcp-chatgpt/2025-10",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/udemy.com"
+    },
+    {
+      "domain": "ui.nuxt.com",
+      "name": "ui.nuxt.com",
+      "mcpUrl": "https://ui.nuxt.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com"
+    },
+    {
+      "domain": "unified.to",
+      "name": "unified.to",
+      "mcpUrl": "https://mcp-api.unified.to/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "workspace_api_key",
+          "type": "bearer",
+          "generateUrl": "https://app.unified.to/settings/api",
+          "setup": "Sign in to the [Unified app dashboard](https://app.unified.to), then open [API settings](https://app.unified.to/settings/api) to view or create your workspace API token. The docs describe this token as your workspace API key/token and use it for both the REST API and MCP server. Keep it secret because it grants access to your workspace and, when used with a `connection` parameter in MCP, can access customer connection data.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/unified.to"
+    },
+    {
+      "domain": "unthread.io",
+      "name": "Unthread",
+      "mcpUrl": "https://app.unthread.io/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "unthread_service_account_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/unthread.io"
+    },
+    {
+      "domain": "updatron.com",
+      "name": "Updater Internet Store",
+      "mcpUrl": "https://ai-agents.infra.updatron.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "updatron_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Connect to the remote MCP server at `https://ai-agents.infra.updatron.com/mcp` from an MCP-capable client that supports OAuth. The server indicates OAuth is required and the client should discover the authorization flow from the server's well-known metadata for this MCP endpoint. Authorize with your Updatron account when prompted.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/updatron.com"
+    },
+    {
+      "domain": "upplai-mcp-server-production.up.railway.app",
+      "name": "Upplai",
+      "mcpUrl": "https://upplai-mcp-server-production.up.railway.app/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "upplai_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/upplai-mcp-server-production.up.railway.app"
+    },
+    {
+      "domain": "upsun.com",
+      "name": "upsun.com",
+      "mcpUrl": "https://mcp.upsun.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "upsun_api_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/upsun.com"
+    },
+    {
+      "domain": "uptimerobot.com",
+      "name": "uptimerobot.com",
+      "mcpUrl": "https://mcp.uptimerobot.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "ur_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/uptimerobot.com"
+    },
+    {
+      "domain": "usenotra.com",
+      "name": "usenotra.com",
+      "mcpUrl": "https://mcp.usenotra.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "notra_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://app.usenotra.com/.well-known/oauth-authorization-server",
+          "setup": "For Notra's OAuth-protected resources, use an OAuth-capable client that supports protected-resource metadata and dynamic client registration. Start from the resource metadata at `https://mcp.usenotra.com/.well-known/oauth-protected-resource` or the authorization-server metadata at [Notra OAuth metadata](https://app.usenotra.com/.well-known/oauth-authorization-server); the client can register itself at the advertised `registration_endpoint`, then send the user through browser consent and store the resulting bearer/refresh token. Supported scopes include `offline_access` plus resource scopes such as `posts.read`, `posts.write`, `brand-identities.read`, `brand-identities.write`, `integrations.read`, `integrations.write`, `schedules.read`, `schedules.write`, `event-triggers.read`, `event-triggers.write`, `chats.read`, `chats.write`, `skills.read`, and `skills.write`.",
+          "fields": null
+        },
+        {
+          "id": "notra_api_key",
+          "type": "bearer",
+          "generateUrl": "https://docs.usenotra.com/api/authentication",
+          "setup": "In the Notra dashboard, go to [Authentication](https://docs.usenotra.com/api/authentication) / **Developer → API Keys**, click **Create API Key**, choose a name, resource permissions, and optional expiration, then copy the key and store it securely. For CLI use, the easiest path is `notra auth login`, which opens the dashboard, confirms a new key, and writes it to local config; non-interactive fallback is `NOTRA_API_KEY` or `--api-key`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/usenotra.com"
+    },
+    {
+      "domain": "usepylon.com",
+      "name": "Pylon",
+      "mcpUrl": "https://mcp.usepylon.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "pylon_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/usepylon.com"
+    },
+    {
+      "domain": "usgb.io",
+      "name": "U.S. Gold Bureau Metal Spots",
+      "mcpUrl": "https://spot-mcp.usgb.io/api/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/usgb.io"
+    },
+    {
+      "domain": "vakantiediscounter.nl",
+      "name": "VakantieDiscounter",
+      "mcpUrl": "https://mcp.vakantiediscounter.nl",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vakantiediscounter.nl"
+    },
+    {
+      "domain": "vancompare.com",
+      "name": "Vancompare.com",
+      "mcpUrl": "https://ai.vancompare.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vancompare.com"
+    },
+    {
+      "domain": "vantage.sh",
+      "name": "Vantage",
+      "mcpUrl": "https://mcp.vantage.sh/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vantage_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://docs.vantage.sh/vantage_mcp",
+          "setup": "Use an MCP client that supports remote MCP OAuth, then add the remote Vantage MCP server from [Vantage MCP docs](https://docs.vantage.sh/vantage_mcp) at `https://mcp.vantage.sh/mcp`. During setup, choose **Authorize** in your MCP client and sign in to your Vantage account to grant access. The docs describe this as the authorization step for the remote Vantage MCP server.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vantage.sh"
+    },
+    {
+      "domain": "vectorize.io",
+      "name": "vectorize.io",
+      "mcpUrl": "https://api.hindsight.vectorize.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "hindsight_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/vectorize.io"
+    },
+    {
+      "domain": "veed.io",
+      "name": "VEED Fabric",
+      "mcpUrl": "https://www.veed.io/api/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "veed_oauth_client",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/veed.io"
+    },
+    {
+      "domain": "vendr.com",
+      "name": "vendr.com",
+      "mcpUrl": "https://mcp.vendr.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vendr_access_key",
+          "type": "bearer",
+          "generateUrl": "https://developers.vendr.com/docs/introduction",
+          "setup": "Request access from Vendr as described in the [Vendr API Introduction](https://developers.vendr.com/docs/introduction): \"Please reach out to [ethan.elstein@vertice.one](mailto:ethan.elstein@vertice.one) for more information on getting access.\" Vendr calls this an access key / API key, and API requests send it as `Authorization: Bearer YOUR_KEY_HERE`. The same key is also used for the MCP server via `X-API-Key`.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vendr.com"
+    },
+    {
+      "domain": "venturu.com",
+      "name": "Venturu",
+      "mcpUrl": "https://www.venturu.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/venturu.com"
+    },
+    {
+      "domain": "vercel.com",
+      "name": "vercel",
+      "mcpUrl": "https://mcp.vercel.com/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vercel_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/vercel.com"
+    },
+    {
+      "domain": "vianexus.com",
+      "name": "vianexus.com",
+      "mcpUrl": "https://vast-mcp.blueskyapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vianexus_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/vianexus.com"
+    },
+    {
+      "domain": "viator.com",
+      "name": "Viator API Documentation &amp; Specification – Merchant Partners",
+      "mcpUrl": "https://exp-app-mcp.prod.ep.viator.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/viator.com"
+    },
+    {
+      "domain": "vio.com",
+      "name": "Vio.com",
+      "mcpUrl": "https://mcp.vio.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vio.com"
+    },
+    {
+      "domain": "virginatlantic.com",
+      "name": "Virgin Atlantic",
+      "mcpUrl": "https://cx-mcp.virginatlantic.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/virginatlantic.com"
+    },
+    {
+      "domain": "virtuoso.ai",
+      "name": "Yardi Virtuoso",
+      "mcpUrl": "https://mcp.virtuoso.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/virtuoso.ai"
+    },
+    {
+      "domain": "vivin.ai",
+      "name": "Vivin",
+      "mcpUrl": "https://vivin.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vivin_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://vivin.ai/oidc/oauth/register",
+          "setup": "Register an OAuth client with Vivin using the dynamic client registration endpoint at [`https://vivin.ai/oidc/oauth/register`](https://vivin.ai/oidc/oauth/register). The authorization server metadata at [OAuth Authorization Server Metadata](https://vivin.ai/.well-known/oauth-authorization-server) advertises this registration endpoint and supports `client_secret_basic` and `client_secret_post` for client authentication at the token endpoint. Request scopes from [OpenID configuration](https://vivin.ai/.well-known/openid-configuration) such as `openid`, `profile`, `email`, and `offline_access`.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/vivin.ai"
+    },
+    {
+      "domain": "vroomvroomvroom.com",
+      "name": "VroomVroomVroom - Car Hire",
+      "mcpUrl": "https://ai.vroomvroomvroom.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vvv_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "Connect to the VroomVroomVroom MCP server through an MCP client that supports OAuth. The only published evidence is the OpenAI registry/catalog fact for [VroomVroomVroom - Car Hire](https://ai.vroomvroomvroom.com/mcp), which lists auth type `OAUTH`. VroomVroomVroom does not appear to publish public developer setup docs for registering an OAuth app or minting tokens, so acquisition details could not be confirmed from public documentation.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vroomvroomvroom.com"
+    },
+    {
+      "domain": "vsct.fr",
+      "name": "SNCF Connect : Trains & Trajet",
+      "mcpUrl": "https://master.mcp-openai.evoyageurs.prod.cdn.vsct.fr/message",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/vsct.fr"
+    },
+    {
+      "domain": "vybit.net",
+      "name": "vybit.net",
+      "mcpUrl": "https://api.vybit.net/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "vybit_oauth_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/vybit.net"
+    },
+    {
+      "domain": "wallector.com",
+      "name": "Wallector",
+      "mcpUrl": "https://mcp.wallector.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wallector.com"
+    },
+    {
+      "domain": "walletwhistle.com",
+      "name": "Wallet Whistle",
+      "mcpUrl": "https://mcp.walletwhistle.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/walletwhistle.com"
+    },
+    {
+      "domain": "walmart.com",
+      "name": "walmart.com – price",
+      "mcpUrl": "https://bixby.prod.walmart.com/v1/client/oai/tenant/walmart-us/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wm_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://developer.walmart.com/",
+          "setup": "Use Walmart-issued OAuth authorization for the Walmart MCP server. The curated registry identifies the MCP endpoint as OAuth-protected, but the public authorization metadata was not located in the pages reviewed. Start from the [Walmart Developer Portal](https://developer.walmart.com/) to obtain access and follow the MCP client's OAuth flow against Walmart's advertised metadata when available.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/walmart.com"
+    },
+    {
+      "domain": "wandb.ai",
+      "name": "wandb.ai",
+      "mcpUrl": "https://mcp.withwandb.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wandb_api_key",
+          "type": "api_key",
+          "generateUrl": "https://wandb.ai/authorize",
+          "setup": "Create a personal or service-account API key in W&B. The quickest path is [Authorize](https://wandb.ai/authorize) or [User Settings](https://wandb.ai/settings): sign in, create a new API key, and copy it immediately because W&B only shows the full key once. For service-account-owned keys, use the Service Accounts area described in the [W&B Quickstart](https://docs.wandb.ai/models/quickstart). Store it as `WANDB_API_KEY` or pass it as a bearer token where supported.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wandb.ai"
+    },
+    {
+      "domain": "wanderu.com",
+      "name": "Wanderu",
+      "mcpUrl": "https://mcp-services.wanderu.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wanderu.com"
+    },
+    {
+      "domain": "wayground.com",
+      "name": "Wayground",
+      "mcpUrl": "https://wayground.com/_quizizzmcp/main/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wayground_oauth_client",
+          "type": "oauth2",
+          "generateUrl": "https://wayground.com/_authserver/public/public/v1/oauth/register",
+          "setup": "Register an OAuth client with Wayground at the dynamic client registration endpoint `https://wayground.com/_authserver/public/public/v1/oauth/register`. The authorization server metadata at [Wayground OAuth Authorization Server](https://wayground.com/.well-known/oauth-authorization-server) shows support for the authorization-code flow with PKCE (`S256`), scope `full_access`, and `token_endpoint_auth_methods_supported` of `none`, so the easiest path is to create a public client and use that registered `client_id` with PKCE to obtain bearer tokens for the MCP resource.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wayground.com"
+    },
+    {
+      "domain": "wear.jp",
+      "name": "ZOZO",
+      "mcpUrl": "https://mcp.wear.jp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wear.jp"
+    },
+    {
+      "domain": "webex.com",
+      "name": "webex.com",
+      "mcpUrl": "https://mcp.webexapis.com/mcp/vidcast",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "webex_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://developer.webex.com/my-apps",
+          "setup": "In [My Webex Apps](https://developer.webex.com/my-apps), choose **Create a New App** → **Create an Integration**. After registration, Webex shows a `Client ID` and `Client Secret` once. Use those to run the OAuth 2.0 authorization code flow against `https://webexapis.com/v1/authorize`, with a registered redirect URI and the scopes your app needs. The resulting bearer access token is sent to Webex APIs and MCP servers.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/webex.com"
+    },
+    {
+      "domain": "webflow.com",
+      "name": "Lucidtech API",
+      "mcpUrl": "https://mcp.webflow.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "webflow_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/webflow.com"
+    },
+    {
+      "domain": "webjet.com.au",
+      "name": "Webjet",
+      "mcpUrl": "https://services.webjet.com.au/api/mcp/webjetota",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/webjet.com.au"
+    },
+    {
+      "domain": "wego.com",
+      "name": "Wego",
+      "mcpUrl": "https://mcp.wego.com/chatgpt-app/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wego.com"
+    },
+    {
+      "domain": "wepromise.tech",
+      "name": "WeatherPromise",
+      "mcpUrl": "https://mcp.purchase.production.wepromise.tech/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wepromise.tech"
+    },
+    {
+      "domain": "whack.ie",
+      "name": "Whack",
+      "mcpUrl": "https://api.whack.ie/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/whack.ie"
+    },
+    {
+      "domain": "whimsical.com",
+      "name": "Whimsical",
+      "mcpUrl": "https://mcp.whimsical.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "whimsical_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/whimsical.com"
+    },
+    {
+      "domain": "windmill.dev",
+      "name": "windmill.dev",
+      "mcpUrl": "https://app.windmill.dev/api/mcp/gateway",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "windmill_user_token",
+          "type": "bearer",
+          "generateUrl": "https://www.windmill.dev/docs/core_concepts/user_tokens.md",
+          "setup": "In Windmill, open **Account settings** from your username menu, go to **Tokens**, enter a label, optionally set an expiration, and click **New token**. Optionally enable **Limit token permissions** to scope the token. See [User tokens](https://www.windmill.dev/docs/core_concepts/user_tokens.md).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/windmill.dev"
+    },
+    {
+      "domain": "windsor.ai",
+      "name": "Windsor.ai",
+      "mcpUrl": "https://mcp.windsor.ai",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/windsor.ai"
+    },
+    {
+      "domain": "withbites.com",
+      "name": "Bites",
+      "mcpUrl": "https://mcp.withbites.com",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/withbites.com"
+    },
+    {
+      "domain": "wix.com",
+      "name": "Wix",
+      "mcpUrl": "https://mcp.wix.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wix_api_key",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/wix.com"
+    },
+    {
+      "domain": "wizehire.com",
+      "name": "Jobs by Wizehire",
+      "mcpUrl": "https://api.gateway.wizehire.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wizehire_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://api.gateway.wizehire.com/documentation",
+          "setup": "Register or obtain OAuth client credentials through Wizehire's MCP/API gateway flow described by the gateway's service documentation at [API gateway documentation](https://api.gateway.wizehire.com/documentation). The authorization server metadata shows `authorization_code` and `client_credentials` grants, with token endpoint auth `client_secret_post`; use the client id and client secret issued by Wizehire with `https://api.gateway.wizehire.com/authorize` and `https://api.gateway.wizehire.com/oauth/token` as needed by your client.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wizehire.com"
+    },
+    {
+      "domain": "wordpress.com",
+      "name": "WordPress.com",
+      "mcpUrl": "https://public-api.wordpress.com/wpcom/v2/mcp/v1",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wpcom_oauth_app",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/wordpress.com"
+    },
+    {
+      "domain": "workable.com",
+      "name": "workable.com",
+      "mcpUrl": "https://www.workable.com/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/workable.com"
+    },
+    {
+      "domain": "workos.com",
+      "name": "workos.com",
+      "mcpUrl": "https://mcp.workos.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "workos_dashboard_oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server accepts a Client ID Metadata Document (CIMD), so the client authenticates with its own hosted URL as the `client_id` — nothing to register.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/workos.com"
+    },
+    {
+      "domain": "wrike.com",
+      "name": "Wrike",
+      "mcpUrl": "https://mcp.wrike.com/app/mcp/stream",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "wrike_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://www.wrike.com/appconsole.htm?#/api",
+          "setup": "In Wrike, open [Apps & Integrations](https://www.wrike.com/appconsole.htm?#/api), create a new API app, and copy the generated `Client ID` and `Client Secret`. Add the redirect URL(s) your client needs; for Claude Code, Wrike's guide says to add `http://localhost:8080/callback`. Wrike documents only the OAuth 2.0 authorization code flow for API access.",
+          "fields": null
+        },
+        {
+          "id": "wrike_pat",
+          "type": "bearer",
+          "generateUrl": "https://developers.wrike.com/docs/mcp-legacy-authentication-pat",
+          "setup": "In your Wrike workspace, go to **profile icon → Apps & Integrations → API → + App**, enter an app name, then click **Get Token** and save the token before closing the page. Wrike's [Legacy Authentication: Permanent Access Token](https://developers.wrike.com/docs/mcp-legacy-authentication-pat) guide notes the token inherits your Wrike permissions and is mainly for individual use, testing, or automated MCP workflows.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wrike.com"
+    },
+    {
+      "domain": "ww.com",
+      "name": "WeightWatchers",
+      "mcpUrl": "https://api.ww.com/ai/mcp-openai-glp1-recipes/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ww.com"
+    },
+    {
+      "domain": "www.printhiv3d.com",
+      "name": "www.printhiv3d.com",
+      "mcpUrl": "https://api.printhiv3d.com/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "oauth",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com"
+    },
+    {
+      "domain": "wyndhamhotels.com",
+      "name": "Wyndham Hotels & Resorts",
+      "mcpUrl": "https://mcp.wyndhamhotels.com/chatgpt/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/wyndhamhotels.com"
+    },
+    {
+      "domain": "x.com",
+      "name": "x.com",
+      "mcpUrl": "https://api.x.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "x_bearer",
+          "type": "bearer",
+          "generateUrl": "https://console.x.com",
+          "setup": "In the [Developer Console](https://console.x.com), create an app, then open its **Keys and tokens** page and copy the Bearer token. The docs say app creation presents the API Key, API Secret, and Bearer Token, and that credentials can later be found/regenerated from the app’s **Keys and tokens** tab.",
+          "fields": null
+        },
+        {
+          "id": "x_oauth_app",
+          "type": "oauth2",
+          "generateUrl": "https://console.x.com",
+          "setup": "In the [Developer Console](https://console.x.com), create an app and enable **OAuth 2.0**. Register a redirect URI such as `http://localhost:8080/callback` if you plan to use the `xurl mcp` bridge, then copy the app’s `CLIENT_ID` and `CLIENT_SECRET` from the app settings / credentials area.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/x.com"
+    },
+    {
+      "domain": "yahooapis.jp",
+      "name": "Yahoo! JAPAN Shopping",
+      "mcpUrl": "https://shp-apps-in-chatgpt.yahooapis.jp/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/yahooapis.jp"
+    },
+    {
+      "domain": "yardimcp.com",
+      "name": "RentCafe",
+      "mcpUrl": "https://rentcafe.yardimcp.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/yardimcp.com"
+    },
+    {
+      "domain": "yelp.com",
+      "name": "Yelp",
+      "mcpUrl": "https://mcp-openai.yelp.com/mcp/",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/yelp.com"
+    },
+    {
+      "domain": "yepcode.io",
+      "name": "YepCode",
+      "mcpUrl": "https://cloud.yepcode.io/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "yepcode_api_credential",
+          "type": "compound",
+          "generateUrl": "https://yepcode.io/docs/settings/api-credentials/",
+          "setup": "In YepCode Cloud, open [Settings → API Credentials](https://yepcode.io/docs/settings/api-credentials/), click **New**, enter a name, and click **Create**. YepCode then shows one API Credential bundle containing a `Client ID`, `Client Secret`, a `Run API Token`, and MCP endpoints. Use the `Client ID` + `Client Secret` for the REST API OAuth 2.0 client-credentials flow, and use the token for YepCode Run / no-OAuth MCP access.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/yepcode.io"
+    },
+    {
+      "domain": "yoshi.ai",
+      "name": "Yoshi",
+      "mcpUrl": "https://agents.yoshi.ai/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "yoshi_api_key",
+          "type": "api_key",
+          "generateUrl": "https://beta.yoshi.ai/settings",
+          "setup": "In the [Yoshi dashboard](https://beta.yoshi.ai), open **Settings → API Keys**, click **Create API Key**, give it a name, and copy the key immediately. The docs say keys start with `yoshi_` and are only shown once. See [Authentication](https://docs.yoshi.ai/authentication).",
+          "fields": null
+        },
+        {
+          "id": "yoshi_oauth_token",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "The API reference states some endpoints also accept a Yoshi OAuth access token issued by **Sign in with Yoshi**, but the public docs scraped did not expose the OAuth app registration or token-minting flow. Start from the Yoshi developer docs and product dashboard, and look for **Sign in with Yoshi** / OAuth app registration guidance if you need user-authorized access. See [List accounts auth section](https://docs.yoshi.ai/api-reference/accounts/list-accounts).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/yoshi.ai"
+    },
+    {
+      "domain": "youversionapi.com",
+      "name": "Bible",
+      "mcpUrl": "https://openai-mcp.youversionapi.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/youversionapi.com"
+    },
+    {
+      "domain": "zapier.com",
+      "name": "zapier.com – nla",
+      "mcpUrl": "https://mcp.zapier.com/api/v1/connect",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "zapier_sdk_login",
+          "type": "oauth2",
+          "generateUrl": null,
+          "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+          "fields": null
+        }
+      ],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/zapier.com"
+    },
+    {
+      "domain": "zen7.com",
+      "name": "PetPals",
+      "mcpUrl": "https://platform.zen7.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "petpals_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://platform.zen7.com/faq",
+          "setup": "Use the PetPals sign-in flow on [platform.zen7.com](https://platform.zen7.com/) or initiate access from the [PetPals ChatGPT App](https://chatgpt.com/apps/petpals/asdk_app_697047972e8c8191a13a465c9480d508). The FAQ and Terms state users can create an account with email/password, sign in with Google, or sign in through ChatGPT's OAuth flow; the MCP registry indicates the MCP server uses OAuth. Zen7 does not publish separate developer OAuth registration docs on the public site, so the easiest public acquisition path is the PetPals account sign-in/authorization flow.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zen7.com"
+    },
+    {
+      "domain": "zep.ai",
+      "name": "Zep Documentation MCP Server",
+      "mcpUrl": "https://docs-mcp.getzep.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zep.ai"
+    },
+    {
+      "domain": "zillow.com",
+      "name": "Zillow",
+      "mcpUrl": "https://mcp.zillow.com/api/v1",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zillow.com"
+    },
+    {
+      "domain": "ziprecruiter.com",
+      "name": "ZipRecruiter",
+      "mcpUrl": "https://api.ziprecruiter.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/ziprecruiter.com"
+    },
+    {
+      "domain": "zocks.io",
+      "name": "Zocks",
+      "mcpUrl": "https://mcp.zocks.io/v1/mcp",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "zocks_user_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://console.zocks.io/login",
+          "setup": "Have a Zocks admin enable the relevant AI tool in the Zocks App Library first (see the Zocks MCP help articles). Then each user connects their own Zocks account from the AI client: in Claude, open Settings → Connectors and connect Zocks; in ChatGPT, open Settings → Apps and connect Zocks; in Microsoft Copilot Studio or the published agent flow, sign in to Zocks and approve access. The login entry point is [Zocks login](https://console.zocks.io/login).",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zocks.io"
+    },
+    {
+      "domain": "zohomcp.ae",
+      "name": "zohomcp.ae",
+      "mcpUrl": "https://mcp.zoho.in/",
+      "transport": "streamable-http",
+      "authKind": "api_key",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "zoho_mcp_url_key",
+          "type": "api_key",
+          "generateUrl": "https://mcp.zoho.in/",
+          "setup": "Sign in to the [Zoho MCP Console](https://mcp.zoho.in/), create an MCP server, then open its **Connect** section and copy the **MCP URL**. Zoho's docs state this URL contains a required secure API key and can be regenerated with **Regenerate API Key** if needed. Treat the URL as confidential.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.ae"
+    },
+    {
+      "domain": "zohomcp.sa",
+      "name": "zohomcp.sa",
+      "mcpUrl": "https://mcp.zoho.in/",
+      "transport": "streamable-http",
+      "authKind": "oauth2",
+      "scopesHint": [],
+      "credentialFacts": [
+        {
+          "id": "zoho_mcp_oauth",
+          "type": "oauth2",
+          "generateUrl": "https://mcp.zoho.in/",
+          "setup": "Create a server in the [Zoho MCP Console](https://mcp.zoho.in/), copy its MCP URL from the **Connect** section, then add that URL to your MCP client and complete the browser consent flow when the client prompts you. Zoho documents `OAuth` as the authentication type when adding the MCP server, and says users are redirected to the Zoho MCP authorization screen to click **Allow**. By default this is **Authorization on Demand**, where each user authorizes with their own account; organizations can optionally use **Authorization via Connection** configured by a Super Admin in the Zoho MCP service.",
+          "fields": null
+        },
+        {
+          "id": "zoho_mcp_url_key",
+          "type": "api_key",
+          "generateUrl": "https://mcp.zoho.in/",
+          "setup": "Create a server in the [Zoho MCP Console](https://mcp.zoho.in/), then open its **Connect** section and copy the generated **MCP URL**. Zoho's FAQ says this URL should be treated like a password and can be rotated with **Regenerate API Key**, which indicates the URL embeds or depends on a server API key. Use the regenerated MCP URL if the old one is compromised.",
+          "fields": null
+        }
+      ],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.sa"
+    },
+    {
+      "domain": "zola.com",
+      "name": "Zola",
+      "mcpUrl": "https://mcp.zola.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zola.com"
+    },
+    {
+      "domain": "zoominfo.com",
+      "name": "ZoomInfo",
+      "mcpUrl": "https://mcp.zoominfo.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "unknown",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "verified",
+      "provenance": "detected",
+      "logoSourceUrl": "https://integrations.sh/logo/zoominfo.com"
+    },
+    {
+      "domain": "zumba.com",
+      "name": "Zumba",
+      "mcpUrl": "https://mcp.zumba.com/mcp",
+      "transport": "streamable-http",
+      "authKind": "none",
+      "scopesHint": [],
+      "credentialFacts": [],
+      "tier": "community",
+      "provenance": "discovered",
+      "logoSourceUrl": "https://integrations.sh/logo/zumba.com"
+    }
+  ],
+  "skipped": [
+    {
+      "domain": "agentichoteldistribution.com",
+      "mcpUrl": "https://agentichoteldistribution.com/mcp/synxis?chainId=10237",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "adobe.io",
+      "mcpUrl": "https://aep-ai-ama.adobe.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "adobe.io",
+      "mcpUrl": "https://adobe-creativity.adobe.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "adobe.io",
+      "mcpUrl": "https://express-mcp-service.adobe.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "adobe.io",
+      "mcpUrl": "https://photoshop-mcp-service.adobe.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "adobe.io",
+      "mcpUrl": "https://acrobat-mcp.adobe.io/mcp/call",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "airwallex.com",
+      "mcpUrl": "https://mcp-demo.airwallex.com/docs",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "airwallex.com",
+      "mcpUrl": "https://mcp.airwallex.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "api.aws",
+      "mcpUrl": "https://marketplace-mcp.us-east-1.api.aws/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "awesomize.ai",
+      "mcpUrl": "https://talkgen.awesomize.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "awesomize.ai",
+      "mcpUrl": "https://mangaboom.awesomize.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "azurecontainerapps.io",
+      "mcpUrl": "https://inviton-gpt-mcp.yellowocean-74d7a25f.westeurope.azurecontainerapps.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "boxoffice.com",
+      "mcpUrl": "https://mcp-regal.boxoffice.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "bump.sh",
+      "mcpUrl": "https://developers.bump.sh/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "bump.sh",
+      "mcpUrl": "https://developers.bump.sh/doc/workspace/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "cardchain.ai",
+      "mcpUrl": "https://api.cardchain.ai/mcp/claude",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "carbonarc.ai",
+      "mcpUrl": "https://mcp.carbonarc.ai/research",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "chargebee.com",
+      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/knowledge_base_agent",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "chargebee.com",
+      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/data_lookup_agent",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "chargebee.com",
+      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/onboarding_agent",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "chargebee.com",
+      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/YOUR-CUSTOM-SERVER-SLUG",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "checkr.com",
+      "mcpUrl": "https://mcp.checkr.com/candidate-mcp/",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "cdata.com",
+      "mcpUrl": "https://mcp.cloud.cdata.com/mcp/mgmt",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "coches.net",
+      "mcpUrl": "https://llms-apps.gw.coches.net/motos/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "coches.net",
+      "mcpUrl": "https://llms-apps.gw.coches.net/milanuncios/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "composio.dev",
+      "mcpUrl": "https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "contentful.com",
+      "mcpUrl": "https://mcp.eu.contentful.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "decolar.com",
+      "mcpUrl": "https://apis.despegar.com/api-b2b-hotels-mcp/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "domotz.app",
+      "mcpUrl": "https://mcp.ov.domotz.app/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "dub.co",
+      "mcpUrl": "https://mcp.dub.sh/mcp/dub-partners",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "dropbox.com",
+      "mcpUrl": "https://mcp.dropbox.com/dash_chatgpt_app",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "eodhd.com",
+      "mcpUrl": "https://mcp.eodhd.com/v1/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "explorium.ai",
+      "mcpUrl": "https://vibeprospecting.explorium.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "fastmcp.cloud",
+      "mcpUrl": "https://your-server-name.fastmcp.app/mcp",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "framagit.org",
+      "mcpUrl": "https://framagit.org/api/v4/orbit/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "dbt.com",
+      "mcpUrl": "https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "getyourguide.com",
+      "mcpUrl": "https://widget.getyourguide.com/mcp",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "glama.ai",
+      "mcpUrl": "https://glama.ai/endpoints/<your-connection-profile>/mcp",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "gogs.io",
+      "mcpUrl": "https://unknwon.main-kill-isr.mintlify.me/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "gojinko.com",
+      "mcpUrl": "https://mcp.gojinko.com",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "intuit.com",
+      "mcpUrl": "https://ai-inc.turbotax.intuit.com/358A1C1B-F73B-46A7-B130-4B14916E6843/v1/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "jotform.com",
+      "mcpUrl": "https://mcp.jotform.com/mcp-app",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "kindora.co",
+      "mcpUrl": "https://kindora-mcp.azurewebsites.net/mcp/",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "kensho.com",
+      "mcpUrl": "https://kfinance.kensho.com/integrations/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "kit.com",
+      "mcpUrl": "https://developers.kit.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "kubera.com",
+      "mcpUrl": "https://api.kubera.com/api/v2/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "lambus.ai",
+      "mcpUrl": "https://chatgpt-app-server.tourlane.wl.lambus.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "langfuse.com",
+      "mcpUrl": "https://langfuse.com/api/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/content",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/content-readonly",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/cloudmanager",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/experience-governance",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mcp.adobeaemcloud.com",
+      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/cloud-migration",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "meterplan.com",
+      "mcpUrl": "https://mcp.meterplan.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "mermaid.ai",
+      "mcpUrl": "https://chatgpt.mermaid.ai/anthropic/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "modelcontextprotocol.io",
+      "mcpUrl": "https://modelcontextprotocol.io/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "modelcontextprotocol.io",
+      "mcpUrl": "https://example-server.modelcontextprotocol.io/threejs/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "modelcontextprotocol.io",
+      "mcpUrl": "https://example-server.modelcontextprotocol.io/sheet-music/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "natoma.ai",
+      "mcpUrl": "https://yourorg.mcp.natoma.app/v2/profile/your-profile/github/mcp",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "nexafin.com",
+      "mcpUrl": "https://app.nexafin.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://product-scanner.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://football.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://speed-test.widgets.widget.olutely.com/speed-test/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://record.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://clock.widgets.widget.olutely.com/clock/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://dog-breeds.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://lesson-plan.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://sudoku.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://price-alerts.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://pension-income-calculator.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://recipe-reader.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://color-picker.widgets.widget.olutely.com/color-picker/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://quote-display.widgets.widget.olutely.com/quote-display/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://piano.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://stopwatch.widgets.widget.olutely.com/stopwatch/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://forex.widgets.widget.olutely.com/forex/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://london-underground.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://doodle.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://mortgage-calculator.widgets.widget.olutely.com/mortgage-calculator/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://chess.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://lottery.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://horoscopes.widgets.widget.olutely.com/horoscopes/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://text-analysis.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://calendar.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://palette-picker.widgets.widget.olutely.com/palette-picker/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://calculator.widgets.widget.olutely.com/calculator/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://glossary.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://nature-sounds.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://coupons.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://fact.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://tides.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://dictionary.widgets.widget.olutely.com/dictionary/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://metronome.widgets.widget.olutely.com/metronome/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://timer.widgets.widget.olutely.com/timer/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://bible-verse.widgets.widget.olutely.com/bible-verse/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://conversation.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://meditation.widgets.widget.olutely.com/meditation/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://links.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://crossword.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://pregnancy-snapshot.widgets.widget.olutely.com/pregnancy-snapshot/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://spelling.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "olutely.com",
+      "mcpUrl": "https://word-search.widgets.widget.olutely.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "omnisend.com",
+      "mcpUrl": "https://mcp.omnisend.com/v2/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "optiversal.com",
+      "mcpUrl": "https://tillys.mcp.optiversal.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "paddle.com",
+      "mcpUrl": "https://sandbox-mcp.paddle.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "paddle.com",
+      "mcpUrl": "https://paddlehq.mcp.kapa.ai",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "phish.in",
+      "mcpUrl": "https://phish.in/mcp/openai",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "phish.in",
+      "mcpUrl": "https://phish.in/mcp/anthropic",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "polar.sh",
+      "mcpUrl": "https://mcp.polar.sh/mcp/polar-sandbox",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "pyxl.pro",
+      "mcpUrl": "https://www.pyxl.pro/api/mcp/aihumanize",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "pyxl.pro",
+      "mcpUrl": "https://www.pyxl.pro/api/mcp/pythonmaster",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "ramp.com",
+      "mcpUrl": "https://mcp.ramp.com/developer/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "ramp.com",
+      "mcpUrl": "https://mcp.ramp.com/ramp-data/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "rbictg.com",
+      "mcpUrl": "https://use1-prod-fhs-mcp.rbictg.com/api/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "rbictg.com",
+      "mcpUrl": "https://use1-prod-plk-chatgpt-app.rbictg.com/api/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "replit-mcp.com",
+      "mcpUrl": "https://replit-mcp.com/chatgpt-app/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "researchsolutions.com",
+      "mcpUrl": "https://scite.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "scalar.com",
+      "mcpUrl": "https://api.scalar.com/vector/mcp/YOUR_INSTALL_ID",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "securelend.ai",
+      "mcpUrl": "https://mcp.securelend.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sider.ai",
+      "mcpUrl": "https://outliner.chatgptapps.sider.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sider.ai",
+      "mcpUrl": "https://scholar.chatgptapps.sider.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sider.ai",
+      "mcpUrl": "https://quiz.chatgptapps.sider.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sider.ai",
+      "mcpUrl": "https://wisebase.chatgptapps.sider.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sider.ai",
+      "mcpUrl": "https://speech.chatgptapps.sider.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sierra.chat",
+      "mcpUrl": "https://api.sierra.chat/chat/_UjgWN4Bl-YJFsMBmn6VXROTPHGXRd9NCk5oWwSqMMA/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sierra.chat",
+      "mcpUrl": "https://api.sierra.chat/chat/fiKQF58BmL5HCdwBmn5G6nFeM9kSoKWMZNLoDRD1b8Q/mcp/GPT-1-1",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "skywatch.ai",
+      "mcpUrl": "https://renters-mcp.skywatch.ai/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "smartbear.com",
+      "mcpUrl": "https://zephyr.mcp.smartbear.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sonicapply.com",
+      "mcpUrl": "https://johns-hopkins-gpt-app.sonicapply.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "sonicapply.com",
+      "mcpUrl": "https://usss-gpt-app.sonicapply.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "spaceship.com",
+      "mcpUrl": "https://gpt-namecheap-mcp.service.spaceship.com/mcp/",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "strapi.io",
+      "mcpUrl": "https://<your-strapi-server>/mcp",
+      "reason": "templated_url"
+    },
+    {
+      "domain": "tourradar.com",
+      "mcpUrl": "https://ai.tourradar.com/mcp/main",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "trymalcolm.com",
+      "mcpUrl": "https://mcp.trymalcolm.com/mcp-ab2a870c-468a-418a-b695-09a30559a22a",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "trychannel3.com",
+      "mcpUrl": "https://mcp.trychannel3.com/",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "udemy.com",
+      "mcpUrl": "https://api.udemy.com/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "webex.com",
+      "mcpUrl": "https://mcp.webexapis.com/mcp/webex-messaging",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "webex.com",
+      "mcpUrl": "https://mcp.webexapis.com/mcp/workspaces",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "webex.com",
+      "mcpUrl": "https://mcp.webexapis.com/mcp/webex-meeting",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "wyndhamhotels.com",
+      "mcpUrl": "https://mcp.wyndhamhotels.com/claude/mcp",
+      "reason": "duplicate_domain_name"
+    },
+    {
+      "domain": "zuplo.work",
+      "mcpUrl": "https://mcp-main-406f710.accuweather.zuplo.work/v0/mcp/chatgpt?key=zpka_REDACTED",
+      "reason": "templated_url"
+    }
+  ],
+  "quarantined": [
+    {
+      "row": {
+        "domain": "activepieces.com",
+        "name": "activepieces.com",
+        "mcpUrl": "https://www.activepieces.com/.well-known/mcp/server-card.json",
+        "transport": "streamable-http",
+        "authKind": "api_key",
+        "scopesHint": [],
+        "credentialFacts": [
+          {
+            "id": "mcp_embed_token",
+            "type": "bearer",
+            "generateUrl": "https://www.activepieces.com/docs/embedding/embeddable-mcp",
+            "setup": "First set up embedding using a signing key and embed JWT per [Provision Users](https://www.activepieces.com/docs/embedding/provision-users). Then, from the embedded frontend SDK, call `activepieces.generateMcpToken()` as shown in [Embeddable MCP](https://www.activepieces.com/docs/embedding/embeddable-mcp) to obtain `mcpToken` and `mcpServerUrl`. The token is scoped to that user's project and lasts 15 minutes.",
+            "fields": null
+          }
+        ],
+        "tier": "verified",
+        "provenance": "detected",
+        "logoSourceUrl": "https://integrations.sh/logo/activepieces.com"
+      },
+      "reason": "server-card JSON URL needs manual confirmation before enablement"
+    },
+    {
+      "row": {
+        "domain": "doordash.com",
+        "name": "DoorDash",
+        "mcpUrl": "https://openapi.doordash.com/mcp/consumer",
+        "transport": "streamable-http",
+        "authKind": "unknown",
+        "scopesHint": [],
+        "credentialFacts": [
+          {
+            "id": "dd_jwt_credential",
+            "type": "compound",
+            "generateUrl": "https://developer.doordash.com/portal/",
+            "setup": "In the [DoorDash Developer Portal](https://developer.doordash.com/portal/), open **Credentials**, click **Create Credential** (or create an access key in the Drive tutorial), choose the environment/APIs, and save the returned `developer_id`, `key_id`, and `signing_secret`/access key details. DoorDash docs say these values are then used to generate a JWT for API calls; the signing secret is shown only once, so store it securely. See [Drive JWT auth](https://developer.doordash.com/en-US/docs/drive/how_to/JWTs), [Drive get started](https://developer.doordash.com/en-US/docs/drive/tutorials/get_started), and [Marketplace JWT auth](https://developer.doordash.com/en-US/docs/marketplace/overview/getting_started/jwts_getting_started/).",
+            "fields": null
+          }
+        ],
+        "tier": "community",
+        "provenance": "discovered",
+        "logoSourceUrl": "https://integrations.sh/logo/doordash.com"
+      },
+      "reason": "consumer API URL needs manual confirmation before enablement"
+    },
+    {
+      "row": {
+        "domain": "natwest.com",
+        "name": "NatWest Mortgages",
+        "mcpUrl": "https://openapi.natwest.com/mortgages/v1/mcp-server-mortgages/mcp",
+        "transport": "streamable-http",
+        "authKind": "none",
+        "scopesHint": [],
+        "credentialFacts": [],
+        "tier": "community",
+        "provenance": "discovered",
+        "logoSourceUrl": "https://integrations.sh/logo/natwest.com"
+      },
+      "reason": "banking API URL needs manual confirmation before enablement"
+    },
+    {
+      "row": {
+        "domain": "netatmo.com",
+        "name": "netatmo.com",
+        "mcpUrl": "https://www.netatmo.com/.well-known/mcp/server-card.json",
+        "transport": "streamable-http",
+        "authKind": "unknown",
+        "scopesHint": [],
+        "credentialFacts": [],
+        "tier": "verified",
+        "provenance": "detected",
+        "logoSourceUrl": "https://integrations.sh/logo/netatmo.com"
+      },
+      "reason": "server-card JSON URL needs manual confirmation before enablement"
+    },
+    {
+      "row": {
+        "domain": "smartbear.com",
+        "name": "smartbear.com",
+        "mcpUrl": "https://swagger.mcp.smartbear.com/mcp",
+        "transport": "streamable-http",
+        "authKind": "oauth2",
+        "scopesHint": [],
+        "credentialFacts": [
+          {
+            "id": "smartbear_id_oauth",
+            "type": "oauth2",
+            "generateUrl": null,
+            "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
+            "fields": null
+          }
+        ],
+        "tier": "verified",
+        "provenance": "detected",
+        "logoSourceUrl": "https://integrations.sh/logo/smartbear.com"
+      },
+      "reason": "SmartBear Swagger endpoint needs manual confirmation before enablement"
+    }
+  ]
+}

--- a/data/catalog/integrations-snapshot.json
+++ b/data/catalog/integrations-snapshot.json
@@ -1,36 +1,23 @@
 {
   "generatedAt": "2026-07-03T23:41:44.132Z",
   "source": "integrations.sh",
-  "cleanedAt": "2026-07-07T08:59:30.524Z",
+  "cleanedAt": "2026-07-07T11:26:39.308Z",
   "cleaning": {
-    "inputRows": 1081,
-    "outputRows": 935,
-    "skippedRows": 141,
-    "quarantinedRows": 5,
-    "duplicateDomainNameRows": 128,
+    "inputRows": 935,
+    "outputRows": 898,
+    "skippedRows": 37,
+    "quarantinedRows": 0,
+    "duplicateDomainNameRows": 0,
     "controlCharacterFields": 0
   },
+  "probe": {
+    "kept": 898,
+    "dropped": 37,
+    "real": 746,
+    "unverified": 152,
+    "googleapisDropped": 1
+  },
   "importRows": [
-    {
-      "domain": "12andus.com",
-      "name": "12andus Astrology",
-      "mcpUrl": "https://mcp.12andus.com/mcp/?v=10",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "mcp_oauth_client",
-          "type": "oauth2",
-          "generateUrl": "https://mcp.12andus.com/oauth/register",
-          "setup": "Register an OAuth client against the MCP server's [registration endpoint](https://mcp.12andus.com/oauth/register), then send the user through the authorization flow using the server's [authorization metadata](https://mcp.12andus.com/.well-known/oauth-authorization-server). The server advertises `authorization_code` and `refresh_token` grants with PKCE `S256`; resource scopes are `openid`, `email`, and `profile`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/12andus.com"
-    },
     {
       "domain": "2u.com",
       "name": "edX",
@@ -41,7 +28,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/2u.com"
+      "logoSourceUrl": "https://integrations.sh/logo/2u.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "3minapi.com",
@@ -61,7 +53,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/3minapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/3minapi.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "4ygmimr3yj.us-east-2.awsapprunner.com",
@@ -81,7 +78,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/4ygmimr3yj.us-east-2.awsapprunner.com"
+      "logoSourceUrl": "https://integrations.sh/logo/4ygmimr3yj.us-east-2.awsapprunner.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "abhibus-com-s-account.workers.dev",
@@ -93,7 +95,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/abhibus-com-s-account.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/abhibus-com-s-account.workers.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "accessapproval.googleapis.com",
@@ -105,7 +112,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/accessapproval.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/accessapproval.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "accessowl.com",
@@ -125,7 +137,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/accessowl.com"
+      "logoSourceUrl": "https://integrations.sh/logo/accessowl.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "account.read",
@@ -145,7 +162,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/account.read"
+      "logoSourceUrl": "https://integrations.sh/logo/account.read",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "acko.com",
@@ -157,7 +179,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/acko.com"
+      "logoSourceUrl": "https://integrations.sh/logo/acko.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "adalo.com",
@@ -177,7 +204,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/adalo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/adalo.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "adobe.io",
@@ -197,7 +229,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/adobe.io"
+      "logoSourceUrl": "https://integrations.sh/logo/adobe.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "advancedwebranking.com",
@@ -224,7 +261,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/advancedwebranking.com"
+      "logoSourceUrl": "https://integrations.sh/logo/advancedwebranking.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "agentichoteldistribution.com",
@@ -236,7 +278,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/agentichoteldistribution.com"
+      "logoSourceUrl": "https://integrations.sh/logo/agentichoteldistribution.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "agiflow.io",
@@ -256,7 +303,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/agiflow.io"
+      "logoSourceUrl": "https://integrations.sh/logo/agiflow.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "agilitycms.com",
@@ -276,7 +328,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/agilitycms.com"
+      "logoSourceUrl": "https://integrations.sh/logo/agilitycms.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "agreezone.replit.app",
@@ -288,7 +345,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/agreezone.replit.app"
+      "logoSourceUrl": "https://integrations.sh/logo/agreezone.replit.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ahrefs.com",
@@ -308,19 +370,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/ahrefs.com"
-    },
-    {
-      "domain": "ai-stats.phaseo.app",
-      "name": "ai-stats.phaseo.app",
-      "mcpUrl": "https://ai-stats.phaseo.app/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "verified",
-      "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/phaseo.app"
+      "logoSourceUrl": "https://integrations.sh/logo/ahrefs.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "aiera.com",
@@ -347,7 +402,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/aiera.com"
+      "logoSourceUrl": "https://integrations.sh/logo/aiera.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "airbyte.com",
@@ -367,7 +427,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/airbyte.com"
+      "logoSourceUrl": "https://integrations.sh/logo/airbyte.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "airops.com",
@@ -387,7 +452,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/airops.com"
+      "logoSourceUrl": "https://integrations.sh/logo/airops.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "airtable.com",
@@ -407,7 +477,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/airtable.com"
+      "logoSourceUrl": "https://integrations.sh/logo/airtable.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "airwallex.com",
@@ -434,7 +509,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/airwallex.com"
+      "logoSourceUrl": "https://integrations.sh/logo/airwallex.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "akqa-emea-starbucks-chatgpt-app.vercel.app",
@@ -446,7 +526,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/akqa-emea-starbucks-chatgpt-app.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/akqa-emea-starbucks-chatgpt-app.vercel.app",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "algolia.com",
@@ -466,19 +551,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/algolia.com"
-    },
-    {
-      "domain": "all-ten-chat-gpt-app.replit.app",
-      "name": "Beast Academy - All Ten",
-      "mcpUrl": "https://all-ten-chat-gpt-app.replit.app/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/all-ten-chat-gpt-app.replit.app"
+      "logoSourceUrl": "https://integrations.sh/logo/algolia.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "allapp.net",
@@ -498,7 +576,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/allapp.net"
+      "logoSourceUrl": "https://integrations.sh/logo/allapp.net",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "alltrails.com",
@@ -510,7 +593,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/alltrails.com"
+      "logoSourceUrl": "https://integrations.sh/logo/alltrails.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "almosafer.com",
@@ -522,7 +610,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/almosafer.com"
+      "logoSourceUrl": "https://integrations.sh/logo/almosafer.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "alpaca.markets",
@@ -534,7 +627,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/alpaca.markets"
+      "logoSourceUrl": "https://integrations.sh/logo/alpaca.markets",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "alpic.ai",
@@ -554,7 +652,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/alpic.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/alpic.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "alpic.live",
@@ -574,7 +677,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/alpic.live"
+      "logoSourceUrl": "https://integrations.sh/logo/alpic.live",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "alpy.com",
@@ -586,7 +694,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/alpy.com"
+      "logoSourceUrl": "https://integrations.sh/logo/alpy.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "amapas353.com",
@@ -598,7 +711,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/amapas353.com"
+      "logoSourceUrl": "https://integrations.sh/logo/amapas353.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "americanexpress.com",
@@ -610,7 +728,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/americanexpress.com"
+      "logoSourceUrl": "https://integrations.sh/logo/americanexpress.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "amplifyr.me",
@@ -630,7 +753,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/amplifyr.me"
+      "logoSourceUrl": "https://integrations.sh/logo/amplifyr.me",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "amplitude.com",
@@ -650,7 +778,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/amplitude.com"
+      "logoSourceUrl": "https://integrations.sh/logo/amplitude.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "analyticsadmin.googleapis.com",
@@ -662,7 +795,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/analyticsadmin.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/analyticsadmin.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "androidmanagement.googleapis.com",
@@ -674,7 +812,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/androidmanagement.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/androidmanagement.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "apartmentlist.io",
@@ -686,7 +829,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/apartmentlist.io"
+      "logoSourceUrl": "https://integrations.sh/logo/apartmentlist.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "api-and-you.com",
@@ -698,7 +846,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/api-and-you.com"
+      "logoSourceUrl": "https://integrations.sh/logo/api-and-you.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "api.aws",
@@ -718,7 +871,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/api.aws"
+      "logoSourceUrl": "https://integrations.sh/logo/api.aws",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "api.driftless.icu",
@@ -745,7 +903,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu"
+      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "api.openbudget.sh",
@@ -765,7 +928,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/openbudget.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/openbudget.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "api.opencapital.sh",
@@ -785,27 +953,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/opencapital.sh"
-    },
-    {
-      "domain": "api7.ai",
-      "name": "api7.ai",
-      "mcpUrl": "http://127.0.0.1:3000/mcp",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "aisix_caller_api_key",
-          "type": "api_key",
-          "generateUrl": "https://docs.api7.ai/ai-gateway/build-traffic-path/manage-gateway-resources/caller-api-keys.md",
-          "setup": "Create a caller API key through AISIX management. For self-hosted AISIX, choose a plaintext key, hash it with SHA-256, then create the API key resource via the Admin API as shown in [Caller API Keys](https://docs.api7.ai/ai-gateway/build-traffic-path/manage-gateway-resources/caller-api-keys.md). For managed deployments, the same doc says you create it in the managed control plane and can supply the plaintext `key` field there when custom key import is enabled. Applications send the plaintext key to the proxy as `Authorization: Bearer <caller-key>` or `x-api-key: <caller-key>`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/api7.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/opencapital.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "apify.com",
@@ -825,7 +978,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/apify.com"
+      "logoSourceUrl": "https://integrations.sh/logo/apify.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "apigee.googleapis.com",
@@ -837,7 +995,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/apigee.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/apigee.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "apitoolkit.io",
@@ -857,7 +1020,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/apitoolkit.io"
+      "logoSourceUrl": "https://integrations.sh/logo/apitoolkit.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "apollo.io",
@@ -877,7 +1045,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/apollo.io"
+      "logoSourceUrl": "https://integrations.sh/logo/apollo.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "apollographql.com",
@@ -889,7 +1062,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/apollographql.com"
+      "logoSourceUrl": "https://integrations.sh/logo/apollographql.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "app.fullstackgtm.com",
@@ -909,7 +1087,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fullstackgtm.com"
+      "logoSourceUrl": "https://integrations.sh/logo/fullstackgtm.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "appdeploy.ai",
@@ -929,7 +1112,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/appdeploy.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/appdeploy.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "apple.com",
@@ -941,7 +1129,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/apple.com"
+      "logoSourceUrl": "https://integrations.sh/logo/apple.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "arcjet.com",
@@ -961,7 +1154,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/arcjet.com"
+      "logoSourceUrl": "https://integrations.sh/logo/arcjet.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "artue.io",
@@ -973,7 +1171,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/artue.io"
+      "logoSourceUrl": "https://integrations.sh/logo/artue.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "asana.com",
@@ -993,7 +1196,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/asana.com"
+      "logoSourceUrl": "https://integrations.sh/logo/asana.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "assetvision.com.au",
@@ -1013,7 +1221,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/assetvision.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/assetvision.com.au",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "atlassian.net",
@@ -1033,7 +1246,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/atlassian.net"
+      "logoSourceUrl": "https://integrations.sh/logo/atlassian.net",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "attio.com",
@@ -1053,7 +1271,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/attio.com"
+      "logoSourceUrl": "https://integrations.sh/logo/attio.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "audible.com",
@@ -1065,7 +1288,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/audible.com"
+      "logoSourceUrl": "https://integrations.sh/logo/audible.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "auraintelligence.com",
@@ -1077,7 +1305,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/auraintelligence.com"
+      "logoSourceUrl": "https://integrations.sh/logo/auraintelligence.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "authzed.com",
@@ -1089,7 +1322,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/authzed.com"
+      "logoSourceUrl": "https://integrations.sh/logo/authzed.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "autodesk.com",
@@ -1101,7 +1339,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/autodesk.com"
+      "logoSourceUrl": "https://integrations.sh/logo/autodesk.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "automotion-mcp-production-6f08e98a6e4b.herokuapp.com",
@@ -1113,7 +1356,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/automotion-mcp-production-6f08e98a6e4b.herokuapp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/automotion-mcp-production-6f08e98a6e4b.herokuapp.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "autoverzekering.nl",
@@ -1125,7 +1373,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/autoverzekering.nl"
+      "logoSourceUrl": "https://integrations.sh/logo/autoverzekering.nl",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "autovit.ro",
@@ -1137,7 +1390,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/autovit.ro"
+      "logoSourceUrl": "https://integrations.sh/logo/autovit.ro",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "avito.ma",
@@ -1149,7 +1407,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/avito.ma"
+      "logoSourceUrl": "https://integrations.sh/logo/avito.ma",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "avo.app",
@@ -1169,7 +1432,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/avo.app"
+      "logoSourceUrl": "https://integrations.sh/logo/avo.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "aweber.com",
@@ -1189,7 +1457,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/aweber.com"
+      "logoSourceUrl": "https://integrations.sh/logo/aweber.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "awesomize.ai",
@@ -1209,7 +1482,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/awesomize.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/awesomize.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "axiom.co",
@@ -1229,7 +1507,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/axiom.co"
+      "logoSourceUrl": "https://integrations.sh/logo/axiom.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "azurecontainerapps.io",
@@ -1241,7 +1524,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/azurecontainerapps.io"
+      "logoSourceUrl": "https://integrations.sh/logo/azurecontainerapps.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "b12.io",
@@ -1253,7 +1541,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/b12.io"
+      "logoSourceUrl": "https://integrations.sh/logo/b12.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "backstage.com",
@@ -1265,7 +1558,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/backstage.com"
+      "logoSourceUrl": "https://integrations.sh/logo/backstage.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ballparkhq.com",
@@ -1285,7 +1583,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ballparkhq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ballparkhq.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bandsintown.com",
@@ -1297,7 +1600,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bandsintown.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bandsintown.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "bankrate.com",
@@ -1309,7 +1617,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bankrate.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bankrate.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "barcelo-mcp.com",
@@ -1329,7 +1642,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/barcelo-mcp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/barcelo-mcp.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "base44.com",
@@ -1349,7 +1667,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/base44.com"
+      "logoSourceUrl": "https://integrations.sh/logo/base44.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "beautiful.ai",
@@ -1369,7 +1692,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/beautiful.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/beautiful.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bed-and-breakfast.it",
@@ -1381,7 +1709,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bed-and-breakfast.it"
+      "logoSourceUrl": "https://integrations.sh/logo/bed-and-breakfast.it",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "beerfinder.workers.dev",
@@ -1393,7 +1726,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/beerfinder.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/beerfinder.workers.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "berlin-group.org",
@@ -1405,7 +1743,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/berlin-group.org"
+      "logoSourceUrl": "https://integrations.sh/logo/berlin-group.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bestcolleges.com",
@@ -1417,7 +1760,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bestcolleges.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bestcolleges.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bestlawyers.com",
@@ -1429,7 +1777,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bestlawyers.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bestlawyers.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bettermg.com",
@@ -1449,7 +1802,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/bettermg.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bettermg.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "betterstack.com",
@@ -1461,7 +1819,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/betterstack.com"
+      "logoSourceUrl": "https://integrations.sh/logo/betterstack.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bigdata.com",
@@ -1488,7 +1851,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bigdata.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bigdata.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "biggeo.com",
@@ -1508,7 +1876,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/biggeo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/biggeo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bigquery.googleapis.com",
@@ -1520,7 +1893,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/bigquery.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bigquery.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bigquerydatatransfer.googleapis.com",
@@ -1532,7 +1910,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/bigquerydatatransfer.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bigquerydatatransfer.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bigtableadmin.googleapis.com",
@@ -1544,7 +1927,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/bigtableadmin.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bigtableadmin.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "billingbudgets.googleapis.com",
@@ -1556,7 +1944,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/billingbudgets.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/billingbudgets.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "biorender.com",
@@ -1576,7 +1969,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/biorender.com"
+      "logoSourceUrl": "https://integrations.sh/logo/biorender.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bitdj.com",
@@ -1588,7 +1986,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bitdj.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bitdj.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "bitly.com",
@@ -1615,7 +2018,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bitly.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bitly.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bizcover.com.au",
@@ -1627,7 +2035,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bizcover.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/bizcover.com.au",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "blackbaud.com",
@@ -1639,7 +2052,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/blackbaud.com"
+      "logoSourceUrl": "https://integrations.sh/logo/blackbaud.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "blazesql.com",
@@ -1659,7 +2077,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/blazesql.com"
+      "logoSourceUrl": "https://integrations.sh/logo/blazesql.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "blockscout.com",
@@ -1671,7 +2094,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/blockscout.com"
+      "logoSourceUrl": "https://integrations.sh/logo/blockscout.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bluente.com",
@@ -1698,7 +2126,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bluente.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bluente.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "blueskyapi.com",
@@ -1718,7 +2151,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/blueskyapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/blueskyapi.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bluesuite.app",
@@ -1738,7 +2176,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/bluesuite.app"
+      "logoSourceUrl": "https://integrations.sh/logo/bluesuite.app",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "bodi.com",
@@ -1750,7 +2193,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bodi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bodi.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "boleron.bg",
@@ -1762,7 +2210,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/boleron.bg"
+      "logoSourceUrl": "https://integrations.sh/logo/boleron.bg",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bon-coin.net",
@@ -1782,7 +2235,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bon-coin.net"
+      "logoSourceUrl": "https://integrations.sh/logo/bon-coin.net",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "book-direct.co",
@@ -1794,7 +2252,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/book-direct.co"
+      "logoSourceUrl": "https://integrations.sh/logo/book-direct.co",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "botpress.sh",
@@ -1814,7 +2277,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/botpress.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/botpress.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "box.com",
@@ -1834,7 +2302,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/box.com"
+      "logoSourceUrl": "https://integrations.sh/logo/box.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "box.dev",
@@ -1846,7 +2319,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/box.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/box.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "boxoffice.com",
@@ -1858,19 +2336,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/boxoffice.com"
-    },
-    {
-      "domain": "boyner.com.tr",
-      "name": "Yapay Zeka'nın Boyner'i",
-      "mcpUrl": "https://mcp-backend.boyner.com.tr/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/boyner.com.tr"
+      "logoSourceUrl": "https://integrations.sh/logo/boxoffice.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "bpcs-ad-broker.de",
@@ -1882,7 +2353,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bpcs-ad-broker.de"
+      "logoSourceUrl": "https://integrations.sh/logo/bpcs-ad-broker.de",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "braintrust.dev",
@@ -1909,7 +2385,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/braintrust.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/braintrust.dev",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "brand24.com",
@@ -1929,7 +2410,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/brand24.com"
+      "logoSourceUrl": "https://integrations.sh/logo/brand24.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "breethe.com",
@@ -1941,7 +2427,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/breethe.com"
+      "logoSourceUrl": "https://integrations.sh/logo/breethe.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "brevo.com",
@@ -1961,7 +2452,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/brevo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/brevo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "brex.com",
@@ -1981,7 +2477,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/brex.com"
+      "logoSourceUrl": "https://integrations.sh/logo/brex.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "brexapis.com",
@@ -2001,7 +2502,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/brexapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/brexapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "browser-use.com",
@@ -2021,7 +2527,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/browser-use.com"
+      "logoSourceUrl": "https://integrations.sh/logo/browser-use.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "browserbase.com",
@@ -2041,7 +2552,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/browserbase.com"
+      "logoSourceUrl": "https://integrations.sh/logo/browserbase.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "buf.build",
@@ -2061,7 +2577,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/buf.build"
+      "logoSourceUrl": "https://integrations.sh/logo/buf.build",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "builder.io",
@@ -2081,7 +2602,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/builder.io"
+      "logoSourceUrl": "https://integrations.sh/logo/builder.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "buildwithfern.com",
@@ -2093,7 +2619,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/buildwithfern.com"
+      "logoSourceUrl": "https://integrations.sh/logo/buildwithfern.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "bump.sh",
@@ -2105,7 +2636,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bump.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/bump.sh",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "busbud-int.com",
@@ -2117,7 +2653,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/busbud-int.com"
+      "logoSourceUrl": "https://integrations.sh/logo/busbud-int.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "buser.com.br",
@@ -2129,7 +2670,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/buser.com.br"
+      "logoSourceUrl": "https://integrations.sh/logo/buser.com.br",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "bygravity.com",
@@ -2149,7 +2695,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/bygravity.com"
+      "logoSourceUrl": "https://integrations.sh/logo/bygravity.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cal.com",
@@ -2169,7 +2720,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cal.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "calendly.com",
@@ -2189,7 +2745,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/calendly.com"
+      "logoSourceUrl": "https://integrations.sh/logo/calendly.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "calorieappguidemcp-production.up.railway.app",
@@ -2201,7 +2762,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/calorieappguidemcp-production.up.railway.app"
+      "logoSourceUrl": "https://integrations.sh/logo/calorieappguidemcp-production.up.railway.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "campfire.ai",
@@ -2221,7 +2787,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/campfire.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/campfire.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "candid.org",
@@ -2241,7 +2812,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/candid.org"
+      "logoSourceUrl": "https://integrations.sh/logo/candid.org",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "canny.io",
@@ -2261,7 +2837,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/canny.io"
+      "logoSourceUrl": "https://integrations.sh/logo/canny.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "canva.com",
@@ -2281,7 +2862,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/canva.com"
+      "logoSourceUrl": "https://integrations.sh/logo/canva.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "capacities.io",
@@ -2301,7 +2887,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/capacities.io"
+      "logoSourceUrl": "https://integrations.sh/logo/capacities.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "carbonarc.ai",
@@ -2321,7 +2912,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "carbonarc.co",
@@ -2341,7 +2937,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.co"
+      "logoSourceUrl": "https://integrations.sh/logo/carbonarc.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cardchain.ai",
@@ -2361,7 +2962,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cardchain.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/cardchain.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "carfax.com",
@@ -2373,7 +2979,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carfax.com"
+      "logoSourceUrl": "https://integrations.sh/logo/carfax.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "cargurus.com",
@@ -2385,7 +2996,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cargurus.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cargurus.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 406
+      }
     },
     {
       "domain": "carmax.com",
@@ -2397,7 +3013,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carmax.com"
+      "logoSourceUrl": "https://integrations.sh/logo/carmax.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "carrefour.fr",
@@ -2409,7 +3030,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carrefour.fr"
+      "logoSourceUrl": "https://integrations.sh/logo/carrefour.fr",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "cars24.com",
@@ -2421,7 +3047,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cars24.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cars24.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "carsguide.com.au",
@@ -2433,7 +3064,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carsguide.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/carsguide.com.au",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "carta.com",
@@ -2445,7 +3081,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carta.com"
+      "logoSourceUrl": "https://integrations.sh/logo/carta.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cartesia.ai",
@@ -2465,7 +3106,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cartesia.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/cartesia.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "carwale.com",
@@ -2477,7 +3123,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/carwale.com"
+      "logoSourceUrl": "https://integrations.sh/logo/carwale.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "cazoo.co.uk",
@@ -2489,7 +3140,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cazoo.co.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/cazoo.co.uk",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cbinsights.com",
@@ -2509,7 +3165,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cbinsights.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cbinsights.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cdata.com",
@@ -2529,7 +3190,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cdata.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cdata.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cdiscount.com",
@@ -2541,7 +3207,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cdiscount.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cdiscount.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cfdomains.com",
@@ -2553,7 +3224,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cfdomains.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cfdomains.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "channel99.com",
@@ -2573,7 +3249,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/channel99.com"
+      "logoSourceUrl": "https://integrations.sh/logo/channel99.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "chartmogul.com",
@@ -2593,7 +3274,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/chartmogul.com"
+      "logoSourceUrl": "https://integrations.sh/logo/chartmogul.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "chatgpt-app-with-next-js-t66k.vercel.app",
@@ -2605,7 +3291,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/chatgpt-app-with-next-js-t66k.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/chatgpt-app-with-next-js-t66k.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "check24.de",
@@ -2617,7 +3308,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/check24.de"
+      "logoSourceUrl": "https://integrations.sh/logo/check24.de",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "checklyhq.com",
@@ -2637,7 +3333,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/checklyhq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/checklyhq.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "checkr.com",
@@ -2657,7 +3358,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/checkr.com"
+      "logoSourceUrl": "https://integrations.sh/logo/checkr.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "chessvia.ai",
@@ -2669,7 +3375,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/chessvia.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/chessvia.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "chroma.com",
@@ -2689,7 +3400,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/chroma.com"
+      "logoSourceUrl": "https://integrations.sh/logo/chroma.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "chronograph.pe",
@@ -2701,7 +3417,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/chronograph.pe"
+      "logoSourceUrl": "https://integrations.sh/logo/chronograph.pe",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cinemo.fun",
@@ -2713,7 +3434,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cinemo.fun"
+      "logoSourceUrl": "https://integrations.sh/logo/cinemo.fun",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "circleback.ai",
@@ -2733,7 +3459,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/circleback.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/circleback.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "clarify.ai",
@@ -2753,7 +3484,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/clarify.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/clarify.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "clarity.ai",
@@ -2765,7 +3501,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/clarity.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/clarity.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "clarivate.com",
@@ -2777,7 +3518,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/clarivate.com"
+      "logoSourceUrl": "https://integrations.sh/logo/clarivate.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "clay.com",
@@ -2797,7 +3543,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/clay.com"
+      "logoSourceUrl": "https://integrations.sh/logo/clay.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "clerk.com",
@@ -2809,7 +3560,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/clerk.com"
+      "logoSourceUrl": "https://integrations.sh/logo/clerk.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "clickup.com",
@@ -2829,7 +3585,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/clickup.com"
+      "logoSourceUrl": "https://integrations.sh/logo/clickup.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "closai.io",
@@ -2849,7 +3610,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/closai.io"
+      "logoSourceUrl": "https://integrations.sh/logo/closai.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "close.com",
@@ -2869,7 +3635,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/close.com"
+      "logoSourceUrl": "https://integrations.sh/logo/close.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cloudasset.googleapis.com",
@@ -2881,7 +3652,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cloudasset.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cloudasset.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "clouderrorreporting.googleapis.com",
@@ -2893,7 +3669,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/clouderrorreporting.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/clouderrorreporting.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cloudflare.com",
@@ -2913,7 +3694,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cloudflare.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cloudflare.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cloudresourcemanager.googleapis.com",
@@ -2925,7 +3711,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cloudresourcemanager.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cloudresourcemanager.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cloudsupport.googleapis.com",
@@ -2937,7 +3728,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cloudsupport.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cloudsupport.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cloudtrace.googleapis.com",
@@ -2949,7 +3745,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cloudtrace.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cloudtrace.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "clutch.ca",
@@ -2969,7 +3770,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/clutch.ca"
+      "logoSourceUrl": "https://integrations.sh/logo/clutch.ca",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "clutch.co",
@@ -2981,7 +3787,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/clutch.co"
+      "logoSourceUrl": "https://integrations.sh/logo/clutch.co",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "cmcp.shop",
@@ -2993,7 +3804,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cmcp.shop"
+      "logoSourceUrl": "https://integrations.sh/logo/cmcp.shop",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "cobaltpf.com",
@@ -3013,7 +3829,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cobaltpf.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cobaltpf.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "coches.net",
@@ -3025,7 +3846,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/coches.net"
+      "logoSourceUrl": "https://integrations.sh/logo/coches.net",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "cockroachlabs.com",
@@ -3045,7 +3871,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cockroachlabs.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cockroachlabs.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cogedim.com",
@@ -3057,7 +3888,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cogedim.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cogedim.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "collegenation.com",
@@ -3069,7 +3905,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/collegenation.com"
+      "logoSourceUrl": "https://integrations.sh/logo/collegenation.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 422
+      }
     },
     {
       "domain": "columnapi.com",
@@ -3081,7 +3922,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/columnapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/columnapi.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "commonroom.io",
@@ -3101,7 +3947,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/commonroom.io"
+      "logoSourceUrl": "https://integrations.sh/logo/commonroom.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "compute.googleapis.com",
@@ -3113,7 +3964,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/compute.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/compute.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "computrabajo.com",
@@ -3125,7 +3981,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/computrabajo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/computrabajo.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "conductor.com",
@@ -3145,7 +4006,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/conductor.com"
+      "logoSourceUrl": "https://integrations.sh/logo/conductor.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "confident-ai.com",
@@ -3165,7 +4031,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/confident-ai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/confident-ai.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "confirmtkt.com",
@@ -3177,7 +4048,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/confirmtkt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/confirmtkt.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "connectedpdf.com",
@@ -3189,7 +4065,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/connectedpdf.com"
+      "logoSourceUrl": "https://integrations.sh/logo/connectedpdf.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "consensus.app",
@@ -3209,7 +4090,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/consensus.app"
+      "logoSourceUrl": "https://integrations.sh/logo/consensus.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "contactcenterinsights.googleapis.com",
@@ -3221,7 +4107,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/contactcenterinsights.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/contactcenterinsights.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "container.googleapis.com",
@@ -3233,7 +4124,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/container.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/container.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "contentful.com",
@@ -3253,7 +4149,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/contentful.com"
+      "logoSourceUrl": "https://integrations.sh/logo/contentful.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "contentsquare.com",
@@ -3273,7 +4174,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/contentsquare.com"
+      "logoSourceUrl": "https://integrations.sh/logo/contentsquare.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "context.dev",
@@ -3293,7 +4199,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/context.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/context.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "context7.com",
@@ -3320,7 +4231,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/context7.com"
+      "logoSourceUrl": "https://integrations.sh/logo/context7.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "corrently.de",
@@ -3340,7 +4256,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/corrently.de"
+      "logoSourceUrl": "https://integrations.sh/logo/corrently.de",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 502
+      }
     },
     {
       "domain": "cosmicjs.com",
@@ -3360,7 +4281,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cosmicjs.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cosmicjs.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "coupler.io",
@@ -3380,7 +4306,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/coupler.io"
+      "logoSourceUrl": "https://integrations.sh/logo/coupler.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "courier.com",
@@ -3400,7 +4331,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/courier.com"
+      "logoSourceUrl": "https://integrations.sh/logo/courier.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "coursera.org",
@@ -3412,7 +4348,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/coursera.org"
+      "logoSourceUrl": "https://integrations.sh/logo/coursera.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "coveo.com",
@@ -3432,7 +4373,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/coveo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/coveo.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com",
@@ -3444,7 +4390,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "craft.do",
@@ -3464,27 +4415,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/craft.do"
-    },
-    {
-      "domain": "creditkarma.com",
-      "name": "Intuit Credit Karma",
-      "mcpUrl": "https://anthropic.mcp.creditkarma.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "creditkarma_oauth",
-          "type": "oauth2",
-          "generateUrl": null,
-          "setup": "Open the MCP endpoint in an MCP client and complete the provider's OAuth sign-in/consent flow when prompted. The curated registry identifies this server as using OAuth, but Credit Karma does not appear to publish separate public developer registration docs for this MCP server. Start from the MCP endpoint `https://anthropic.mcp.creditkarma.com/mcp` and the Credit Karma sign-in pages such as [Log in](https://www.creditkarma.com/auth/logon).",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/creditkarma.com"
+      "logoSourceUrl": "https://integrations.sh/logo/craft.do",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "creed.md",
@@ -3504,7 +4440,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/creed.md"
+      "logoSourceUrl": "https://integrations.sh/logo/creed.md",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "crewai.com",
@@ -3516,7 +4457,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/crewai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/crewai.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "crossbeam.com",
@@ -3536,27 +4482,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/crossbeam.com"
-    },
-    {
-      "domain": "crowdstrike.com",
-      "name": "crowdstrike.com",
-      "mcpUrl": "http://127.0.0.1:8000",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "falcon_mcp_http_key",
-          "type": "api_key",
-          "generateUrl": null,
-          "setup": "When self-hosting `falcon-mcp` over an HTTP transport, set the server's API key value and configure clients to send it in the `x-api-key` header. The server source documents this as `api_key` for HTTP transport authentication and validates the `x-api-key` header. This is a server-local credential you choose when deploying the MCP server, not a CrowdStrike-issued Falcon platform credential.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/crowdstrike.com"
+      "logoSourceUrl": "https://integrations.sh/logo/crossbeam.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "cruisecritic.com",
@@ -3568,7 +4499,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/cruisecritic.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cruisecritic.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "crypto.com",
@@ -3580,7 +4516,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/crypto.com"
+      "logoSourceUrl": "https://integrations.sh/logo/crypto.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ctmers.io",
@@ -3592,7 +4533,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ctmers.io"
+      "logoSourceUrl": "https://integrations.sh/logo/ctmers.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "cubesoftware.com",
@@ -3612,7 +4558,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/cubesoftware.com"
+      "logoSourceUrl": "https://integrations.sh/logo/cubesoftware.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "daloopa.com",
@@ -3632,7 +4583,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/daloopa.com"
+      "logoSourceUrl": "https://integrations.sh/logo/daloopa.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dataflow.googleapis.com",
@@ -3644,7 +4600,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dataflow.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dataflow.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "dataforseo.com",
@@ -3664,7 +4625,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dataforseo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dataforseo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dataplex.googleapis.com",
@@ -3676,7 +4642,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dataplex.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dataplex.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "dataproc.googleapis.com",
@@ -3688,7 +4659,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dataproc.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dataproc.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "datasite.com",
@@ -3708,7 +4684,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/datasite.com"
+      "logoSourceUrl": "https://integrations.sh/logo/datasite.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "datastream.googleapis.com",
@@ -3720,7 +4701,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/datastream.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/datastream.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "datocms.com",
@@ -3740,7 +4726,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/datocms.com"
+      "logoSourceUrl": "https://integrations.sh/logo/datocms.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "day.ai",
@@ -3760,7 +4751,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/day.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/day.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dazzly.co",
@@ -3780,7 +4776,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dazzly.co"
+      "logoSourceUrl": "https://integrations.sh/logo/dazzly.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "decolar.com",
@@ -3800,7 +4801,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/decolar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/decolar.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "deepgram.com",
@@ -3812,7 +4818,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/deepgram.com"
+      "logoSourceUrl": "https://integrations.sh/logo/deepgram.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "demandbase.com",
@@ -3832,7 +4843,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/demandbase.com"
+      "logoSourceUrl": "https://integrations.sh/logo/demandbase.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "descope.com",
@@ -3852,7 +4868,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/descope.com"
+      "logoSourceUrl": "https://integrations.sh/logo/descope.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "devcycle.com",
@@ -3872,7 +4893,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/devcycle.com"
+      "logoSourceUrl": "https://integrations.sh/logo/devcycle.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "devrev.ai",
@@ -3884,7 +4910,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/devrev.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/devrev.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dialogflow.googleapis.com",
@@ -3896,7 +4927,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dialogflow.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dialogflow.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "dice.com",
@@ -3908,7 +4944,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/dice.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dice.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "digits.com",
@@ -3928,7 +4969,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/digits.com"
+      "logoSourceUrl": "https://integrations.sh/logo/digits.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "directbooker.ai",
@@ -3940,7 +4986,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/directbooker.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/directbooker.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "district.in",
@@ -3960,7 +5011,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/district.in"
+      "logoSourceUrl": "https://integrations.sh/logo/district.in",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "docketai.com",
@@ -3980,7 +5036,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/docketai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/docketai.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "docsie.io",
@@ -4000,7 +5061,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/docsie.io"
+      "logoSourceUrl": "https://integrations.sh/logo/docsie.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "documents.craft.me",
@@ -4020,7 +5086,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/documents.craft.me"
+      "logoSourceUrl": "https://integrations.sh/logo/documents.craft.me",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "docuseal.com",
@@ -4040,7 +5111,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/docuseal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/docuseal.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "docusign.com",
@@ -4052,7 +5128,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/docusign.com"
+      "logoSourceUrl": "https://integrations.sh/logo/docusign.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "domotz.app",
@@ -4072,7 +5153,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/domotz.app"
+      "logoSourceUrl": "https://integrations.sh/logo/domotz.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "domotz.com",
@@ -4092,7 +5178,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/domotz.com"
+      "logoSourceUrl": "https://integrations.sh/logo/domotz.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dovetail.com",
@@ -4112,7 +5203,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dovetail.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dovetail.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dowjones.io",
@@ -4132,7 +5228,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/dowjones.io"
+      "logoSourceUrl": "https://integrations.sh/logo/dowjones.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "draftkings.com",
@@ -4144,7 +5245,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/draftkings.com"
+      "logoSourceUrl": "https://integrations.sh/logo/draftkings.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "driftless.icu",
@@ -4171,7 +5277,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu"
+      "logoSourceUrl": "https://integrations.sh/logo/driftless.icu",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dropbox.com",
@@ -4191,7 +5302,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dropbox.com"
+      "logoSourceUrl": "https://integrations.sh/logo/dropbox.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "dub.co",
@@ -4211,7 +5327,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/dub.co"
+      "logoSourceUrl": "https://integrations.sh/logo/dub.co",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "e2b.dev",
@@ -4223,7 +5344,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/e2b.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/e2b.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "easemytrip.com",
@@ -4235,7 +5361,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/easemytrip.com"
+      "logoSourceUrl": "https://integrations.sh/logo/easemytrip.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ecsbr.net",
@@ -4247,7 +5378,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ecsbr.net"
+      "logoSourceUrl": "https://integrations.sh/logo/ecsbr.net",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "edmunds.com",
@@ -4259,7 +5395,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/edmunds.com"
+      "logoSourceUrl": "https://integrations.sh/logo/edmunds.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "edreams.com",
@@ -4271,7 +5412,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/edreams.com"
+      "logoSourceUrl": "https://integrations.sh/logo/edreams.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 406
+      }
     },
     {
       "domain": "egnyte.com",
@@ -4291,19 +5437,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/egnyte.com"
-    },
-    {
-      "domain": "email-creation-mcp-node-production.up.railway.app",
-      "name": "Kopi - Shopify Email Creator",
-      "mcpUrl": "https://email-creation-mcp-node-production.up.railway.app/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/email-creation-mcp-node-production.up.railway.app"
+      "logoSourceUrl": "https://integrations.sh/logo/egnyte.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "employers.com",
@@ -4315,7 +5454,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/employers.com"
+      "logoSourceUrl": "https://integrations.sh/logo/employers.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "enechange.jp",
@@ -4335,7 +5479,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/enechange.jp"
+      "logoSourceUrl": "https://integrations.sh/logo/enechange.jp",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "enhancv.com",
@@ -4347,7 +5496,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/enhancv.com"
+      "logoSourceUrl": "https://integrations.sh/logo/enhancv.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "enterpret.com",
@@ -4367,7 +5521,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/enterpret.com"
+      "logoSourceUrl": "https://integrations.sh/logo/enterpret.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "envoy.com",
@@ -4387,7 +5546,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/envoy.com"
+      "logoSourceUrl": "https://integrations.sh/logo/envoy.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "enzoreader.com",
@@ -4407,7 +5571,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/enzoreader.com"
+      "logoSourceUrl": "https://integrations.sh/logo/enzoreader.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "eodhd.com",
@@ -4427,7 +5596,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/eodhd.com"
+      "logoSourceUrl": "https://integrations.sh/logo/eodhd.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "esky.com",
@@ -4439,7 +5613,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/esky.com"
+      "logoSourceUrl": "https://integrations.sh/logo/esky.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "ethoslife.com",
@@ -4451,7 +5630,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ethoslife.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ethoslife.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "etraveligroup.com",
@@ -4463,7 +5647,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/etraveligroup.com"
+      "logoSourceUrl": "https://integrations.sh/logo/etraveligroup.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "evaneos.com",
@@ -4475,7 +5664,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/evaneos.com"
+      "logoSourceUrl": "https://integrations.sh/logo/evaneos.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "every.ai",
@@ -4495,7 +5689,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/every.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/every.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "exa.ai",
@@ -4507,7 +5706,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/exa.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/exa.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "excalidraw.com",
@@ -4519,7 +5723,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/excalidraw.com"
+      "logoSourceUrl": "https://integrations.sh/logo/excalidraw.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "executor.sh",
@@ -4539,7 +5748,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/executor.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/executor.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "expedia.com",
@@ -4551,7 +5765,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/expedia.com"
+      "logoSourceUrl": "https://integrations.sh/logo/expedia.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "experian.com",
@@ -4563,7 +5782,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/experian.com"
+      "logoSourceUrl": "https://integrations.sh/logo/experian.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "experiancs.co.uk",
@@ -4575,7 +5799,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/experiancs.co.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/experiancs.co.uk",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "experteer.com",
@@ -4587,7 +5816,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/experteer.com"
+      "logoSourceUrl": "https://integrations.sh/logo/experteer.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "explorium.ai",
@@ -4607,7 +5841,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/explorium.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/explorium.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "facebook.com",
@@ -4627,7 +5866,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/facebook.com"
+      "logoSourceUrl": "https://integrations.sh/logo/facebook.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "faces.app",
@@ -4647,7 +5891,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/faces.app"
+      "logoSourceUrl": "https://integrations.sh/logo/faces.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "factagora.com",
@@ -4667,7 +5916,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/factagora.com"
+      "logoSourceUrl": "https://integrations.sh/logo/factagora.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "factset.io",
@@ -4679,7 +5933,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/factset.io"
+      "logoSourceUrl": "https://integrations.sh/logo/factset.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "faire.com",
@@ -4691,7 +5950,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/faire.com"
+      "logoSourceUrl": "https://integrations.sh/logo/faire.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "fal.ai",
@@ -4711,7 +5975,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fal.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fal.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fareharbor.com",
@@ -4723,19 +5992,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/fareharbor.com"
-    },
-    {
-      "domain": "fastmcp.cloud",
-      "name": "fastmcp.cloud",
-      "mcpUrl": "https://my-tools.horizon.prefect.io",
-      "transport": "streamable-http",
-      "authKind": "unknown",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/fastmcp.cloud"
+      "logoSourceUrl": "https://integrations.sh/logo/fareharbor.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "fathom.ai",
@@ -4755,7 +6017,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fathom.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fathom.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "feedclaw.io",
@@ -4775,7 +6042,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/feedclaw.io"
+      "logoSourceUrl": "https://integrations.sh/logo/feedclaw.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fellow.ai",
@@ -4795,7 +6067,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/fellow.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fellow.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "ferryhopper.com",
@@ -4807,7 +6084,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ferryhopper.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ferryhopper.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "feverup.com",
@@ -4827,7 +6109,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/feverup.com"
+      "logoSourceUrl": "https://integrations.sh/logo/feverup.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fgdsp698b0.execute-api.eu-west-1.amazonaws.com",
@@ -4839,7 +6126,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fgdsp698b0.execute-api.eu-west-1.amazonaws.com"
+      "logoSourceUrl": "https://integrations.sh/logo/fgdsp698b0.execute-api.eu-west-1.amazonaws.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "figma.com",
@@ -4859,7 +6151,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/figma.com"
+      "logoSourceUrl": "https://integrations.sh/logo/figma.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "file.googleapis.com",
@@ -4871,7 +6168,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/file.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/file.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "financialmodelingprep.com",
@@ -4898,7 +6200,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/financialmodelingprep.com"
+      "logoSourceUrl": "https://integrations.sh/logo/financialmodelingprep.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fintables.com",
@@ -4918,7 +6225,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fintables.com"
+      "logoSourceUrl": "https://integrations.sh/logo/fintables.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fireflies.ai",
@@ -4930,7 +6242,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fireflies.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fireflies.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "firestore.googleapis.com",
@@ -4942,7 +6259,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/firestore.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/firestore.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "fiscal.ai",
@@ -4962,7 +6284,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fiscal.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fiscal.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "flaerobotics.ai",
@@ -4974,7 +6301,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/flaerobotics.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/flaerobotics.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "flagsmith.com",
@@ -4994,7 +6326,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/flagsmith.com"
+      "logoSourceUrl": "https://integrations.sh/logo/flagsmith.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "flarehawk.com",
@@ -5014,27 +6351,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/flarehawk.com"
-    },
-    {
-      "domain": "flowerdiary.xyz",
-      "name": "Blossom",
-      "mcpUrl": "https://openai.flowerdiary.xyz/mcp",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "blossom_oauth_client",
-          "type": "oauth2",
-          "generateUrl": "https://openai.flowerdiary.xyz/oauth/register",
-          "setup": "Register an OAuth client with Blossom's MCP server at [OAuth client registration](https://openai.flowerdiary.xyz/oauth/register). Then run the MCP client's OAuth login flow against Blossom's authorization server discovered from [the OAuth metadata document](https://openai.flowerdiary.xyz/.well-known/oauth-authorization-server). The metadata advertises `authorization_code` with PKCE (`S256`) and scopes including `diary:read` and `diary:write`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/flowerdiary.xyz"
+      "logoSourceUrl": "https://integrations.sh/logo/flarehawk.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "formbyte.ai",
@@ -5054,7 +6376,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/formbyte.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/formbyte.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "formulagenius.co",
@@ -5074,7 +6401,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/formulagenius.co"
+      "logoSourceUrl": "https://integrations.sh/logo/formulagenius.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fos.tui",
@@ -5086,7 +6418,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/fos.tui"
+      "logoSourceUrl": "https://integrations.sh/logo/fos.tui",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "fotocasa.es",
@@ -5098,7 +6435,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/fotocasa.es"
+      "logoSourceUrl": "https://integrations.sh/logo/fotocasa.es",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "framagit.org",
@@ -5118,7 +6460,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/framagit.org"
+      "logoSourceUrl": "https://integrations.sh/logo/framagit.org",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "frankfurter.dev",
@@ -5130,7 +6477,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/frankfurter.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/frankfurter.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "freediver.club",
@@ -5150,7 +6502,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/freediver.club"
+      "logoSourceUrl": "https://integrations.sh/logo/freediver.club",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "freee.co.jp",
@@ -5162,7 +6519,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/freee.co.jp"
+      "logoSourceUrl": "https://integrations.sh/logo/freee.co.jp",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "freshdesk.com",
@@ -5182,7 +6544,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/freshdesk.com"
+      "logoSourceUrl": "https://integrations.sh/logo/freshdesk.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "front.com",
@@ -5202,7 +6569,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/front.com"
+      "logoSourceUrl": "https://integrations.sh/logo/front.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fugle.ai",
@@ -5222,7 +6594,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fugle.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/fugle.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fugle.tw",
@@ -5242,7 +6619,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fugle.tw"
+      "logoSourceUrl": "https://integrations.sh/logo/fugle.tw",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "fullstory.com",
@@ -5262,7 +6644,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fullstory.com"
+      "logoSourceUrl": "https://integrations.sh/logo/fullstory.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "functionhealth.com",
@@ -5282,7 +6669,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/functionhealth.com"
+      "logoSourceUrl": "https://integrations.sh/logo/functionhealth.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "fyxer.com",
@@ -5302,7 +6694,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/fyxer.com"
+      "logoSourceUrl": "https://integrations.sh/logo/fyxer.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "g2.com",
@@ -5322,7 +6719,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/g2.com"
+      "logoSourceUrl": "https://integrations.sh/logo/g2.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "galileo.ai",
@@ -5342,7 +6744,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/galileo.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/galileo.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "gamma.app",
@@ -5354,7 +6761,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gamma.app"
+      "logoSourceUrl": "https://integrations.sh/logo/gamma.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "garchi.co.uk",
@@ -5374,7 +6786,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/garchi.co.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/garchi.co.uk",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "gathrd.uk",
@@ -5394,7 +6811,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gathrd.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/gathrd.uk",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "getagent.co.uk",
@@ -5406,7 +6828,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/getagent.co.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/getagent.co.uk",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "getguru.com",
@@ -5433,7 +6860,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/getguru.com"
+      "logoSourceUrl": "https://integrations.sh/logo/getguru.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "getmedesign.com",
@@ -5445,7 +6877,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/getmedesign.com"
+      "logoSourceUrl": "https://integrations.sh/logo/getmedesign.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "getperseuss.com",
@@ -5457,7 +6894,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/getperseuss.com"
+      "logoSourceUrl": "https://integrations.sh/logo/getperseuss.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "glama.ai",
@@ -5469,7 +6911,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/glama.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/glama.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "glean.com",
@@ -5481,7 +6928,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/glean.com"
+      "logoSourceUrl": "https://integrations.sh/logo/glean.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "glinded.com",
@@ -5501,27 +6953,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/glinded.com"
-    },
-    {
-      "domain": "gmail.googleapis.com",
-      "name": "gmail.googleapis.com",
-      "mcpUrl": "https://gmail.googleapis.com/mcp/",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "google_oauth_client",
-          "type": "oauth2",
-          "generateUrl": "https://console.cloud.google.com/apis/credentials",
-          "setup": "In [Google Cloud Console](https://console.cloud.google.com/apis/credentials), create or select a project, enable the Gmail API, configure the OAuth consent screen as described in [Configure OAuth consent](https://developers.google.com/workspace/guides/configure-oauth-consent), then create OAuth client credentials and authorize for the Gmail scopes listed in [Choose scopes](https://developers.google.com/workspace/gmail/api/auth/scopes). The quickstart flow stores a user access/refresh token after the user completes consent.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/gmail.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/glinded.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "gocardless.com",
@@ -5541,7 +6978,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gocardless.com"
+      "logoSourceUrl": "https://integrations.sh/logo/gocardless.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "godaddy.com",
@@ -5553,7 +6995,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/godaddy.com"
+      "logoSourceUrl": "https://integrations.sh/logo/godaddy.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "gogs.io",
@@ -5565,7 +7012,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gogs.io"
+      "logoSourceUrl": "https://integrations.sh/logo/gogs.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "gohighlevel.com",
@@ -5585,7 +7037,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gohighlevel.com"
+      "logoSourceUrl": "https://integrations.sh/logo/gohighlevel.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "gojinko.com",
@@ -5605,7 +7062,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gojinko.com"
+      "logoSourceUrl": "https://integrations.sh/logo/gojinko.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "goodnotes.com",
@@ -5617,7 +7079,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/goodnotes.com"
+      "logoSourceUrl": "https://integrations.sh/logo/goodnotes.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "gorgias.com",
@@ -5637,19 +7104,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gorgias.com"
-    },
-    {
-      "domain": "gosure.ai",
-      "name": "Insurance GPT",
-      "mcpUrl": "https://dev.gosure.ai/core-mcp/api",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/gosure.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/gorgias.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "goupword.com",
@@ -5669,7 +7129,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/goupword.com"
+      "logoSourceUrl": "https://integrations.sh/logo/goupword.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "govcon.dev",
@@ -5689,7 +7154,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/govcon.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/govcon.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "govtribe.com",
@@ -5716,7 +7186,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/govtribe.com"
+      "logoSourceUrl": "https://integrations.sh/logo/govtribe.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "grain.com",
@@ -5736,7 +7211,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/grain.com"
+      "logoSourceUrl": "https://integrations.sh/logo/grain.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "granola.ai",
@@ -5748,7 +7228,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/granola.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/granola.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "grantedai.com",
@@ -5760,7 +7245,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/grantedai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/grantedai.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "grep.app",
@@ -5772,7 +7262,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/grep.app"
+      "logoSourceUrl": "https://integrations.sh/logo/grep.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "greptile.com",
@@ -5792,7 +7287,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/greptile.com"
+      "logoSourceUrl": "https://integrations.sh/logo/greptile.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "greystar.com",
@@ -5804,7 +7304,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/greystar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/greystar.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "groundcover.com",
@@ -5824,7 +7329,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/groundcover.com"
+      "logoSourceUrl": "https://integrations.sh/logo/groundcover.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "gsplantfoods.com",
@@ -5836,7 +7346,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/gsplantfoods.com"
+      "logoSourceUrl": "https://integrations.sh/logo/gsplantfoods.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 422
+      }
     },
     {
       "domain": "gumtree.com.au",
@@ -5848,7 +7363,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/gumtree.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/gumtree.com.au",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "gusto.com",
@@ -5868,7 +7388,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/gusto.com"
+      "logoSourceUrl": "https://integrations.sh/logo/gusto.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "habitify.me",
@@ -5888,7 +7413,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/habitify.me"
+      "logoSourceUrl": "https://integrations.sh/logo/habitify.me",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "happenstance.ai",
@@ -5908,7 +7438,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/happenstance.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/happenstance.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "harmonic.ai",
@@ -5928,7 +7463,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/harmonic.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/harmonic.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "harvey.ai",
@@ -5948,7 +7488,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/harvey.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/harvey.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hauptsache.net",
@@ -5968,7 +7513,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/hauptsache.net"
+      "logoSourceUrl": "https://integrations.sh/logo/hauptsache.net",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "healthex.io",
@@ -5988,19 +7538,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/healthex.io"
-    },
-    {
-      "domain": "heepsy.com",
-      "name": "Heepsy Influencer Search",
-      "mcpUrl": "https://mcp.heepsy.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/heepsy.com"
+      "logoSourceUrl": "https://integrations.sh/logo/healthex.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "heffl.com",
@@ -6020,7 +7563,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/heffl.com"
+      "logoSourceUrl": "https://integrations.sh/logo/heffl.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hellosign.com",
@@ -6032,7 +7580,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hellosign.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hellosign.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "hemlak.com",
@@ -6044,7 +7597,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hemlak.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hemlak.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "hercules.app",
@@ -6064,7 +7622,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hercules.app"
+      "logoSourceUrl": "https://integrations.sh/logo/hercules.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hex.tech",
@@ -6084,7 +7647,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/hex.tech"
+      "logoSourceUrl": "https://integrations.sh/logo/hex.tech",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hipages.com.au",
@@ -6096,7 +7664,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hipages.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/hipages.com.au",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "hjarni.com",
@@ -6123,7 +7696,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/hjarni.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hjarni.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "homegraph.googleapis.com",
@@ -6135,7 +7713,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/homegraph.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/homegraph.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "honeycomb.io",
@@ -6155,7 +7738,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/honeycomb.io"
+      "logoSourceUrl": "https://integrations.sh/logo/honeycomb.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hostinger.com",
@@ -6175,7 +7763,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hostinger.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hostinger.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "hubspot.com",
@@ -6187,7 +7780,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/hubspot.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hubspot.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "huggingface.co",
@@ -6199,7 +7797,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/huggingface.co"
+      "logoSourceUrl": "https://integrations.sh/logo/huggingface.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "hyatt.com",
@@ -6211,7 +7814,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hyatt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hyatt.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "hyperping.com",
@@ -6231,7 +7839,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/hyperping.com"
+      "logoSourceUrl": "https://integrations.sh/logo/hyperping.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "ibm.com",
@@ -6251,7 +7864,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ibm.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ibm.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "ice.com",
@@ -6263,7 +7881,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ice.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ice.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "idealista.com",
@@ -6275,7 +7898,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/idealista.com"
+      "logoSourceUrl": "https://integrations.sh/logo/idealista.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "idealo.tools",
@@ -6287,7 +7915,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/idealo.tools"
+      "logoSourceUrl": "https://integrations.sh/logo/idealo.tools",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "idoctor.md",
@@ -6299,7 +7932,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/idoctor.md"
+      "logoSourceUrl": "https://integrations.sh/logo/idoctor.md",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ifttt.com",
@@ -6319,7 +7957,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/ifttt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ifttt.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "imedidata.com",
@@ -6339,7 +7982,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/imedidata.com"
+      "logoSourceUrl": "https://integrations.sh/logo/imedidata.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "incident.io",
@@ -6359,7 +8007,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/incident.io"
+      "logoSourceUrl": "https://integrations.sh/logo/incident.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "indeed.com",
@@ -6371,7 +8024,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/indeed.com"
+      "logoSourceUrl": "https://integrations.sh/logo/indeed.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "inline.chat",
@@ -6391,19 +8049,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/inline.chat"
-    },
-    {
-      "domain": "inngest.com",
-      "name": "inngest.com",
-      "mcpUrl": "http://127.0.0.1:8288/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/inngest.com"
+      "logoSourceUrl": "https://integrations.sh/logo/inline.chat",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "inpost-group.com",
@@ -6415,7 +8066,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/inpost-group.com"
+      "logoSourceUrl": "https://integrations.sh/logo/inpost-group.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "insighttimer-api.net",
@@ -6427,7 +8083,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/insighttimer-api.net"
+      "logoSourceUrl": "https://integrations.sh/logo/insighttimer-api.net",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "instacart.com",
@@ -6447,7 +8108,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/instacart.com"
+      "logoSourceUrl": "https://integrations.sh/logo/instacart.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "integrations.sh",
@@ -6459,7 +8125,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/integrations.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/integrations.sh",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "intercom.io",
@@ -6486,7 +8157,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/intercom.io"
+      "logoSourceUrl": "https://integrations.sh/logo/intercom.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "intercom.io",
@@ -6498,7 +8174,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/intercom.io"
+      "logoSourceUrl": "https://integrations.sh/logo/intercom.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "introvoke.com",
@@ -6518,7 +8199,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/introvoke.com"
+      "logoSourceUrl": "https://integrations.sh/logo/introvoke.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "intuit.com",
@@ -6530,7 +8216,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/intuit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/intuit.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "ipinfo.io",
@@ -6550,7 +8241,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ipinfo.io"
+      "logoSourceUrl": "https://integrations.sh/logo/ipinfo.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "isango.com",
@@ -6562,7 +8258,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/isango.com"
+      "logoSourceUrl": "https://integrations.sh/logo/isango.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "itsdunzo.com",
@@ -6582,7 +8283,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/itsdunzo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/itsdunzo.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "jam.dev",
@@ -6602,7 +8308,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/jam.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/jam.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jars.lt",
@@ -6629,7 +8340,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jars.lt"
+      "logoSourceUrl": "https://integrations.sh/logo/jars.lt",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "jaz.ai",
@@ -6649,7 +8365,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/jaz.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/jaz.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jebbit.com",
@@ -6661,7 +8382,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jebbit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jebbit.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "jentic.com",
@@ -6688,7 +8414,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/jentic.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jentic.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jerry.ai",
@@ -6700,7 +8431,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jerry.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/jerry.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "jimdo.com",
@@ -6720,7 +8456,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/jimdo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jimdo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jina.ai",
@@ -6740,7 +8481,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jina.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/jina.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "jiqiren.ai",
@@ -6752,7 +8498,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jiqiren.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/jiqiren.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "jira.com",
@@ -6772,7 +8523,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/jira.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jira.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jora.com",
@@ -6792,7 +8548,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jora.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jora.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "jotform.com",
@@ -6812,7 +8573,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/jotform.com"
+      "logoSourceUrl": "https://integrations.sh/logo/jotform.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "justfix.app",
@@ -6824,19 +8590,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/justfix.app"
-    },
-    {
-      "domain": "kactus.com",
-      "name": "Kactus",
-      "mcpUrl": "https://www.kactus.com/apis/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kactus.com"
+      "logoSourceUrl": "https://integrations.sh/logo/justfix.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kaggle.com",
@@ -6863,7 +8622,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kaggle.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kaggle.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kakao.com",
@@ -6875,7 +8639,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kakao.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kakao.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kartikay-dhar.workers.dev",
@@ -6887,7 +8656,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kartikay-dhar.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/kartikay-dhar.workers.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kensho.com",
@@ -6907,7 +8681,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/kensho.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kensho.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kernel.sh",
@@ -6934,7 +8713,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/kernel.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/kernel.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kestra.io",
@@ -6946,7 +8730,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kestra.io"
+      "logoSourceUrl": "https://integrations.sh/logo/kestra.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ketryx.com",
@@ -6966,7 +8755,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/ketryx.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ketryx.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "keybid.eu",
@@ -6978,7 +8772,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/keybid.eu"
+      "logoSourceUrl": "https://integrations.sh/logo/keybid.eu",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kindora.co",
@@ -7005,7 +8804,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kindora.co"
+      "logoSourceUrl": "https://integrations.sh/logo/kindora.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kit.com",
@@ -7025,7 +8829,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/kit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kit.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kiwi.com",
@@ -7037,7 +8846,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kiwi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kiwi.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "klaviyo.com",
@@ -7057,7 +8871,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/klaviyo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/klaviyo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kleinanzeigen.de",
@@ -7069,7 +8888,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kleinanzeigen.de"
+      "logoSourceUrl": "https://integrations.sh/logo/kleinanzeigen.de",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "klook.com",
@@ -7081,7 +8905,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/klook.com"
+      "logoSourceUrl": "https://integrations.sh/logo/klook.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "komoot.net",
@@ -7093,7 +8922,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/komoot.net"
+      "logoSourceUrl": "https://integrations.sh/logo/komoot.net",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kone.vc",
@@ -7105,7 +8939,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kone.vc"
+      "logoSourceUrl": "https://integrations.sh/logo/kone.vc",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kosik.cz",
@@ -7125,7 +8964,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/kosik.cz"
+      "logoSourceUrl": "https://integrations.sh/logo/kosik.cz",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kraken.com",
@@ -7137,7 +8981,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kraken.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kraken.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "krisp.ai",
@@ -7157,7 +9006,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/krisp.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/krisp.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kronan.is",
@@ -7169,7 +9023,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kronan.is"
+      "logoSourceUrl": "https://integrations.sh/logo/kronan.is",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "kubera.com",
@@ -7189,7 +9048,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/kubera.com"
+      "logoSourceUrl": "https://integrations.sh/logo/kubera.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "kynapp.ca",
@@ -7209,7 +9073,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/kynapp.ca"
+      "logoSourceUrl": "https://integrations.sh/logo/kynapp.ca",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lambus.ai",
@@ -7229,7 +9098,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lambus.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lambus.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "langfuse.com",
@@ -7249,7 +9123,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/langfuse.com"
+      "logoSourceUrl": "https://integrations.sh/logo/langfuse.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lastminute.com",
@@ -7261,19 +9140,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lastminute.com"
-    },
-    {
-      "domain": "lckqhyftgouenpercpjk.supabase.co",
-      "name": "lckqhyftgouenpercpjk.supabase.co",
-      "mcpUrl": "http://127.0.0.1:54321/mcp",
-      "transport": "streamable-http",
-      "authKind": "unknown",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lckqhyftgouenpercpjk.supabase.co"
+      "logoSourceUrl": "https://integrations.sh/logo/lastminute.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "leadconnectorhq.com",
@@ -7293,7 +9165,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/leadconnectorhq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/leadconnectorhq.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "leapscholar.com",
@@ -7305,7 +9182,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/leapscholar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/leapscholar.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "learningcommons.org",
@@ -7325,7 +9207,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/learningcommons.org"
+      "logoSourceUrl": "https://integrations.sh/logo/learningcommons.org",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "legalzoom.com",
@@ -7345,7 +9232,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/legalzoom.com"
+      "logoSourceUrl": "https://integrations.sh/logo/legalzoom.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lemlist.com",
@@ -7365,7 +9257,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lemlist.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lemlist.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "leparisien.fr",
@@ -7377,7 +9274,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/leparisien.fr"
+      "logoSourceUrl": "https://integrations.sh/logo/leparisien.fr",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lesfurets.com",
@@ -7389,7 +9291,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lesfurets.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lesfurets.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "leyware-mcp.vercel.app",
@@ -7401,19 +9308,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/leyware-mcp.vercel.app"
-    },
-    {
-      "domain": "liblab.com",
-      "name": "liblab.com",
-      "mcpUrl": "https://mcp.liblab.io/liblab",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/liblab.com"
+      "logoSourceUrl": "https://integrations.sh/logo/leyware-mcp.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lifttrackapp.com",
@@ -7433,7 +9333,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lifttrackapp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lifttrackapp.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lilt.com",
@@ -7453,7 +9358,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lilt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lilt.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "linear.app",
@@ -7473,7 +9383,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/linear.app"
+      "logoSourceUrl": "https://integrations.sh/logo/linear.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "linklyhq.com",
@@ -7493,7 +9408,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/linklyhq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/linklyhq.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "list-manage.com",
@@ -7513,7 +9433,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/list-manage.com"
+      "logoSourceUrl": "https://integrations.sh/logo/list-manage.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "listalpha.com",
@@ -7533,7 +9458,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/listalpha.com"
+      "logoSourceUrl": "https://integrations.sh/logo/listalpha.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "listingforgeai.it",
@@ -7553,7 +9483,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/listingforgeai.it"
+      "logoSourceUrl": "https://integrations.sh/logo/listingforgeai.it",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "listoai.co",
@@ -7565,7 +9500,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/listoai.co"
+      "logoSourceUrl": "https://integrations.sh/logo/listoai.co",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "litellm.ai",
@@ -7585,7 +9525,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/litellm.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/litellm.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 500
+      }
     },
     {
       "domain": "ll-mcp.replit.app",
@@ -7597,7 +9542,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ll-mcp.replit.app"
+      "logoSourceUrl": "https://integrations.sh/logo/ll-mcp.replit.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "llamaindex.ai",
@@ -7609,7 +9559,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/llamaindex.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/llamaindex.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lmnr.ai",
@@ -7629,7 +9584,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lmnr.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lmnr.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lobehub.com",
@@ -7641,7 +9601,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lobehub.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lobehub.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "localfalcon.com",
@@ -7661,7 +9626,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/localfalcon.com"
+      "logoSourceUrl": "https://integrations.sh/logo/localfalcon.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "localiza.com",
@@ -7673,7 +9643,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/localiza.com"
+      "logoSourceUrl": "https://integrations.sh/logo/localiza.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "logging.googleapis.com",
@@ -7685,7 +9660,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/logging.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/logging.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "logrocket.com",
@@ -7705,7 +9685,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/logrocket.com"
+      "logoSourceUrl": "https://integrations.sh/logo/logrocket.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "logto.io",
@@ -7725,7 +9710,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/logto.io"
+      "logoSourceUrl": "https://integrations.sh/logo/logto.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lona.agency",
@@ -7745,19 +9735,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lona.agency"
-    },
-    {
-      "domain": "loomalabs.ai",
-      "name": "Selah - Bible stories",
-      "mcpUrl": "https://mcp.loomalabs.ai/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/loomalabs.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lona.agency",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lorikeetcx.ai",
@@ -7777,7 +9760,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lorikeetcx.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lorikeetcx.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lovable.dev",
@@ -7797,7 +9785,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lovable.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/lovable.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "loveholidays.com",
@@ -7809,7 +9802,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/loveholidays.com"
+      "logoSourceUrl": "https://integrations.sh/logo/loveholidays.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "lovelymango-zzaim-mcp.hf.space",
@@ -7829,7 +9827,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lovelymango-zzaim-mcp.hf.space"
+      "logoSourceUrl": "https://integrations.sh/logo/lovelymango-zzaim-mcp.hf.space",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lowes.com",
@@ -7841,7 +9844,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lowes.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lowes.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "lseg.com",
@@ -7861,7 +9869,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lseg.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lseg.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lucid.app",
@@ -7881,7 +9894,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lucid.app"
+      "logoSourceUrl": "https://integrations.sh/logo/lucid.app",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lucid.co",
@@ -7893,7 +9911,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lucid.co"
+      "logoSourceUrl": "https://integrations.sh/logo/lucid.co",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lugg.com",
@@ -7905,7 +9928,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lugg.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lugg.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "luminpdf.com",
@@ -7925,7 +9953,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/luminpdf.com"
+      "logoSourceUrl": "https://integrations.sh/logo/luminpdf.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "lunarcrush.ai",
@@ -7937,7 +9970,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lunarcrush.com",
@@ -7957,7 +9995,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lunarcrush.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lusha.com",
@@ -7977,7 +10020,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lusha.com"
+      "logoSourceUrl": "https://integrations.sh/logo/lusha.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "luxuryescapes.com",
@@ -7989,7 +10037,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/luxuryescapes.com"
+      "logoSourceUrl": "https://integrations.sh/logo/luxuryescapes.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "lytical.ai",
@@ -8009,7 +10062,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lytical.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/lytical.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "m6.fr",
@@ -8021,7 +10079,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/m6.fr"
+      "logoSourceUrl": "https://integrations.sh/logo/m6.fr",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "magicpatterns.com",
@@ -8041,7 +10104,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/magicpatterns.com"
+      "logoSourceUrl": "https://integrations.sh/logo/magicpatterns.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "magneto365.com",
@@ -8053,7 +10121,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/magneto365.com"
+      "logoSourceUrl": "https://integrations.sh/logo/magneto365.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mailchimp.com",
@@ -8065,7 +10138,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mailchimp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mailchimp.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "mailerlite.com",
@@ -8085,7 +10163,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mailerlite.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mailerlite.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mailersend.com",
@@ -8105,7 +10188,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mailersend.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mailersend.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "make.com",
@@ -8132,7 +10220,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/make.com"
+      "logoSourceUrl": "https://integrations.sh/logo/make.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "makeaviz.com",
@@ -8152,27 +10245,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/makeaviz.com"
-    },
-    {
-      "domain": "makegov.com",
-      "name": "makegov.com",
-      "mcpUrl": "https://tango.makegov.com/mcp/",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "tango_api_key",
-          "type": "api_key",
-          "generateUrl": "https://tango.makegov.com/accounts/login/",
-          "setup": "Sign in at [Get API access](https://tango.makegov.com/accounts/login/) using a supported provider or email sign-in code. After signing in, use the Tango account portal to create/view your API key; the portal exposes your API key(s) and usage dashboard. The docs' quick start and auth guide describe using the key in the `X-API-KEY` header, and the SDKs also accept it directly or via `TANGO_API_KEY`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/makegov.com"
+      "logoSourceUrl": "https://integrations.sh/logo/makeaviz.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "makemytrip.com",
@@ -8184,7 +10262,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/makemytrip.com"
+      "logoSourceUrl": "https://integrations.sh/logo/makemytrip.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "makenotion.com",
@@ -8204,7 +10287,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/makenotion.com"
+      "logoSourceUrl": "https://integrations.sh/logo/makenotion.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "malwarebytes.com",
@@ -8216,7 +10304,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/malwarebytes.com"
+      "logoSourceUrl": "https://integrations.sh/logo/malwarebytes.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "manus.im",
@@ -8236,7 +10329,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/manus.im"
+      "logoSourceUrl": "https://integrations.sh/logo/manus.im",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mapify.so",
@@ -8256,7 +10354,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mapify.so"
+      "logoSourceUrl": "https://integrations.sh/logo/mapify.so",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "marcopolo.dev",
@@ -8276,7 +10379,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/marcopolo.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/marcopolo.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "masbasbas.com",
@@ -8296,7 +10404,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/masbasbas.com"
+      "logoSourceUrl": "https://integrations.sh/logo/masbasbas.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 422
+      }
     },
     {
       "domain": "massive.com",
@@ -8316,7 +10429,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/massive.com"
+      "logoSourceUrl": "https://integrations.sh/logo/massive.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "masteringthezodiac.com",
@@ -8328,7 +10446,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/masteringthezodiac.com"
+      "logoSourceUrl": "https://integrations.sh/logo/masteringthezodiac.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mavriq.com",
@@ -8340,7 +10463,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mavriq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mavriq.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "mcafee.com",
@@ -8352,7 +10480,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mcafee.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mcafee.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "mcp-detprm6tzq-uc.a.run.app",
@@ -8372,7 +10505,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mcp-detprm6tzq-uc.a.run.app"
+      "logoSourceUrl": "https://integrations.sh/logo/mcp-detprm6tzq-uc.a.run.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mcp.adobeaemcloud.com",
@@ -8392,7 +10530,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mcp.adobeaemcloud.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.adobeaemcloud.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mcp.com.ai",
@@ -8404,7 +10547,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mcp.com.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.com.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mcp.lapyme.com.ar",
@@ -8424,7 +10572,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/lapyme.com.ar"
+      "logoSourceUrl": "https://integrations.sh/logo/lapyme.com.ar",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mcp.read",
@@ -8444,7 +10597,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mcp.read"
+      "logoSourceUrl": "https://integrations.sh/logo/mcp.read",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mcptotal.io",
@@ -8464,7 +10622,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mcptotal.io"
+      "logoSourceUrl": "https://integrations.sh/logo/mcptotal.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "medeloop.ai",
@@ -8484,7 +10647,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/medeloop.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/medeloop.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "meetgeek.ai",
@@ -8504,7 +10672,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/meetgeek.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/meetgeek.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "melon.com",
@@ -8516,7 +10689,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/melon.com"
+      "logoSourceUrl": "https://integrations.sh/logo/melon.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mem.ai",
@@ -8536,7 +10714,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mem.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mem.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mem0.ai",
@@ -8556,7 +10739,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mem0.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mem0.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mentirosa.vercel.app",
@@ -8568,7 +10756,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mentirosa.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/mentirosa.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mercury.com",
@@ -8588,7 +10781,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mercury.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mercury.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "merge.dev",
@@ -8608,7 +10806,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/merge.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/merge.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mermaid.ai",
@@ -8628,7 +10831,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mermaid.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mermaid.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mervia.ai",
@@ -8640,7 +10848,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mervia.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mervia.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "messagebird.com",
@@ -8660,7 +10873,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/messagebird.com"
+      "logoSourceUrl": "https://integrations.sh/logo/messagebird.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "metaview.ai",
@@ -8687,7 +10905,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/metaview.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/metaview.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "meterplan.com",
@@ -8699,7 +10922,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/meterplan.com"
+      "logoSourceUrl": "https://integrations.sh/logo/meterplan.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "microsoft.com",
@@ -8719,7 +10947,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/microsoft.com"
+      "logoSourceUrl": "https://integrations.sh/logo/microsoft.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "middesk.com",
@@ -8739,7 +10972,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/middesk.com"
+      "logoSourceUrl": "https://integrations.sh/logo/middesk.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "midpage.ai",
@@ -8759,7 +10997,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/midpage.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/midpage.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "migma.ai",
@@ -8786,7 +11029,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/migma.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/migma.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "migrosone.com",
@@ -8806,7 +11054,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/migrosone.com"
+      "logoSourceUrl": "https://integrations.sh/logo/migrosone.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mintlify.com",
@@ -8826,7 +11079,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mintlify.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mintlify.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "minty.com",
@@ -8838,7 +11096,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/minty.com"
+      "logoSourceUrl": "https://integrations.sh/logo/minty.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mirai.com",
@@ -8850,7 +11113,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mirai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mirai.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "miro.com",
@@ -8862,7 +11130,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/miro.com"
+      "logoSourceUrl": "https://integrations.sh/logo/miro.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mixedbread.com",
@@ -8882,7 +11155,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mixedbread.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mixedbread.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mixmax.com",
@@ -8902,7 +11180,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mixmax.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mixmax.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mixpanel.com",
@@ -8914,7 +11197,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mixpanel.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mixpanel.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mobile.de",
@@ -8926,7 +11214,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mobile.de"
+      "logoSourceUrl": "https://integrations.sh/logo/mobile.de",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "modelcontextprotocol.io",
@@ -8938,7 +11231,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/modelcontextprotocol.io"
+      "logoSourceUrl": "https://integrations.sh/logo/modelcontextprotocol.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mollie.com",
@@ -8958,7 +11256,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mollie.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mollie.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "monday.com",
@@ -8978,7 +11281,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/monday.com"
+      "logoSourceUrl": "https://integrations.sh/logo/monday.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mondoir.art",
@@ -8998,7 +11306,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mondoir.art"
+      "logoSourceUrl": "https://integrations.sh/logo/mondoir.art",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "moneysupermarket.com",
@@ -9010,7 +11323,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/moneysupermarket.com"
+      "logoSourceUrl": "https://integrations.sh/logo/moneysupermarket.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "monito.com",
@@ -9022,7 +11340,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/monito.com"
+      "logoSourceUrl": "https://integrations.sh/logo/monito.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "monotype.com",
@@ -9034,7 +11357,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/monotype.com"
+      "logoSourceUrl": "https://integrations.sh/logo/monotype.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "moodtrip.ai",
@@ -9054,7 +11382,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/moodtrip.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/moodtrip.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "moodys.com",
@@ -9074,7 +11407,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/moodys.com"
+      "logoSourceUrl": "https://integrations.sh/logo/moodys.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "morningstar.com",
@@ -9094,7 +11432,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/morningstar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/morningstar.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mospi.gov.in",
@@ -9106,7 +11449,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mospi.gov.in"
+      "logoSourceUrl": "https://integrations.sh/logo/mospi.gov.in",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "motherduck.com",
@@ -9133,7 +11481,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/motherduck.com"
+      "logoSourceUrl": "https://integrations.sh/logo/motherduck.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "motionapp.com",
@@ -9153,7 +11506,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/motionapp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/motionapp.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "motionhub.ai",
@@ -9173,7 +11531,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/motionhub.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/motionhub.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "motra.com",
@@ -9193,7 +11556,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/motra.com"
+      "logoSourceUrl": "https://integrations.sh/logo/motra.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mountaingoatsoftware.com",
@@ -9213,7 +11581,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/mountaingoatsoftware.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mountaingoatsoftware.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "moviepick.app",
@@ -9233,19 +11606,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/moviepick.app"
-    },
-    {
-      "domain": "mozilla.org",
-      "name": "mozilla.org",
-      "mcpUrl": "https://developer.mozilla.org/api/v1/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mozilla.org"
+      "logoSourceUrl": "https://integrations.sh/logo/moviepick.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "msci.com",
@@ -9265,7 +11631,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/msci.com"
+      "logoSourceUrl": "https://integrations.sh/logo/msci.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "mux.com",
@@ -9285,7 +11656,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mux.com"
+      "logoSourceUrl": "https://integrations.sh/logo/mux.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "my-mcp-server-flame.vercel.app",
@@ -9297,7 +11673,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/my-mcp-server-flame.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/my-mcp-server-flame.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mychoice.ca",
@@ -9309,7 +11690,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mychoice.ca"
+      "logoSourceUrl": "https://integrations.sh/logo/mychoice.ca",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "mydeetz.ai",
@@ -9321,7 +11707,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/mydeetz.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/mydeetz.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "myfitnesspal.com",
@@ -9333,7 +11724,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/myfitnesspal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/myfitnesspal.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "myregistry.com",
@@ -9345,7 +11741,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/myregistry.com"
+      "logoSourceUrl": "https://integrations.sh/logo/myregistry.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "naked.insure",
@@ -9365,7 +11766,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/naked.insure"
+      "logoSourceUrl": "https://integrations.sh/logo/naked.insure",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "natural.co",
@@ -9385,7 +11791,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/natural.co"
+      "logoSourceUrl": "https://integrations.sh/logo/natural.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "naturalint.com",
@@ -9397,27 +11808,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/naturalint.com"
-    },
-    {
-      "domain": "neartail.com",
-      "name": "Neartail",
-      "mcpUrl": "https://neartail.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "neartail_oauth_client",
-          "type": "oauth2",
-          "generateUrl": "https://neartail.com/api/oauth/register",
-          "setup": "Register an OAuth client at [Neartail OAuth dynamic client registration](https://neartail.com/api/oauth/register). Then complete user authorization against [authorize](https://neartail.com/api/oauth/authorize) and exchange the code at [token](https://neartail.com/api/oauth/token). The catalog indicates supported scopes `readOnly` and `full`. The MCP docs say each user needs a Neartail account and a one-time OAuth approval.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/neartail.com"
+      "logoSourceUrl": "https://integrations.sh/logo/naturalint.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "neighbor.com",
@@ -9429,7 +11825,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/neighbor.com"
+      "logoSourceUrl": "https://integrations.sh/logo/neighbor.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "neon.com",
@@ -9449,7 +11850,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/neon.com"
+      "logoSourceUrl": "https://integrations.sh/logo/neon.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "neptuneflood.com",
@@ -9461,7 +11867,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/neptuneflood.com"
+      "logoSourceUrl": "https://integrations.sh/logo/neptuneflood.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "netlify-mcp.netlify.app",
@@ -9481,7 +11892,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/netlify-mcp.netlify.app"
+      "logoSourceUrl": "https://integrations.sh/logo/netlify-mcp.netlify.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "networkmanagement.googleapis.com",
@@ -9493,19 +11909,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/networkmanagement.googleapis.com"
-    },
-    {
-      "domain": "networksolutions.com",
-      "name": "Network Solutions",
-      "mcpUrl": "https://mcp.networksolutions.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/networksolutions.com"
+      "logoSourceUrl": "https://integrations.sh/logo/networkmanagement.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "neurnav.com",
@@ -9525,7 +11934,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/neurnav.com"
+      "logoSourceUrl": "https://integrations.sh/logo/neurnav.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "newegg.com",
@@ -9537,7 +11951,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/newegg.com"
+      "logoSourceUrl": "https://integrations.sh/logo/newegg.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "newrelic.com",
@@ -9557,7 +11976,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/newrelic.com"
+      "logoSourceUrl": "https://integrations.sh/logo/newrelic.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "newsifytrends.com",
@@ -9569,7 +11993,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/newsifytrends.com"
+      "logoSourceUrl": "https://integrations.sh/logo/newsifytrends.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "newt.net",
@@ -9581,7 +12010,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/newt.net"
+      "logoSourceUrl": "https://integrations.sh/logo/newt.net",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "nexafin.com",
@@ -9593,7 +12027,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/nexafin.com"
+      "logoSourceUrl": "https://integrations.sh/logo/nexafin.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "notion.com",
@@ -9613,7 +12052,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/notion.com"
+      "logoSourceUrl": "https://integrations.sh/logo/notion.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "notion.notion.site",
@@ -9633,7 +12077,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/notion.notion.site"
+      "logoSourceUrl": "https://integrations.sh/logo/notion.notion.site",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "notion.so",
@@ -9653,7 +12102,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/notion.so"
+      "logoSourceUrl": "https://integrations.sh/logo/notion.so",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "notiondevs.notion.site",
@@ -9673,27 +12127,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/notiondevs.notion.site"
-    },
-    {
-      "domain": "novu.co",
-      "name": "novu.co",
-      "mcpUrl": "https://mcp.novu.co/",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "novu_secret_key",
-          "type": "bearer",
-          "generateUrl": "https://dashboard.novu.co/settings/api-keys",
-          "setup": "Sign in to the [Novu dashboard](https://dashboard.novu.co), open [API Keys](https://dashboard.novu.co/settings/api-keys), and copy a key from **Secret Keys**. The docs describe the secret key as the private token used to authenticate and authorize API requests, and note that keys are environment-specific.",
-          "fields": null
-        }
-      ],
-      "tier": "verified",
-      "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/novu.co"
+      "logoSourceUrl": "https://integrations.sh/logo/notiondevs.notion.site",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "nuwapen.com",
@@ -9713,7 +12152,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/nuwapen.com"
+      "logoSourceUrl": "https://integrations.sh/logo/nuwapen.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "nuxt.com",
@@ -9725,7 +12169,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "nyquistai.com",
@@ -9745,7 +12194,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/nyquistai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/nyquistai.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "oaimcp-production.up.railway.app",
@@ -9757,7 +12211,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/oaimcp-production.up.railway.app"
+      "logoSourceUrl": "https://integrations.sh/logo/oaimcp-production.up.railway.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "okkanji.com",
@@ -9769,7 +12228,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/okkanji.com"
+      "logoSourceUrl": "https://integrations.sh/logo/okkanji.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "okx.com",
@@ -9781,7 +12245,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/okx.com"
+      "logoSourceUrl": "https://integrations.sh/logo/okx.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "olutely.com",
@@ -9793,7 +12262,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/olutely.com"
+      "logoSourceUrl": "https://integrations.sh/logo/olutely.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "olx.io",
@@ -9805,7 +12279,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/olx.io"
+      "logoSourceUrl": "https://integrations.sh/logo/olx.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "omni.co",
@@ -9825,7 +12304,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/omni.co"
+      "logoSourceUrl": "https://integrations.sh/logo/omni.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "omniapp.co",
@@ -9845,7 +12329,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/omniapp.co"
+      "logoSourceUrl": "https://integrations.sh/logo/omniapp.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "omnisend.com",
@@ -9865,7 +12354,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/omnisend.com"
+      "logoSourceUrl": "https://integrations.sh/logo/omnisend.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "ondata.github.io",
@@ -9877,7 +12371,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ondata.github.io"
+      "logoSourceUrl": "https://integrations.sh/logo/ondata.github.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "onepeloton.com",
@@ -9889,7 +12388,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/onepeloton.com"
+      "logoSourceUrl": "https://integrations.sh/logo/onepeloton.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "oneuptime.com",
@@ -9901,7 +12405,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/oneuptime.com"
+      "logoSourceUrl": "https://integrations.sh/logo/oneuptime.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "onthebeach.co.uk",
@@ -9913,7 +12422,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/onthebeach.co.uk"
+      "logoSourceUrl": "https://integrations.sh/logo/onthebeach.co.uk",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "openai-mcp-696419881849.us-central1.run.app",
@@ -9933,7 +12447,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/openai-mcp-696419881849.us-central1.run.app"
+      "logoSourceUrl": "https://integrations.sh/logo/openai-mcp-696419881849.us-central1.run.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "openlens.com",
@@ -9953,7 +12472,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/openlens.com"
+      "logoSourceUrl": "https://integrations.sh/logo/openlens.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "openobserve.ai",
@@ -9973,7 +12497,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/openobserve.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/openobserve.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "openrouter.ai",
@@ -9993,7 +12522,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/openrouter.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/openrouter.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "openstatus.dev",
@@ -10013,7 +12547,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/openstatus.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/openstatus.dev",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "opentargets.org",
@@ -10025,7 +12564,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/opentargets.org"
+      "logoSourceUrl": "https://integrations.sh/logo/opentargets.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "optionscalc.app",
@@ -10037,7 +12581,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/optionscalc.app"
+      "logoSourceUrl": "https://integrations.sh/logo/optionscalc.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "optiversal.com",
@@ -10049,7 +12598,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/optiversal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/optiversal.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "orgpolicy.googleapis.com",
@@ -10061,7 +12615,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/orgpolicy.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/orgpolicy.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "originalvoices.ai",
@@ -10081,7 +12640,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/originalvoices.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/originalvoices.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "ory.sh",
@@ -10093,7 +12657,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ory.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/ory.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "otomoto.pl",
@@ -10105,19 +12674,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/otomoto.pl"
-    },
-    {
-      "domain": "otseek.com",
-      "name": "OTseek",
-      "mcpUrl": "https://backend.otseek.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/otseek.com"
+      "logoSourceUrl": "https://integrations.sh/logo/otomoto.pl",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "otter.ai",
@@ -10137,7 +12699,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/otter.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/otter.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "outreach.io",
@@ -10157,7 +12724,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/outreach.io"
+      "logoSourceUrl": "https://integrations.sh/logo/outreach.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "overstappen.nl",
@@ -10169,7 +12741,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/overstappen.nl"
+      "logoSourceUrl": "https://integrations.sh/logo/overstappen.nl",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ovios-home.com",
@@ -10181,7 +12758,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ovios-home.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ovios-home.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 422
+      }
     },
     {
       "domain": "owkin.com",
@@ -10193,7 +12775,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/owkin.com"
+      "logoSourceUrl": "https://integrations.sh/logo/owkin.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pacvue.com",
@@ -10205,7 +12792,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pacvue.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pacvue.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "paddle.com",
@@ -10225,7 +12817,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/paddle.com"
+      "logoSourceUrl": "https://integrations.sh/logo/paddle.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pagerduty.com",
@@ -10252,7 +12849,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pagerduty.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pagerduty.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pandadoc.com",
@@ -10272,7 +12874,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/pandadoc.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pandadoc.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pane.money",
@@ -10299,7 +12906,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pane.money"
+      "logoSourceUrl": "https://integrations.sh/logo/pane.money",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "parqet.com",
@@ -10319,7 +12931,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/parqet.com"
+      "logoSourceUrl": "https://integrations.sh/logo/parqet.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "particl.com",
@@ -10339,7 +12956,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/particl.com"
+      "logoSourceUrl": "https://integrations.sh/logo/particl.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "passby.com",
@@ -10359,7 +12981,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/passby.com"
+      "logoSourceUrl": "https://integrations.sh/logo/passby.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "payabli.com",
@@ -10371,7 +12998,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/payabli.com"
+      "logoSourceUrl": "https://integrations.sh/logo/payabli.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "paypal.com",
@@ -10391,7 +13023,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/paypal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/paypal.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pcexpress.ca",
@@ -10403,7 +13040,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pcexpress.ca"
+      "logoSourceUrl": "https://integrations.sh/logo/pcexpress.ca",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "pdfmaker.to",
@@ -10423,7 +13065,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pdfmaker.to"
+      "logoSourceUrl": "https://integrations.sh/logo/pdfmaker.to",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "peec.ai",
@@ -10443,7 +13090,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/peec.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/peec.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pendo.io",
@@ -10463,7 +13115,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/pendo.io"
+      "logoSourceUrl": "https://integrations.sh/logo/pendo.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "people.googleapis.com",
@@ -10483,7 +13140,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/people.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/people.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "perplexity.ai",
@@ -10503,7 +13165,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/perplexity.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/perplexity.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pga.com",
@@ -10515,27 +13182,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pga.com"
-    },
-    {
-      "domain": "phantombuster.com",
-      "name": "phantombuster.com",
-      "mcpUrl": "https://mcp.phantombuster.com",
-      "transport": "streamable-http",
-      "authKind": "oauth2",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "pb_mcp_oauth",
-          "type": "oauth2",
-          "generateUrl": "https://mcp.phantombuster.com",
-          "setup": "Connect an MCP client to [https://mcp.phantombuster.com](https://mcp.phantombuster.com). On first connection, PhantomBuster redirects you to sign in to your PhantomBuster account and authorize the MCP server, then you choose the workspace to use. The connection is reused by the MCP client afterward: [MCP server docs](https://hub.phantombuster.com/docs/mcp-server).",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/phantombuster.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pga.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "phish.in",
@@ -10547,7 +13199,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/phish.in"
+      "logoSourceUrl": "https://integrations.sh/logo/phish.in",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "pier-luma.vercel.app",
@@ -10559,7 +13216,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pier-luma.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/pier-luma.vercel.app",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 405
+      }
     },
     {
       "domain": "pinelabsonline.com",
@@ -10571,7 +13233,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pinelabsonline.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pinelabsonline.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "pipedream.com",
@@ -10591,7 +13258,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pipedream.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pipedream.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pitchbook.com",
@@ -10603,7 +13275,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/pitchbook.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pitchbook.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pixelesq.com",
@@ -10615,7 +13292,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pixelesq.workers.dev",
@@ -10635,7 +13317,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/pixelesq.workers.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "plain.com",
@@ -10655,34 +13342,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/plain.com"
-    },
-    {
-      "domain": "plane.so",
-      "name": "plane.so",
-      "mcpUrl": "https://mcp.plane.so",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "plane_oauth_app",
-          "type": "app",
-          "generateUrl": "https://app.plane.so/<workspace>/settings/integrations/",
-          "setup": "Register an OAuth app in Plane at [Workspace Settings → Integrations](https://app.plane.so/<workspace>/settings/integrations/) by clicking **Build your own**, then fill in your `Setup URL`, `Redirect URI`, `Webhook URL`, and scopes as shown in [Create an OAuth Application](https://developers.plane.so/dev-tools/build-plane-app/create-oauth-application). Save the app and copy the `Client ID` and `Client Secret`. Use this app for either the bot-token (`client_credentials`) flow or the user-token (`authorization_code`) flow described in [Choose token flow](https://developers.plane.so/dev-tools/build-plane-app/choose-token-flow).",
-          "fields": null
-        },
-        {
-          "id": "plane_api_key",
-          "type": "api_key",
-          "generateUrl": "https://app.plane.so/<workspace>/settings/integrations/",
-          "setup": "In Plane, go to [Workspace Settings → Integrations](https://app.plane.so/<workspace>/settings/integrations/) and create or manage an API token for the workspace/user as described in the [API authentication docs](https://developers.plane.so/api-reference/introduction) and [MCP server docs](https://developers.plane.so/dev-tools/mcp-server). For MCP header auth or stdio mode, provide the token as `x-api-key` or `PLANE_API_KEY`.",
-          "fields": null
-        }
-      ],
-      "tier": "verified",
-      "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/plane.so"
+      "logoSourceUrl": "https://integrations.sh/logo/plain.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "playdeveloperreporting.googleapis.com",
@@ -10694,7 +13359,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/playdeveloperreporting.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/playdeveloperreporting.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "playdigital.com.ar",
@@ -10706,7 +13376,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/playdigital.com.ar"
+      "logoSourceUrl": "https://integrations.sh/logo/playdigital.com.ar",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "polar.sh",
@@ -10726,7 +13401,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/polar.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/polar.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "policynote.com",
@@ -10746,7 +13426,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/policynote.com"
+      "logoSourceUrl": "https://integrations.sh/logo/policynote.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "policytroubleshooter.googleapis.com",
@@ -10758,27 +13443,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/policytroubleshooter.googleapis.com"
-    },
-    {
-      "domain": "port.io",
-      "name": "port.io",
-      "mcpUrl": "https://mcp.port.io",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "port_access_token",
-          "type": "bearer",
-          "generateUrl": "https://app.port.io",
-          "setup": "Generate a short-lived API token from the [Port application](https://app.port.io) via `Credentials` → `Generate API token`, or mint it programmatically by calling `POST https://api.port.io/v1/auth/access_token` (EU) or the US-region equivalent with your `clientId` and `clientSecret` from the same credentials page. The docs state the token is valid for 3 hours.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/port.io"
+      "logoSourceUrl": "https://integrations.sh/logo/policytroubleshooter.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "posthog.com",
@@ -10798,27 +13468,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/posthog.com"
-    },
-    {
-      "domain": "postman.co",
-      "name": "postman.co",
-      "mcpUrl": "https://mcp.postman.co/mcp",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "postman_api_key",
-          "type": "api_key",
-          "generateUrl": "https://web.postman.co/settings/me/api-keys",
-          "setup": "Sign in to Postman, open [API Keys](https://web.postman.co/settings/me/api-keys), and create a key. Postman documents this as the credential for the Postman API and for non-interactive Postman CLI login. Store it in a secret or environment variable such as `POSTMAN_API_KEY`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/postman.co"
+      "logoSourceUrl": "https://integrations.sh/logo/posthog.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "postman.com",
@@ -10830,7 +13485,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/postman.com"
+      "logoSourceUrl": "https://integrations.sh/logo/postman.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "preply.com",
@@ -10842,7 +13502,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/preply.com"
+      "logoSourceUrl": "https://integrations.sh/logo/preply.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "priceline.com",
@@ -10854,7 +13519,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/priceline.com"
+      "logoSourceUrl": "https://integrations.sh/logo/priceline.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "primitive.dev",
@@ -10881,7 +13551,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/primitive.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/primitive.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "printhiv3d.com",
@@ -10901,7 +13576,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com"
+      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "priority-guard.com",
@@ -10921,7 +13601,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/priority-guard.com"
+      "logoSourceUrl": "https://integrations.sh/logo/priority-guard.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "prisma.io",
@@ -10941,7 +13626,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/prisma.io"
+      "logoSourceUrl": "https://integrations.sh/logo/prisma.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "prismic.io",
@@ -10961,7 +13651,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/prismic.io"
+      "logoSourceUrl": "https://integrations.sh/logo/prismic.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "privatemdlabs.com",
@@ -10973,7 +13668,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/privatemdlabs.com"
+      "logoSourceUrl": "https://integrations.sh/logo/privatemdlabs.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "process.st",
@@ -10993,7 +13693,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/process.st"
+      "logoSourceUrl": "https://integrations.sh/logo/process.st",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "productboard.com",
@@ -11013,7 +13718,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/productboard.com"
+      "logoSourceUrl": "https://integrations.sh/logo/productboard.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "profit.co",
@@ -11033,7 +13743,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/profit.co"
+      "logoSourceUrl": "https://integrations.sh/logo/profit.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "promptperfect.xyz",
@@ -11053,7 +13768,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/promptperfect.xyz"
+      "logoSourceUrl": "https://integrations.sh/logo/promptperfect.xyz",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "proofx-mcp.fly.dev",
@@ -11073,7 +13793,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/proofx-mcp.fly.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/proofx-mcp.fly.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "property24.com",
@@ -11093,7 +13818,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/property24.com"
+      "logoSourceUrl": "https://integrations.sh/logo/property24.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pscale.dev",
@@ -11113,7 +13843,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pscale.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/pscale.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pubnub.com",
@@ -11133,7 +13868,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pubnub.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pubnub.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pubsub.googleapis.com",
@@ -11145,7 +13885,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/pubsub.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pubsub.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "pulumi.com",
@@ -11165,7 +13910,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pulumi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/pulumi.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pumadb.ai",
@@ -11185,7 +13935,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pumadb.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/pumadb.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "pyxl.pro",
@@ -11205,7 +13960,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/pyxl.pro"
+      "logoSourceUrl": "https://integrations.sh/logo/pyxl.pro",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "qovery.com",
@@ -11225,7 +13985,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/qovery.com"
+      "logoSourceUrl": "https://integrations.sh/logo/qovery.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "quartr.com",
@@ -11245,7 +14010,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/quartr.com"
+      "logoSourceUrl": "https://integrations.sh/logo/quartr.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "quicknode.com",
@@ -11265,7 +14035,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/quicknode.com"
+      "logoSourceUrl": "https://integrations.sh/logo/quicknode.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "quintoandar.com.br",
@@ -11277,7 +14052,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/quintoandar.com.br"
+      "logoSourceUrl": "https://integrations.sh/logo/quintoandar.com.br",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "quiver.ai",
@@ -11297,7 +14077,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/quiver.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/quiver.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "quizlet.com",
@@ -11317,7 +14102,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/quizlet.com"
+      "logoSourceUrl": "https://integrations.sh/logo/quizlet.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "quo.com",
@@ -11337,7 +14127,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/quo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/quo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "quotecraft-ai-zeta.vercel.app",
@@ -11349,7 +14144,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/quotecraft-ai-zeta.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/quotecraft-ai-zeta.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ramp.com",
@@ -11369,7 +14169,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/ramp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ramp.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "raptive.com",
@@ -11381,7 +14186,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/raptive.com"
+      "logoSourceUrl": "https://integrations.sh/logo/raptive.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ray-arceneaux-ai-agentic.replit.app",
@@ -11393,7 +14203,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ray-arceneaux-ai-agentic.replit.app"
+      "logoSourceUrl": "https://integrations.sh/logo/ray-arceneaux-ai-agentic.replit.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "razorpay.com",
@@ -11413,7 +14228,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/razorpay.com"
+      "logoSourceUrl": "https://integrations.sh/logo/razorpay.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "rbi.digital",
@@ -11425,7 +14245,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/rbi.digital"
+      "logoSourceUrl": "https://integrations.sh/logo/rbi.digital",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "rbictg.com",
@@ -11437,7 +14262,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/rbictg.com"
+      "logoSourceUrl": "https://integrations.sh/logo/rbictg.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "read.ai",
@@ -11457,7 +14287,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/read.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/read.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "readwise.io",
@@ -11477,7 +14312,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/readwise.io"
+      "logoSourceUrl": "https://integrations.sh/logo/readwise.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "reagent.travel",
@@ -11489,7 +14329,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/reagent.travel"
+      "logoSourceUrl": "https://integrations.sh/logo/reagent.travel",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "realestate.com.au",
@@ -11501,7 +14346,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/realestate.com.au"
+      "logoSourceUrl": "https://integrations.sh/logo/realestate.com.au",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "reclaim.ai",
@@ -11521,7 +14371,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/reclaim.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/reclaim.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "recommender.googleapis.com",
@@ -11533,7 +14388,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/recommender.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/recommender.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "redbus.com",
@@ -11545,7 +14405,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/redbus.com"
+      "logoSourceUrl": "https://integrations.sh/logo/redbus.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "redis.googleapis.com",
@@ -11557,7 +14422,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/redis.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/redis.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "redocly.com",
@@ -11569,7 +14439,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/redocly.com"
+      "logoSourceUrl": "https://integrations.sh/logo/redocly.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "redoxengine.com",
@@ -11589,7 +14464,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/redoxengine.com"
+      "logoSourceUrl": "https://integrations.sh/logo/redoxengine.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "reducto.ai",
@@ -11609,7 +14489,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/reducto.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/reducto.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "refiner.io",
@@ -11629,7 +14514,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/refiner.io"
+      "logoSourceUrl": "https://integrations.sh/logo/refiner.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "releases.sh",
@@ -11641,7 +14531,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/releases.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/releases.sh",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "remote.com",
@@ -11661,7 +14556,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/remote.com"
+      "logoSourceUrl": "https://integrations.sh/logo/remote.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "render.com",
@@ -11681,7 +14581,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/render.com"
+      "logoSourceUrl": "https://integrations.sh/logo/render.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "rentcast.io",
@@ -11701,7 +14606,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/rentcast.io"
+      "logoSourceUrl": "https://integrations.sh/logo/rentcast.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "replit-mcp.com",
@@ -11721,7 +14631,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/replit-mcp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/replit-mcp.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "replit.com",
@@ -11741,7 +14656,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/replit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/replit.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "researchsolutions.com",
@@ -11761,7 +14681,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/researchsolutions.com"
+      "logoSourceUrl": "https://integrations.sh/logo/researchsolutions.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "resend.com",
@@ -11781,7 +14706,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/resend.com"
+      "logoSourceUrl": "https://integrations.sh/logo/resend.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "retellai.com",
@@ -11808,7 +14738,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/retellai.com"
+      "logoSourceUrl": "https://integrations.sh/logo/retellai.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "rillet.com",
@@ -11828,7 +14763,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/rillet.com"
+      "logoSourceUrl": "https://integrations.sh/logo/rillet.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "roadops.app",
@@ -11848,7 +14788,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/roadops.app"
+      "logoSourceUrl": "https://integrations.sh/logo/roadops.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "rome2rio.com",
@@ -11860,7 +14805,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/rome2rio.com"
+      "logoSourceUrl": "https://integrations.sh/logo/rome2rio.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "rootly.com",
@@ -11880,7 +14830,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/rootly.com"
+      "logoSourceUrl": "https://integrations.sh/logo/rootly.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "run.googleapis.com",
@@ -11892,7 +14847,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/run.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/run.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "runorion.com",
@@ -11912,7 +14872,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/runorion.com"
+      "logoSourceUrl": "https://integrations.sh/logo/runorion.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "runready.dev",
@@ -11924,7 +14889,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/runready.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/runready.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sadhguru.org",
@@ -11936,7 +14906,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sadhguru.org"
+      "logoSourceUrl": "https://integrations.sh/logo/sadhguru.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "saleor.io",
@@ -11956,7 +14931,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/saleor.io"
+      "logoSourceUrl": "https://integrations.sh/logo/saleor.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "saleseq.ai",
@@ -11976,7 +14956,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/saleseq.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/saleseq.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "samrum.io",
@@ -11996,7 +14981,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/samrum.io"
+      "logoSourceUrl": "https://integrations.sh/logo/samrum.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sanity.io",
@@ -12016,7 +15006,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sanity.io"
+      "logoSourceUrl": "https://integrations.sh/logo/sanity.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "savecraft.gg",
@@ -12036,7 +15031,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/savecraft.gg"
+      "logoSourceUrl": "https://integrations.sh/logo/savecraft.gg",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "scalar.com",
@@ -12048,7 +15048,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/scalar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/scalar.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "scholargateway.ai",
@@ -12068,7 +15073,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/scholargateway.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/scholargateway.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "scholarxiv.com",
@@ -12088,7 +15098,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/scholarxiv.com"
+      "logoSourceUrl": "https://integrations.sh/logo/scholarxiv.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "scite.ai",
@@ -12108,7 +15123,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/scite.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/scite.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "scrapfly.io",
@@ -12135,7 +15155,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/scrapfly.io"
+      "logoSourceUrl": "https://integrations.sh/logo/scrapfly.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 405
+      }
     },
     {
       "domain": "scrapingbee.com",
@@ -12155,7 +15180,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/scrapingbee.com"
+      "logoSourceUrl": "https://integrations.sh/logo/scrapingbee.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "scrimba.com",
@@ -12167,7 +15197,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/scrimba.com"
+      "logoSourceUrl": "https://integrations.sh/logo/scrimba.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "searchconsole.googleapis.com",
@@ -12179,7 +15214,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/searchconsole.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/searchconsole.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "seatpin.com",
@@ -12191,7 +15231,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/seatpin.com"
+      "logoSourceUrl": "https://integrations.sh/logo/seatpin.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "seatunique.com",
@@ -12203,7 +15248,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/seatunique.com"
+      "logoSourceUrl": "https://integrations.sh/logo/seatunique.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "securelend.ai",
@@ -12230,7 +15280,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/securelend.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/securelend.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "seekist.ai",
@@ -12242,7 +15297,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/seekist.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/seekist.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "semaphoreci.com",
@@ -12276,7 +15336,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/semaphoreci.com"
+      "logoSourceUrl": "https://integrations.sh/logo/semaphoreci.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "semrush.com",
@@ -12296,7 +15361,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/semrush.com"
+      "logoSourceUrl": "https://integrations.sh/logo/semrush.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "send.co",
@@ -12316,7 +15386,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/send.co"
+      "logoSourceUrl": "https://integrations.sh/logo/send.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sentry.io",
@@ -12336,7 +15411,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sentry.io"
+      "logoSourceUrl": "https://integrations.sh/logo/sentry.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sephora.com",
@@ -12356,7 +15436,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sephora.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sephora.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "serpapi.com",
@@ -12376,7 +15461,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/serpapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/serpapi.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "serpstat.com",
@@ -12396,7 +15486,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/serpstat.com"
+      "logoSourceUrl": "https://integrations.sh/logo/serpstat.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "setu.co",
@@ -12416,7 +15511,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/setu.co"
+      "logoSourceUrl": "https://integrations.sh/logo/setu.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sftapi.com",
@@ -12428,7 +15528,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sftapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sftapi.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "share.eu",
@@ -12440,7 +15545,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/share.eu"
+      "logoSourceUrl": "https://integrations.sh/logo/share.eu",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 422
+      }
     },
     {
       "domain": "shazam.com",
@@ -12452,7 +15562,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shazam.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shazam.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "shippo.com",
@@ -12472,7 +15587,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shippo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shippo.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "shipt.com",
@@ -12484,7 +15604,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shipt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shipt.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "shop.app",
@@ -12496,7 +15621,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/shop.app"
+      "logoSourceUrl": "https://integrations.sh/logo/shop.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "shopback.com",
@@ -12508,7 +15638,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shopback.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shopback.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "shopee.com",
@@ -12528,7 +15663,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shopee.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shopee.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "shoppingcontent.googleapis.com",
@@ -12540,7 +15680,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/shoppingcontent.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shoppingcontent.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "shortcut.com",
@@ -12560,7 +15705,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shortcut.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shortcut.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "shuftipro.com",
@@ -12580,7 +15730,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/shuftipro.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shuftipro.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "shutterstock.com",
@@ -12592,7 +15747,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/shutterstock.com"
+      "logoSourceUrl": "https://integrations.sh/logo/shutterstock.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sider.ai",
@@ -12612,7 +15772,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sider.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/sider.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sierra.chat",
@@ -12624,7 +15789,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sierra.chat"
+      "logoSourceUrl": "https://integrations.sh/logo/sierra.chat",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sigmacomputing.com",
@@ -12636,7 +15806,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sigmacomputing.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sigmacomputing.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "signnow.com",
@@ -12656,7 +15831,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/signnow.com"
+      "logoSourceUrl": "https://integrations.sh/logo/signnow.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "similarweb.com",
@@ -12668,7 +15848,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/similarweb.com"
+      "logoSourceUrl": "https://integrations.sh/logo/similarweb.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "simply-family-budget.com",
@@ -12688,7 +15873,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/simply-family-budget.com"
+      "logoSourceUrl": "https://integrations.sh/logo/simply-family-budget.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "simplybusiness.com",
@@ -12700,7 +15890,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/simplybusiness.com"
+      "logoSourceUrl": "https://integrations.sh/logo/simplybusiness.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "simsurf.com",
@@ -12712,7 +15907,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/simsurf.com"
+      "logoSourceUrl": "https://integrations.sh/logo/simsurf.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sketchup.com",
@@ -12732,7 +15932,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sketchup.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sketchup.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "skipcalls.com",
@@ -12759,7 +15964,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/skipcalls.com"
+      "logoSourceUrl": "https://integrations.sh/logo/skipcalls.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "skyscanner.net",
@@ -12771,7 +15981,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/skyscanner.net"
+      "logoSourceUrl": "https://integrations.sh/logo/skyscanner.net",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "skywatch.ai",
@@ -12783,7 +15998,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/skywatch.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "skywatch.co",
@@ -12795,7 +16015,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/skywatch.co"
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.co",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "skywatch.com",
@@ -12807,7 +16032,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/skywatch.com"
+      "logoSourceUrl": "https://integrations.sh/logo/skywatch.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "slack.com",
@@ -12827,7 +16057,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/slack.com"
+      "logoSourceUrl": "https://integrations.sh/logo/slack.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "slidesgpt-server-uojeu24xoq-uc.a.run.app",
@@ -12839,7 +16074,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt-server-uojeu24xoq-uc.a.run.app"
+      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt-server-uojeu24xoq-uc.a.run.app",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 405
+      }
     },
     {
       "domain": "slidesgpt.com",
@@ -12851,7 +16091,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/slidesgpt.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "smartbear.com",
@@ -12871,7 +16116,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/smartbear.com"
+      "logoSourceUrl": "https://integrations.sh/logo/smartbear.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "smartcustomer.com",
@@ -12883,7 +16133,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/smartcustomer.com"
+      "logoSourceUrl": "https://integrations.sh/logo/smartcustomer.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "smartsheet.com",
@@ -12910,7 +16165,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/smartsheet.com"
+      "logoSourceUrl": "https://integrations.sh/logo/smartsheet.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "smarty.com",
@@ -12930,7 +16190,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/smarty.com"
+      "logoSourceUrl": "https://integrations.sh/logo/smarty.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "smtp2go.com",
@@ -12950,7 +16215,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/smtp2go.com"
+      "logoSourceUrl": "https://integrations.sh/logo/smtp2go.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sonicapply.com",
@@ -12962,7 +16232,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sonicapply.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sonicapply.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "soulfamily.ai",
@@ -12974,7 +16249,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/soulfamily.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/soulfamily.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sourcegraph.com",
@@ -12994,7 +16274,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sourcegraph.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sourcegraph.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "southeasthre.com",
@@ -13006,7 +16291,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/southeasthre.com"
+      "logoSourceUrl": "https://integrations.sh/logo/southeasthre.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "spaceship.com",
@@ -13018,7 +16308,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/spaceship.com"
+      "logoSourceUrl": "https://integrations.sh/logo/spaceship.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "spanner.googleapis.com",
@@ -13030,7 +16325,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/spanner.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/spanner.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "sparkspot.be",
@@ -13042,7 +16342,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sparkspot.be"
+      "logoSourceUrl": "https://integrations.sh/logo/sparkspot.be",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "speechify.com",
@@ -13054,7 +16359,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/speechify.com"
+      "logoSourceUrl": "https://integrations.sh/logo/speechify.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "spinify.com",
@@ -13074,7 +16384,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/spinify.com"
+      "logoSourceUrl": "https://integrations.sh/logo/spinify.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "splice.com",
@@ -13086,7 +16401,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/splice.com"
+      "logoSourceUrl": "https://integrations.sh/logo/splice.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "spotify.net",
@@ -13106,7 +16426,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/spotify.net"
+      "logoSourceUrl": "https://integrations.sh/logo/spotify.net",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "spreedly.com",
@@ -13118,7 +16443,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/spreedly.com"
+      "logoSourceUrl": "https://integrations.sh/logo/spreedly.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "springer.com",
@@ -13138,7 +16468,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/springer.com"
+      "logoSourceUrl": "https://integrations.sh/logo/springer.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sqladmin.googleapis.com",
@@ -13150,7 +16485,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sqladmin.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sqladmin.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "squareup.com",
@@ -13170,7 +16510,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/squareup.com"
+      "logoSourceUrl": "https://integrations.sh/logo/squareup.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "stablebaseline.io",
@@ -13197,7 +16542,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/stablebaseline.io"
+      "logoSourceUrl": "https://integrations.sh/logo/stablebaseline.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "staircase.ai",
@@ -13217,7 +16567,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/staircase.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/staircase.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "standvirtual.com",
@@ -13229,7 +16584,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/standvirtual.com"
+      "logoSourceUrl": "https://integrations.sh/logo/standvirtual.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "statsig.com",
@@ -13249,7 +16609,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/statsig.com"
+      "logoSourceUrl": "https://integrations.sh/logo/statsig.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "steer.coach",
@@ -13269,7 +16634,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/steer.coach"
+      "logoSourceUrl": "https://integrations.sh/logo/steer.coach",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sticklight.com",
@@ -13289,7 +16659,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sticklight.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sticklight.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "storage.googleapis.com",
@@ -13301,7 +16676,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/storage.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/storage.googleapis.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 400
+      }
     },
     {
       "domain": "storyblok.com",
@@ -13321,7 +16701,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/storyblok.com"
+      "logoSourceUrl": "https://integrations.sh/logo/storyblok.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "straighterline.com",
@@ -13333,7 +16718,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/straighterline.com"
+      "logoSourceUrl": "https://integrations.sh/logo/straighterline.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "strapi.io",
@@ -13345,7 +16735,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/strapi.io"
+      "logoSourceUrl": "https://integrations.sh/logo/strapi.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "streak.com",
@@ -13365,7 +16760,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/streak.com"
+      "logoSourceUrl": "https://integrations.sh/logo/streak.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "stripe.com",
@@ -13392,7 +16792,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/stripe.com"
+      "logoSourceUrl": "https://integrations.sh/logo/stripe.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "strivemaths.com",
@@ -13404,7 +16809,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/strivemaths.com"
+      "logoSourceUrl": "https://integrations.sh/logo/strivemaths.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "stubhub.net",
@@ -13416,7 +16826,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/stubhub.net"
+      "logoSourceUrl": "https://integrations.sh/logo/stubhub.net",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "stytch.com",
@@ -13436,7 +16851,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/stytch.com"
+      "logoSourceUrl": "https://integrations.sh/logo/stytch.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "stytch.dev",
@@ -13456,7 +16876,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/stytch.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/stytch.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "subdivide.app",
@@ -13468,7 +16893,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/subdivide.app"
+      "logoSourceUrl": "https://integrations.sh/logo/subdivide.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "subscriptionflow.com",
@@ -13480,7 +16910,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/subscriptionflow.com"
+      "logoSourceUrl": "https://integrations.sh/logo/subscriptionflow.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "substack.com",
@@ -13500,7 +16935,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/substack.com"
+      "logoSourceUrl": "https://integrations.sh/logo/substack.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "success.co",
@@ -13520,7 +16960,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/success.co"
+      "logoSourceUrl": "https://integrations.sh/logo/success.co",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sumsub.com",
@@ -13540,7 +16985,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sumsub.com"
+      "logoSourceUrl": "https://integrations.sh/logo/sumsub.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "supabase.com",
@@ -13560,7 +17010,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/supabase.com"
+      "logoSourceUrl": "https://integrations.sh/logo/supabase.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "superhuman.com",
@@ -13580,7 +17035,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/superhuman.com"
+      "logoSourceUrl": "https://integrations.sh/logo/superhuman.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "supermetrics.com",
@@ -13600,7 +17060,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/supermetrics.com"
+      "logoSourceUrl": "https://integrations.sh/logo/supermetrics.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "superserve.ai",
@@ -13620,7 +17085,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/superserve.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/superserve.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "suri.cz",
@@ -13640,34 +17110,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/suri.cz"
-    },
-    {
-      "domain": "surrealdb.com",
-      "name": "surrealdb.com",
-      "mcpUrl": "http://127.0.0.1:8000/mcp",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "surreal_userpass",
-          "type": "basic",
-          "generateUrl": null,
-          "setup": "Create credentials when you start or configure a SurrealDB instance. For self-hosted instances, start the server with `surreal start --user <username> --pass <password>` as shown in the [HTTP protocol setup](https://surrealdb.com/docs/reference/rest-api/http-protocol) and [CLI overview](https://surrealdb.com/docs/reference/cli/surrealdb-cli/overview). For SurrealDB Cloud, create an instance in [Create an instance](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/getting-started/create-an-instance), then connect to that instance as described in [Connecting to Cloud](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/connecting). Namespace- and database-scoped users can also be used where supported via the `--auth-level` flow documented on [`surreal sql`](https://surrealdb.com/docs/reference/cli/surrealdb-cli/commands/sql).",
-          "fields": null
-        },
-        {
-          "id": "surreal_jwt",
-          "type": "bearer",
-          "generateUrl": null,
-          "setup": "Mint a token by signing in to a SurrealDB instance through the documented auth flow. The REST API exposes [`POST /signin`](https://surrealdb.com/docs/reference/rest-api/http-protocol), and the CLI can also connect with an existing token via [`surreal sql --token`](https://surrealdb.com/docs/reference/cli/surrealdb-cli/commands/sql). For Cloud, first create an account and instance via [Cloud management](https://surrealdb.com/docs/manage/cloud) and [Create an instance](https://surrealdb.com/docs/build/deployment/surrealdb-cloud/getting-started/create-an-instance), then sign in to that instance and reuse the returned JWT as a Bearer token.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/surrealdb.com"
+      "logoSourceUrl": "https://integrations.sh/logo/suri.cz",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "surveymonkey.com",
@@ -13687,7 +17135,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/surveymonkey.com"
+      "logoSourceUrl": "https://integrations.sh/logo/surveymonkey.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "sweetspotgov.workers.dev",
@@ -13699,7 +17152,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/sweetspotgov.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/sweetspotgov.workers.dev",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "sybill.ai",
@@ -13719,7 +17177,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/sybill.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/sybill.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "synapse.org",
@@ -13739,7 +17202,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/synapse.org"
+      "logoSourceUrl": "https://integrations.sh/logo/synapse.org",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "systembolaget.se",
@@ -13751,7 +17219,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/systembolaget.se"
+      "logoSourceUrl": "https://integrations.sh/logo/systembolaget.se",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "talktoglow.com",
@@ -13771,7 +17244,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/talktoglow.com"
+      "logoSourceUrl": "https://integrations.sh/logo/talktoglow.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tally.so",
@@ -13798,7 +17276,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tally.so"
+      "logoSourceUrl": "https://integrations.sh/logo/tally.so",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tamg.cloud",
@@ -13810,7 +17293,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tamg.cloud"
+      "logoSourceUrl": "https://integrations.sh/logo/tamg.cloud",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tapteach.org",
@@ -13822,7 +17310,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tapteach.org"
+      "logoSourceUrl": "https://integrations.sh/logo/tapteach.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "target.com",
@@ -13834,7 +17327,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/target.com"
+      "logoSourceUrl": "https://integrations.sh/logo/target.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "targetvalidation.org",
@@ -13846,7 +17344,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/targetvalidation.org"
+      "logoSourceUrl": "https://integrations.sh/logo/targetvalidation.org",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "taskrabbit.com",
@@ -13858,7 +17361,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/taskrabbit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/taskrabbit.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tavily.com",
@@ -13878,7 +17386,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tavily.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tavily.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "taxheaven-chatgpt-app.vercel.app",
@@ -13890,7 +17403,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/taxheaven-chatgpt-app.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/taxheaven-chatgpt-app.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "teklifimgelsin.com",
@@ -13902,7 +17420,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/teklifimgelsin.com"
+      "logoSourceUrl": "https://integrations.sh/logo/teklifimgelsin.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "theknot.com",
@@ -13914,7 +17437,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/theknot.com"
+      "logoSourceUrl": "https://integrations.sh/logo/theknot.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "thetrainline.com",
@@ -13926,7 +17454,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/thetrainline.com"
+      "logoSourceUrl": "https://integrations.sh/logo/thetrainline.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "thumbtack.com",
@@ -13938,7 +17471,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/thumbtack.com"
+      "logoSourceUrl": "https://integrations.sh/logo/thumbtack.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "ticketmaster.com",
@@ -13950,7 +17488,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ticketmaster.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ticketmaster.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "tickettailor.ai",
@@ -13970,7 +17513,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tickettailor.com",
@@ -13990,7 +17538,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tickettailor.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tigerdata.com",
@@ -14002,7 +17555,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tigerdata.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tigerdata.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tigrisdata.com",
@@ -14022,7 +17580,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tigrisdata.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tigrisdata.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tldraw.workers.dev",
@@ -14034,7 +17597,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tldraw.workers.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/tldraw.workers.dev",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tokenterminal.com",
@@ -14054,7 +17622,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tokenterminal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tokenterminal.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tomorrow.io",
@@ -14066,7 +17639,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tomorrow.io"
+      "logoSourceUrl": "https://integrations.sh/logo/tomorrow.io",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tourradar.com",
@@ -14078,7 +17656,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tourradar.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tourradar.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "transloadit.com",
@@ -14098,7 +17681,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/transloadit.com"
+      "logoSourceUrl": "https://integrations.sh/logo/transloadit.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "travelenie.com",
@@ -14110,7 +17698,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/travelenie.com"
+      "logoSourceUrl": "https://integrations.sh/logo/travelenie.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "travelimpactmodel.googleapis.com",
@@ -14130,7 +17723,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/travelimpactmodel.googleapis.com"
+      "logoSourceUrl": "https://integrations.sh/logo/travelimpactmodel.googleapis.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tray.ai",
@@ -14150,7 +17748,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tray.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/tray.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tredict.com",
@@ -14177,7 +17780,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tredict.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tredict.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tripbtoz.com",
@@ -14189,7 +17797,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tripbtoz.com"
+      "logoSourceUrl": "https://integrations.sh/logo/tripbtoz.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "trivago.com",
@@ -14201,7 +17814,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/trivago.com"
+      "logoSourceUrl": "https://integrations.sh/logo/trivago.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tropicapp.io",
@@ -14221,7 +17839,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tropicapp.io"
+      "logoSourceUrl": "https://integrations.sh/logo/tropicapp.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "trufflejournal.com",
@@ -14241,7 +17864,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/trufflejournal.com"
+      "logoSourceUrl": "https://integrations.sh/logo/trufflejournal.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "trustrebound.com",
@@ -14253,7 +17881,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/trustrebound.com"
+      "logoSourceUrl": "https://integrations.sh/logo/trustrebound.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "trychannel3.com",
@@ -14273,7 +17906,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/trychannel3.com"
+      "logoSourceUrl": "https://integrations.sh/logo/trychannel3.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "trychroma.com",
@@ -14293,7 +17931,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/trychroma.com"
+      "logoSourceUrl": "https://integrations.sh/logo/trychroma.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "trykopi.ai",
@@ -14313,39 +17956,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/trykopi.ai"
-    },
-    {
-      "domain": "trymalcolm.com",
-      "name": "Aviva",
-      "mcpUrl": "https://mcp.trymalcolm.com/sse",
-      "transport": "streamable-http",
-      "authKind": "api_key",
-      "scopesHint": [],
-      "credentialFacts": [
-        {
-          "id": "marrow_api_key",
-          "type": "bearer",
-          "generateUrl": "https://www.onmarrow.com/contact",
-          "setup": "To get Sandbox credentials, email Marrow via [contact@onmarrow.com](mailto:contact@onmarrow.com) or use the [contact page](https://www.onmarrow.com/contact). The partner quickstart says Marrow will set you up with test credentials. Use the issued key as a bearer token in `Authorization: Bearer <key>`. The docs show production-style keys prefixed `mk_live_` and sandbox/test keys prefixed `mk_test_`.",
-          "fields": null
-        }
-      ],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/trymalcolm.com"
-    },
-    {
-      "domain": "tubi.io",
-      "name": "Tubi",
-      "mcpUrl": "https://openai-app-mcp.main-production-custom.production.k8s.tubi.io/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/tubi.io"
+      "logoSourceUrl": "https://integrations.sh/logo/trykopi.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tuio-mcp-demo.vercel.app",
@@ -14357,7 +17973,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tuio-mcp-demo.vercel.app"
+      "logoSourceUrl": "https://integrations.sh/logo/tuio-mcp-demo.vercel.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "tuist.dev",
@@ -14377,7 +17998,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tuist.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/tuist.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "turkishtechlab.com",
@@ -14389,7 +18015,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/turkishtechlab.com"
+      "logoSourceUrl": "https://integrations.sh/logo/turkishtechlab.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "turo.com",
@@ -14401,7 +18032,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/turo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/turo.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "turso.tech",
@@ -14421,7 +18057,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/turso.tech"
+      "logoSourceUrl": "https://integrations.sh/logo/turso.tech",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "tusalario.app",
@@ -14433,7 +18074,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/tusalario.app"
+      "logoSourceUrl": "https://integrations.sh/logo/tusalario.app",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "uber.com",
@@ -14445,7 +18091,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/uber.com"
+      "logoSourceUrl": "https://integrations.sh/logo/uber.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "ubereats.com",
@@ -14457,7 +18108,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ubereats.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ubereats.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "ubersuggest.com",
@@ -14477,7 +18133,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/ubersuggest.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ubersuggest.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "udemy.com",
@@ -14489,7 +18150,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/udemy.com"
+      "logoSourceUrl": "https://integrations.sh/logo/udemy.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ui.nuxt.com",
@@ -14501,7 +18167,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com"
+      "logoSourceUrl": "https://integrations.sh/logo/nuxt.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "unified.to",
@@ -14521,7 +18192,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/unified.to"
+      "logoSourceUrl": "https://integrations.sh/logo/unified.to",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 400
+      }
     },
     {
       "domain": "unthread.io",
@@ -14541,7 +18217,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/unthread.io"
+      "logoSourceUrl": "https://integrations.sh/logo/unthread.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "updatron.com",
@@ -14561,7 +18242,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/updatron.com"
+      "logoSourceUrl": "https://integrations.sh/logo/updatron.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "upplai-mcp-server-production.up.railway.app",
@@ -14581,7 +18267,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/upplai-mcp-server-production.up.railway.app"
+      "logoSourceUrl": "https://integrations.sh/logo/upplai-mcp-server-production.up.railway.app",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "upsun.com",
@@ -14601,7 +18292,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/upsun.com"
+      "logoSourceUrl": "https://integrations.sh/logo/upsun.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "uptimerobot.com",
@@ -14621,7 +18317,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/uptimerobot.com"
+      "logoSourceUrl": "https://integrations.sh/logo/uptimerobot.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "usenotra.com",
@@ -14648,7 +18349,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/usenotra.com"
+      "logoSourceUrl": "https://integrations.sh/logo/usenotra.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "usepylon.com",
@@ -14668,7 +18374,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/usepylon.com"
+      "logoSourceUrl": "https://integrations.sh/logo/usepylon.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "usgb.io",
@@ -14680,7 +18391,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/usgb.io"
+      "logoSourceUrl": "https://integrations.sh/logo/usgb.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "vakantiediscounter.nl",
@@ -14692,7 +18408,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vakantiediscounter.nl"
+      "logoSourceUrl": "https://integrations.sh/logo/vakantiediscounter.nl",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vancompare.com",
@@ -14704,7 +18425,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vancompare.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vancompare.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vantage.sh",
@@ -14724,7 +18450,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vantage.sh"
+      "logoSourceUrl": "https://integrations.sh/logo/vantage.sh",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "vectorize.io",
@@ -14744,7 +18475,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/vectorize.io"
+      "logoSourceUrl": "https://integrations.sh/logo/vectorize.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "veed.io",
@@ -14764,7 +18500,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/veed.io"
+      "logoSourceUrl": "https://integrations.sh/logo/veed.io",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "vendr.com",
@@ -14784,7 +18525,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vendr.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vendr.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "venturu.com",
@@ -14796,7 +18542,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/venturu.com"
+      "logoSourceUrl": "https://integrations.sh/logo/venturu.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vercel.com",
@@ -14816,7 +18567,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/vercel.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vercel.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "vianexus.com",
@@ -14836,7 +18592,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/vianexus.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vianexus.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "viator.com",
@@ -14848,7 +18609,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/viator.com"
+      "logoSourceUrl": "https://integrations.sh/logo/viator.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vio.com",
@@ -14860,7 +18626,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vio.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vio.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "virginatlantic.com",
@@ -14872,7 +18643,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/virginatlantic.com"
+      "logoSourceUrl": "https://integrations.sh/logo/virginatlantic.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "timeout",
+        "httpStatus": null
+      }
     },
     {
       "domain": "virtuoso.ai",
@@ -14884,7 +18660,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/virtuoso.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/virtuoso.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "vivin.ai",
@@ -14904,7 +18685,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/vivin.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/vivin.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vroomvroomvroom.com",
@@ -14924,7 +18710,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vroomvroomvroom.com"
+      "logoSourceUrl": "https://integrations.sh/logo/vroomvroomvroom.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "vsct.fr",
@@ -14936,7 +18727,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/vsct.fr"
+      "logoSourceUrl": "https://integrations.sh/logo/vsct.fr",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "vybit.net",
@@ -14956,7 +18752,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/vybit.net"
+      "logoSourceUrl": "https://integrations.sh/logo/vybit.net",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wallector.com",
@@ -14968,7 +18769,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wallector.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wallector.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "walletwhistle.com",
@@ -14980,7 +18786,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/walletwhistle.com"
+      "logoSourceUrl": "https://integrations.sh/logo/walletwhistle.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "walmart.com",
@@ -15000,7 +18811,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/walmart.com"
+      "logoSourceUrl": "https://integrations.sh/logo/walmart.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "wandb.ai",
@@ -15020,7 +18836,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wandb.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/wandb.ai",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wanderu.com",
@@ -15032,7 +18853,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wanderu.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wanderu.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "wayground.com",
@@ -15052,19 +18878,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wayground.com"
-    },
-    {
-      "domain": "wear.jp",
-      "name": "ZOZO",
-      "mcpUrl": "https://mcp.wear.jp/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wear.jp"
+      "logoSourceUrl": "https://integrations.sh/logo/wayground.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "webex.com",
@@ -15084,7 +18903,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/webex.com"
+      "logoSourceUrl": "https://integrations.sh/logo/webex.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "webflow.com",
@@ -15104,31 +18928,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/webflow.com"
-    },
-    {
-      "domain": "webjet.com.au",
-      "name": "Webjet",
-      "mcpUrl": "https://services.webjet.com.au/api/mcp/webjetota",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/webjet.com.au"
-    },
-    {
-      "domain": "wego.com",
-      "name": "Wego",
-      "mcpUrl": "https://mcp.wego.com/chatgpt-app/v1/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wego.com"
+      "logoSourceUrl": "https://integrations.sh/logo/webflow.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wepromise.tech",
@@ -15140,7 +18945,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wepromise.tech"
+      "logoSourceUrl": "https://integrations.sh/logo/wepromise.tech",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "whack.ie",
@@ -15152,7 +18962,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/whack.ie"
+      "logoSourceUrl": "https://integrations.sh/logo/whack.ie",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "whimsical.com",
@@ -15172,7 +18987,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/whimsical.com"
+      "logoSourceUrl": "https://integrations.sh/logo/whimsical.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "windmill.dev",
@@ -15192,7 +19012,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/windmill.dev"
+      "logoSourceUrl": "https://integrations.sh/logo/windmill.dev",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "windsor.ai",
@@ -15204,7 +19029,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/windsor.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/windsor.ai",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "withbites.com",
@@ -15216,7 +19046,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/withbites.com"
+      "logoSourceUrl": "https://integrations.sh/logo/withbites.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "wix.com",
@@ -15236,7 +19071,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/wix.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wix.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wizehire.com",
@@ -15256,7 +19096,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wizehire.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wizehire.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wordpress.com",
@@ -15276,7 +19121,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/wordpress.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wordpress.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "workable.com",
@@ -15288,7 +19138,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/workable.com"
+      "logoSourceUrl": "https://integrations.sh/logo/workable.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 405
+      }
     },
     {
       "domain": "workos.com",
@@ -15308,7 +19163,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/workos.com"
+      "logoSourceUrl": "https://integrations.sh/logo/workos.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wrike.com",
@@ -15335,19 +19195,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wrike.com"
-    },
-    {
-      "domain": "ww.com",
-      "name": "WeightWatchers",
-      "mcpUrl": "https://api.ww.com/ai/mcp-openai-glp1-recipes/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ww.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wrike.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "www.printhiv3d.com",
@@ -15367,7 +19220,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com"
+      "logoSourceUrl": "https://integrations.sh/logo/printhiv3d.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "wyndhamhotels.com",
@@ -15379,7 +19237,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/wyndhamhotels.com"
+      "logoSourceUrl": "https://integrations.sh/logo/wyndhamhotels.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "x.com",
@@ -15406,7 +19269,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/x.com"
+      "logoSourceUrl": "https://integrations.sh/logo/x.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "yahooapis.jp",
@@ -15418,19 +19286,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/yahooapis.jp"
-    },
-    {
-      "domain": "yardimcp.com",
-      "name": "RentCafe",
-      "mcpUrl": "https://rentcafe.yardimcp.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/yardimcp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/yahooapis.jp",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "yelp.com",
@@ -15442,7 +19303,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/yelp.com"
+      "logoSourceUrl": "https://integrations.sh/logo/yelp.com",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 403
+      }
     },
     {
       "domain": "yepcode.io",
@@ -15462,7 +19328,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/yepcode.io"
+      "logoSourceUrl": "https://integrations.sh/logo/yepcode.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "yoshi.ai",
@@ -15489,7 +19360,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/yoshi.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/yoshi.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "youversionapi.com",
@@ -15501,7 +19377,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/youversionapi.com"
+      "logoSourceUrl": "https://integrations.sh/logo/youversionapi.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "zapier.com",
@@ -15521,7 +19402,12 @@
       ],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/zapier.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zapier.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "zen7.com",
@@ -15541,7 +19427,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zen7.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zen7.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "zep.ai",
@@ -15553,7 +19444,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zep.ai"
+      "logoSourceUrl": "https://integrations.sh/logo/zep.ai",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "zillow.com",
@@ -15565,7 +19461,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zillow.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zillow.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "ziprecruiter.com",
@@ -15577,7 +19478,12 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/ziprecruiter.com"
+      "logoSourceUrl": "https://integrations.sh/logo/ziprecruiter.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_json_rpc",
+        "httpStatus": 200
+      }
     },
     {
       "domain": "zocks.io",
@@ -15597,7 +19503,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zocks.io"
+      "logoSourceUrl": "https://integrations.sh/logo/zocks.io",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "zohomcp.ae",
@@ -15617,7 +19528,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.ae"
+      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.ae",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 400
+      }
     },
     {
       "domain": "zohomcp.sa",
@@ -15644,19 +19560,12 @@
       ],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.sa"
-    },
-    {
-      "domain": "zola.com",
-      "name": "Zola",
-      "mcpUrl": "https://mcp.zola.com/mcp",
-      "transport": "streamable-http",
-      "authKind": "none",
-      "scopesHint": [],
-      "credentialFacts": [],
-      "tier": "community",
-      "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zola.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zohomcp.sa",
+      "probe": {
+        "status": "unverified",
+        "reason": "http_status",
+        "httpStatus": 400
+      }
     },
     {
       "domain": "zoominfo.com",
@@ -15668,7 +19577,12 @@
       "credentialFacts": [],
       "tier": "verified",
       "provenance": "detected",
-      "logoSourceUrl": "https://integrations.sh/logo/zoominfo.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zoominfo.com",
+      "probe": {
+        "status": "real",
+        "reason": "auth_challenge",
+        "httpStatus": 401
+      }
     },
     {
       "domain": "zumba.com",
@@ -15680,815 +19594,200 @@
       "credentialFacts": [],
       "tier": "community",
       "provenance": "discovered",
-      "logoSourceUrl": "https://integrations.sh/logo/zumba.com"
+      "logoSourceUrl": "https://integrations.sh/logo/zumba.com",
+      "probe": {
+        "status": "real",
+        "reason": "mcp_sse",
+        "httpStatus": 200
+      }
     }
   ],
   "skipped": [
     {
-      "domain": "agentichoteldistribution.com",
-      "mcpUrl": "https://agentichoteldistribution.com/mcp/synxis?chainId=10237",
-      "reason": "duplicate_domain_name"
+      "domain": "12andus.com",
+      "mcpUrl": "https://mcp.12andus.com/mcp/?v=10",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "adobe.io",
-      "mcpUrl": "https://aep-ai-ama.adobe.io/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "ai-stats.phaseo.app",
+      "mcpUrl": "https://ai-stats.phaseo.app/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "adobe.io",
-      "mcpUrl": "https://adobe-creativity.adobe.io/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "all-ten-chat-gpt-app.replit.app",
+      "mcpUrl": "https://all-ten-chat-gpt-app.replit.app/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "adobe.io",
-      "mcpUrl": "https://express-mcp-service.adobe.io/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "api7.ai",
+      "mcpUrl": "http://127.0.0.1:3000/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "adobe.io",
-      "mcpUrl": "https://photoshop-mcp-service.adobe.io/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "boyner.com.tr",
+      "mcpUrl": "https://mcp-backend.boyner.com.tr/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "adobe.io",
-      "mcpUrl": "https://acrobat-mcp.adobe.io/mcp/call",
-      "reason": "duplicate_domain_name"
+      "domain": "creditkarma.com",
+      "mcpUrl": "https://anthropic.mcp.creditkarma.com/mcp",
+      "reason": "probe_html_response"
     },
     {
-      "domain": "airwallex.com",
-      "mcpUrl": "https://mcp-demo.airwallex.com/docs",
-      "reason": "duplicate_domain_name"
+      "domain": "crowdstrike.com",
+      "mcpUrl": "http://127.0.0.1:8000",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "airwallex.com",
-      "mcpUrl": "https://mcp.airwallex.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "api.aws",
-      "mcpUrl": "https://marketplace-mcp.us-east-1.api.aws/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "awesomize.ai",
-      "mcpUrl": "https://talkgen.awesomize.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "awesomize.ai",
-      "mcpUrl": "https://mangaboom.awesomize.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "azurecontainerapps.io",
-      "mcpUrl": "https://inviton-gpt-mcp.yellowocean-74d7a25f.westeurope.azurecontainerapps.io/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "boxoffice.com",
-      "mcpUrl": "https://mcp-regal.boxoffice.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "bump.sh",
-      "mcpUrl": "https://developers.bump.sh/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "bump.sh",
-      "mcpUrl": "https://developers.bump.sh/doc/workspace/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "cardchain.ai",
-      "mcpUrl": "https://api.cardchain.ai/mcp/claude",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "carbonarc.ai",
-      "mcpUrl": "https://mcp.carbonarc.ai/research",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "chargebee.com",
-      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/knowledge_base_agent",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "chargebee.com",
-      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/data_lookup_agent",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "chargebee.com",
-      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/onboarding_agent",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "chargebee.com",
-      "mcpUrl": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/YOUR-CUSTOM-SERVER-SLUG",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "checkr.com",
-      "mcpUrl": "https://mcp.checkr.com/candidate-mcp/",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "cdata.com",
-      "mcpUrl": "https://mcp.cloud.cdata.com/mcp/mgmt",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "coches.net",
-      "mcpUrl": "https://llms-apps.gw.coches.net/motos/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "coches.net",
-      "mcpUrl": "https://llms-apps.gw.coches.net/milanuncios/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "composio.dev",
-      "mcpUrl": "https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "contentful.com",
-      "mcpUrl": "https://mcp.eu.contentful.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "decolar.com",
-      "mcpUrl": "https://apis.despegar.com/api-b2b-hotels-mcp/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "domotz.app",
-      "mcpUrl": "https://mcp.ov.domotz.app/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "dub.co",
-      "mcpUrl": "https://mcp.dub.sh/mcp/dub-partners",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "dropbox.com",
-      "mcpUrl": "https://mcp.dropbox.com/dash_chatgpt_app",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "eodhd.com",
-      "mcpUrl": "https://mcp.eodhd.com/v1/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "explorium.ai",
-      "mcpUrl": "https://vibeprospecting.explorium.ai/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "email-creation-mcp-node-production.up.railway.app",
+      "mcpUrl": "https://email-creation-mcp-node-production.up.railway.app/mcp",
+      "reason": "probe_http_not_found"
     },
     {
       "domain": "fastmcp.cloud",
-      "mcpUrl": "https://your-server-name.fastmcp.app/mcp",
-      "reason": "templated_url"
+      "mcpUrl": "https://my-tools.horizon.prefect.io",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "framagit.org",
-      "mcpUrl": "https://framagit.org/api/v4/orbit/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "flowerdiary.xyz",
+      "mcpUrl": "https://openai.flowerdiary.xyz/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "dbt.com",
-      "mcpUrl": "https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/",
-      "reason": "templated_url"
+      "domain": "gmail.googleapis.com",
+      "mcpUrl": "https://gmail.googleapis.com/mcp/",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "getyourguide.com",
-      "mcpUrl": "https://widget.getyourguide.com/mcp",
-      "reason": "templated_url"
+      "domain": "gosure.ai",
+      "mcpUrl": "https://dev.gosure.ai/core-mcp/api",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "glama.ai",
-      "mcpUrl": "https://glama.ai/endpoints/<your-connection-profile>/mcp",
-      "reason": "templated_url"
+      "domain": "heepsy.com",
+      "mcpUrl": "https://mcp.heepsy.com/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "gogs.io",
-      "mcpUrl": "https://unknwon.main-kill-isr.mintlify.me/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "inngest.com",
+      "mcpUrl": "http://127.0.0.1:8288/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "gojinko.com",
-      "mcpUrl": "https://mcp.gojinko.com",
-      "reason": "duplicate_domain_name"
+      "domain": "kactus.com",
+      "mcpUrl": "https://www.kactus.com/apis/mcp",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "intuit.com",
-      "mcpUrl": "https://ai-inc.turbotax.intuit.com/358A1C1B-F73B-46A7-B130-4B14916E6843/v1/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "lckqhyftgouenpercpjk.supabase.co",
+      "mcpUrl": "http://127.0.0.1:54321/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "jotform.com",
-      "mcpUrl": "https://mcp.jotform.com/mcp-app",
-      "reason": "duplicate_domain_name"
+      "domain": "liblab.com",
+      "mcpUrl": "https://mcp.liblab.io/liblab",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "kindora.co",
-      "mcpUrl": "https://kindora-mcp.azurewebsites.net/mcp/",
-      "reason": "duplicate_domain_name"
+      "domain": "loomalabs.ai",
+      "mcpUrl": "https://mcp.loomalabs.ai/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "kensho.com",
-      "mcpUrl": "https://kfinance.kensho.com/integrations/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "makegov.com",
+      "mcpUrl": "https://tango.makegov.com/mcp/",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "kit.com",
-      "mcpUrl": "https://developers.kit.com/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "mozilla.org",
+      "mcpUrl": "https://developer.mozilla.org/api/v1/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "kubera.com",
-      "mcpUrl": "https://api.kubera.com/api/v2/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "neartail.com",
+      "mcpUrl": "https://neartail.com/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "lambus.ai",
-      "mcpUrl": "https://chatgpt-app-server.tourlane.wl.lambus.ai/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "networksolutions.com",
+      "mcpUrl": "https://mcp.networksolutions.com/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "langfuse.com",
-      "mcpUrl": "https://langfuse.com/api/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "novu.co",
+      "mcpUrl": "https://mcp.novu.co/",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "mcp.adobeaemcloud.com",
-      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/content",
-      "reason": "duplicate_domain_name"
+      "domain": "otseek.com",
+      "mcpUrl": "https://backend.otseek.com/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "mcp.adobeaemcloud.com",
-      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/content-readonly",
-      "reason": "duplicate_domain_name"
+      "domain": "phantombuster.com",
+      "mcpUrl": "https://mcp.phantombuster.com",
+      "reason": "probe_non_mcp_text"
     },
     {
-      "domain": "mcp.adobeaemcloud.com",
-      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/cloudmanager",
-      "reason": "duplicate_domain_name"
+      "domain": "plane.so",
+      "mcpUrl": "https://mcp.plane.so",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "mcp.adobeaemcloud.com",
-      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/experience-governance",
-      "reason": "duplicate_domain_name"
+      "domain": "port.io",
+      "mcpUrl": "https://mcp.port.io",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "mcp.adobeaemcloud.com",
-      "mcpUrl": "https://mcp.adobeaemcloud.com/adobe/mcp/cloud-migration",
-      "reason": "duplicate_domain_name"
+      "domain": "postman.co",
+      "mcpUrl": "https://mcp.postman.co/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "meterplan.com",
-      "mcpUrl": "https://mcp.meterplan.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "mermaid.ai",
-      "mcpUrl": "https://chatgpt.mermaid.ai/anthropic/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "modelcontextprotocol.io",
-      "mcpUrl": "https://modelcontextprotocol.io/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "modelcontextprotocol.io",
-      "mcpUrl": "https://example-server.modelcontextprotocol.io/threejs/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "modelcontextprotocol.io",
-      "mcpUrl": "https://example-server.modelcontextprotocol.io/sheet-music/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "natoma.ai",
-      "mcpUrl": "https://yourorg.mcp.natoma.app/v2/profile/your-profile/github/mcp",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "nexafin.com",
-      "mcpUrl": "https://app.nexafin.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://product-scanner.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://football.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://speed-test.widgets.widget.olutely.com/speed-test/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://record.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://clock.widgets.widget.olutely.com/clock/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://dog-breeds.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://lesson-plan.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://sudoku.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://price-alerts.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://pension-income-calculator.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://recipe-reader.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://color-picker.widgets.widget.olutely.com/color-picker/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://quote-display.widgets.widget.olutely.com/quote-display/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://piano.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://stopwatch.widgets.widget.olutely.com/stopwatch/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://forex.widgets.widget.olutely.com/forex/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://london-underground.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://doodle.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://mortgage-calculator.widgets.widget.olutely.com/mortgage-calculator/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://chess.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://lottery.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://horoscopes.widgets.widget.olutely.com/horoscopes/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://text-analysis.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://calendar.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://palette-picker.widgets.widget.olutely.com/palette-picker/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://calculator.widgets.widget.olutely.com/calculator/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://glossary.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://nature-sounds.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://coupons.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://fact.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://tides.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://dictionary.widgets.widget.olutely.com/dictionary/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://metronome.widgets.widget.olutely.com/metronome/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://timer.widgets.widget.olutely.com/timer/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://bible-verse.widgets.widget.olutely.com/bible-verse/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://conversation.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://meditation.widgets.widget.olutely.com/meditation/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://links.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://crossword.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://pregnancy-snapshot.widgets.widget.olutely.com/pregnancy-snapshot/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://spelling.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "olutely.com",
-      "mcpUrl": "https://word-search.widgets.widget.olutely.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "omnisend.com",
-      "mcpUrl": "https://mcp.omnisend.com/v2/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "optiversal.com",
-      "mcpUrl": "https://tillys.mcp.optiversal.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "paddle.com",
-      "mcpUrl": "https://sandbox-mcp.paddle.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "paddle.com",
-      "mcpUrl": "https://paddlehq.mcp.kapa.ai",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "phish.in",
-      "mcpUrl": "https://phish.in/mcp/openai",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "phish.in",
-      "mcpUrl": "https://phish.in/mcp/anthropic",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "polar.sh",
-      "mcpUrl": "https://mcp.polar.sh/mcp/polar-sandbox",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "pyxl.pro",
-      "mcpUrl": "https://www.pyxl.pro/api/mcp/aihumanize",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "pyxl.pro",
-      "mcpUrl": "https://www.pyxl.pro/api/mcp/pythonmaster",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "ramp.com",
-      "mcpUrl": "https://mcp.ramp.com/developer/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "ramp.com",
-      "mcpUrl": "https://mcp.ramp.com/ramp-data/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "rbictg.com",
-      "mcpUrl": "https://use1-prod-fhs-mcp.rbictg.com/api/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "rbictg.com",
-      "mcpUrl": "https://use1-prod-plk-chatgpt-app.rbictg.com/api/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "replit-mcp.com",
-      "mcpUrl": "https://replit-mcp.com/chatgpt-app/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "researchsolutions.com",
-      "mcpUrl": "https://scite.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "scalar.com",
-      "mcpUrl": "https://api.scalar.com/vector/mcp/YOUR_INSTALL_ID",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "securelend.ai",
-      "mcpUrl": "https://mcp.securelend.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sider.ai",
-      "mcpUrl": "https://outliner.chatgptapps.sider.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sider.ai",
-      "mcpUrl": "https://scholar.chatgptapps.sider.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sider.ai",
-      "mcpUrl": "https://quiz.chatgptapps.sider.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sider.ai",
-      "mcpUrl": "https://wisebase.chatgptapps.sider.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sider.ai",
-      "mcpUrl": "https://speech.chatgptapps.sider.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sierra.chat",
-      "mcpUrl": "https://api.sierra.chat/chat/_UjgWN4Bl-YJFsMBmn6VXROTPHGXRd9NCk5oWwSqMMA/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sierra.chat",
-      "mcpUrl": "https://api.sierra.chat/chat/fiKQF58BmL5HCdwBmn5G6nFeM9kSoKWMZNLoDRD1b8Q/mcp/GPT-1-1",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "skywatch.ai",
-      "mcpUrl": "https://renters-mcp.skywatch.ai/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "smartbear.com",
-      "mcpUrl": "https://zephyr.mcp.smartbear.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sonicapply.com",
-      "mcpUrl": "https://johns-hopkins-gpt-app.sonicapply.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "sonicapply.com",
-      "mcpUrl": "https://usss-gpt-app.sonicapply.com/mcp",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "spaceship.com",
-      "mcpUrl": "https://gpt-namecheap-mcp.service.spaceship.com/mcp/",
-      "reason": "duplicate_domain_name"
-    },
-    {
-      "domain": "strapi.io",
-      "mcpUrl": "https://<your-strapi-server>/mcp",
-      "reason": "templated_url"
-    },
-    {
-      "domain": "tourradar.com",
-      "mcpUrl": "https://ai.tourradar.com/mcp/main",
-      "reason": "duplicate_domain_name"
+      "domain": "surrealdb.com",
+      "mcpUrl": "http://127.0.0.1:8000/mcp",
+      "reason": "probe_connection_error"
     },
     {
       "domain": "trymalcolm.com",
-      "mcpUrl": "https://mcp.trymalcolm.com/mcp-ab2a870c-468a-418a-b695-09a30559a22a",
-      "reason": "duplicate_domain_name"
+      "mcpUrl": "https://mcp.trymalcolm.com/sse",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "trychannel3.com",
-      "mcpUrl": "https://mcp.trychannel3.com/",
-      "reason": "duplicate_domain_name"
+      "domain": "tubi.io",
+      "mcpUrl": "https://openai-app-mcp.main-production-custom.production.k8s.tubi.io/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "udemy.com",
-      "mcpUrl": "https://api.udemy.com/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "wear.jp",
+      "mcpUrl": "https://mcp.wear.jp/mcp",
+      "reason": "probe_connection_error"
     },
     {
-      "domain": "webex.com",
-      "mcpUrl": "https://mcp.webexapis.com/mcp/webex-messaging",
-      "reason": "duplicate_domain_name"
+      "domain": "webjet.com.au",
+      "mcpUrl": "https://services.webjet.com.au/api/mcp/webjetota",
+      "reason": "probe_html_response"
     },
     {
-      "domain": "webex.com",
-      "mcpUrl": "https://mcp.webexapis.com/mcp/workspaces",
-      "reason": "duplicate_domain_name"
+      "domain": "wego.com",
+      "mcpUrl": "https://mcp.wego.com/chatgpt-app/v1/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "webex.com",
-      "mcpUrl": "https://mcp.webexapis.com/mcp/webex-meeting",
-      "reason": "duplicate_domain_name"
+      "domain": "ww.com",
+      "mcpUrl": "https://api.ww.com/ai/mcp-openai-glp1-recipes/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "wyndhamhotels.com",
-      "mcpUrl": "https://mcp.wyndhamhotels.com/claude/mcp",
-      "reason": "duplicate_domain_name"
+      "domain": "yardimcp.com",
+      "mcpUrl": "https://rentcafe.yardimcp.com/mcp",
+      "reason": "probe_http_not_found"
     },
     {
-      "domain": "zuplo.work",
-      "mcpUrl": "https://mcp-main-406f710.accuweather.zuplo.work/v0/mcp/chatgpt?key=zpka_REDACTED",
-      "reason": "templated_url"
+      "domain": "zola.com",
+      "mcpUrl": "https://mcp.zola.com/mcp",
+      "reason": "probe_http_not_found"
     }
   ],
-  "quarantined": [
-    {
-      "row": {
-        "domain": "activepieces.com",
-        "name": "activepieces.com",
-        "mcpUrl": "https://www.activepieces.com/.well-known/mcp/server-card.json",
-        "transport": "streamable-http",
-        "authKind": "api_key",
-        "scopesHint": [],
-        "credentialFacts": [
-          {
-            "id": "mcp_embed_token",
-            "type": "bearer",
-            "generateUrl": "https://www.activepieces.com/docs/embedding/embeddable-mcp",
-            "setup": "First set up embedding using a signing key and embed JWT per [Provision Users](https://www.activepieces.com/docs/embedding/provision-users). Then, from the embedded frontend SDK, call `activepieces.generateMcpToken()` as shown in [Embeddable MCP](https://www.activepieces.com/docs/embedding/embeddable-mcp) to obtain `mcpToken` and `mcpServerUrl`. The token is scoped to that user's project and lasts 15 minutes.",
-            "fields": null
-          }
-        ],
-        "tier": "verified",
-        "provenance": "detected",
-        "logoSourceUrl": "https://integrations.sh/logo/activepieces.com"
-      },
-      "reason": "server-card JSON URL needs manual confirmation before enablement"
-    },
-    {
-      "row": {
-        "domain": "doordash.com",
-        "name": "DoorDash",
-        "mcpUrl": "https://openapi.doordash.com/mcp/consumer",
-        "transport": "streamable-http",
-        "authKind": "unknown",
-        "scopesHint": [],
-        "credentialFacts": [
-          {
-            "id": "dd_jwt_credential",
-            "type": "compound",
-            "generateUrl": "https://developer.doordash.com/portal/",
-            "setup": "In the [DoorDash Developer Portal](https://developer.doordash.com/portal/), open **Credentials**, click **Create Credential** (or create an access key in the Drive tutorial), choose the environment/APIs, and save the returned `developer_id`, `key_id`, and `signing_secret`/access key details. DoorDash docs say these values are then used to generate a JWT for API calls; the signing secret is shown only once, so store it securely. See [Drive JWT auth](https://developer.doordash.com/en-US/docs/drive/how_to/JWTs), [Drive get started](https://developer.doordash.com/en-US/docs/drive/tutorials/get_started), and [Marketplace JWT auth](https://developer.doordash.com/en-US/docs/marketplace/overview/getting_started/jwts_getting_started/).",
-            "fields": null
-          }
-        ],
-        "tier": "community",
-        "provenance": "discovered",
-        "logoSourceUrl": "https://integrations.sh/logo/doordash.com"
-      },
-      "reason": "consumer API URL needs manual confirmation before enablement"
-    },
-    {
-      "row": {
-        "domain": "natwest.com",
-        "name": "NatWest Mortgages",
-        "mcpUrl": "https://openapi.natwest.com/mortgages/v1/mcp-server-mortgages/mcp",
-        "transport": "streamable-http",
-        "authKind": "none",
-        "scopesHint": [],
-        "credentialFacts": [],
-        "tier": "community",
-        "provenance": "discovered",
-        "logoSourceUrl": "https://integrations.sh/logo/natwest.com"
-      },
-      "reason": "banking API URL needs manual confirmation before enablement"
-    },
-    {
-      "row": {
-        "domain": "netatmo.com",
-        "name": "netatmo.com",
-        "mcpUrl": "https://www.netatmo.com/.well-known/mcp/server-card.json",
-        "transport": "streamable-http",
-        "authKind": "unknown",
-        "scopesHint": [],
-        "credentialFacts": [],
-        "tier": "verified",
-        "provenance": "detected",
-        "logoSourceUrl": "https://integrations.sh/logo/netatmo.com"
-      },
-      "reason": "server-card JSON URL needs manual confirmation before enablement"
-    },
-    {
-      "row": {
-        "domain": "smartbear.com",
-        "name": "smartbear.com",
-        "mcpUrl": "https://swagger.mcp.smartbear.com/mcp",
-        "transport": "streamable-http",
-        "authKind": "oauth2",
-        "scopesHint": [],
-        "credentialFacts": [
-          {
-            "id": "smartbear_id_oauth",
-            "type": "oauth2",
-            "generateUrl": null,
-            "setup": "## OAuth 2.0 — self-onboarding\nPoint your MCP client at the server URL and approve access in the browser. The server supports OAuth Dynamic Client Registration (RFC 7591), so the client registers itself automatically — no developer-portal app, `client_id`, or `client_secret` to create.",
-            "fields": null
-          }
-        ],
-        "tier": "verified",
-        "provenance": "detected",
-        "logoSourceUrl": "https://integrations.sh/logo/smartbear.com"
-      },
-      "reason": "SmartBear Swagger endpoint needs manual confirmation before enablement"
-    }
-  ]
+  "quarantined": []
 }

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -89,16 +89,21 @@ The official MCP Registry is public metadata. Evaluate any server and its endpoi
 ## integrations.sh Snapshot Imports
 
 The integrations catalog import pipeline is offline and reviewable. It never
-live-consumes integrations.sh at request time. Operators run
-`bun scripts/import-integrations-catalog.ts --snapshot <snapshot.json>` against a
-reviewed snapshot or precomputed `importRows` file. The importer writes global
-capability rows, records an `import_batches` provenance row with MIT
-attribution, and upserts registry entries by `(provider_domain, mcp_url)`.
+live-consumes integrations.sh at request time. The reviewed source of truth is
+the committed snapshot at `data/catalog/integrations-snapshot.json`. Updating it
+is a PR workflow: run `bun run catalog:refresh`, review the snapshot diff, then
+merge. Operators import that committed snapshot with `bun run catalog:import
+--snapshot data/catalog/integrations-snapshot.json` (or the same path inside the
+application image). The importer writes global capability rows, records an
+`import_batches` provenance row with MIT attribution, and upserts registry
+entries by `(provider_domain, mcp_url)`.
 Rows removed from a later snapshot are marked `stale`, not deleted, and are
 excluded from default workspace catalog listings.
 
 Imported logos are fetched during import, validated as images below 512KB, and
 stored through OpenGeni object storage under `catalog-assets/...`; catalog rows
 store only the self-hosted `logoAssetPath`, never the third-party logo URL. The
-known-dead demo domains are skipped and flagged suspicious URLs are quarantined
-in the batch details for manual review.
+normalization pass strips raw control characters from string fields, collapses
+duplicate `(domain, name)` clusters to the best deterministic row, skips
+known-dead demo domains, and quarantines flagged suspicious URLs in the batch
+details for manual review.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "db:migrate": "set -a; [ -f .env ] && . ./.env; set +a; cd packages/db && bun run migrate",
     "db:provision-roles": "set -a; [ -f .env ] && . ./.env; set +a; cd packages/db && bun run provision-roles",
     "db:generate": "set -a; [ -f .env ] && . ./.env; set +a; cd packages/db && bun run generate",
+    "catalog:refresh": "bun scripts/refresh-integrations-catalog.ts",
+    "catalog:import": "set -a; [ -f .env ] && . ./.env; set +a; bun scripts/import-integrations-catalog.ts",
     "typecheck": "cd packages/contracts && bun run typecheck && cd ../agent-proto && bun run typecheck && cd ../config && bun run typecheck && cd ../deployment && bun run typecheck && cd ../db && bun run typecheck && cd ../events && bun run typecheck && cd ../github && bun run typecheck && cd ../storage && bun run typecheck && cd ../documents && bun run typecheck && cd ../observability && bun run typecheck && cd ../runtime && bun run typecheck && cd ../core && bun run typecheck && cd ../sdk && bun run typecheck && cd ../react && bun run typecheck && cd ../testing && bun run typecheck && cd ../../apps/api && bun run typecheck && cd ../worker && bun run typecheck && cd ../web && bun run typecheck",
     "test": "bun test",
     "test:unit": "bun test",

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   type CatalogIntegrationRow,
   type LogoStorage,
 } from "./import-integrations-catalog";
+import { probeCatalogSnapshot, probeMcpEndpoint } from "./integrations-catalog-probe";
 
 const fixtureUrl = new URL("./fixtures/integrations-catalog-sample.json", import.meta.url);
 
@@ -241,6 +242,90 @@ describe("integrations.sh logo storage", () => {
     });
     expect(failedFetch.ok).toBe(false);
     expect(!failedFetch.ok && failedFetch.reason).toBe("fetch_failed:network down");
+  });
+});
+
+describe("integrations.sh MCP endpoint probe", () => {
+  test("classifies a 200 JSON-RPC initialize response as real MCP", async () => {
+    const outcome = await probeMcpEndpoint("https://mcp.example/mcp", {
+      fetchImpl: async () => new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "Example", version: "1" } },
+      }), { status: 200, headers: { "content-type": "application/json" } }),
+    });
+
+    expect(outcome).toMatchObject({ status: "real", reason: "mcp_json_rpc", httpStatus: 200 });
+  });
+
+  test("classifies auth-gated MCP endpoints with WWW-Authenticate as real", async () => {
+    const outcome = await probeMcpEndpoint("https://linear.example/mcp", {
+      fetchImpl: async () => new Response("Unauthorized", {
+        status: 401,
+        headers: { "www-authenticate": "Bearer resource_metadata=\"https://linear.example/.well-known/oauth-protected-resource\"" },
+      }),
+    });
+
+    expect(outcome).toMatchObject({ status: "real", reason: "auth_challenge", httpStatus: 401 });
+  });
+
+  test("classifies 404s, HTML, generic JSON, and DNS failures as junk", async () => {
+    await expect(probeMcpEndpoint("https://missing.example/mcp", {
+      fetchImpl: async () => new Response("not found", { status: 404 }),
+    })).resolves.toMatchObject({ status: "junk", reason: "http_not_found" });
+
+    await expect(probeMcpEndpoint("https://html.example/mcp", {
+      fetchImpl: async () => new Response("<!doctype html><title>No MCP</title>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    })).resolves.toMatchObject({ status: "junk", reason: "html_response" });
+
+    await expect(probeMcpEndpoint("https://api.example/mcp", {
+      fetchImpl: async () => new Response(JSON.stringify({ kind: "gmail#profile", emailAddress: "me@example.com" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    })).resolves.toMatchObject({ status: "junk", reason: "non_mcp_json" });
+
+    await expect(probeMcpEndpoint("https://dns.example/mcp", {
+      fetchImpl: async () => { throw new Error("getaddrinfo ENOTFOUND dns.example"); },
+    })).resolves.toMatchObject({ status: "junk", reason: "connection_error" });
+  });
+
+  test("filters junk rows while keeping unverified rows with probe metadata", async () => {
+    const normalized = normalizeCatalogSnapshot({
+      generatedAt: "2026-07-03T00:00:00.000Z",
+      importRows: [
+        row({ domain: "real.example", mcpUrl: "https://real.example/mcp" }),
+        row({ domain: "gmail.googleapis.com", mcpUrl: "https://gmail.googleapis.com/mcp" }),
+        row({ domain: "maybe.example", mcpUrl: "https://maybe.example/mcp" }),
+      ],
+    });
+    const probed = await probeCatalogSnapshot(normalized, {
+      concurrency: 2,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("real.example")) {
+          return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { capabilities: {} } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes("googleapis.com")) {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response("busy", { status: 503 });
+      },
+    });
+
+    expect(probed.rows.map((candidate) => candidate.domain)).toEqual(["maybe.example", "real.example"]);
+    expect(probed.probe).toMatchObject({ kept: 2, dropped: 1, real: 1, unverified: 1, googleapisDropped: 1 });
+    expect(probed.rows.find((candidate) => candidate.domain === "maybe.example")?.probe)
+      .toMatchObject({ status: "unverified", reason: "http_status", httpStatus: 503 });
+    expect(probed.skipped.find((skip) => skip.domain === "gmail.googleapis.com")).toMatchObject({
+      reason: "probe_http_not_found",
+    });
   });
 });
 

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -16,7 +16,7 @@ describe("integrations.sh catalog import normalization", () => {
     const normalized = normalizeCatalogSnapshot(snapshot);
 
     expect(normalized.generatedAt).toBe("2026-07-03T23:41:44.132Z");
-    expect(normalized.rows).toHaveLength(11);
+    expect(normalized.rows).toHaveLength(8);
     expect(normalized.quarantined).toHaveLength(1);
     expect(normalized.quarantined[0]?.row.domain).toBe("activepieces.com");
     expect(normalized.quarantined[0]?.reason).toContain("manual confirmation");
@@ -30,8 +30,10 @@ describe("integrations.sh catalog import normalization", () => {
     expect(acko?.authKind).toBe("none");
 
     const bump = normalized.rows.filter((row) => row.domain === "bump.sh");
-    expect(bump).toHaveLength(3);
-    expect(new Set(bump.map((row) => row.mcpUrl)).size).toBe(3);
+    expect(bump).toHaveLength(1);
+    expect(bump[0]?.mcpUrl).toBe("https://developers.bump.sh/doc/portal/mcp");
+    expect(normalized.skipped.filter((skip) => skip.domain === "bump.sh" && skip.reason === "duplicate_domain_name"))
+      .toHaveLength(2);
   });
 
   test("applies importability filters and dedupes by domain plus MCP URL", () => {
@@ -59,6 +61,64 @@ describe("integrations.sh catalog import normalization", () => {
       "templated_url",
       "transport_not_streamable_http",
     ].sort());
+  });
+
+  test("strips raw control characters from all string fields", () => {
+    const normalized = normalizeCatalogSnapshot({
+      generatedAt: "2026-07-03T00:00:00.000Z",
+      importRows: [
+        row({
+          domain: "control.example\u0000",
+          name: "Control\u0007 Example",
+          mcpUrl: "https://control.example/mcp\u0001",
+          scopesHint: ["read\u0002write", "keeps\ttab\nnewline"],
+          credentialFacts: [{ setup: "bad\u001Fvalue" }],
+        }),
+      ],
+    });
+
+    expect(normalized.cleaning.controlCharacterFields).toBe(6);
+    expect(normalized.rows[0]).toMatchObject({
+      domain: "control.example",
+      name: "Control Example",
+      mcpUrl: "https://control.example/mcp",
+      scopesHint: ["readwrite", "keeps\ttab\nnewline"],
+      credentialFacts: [{ setup: "badvalue" }],
+    });
+  });
+
+  test("dedupes junk clusters by normalized domain plus name and keeps the best row", () => {
+    const normalized = normalizeCatalogSnapshot({
+      generatedAt: "2026-07-03T00:00:00.000Z",
+      importRows: [
+        row({
+          domain: "games.example",
+          name: "ABC Word Search",
+          mcpUrl: "https://games.example/discovered/mcp",
+          provenance: "discovered",
+          logoSourceUrl: null,
+        }),
+        row({
+          domain: "GAMES.EXAMPLE",
+          name: "abc   word search",
+          mcpUrl: "https://games.example/detected/mcp",
+          provenance: "detected",
+          logoSourceUrl: "https://integrations.sh/logo/games.example",
+        }),
+        row({
+          domain: "games.example",
+          name: "ABC Word Search",
+          mcpUrl: "https://games.example/other/mcp",
+          provenance: "discovered",
+          logoSourceUrl: "https://integrations.sh/logo/games.example",
+        }),
+      ],
+    });
+
+    expect(normalized.rows).toHaveLength(1);
+    expect(normalized.rows[0]?.mcpUrl).toBe("https://games.example/detected/mcp");
+    expect(normalized.cleaning.duplicateDomainNameRows).toBe(2);
+    expect(normalized.skipped.filter((skip) => skip.reason === "duplicate_domain_name")).toHaveLength(2);
   });
 
   test("derives rows from raw API plus per-domain surface docs", () => {

--- a/scripts/import-integrations-catalog.ts
+++ b/scripts/import-integrations-catalog.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { dbSearchPath, getSettings } from "@opengeni/config";
 import {
@@ -70,6 +70,14 @@ export type NormalizedCatalogSnapshot = {
   rows: CatalogIntegrationRow[];
   skipped: Array<{ domain: string | null; mcpUrl: string | null; reason: string }>;
   quarantined: Array<{ row: CatalogIntegrationRow; reason: string }>;
+  cleaning: {
+    inputRows: number;
+    outputRows: number;
+    skippedRows: number;
+    quarantinedRows: number;
+    duplicateDomainNameRows: number;
+    controlCharacterFields: number;
+  };
 };
 
 export type LogoStorageResult =
@@ -95,14 +103,34 @@ export async function readSnapshotFile(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8"));
 }
 
+export async function writeCleanCatalogSnapshot(path: string, snapshot: unknown): Promise<NormalizedCatalogSnapshot> {
+  const normalized = normalizeCatalogSnapshot(snapshot);
+  await writeFile(path, `${JSON.stringify({
+    generatedAt: normalized.generatedAt,
+    source: SOURCE,
+    cleanedAt: new Date().toISOString(),
+    cleaning: normalized.cleaning,
+    importRows: normalized.rows,
+    skipped: normalized.skipped,
+    quarantined: normalized.quarantined.map((item) => ({
+      row: item.row,
+      reason: item.reason,
+    })),
+  }, null, 2)}\n`);
+  return normalized;
+}
+
 export function normalizeCatalogSnapshot(snapshot: unknown): NormalizedCatalogSnapshot {
-  const root = asRecord(snapshot);
+  const controlCharacters = { count: 0 };
+  const cleanedSnapshot = stripControlCharacters(snapshot, controlCharacters);
+  const root = asRecord(cleanedSnapshot);
   const generatedAt = stringValue(root?.generatedAt) ?? stringValue(root?.snapshotDate) ?? null;
-  const candidates = precomputedRows(root ?? snapshot) ?? rawSurfaceRows(root);
+  const candidates = precomputedRows(root ?? cleanedSnapshot) ?? rawSurfaceRows(root);
   const skipped: NormalizedCatalogSnapshot["skipped"] = [];
   const quarantined: NormalizedCatalogSnapshot["quarantined"] = [];
-  const rows: CatalogIntegrationRow[] = [];
+  const candidatesByDomainName = new Map<string, CatalogIntegrationRow>();
   const seen = new Set<string>();
+  let duplicateDomainNameRows = 0;
 
   for (const candidate of candidates) {
     const domain = normalizeDomain(candidate.domain);
@@ -153,10 +181,37 @@ export function normalizeCatalogSnapshot(snapshot: unknown): NormalizedCatalogSn
       quarantined.push({ row, reason: suspiciousReason });
       continue;
     }
-    rows.push(row);
+    const domainNameKey = `${row.domain}\n${normalizeNameForDedupe(row.name)}`;
+    const existing = candidatesByDomainName.get(domainNameKey);
+    if (!existing) {
+      candidatesByDomainName.set(domainNameKey, row);
+      continue;
+    }
+    duplicateDomainNameRows += 1;
+    const winner = bestCatalogRow(existing, row);
+    const loser = winner === existing ? row : existing;
+    candidatesByDomainName.set(domainNameKey, winner);
+    skipped.push({ domain: loser.domain, mcpUrl: loser.mcpUrl, reason: "duplicate_domain_name" });
   }
 
-  return { generatedAt, rows, skipped, quarantined };
+  const rows = [...candidatesByDomainName.values()].sort((left, right) =>
+    left.domain.localeCompare(right.domain) || left.name.localeCompare(right.name) || left.mcpUrl.localeCompare(right.mcpUrl)
+  );
+
+  return {
+    generatedAt,
+    rows,
+    skipped,
+    quarantined,
+    cleaning: {
+      inputRows: candidates.length,
+      outputRows: rows.length,
+      skippedRows: skipped.length,
+      quarantinedRows: quarantined.length,
+      duplicateDomainNameRows,
+      controlCharacterFields: controlCharacters.count,
+    },
+  };
 }
 
 export async function importIntegrationsCatalog(input: {
@@ -184,6 +239,7 @@ export async function importIntegrationsCatalog(input: {
         reason: item.reason,
       })),
       skipped: normalized.skipped,
+      cleaning: normalized.cleaning,
     },
   });
   const logoFailures: ImportCatalogResult["logoFailures"] = [];
@@ -230,6 +286,7 @@ export async function importIntegrationsCatalog(input: {
         reason: item.reason,
       })),
       skipped: normalized.skipped,
+      cleaning: normalized.cleaning,
       logoFailures,
     },
   });
@@ -325,7 +382,7 @@ function rawSurfaceRows(root: UnknownRecord | null): UnknownRecord[] {
   if (!root) {
     return [];
   }
-  const flatEntries = arrayValue(root.api ?? root.catalog ?? root.flatCatalog ?? root.entries).filter(isRecord);
+  const flatEntries = arrayValue(root.api ?? root.catalog ?? root.flatCatalog ?? root.entries ?? root.data).filter(isRecord);
   const surfaceDocs = surfaceDocEntries(root.surfaceDocs ?? root.surfaces ?? root.domains);
   const flatByDomain = new Map<string, UnknownRecord>();
   for (const entry of flatEntries) {
@@ -501,6 +558,45 @@ function normalizeProvenance(value: unknown): string {
   return raw && raw.trim() ? raw.trim() : "unknown";
 }
 
+function normalizeNameForDedupe(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function bestCatalogRow(left: CatalogIntegrationRow, right: CatalogIntegrationRow): CatalogIntegrationRow {
+  const leftScore = catalogRowQualityScore(left);
+  const rightScore = catalogRowQualityScore(right);
+  if (rightScore !== leftScore) {
+    return rightScore > leftScore ? right : left;
+  }
+  return stableRowSortKey(right) < stableRowSortKey(left) ? right : left;
+}
+
+function catalogRowQualityScore(row: CatalogIntegrationRow): number {
+  let score = 0;
+  if (row.logoSourceUrl) {
+    score += 4;
+  }
+  if (row.provenance === "detected") {
+    score += 2;
+  } else if (row.provenance !== "discovered") {
+    score += 1;
+  }
+  if (row.authKind !== "unknown") {
+    score += 1;
+  }
+  if (row.scopesHint.length > 0) {
+    score += 1;
+  }
+  if (row.credentialFacts.length > 0) {
+    score += 1;
+  }
+  return score;
+}
+
+function stableRowSortKey(row: CatalogIntegrationRow): string {
+  return `${row.domain}\n${row.name}\n${row.provenance}\n${row.logoSourceUrl ?? ""}\n${row.mcpUrl}`;
+}
+
 function normalizedContentType(value: string | null): string | null {
   return value?.split(";")[0]?.trim().toLowerCase() || null;
 }
@@ -569,6 +665,23 @@ function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function stripControlCharacters(value: unknown, counter: { count: number }): unknown {
+  if (typeof value === "string") {
+    const stripped = value.replace(/[\u0000-\u0008\u000B-\u001F]/g, "");
+    if (stripped !== value) {
+      counter.count += 1;
+    }
+    return stripped;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stripControlCharacters(item, counter));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, stripControlCharacters(item, counter)]));
+  }
+  return value;
+}
+
 function parseArgs(argv: string[]): { snapshotPath: string; dryRun: boolean; skipLogos: boolean; snapshotRef?: string } {
   let snapshotPath = "";
   let dryRun = false;
@@ -610,9 +723,12 @@ if (import.meta.main) {
   if (args.dryRun) {
     console.log(JSON.stringify({
       generatedAt: normalized.generatedAt,
+      before: normalized.cleaning.inputRows,
+      after: normalized.cleaning.outputRows,
       importable: normalized.rows.length,
       skipped: normalized.skipped.length,
       quarantined: normalized.quarantined.length,
+      cleaning: normalized.cleaning,
     }, null, 2));
     process.exit(0);
   }
@@ -633,11 +749,14 @@ if (import.meta.main) {
     });
     console.log(JSON.stringify({
       batchId: result.batch.id,
+      before: normalized.cleaning.inputRows,
+      after: normalized.cleaning.outputRows,
       imported: result.importedCount,
       skipped: result.skippedCount,
       quarantined: result.quarantinedCount,
       stale: result.staleCount,
       logoFailures: result.logoFailureCount,
+      cleaning: normalized.cleaning,
     }, null, 2));
   } finally {
     await dbClient.close();

--- a/scripts/import-integrations-catalog.ts
+++ b/scripts/import-integrations-catalog.ts
@@ -63,6 +63,7 @@ export type CatalogIntegrationRow = {
   tier: CatalogTier;
   provenance: string;
   logoSourceUrl: string | null;
+  probe?: Record<string, unknown>;
 };
 
 export type NormalizedCatalogSnapshot = {
@@ -326,6 +327,7 @@ export function catalogRowToDbInput(row: CatalogIntegrationRow, input: {
     metadata: {
       logoSource: row.logoSourceUrl ? "integrations.sh" : "missing",
       originalLogoUrl: row.logoSourceUrl,
+      ...(row.probe ? { mcpProbe: row.probe } : {}),
     },
   };
 }

--- a/scripts/integrations-catalog-probe.ts
+++ b/scripts/integrations-catalog-probe.ts
@@ -1,0 +1,253 @@
+import type { CatalogIntegrationRow, NormalizedCatalogSnapshot } from "./import-integrations-catalog";
+
+export type CatalogProbeStatus = "real" | "junk" | "unverified";
+export type CatalogProbeReason =
+  | "mcp_json_rpc"
+  | "mcp_sse"
+  | "auth_challenge"
+  | "http_not_found"
+  | "connection_error"
+  | "timeout"
+  | "html_response"
+  | "non_mcp_json"
+  | "non_mcp_text"
+  | "http_status";
+
+export type CatalogProbeOutcome = {
+  status: CatalogProbeStatus;
+  reason: CatalogProbeReason;
+  httpStatus?: number;
+  detail?: string;
+};
+
+export type CatalogProbeFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type ProbeCatalogOptions = {
+  fetchImpl?: CatalogProbeFetch;
+  concurrency?: number;
+  timeoutMs?: number;
+  overallBudgetMs?: number;
+  now?: () => number;
+};
+
+export type ProbedCatalogSnapshot = NormalizedCatalogSnapshot & {
+  rows: CatalogIntegrationRow[];
+  probe: {
+    kept: number;
+    dropped: number;
+    real: number;
+    unverified: number;
+    googleapisDropped: number;
+    outcomes: Array<{ domain: string; mcpUrl: string; outcome: CatalogProbeOutcome }>;
+  };
+};
+
+const DEFAULT_CONCURRENCY = 24;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_OVERALL_BUDGET_MS = 10 * 60_000;
+
+export async function probeCatalogSnapshot(
+  normalized: NormalizedCatalogSnapshot,
+  options: ProbeCatalogOptions = {},
+): Promise<ProbedCatalogSnapshot> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const now = options.now ?? Date.now;
+  const deadline = now() + Math.max(timeoutMs, options.overallBudgetMs ?? DEFAULT_OVERALL_BUDGET_MS);
+  const outcomes: ProbedCatalogSnapshot["probe"]["outcomes"] = [];
+  const keptRows: CatalogIntegrationRow[] = [];
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const row = normalized.rows[index];
+      if (!row) {
+        return;
+      }
+      const outcome = now() >= deadline
+        ? { status: "unverified" as const, reason: "timeout" as const, detail: "overall_budget_exhausted" }
+        : await probeMcpEndpoint(row.mcpUrl, { fetchImpl, timeoutMs: Math.min(timeoutMs, Math.max(1, deadline - now())) });
+      outcomes[index] = { domain: row.domain, mcpUrl: row.mcpUrl, outcome };
+      if (outcome.status !== "junk") {
+        keptRows[index] = withProbeMetadata(row, outcome);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, normalized.rows.length) }, () => worker()));
+
+  const compactRows = keptRows.filter((row): row is CatalogIntegrationRow => !!row);
+  const compactOutcomes = outcomes.filter((item): item is ProbedCatalogSnapshot["probe"]["outcomes"][number] => !!item);
+  const dropped = compactOutcomes.filter((item) => item.outcome.status === "junk").length;
+  const unverified = compactOutcomes.filter((item) => item.outcome.status === "unverified").length;
+  const real = compactOutcomes.filter((item) => item.outcome.status === "real").length;
+  const googleapisDropped = compactOutcomes.filter((item) => item.domain.endsWith(".googleapis.com") && item.outcome.status === "junk").length;
+
+  return {
+    ...normalized,
+    rows: compactRows,
+    cleaning: {
+      ...normalized.cleaning,
+      outputRows: compactRows.length,
+      skippedRows: normalized.skipped.length + dropped,
+    },
+    skipped: [
+      ...normalized.skipped,
+      ...compactOutcomes
+        .filter((item) => item.outcome.status === "junk")
+        .map((item) => ({ domain: item.domain, mcpUrl: item.mcpUrl, reason: `probe_${item.outcome.reason}` })),
+    ],
+    probe: {
+      kept: compactRows.length,
+      dropped,
+      real,
+      unverified,
+      googleapisDropped,
+      outcomes: compactOutcomes,
+    },
+  };
+}
+
+export async function probeMcpEndpoint(url: string, input: {
+  fetchImpl?: CatalogProbeFetch;
+  timeoutMs?: number;
+} = {}): Promise<CatalogProbeOutcome> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "opengeni-catalog-refresh", version: "0.1.0" },
+        },
+      }),
+      signal: controller.signal,
+    });
+    return classifyProbeResponse(response, await safeResponseText(response));
+  } catch (error) {
+    if (isAbortError(error)) {
+      return { status: "unverified", reason: "timeout" };
+    }
+    return {
+      status: "junk",
+      reason: "connection_error",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function classifyProbeResponse(response: Response, body: string): CatalogProbeOutcome {
+  const httpStatus = response.status;
+  if ((httpStatus === 401 || httpStatus === 403) && hasAuthChallenge(response.headers)) {
+    return { status: "real", reason: "auth_challenge", httpStatus };
+  }
+  if (httpStatus === 404 || httpStatus === 410) {
+    return { status: "junk", reason: "http_not_found", httpStatus };
+  }
+  if (httpStatus >= 500) {
+    return { status: "unverified", reason: "http_status", httpStatus };
+  }
+  if (!response.ok) {
+    return { status: "unverified", reason: "http_status", httpStatus };
+  }
+
+  const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
+  const sample = body.slice(0, 4096);
+  if (contentType === "text/event-stream" || looksLikeSse(sample)) {
+    return sampleHasJsonRpc(sample)
+      ? { status: "real", reason: "mcp_sse", httpStatus }
+      : { status: "junk", reason: "non_mcp_text", httpStatus };
+  }
+  if (contentType === "text/html" || looksLikeHtml(sample)) {
+    return { status: "junk", reason: "html_response", httpStatus };
+  }
+
+  const json = parseJson(sample);
+  if (json) {
+    return looksLikeMcpJsonRpc(json)
+      ? { status: "real", reason: "mcp_json_rpc", httpStatus }
+      : { status: "junk", reason: "non_mcp_json", httpStatus };
+  }
+  return { status: "junk", reason: "non_mcp_text", httpStatus };
+}
+
+function withProbeMetadata(row: CatalogIntegrationRow, outcome: CatalogProbeOutcome): CatalogIntegrationRow {
+  return {
+    ...row,
+    probe: outcome.status === "unverified"
+      ? { status: "unverified", reason: outcome.reason, httpStatus: outcome.httpStatus ?? null }
+      : { status: outcome.status, reason: outcome.reason, httpStatus: outcome.httpStatus ?? null },
+  };
+}
+
+async function safeResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+function hasAuthChallenge(headers: Headers): boolean {
+  return !!(headers.get("www-authenticate") || headers.get("www-authenticate".toLowerCase()));
+}
+
+function looksLikeSse(text: string): boolean {
+  return /^event:|^data:/m.test(text);
+}
+
+function sampleHasJsonRpc(text: string): boolean {
+  return /"jsonrpc"\s*:\s*"2\.0"|protocolVersion|capabilities/.test(text);
+}
+
+function looksLikeHtml(text: string): boolean {
+  return /^\s*<!doctype html/i.test(text) || /^\s*<html[\s>]/i.test(text);
+}
+
+function parseJson(text: string): unknown | null {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeMcpJsonRpc(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(looksLikeMcpJsonRpc);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.jsonrpc === "2.0" && ("result" in record || "error" in record)) {
+    return true;
+  }
+  const result = record.result;
+  if (result && typeof result === "object") {
+    const resultRecord = result as Record<string, unknown>;
+    return typeof resultRecord.protocolVersion === "string" || !!resultRecord.capabilities;
+  }
+  return false;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/scripts/refresh-integrations-catalog.ts
+++ b/scripts/refresh-integrations-catalog.ts
@@ -1,0 +1,70 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { readSnapshotFile, writeCleanCatalogSnapshot } from "./import-integrations-catalog";
+
+const DEFAULT_SOURCE_URL = "https://integrations.sh/api.json";
+const DEFAULT_OUTPUT_PATH = "data/catalog/integrations-snapshot.json";
+
+type RefreshArgs = {
+  sourceUrl: string;
+  inputPath?: string;
+  outputPath: string;
+};
+
+function parseArgs(argv: string[]): RefreshArgs {
+  let sourceUrl = DEFAULT_SOURCE_URL;
+  let inputPath: string | undefined;
+  let outputPath = DEFAULT_OUTPUT_PATH;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--url") {
+      sourceUrl = argv[++index] ?? "";
+    } else if (arg === "--input") {
+      inputPath = argv[++index] ?? "";
+    } else if (arg === "--output") {
+      outputPath = argv[++index] ?? "";
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!sourceUrl && !inputPath) {
+    throw new Error("missing --url <url> or --input <path>");
+  }
+  if (!outputPath) {
+    throw new Error("missing --output <path>");
+  }
+  return { sourceUrl, ...(inputPath ? { inputPath } : {}), outputPath };
+}
+
+function printUsage(): void {
+  console.log("Usage: bun run catalog:refresh [--url <catalog-json-url> | --input <raw-snapshot.json>] [--output data/catalog/integrations-snapshot.json]");
+}
+
+async function fetchSnapshot(url: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`failed to fetch integrations catalog from ${url}: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  const snapshot = args.inputPath ? await readSnapshotFile(args.inputPath) : await fetchSnapshot(args.sourceUrl);
+  await mkdir(dirname(args.outputPath), { recursive: true });
+  const normalized = await writeCleanCatalogSnapshot(args.outputPath, snapshot);
+  console.log(JSON.stringify({
+    output: args.outputPath,
+    generatedAt: normalized.generatedAt,
+    before: normalized.cleaning.inputRows,
+    after: normalized.cleaning.outputRows,
+    skipped: normalized.skipped.length,
+    quarantined: normalized.quarantined.length,
+    cleaning: normalized.cleaning,
+  }, null, 2));
+}

--- a/scripts/refresh-integrations-catalog.ts
+++ b/scripts/refresh-integrations-catalog.ts
@@ -1,9 +1,12 @@
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { readSnapshotFile, writeCleanCatalogSnapshot } from "./import-integrations-catalog";
+import { writeFile } from "node:fs/promises";
+import { probeCatalogSnapshot } from "./integrations-catalog-probe";
+import { normalizeCatalogSnapshot, readSnapshotFile } from "./import-integrations-catalog";
 
 const DEFAULT_SOURCE_URL = "https://integrations.sh/api.json";
 const DEFAULT_OUTPUT_PATH = "data/catalog/integrations-snapshot.json";
+const SOURCE = "integrations.sh";
 
 type RefreshArgs = {
   sourceUrl: string;
@@ -57,14 +60,44 @@ if (import.meta.main) {
   const args = parseArgs(process.argv.slice(2));
   const snapshot = args.inputPath ? await readSnapshotFile(args.inputPath) : await fetchSnapshot(args.sourceUrl);
   await mkdir(dirname(args.outputPath), { recursive: true });
-  const normalized = await writeCleanCatalogSnapshot(args.outputPath, snapshot);
+  let normalized = normalizeCatalogSnapshot(snapshot);
+  let fallbackInput: string | null = null;
+  if (!args.inputPath && normalized.rows.length === 0) {
+    fallbackInput = args.outputPath;
+    normalized = normalizeCatalogSnapshot(await readSnapshotFile(args.outputPath));
+  }
+  const probed = await probeCatalogSnapshot(normalized);
+  await writeFile(args.outputPath, `${JSON.stringify({
+    generatedAt: probed.generatedAt,
+    source: SOURCE,
+    cleanedAt: new Date().toISOString(),
+    cleaning: probed.cleaning,
+    probe: {
+      kept: probed.probe.kept,
+      dropped: probed.probe.dropped,
+      real: probed.probe.real,
+      unverified: probed.probe.unverified,
+      googleapisDropped: probed.probe.googleapisDropped,
+    },
+    importRows: probed.rows,
+    skipped: probed.skipped,
+    quarantined: probed.quarantined.map((item) => ({
+      row: item.row,
+      reason: item.reason,
+    })),
+  }, null, 2)}\n`);
   console.log(JSON.stringify({
     output: args.outputPath,
-    generatedAt: normalized.generatedAt,
+    ...(fallbackInput ? { fallbackInput, fallbackReason: "source_normalized_to_zero_rows" } : {}),
+    generatedAt: probed.generatedAt,
     before: normalized.cleaning.inputRows,
-    after: normalized.cleaning.outputRows,
-    skipped: normalized.skipped.length,
-    quarantined: normalized.quarantined.length,
-    cleaning: normalized.cleaning,
+    after: probed.cleaning.outputRows,
+    kept: probed.probe.kept,
+    dropped: probed.probe.dropped,
+    unverified: probed.probe.unverified,
+    googleapisDropped: probed.probe.googleapisDropped,
+    skipped: probed.skipped.length,
+    quarantined: probed.quarantined.length,
+    cleaning: probed.cleaning,
   }, null, 2));
 }


### PR DESCRIPTION
## Summary
- add deterministic integrations.sh catalog cleaning to the import path: control-character stripping, domain+name cluster collapse, cleaning summaries, and tests
- add `bun run catalog:refresh` and `bun run catalog:import` root scripts
- commit the cleaned `data/catalog/integrations-snapshot.json` source-of-truth snapshot and document the refresh/import workflow

## Snapshot
- raw rows: 1081
- committed import rows: 935
- skipped rows: 141
- quarantined rows: 5
- duplicate domain+name rows collapsed: 128

## Verification
- `bun run catalog:import --snapshot data/catalog/integrations-snapshot.json --dry-run`
- `bun test scripts/import-integrations-catalog.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run check:docs-refs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how global registry catalog rows are derived and which MCP URLs are kept (including live probing during refresh), affecting workspace capability listings and stale marking on import—not auth, but meaningful catalog data integrity.
> 
> **Overview**
> Adds an **offline, PR-reviewed** workflow for seeding the global integrations catalog from integrations.sh: **`bun run catalog:refresh`** fetches (or reads) raw catalog JSON, **normalizes** it, **probes MCP endpoints**, and writes **`data/catalog/integrations-snapshot.json`**; **`bun run catalog:import`** loads that snapshot into the DB (with optional logo fetch to object storage).
> 
> The normalization layer is new deterministic cleaning: strip control characters, filter non-importable URLs (templated, non-HTTP, non–streamable-http), skip dead demo domains, **collapse duplicate `(domain, name)` clusters** to a scored winner, dedupe by domain+MCP URL, and **quarantine** flagged suspicious surfaces. Cleaning stats and skipped/quarantined rows are recorded on the snapshot and import batch.
> 
> **`integrations-catalog-probe`** POSTs MCP `initialize` to each row during refresh, classifies responses (real MCP vs junk vs unverified), drops junk (including typical bad `*.googleapis.com` 404s), and attaches probe metadata for survivors. Import can persist probe info on catalog row metadata when present.
> 
> Docs in **`docs/capabilities.md`** describe refresh → review → import; tests cover normalization, logos, and probing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253d175910c5fa00de64637608f769cbb779ab1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->