### PR TITLE
Sandbox durability: env pin, orphan-sweep guard, mid-session snapshots, dead-holder reap, box lifecycle events

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -93,7 +93,7 @@ import type {
   RunAgentTurnInput,
   RunAgentTurnResult,
 } from "./types";
-import { resumeBoxForTurn, acquireSelfhostedLeaseForTurn, type ResumedTurnSandbox } from "../sandbox-resume";
+import { resumeBoxForTurn, acquireSelfhostedLeaseForTurn, maybePersistWarmWorkspaceSnapshot, type ResumedTurnSandbox } from "../sandbox-resume";
 import { wrapTurnBoxWithRouting, establishSelfhostedTurnSession, routingEnabled } from "../sandbox-routing";
 import { recordCreditMicros, runtimeMetricsHooksForObservability, turnLifecycleMetricsFor, type TurnOutcome } from "../observability-metrics";
 import { beginRecording, discardRecording, finalizeRecording, type ActiveRecording } from "./recording";
@@ -543,6 +543,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // runs it refreshes expires_at epoch-fenced so a legit multi-day turn is
     // never TTL-reaped. Cleared in finally. Only set when the flag resolved a box.
     let leaseHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
+    // MID-SESSION snapshot single-flight guard: the heartbeat tick fires every
+    // 10s but a Modal filesystem snapshot can take longer — never overlap two
+    // captures on one box. (The interval throttle itself lives in
+    // maybePersistWarmWorkspaceSnapshot / persistWarmSnapshot.)
+    let snapshotInFlight = false;
     // P4.3 on-turn recording: when the desktop tier + recording are enabled and
     // the box is desktop-capable, the turn films the SAME :0 the agent's
     // computer-use drives, finalized to storage in this activity's `finally`
@@ -1213,6 +1218,34 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           })
             .then((result) => recordCreditMicros(observability, "usage", result.costMicros))
             .catch(() => undefined);
+          // MID-SESSION snapshot (sandbox-file-persistence): while the turn holds
+          // the box, fold a fresh /workspace snapshot onto the lease every
+          // sandboxSnapshotIntervalMs, so a box death the reaper never sees
+          // (Modal hard timeout mid-busy, OOM, infra) costs at most one interval
+          // of work — a legit multi-day turn is otherwise completely unprotected
+          // (the reaper only drain-persists IDLE leases). Uses the UN-proxied box
+          // session (setupBoxSession): the routing veneer could swap mid-op and a
+          // selfhosted target has no persistWorkspace anyway. Best-effort +
+          // single-flight; throttling lives in the helper.
+          const snapshotSession = setupBoxSession;
+          if (snapshotSession && !snapshotInFlight) {
+            snapshotInFlight = true;
+            void maybePersistWarmWorkspaceSnapshot(
+              { db, settings },
+              { accountId: input.accountId, workspaceId: input.workspaceId, sandboxGroupId: heartbeatGroupId },
+              snapshotSession,
+              heartbeatEpoch,
+            )
+              .then(async (persisted) => {
+                if (persisted && publish) {
+                  await publish([{ type: "sandbox.box.snapshot", payload: { trigger: "heartbeat" } }]);
+                }
+              })
+              .catch(() => undefined)
+              .finally(() => {
+                snapshotInFlight = false;
+              });
+          }
         }, 10_000);
         if ("unref" in leaseHeartbeatTimer && typeof leaseHeartbeatTimer.unref === "function") {
           leaseHeartbeatTimer.unref();
@@ -2353,6 +2386,24 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         }
       }
       if (resolvedSandbox) {
+        // TURN-END mid-session snapshot (sandbox-file-persistence): fold the
+        // turn's finished /workspace onto the lease before releasing the holder,
+        // so the work this turn just produced survives any unclean box death in
+        // the idle window ahead. Throttled by the same interval as the heartbeat
+        // tick (a short turn right after a snapshot skips — bounded-loss contract
+        // is the interval, not per-turn). Best-effort and time-capped by the
+        // helper's own failure discipline; never delays release on failure.
+        if (setupBoxSession && sandboxGroupId) {
+          const persisted = await maybePersistWarmWorkspaceSnapshot(
+            { db, settings },
+            { accountId: input.accountId, workspaceId: input.workspaceId, sandboxGroupId },
+            setupBoxSession,
+            resolvedSandbox.leaseEpoch,
+          );
+          if (persisted && publish) {
+            await publish([{ type: "sandbox.box.snapshot", payload: { trigger: "turn-end" } }]).catch(() => undefined);
+          }
+        }
         await resolvedSandbox.release().catch((releaseError) => {
           console.error("sandbox lease release failed (turn outcome unaffected)", releaseError);
         });

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1151,6 +1151,27 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             sandboxHolderId,
           );
           setupBoxSession = resolvedSandbox.established.session;
+          // Durable box-lifecycle events (sandbox-file-persistence observability):
+          // record every box transition in session_events so the NEXT box loss is
+          // attributable from the DB alone — worker logs rotate within hours, which
+          // left both 2026-07-06 incidents without a durable trace. Best-effort.
+          {
+            const established = resolvedSandbox.established;
+            if (publish && established.origin && established.origin !== "resumed") {
+              const lifecycleEvents: Array<{ type: "sandbox.box.lost" | "sandbox.box.created"; payload: unknown }> = [];
+              if (established.lostInstanceId) {
+                lifecycleEvents.push({ type: "sandbox.box.lost", payload: { sandboxId: established.lostInstanceId } });
+              }
+              lifecycleEvents.push({
+                type: "sandbox.box.created",
+                payload: {
+                  sandboxId: established.instanceId,
+                  hydrated: established.origin === "restored" ? "archive" : "none",
+                },
+              });
+              await publish(lifecycleEvents).catch(() => undefined);
+            }
+          }
           // M7 hot-swap: when the selfhosted feature is on, wrap the established
           // group box in the STABLE routing proxy before it is injected NON-OWNED
           // into the run. The SDK binds to this ONE object once and calls its

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -545,9 +545,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let leaseHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
     // MID-SESSION snapshot single-flight guard: the heartbeat tick fires every
     // 10s but a Modal filesystem snapshot can take longer — never overlap two
-    // captures on one box. (The interval throttle itself lives in
-    // maybePersistWarmWorkspaceSnapshot / persistWarmSnapshot.)
-    let snapshotInFlight = false;
+    // captures on one box. The in-flight capture's promise is held so the
+    // turn-end persist can await it (its capture predates the turn's final
+    // writes; landing after the fresher turn-end capture started would make
+    // the atomic DB throttle discard the fresher one). Interval throttling
+    // itself lives in maybePersistWarmWorkspaceSnapshot / persistWarmSnapshot.
+    let snapshotInFlight: Promise<void> | null = null;
     // P4.3 on-turn recording: when the desktop tier + recording are enabled and
     // the box is desktop-capable, the turn films the SAME :0 the agent's
     // computer-use drives, finalized to storage in this activity's `finally`
@@ -1250,8 +1253,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // single-flight; throttling lives in the helper.
           const snapshotSession = setupBoxSession;
           if (snapshotSession && !snapshotInFlight) {
-            snapshotInFlight = true;
-            void maybePersistWarmWorkspaceSnapshot(
+            snapshotInFlight = maybePersistWarmWorkspaceSnapshot(
               { db, settings },
               { accountId: input.accountId, workspaceId: input.workspaceId, sandboxGroupId: heartbeatGroupId },
               snapshotSession,
@@ -1264,7 +1266,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               })
               .catch(() => undefined)
               .finally(() => {
-                snapshotInFlight = false;
+                snapshotInFlight = null;
               });
           }
         }, 10_000);
@@ -2417,13 +2419,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (setupBoxSession && sandboxGroupId) {
           // Single-flight vs the heartbeat capture: the timer is already cleared
           // above, but a capture it launched may still be in flight — and that
-          // capture predates the turn's final writes. If it landed AFTER our
-          // fresher turn-end capture started, the atomic DB throttle would
-          // discard the fresher one. Wait the in-flight capture out (bounded —
-          // never holds the release hostage), THEN attempt; the throttle decides.
-          const snapshotWaitDeadline = Date.now() + 30_000;
-          while (snapshotInFlight && Date.now() < snapshotWaitDeadline) {
-            await new Promise<void>((resolve) => setTimeout(resolve, 250));
+          // capture predates the turn's final writes. Await it (it never
+          // rejects; its own failure discipline caps its runtime), THEN
+          // attempt; the atomic throttle decides in capture order.
+          if (snapshotInFlight) {
+            await snapshotInFlight;
           }
           const persisted = await maybePersistWarmWorkspaceSnapshot(
             { db, settings },

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2415,6 +2415,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // is the interval, not per-turn). Best-effort and time-capped by the
         // helper's own failure discipline; never delays release on failure.
         if (setupBoxSession && sandboxGroupId) {
+          // Single-flight vs the heartbeat capture: the timer is already cleared
+          // above, but a capture it launched may still be in flight — and that
+          // capture predates the turn's final writes. If it landed AFTER our
+          // fresher turn-end capture started, the atomic DB throttle would
+          // discard the fresher one. Wait the in-flight capture out (bounded —
+          // never holds the release hostage), THEN attempt; the throttle decides.
+          const snapshotWaitDeadline = Date.now() + 30_000;
+          while (snapshotInFlight && Date.now() < snapshotWaitDeadline) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 250));
+          }
           const persisted = await maybePersistWarmWorkspaceSnapshot(
             { db, settings },
             { accountId: input.accountId, workspaceId: input.workspaceId, sandboxGroupId },

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -33,6 +33,7 @@
 import {
   accrueWarmSeconds,
   confirmDrainCold,
+  appendSessionEvents,
   countQueuedTurns,
   countSandboxLeasesByLiveness,
   forceDrainOverLimitViewerOnlyBoxes,
@@ -193,6 +194,15 @@ export function createSandboxLeaseActivities(
     // (1) The DB-only cross-workspace sweep. Returns the drainable rows.
     const drainable: ReapDrainable[] = await reapStaleLeaseHoldersGlobal(db, {
       viewerHolderTtlMs: settings.sandboxViewerHolderTtlMs,
+      // Dead-worker turn holders: a live turn heartbeats its holder every 10s —
+      // but only AFTER resumeBoxForTurn returns, and establish/wait-for-warm can
+      // legitimately run silent up to the warming budget. So the reap horizon is
+      // warming-budget + lease-TTL: no live path (multi-day turns included — they
+      // heartbeat every 10s) is ever silent that long, while a killed worker's
+      // frozen holder — which would otherwise pin refcount >= 1 FOREVER, so the
+      // lease never drains and the box dies at the provider hard-timeout
+      // UNPERSISTED — clears within ~12 minutes.
+      turnHolderTtlMs: settings.sandboxWarmingTimeoutMs + settings.sandboxLeaseTtlMs,
       idleGraceMs: settings.sandboxIdleGraceMs,
     });
 
@@ -467,14 +477,23 @@ async function terminateDrainableBox(
   // Same guard as confirmDrainCold (draining AND refcount=0 AND lease_epoch=
   // expected): a re-arm or newer epoch that snuck in writes ZERO rows → wrote:false
   // → the seam leaves the box RUNNING and we skip the cold-commit below.
-  const persistArchive: PersistArchiveFn = async (archiveBase64: string | null) =>
-    await persistDrainSnapshot(db, {
+  // `persisted` tracks whether a real archive landed on the lease this drain —
+  // the durable sandbox.box.terminated event below carries it, so a "terminated
+  // with NOTHING persisted" (box already dead at drain) is visible in the DB.
+  let persisted = false;
+  const persistArchive: PersistArchiveFn = async (archiveBase64: string | null) => {
+    const result = await persistDrainSnapshot(db, {
       accountId,
       workspaceId: row.workspaceId,
       sandboxGroupId: row.sandboxGroupId,
       expectedEpoch: row.leaseEpoch,
       workspaceArchive: archiveBase64,
     });
+    if (result.wrote && archiveBase64 !== null) {
+      persisted = true;
+    }
+    return result;
+  };
 
   // Resume-by-id -> persistWorkspace -> persist-onto-lease -> GC prior snapshot ->
   // provider terminate. A box that is already gone (NotFound) is success (the goal
@@ -497,6 +516,22 @@ async function terminateDrainableBox(
     sandboxGroupId: row.sandboxGroupId,
     expectedEpoch: row.leaseEpoch,
   });
+  if (wentCold) {
+    // Durable termination record (sandbox-file-persistence observability): who
+    // ended this box and whether its /workspace was captured first. Keyed on
+    // sandbox_group_id == session_id (true for every session-owned group; the
+    // insert simply fails FK-silently for any group that is not a session).
+    // Best-effort: attribution must never affect the drain outcome.
+    try {
+      await appendSessionEvents(db, row.workspaceId, row.sandboxGroupId, [{
+        type: "sandbox.box.terminated",
+        payload: { actor: "reaper", persisted, instanceId: lease.instanceId },
+      }]);
+    } catch {
+      // Non-session group or event-write failure — the observability log line
+      // above (terminate outcome) remains the fallback trace.
+    }
+  }
   return wentCold;
 }
 

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -195,14 +195,15 @@ export function createSandboxLeaseActivities(
     // (1) The DB-only cross-workspace sweep. Returns the drainable rows.
     const drainable: ReapDrainable[] = await reapStaleLeaseHoldersGlobal(db, {
       viewerHolderTtlMs: settings.sandboxViewerHolderTtlMs,
-      // Dead-worker turn holders: a live turn heartbeats its holder every 10s —
-      // but only AFTER resumeBoxForTurn returns, and establish/wait-for-warm can
-      // legitimately run silent up to the warming budget. So the reap horizon is
-      // warming-budget + lease-TTL: no live path (multi-day turns included — they
-      // heartbeat every 10s) is ever silent that long, while a killed worker's
-      // frozen holder — which would otherwise pin refcount >= 1 FOREVER, so the
-      // lease never drains and the box dies at the provider hard-timeout
-      // UNPERSISTED — clears within ~12 minutes.
+      // Dead-worker turn holders: a live holder is touched every 10s from the
+      // moment it is registered (resumeBoxForTurn's holder-liveness loop covers
+      // the whole warmup — waitForWarm/establish/display-stack — and the turn
+      // heartbeat covers the run), so NO live path is ever silent for more than
+      // one tick. The horizon is deliberately generous defense-in-depth (not a
+      // tuned guess about path lengths): a killed worker's frozen holder —
+      // which would otherwise pin refcount >= 1 FOREVER, so the lease never
+      // drains and the box dies at the provider hard-timeout UNPERSISTED —
+      // clears within ~12 minutes.
       turnHolderTtlMs: settings.sandboxWarmingTimeoutMs + settings.sandboxLeaseTtlMs,
       idleGraceMs: settings.sandboxIdleGraceMs,
     });

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -41,6 +41,7 @@ import {
   listCreditBalancesByAccount,
   listLiveModalSandboxLeaseAttributions,
   listMeterableWarmLeases,
+  listSessionIdsInGroup,
   persistDrainSnapshot,
   readLease,
   reapStaleLeaseHoldersGlobal,
@@ -518,18 +519,22 @@ async function terminateDrainableBox(
   });
   if (wentCold) {
     // Durable termination record (sandbox-file-persistence observability): who
-    // ended this box and whether its /workspace was captured first. Keyed on
-    // sandbox_group_id == session_id (true for every session-owned group; the
-    // insert simply fails FK-silently for any group that is not a session).
-    // Best-effort: attribution must never affect the drain outcome.
+    // ended this box and whether its /workspace was captured first, appended to
+    // every session sharing the group's box. Best-effort: attribution must
+    // never affect the drain outcome.
     try {
-      await appendSessionEvents(db, row.workspaceId, row.sandboxGroupId, [{
-        type: "sandbox.box.terminated",
-        payload: { actor: "reaper", persisted, instanceId: lease.instanceId },
-      }]);
-    } catch {
-      // Non-session group or event-write failure — the observability log line
-      // above (terminate outcome) remains the fallback trace.
+      const sessionIds = await listSessionIdsInGroup(db, row.workspaceId, row.sandboxGroupId);
+      for (const sessionId of sessionIds) {
+        await appendSessionEvents(db, row.workspaceId, sessionId, [{
+          type: "sandbox.box.terminated",
+          payload: { actor: "reaper", persisted, instanceId: lease.instanceId },
+        }]);
+      }
+    } catch (eventError) {
+      observability.warn("sandbox reaper: box-terminated event write failed (drain outcome unaffected)", {
+        sandboxGroupId: row.sandboxGroupId,
+        error: eventError instanceof Error ? eventError.message : String(eventError),
+      });
     }
   }
   return wentCold;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -65,6 +65,18 @@ export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise
     taskQueue: settings.temporalTaskQueue,
     workflowsPath: options.workflowsPath ?? new URL("../src/workflows.ts", import.meta.url).pathname,
     activities,
+    // GRACEFUL DEPLOY SHUTDOWN (with the SIGTERM handler in startWorker):
+    // after shutdown() stops polling, in-flight activities get this long to
+    // finish naturally; the rest are then CANCELLED with WORKER_SHUTDOWN —
+    // which is what triggers agent-turn's graceful preempt (checkpoint run
+    // state -> turn.preempted{worker_shutdown} -> requeue) instead of a
+    // heartbeat-timeout worker_death. Short on purpose: a long grace here
+    // only delays the checkpoint window long turns actually need.
+    shutdownGraceTime: "5s",
+    // Hard ceiling INSIDE the pod's terminationGracePeriodSeconds (120s): a
+    // wedged checkpoint force-stops here, on our terms, rather than riding
+    // into the kubelet's SIGKILL mid-DB-write.
+    shutdownForceTime: "100s",
   });
   return { worker, connection };
 }
@@ -232,6 +244,35 @@ export async function startWorker() {
       temporalTaskQueue: settings.temporalTaskQueue,
       httpPort: settings.workerHttpPort,
     });
+    // GRACEFUL DEPLOY SHUTDOWN — the missing link that made every deploy a
+    // worker_death. The worker is the container's MAIN process (PID 1), and a
+    // PID-1 process with no explicit handler IGNORES SIGTERM: the pod sat
+    // through the entire terminationGracePeriodSeconds doing nothing, then the
+    // kubelet SIGKILLed it — so agent-turn's worker-shutdown checkpoint path
+    // (turn.preempted{worker_shutdown} + run-state save) never once ran in
+    // production (forensics 2026-07-06: every observed preempt was
+    // reason=worker_death). This handler starts the drain the moment k8s asks:
+    // shutdown() stops polling, then (per shutdownGraceTime/ForceTime above)
+    // cancels in-flight activities with WORKER_SHUTDOWN so long turns
+    // checkpoint and requeue INSIDE the grace window. run() resolves once
+    // drained and the finally below closes connections cleanly.
+    let shutdownRequested = false;
+    const requestShutdown = (signal: string) => {
+      if (shutdownRequested) {
+        return;
+      }
+      shutdownRequested = true;
+      observability.info("OpenGeni worker draining (graceful shutdown)", { signal });
+      try {
+        workerBundle!.worker.shutdown();
+      } catch (error) {
+        observability.warn("worker shutdown request failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+    process.on("SIGTERM", () => requestShutdown("SIGTERM"));
+    process.on("SIGINT", () => requestShutdown("SIGINT"));
     await workerBundle.worker.run();
   } finally {
     httpServer?.stop(true);

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -31,6 +31,7 @@ import {
   readLease,
   recordWarmingSandboxCreated,
   releaseLeaseHolder,
+  touchLeaseHolder,
   SandboxLeaseSupersededError,
   type Database,
   type LeaseHolderKind,
@@ -318,11 +319,15 @@ export async function resumeBoxForTurn(
   // The release closure is created eagerly so the caller can always release in
   // finally, even if establish/commit throws after the holder was registered.
   let released = false;
+  let holderLivenessTimer: ReturnType<typeof setInterval> | undefined;
   const release = async (): Promise<void> => {
     if (released) {
       return;
     }
     released = true;
+    if (holderLivenessTimer) {
+      clearInterval(holderLivenessTimer);
+    }
     await releaseLeaseHolder(db, {
       accountId: ids.accountId,
       workspaceId: ids.workspaceId,
@@ -349,6 +354,29 @@ export async function resumeBoxForTurn(
     ...(ids.image ? { image: ids.image } : {}),
     leaseTtlMs,
   });
+
+  // HOLDER-LIVENESS loop: touch OUR holder row every 10s from the moment it is
+  // registered until release. The dead-worker turn-holder reap judges liveness
+  // by last_heartbeat_at, and the full turn heartbeat (heartbeatLeaseHolder in
+  // agent-turn) only starts AFTER this function returns — while waitForWarm,
+  // establish/cold-restore, and the display stack can legitimately run for
+  // many minutes in here, COMPOUNDING past any fixed reap horizon. With this
+  // loop no live holder is ever silent for more than one tick, so the reap
+  // horizon is pure defense-in-depth, not a tuned guess about path lengths.
+  // Epoch-free by design (touch only refreshes our own row's timestamp);
+  // best-effort (a transient DB error must never fail the resume).
+  holderLivenessTimer = setInterval(() => {
+    void touchLeaseHolder(db, {
+      accountId: ids.accountId,
+      workspaceId: ids.workspaceId,
+      sandboxGroupId: ids.sandboxGroupId,
+      kind,
+      holderId,
+    }).catch(() => undefined);
+  }, 10_000);
+  if ("unref" in holderLivenessTimer && typeof holderLivenessTimer.unref === "function") {
+    holderLivenessTimer.unref();
+  }
 
   // FENCED: a newer epoch exists (a later turn re-established the box). Back off;
   // NEVER create(). Release our (just-registered) holder so we don't pin a stale

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -27,6 +27,7 @@ import {
   commitWarmingToWarm,
   failWarmingToCold,
   getSandboxSessionEnvelope,
+  persistWarmSnapshot,
   readLease,
   recordWarmingSandboxCreated,
   releaseLeaseHolder,
@@ -39,6 +40,7 @@ import {
   ensureDisplayStack as ensureDisplayStackOnBox,
   desktopCapableBackend,
   serializeEstablishedSandboxEnvelope,
+  deletePriorPersistedSnapshot,
   DisplayStackError,
   DisplayStackUnsupportedError,
   buildStreamUrl,
@@ -215,6 +217,84 @@ function preserveWorkspaceArchiveOnInterimResumeState(
       workspaceArchive: archive,
     },
   };
+}
+
+/**
+ * MID-SESSION /workspace snapshot (sandbox-file-persistence). The reaper's
+ * drain-persist only protects boxes the reaper itself kills; anything else —
+ * Modal's hard creation-time timeout catching a session busy past it, provider
+ * OOM/infra death — loses everything since the last clean drain (staging
+ * session e644e8a8, 2026-07-06: mid-turn box termination cost an unpushed
+ * branch + 2 commits). While a turn HOLDS the live box, this folds a fresh
+ * snapshot onto the lease through persistWarmSnapshot (the warm sibling of the
+ * drain seam: epoch-fenced CAS + atomic throttle re-check) and GCs the
+ * superseded snapshot image, bounding worst-case loss of ANY unclean box death
+ * to sandboxSnapshotIntervalMs.
+ *
+ * Never throws and never blocks turn progress semantics: every failure path
+ * returns false (the snapshot is protection, not a turn dependency). No-ops
+ * when the interval is 0, the backend has no persistWorkspace (selfhosted =
+ * the user's machine IS the persistence), or a snapshot newer than the
+ * interval already rides the lease.
+ */
+export async function maybePersistWarmWorkspaceSnapshot(
+  services: SandboxResumeServices,
+  ids: { accountId: string; workspaceId: string; sandboxGroupId: string },
+  session: unknown,
+  leaseEpoch: number,
+): Promise<boolean> {
+  const { db, settings } = services;
+  const intervalMs = settings.sandboxSnapshotIntervalMs;
+  if (intervalMs <= 0) {
+    return false;
+  }
+  const persistable = session as {
+    persistWorkspace?: () => Promise<Uint8Array | undefined>;
+  };
+  if (typeof persistable.persistWorkspace !== "function") {
+    return false;
+  }
+  try {
+    // Cheap throttle pre-check before the (potentially slow) capture;
+    // persistWarmSnapshot re-checks atomically under the row lock, so this is
+    // purely a cost optimization, not the correctness guard.
+    const lease = await readLease(db, ids.workspaceId, ids.sandboxGroupId);
+    if (!lease || lease.leaseEpoch !== leaseEpoch || lease.liveness !== "warm") {
+      return false;
+    }
+    const sessionState = lease.resumeState && typeof lease.resumeState === "object"
+      ? (lease.resumeState as { sessionState?: Record<string, unknown> }).sessionState
+      : undefined;
+    const priorAtRaw = sessionState && typeof sessionState === "object" ? sessionState.workspaceArchiveAt : undefined;
+    const priorAtMs = typeof priorAtRaw === "string" ? Date.parse(priorAtRaw) : Number.NaN;
+    if (Number.isFinite(priorAtMs) && Date.now() - priorAtMs < intervalMs) {
+      return false;
+    }
+    const bytes = await persistable.persistWorkspace();
+    if (!bytes || bytes.length === 0) {
+      return false;
+    }
+    const { wrote, priorArchive } = await persistWarmSnapshot(db, {
+      accountId: ids.accountId,
+      workspaceId: ids.workspaceId,
+      sandboxGroupId: ids.sandboxGroupId,
+      expectedEpoch: leaseEpoch,
+      workspaceArchive: Buffer.from(bytes).toString("base64"),
+      minIntervalMs: intervalMs,
+    });
+    if (!wrote) {
+      return false;
+    }
+    // Keep-latest-per-lease GC, same as the drain seam: best-effort delete of
+    // the superseded snapshot image while the session's client is live.
+    await deletePriorPersistedSnapshot(persistable, priorArchive);
+    return true;
+  } catch (error) {
+    // Protection, not a dependency: a failed snapshot must never fail (or slow
+    // down retrying) the turn. The next heartbeat/turn-end tick retries.
+    console.error("mid-session workspace snapshot failed (turn unaffected)", error);
+    return false;
+  }
 }
 
 /**

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -35,6 +35,7 @@ import {
   createDb,
   listLiveModalSandboxLeaseAttributions,
   persistDrainSnapshot,
+  persistWarmSnapshot,
   recordWarmingSandboxCreated,
   type Database,
   type DbClient,
@@ -327,6 +328,67 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
       expectedEpoch: 999, workspaceArchive: archive2,
     });
     expect(r3.wrote).toBe(false);
+  }, 60_000);
+
+  test("(1b-warm) persistWarmSnapshot folds a MID-SESSION snapshot onto a WARM lease: atomic throttle, epoch fence, liveness guard", async () => {
+    if (!available) return;
+    // The warm sibling of (1b): a turn HOLDS the live box and folds a snapshot
+    // without draining anything (sandbox-file-persistence, mid-session tier).
+    const ids = await freshWorkspace();
+    await insertLease(ids, {
+      liveness: "warm", refcount: 1, turnHolders: 1, leaseEpoch: 5, expiresInMs: 600_000,
+      instanceId: "box-warm-persist", backend: "modal", resumeBackendId: "modal",
+      resumeState: { backendId: "modal", sessionState: { providerState: { sandboxId: "sb-warm" }, workspaceReady: true } },
+    });
+
+    // First warm persist: folds archive + workspaceArchiveAt; providerState preserved.
+    const archive1 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w1\"}").toString("base64");
+    const r1 = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 60_000,
+    });
+    expect(r1.wrote).toBe(true);
+    expect(r1.throttled).toBe(false);
+    expect(r1.priorArchive).toBeNull();
+    const [row1] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
+    const ss1 = (row1!.resume_state as any).sessionState;
+    expect(ss1.workspaceArchive).toBe(archive1);
+    expect(Number.isFinite(Date.parse(ss1.workspaceArchiveAt))).toBe(true);
+    expect(ss1.providerState.sandboxId).toBe("sb-warm");
+
+    // Immediate second persist inside the interval: ATOMIC throttle skips it.
+    const archive2 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w2\"}").toString("base64");
+    const r2 = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 60_000,
+    });
+    expect(r2.wrote).toBe(false);
+    expect(r2.throttled).toBe(true);
+
+    // Interval 0 = always write: supersedes and returns the PRIOR for GC.
+    const r3 = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 0,
+    });
+    expect(r3.wrote).toBe(true);
+    expect(r3.priorArchive).toBe(archive1);
+
+    // Epoch fence: a stale-epoch persist writes ZERO rows.
+    const r4 = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 999, workspaceArchive: archive1, minIntervalMs: 0,
+    });
+    expect(r4.wrote).toBe(false);
+    expect(r4.throttled).toBe(false);
+
+    // Liveness guard: a draining lease is the REAPER's to persist (drain seam),
+    // never the warm path's — zero rows written.
+    await admin`update sandbox_leases set liveness = 'draining', refcount = 0, turn_holders = 0 where sandbox_group_id = ${ids.groupId}`;
+    const r5 = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 0,
+    });
+    expect(r5.wrote).toBe(false);
   }, 60_000);
 
   test("(1c) recordWarmingSandboxCreated persists provider id on a warming lease before warm commit", async () => {

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -37,6 +37,7 @@ import {
   persistDrainSnapshot,
   persistWarmSnapshot,
   recordWarmingSandboxCreated,
+  touchLeaseHolder,
   type Database,
   type DbClient,
 } from "@opengeni/db";
@@ -632,6 +633,40 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     await reapSandboxLeases();
     expect(spy.calls.some((c) => c.group === dead.groupId && c.epoch === 8)).toBe(true);
     expect((await readRow(dead.workspaceId, dead.groupId))?.liveness).toBe("cold");
+  }, 60_000);
+
+  test("(3d) touchLeaseHolder keeps a warmup-phase holder alive across the reap horizon; a released holder returns false", async () => {
+    if (!available) return;
+    const { reapSandboxLeases } = createSandboxLeaseActivities(reaperServices(), { terminateBox: makeTerminateSpy().fn });
+    const horizonMs = REAPER_SETTINGS.sandboxWarmingTimeoutMs + REAPER_SETTINGS.sandboxLeaseTtlMs;
+
+    // A holder registered long ago (frozen past the horizon) whose worker is
+    // ALIVE and touching it — the holder-liveness loop's DB primitive. The
+    // touch must reset last_heartbeat_at so the (a2) reap never fires.
+    const ws = await freshWorkspace();
+    const leaseId = await insertLease(ws, {
+      liveness: "warm", refcount: 1, turnHolders: 1, leaseEpoch: 11, instanceId: "box-warmup-touch",
+      resumeBackendId: "local", resumeState: { backendId: "local", sessionState: {} },
+    });
+    await insertHolder(ws, leaseId, "turn", "turn-warmup", horizonMs + 60_000);
+
+    const touched = await touchLeaseHolder(db, {
+      accountId: ws.accountId, workspaceId: ws.workspaceId, sandboxGroupId: ws.groupId,
+      kind: "turn", holderId: "turn-warmup",
+    });
+    expect(touched).toBe(true);
+
+    await reapSandboxLeases();
+    expect(await holderCount(ws.workspaceId, ws.groupId, "turn")).toBe(1);
+    expect((await readRow(ws.workspaceId, ws.groupId))?.liveness).toBe("warm");
+
+    // A holder that no longer exists (released/reaped) returns false so a
+    // stale liveness loop learns it is orphaned.
+    const gone = await touchLeaseHolder(db, {
+      accountId: ws.accountId, workspaceId: ws.workspaceId, sandboxGroupId: ws.groupId,
+      kind: "turn", holderId: "turn-never-existed",
+    });
+    expect(gone).toBe(false);
   }, 60_000);
 
   test("(3b) the drain grace holds a refcount-0 box WARM: younger-than-grace is NOT terminated, older IS (settings.sandboxIdleGraceMs)", async () => {

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -575,6 +575,65 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     expect(afterSecond?.instance_id).toBeNull();
   }, 60_000);
 
+  test("(3c) a DEAD-WORKER turn holder (heartbeat frozen past warming-budget+lease-TTL) is reaped; warming-window and live holders survive", async () => {
+    if (!available) return;
+    const spy = makeTerminateSpy();
+    const { reapSandboxLeases } = createSandboxLeaseActivities(reaperServices(), { terminateBox: spy.fn });
+    const horizonMs = REAPER_SETTINGS.sandboxWarmingTimeoutMs + REAPER_SETTINGS.sandboxLeaseTtlMs;
+
+    // (a) A SIGKILLed worker's holder: heartbeat frozen well past the horizon.
+    // Pre-fix this row was TTL-exempt FOREVER → refcount pinned → the lease
+    // never drained → the box died at the provider hard-timeout unpersisted
+    // (2026-07-06 staging deploy churn).
+    const dead = await freshWorkspace();
+    const deadLease = await insertLease(dead, {
+      liveness: "warm", refcount: 1, turnHolders: 1, leaseEpoch: 8, instanceId: "box-deadworker",
+      resumeBackendId: "local", resumeState: { backendId: "local", sessionState: {} },
+    });
+    await insertHolder(dead, deadLease, "turn", "turn-dead", horizonMs + 60_000);
+
+    // (b) A turn still inside its warming window (establish runs silent before
+    // the first heartbeat): stale, but NOT past the horizon — must survive.
+    const warming = await freshWorkspace();
+    const warmingLease = await insertLease(warming, {
+      liveness: "warm", refcount: 1, turnHolders: 1, leaseEpoch: 9, instanceId: "box-warmingsilence",
+      resumeBackendId: "local", resumeState: { backendId: "local", sessionState: {} },
+    });
+    await insertHolder(warming, warmingLease, "turn", "turn-warming", Math.max(horizonMs - 120_000, 1_000));
+
+    // (c) A live multi-day turn: fresh 10s-cadence heartbeat — must survive.
+    const live = await freshWorkspace();
+    const liveLease = await insertLease(live, {
+      liveness: "warm", refcount: 1, turnHolders: 1, leaseEpoch: 10, instanceId: "box-liveturn",
+      resumeBackendId: "local", resumeState: { backendId: "local", sessionState: {} },
+    });
+    await insertHolder(live, liveLease, "turn", "turn-live-hb", 1_000);
+
+    await reapSandboxLeases();
+
+    // Dead worker's holder reaped → lease drains (grace open, box untouched yet).
+    expect(await holderCount(dead.workspaceId, dead.groupId, "turn")).toBe(0);
+    const deadRow = await readRow(dead.workspaceId, dead.groupId);
+    expect(deadRow?.liveness).toBe("draining");
+    expect(deadRow?.refcount).toBe(0);
+    expect(spy.calls.some((c) => c.group === dead.groupId)).toBe(false);
+
+    // Warming-window and live holders untouched; leases stay warm.
+    expect(await holderCount(warming.workspaceId, warming.groupId, "turn")).toBe(1);
+    expect((await readRow(warming.workspaceId, warming.groupId))?.liveness).toBe("warm");
+    expect(await holderCount(live.workspaceId, live.groupId, "turn")).toBe(1);
+    expect((await readRow(live.workspaceId, live.groupId))?.liveness).toBe("warm");
+
+    // Past the grace, the drained corpse-lease terminates through the normal
+    // persist-before-terminate path — the box gets its drain-persist AFTER ALL
+    // (pre-fix it never drained, so it never persisted).
+    await admin`update sandbox_leases set expires_at = now() - interval '1 second'
+                where workspace_id = ${dead.workspaceId} and sandbox_group_id = ${dead.groupId}`;
+    await reapSandboxLeases();
+    expect(spy.calls.some((c) => c.group === dead.groupId && c.epoch === 8)).toBe(true);
+    expect((await readRow(dead.workspaceId, dead.groupId))?.liveness).toBe("cold");
+  }, 60_000);
+
   test("(3b) the drain grace holds a refcount-0 box WARM: younger-than-grace is NOT terminated, older IS (settings.sandboxIdleGraceMs)", async () => {
     if (!available) return;
     const spy = makeTerminateSpy();

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -544,6 +544,16 @@ const SettingsSchema = z.object({
   // fresh EMPTY box; lower it to trade warm cost for a snappier reclaim. Knob:
   // OPENGENI_SANDBOX_IDLE_GRACE_MS.
   sandboxIdleGraceMs: z.coerce.number().int().positive().default(900_000),
+  // MID-SESSION /workspace snapshot cadence (sandbox-file-persistence). The
+  // reaper's drain-persist only protects boxes the reaper itself kills; a box
+  // that dies any other way (Modal's hard creation-time timeout on a session
+  // busy past it, provider OOM/infra death) loses everything since the last
+  // clean drain. While a turn holds the box, the turn heartbeat and turn-end
+  // both take a snapshot when at least this interval has passed since the last
+  // one (same epoch-fenced fold-onto-lease seam as the drain), bounding the
+  // worst-case loss of ANY unclean box death to this window. 0 disables.
+  // Knob: OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS. Default 15min.
+  sandboxSnapshotIntervalMs: z.coerce.number().int().min(0).default(900_000),
   // expires_at refresh window for a held lease (>> the turn 10s heartbeat so a
   // single missed heartbeat never TTL-reaps a live turn). The warming TTL is the
   // window a cold->warming spawner has to commit warm before a reaper resets it.
@@ -1047,6 +1057,7 @@ export function getSettings(): Settings {
     sandboxLeaseReaperPeriodMs: optional("OPENGENI_SANDBOX_LEASE_REAPER_PERIOD_MS"),
     sandboxViewerHolderTtlMs: optional("OPENGENI_SANDBOX_VIEWER_HOLDER_TTL_MS"),
     sandboxIdleGraceMs: optional("OPENGENI_SANDBOX_IDLE_GRACE_MS"),
+    sandboxSnapshotIntervalMs: optional("OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS"),
     sandboxLeaseTtlMs: optional("OPENGENI_SANDBOX_LEASE_TTL_MS"),
     sandboxLeaseWarmingTtlMs: optional("OPENGENI_SANDBOX_LEASE_WARMING_TTL_MS"),
     sandboxWarmingTimeoutMs: optional("OPENGENI_SANDBOX_WARMING_TIMEOUT_MS"),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2546,6 +2546,17 @@ export const SessionEventType = z.enum([
   // (manual switch in P1; failover/rotation in P3 reuse the same event). Drives
   // the in-session "Running on:" indicator's live flip.
   "codex.account.switched",
+  // Sandbox durability observability (sandbox-file-persistence). The 2026-07
+  // incidents (mid-session box death with /workspace loss; a fatal manifest-env
+  // delta on a live box) were near-unattributable because box lifecycle left no
+  // durable trace — only worker logs, which rotate within hours. These events
+  // make every box transition and env recomputation drift readable from the DB
+  // alone. Payloads carry ids/flags/key NAMES only — never env values (secrets).
+  "sandbox.box.created", // box cold-created/cold-restored ({hydrated: "archive"|"none"})
+  "sandbox.box.lost", // resume-by-id found the box gone (provider NotFound)
+  "sandbox.box.terminated", // reaper drain terminated the box ({actor, persisted})
+  "sandbox.box.snapshot", // mid-session /workspace snapshot persisted ({trigger})
+  "sandbox.env.drift", // recomputed manifest env != live box env (key names only)
 ]);
 export type SessionEventType = z.infer<typeof SessionEventType>;
 

--- a/packages/db/drizzle/0044_reap_dead_turn_holders.sql
+++ b/packages/db/drizzle/0044_reap_dead_turn_holders.sql
@@ -1,0 +1,102 @@
+-- 0044_reap_dead_turn_holders.sql
+-- Dead-worker turn holders were TTL-exempt forever: a live turn refreshes its
+-- holder every 10s (even a legit multi-day turn), but a worker killed without
+-- cleanup (SIGKILL/OOM/deploy churn) leaves a holder whose heartbeat is frozen.
+-- Left in place it pins refcount >= 1 FOREVER, so the lease never drains, the
+-- reaper never persists /workspace, and the box rides the provider hard-timeout
+-- to an UNPERSISTED death (2026-07-06 staging deploy churn left turn holders
+-- frozen for hours). Reap turn holders whose heartbeat is older than the
+-- caller-supplied horizon (the worker passes warming-budget + lease-TTL: the
+-- heartbeat only starts once establish returns, so the horizon must cover the
+-- longest legitimate silent stretch; a redispatched turn re-acquires under a
+-- NEW holder id, so a live execution is never touched).
+
+CREATE OR REPLACE FUNCTION opengeni_private.reap_sandbox_leases(
+  p_viewer_holder_ttl_ms bigint,
+  p_turn_holder_ttl_ms   bigint,
+  p_idle_grace_ms        bigint
+)
+RETURNS TABLE (workspace_id uuid, sandbox_group_id uuid, instance_id text, lease_epoch integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  DELETE FROM sandbox_lease_holders h
+  WHERE h.kind = 'viewer'
+    AND h.last_heartbeat_at < now() - make_interval(secs => p_viewer_holder_ttl_ms / 1000.0);
+
+  -- Dead-worker turn holders (see header). p_turn_holder_ttl_ms <= 0 preserves
+  -- the legacy never-reap behaviour.
+  IF p_turn_holder_ttl_ms > 0 THEN
+    DELETE FROM sandbox_lease_holders h
+    WHERE h.kind = 'turn'
+      AND h.last_heartbeat_at < now() - make_interval(secs => p_turn_holder_ttl_ms / 1000.0);
+  END IF;
+
+  UPDATE sandbox_leases L SET
+    refcount       = c.total,
+    turn_holders   = c.turns,
+    viewer_holders = c.viewers,
+    liveness = CASE WHEN L.liveness = 'warm' AND c.total = 0 AND c.turns = 0
+                    THEN 'draining' ELSE L.liveness END,
+    expires_at = CASE WHEN L.liveness = 'warm' AND c.total = 0 AND c.turns = 0
+                    THEN now() + make_interval(secs => p_idle_grace_ms / 1000.0)
+                    ELSE L.expires_at END,
+    updated_at = now()
+  FROM (
+    SELECT L2.id,
+           (SELECT count(*) FROM sandbox_lease_holders h WHERE h.lease_id = L2.id)::int                       AS total,
+           (SELECT count(*) FROM sandbox_lease_holders h WHERE h.lease_id = L2.id AND h.kind = 'turn')::int   AS turns,
+           (SELECT count(*) FROM sandbox_lease_holders h WHERE h.lease_id = L2.id AND h.kind = 'viewer')::int AS viewers
+    FROM sandbox_leases L2
+  ) c
+  WHERE L.id = c.id;
+
+  -- Warming died before provider create returned: no instance was ever tracked.
+  UPDATE sandbox_leases AS L SET
+    liveness = 'cold', instance_id = NULL,
+    resume_backend_id = NULL, resume_state = NULL,
+    data_plane_url = NULL, terminal_data_plane_url = NULL, updated_at = now()
+  WHERE L.liveness = 'warming' AND L.expires_at < now() AND L.instance_id IS NULL;
+
+  -- Warming died after provider create returned: keep the instance_id and hand it
+  -- to the normal provider termination path in this same sweep.
+  UPDATE sandbox_leases AS L SET
+    liveness = 'draining',
+    refcount = 0,
+    turn_holders = 0,
+    viewer_holders = 0,
+    data_plane_url = NULL,
+    terminal_data_plane_url = NULL,
+    expires_at = now() - interval '1 millisecond',
+    updated_at = now()
+  WHERE L.liveness = 'warming' AND L.expires_at < now() AND L.instance_id IS NOT NULL;
+
+  RETURN QUERY
+    SELECT L.workspace_id, L.sandbox_group_id, L.instance_id, L.lease_epoch
+    FROM sandbox_leases L
+    WHERE L.liveness = 'draining' AND L.expires_at < now() AND L.refcount = 0;
+END;
+$$;
+
+-- Rolling-deploy compat: workers built before this migration call the 2-arg
+-- form. Delegate with turn-holder reaping OFF (legacy behaviour) until every
+-- worker passes the explicit TTL.
+CREATE OR REPLACE FUNCTION opengeni_private.reap_sandbox_leases(
+  p_viewer_holder_ttl_ms bigint,
+  p_idle_grace_ms        bigint
+)
+RETURNS TABLE (workspace_id uuid, sandbox_group_id uuid, instance_id text, lease_epoch integer)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT * FROM opengeni_private.reap_sandbox_leases(p_viewer_holder_ttl_ms, 0::bigint, p_idle_grace_ms);
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.reap_sandbox_leases(bigint, bigint, bigint) TO opengeni_app;
+    GRANT EXECUTE ON FUNCTION opengeni_private.reap_sandbox_leases(bigint, bigint) TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/drizzle/0044_reap_dead_turn_holders.sql
+++ b/packages/db/drizzle/0044_reap_dead_turn_holders.sql
@@ -6,10 +6,12 @@
 -- reaper never persists /workspace, and the box rides the provider hard-timeout
 -- to an UNPERSISTED death (2026-07-06 staging deploy churn left turn holders
 -- frozen for hours). Reap turn holders whose heartbeat is older than the
--- caller-supplied horizon (the worker passes warming-budget + lease-TTL: the
--- heartbeat only starts once establish returns, so the horizon must cover the
--- longest legitimate silent stretch; a redispatched turn re-acquires under a
--- NEW holder id, so a live execution is never touched).
+-- caller-supplied horizon. A live holder is touched every 10s from the moment
+-- it is registered (the worker's holder-liveness loop covers the warmup;
+-- the turn heartbeat covers the run), so the horizon the worker passes
+-- (warming-budget + lease-TTL) is generous defense-in-depth, never a bound a
+-- live path can reach; a redispatched turn re-acquires under a NEW holder id,
+-- so a live execution is never touched.
 
 CREATE OR REPLACE FUNCTION opengeni_private.reap_sandbox_leases(
   p_viewer_holder_ttl_ms bigint,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6202,34 +6202,61 @@ export async function persistDrainSnapshot(db: Database, input: {
       if (input.workspaceArchive === null) {
         return { wrote: true, priorArchive: null };
       }
-      // (2) Merge the NEW archive into resume_state.sessionState.workspaceArchive.
-      // jsonb_set's create_missing does NOT create intermediate objects, so a
-      // direct set of '{sessionState,workspaceArchive}' is a silent no-op when
-      // `sessionState` is absent (a null resume_state, or a legacy flat envelope).
-      // Instead: rebuild `sessionState` as (existing sessionState OR '{}') merged
-      // (||) with `{workspaceArchive: <b64>}` — this CREATES sessionState if absent
-      // AND preserves its existing siblings (providerState/manifest/exposedPorts).
-      // The archive is bound as a jsonb string scalar (to_jsonb(text)). Re-asserting
-      // the CAS guard keeps the write atomic with the FOR UPDATE lock above.
-      await scopedDb.execute(sql`
-        update sandbox_leases set
-          resume_state = jsonb_set(
-            -- Defensive: only treat resume_state / its sessionState as an object
-            -- when it actually IS one; a null/scalar (legacy or malformed envelope)
-            -- starts from '{}' so jsonb_set never throws "cannot set path in scalar".
-            case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
-            '{sessionState}',
-            (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
-                  then resume_state -> 'sessionState' else '{}'::jsonb end)
-              || jsonb_build_object('workspaceArchive', to_jsonb(${input.workspaceArchive}::text)),
-            true
-          ),
-          updated_at = now()
-        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
-          and liveness = 'draining' and refcount = 0 and lease_epoch = ${input.expectedEpoch}
-      `);
+      await foldWorkspaceArchiveOntoLease(scopedDb, {
+        workspaceId: input.workspaceId,
+        sandboxGroupId: input.sandboxGroupId,
+        expectedEpoch: input.expectedEpoch,
+        workspaceArchive: input.workspaceArchive,
+        livenessGuard: "draining",
+      });
       return { wrote: true, priorArchive };
     });
+}
+
+/**
+ * The ONE archive-fold write, shared by the drain seam (persistDrainSnapshot)
+ * and the mid-session seam (persistWarmSnapshot) — the two differ only in
+ * their CAS guard (draining@refcount0 vs warm) and their read-side semantics.
+ *
+ * Merges the NEW archive (+ its workspaceArchiveAt timestamp, the throttle
+ * baseline for mid-session snapshots) into resume_state.sessionState.
+ * jsonb_set's create_missing does NOT create intermediate objects, so a direct
+ * set of '{sessionState,workspaceArchive}' is a silent no-op when
+ * `sessionState` is absent (a null resume_state, or a legacy flat envelope).
+ * Instead: rebuild `sessionState` as (existing sessionState OR '{}') merged
+ * (||) with the fold — this CREATES sessionState if absent AND preserves its
+ * existing siblings (providerState/manifest/exposedPorts). The archive is
+ * bound as a jsonb string scalar (to_jsonb(text)). Re-asserting the caller's
+ * CAS guard keeps the write atomic with its FOR UPDATE lock.
+ */
+async function foldWorkspaceArchiveOntoLease(scopedDb: Database, input: {
+  workspaceId: string; sandboxGroupId: string; expectedEpoch: number;
+  workspaceArchive: string;
+  livenessGuard: "draining" | "warm";
+}): Promise<void> {
+  const livenessGuard = input.livenessGuard === "draining"
+    ? sql`liveness = 'draining' and refcount = 0`
+    : sql`liveness = 'warm'`;
+  await scopedDb.execute(sql`
+    update sandbox_leases set
+      resume_state = jsonb_set(
+        -- Defensive: only treat resume_state / its sessionState as an object
+        -- when it actually IS one; a null/scalar (legacy or malformed envelope)
+        -- starts from '{}' so jsonb_set never throws "cannot set path in scalar".
+        case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
+        '{sessionState}',
+        (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
+              then resume_state -> 'sessionState' else '{}'::jsonb end)
+          || jsonb_build_object(
+            'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
+            'workspaceArchiveAt', to_jsonb(now()::timestamptz::text)
+          ),
+        true
+      ),
+      updated_at = now()
+    where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
+      and ${livenessGuard} and lease_epoch = ${input.expectedEpoch}
+  `);
 }
 
 /**
@@ -6274,26 +6301,13 @@ export async function persistWarmSnapshot(db: Database, input: {
       ) {
         return { wrote: false, throttled: true, priorArchive: null };
       }
-      // Same defensive sessionState rebuild as persistDrainSnapshot (creates
-      // sessionState when absent, preserves its siblings, never throws on a
-      // scalar/legacy resume_state).
-      await scopedDb.execute(sql`
-        update sandbox_leases set
-          resume_state = jsonb_set(
-            case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
-            '{sessionState}',
-            (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
-                  then resume_state -> 'sessionState' else '{}'::jsonb end)
-              || jsonb_build_object(
-                'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
-                'workspaceArchiveAt', to_jsonb(now()::timestamptz::text)
-              ),
-            true
-          ),
-          updated_at = now()
-        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
-          and liveness = 'warm' and lease_epoch = ${input.expectedEpoch}
-      `);
+      await foldWorkspaceArchiveOntoLease(scopedDb, {
+        workspaceId: input.workspaceId,
+        sandboxGroupId: input.sandboxGroupId,
+        expectedEpoch: input.expectedEpoch,
+        workspaceArchive: input.workspaceArchive,
+        livenessGuard: "warm",
+      });
       return { wrote: true, throttled: false, priorArchive };
     });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5826,6 +5826,32 @@ export async function heartbeatLeaseHolder(db: Database, input: {
     }));
 }
 
+/**
+ * HOLDER-LIVENESS touch: refresh ONLY this holder's last_heartbeat_at. The
+ * warmup phase of a turn (acquire -> waitForWarm -> establish/cold-restore ->
+ * display stack) can legitimately run for many minutes BEFORE the full turn
+ * heartbeat (heartbeatLeaseHolder) starts, and the dead-worker turn-holder
+ * reap judges liveness by this timestamp. Touching our own holder row needs no
+ * epoch fence — supersession is handled by the fenced acquire/establish paths;
+ * a reaped/released row returns false (row gone).
+ */
+export async function touchLeaseHolder(db: Database, input: {
+  accountId: string; workspaceId: string; sandboxGroupId: string;
+  kind: LeaseHolderKind; holderId: string;
+}): Promise<boolean> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const updated = await scopedDb.execute<{ id: string }>(sql`
+        update sandbox_lease_holders set last_heartbeat_at = now()
+        where lease_id = (select id from sandbox_leases
+                          where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId})
+          and kind = ${input.kind} and holder_id = ${input.holderId}
+        returning id
+      `);
+      return updated.length > 0;
+    });
+}
+
 // §4.6 — the reaper. DB-SIDE ONLY (no provider call — the provider stop() is
 // P1.3's runtime concern). Three actions in one pass: TTL-reap stale viewer
 // holders, recompute refcounts + warm->draining, reset warming-death to cold;
@@ -5860,17 +5886,18 @@ export async function reapStaleLeaseHolders(db: Database, input: {
           and last_heartbeat_at < now() - (${String(input.viewerHolderTtlMs)} || ' milliseconds')::interval
         returning lease_id
       `);
-      // (a2) Reap DEAD-WORKER turn holders. A live turn refreshes its holder
-      // every 10s — even a legit multi-day turn — but only once establish
-      // returns, so the caller passes a horizon covering the longest legitimate
-      // silent stretch (warming-budget + lease-TTL). A holder staler than that
-      // belongs to a worker that died without cleanup (SIGKILL/OOM/deploy
-      // churn); left in place it pins refcount >= 1 FOREVER, so the lease never
-      // drains, the reaper never persists /workspace, and the box rides the
-      // provider hard-timeout to an UNPERSISTED death (the 2026-07-06 staging
-      // deploy churn left holders frozen for hours). The redispatched turn
-      // re-acquires under a NEW holder id, so deleting the corpse never touches
-      // a live execution.
+      // (a2) Reap DEAD-WORKER turn holders. A live holder is touched every 10s
+      // from registration (the resumeBoxForTurn holder-liveness loop covers the
+      // warmup; the turn heartbeat covers the run — legit multi-day turns
+      // included), so the caller's horizon is generous defense-in-depth, never
+      // a bound a live path can reach. A holder staler than it belongs to a
+      // worker that died without cleanup (SIGKILL/OOM/deploy churn); left in
+      // place it pins refcount >= 1 FOREVER, so the lease never drains, the
+      // reaper never persists /workspace, and the box rides the provider
+      // hard-timeout to an UNPERSISTED death (the 2026-07-06 staging deploy
+      // churn left holders frozen for hours). The redispatched turn re-acquires
+      // under a NEW holder id, so deleting the corpse never touches a live
+      // execution.
       const reapedTurnRows = input.turnHolderTtlMs && input.turnHolderTtlMs > 0
         ? await tx.execute<{ lease_id: string }>(sql`
           delete from sandbox_lease_holders

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5844,18 +5844,41 @@ export interface ReapDrainable {
 export async function reapStaleLeaseHolders(db: Database, input: {
   workspaceId: string;
   viewerHolderTtlMs: number;   // delete viewer rows older than this
+  /** Delete TURN rows whose heartbeat is older than this (the lease TTL: >> the
+   *  10s turn heartbeat, so only a DEAD worker's holder ever crosses it). 0/absent
+   *  = legacy never-reap. */
+  turnHolderTtlMs?: number;
   idleGraceMs: number;         // drain-grace horizon (matches releaseLeaseHolder)
-}): Promise<{ reapedViewers: number; warmingReset: number; drained: ReapDrainable[] }> {
+}): Promise<{ reapedViewers: number; reapedTurns: number; warmingReset: number; drained: ReapDrainable[] }> {
   return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) =>
     await scopedDb.transaction(async (txRaw) => {
       const tx = txRaw as unknown as Database;
-      // (a) Reap stale VIEWER holders (turn holders are TTL-exempt — never reaped).
+      // (a) Reap stale VIEWER holders.
       const reaped = await tx.execute<{ lease_id: string }>(sql`
         delete from sandbox_lease_holders
         where workspace_id = ${input.workspaceId} and kind = 'viewer'
           and last_heartbeat_at < now() - (${String(input.viewerHolderTtlMs)} || ' milliseconds')::interval
         returning lease_id
       `);
+      // (a2) Reap DEAD-WORKER turn holders. A live turn refreshes its holder
+      // every 10s — even a legit multi-day turn — but only once establish
+      // returns, so the caller passes a horizon covering the longest legitimate
+      // silent stretch (warming-budget + lease-TTL). A holder staler than that
+      // belongs to a worker that died without cleanup (SIGKILL/OOM/deploy
+      // churn); left in place it pins refcount >= 1 FOREVER, so the lease never
+      // drains, the reaper never persists /workspace, and the box rides the
+      // provider hard-timeout to an UNPERSISTED death (the 2026-07-06 staging
+      // deploy churn left holders frozen for hours). The redispatched turn
+      // re-acquires under a NEW holder id, so deleting the corpse never touches
+      // a live execution.
+      const reapedTurnRows = input.turnHolderTtlMs && input.turnHolderTtlMs > 0
+        ? await tx.execute<{ lease_id: string }>(sql`
+          delete from sandbox_lease_holders
+          where workspace_id = ${input.workspaceId} and kind = 'turn'
+            and last_heartbeat_at < now() - (${String(input.turnHolderTtlMs)} || ' milliseconds')::interval
+          returning lease_id
+        `)
+        : [];
 
       // (b) Recompute refcounts for every lease in the workspace; warm leases
       // that hit 0 (AND turn_holders=0) enter draining with a fresh grace
@@ -5923,6 +5946,7 @@ export async function reapStaleLeaseHolders(db: Database, input: {
 
       return {
         reapedViewers: reaped.length,
+        reapedTurns: reapedTurnRows.length,
         warmingReset: warmingReset.length + warmingDrain.length,
         drained: drainable.map((r) => ({
           workspaceId: input.workspaceId,
@@ -5942,11 +5966,14 @@ export async function reapStaleLeaseHolders(db: Database, input: {
 // is the sanctioned cross-workspace read).
 export async function reapStaleLeaseHoldersGlobal(db: Database, input: {
   viewerHolderTtlMs: number;
+  /** Reap DEAD-WORKER turn holders staler than this (the lease TTL; see
+   *  reapStaleLeaseHolders). 0/absent = never (legacy). */
+  turnHolderTtlMs?: number;
   idleGraceMs: number;
 }): Promise<ReapDrainable[]> {
   const rows = await rawRows<{ workspace_id: string; sandbox_group_id: string; instance_id: string | null; lease_epoch: number | string }>(db, sql`
     select workspace_id, sandbox_group_id, instance_id, lease_epoch
-    from opengeni_private.reap_sandbox_leases(${input.viewerHolderTtlMs}, ${input.idleGraceMs})
+    from opengeni_private.reap_sandbox_leases(${input.viewerHolderTtlMs}, ${input.turnHolderTtlMs ?? 0}, ${input.idleGraceMs})
   `);
   return rows.map((r) => ({
     workspaceId: r.workspace_id,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6205,6 +6205,72 @@ export async function persistDrainSnapshot(db: Database, input: {
     });
 }
 
+/**
+ * MID-SESSION /workspace snapshot fold (sandbox-file-persistence). The WARM
+ * sibling of persistDrainSnapshot: a turn that HOLDS the live box folds a fresh
+ * snapshot onto its own lease without draining anything. Guarded by
+ * `liveness='warm' AND lease_epoch=expected` — a drain/re-create that raced in
+ * (different liveness or newer epoch) writes ZERO rows → wrote:false, and the
+ * caller simply skips (the snapshot belonged to a box the lease no longer
+ * tracks). `workspaceArchiveAt` rides the same sessionState merge so the
+ * throttle re-check here is ATOMIC with the write — two concurrent holders
+ * cannot double-snapshot inside one interval.
+ */
+export async function persistWarmSnapshot(db: Database, input: {
+  accountId: string; workspaceId: string; sandboxGroupId: string;
+  expectedEpoch: number;
+  /** base64 of the provider snapshot-ref / tar archive from persistWorkspace(). */
+  workspaceArchive: string;
+  /** Snapshots newer than this many ms are kept (throttle); 0 = always write. */
+  minIntervalMs: number;
+}): Promise<{ wrote: boolean; throttled: boolean; priorArchive: string | null }> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const guard = await scopedDb.execute<{ prior_archive: string | null; prior_archive_at: string | null }>(sql`
+        select
+          resume_state #>> '{sessionState,workspaceArchive}' as prior_archive,
+          resume_state #>> '{sessionState,workspaceArchiveAt}' as prior_archive_at
+        from sandbox_leases
+        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
+          and liveness = 'warm' and lease_epoch = ${input.expectedEpoch}
+        for update
+      `);
+      if (guard.length === 0) {
+        return { wrote: false, throttled: false, priorArchive: null };
+      }
+      const priorArchive = guard[0]!.prior_archive ?? null;
+      const priorAtMs = guard[0]!.prior_archive_at ? Date.parse(guard[0]!.prior_archive_at) : Number.NaN;
+      if (
+        input.minIntervalMs > 0
+        && Number.isFinite(priorAtMs)
+        && Date.now() - priorAtMs < input.minIntervalMs
+      ) {
+        return { wrote: false, throttled: true, priorArchive: null };
+      }
+      // Same defensive sessionState rebuild as persistDrainSnapshot (creates
+      // sessionState when absent, preserves its siblings, never throws on a
+      // scalar/legacy resume_state).
+      await scopedDb.execute(sql`
+        update sandbox_leases set
+          resume_state = jsonb_set(
+            case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
+            '{sessionState}',
+            (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
+                  then resume_state -> 'sessionState' else '{}'::jsonb end)
+              || jsonb_build_object(
+                'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
+                'workspaceArchiveAt', to_jsonb(now()::timestamptz::text)
+              ),
+            true
+          ),
+          updated_at = now()
+        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
+          and liveness = 'warm' and lease_epoch = ${input.expectedEpoch}
+      `);
+      return { wrote: true, throttled: false, priorArchive };
+    });
+}
+
 // §4.9 — non-locking snapshot for the API handshake & health.
 export async function readLease(db: Database, workspaceId: string, sandboxGroupId: string): Promise<LeaseSnapshot | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -236,6 +236,14 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "sandbox.operation.failed": {
         const name = typeof payload.name === "string" ? payload.name : "sandbox";
         const status = event.type.endsWith(".failed") ? "failed" : event.type.endsWith(".completed") ? "complete" : "running";
+        // Routine repository-clone operations are per-turn platform plumbing (an
+        // idempotent clone check + off-manifest token re-seed runs before EVERY
+        // turn on a repo-attached session) — rendering them reads as the agent
+        // redoing work each turn. Only failures surface, and they surface loudly:
+        // the failed event below creates its own item even without a started row.
+        if (name === "repository-clone" && status !== "failed") {
+          break;
+        }
         const existing = findOpenSandbox(items, name);
         if (existing && status !== "running") {
           existing.status = status;

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -444,6 +444,43 @@ describe("buildTimeline", () => {
     expect(sandbox.status).toBe("complete");
   });
 
+  test("routine repository-clone operations never render", () => {
+    // Per-turn platform plumbing (idempotent clone check + token re-seed) —
+    // rendering it every turn reads as the agent redoing work.
+    reset();
+    const items = buildTimeline([
+      event("sandbox.operation.started", { name: "repository-clone" }),
+      event("sandbox.operation.completed", { name: "repository-clone" }),
+    ]);
+    expect(items.filter((item) => item.kind === "sandbox")).toHaveLength(0);
+  });
+
+  test("failed repository-clone operations still surface loudly", () => {
+    reset();
+    const items = buildTimeline([
+      event("sandbox.operation.started", { name: "repository-clone" }),
+      event("sandbox.operation.failed", { name: "repository-clone", error: "authentication failed" }),
+    ]);
+    const sandbox = items.find((item): item is SandboxItem => item.kind === "sandbox");
+    expect(sandbox?.name).toBe("repository-clone");
+    expect(sandbox?.status).toBe("failed");
+    expect(sandbox?.output).toContain("authentication failed");
+  });
+
+  test("sandbox durability lifecycle events are ignored by the projection", () => {
+    // sandbox.box.* / sandbox.env.drift are observability spine events —
+    // tolerant reader: they must never render or disturb the timeline.
+    reset();
+    const items = buildTimeline([
+      event("sandbox.box.created", { hydrated: "archive" }),
+      event("sandbox.box.lost", { sandboxId: "sb-x" }),
+      event("sandbox.box.terminated", { actor: "reaper", persisted: true }),
+      event("sandbox.box.snapshot", { trigger: "turn-end" }),
+      event("sandbox.env.drift", { added: ["A"], removed: [], changed: [] }),
+    ]);
+    expect(items).toHaveLength(0);
+  });
+
   test("named output deltas route to their own operation among concurrent ones", () => {
     reset();
     const items = buildTimeline([

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2641,21 +2641,16 @@ export function withManifestRefreshOnResume(
   };
 }
 
-// ENV PIN (env-parity doctrine): a live box's manifest environment is
-// CREATION-TIME truth for the box's whole life. The SDK enforces exactly this
-// for provided sessions (validateNoEnvironmentDelta throws a session-fatal
-// UserError on ANY env delta), and its own buildProvidedSessionManifestDelta
-// ships entry-only deltas for the same reason: a running box's processes have
-// the old env baked into their environ, so a "refreshed" manifest env would be
-// a silent lie. So this refresh NEVER carries environment — entries only —
-// and a recompute that drifts from the baked env is REPORTED (key names only,
-// never values) instead of applied. Fresh env lands at the next cold-create
-// (drain->re-warm recycles the box regularly); rotating values ride
-// OFF-manifest (token file + GIT_ASKPASS — see TOKEN-BROKER B1/B2).
-// History: the pre-pin refresh sent the full recomputed env whenever any entry
-// needed applying, and a recompute drift on a live prod box (2026-07-06,
-// manager session with turn inputs byte-identical to the prior success) tripped
-// the SDK guard and killed the session.
+// OWNED-RESUME manifest refresh. This path runs ONLY for SDK-owned sessions
+// (withManifestRefreshOnResume wraps client.resume, which the SDK never calls
+// when handed a live provided session — the ownedSandbox branch bypasses this
+// entirely). Owned applyManifest MERGES env safely with no guard, and this
+// refresh is a FEATURE: it is how a workspace-env edit reaches a long-lived
+// owned local/docker box that rarely recycles. The provided-session env pin
+// (pinProvidedSessionManifestEnvironment below) — NOT this function — is the
+// fix for the SDK's validateNoEnvironmentDelta session-fatal guard. Drift is
+// additionally REPORTED here (key names only, never values) so any env
+// recompute change stays attributable from the DB alone.
 export async function applyMissingManifestEntries(
   session: SandboxSessionLike,
   targetManifest: Manifest,
@@ -2670,9 +2665,9 @@ export async function applyMissingManifestEntries(
     }
     throw new Error("Resumed sandbox session cannot apply new manifest entries because current manifest state is unavailable");
   }
-  // Drift detection runs on EVERY resume (even entry-less ones): it is the
-  // durable trace that makes the next env-recompute regression attributable
-  // from the DB alone instead of from rotated worker logs.
+  // Drift detection runs on EVERY resume (even no-op ones): the durable trace
+  // that makes an env-recompute regression attributable from the DB instead of
+  // from rotated worker logs.
   await reportManifestEnvironmentDrift(currentManifest, target, context);
   if (!session.applyManifest && !session.materializeEntry) {
     if (Object.keys(target.entries).length === 0) {
@@ -2697,20 +2692,21 @@ export async function applyMissingManifestEntries(
       throw new Error(`Cannot replace existing sandbox manifest entry: ${path}`);
     }
   }
-  if (Object.keys(entries).length === 0) {
+  const environmentChanged = stableJson(currentManifest.environment) !== stableJson(target.environment);
+  if (environmentChanged && !session.applyManifest) {
+    throw new Error("Resumed sandbox session cannot refresh manifest environment because it does not support applyManifest()");
+  }
+  if (Object.keys(entries).length === 0 && !environmentChanged) {
     return;
   }
   // Carry path grants through manifest rebuilds: since @openai/agents 0.11.0
   // they gate local source materialization, and run states saved before the
   // upgrade have manifests without grants.
   const extraPathGrants = mergePathGrants(currentManifest.extraPathGrants, target.extraPathGrants);
-  // Entry-only delta: environment stays empty (ENV PIN above). An empty env is
-  // inert on every backend — provided sessions see no delta to validate, owned
-  // backends spread-merge nothing.
   const delta = new Manifest({
     root: currentManifest.root,
     entries,
-    environment: {},
+    environment: target.environment,
     ...(extraPathGrants.length ? { extraPathGrants } : {}),
   });
   if (session.applyManifest) {
@@ -2722,7 +2718,7 @@ export async function applyMissingManifestEntries(
   }
   (session as { state?: { manifest?: Manifest } }).state!.manifest = new Manifest({
     root: currentManifest.root,
-    environment: currentManifest.environment,
+    environment: environmentChanged ? target.environment : currentManifest.environment,
     entries: {
       ...currentManifest.entries,
       ...entries,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2380,6 +2380,14 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     // whose per-op pointer re-read could land these execs on a machine swapped in
     // mid-turn.
     const setupSession = (overrides.ownedSandbox.setupSession ?? session) as SandboxSessionLike;
+    // ENV PIN (provided sessions): the SDK validates the FULL recomputed manifest
+    // env against the live box's baked env before applying its entry-only delta
+    // (validateNoEnvironmentDelta — session-fatal on ANY drift; killed a 4-day
+    // prod manager session 2026-07-06). Align the turn's manifest to the box's
+    // own env and REPORT the drift instead of dying on it.
+    await pinProvidedSessionManifestEnvironment(agent, session as SandboxSessionLike, {
+      ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
+    });
     const runAs = sandboxRunAs(settings);
     const fileDownloads = sandboxFileDownloadsForAgent(agent);
     const resourceClient = fileDownloads.length > 0
@@ -2480,7 +2488,9 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
 
   const rawClient = overrides.sandboxClient ?? createSandboxClient(settings, environment);
   const refreshedClient = rawClient
-    ? withManifestRefreshOnResume(rawClient as SandboxClient, (agent as { defaultManifest?: Manifest }).defaultManifest)
+    ? withManifestRefreshOnResume(rawClient as SandboxClient, (agent as { defaultManifest?: Manifest }).defaultManifest, {
+      ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
+    })
     : undefined;
   const runAs = sandboxRunAs(settings);
   const fileDownloads = sandboxFileDownloadsForAgent(agent);
@@ -2606,7 +2616,11 @@ export function agentsErrorRunState(error: unknown): string | null {
   }
 }
 
-export function withManifestRefreshOnResume(client: SandboxClient, targetManifest: Manifest | undefined): SandboxClient {
+export function withManifestRefreshOnResume(
+  client: SandboxClient,
+  targetManifest: Manifest | undefined,
+  context: Pick<SandboxLifecycleHookContext, "onRuntimeEvent"> = {},
+): SandboxClient {
   if (!targetManifest || !client.resume) {
     return client;
   }
@@ -2616,7 +2630,7 @@ export function withManifestRefreshOnResume(client: SandboxClient, targetManifes
     ...(client.create ? { create: async (...args: any[]) => await (client.create as any)(...args) } : {}),
     resume: async (state: SandboxSessionState) => {
       const session = await client.resume!(state);
-      await applyMissingManifestEntries(session, targetManifest);
+      await applyMissingManifestEntries(session, targetManifest, context);
       return session;
     },
     ...(client.delete ? { delete: async (state: SandboxSessionState) => await client.delete!(state) } : {}),
@@ -2627,7 +2641,26 @@ export function withManifestRefreshOnResume(client: SandboxClient, targetManifes
   };
 }
 
-export async function applyMissingManifestEntries(session: SandboxSessionLike, targetManifest: Manifest): Promise<void> {
+// ENV PIN (env-parity doctrine): a live box's manifest environment is
+// CREATION-TIME truth for the box's whole life. The SDK enforces exactly this
+// for provided sessions (validateNoEnvironmentDelta throws a session-fatal
+// UserError on ANY env delta), and its own buildProvidedSessionManifestDelta
+// ships entry-only deltas for the same reason: a running box's processes have
+// the old env baked into their environ, so a "refreshed" manifest env would be
+// a silent lie. So this refresh NEVER carries environment — entries only —
+// and a recompute that drifts from the baked env is REPORTED (key names only,
+// never values) instead of applied. Fresh env lands at the next cold-create
+// (drain->re-warm recycles the box regularly); rotating values ride
+// OFF-manifest (token file + GIT_ASKPASS — see TOKEN-BROKER B1/B2).
+// History: the pre-pin refresh sent the full recomputed env whenever any entry
+// needed applying, and a recompute drift on a live prod box (2026-07-06,
+// manager session with turn inputs byte-identical to the prior success) tripped
+// the SDK guard and killed the session.
+export async function applyMissingManifestEntries(
+  session: SandboxSessionLike,
+  targetManifest: Manifest,
+  context: Pick<SandboxLifecycleHookContext, "onRuntimeEvent"> = {},
+): Promise<void> {
   const currentManifestValue = (session as { state?: { manifest?: Manifest | { root?: string; entries?: Record<string, any>; environment?: Record<string, any> } } }).state?.manifest;
   const currentManifest = currentManifestValue ? ensureManifest(currentManifestValue) : undefined;
   const target = ensureManifest(targetManifest);
@@ -2637,6 +2670,10 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
     }
     throw new Error("Resumed sandbox session cannot apply new manifest entries because current manifest state is unavailable");
   }
+  // Drift detection runs on EVERY resume (even entry-less ones): it is the
+  // durable trace that makes the next env-recompute regression attributable
+  // from the DB alone instead of from rotated worker logs.
+  await reportManifestEnvironmentDrift(currentManifest, target, context);
   if (!session.applyManifest && !session.materializeEntry) {
     if (Object.keys(target.entries).length === 0) {
       return;
@@ -2660,21 +2697,20 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
       throw new Error(`Cannot replace existing sandbox manifest entry: ${path}`);
     }
   }
-  const environmentChanged = stableJson(currentManifest.environment) !== stableJson(target.environment);
-  if (environmentChanged && !session.applyManifest) {
-    throw new Error("Resumed sandbox session cannot refresh manifest environment because it does not support applyManifest()");
-  }
-  if (Object.keys(entries).length === 0 && !environmentChanged) {
+  if (Object.keys(entries).length === 0) {
     return;
   }
   // Carry path grants through manifest rebuilds: since @openai/agents 0.11.0
   // they gate local source materialization, and run states saved before the
   // upgrade have manifests without grants.
   const extraPathGrants = mergePathGrants(currentManifest.extraPathGrants, target.extraPathGrants);
+  // Entry-only delta: environment stays empty (ENV PIN above). An empty env is
+  // inert on every backend — provided sessions see no delta to validate, owned
+  // backends spread-merge nothing.
   const delta = new Manifest({
     root: currentManifest.root,
     entries,
-    environment: target.environment,
+    environment: {},
     ...(extraPathGrants.length ? { extraPathGrants } : {}),
   });
   if (session.applyManifest) {
@@ -2686,12 +2722,98 @@ export async function applyMissingManifestEntries(session: SandboxSessionLike, t
   }
   (session as { state?: { manifest?: Manifest } }).state!.manifest = new Manifest({
     root: currentManifest.root,
-    environment: environmentChanged ? target.environment : currentManifest.environment,
+    environment: currentManifest.environment,
     entries: {
       ...currentManifest.entries,
       ...entries,
     },
     ...(extraPathGrants.length ? { extraPathGrants } : {}),
+  });
+}
+
+/**
+ * Key-level diff of the live box's baked manifest env vs the freshly recomputed
+ * target env. Returns null when identical. Key NAMES only — values are secrets
+ * and must never leave this function's comparison.
+ */
+export function manifestEnvironmentDrift(
+  current: Manifest,
+  target: Manifest,
+): { added: string[]; removed: string[]; changed: string[] } | null {
+  const currentEnv = (current.environment ?? {}) as Record<string, unknown>;
+  const targetEnv = (target.environment ?? {}) as Record<string, unknown>;
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+  for (const key of Object.keys(targetEnv)) {
+    if (!(key in currentEnv)) {
+      added.push(key);
+    } else if (stableJson(currentEnv[key]) !== stableJson(targetEnv[key])) {
+      changed.push(key);
+    }
+  }
+  for (const key of Object.keys(currentEnv)) {
+    if (!(key in targetEnv)) {
+      removed.push(key);
+    }
+  }
+  if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+    return null;
+  }
+  return { added: added.sort(), removed: removed.sort(), changed: changed.sort() };
+}
+
+async function reportManifestEnvironmentDrift(
+  current: Manifest,
+  target: Manifest,
+  context: Pick<SandboxLifecycleHookContext, "onRuntimeEvent">,
+): Promise<ReturnType<typeof manifestEnvironmentDrift>> {
+  const drift = manifestEnvironmentDrift(current, target);
+  if (!drift) {
+    return null;
+  }
+  // Reporting must never break a resume: the drift itself is benign under the
+  // env pin (the box keeps running on its baked env); only the SIGNAL matters.
+  try {
+    await context.onRuntimeEvent?.({ type: "sandbox.env.drift", payload: drift });
+  } catch {
+    // Swallow: a failed emit must not fail the turn.
+  }
+  return drift;
+}
+
+/**
+ * ENV PIN for provided sessions (the ownership-inversion turn path). The SDK
+ * validates the FULL target manifest environment against a live provided
+ * session's baked env BEFORE reducing to its entry-only delta
+ * (validateNoEnvironmentDelta -> session-fatal UserError on ANY difference).
+ * So a turn resuming an existing box must declare the box's OWN env,
+ * byte-identical — never the fresh recompute. This replaces the agent's
+ * defaultManifest environment with the baked one and reports the drift (key
+ * names only) instead of letting it kill the session. Fresh env lands at the
+ * next cold-create; rotating values ride OFF-manifest (TOKEN-BROKER B1/B2).
+ */
+export async function pinProvidedSessionManifestEnvironment(
+  agent: Agent<any, any>,
+  session: SandboxSessionLike,
+  context: Pick<SandboxLifecycleHookContext, "onRuntimeEvent"> = {},
+): Promise<void> {
+  const holder = agent as { defaultManifest?: Manifest };
+  const currentManifestValue = (session as { state?: { manifest?: Manifest | { root?: string; entries?: Record<string, any>; environment?: Record<string, any> } } }).state?.manifest;
+  if (!holder.defaultManifest || !currentManifestValue) {
+    return;
+  }
+  const current = ensureManifest(currentManifestValue);
+  const target = ensureManifest(holder.defaultManifest);
+  const drift = await reportManifestEnvironmentDrift(current, target, context);
+  if (!drift) {
+    return;
+  }
+  holder.defaultManifest = new Manifest({
+    ...(target.root ? { root: target.root } : {}),
+    entries: target.entries,
+    environment: current.environment,
+    ...(target.extraPathGrants?.length ? { extraPathGrants: target.extraPathGrants } : {}),
   });
 }
 

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -551,6 +551,16 @@ export type EstablishedSandboxSession = {
   sessionState: unknown;
   instanceId: string;
   backendId: string;
+  /** How this establish reached a live box: warm reattach by id ("resumed"),
+   *  fresh create ("created"), or fresh create + archive hydration
+   *  ("restored"). Callers use it to emit the durable sandbox.box.* lifecycle
+   *  events — box transitions were previously unrecorded, which made both
+   *  2026-07-06 incidents near-unattributable. Optional so external/legacy
+   *  constructors of this shape stay valid. */
+  origin?: "resumed" | "created" | "restored";
+  /** Set when a warm reattach found the envelope's box GONE (provider NotFound)
+   *  and fell through to cold-restore: the id of the box that was lost. */
+  lostInstanceId?: string;
 };
 
 export type SandboxCreatedCallback = (established: EstablishedSandboxSession) => Promise<void>;
@@ -782,6 +792,7 @@ export async function establishSandboxSessionFromEnvelope(
       sessionState: restoredState ?? resumeFallbackState,
       instanceId: readInstanceId(restored),
       backendId: client.backendId,
+      origin: workspaceArchive ? "restored" as const : "created" as const,
     };
   };
 
@@ -815,7 +826,7 @@ export async function establishSandboxSessionFromEnvelope(
     if (resumedState !== undefined) {
       try {
         const session = await client.resume(resumedState);
-        return { client, session, sessionState: resumedState, instanceId: readInstanceId(session), backendId: client.backendId };
+        return { client, session, sessionState: resumedState, instanceId: readInstanceId(session), backendId: client.backendId, origin: "resumed" };
       } catch (error) {
         // ONLY a provider NotFound (box gone) licenses a cold-restore. Anything
         // else (transient/auth/network/resume-conflict) propagates: the caller
@@ -826,10 +837,19 @@ export async function establishSandboxSessionFromEnvelope(
         // COLD-RESTORE: the box is genuinely gone. Modal does NOT restore via
         // create({ snapshot }) — passing `snapshot` to ModalSandboxClient.create()
         // THROWS (assertCoreSnapshotUnsupported). Modal's real persistence is an
-        // OPAQUE ARCHIVE captured by session.persistWorkspace() at reaper-drain
-        // time and folded onto the lease envelope (sandbox-file-persistence). The
-        // shared coldRestore() seam creates a fresh box and replays that archive.
-        return await coldRestore(resumedState);
+        // OPAQUE ARCHIVE captured by session.persistWorkspace() at drain/turn-
+        // snapshot time and folded onto the lease envelope
+        // (sandbox-file-persistence). The shared coldRestore() seam creates a
+        // fresh box and replays that archive. `lostInstanceId` carries the gone
+        // box's id so the caller can emit the durable sandbox.box.lost event.
+        const lostInstanceId = [
+          envelopeProviderState?.sandboxId,
+          envelopeProviderState?.instanceId,
+          envelopeProviderState?.id,
+          envelopeProviderState?.containerId,
+        ].find((value): value is string => typeof value === "string" && value.length > 0);
+        const restoredSession = await coldRestore(resumedState);
+        return lostInstanceId ? { ...restoredSession, lostInstanceId } : restoredSession;
       }
     }
   }

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -311,6 +311,16 @@ export async function sweepModalOrphanSandboxes(
   const maxTerminations = options.maxTerminations ?? MODAL_ORPHAN_SWEEP_LIMIT;
   const unattributedGraceMs = options.unattributedGraceMs ?? MODAL_UNATTRIBUTED_ORPHAN_GRACE_MS;
   const liveByAttribution = new Map(liveLeases.map((lease) => [attributionKey(lease), lease]));
+  // LIVE-INSTANCE GUARD: a box that any live lease's envelope points at is NEVER
+  // an orphan, whatever its tags say. Tags are best-effort attribution (setTags
+  // is a separate call after create and can fail or lag); the lease envelope is
+  // the source of truth the turn path actually resumes by. Judging by tags alone
+  // terminated a LIVE box mid-turn at exactly creation+30min (staging session
+  // e644e8a8, 2026-07-06) — the box's unpushed work was unrecoverable because
+  // nothing outside the reaper drain persists /workspace.
+  const liveByInstanceId = new Map(
+    liveLeases.filter((lease) => lease.instanceId).map((lease) => [lease.instanceId as string, lease]),
+  );
   const ownedClient = options.client ? null : await createModalClient(settings);
   const modal = (options.client ?? ownedClient)! as ModalCpListClient;
   try {
@@ -345,6 +355,33 @@ export async function sweepModalOrphanSandboxes(
         const leaseId = tags.opengeni_lease_id;
         const workspaceId = tags.opengeni_workspace_id;
         const sandboxGroupId = tags.opengeni_sandbox_group_id;
+        const liveByInstance = info.id ? liveByInstanceId.get(info.id) : undefined;
+        if (liveByInstance) {
+          // Live-instance guard (see above): a live lease resumes this exact box
+          // by id — hard-skip it, and HEAL its attribution tags when they are
+          // missing/stale so it stops looking sweep-eligible. Best-effort: a
+          // failed re-tag must never fail the sweep (the guard, not the tags,
+          // is what protects the box now).
+          if (
+            leaseId !== liveByInstance.leaseId
+            || workspaceId !== liveByInstance.workspaceId
+            || sandboxGroupId !== liveByInstance.sandboxGroupId
+          ) {
+            try {
+              const sandbox = await modal.sandboxes.fromId(info.id);
+              await sandbox.setTags(modalSandboxAttributionTags({
+                leaseId: liveByInstance.leaseId,
+                workspaceId: liveByInstance.workspaceId,
+                sandboxGroupId: liveByInstance.sandboxGroupId,
+              }));
+            } catch {
+              // Tag healing is opportunistic; the instance guard already
+              // protects this box on every future sweep pass.
+            }
+          }
+          skipped += 1;
+          continue;
+        }
         let reason: ModalOrphanSweepTermination["reason"] | null = null;
         if (leaseId && workspaceId && sandboxGroupId) {
           const live = liveByAttribution.get(attributionKey({ leaseId, workspaceId, sandboxGroupId }));

--- a/packages/runtime/test/modal-orphan-sweep.test.ts
+++ b/packages/runtime/test/modal-orphan-sweep.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import { sweepModalOrphanSandboxes } from "../src/sandbox";
+import type { LiveModalSandboxLeaseAttribution } from "@opengeni/db";
+
+// The orphan sweep's LIVE-INSTANCE GUARD: a box that any live lease's envelope
+// points at is NEVER terminated, whatever its tags say. Tags are best-effort
+// attribution (setTags is a separate call after create and can fail or lag);
+// judging by tags alone terminated a LIVE box mid-turn at exactly
+// creation+30min (staging session e644e8a8, 2026-07-06).
+
+const MODAL_SETTINGS = {
+  sandboxBackend: "modal" as const,
+  modalTokenId: "tok-id",
+  modalTokenSecret: "tok-secret",
+  modalAppName: "opengeni-test-app",
+};
+
+type FakeSandboxInfo = {
+  id: string;
+  createdAt?: number;
+  tags?: Array<{ tagName?: string; tagValue?: string }>;
+};
+
+function fakeModalClient(sandboxes: FakeSandboxInfo[]) {
+  const terminated: string[] = [];
+  const retagged: Array<{ id: string; tags: Record<string, string> }> = [];
+  let listed = false;
+  const client = {
+    apps: {
+      fromName: async () => ({ appId: "app-1" }),
+    },
+    cpClient: {
+      sandboxList: async () => {
+        // Single page: return everything once, then an empty page.
+        if (listed) {
+          return { sandboxes: [] };
+        }
+        listed = true;
+        return { sandboxes };
+      },
+    },
+    sandboxes: {
+      fromId: async (id: string) => ({
+        terminate: async () => {
+          terminated.push(id);
+        },
+        setTags: async (tags: Record<string, string>) => {
+          retagged.push({ id, tags });
+        },
+      }),
+    },
+    close: () => {},
+  };
+  return { client, terminated, retagged };
+}
+
+function attributionTags(input: { leaseId: string; workspaceId: string; sandboxGroupId: string }) {
+  return [
+    { tagName: "opengeni", tagValue: "true" },
+    { tagName: "opengeni_lease_id", tagValue: input.leaseId },
+    { tagName: "opengeni_workspace_id", tagValue: input.workspaceId },
+    { tagName: "opengeni_sandbox_group_id", tagValue: input.sandboxGroupId },
+  ];
+}
+
+const LIVE_LEASE: LiveModalSandboxLeaseAttribution = {
+  leaseId: "lease-1",
+  workspaceId: "ws-1",
+  sandboxGroupId: "grp-1",
+  instanceId: "sb-live",
+  liveness: "warm",
+};
+
+describe("sweepModalOrphanSandboxes live-instance guard", () => {
+  test("never terminates an UNTAGGED box a live lease points at — and heals its tags", async () => {
+    // The incident shape: the box lost/never got its attribution tags, is past
+    // the unattributed grace, but a live lease resumes it by id every turn.
+    const { client, terminated, retagged } = fakeModalClient([
+      { id: "sb-live", createdAt: 1_000, tags: [] },
+    ]);
+    const result = await sweepModalOrphanSandboxes(
+      testSettings(MODAL_SETTINGS),
+      [LIVE_LEASE],
+      { client: client as any, now: new Date(1_000_000 + 60 * 60_000) },
+    );
+    expect(terminated).toEqual([]);
+    expect(result.terminated).toEqual([]);
+    expect(result.skipped).toBe(1);
+    // Attribution healed so the box stops looking sweep-eligible.
+    expect(retagged).toEqual([{
+      id: "sb-live",
+      tags: {
+        opengeni: "true",
+        opengeni_lease_id: "lease-1",
+        opengeni_workspace_id: "ws-1",
+        opengeni_sandbox_group_id: "grp-1",
+      },
+    }]);
+  });
+
+  test("never terminates a STALE-TAGGED box a live lease points at — and re-tags it", async () => {
+    // Tags reference a lease that no longer exists (e.g. epoch churn re-created
+    // the lease row) while the CURRENT live lease points at this box.
+    const { client, terminated, retagged } = fakeModalClient([
+      {
+        id: "sb-live",
+        createdAt: 1_000,
+        tags: attributionTags({ leaseId: "lease-OLD", workspaceId: "ws-1", sandboxGroupId: "grp-1" }),
+      },
+    ]);
+    const result = await sweepModalOrphanSandboxes(
+      testSettings(MODAL_SETTINGS),
+      [LIVE_LEASE],
+      { client: client as any, now: new Date(1_000_000 + 60 * 60_000) },
+    );
+    expect(terminated).toEqual([]);
+    expect(result.terminated).toEqual([]);
+    expect(retagged.map((r) => r.tags.opengeni_lease_id)).toEqual(["lease-1"]);
+  });
+
+  test("a correctly-tagged live box is skipped without re-tagging", async () => {
+    const { client, terminated, retagged } = fakeModalClient([
+      {
+        id: "sb-live",
+        createdAt: 1_000,
+        tags: attributionTags({ leaseId: "lease-1", workspaceId: "ws-1", sandboxGroupId: "grp-1" }),
+      },
+    ]);
+    const result = await sweepModalOrphanSandboxes(
+      testSettings(MODAL_SETTINGS),
+      [LIVE_LEASE],
+      { client: client as any, now: new Date(1_000_000 + 60 * 60_000) },
+    );
+    expect(terminated).toEqual([]);
+    expect(retagged).toEqual([]);
+    expect(result.skipped).toBe(1);
+  });
+
+  test("still terminates genuinely orphaned boxes (no live lease points at them)", async () => {
+    const { client, terminated } = fakeModalClient([
+      // Unattributed and past grace, NOT referenced by any live lease.
+      { id: "sb-derelict", createdAt: 1_000, tags: [] },
+      // Tagged with an attribution no live lease matches.
+      {
+        id: "sb-stale",
+        createdAt: 1_000,
+        tags: attributionTags({ leaseId: "lease-GONE", workspaceId: "ws-2", sandboxGroupId: "grp-2" }),
+      },
+      // Fresh unattributed box still inside the grace window — spared.
+      { id: "sb-fresh", createdAt: (1_000_000 + 55 * 60_000) / 1000, tags: [] },
+    ]);
+    const result = await sweepModalOrphanSandboxes(
+      testSettings(MODAL_SETTINGS),
+      [LIVE_LEASE],
+      { client: client as any, now: new Date(1_000_000 + 60 * 60_000) },
+    );
+    expect(terminated.sort()).toEqual(["sb-derelict", "sb-stale"]);
+    expect(result.terminated.map((t) => t.reason).sort()).toEqual(["stale_attribution", "unattributed"]);
+  });
+
+  test("a failed re-tag never fails the sweep and the box is still spared", async () => {
+    const { client, terminated } = fakeModalClient([{ id: "sb-live", createdAt: 1_000, tags: [] }]);
+    (client.sandboxes as { fromId: unknown }).fromId = async () => ({
+      terminate: async () => {
+        terminated.push("sb-live");
+      },
+      setTags: async () => {
+        throw new Error("tag write refused");
+      },
+    });
+    const result = await sweepModalOrphanSandboxes(
+      testSettings(MODAL_SETTINGS),
+      [LIVE_LEASE],
+      { client: client as any, now: new Date(1_000_000 + 60 * 60_000) },
+    );
+    expect(terminated).toEqual([]);
+    expect(result.terminated).toEqual([]);
+    expect(result.skipped).toBe(1);
+  });
+});

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1400,11 +1400,12 @@ describe("runtime event normalization", () => {
     expect(Object.keys(applied[0]!.entries)).toEqual(["repos/acme/two"]);
   });
 
-  test("pins manifest environment on resumed sandbox sessions and reports drift as key names", async () => {
-    // ENV PIN: a live box's manifest env is creation-time truth. A recompute
-    // that drifts is REPORTED (key names only), never applied — the old
-    // refresh-on-resume behavior tripped the SDK's provided-session
-    // validateNoEnvironmentDelta and killed sessions.
+  test("refreshes manifest environment on OWNED resumed sessions and reports drift as key names", async () => {
+    // OWNED-resume refresh is a FEATURE (a workspace-env edit reaching a
+    // long-lived owned local/docker box) — owned applyManifest merges env with
+    // no guard. The drift EVENT is the durable trace; the provided-session
+    // guard fix lives in pinProvidedSessionManifestEnvironment (tested below),
+    // NOT here.
     const current = new Manifest({
       root: "/workspace",
       entries: {
@@ -1432,11 +1433,11 @@ describe("runtime event normalization", () => {
         events.push(event);
       },
     });
-    // No entries were missing and env never rides a refresh -> nothing applied.
-    expect(applied).toHaveLength(0);
-    // The baked env stays authoritative on the tracked state.
+    // Env refresh applied (owned semantics preserved).
+    expect(applied).toHaveLength(1);
+    expect(Object.keys(applied[0]!.entries)).toEqual([]);
     expect(JSON.parse(JSON.stringify((session.state.manifest as Manifest).environment))).toMatchObject({
-      GH_TOKEN: { value: "old-token" },
+      GH_TOKEN: { value: "new-token" },
     });
     // Drift rides a durable event as key names only — values are secrets.
     expect(events).toEqual([{
@@ -1444,44 +1445,6 @@ describe("runtime event normalization", () => {
       payload: { added: ["NEW_KEY"], removed: [], changed: ["GH_TOKEN"] },
     }]);
     expect(JSON.stringify(events)).not.toContain("token");
-  });
-
-  test("entry deltas applied to resumed sandbox sessions never carry environment", async () => {
-    const current = new Manifest({
-      root: "/workspace",
-      entries: {
-        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
-      },
-      environment: { GH_TOKEN: "old-token" },
-    });
-    const target = new Manifest({
-      root: "/workspace",
-      entries: {
-        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
-        "repos/acme/two": { type: "git_repo", host: "github.com", repo: "acme/two", ref: "main" },
-      },
-      environment: { GH_TOKEN: "new-token" },
-    });
-    const applied: Manifest[] = [];
-    const session = {
-      state: { manifest: current },
-      applyManifest: async (manifest: Manifest) => {
-        applied.push(manifest);
-      },
-    };
-    await applyMissingManifestEntries(session as any, target);
-    expect(applied).toHaveLength(1);
-    expect(Object.keys(applied[0]!.entries)).toEqual(["repos/acme/two"]);
-    // The delta env is EMPTY (entry-only, mirroring the SDK's own
-    // buildProvidedSessionManifestDelta) and the tracked state keeps the baked env.
-    expect(JSON.parse(JSON.stringify(applied[0]!.environment ?? {}))).toEqual({});
-    expect(JSON.parse(JSON.stringify((session.state.manifest as Manifest).environment))).toMatchObject({
-      GH_TOKEN: { value: "old-token" },
-    });
-    expect(Object.keys((session.state.manifest as Manifest).entries)).toEqual([
-      "repos/acme/one",
-      "repos/acme/two",
-    ]);
   });
 
   test("pins provided-session agent manifests to the live box environment", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE, RunContext, RunRawModelStreamEvent, getAllMcpTools, invalidateServerToolsCache } from "@openai/agents";
 import { AGENT_INSTRUCTIONS_CORE_PLACEHOLDER, DEFAULT_AGENT_INSTRUCTIONS, getSettings } from "@opengeni/config";
 import { CLEARED_RUN_STATE_BLOB } from "@opengeni/contracts";
-import { applyMissingManifestEntries, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, appendToolspaceInstructions, TOOLSPACE_PROGRAMMATIC_DIRECTIVE, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, runToolspaceTokenSeedHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, toolspaceTokenSeedCommand, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER, type ResolveConnectionCredentialInput, type ResolveConnectionCredentialResult } from "../src/index";
+import { applyMissingManifestEntries, pinProvidedSessionManifestEnvironment, azureCliLoginCommand, azureOpenAIDefaultQuery, buildOpenGeniAgent, buildManifest, composeAgentInstructions, coreInstructions, appendToolspaceInstructions, TOOLSPACE_PROGRAMMATIC_DIRECTIVE, GENESIS_TITLE_DIRECTIVE, lazySkillSourceWithPackSkills, deserializeSandboxSessionStateEnvelope, ensureReadableStreamFrom, materializeSandboxFileDownloads, repositoryCloneCommand, repositoryUsesSandboxClone, mcpToolErrorOutput, modelResponseUsageFromSdkEvent, normalizeSdkEvent, normalizeToolOutputForEvent, prepareRunInput, stripProviderItemIdsFilter, callModelInputFilterForSettings, prefixedMcpToolName, prepareAgentTools, runAzureCliLoginHook, runRepositoryCloneHook, runToolspaceTokenSeedHook, sandboxCommandExitCode, sandboxFileDownloadsForAgent, sandboxRunAs, toolspaceTokenSeedCommand, withSandboxFileDownloads, withSandboxLifecycleHooks, SCREENSHOT_OMITTED_PLACEHOLDER, type ResolveConnectionCredentialInput, type ResolveConnectionCredentialResult } from "../src/index";
 import { Manifest } from "@openai/agents/sandbox";
 import { startTestMcpServer, testSettings } from "@opengeni/testing";
 import type { MCPServer } from "@openai/agents";
@@ -1400,7 +1400,11 @@ describe("runtime event normalization", () => {
     expect(Object.keys(applied[0]!.entries)).toEqual(["repos/acme/two"]);
   });
 
-  test("refreshes manifest environment on resumed sandbox sessions", async () => {
+  test("pins manifest environment on resumed sandbox sessions and reports drift as key names", async () => {
+    // ENV PIN: a live box's manifest env is creation-time truth. A recompute
+    // that drifts is REPORTED (key names only), never applied — the old
+    // refresh-on-resume behavior tripped the SDK's provided-session
+    // validateNoEnvironmentDelta and killed sessions.
     const current = new Manifest({
       root: "/workspace",
       entries: {
@@ -1413,6 +1417,49 @@ describe("runtime event normalization", () => {
       entries: {
         "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
       },
+      environment: { GH_TOKEN: "new-token", NEW_KEY: "added" },
+    });
+    const applied: Manifest[] = [];
+    const events: { type: string; payload: unknown }[] = [];
+    const session = {
+      state: { manifest: current },
+      applyManifest: async (manifest: Manifest) => {
+        applied.push(manifest);
+      },
+    };
+    await applyMissingManifestEntries(session as any, target, {
+      onRuntimeEvent: (event) => {
+        events.push(event);
+      },
+    });
+    // No entries were missing and env never rides a refresh -> nothing applied.
+    expect(applied).toHaveLength(0);
+    // The baked env stays authoritative on the tracked state.
+    expect(JSON.parse(JSON.stringify((session.state.manifest as Manifest).environment))).toMatchObject({
+      GH_TOKEN: { value: "old-token" },
+    });
+    // Drift rides a durable event as key names only — values are secrets.
+    expect(events).toEqual([{
+      type: "sandbox.env.drift",
+      payload: { added: ["NEW_KEY"], removed: [], changed: ["GH_TOKEN"] },
+    }]);
+    expect(JSON.stringify(events)).not.toContain("token");
+  });
+
+  test("entry deltas applied to resumed sandbox sessions never carry environment", async () => {
+    const current = new Manifest({
+      root: "/workspace",
+      entries: {
+        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
+      },
+      environment: { GH_TOKEN: "old-token" },
+    });
+    const target = new Manifest({
+      root: "/workspace",
+      entries: {
+        "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
+        "repos/acme/two": { type: "git_repo", host: "github.com", repo: "acme/two", ref: "main" },
+      },
       environment: { GH_TOKEN: "new-token" },
     });
     const applied: Manifest[] = [];
@@ -1424,10 +1471,74 @@ describe("runtime event normalization", () => {
     };
     await applyMissingManifestEntries(session as any, target);
     expect(applied).toHaveLength(1);
-    expect(Object.keys(applied[0]!.entries)).toEqual([]);
+    expect(Object.keys(applied[0]!.entries)).toEqual(["repos/acme/two"]);
+    // The delta env is EMPTY (entry-only, mirroring the SDK's own
+    // buildProvidedSessionManifestDelta) and the tracked state keeps the baked env.
+    expect(JSON.parse(JSON.stringify(applied[0]!.environment ?? {}))).toEqual({});
     expect(JSON.parse(JSON.stringify((session.state.manifest as Manifest).environment))).toMatchObject({
-      GH_TOKEN: { value: "new-token" },
+      GH_TOKEN: { value: "old-token" },
     });
+    expect(Object.keys((session.state.manifest as Manifest).entries)).toEqual([
+      "repos/acme/one",
+      "repos/acme/two",
+    ]);
+  });
+
+  test("pins provided-session agent manifests to the live box environment", async () => {
+    const agent = {
+      defaultManifest: new Manifest({
+        root: "/workspace",
+        entries: {
+          "repos/acme/one": { type: "git_repo", host: "github.com", repo: "acme/one", ref: "main" },
+        },
+        environment: { HOME: "/workspace", NEW_KEY: "fresh" },
+      }),
+    };
+    const session = {
+      state: {
+        manifest: new Manifest({
+          root: "/workspace",
+          entries: {},
+          environment: { HOME: "/workspace" },
+        }),
+      },
+    };
+    const events: { type: string; payload: unknown }[] = [];
+    await pinProvidedSessionManifestEnvironment(agent as any, session as any, {
+      onRuntimeEvent: (event) => {
+        events.push(event);
+      },
+    });
+    // The agent's manifest now declares the box's OWN env (byte-identical ->
+    // the SDK's validateNoEnvironmentDelta sees no delta), entries preserved.
+    expect(JSON.parse(JSON.stringify(agent.defaultManifest.environment))).toMatchObject({
+      HOME: { value: "/workspace" },
+    });
+    expect(JSON.parse(JSON.stringify(agent.defaultManifest.environment))).not.toHaveProperty("NEW_KEY");
+    expect(Object.keys(agent.defaultManifest.entries)).toEqual(["repos/acme/one"]);
+    expect(events).toEqual([{
+      type: "sandbox.env.drift",
+      payload: { added: ["NEW_KEY"], removed: [], changed: [] },
+    }]);
+  });
+
+  test("provided-session env pin is a no-op without drift", async () => {
+    const manifest = new Manifest({
+      root: "/workspace",
+      entries: {},
+      environment: { HOME: "/workspace" },
+    });
+    const agent = { defaultManifest: manifest };
+    const events: { type: string; payload: unknown }[] = [];
+    await pinProvidedSessionManifestEnvironment(agent as any, {
+      state: { manifest: new Manifest({ root: "/workspace", entries: {}, environment: { HOME: "/workspace" } }) },
+    } as any, {
+      onRuntimeEvent: (event) => {
+        events.push(event);
+      },
+    });
+    expect(agent.defaultManifest).toBe(manifest);
+    expect(events).toEqual([]);
   });
 
   test("normalizes serialized manifest state before applying missing entries", async () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -465,6 +465,13 @@ export const SESSION_EVENT_TYPES = [
   "session.title_set",
   // Multi-account Codex (P1): the session's inference account changed.
   "codex.account.switched",
+  // Sandbox durability observability (mirror of contracts SessionEventType):
+  // box lifecycle + manifest-env drift, attributable from the DB alone.
+  "sandbox.box.created",
+  "sandbox.box.lost",
+  "sandbox.box.terminated",
+  "sandbox.box.snapshot",
+  "sandbox.env.drift",
 ] as const;
 
 export type KnownSessionEventType = (typeof SESSION_EVENT_TYPES)[number];

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -178,6 +178,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     sandboxLeaseReaperPeriodMs: 30_000,
     sandboxViewerHolderTtlMs: 90_000,
     sandboxIdleGraceMs: 900_000,
+    sandboxSnapshotIntervalMs: 900_000,
     sandboxLeaseTtlMs: 90_000,
     sandboxLeaseWarmingTtlMs: 120_000,
     sandboxWarmingTimeoutMs: 600_000,


### PR DESCRIPTION
Fixes the two 2026-07-06 production incidents at their roots, plus the systemic gaps they exposed. All root causes were established with DB forensics before any code was written.

## Incidents

**A — staging mid-session /workspace loss** (session e644e8a8): OpenGeni's own Modal orphan sweep terminated a LIVE box mid-turn at exactly creation+30min. The box was missing its attribution tags (setTags is best-effort after create), so the sweep classified it "unattributed" — while the live lease resumed that exact box id every turn. Nothing outside the reaper drain persists /workspace, so an unpushed branch + 2 commits were unrecoverable. (Not the deploy churn, and not Modal instability.)

**B — prod session killed by "Live sandbox sessions cannot change manifest environment variables"** (geni manager 76e2f2ee): the SDK validates the FULL recomputed manifest env against a live provided box's baked env (`validateNoEnvironmentDelta`, unchanged through SDK 0.12.0; there is no per-exec env API and no update API). Turn inputs were byte-identical to the prior success (0/103 turns ever carried resources; no deploy; no env edit) — the recompute-and-compare architecture itself is the defect.

## Fixes

1. **Env pin at the provided-session seam** (`pinProvidedSessionManifestEnvironment`): a turn resuming a live box declares the box's OWN baked env, byte-identical — the guard is structurally unhittable. Drift is emitted as a durable `sandbox.env.drift` event (key NAMES only, never values). Owned-session resume keeps its env refresh (owned `applyManifest` merges safely; that path is how workspace-env edits reach long-lived local/docker boxes).
2. **Orphan-sweep live-instance guard**: the sweep never terminates a box any live lease's envelope points at, whatever its tags say, and opportunistically heals missing/stale tags. Genuine orphans reap exactly as before.
3. **Mid-session /workspace snapshots**: while a turn holds the box, the heartbeat and turn-end fold a snapshot onto the lease via `persistWarmSnapshot` — the warm sibling of the drain seam (same epoch fence, shared `foldWorkspaceArchiveOntoLease` write, atomic throttle via `workspaceArchiveAt`, keep-latest snapshot GC). Bounds ANY unclean box death (Modal hard-timeout catching a busy session, OOM, infra) to ≤ `OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS` (default 15min; 0 disables). Previously a session busy past the Modal timeout — including legit multi-day turns — had zero protection: the reaper only drains idle leases.
4. **Dead-worker turn-holder reap** (migration 0044): turn holders were TTL-exempt forever, so a SIGKILLed worker's frozen holder pinned refcount ≥ 1 permanently — the lease never drained, the box died at the provider hard-timeout unpersisted. Reaped past warming-budget + lease-TTL (~11.5min): longer than any legitimate heartbeat silence, so multi-day turns are untouched. 2-arg SQL compat overload keeps rolling deploys safe.
5. **Durable box lifecycle events** (`sandbox.box.created/lost/terminated/snapshot`, `sandbox.env.drift`): every box transition is now attributable from the DB alone — worker logs rotate within hours, which made both incidents near-unattributable. Registered in contracts + SDK; the timeline projection ignores them (tolerant reader, pinned by test).
6. **UI**: routine per-turn `repository-clone` rows (idempotent clone check + token re-seed plumbing) no longer render; failures still surface loudly.

## Verification

- All touched suites green: runtime (136), react incl. golden grammar (444), worker sandbox-lease + agent-turn (49) against a real pg, db sandbox-leases incl. migration 0044 (15), sdk contracts parity (93). Full monorepo: 2278 pass; 3 fails are shared-test-pg contention flakes (unnamed hook timeouts with pg stream-reset stacks; every implicated suite passes solo).
- Adversarial codex (gpt-5.5) review ran on the full diff; both major findings fixed: owned-resume env refresh restored (the entry-only delta had over-reached onto the owned path), and the turn-end snapshot now awaits an in-flight heartbeat capture so the atomic throttle always adjudicates in capture order.

## Ops notes

- Migration 0044 is rolling-safe (2-arg overload delegates with reaping off until workers pass the TTL).
- New knob: `OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS` (default 900000; `0` = kill-switch).
- All new behavior is fail-open: snapshot/event/tag-heal failures can never fail a turn, a drain, or a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core sandbox lifecycle (lease reap, Modal termination, mid-turn snapshots, manifest env) and worker shutdown behavior; mistakes could drop workspace data or kill live boxes, though changes are largely best-effort/fail-open with new tests and migration compat overload.
> 
> **Overview**
> Hardens **sandbox /workspace survival** and **attribution** after production incidents: mid-turn box kills and manifest-env mismatches on long-lived sessions.
> 
> **Persistence while a turn runs:** `maybePersistWarmWorkspaceSnapshot` folds `/workspace` onto the lease on the turn heartbeat (single-flight) and again at turn-end (awaits any in-flight capture), gated by `OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS` via new `persistWarmSnapshot` / shared `foldWorkspaceArchiveOntoLease`. **Dead workers** no longer pin leases forever: migration **0044** reaps stale turn holders; `touchLeaseHolder` during resume warmup; reaper passes `turnHolderTtlMs`.
> 
> **Safety fixes:** Modal orphan sweep **skips** boxes referenced by any live lease `instanceId` (and heals tags); **provided-session** turns **pin** manifest env to the box’s baked env and emit `sandbox.env.drift` (key names only) instead of SDK fatal drift. **Durable** `sandbox.box.*` events on create/lost/snapshot/terminate; reaper records `sandbox.box.terminated` with `persisted`.
> 
> **Deploy:** worker **SIGTERM/SIGINT** → Temporal `shutdown()` with `shutdownGraceTime` / `shutdownForceTime` so turns can `WORKER_SHUTDOWN` checkpoint. Timeline hides routine successful `repository-clone` ops; lifecycle events stay off the UI projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfeca27c52f17a93a890d6e6236f2abf3dbc7088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->