### PR TITLE
Harden MCP integration connect flow

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -83,6 +83,7 @@ type OAuthStatePayload = {
   workspaceId: string;
   subjectId: string;
   providerDomain: string;
+  mcpUrl: string;
   resource: string;
   requestedScopes: string[];
   authorizeScopes: string[];
@@ -127,8 +128,8 @@ export async function startMcpOAuth(
   context: OAuthStartContext,
 ): Promise<OAuthStartResponse> {
   const { db, settings } = deps;
-  const resource = canonicalMcpResource(context.payload.mcpUrl ?? context.payload.resource);
-  const providerDomain = canonicalProviderDomain(context.payload.providerDomain ?? new URL(resource).hostname);
+  const mcpUrl = canonicalMcpResource(context.payload.mcpUrl ?? context.payload.resource);
+  const providerDomain = canonicalProviderDomain(context.payload.providerDomain ?? new URL(mcpUrl).hostname);
   const returnPath = safeReturnPath(context.payload.returnPath ?? "/integrations");
   const baseUrl = integrationBaseUrl(settings.publicBaseUrl, context.requestUrl);
   const redirectUri = `${baseUrl}/v1/integrations/oauth/callback`;
@@ -140,7 +141,8 @@ export async function startMcpOAuth(
     throw new HTTPException(404, { message: "connection not found" });
   }
 
-  const discovery = await discoverMcpOAuth(resource, settings);
+  const discovery = await discoverMcpOAuth(mcpUrl, settings);
+  const resource = discovery.prm.resource ? canonicalOAuthResource(discovery.prm.resource) : mcpUrl;
   const client = await registerOAuthClient(db, settings, discovery.as, metadataUrl, redirectUri);
   const verifier = randomPkceVerifier();
   const authorizeScopes = chooseAuthorizeScopes(context.payload.requestedScopes, discovery.challenge.scope, discovery.prm.scopesSupported);
@@ -150,6 +152,7 @@ export async function startMcpOAuth(
     workspaceId: context.workspaceId,
     subjectId: context.subjectId,
     providerDomain,
+    mcpUrl,
     resource,
     requestedScopes: uniqueStrings(context.payload.requestedScopes ?? []),
     authorizeScopes,
@@ -226,17 +229,19 @@ export async function completeMcpOAuthCallback(
       tokenEndpoint: state.tokenEndpoint,
       client,
     }));
-    const tools = await stage("tools_list", "tools_list_failed", () => verifyMcpToolsList(settings, state.resource, token));
+    const verification = await verifyMcpToolsListNonFatal(observability, settings, state, token);
     const scopes = grantedScopes(token.scopeText, state.authorizeScopes);
     const credential = credentialBundle(token, state, client);
     const metadata = {
       resource: state.resource,
+      mcpUrl: state.mcpUrl,
       authorizationServer: state.authorizationServer,
       authorizationServerIssuer: state.issuer,
       tokenEndpoint: state.tokenEndpoint,
       clientId: client.clientId,
       clientRegistrationMethod: state.clientRegistrationMethod,
-      mcpTools: tools,
+      mcpToolsVerification: verification.metadata,
+      ...(verification.tools ? { mcpTools: verification.tools } : {}),
     };
     const credentialEncrypted = encryptEnvironmentValue(key, JSON.stringify(credential));
     const connection = await stage("persist", "persist_failed", () => state.connectionId
@@ -273,7 +278,13 @@ export async function completeMcpOAuthCallback(
     // the enable connectionRef straight from the redirect, without a listConnections
     // round-trip that could fail (transient, or a grant lacking connections:read)
     // and leave the connection created but the capability un-enabled.
-    return { redirectTo: callbackReturnPath(state.returnPath, "success", { connectionId: connection.id, providerDomain: connection.providerDomain }) };
+    return {
+      redirectTo: callbackReturnPath(state.returnPath, "success", {
+        connectionId: connection.id,
+        providerDomain: connection.providerDomain,
+        ...(verification.metadata.status === "failed" ? { verification: "failed" } : {}),
+      }),
+    };
   } catch (error) {
     const staged = error instanceof OAuthCallbackStageError
       ? error
@@ -580,12 +591,14 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
   if (iat === undefined || nowSeconds - iat > oauthStateTtlMs / 1000 || nowSeconds < iat) {
     throw new HTTPException(400, { message: "invalid or expired OAuth state" });
   }
+  const resource = requiredString(payload.resource, "state.resource");
   const parsed = {
     accountId: requiredString(payload.accountId, "state.accountId"),
     workspaceId: requiredString(payload.workspaceId, "state.workspaceId"),
     subjectId: requiredString(payload.subjectId, "state.subjectId"),
     providerDomain: requiredString(payload.providerDomain, "state.providerDomain"),
-    resource: requiredString(payload.resource, "state.resource"),
+    mcpUrl: stringValue(payload.mcpUrl) ?? resource,
+    resource,
     requestedScopes: stringArray(payload.requestedScopes),
     authorizeScopes: stringArray(payload.authorizeScopes),
     encryptedPkceVerifier: requiredString(payload.encryptedPkceVerifier, "state.encryptedPkceVerifier"),
@@ -723,6 +736,24 @@ function logOAuthCallbackFailure(
   });
 }
 
+function logOAuthVerificationWarning(
+  observability: Observability | undefined,
+  error: OAuthCallbackStageError,
+  state: OAuthStatePayload,
+): void {
+  observability?.warn("MCP OAuth tools/list verification failed after token exchange", {
+    "opengeni.oauth.stage": error.stage,
+    "opengeni.oauth.reason": error.reason,
+    "opengeni.oauth.provider_domain": state.providerDomain,
+    "opengeni.oauth.resource_host": safeHost(state.resource),
+    "opengeni.oauth.mcp_host": safeHost(state.mcpUrl),
+    "opengeni.oauth.authorization_server": state.authorizationServer,
+    "opengeni.oauth.issuer": state.issuer,
+    "opengeni.oauth.client_registration_method": state.clientRegistrationMethod,
+    error: sanitizedError(error.cause),
+  });
+}
+
 function sanitizedError(error: unknown): string {
   if (error instanceof HTTPException) {
     return `HTTPException ${error.status}: ${error.message}`;
@@ -779,6 +810,42 @@ async function verifyMcpToolsList(settings: Settings, resource: string, token: T
   }
 }
 
+async function verifyMcpToolsListNonFatal(
+  observability: Observability | undefined,
+  settings: Settings,
+  state: OAuthStatePayload,
+  token: TokenResponse,
+): Promise<{
+  metadata:
+    | { status: "ok"; checkedAt: string; toolCount: number }
+    | { status: "failed"; checkedAt: string; reason: string };
+  tools?: Array<{ name: string; description?: string }>;
+}> {
+  try {
+    const tools = await stage("tools_list", "tools_list_failed", () => verifyMcpToolsList(settings, state.mcpUrl, token));
+    return {
+      metadata: {
+        status: "ok",
+        checkedAt: new Date().toISOString(),
+        toolCount: tools.length,
+      },
+      tools,
+    };
+  } catch (error) {
+    const staged = error instanceof OAuthCallbackStageError
+      ? error
+      : new OAuthCallbackStageError("tools_list", "tools_list_failed", error);
+    logOAuthVerificationWarning(observability, staged, state);
+    return {
+      metadata: {
+        status: "failed",
+        checkedAt: new Date().toISOString(),
+        reason: staged.reason,
+      },
+    };
+  }
+}
+
 function credentialBundle(token: TokenResponse, state: OAuthStatePayload, client: OAuthClientRegistration): Record<string, unknown> {
   return {
     access_token: token.accessToken,
@@ -786,6 +853,7 @@ function credentialBundle(token: TokenResponse, state: OAuthStatePayload, client
     token_type: token.tokenType,
     ...(token.expiresAt ? { expires_at: token.expiresAt.toISOString() } : {}),
     resource: state.resource,
+    mcp_url: state.mcpUrl,
     ...(token.scopeText ? { scope: token.scopeText } : state.authorizeScopes.length ? { scope: state.authorizeScopes.join(" ") } : {}),
     token_endpoint: state.tokenEndpoint,
     client_id: client.clientId,
@@ -814,6 +882,23 @@ function canonicalMcpResource(value: string | undefined): string {
   }
   url.hash = "";
   return url.toString();
+}
+
+function canonicalOAuthResource(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HTTPException(422, { message: "MCP protected resource metadata advertised an invalid resource" });
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.hash = "";
+      return url.toString();
+    }
+    return trimmed;
+  } catch {
+    throw new HTTPException(422, { message: "MCP protected resource metadata advertised an invalid resource" });
+  }
 }
 
 function safeReturnPath(value: string): string {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -471,6 +471,22 @@ describe("API helpers", () => {
     })).rejects.toThrow("could not be enabled");
   });
 
+  test("reports invalid MCP catalog endpoints with human copy", async () => {
+    const item = capabilityItem({
+      id: "mcp:gmail",
+      kind: "mcp",
+      name: "Gmail",
+      endpointUrl: "https://gmail.googleapis.com/mcp",
+      runtime: { available: true, mcpServerId: "cap-gmail", transport: "streamable-http", notes: null },
+    });
+
+    await expect(validateMcpCapabilityConnection(item, async () => {
+      throw new Error("Streamable HTTP error: POSTing to endpoint: HTTP 404 Not Found");
+    })).rejects.toThrow(
+      'MCP capability "Gmail" could not be enabled because OpenGeni could not reach a valid Streamable HTTP MCP server at https://gmail.googleapis.com/mcp. Check the endpoint URL or choose a different catalog entry.',
+    );
+  });
+
   test("replays SSE history across all pages", async () => {
     const events = Array.from({ length: 1005 }, (_, index) => ({
       id: `event-${index + 1}`,

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -154,7 +154,7 @@ function startFakeAuthorizationServer(options: {
   codeChallengeMethods?: string[];
   clientIdMetadataDocumentSupported?: boolean;
   dcr?: boolean;
-  tokenAccessToken?: string;
+  tokenAccessToken?: string | ((body: URLSearchParams) => string);
   tokenStatus?: number;
   tokenError?: string;
 } = {}): FakeAuthorizationServer {
@@ -200,7 +200,9 @@ function startFakeAuthorizationServer(options: {
           }, { status: options.tokenStatus });
         }
         return Response.json({
-          access_token: options.tokenAccessToken ?? "mcp-access-token",
+          access_token: typeof options.tokenAccessToken === "function"
+            ? options.tokenAccessToken(body)
+            : options.tokenAccessToken ?? "mcp-access-token",
           refresh_token: "mcp-refresh-token",
           token_type: "Bearer",
           expires_in: 3600,
@@ -446,7 +448,7 @@ describe("connections routes", () => {
       expect(authUrl.pathname).toBe("/authorize");
       expect(authUrl.searchParams.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
       expect(authUrl.searchParams.get("redirect_uri")).toBe("https://api.opengeni.test/v1/integrations/oauth/callback");
-      expect(authUrl.searchParams.get("resource")).toBe(mcp.url);
+      expect(authUrl.searchParams.get("resource")).toBe("urn:test:mcp");
       expect(authUrl.searchParams.get("scope")).toBe("documents:read");
       expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
       expect(authUrl.searchParams.has("code_verifier")).toBe(false);
@@ -456,7 +458,8 @@ describe("connections routes", () => {
       expect(state?.accountId).toBe(workspace.accountId);
       expect(state?.subjectId).toBe("subject-a");
       expect(state?.providerDomain).toBe("mcp.example.com");
-      expect(state?.resource).toBe(mcp.url);
+      expect(state?.mcpUrl).toBe(mcp.url);
+      expect(state?.resource).toBe("urn:test:mcp");
       expect(state?.authorizeScopes).toEqual(["documents:read"]);
       expect(typeof state?.encryptedPkceVerifier).toBe("string");
       const verifier = decryptEnvironmentValue(rawKey, state!.encryptedPkceVerifier as string);
@@ -474,7 +477,7 @@ describe("connections routes", () => {
       expect(location).toContain("providerDomain=mcp.example.com");
 
       expect(as.tokenRequests).toHaveLength(1);
-      expect(as.tokenRequests[0]!.get("resource")).toBe(mcp.url);
+      expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
       expect(as.tokenRequests[0]!.get("redirect_uri")).toBe("https://api.opengeni.test/v1/integrations/oauth/callback");
       expect(as.tokenRequests[0]!.get("code_verifier")).toBe(verifier);
       expect(as.tokenRequests[0]!.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
@@ -487,12 +490,68 @@ describe("connections routes", () => {
       expect(loaded?.credential).toMatchObject({
         access_token: "mcp-access-token",
         refresh_token: "mcp-refresh-token",
-        resource: mcp.url,
+        resource: "urn:test:mcp",
+        mcp_url: mcp.url,
         token_endpoint: `${as.url}/token`,
         client_id: "https://api.opengeni.test/v1/integrations/oauth/client-metadata.json",
       });
       expect(loaded?.metadata.authorizationServerIssuer).toBe(as.url);
+      expect(loaded?.metadata.resource).toBe("urn:test:mcp");
+      expect(loaded?.metadata.mcpUrl).toBe(mcp.url);
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({ status: "ok" });
       expect(loaded?.metadata.mcpTools).toEqual(expect.arrayContaining([expect.objectContaining({ name: "search_documents" })]));
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth uses protected-resource metadata resource as token audience while connecting to the MCP endpoint", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      clientIdMetadataDocumentSupported: true,
+      tokenAccessToken: (body) => `token-for-${body.get("resource")}`,
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer token-for-urn:test:mcp",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource"`,
+    });
+    try {
+      const response = await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providerDomain: "linear.app",
+          mcpUrl: mcp.url,
+          returnPath: "/integrations?connect_item=linear",
+        }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { state: string; authorizationUrl: string };
+      expect(new URL(body.authorizationUrl).searchParams.get("resource")).toBe("urn:test:mcp");
+
+      const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(callback.headers.get("location")).not.toContain("verification=failed");
+      expect(as.tokenRequests).toHaveLength(1);
+      expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
+
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "linear.app",
+        kind: "oauth2",
+      });
+      expect(loaded?.credential).toMatchObject({
+        access_token: "token-for-urn:test:mcp",
+        resource: "urn:test:mcp",
+        mcp_url: mcp.url,
+      });
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({ status: "ok" });
     } finally {
       mcp.close();
       as.close();
@@ -696,7 +755,7 @@ describe("connections routes", () => {
     }
   });
 
-  test("oauth callback verifies MCP tools through guarded fetch redirects", async () => {
+  test("oauth callback records non-fatal tools/list verification failure after guarded fetch redirects", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const originalFetch = globalThis.fetch;
@@ -750,9 +809,20 @@ describe("connections routes", () => {
       const response = await publicApp(client.db, { environment: "production" })
         .request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(state)}`);
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toContain("reason=tools_list_failed");
+      expect(response.headers.get("location")).toContain("integration_oauth=success");
+      expect(response.headers.get("location")).toContain("verification=failed");
       expect(hits).toEqual(["https://1.1.1.1/token", "https://1.1.1.1/mcp"]);
       expect(privateHopHits).toBe(0);
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "verify-redirect.example.com",
+        kind: "oauth2",
+      });
+      expect(loaded?.credential).toMatchObject({ access_token: "mcp-access-token" });
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({
+        status: "failed",
+        reason: "tools_list_failed",
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/core/src/domain/capabilities.ts
+++ b/packages/core/src/domain/capabilities.ts
@@ -436,7 +436,7 @@ export async function validateMcpCapabilityConnection(
     };
   } catch (error) {
     throw new HTTPException(422, {
-      message: `MCP capability "${item.name}" could not be enabled because OpenGeni could not initialize ${item.endpointUrl}: ${mcpProbeErrorMessage(error)}`,
+      message: `MCP capability "${item.name}" could not be enabled because ${mcpProbeErrorMessage(error, item.endpointUrl)}`,
     });
   }
 }
@@ -461,9 +461,16 @@ async function probeStreamableHttpMcpServer(input: McpCapabilityProbeInput): Pro
   }
 }
 
-function mcpProbeErrorMessage(error: unknown): string {
+function mcpProbeErrorMessage(error: unknown, endpointUrl: string): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\s+/g, " ").trim().slice(0, 500) || "unknown error";
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (
+    /404|405|not found|unexpected token|not valid json|invalid json|failed to parse|streamable http error|unable to connect|fetch failed|econnrefused|enotfound|timeout|aborted/i
+      .test(normalized)
+  ) {
+    return `OpenGeni could not reach a valid Streamable HTTP MCP server at ${endpointUrl}. Check the endpoint URL or choose a different catalog entry.`;
+  }
+  return `OpenGeni could not initialize ${endpointUrl}: ${normalized.slice(0, 500) || "unknown error"}`;
 }
 
 export async function disableCapability(input: {


### PR DESCRIPTION
## Summary
- split OAuth protected-resource audience from the MCP endpoint URL so token exchange uses the PRM-advertised resource while tools/list and runtime metadata keep the real MCP URL
- make post-token tools/list verification non-fatal, persist verification status metadata, and warn with structured OAuth fields
- replace raw Streamable HTTP probe failures for invalid catalog endpoints with stable human-facing copy
- add regressions for Linear-style token audience validation, non-fatal verification persistence, and junk Google/Gmail-style MCP endpoint messaging

## Verification
- bun test apps/api/test/connections-routes.test.ts
- bun test apps/api/test/app.test.ts
- bun test apps/web/src/lib/capabilities.test.ts apps/web/src/App.test.ts
- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token audience, credential shape, and callback success semantics for integrations; mistakes could break provider-specific flows (e.g. Linear) or mask MCP connectivity issues after connect.
> 
> **Overview**
> **OAuth MCP connections** now treat the protected-resource metadata **audience** separately from the **Streamable HTTP MCP URL**. Authorize/token exchange use the PRM `resource` (e.g. a URN); `tools/list` verification and stored credentials keep the real `mcpUrl` / `mcp_url`.
> 
> Post-token **tools/list** is **non-fatal**: a successful token exchange still creates or updates the connection, persists `mcpToolsVerification` metadata (ok vs failed), logs a structured warning on failure, and can return `verification=failed` on the success redirect instead of failing the whole callback.
> 
> **MCP capability enable** probes map common unreachable/invalid endpoint errors (404, bad JSON, connection failures) to stable user-facing copy instead of raw transport messages.
> 
> Tests cover PRM audience vs MCP URL (Linear-style), non-fatal verification persistence, and junk catalog endpoint messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0206e2cbf78762ce8b76921c7fb2dffc778f440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->