### PR TITLE
Fix Linear MCP OAuth client registration

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -26,6 +26,11 @@ import { HTTPException } from "hono/http-exception";
 import { canonicalProviderDomain } from "./provider-domain";
 
 export const oauthStateTtlMs = 10 * 60 * 1000;
+const dcrPreferredAuthorizationServers = new Set([
+  // Linear advertises CIMD, but its MCP docs and runtime behavior require
+  // dynamic client registration for tokens accepted by https://mcp.linear.app/mcp.
+  "https://mcp.linear.app",
+]);
 
 type OAuthClientDeps = {
   db: Database;
@@ -414,6 +419,9 @@ async function registerOAuthClient(
   if (operator) {
     return operator;
   }
+  if (prefersDynamicClientRegistration(as)) {
+    return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri);
+  }
   if (as.clientIdMetadataDocumentSupported) {
     return {
       method: "cimd",
@@ -423,6 +431,15 @@ async function registerOAuthClient(
       tokenEndpointAuthMethod: "none",
     };
   }
+  return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri);
+}
+
+async function getOrCreateDynamicClientRegistration(
+  db: Database,
+  settings: Settings,
+  as: AuthorizationServerMetadata,
+  redirectUri: string,
+): Promise<OAuthClientRegistration> {
   const storedClient = await loadIntegrationOAuthClient(db, settings, as.issuer);
   if (storedClient) {
     return {
@@ -460,6 +477,10 @@ async function registerOAuthClient(
     return dcrRegistrationFromStored(winner);
   }
   return dcr;
+}
+
+function prefersDynamicClientRegistration(as: AuthorizationServerMetadata): boolean {
+  return [as.issuer, as.authorizationServer].some((candidate) => dcrPreferredAuthorizationServers.has(normalizedIssuerKey(candidate)));
 }
 
 function dcrRegistrationFromStored(stored: {

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -83,6 +83,7 @@ type OAuthStatePayload = {
   workspaceId: string;
   subjectId: string;
   providerDomain: string;
+  mcpUrl: string;
   resource: string;
   requestedScopes: string[];
   authorizeScopes: string[];
@@ -127,8 +128,8 @@ export async function startMcpOAuth(
   context: OAuthStartContext,
 ): Promise<OAuthStartResponse> {
   const { db, settings } = deps;
-  const resource = canonicalMcpResource(context.payload.mcpUrl ?? context.payload.resource);
-  const providerDomain = canonicalProviderDomain(context.payload.providerDomain ?? new URL(resource).hostname);
+  const mcpUrl = canonicalMcpResource(context.payload.mcpUrl ?? context.payload.resource);
+  const providerDomain = canonicalProviderDomain(context.payload.providerDomain ?? new URL(mcpUrl).hostname);
   const returnPath = safeReturnPath(context.payload.returnPath ?? "/integrations");
   const baseUrl = integrationBaseUrl(settings.publicBaseUrl, context.requestUrl);
   const redirectUri = `${baseUrl}/v1/integrations/oauth/callback`;
@@ -140,7 +141,8 @@ export async function startMcpOAuth(
     throw new HTTPException(404, { message: "connection not found" });
   }
 
-  const discovery = await discoverMcpOAuth(resource, settings);
+  const discovery = await discoverMcpOAuth(mcpUrl, settings);
+  const resource = discovery.prm.resource ? canonicalOAuthResource(discovery.prm.resource) : mcpUrl;
   const client = await registerOAuthClient(db, settings, discovery.as, metadataUrl, redirectUri);
   const verifier = randomPkceVerifier();
   const authorizeScopes = chooseAuthorizeScopes(context.payload.requestedScopes, discovery.challenge.scope, discovery.prm.scopesSupported);
@@ -150,6 +152,7 @@ export async function startMcpOAuth(
     workspaceId: context.workspaceId,
     subjectId: context.subjectId,
     providerDomain,
+    mcpUrl,
     resource,
     requestedScopes: uniqueStrings(context.payload.requestedScopes ?? []),
     authorizeScopes,
@@ -226,17 +229,19 @@ export async function completeMcpOAuthCallback(
       tokenEndpoint: state.tokenEndpoint,
       client,
     }));
-    const tools = await stage("tools_list", "tools_list_failed", () => verifyMcpToolsList(settings, state.resource, token));
+    const verification = await verifyMcpToolsListNonFatal(observability, settings, state, token);
     const scopes = grantedScopes(token.scopeText, state.authorizeScopes);
     const credential = credentialBundle(token, state, client);
     const metadata = {
       resource: state.resource,
+      mcpUrl: state.mcpUrl,
       authorizationServer: state.authorizationServer,
       authorizationServerIssuer: state.issuer,
       tokenEndpoint: state.tokenEndpoint,
       clientId: client.clientId,
       clientRegistrationMethod: state.clientRegistrationMethod,
-      mcpTools: tools,
+      mcpToolsVerification: verification.metadata,
+      ...(verification.tools ? { mcpTools: verification.tools } : {}),
     };
     const credentialEncrypted = encryptEnvironmentValue(key, JSON.stringify(credential));
     const connection = await stage("persist", "persist_failed", () => state.connectionId
@@ -273,7 +278,13 @@ export async function completeMcpOAuthCallback(
     // the enable connectionRef straight from the redirect, without a listConnections
     // round-trip that could fail (transient, or a grant lacking connections:read)
     // and leave the connection created but the capability un-enabled.
-    return { redirectTo: callbackReturnPath(state.returnPath, "success", { connectionId: connection.id, providerDomain: connection.providerDomain }) };
+    return {
+      redirectTo: callbackReturnPath(state.returnPath, "success", {
+        connectionId: connection.id,
+        providerDomain: connection.providerDomain,
+        ...(verification.metadata.status === "failed" ? { verification: "failed" } : {}),
+      }),
+    };
   } catch (error) {
     const staged = error instanceof OAuthCallbackStageError
       ? error
@@ -580,12 +591,14 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
   if (iat === undefined || nowSeconds - iat > oauthStateTtlMs / 1000 || nowSeconds < iat) {
     throw new HTTPException(400, { message: "invalid or expired OAuth state" });
   }
+  const resource = requiredString(payload.resource, "state.resource");
   const parsed = {
     accountId: requiredString(payload.accountId, "state.accountId"),
     workspaceId: requiredString(payload.workspaceId, "state.workspaceId"),
     subjectId: requiredString(payload.subjectId, "state.subjectId"),
     providerDomain: requiredString(payload.providerDomain, "state.providerDomain"),
-    resource: requiredString(payload.resource, "state.resource"),
+    mcpUrl: stringValue(payload.mcpUrl) ?? resource,
+    resource,
     requestedScopes: stringArray(payload.requestedScopes),
     authorizeScopes: stringArray(payload.authorizeScopes),
     encryptedPkceVerifier: requiredString(payload.encryptedPkceVerifier, "state.encryptedPkceVerifier"),
@@ -723,6 +736,24 @@ function logOAuthCallbackFailure(
   });
 }
 
+function logOAuthVerificationWarning(
+  observability: Observability | undefined,
+  error: OAuthCallbackStageError,
+  state: OAuthStatePayload,
+): void {
+  observability?.warn("MCP OAuth tools/list verification failed after token exchange", {
+    "opengeni.oauth.stage": error.stage,
+    "opengeni.oauth.reason": error.reason,
+    "opengeni.oauth.provider_domain": state.providerDomain,
+    "opengeni.oauth.resource_host": safeHost(state.resource),
+    "opengeni.oauth.mcp_host": safeHost(state.mcpUrl),
+    "opengeni.oauth.authorization_server": state.authorizationServer,
+    "opengeni.oauth.issuer": state.issuer,
+    "opengeni.oauth.client_registration_method": state.clientRegistrationMethod,
+    error: sanitizedError(error.cause),
+  });
+}
+
 function sanitizedError(error: unknown): string {
   if (error instanceof HTTPException) {
     return `HTTPException ${error.status}: ${error.message}`;
@@ -779,6 +810,42 @@ async function verifyMcpToolsList(settings: Settings, resource: string, token: T
   }
 }
 
+async function verifyMcpToolsListNonFatal(
+  observability: Observability | undefined,
+  settings: Settings,
+  state: OAuthStatePayload,
+  token: TokenResponse,
+): Promise<{
+  metadata:
+    | { status: "ok"; checkedAt: string; toolCount: number }
+    | { status: "failed"; checkedAt: string; reason: string };
+  tools?: Array<{ name: string; description?: string }>;
+}> {
+  try {
+    const tools = await stage("tools_list", "tools_list_failed", () => verifyMcpToolsList(settings, state.mcpUrl, token));
+    return {
+      metadata: {
+        status: "ok",
+        checkedAt: new Date().toISOString(),
+        toolCount: tools.length,
+      },
+      tools,
+    };
+  } catch (error) {
+    const staged = error instanceof OAuthCallbackStageError
+      ? error
+      : new OAuthCallbackStageError("tools_list", "tools_list_failed", error);
+    logOAuthVerificationWarning(observability, staged, state);
+    return {
+      metadata: {
+        status: "failed",
+        checkedAt: new Date().toISOString(),
+        reason: staged.reason,
+      },
+    };
+  }
+}
+
 function credentialBundle(token: TokenResponse, state: OAuthStatePayload, client: OAuthClientRegistration): Record<string, unknown> {
   return {
     access_token: token.accessToken,
@@ -786,6 +853,7 @@ function credentialBundle(token: TokenResponse, state: OAuthStatePayload, client
     token_type: token.tokenType,
     ...(token.expiresAt ? { expires_at: token.expiresAt.toISOString() } : {}),
     resource: state.resource,
+    mcp_url: state.mcpUrl,
     ...(token.scopeText ? { scope: token.scopeText } : state.authorizeScopes.length ? { scope: state.authorizeScopes.join(" ") } : {}),
     token_endpoint: state.tokenEndpoint,
     client_id: client.clientId,
@@ -814,6 +882,23 @@ function canonicalMcpResource(value: string | undefined): string {
   }
   url.hash = "";
   return url.toString();
+}
+
+function canonicalOAuthResource(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HTTPException(422, { message: "MCP protected resource metadata advertised an invalid resource" });
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.hash = "";
+      return url.toString();
+    }
+    return trimmed;
+  } catch {
+    throw new HTTPException(422, { message: "MCP protected resource metadata advertised an invalid resource" });
+  }
 }
 
 function safeReturnPath(value: string): string {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -471,6 +471,22 @@ describe("API helpers", () => {
     })).rejects.toThrow("could not be enabled");
   });
 
+  test("reports invalid MCP catalog endpoints with human copy", async () => {
+    const item = capabilityItem({
+      id: "mcp:gmail",
+      kind: "mcp",
+      name: "Gmail",
+      endpointUrl: "https://gmail.googleapis.com/mcp",
+      runtime: { available: true, mcpServerId: "cap-gmail", transport: "streamable-http", notes: null },
+    });
+
+    await expect(validateMcpCapabilityConnection(item, async () => {
+      throw new Error("Streamable HTTP error: POSTing to endpoint: HTTP 404 Not Found");
+    })).rejects.toThrow(
+      'MCP capability "Gmail" could not be enabled because OpenGeni could not reach a valid Streamable HTTP MCP server at https://gmail.googleapis.com/mcp. Check the endpoint URL or choose a different catalog entry.',
+    );
+  });
+
   test("replays SSE history across all pages", async () => {
     const events = Array.from({ length: 1005 }, (_, index) => ({
       id: `event-${index + 1}`,

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -153,6 +153,7 @@ function startFakeAuthorizationServer(options: {
   scopesSupported?: string[];
   codeChallengeMethods?: string[];
   clientIdMetadataDocumentSupported?: boolean;
+  issuer?: string;
   dcr?: boolean;
   tokenAccessToken?: string | ((body: URLSearchParams) => string);
   tokenStatus?: number;
@@ -175,7 +176,7 @@ function startFakeAuthorizationServer(options: {
       }
       if (url.pathname === "/.well-known/oauth-authorization-server" || url.pathname === "/.well-known/openid-configuration") {
         return Response.json({
-          issuer: origin,
+          issuer: options.issuer ?? origin,
           authorization_endpoint: `${origin}/authorize`,
           token_endpoint: `${origin}/token`,
           code_challenge_methods_supported: options.codeChallengeMethods ?? ["S256"],
@@ -703,6 +704,58 @@ describe("connections routes", () => {
       const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
       expect(callback.status).toBe(302);
       expect(callback.headers.get("location")).toContain("integration_oauth=success");
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth start prefers DCR for Linear even when CIMD is advertised", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      issuer: "https://mcp.linear.app",
+      clientIdMetadataDocumentSupported: true,
+      dcr: true,
+      scopesSupported: ["read", "write"],
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource", scope="read write"`,
+    });
+    try {
+      const response = await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ providerDomain: "linear.app", mcpUrl: mcp.url, returnPath: "/integrations?connect_item=linear" }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { state: string; authorizationUrl: string };
+      const authUrl = new URL(body.authorizationUrl);
+      expect(authUrl.searchParams.get("client_id")).toBe(`${as.url}/registered-client/1`);
+      expect(authUrl.searchParams.get("client_id")).not.toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
+      expect(authUrl.searchParams.get("resource")).toBe("urn:test:mcp");
+      expect(authUrl.searchParams.get("scope")).toBe("read write");
+      expect(as.registrations).toHaveLength(1);
+      expect(as.registrations[0]).toMatchObject({
+        client_name: "OpenGeni",
+        redirect_uris: ["https://api.opengeni.test/v1/integrations/oauth/callback"],
+        token_endpoint_auth_method: "none",
+      });
+
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
+      expect(state?.clientRegistrationMethod).toBe("dcr");
+      expect(state?.clientId).toBe(`${as.url}/registered-client/1`);
+
+      const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(as.tokenRequests).toHaveLength(1);
+      expect(as.tokenRequests[0]!.get("client_id")).toBe(`${as.url}/registered-client/1`);
+      expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
     } finally {
       mcp.close();
       as.close();

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -154,7 +154,7 @@ function startFakeAuthorizationServer(options: {
   codeChallengeMethods?: string[];
   clientIdMetadataDocumentSupported?: boolean;
   dcr?: boolean;
-  tokenAccessToken?: string;
+  tokenAccessToken?: string | ((body: URLSearchParams) => string);
   tokenStatus?: number;
   tokenError?: string;
 } = {}): FakeAuthorizationServer {
@@ -200,7 +200,9 @@ function startFakeAuthorizationServer(options: {
           }, { status: options.tokenStatus });
         }
         return Response.json({
-          access_token: options.tokenAccessToken ?? "mcp-access-token",
+          access_token: typeof options.tokenAccessToken === "function"
+            ? options.tokenAccessToken(body)
+            : options.tokenAccessToken ?? "mcp-access-token",
           refresh_token: "mcp-refresh-token",
           token_type: "Bearer",
           expires_in: 3600,
@@ -446,7 +448,7 @@ describe("connections routes", () => {
       expect(authUrl.pathname).toBe("/authorize");
       expect(authUrl.searchParams.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
       expect(authUrl.searchParams.get("redirect_uri")).toBe("https://api.opengeni.test/v1/integrations/oauth/callback");
-      expect(authUrl.searchParams.get("resource")).toBe(mcp.url);
+      expect(authUrl.searchParams.get("resource")).toBe("urn:test:mcp");
       expect(authUrl.searchParams.get("scope")).toBe("documents:read");
       expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
       expect(authUrl.searchParams.has("code_verifier")).toBe(false);
@@ -456,7 +458,8 @@ describe("connections routes", () => {
       expect(state?.accountId).toBe(workspace.accountId);
       expect(state?.subjectId).toBe("subject-a");
       expect(state?.providerDomain).toBe("mcp.example.com");
-      expect(state?.resource).toBe(mcp.url);
+      expect(state?.mcpUrl).toBe(mcp.url);
+      expect(state?.resource).toBe("urn:test:mcp");
       expect(state?.authorizeScopes).toEqual(["documents:read"]);
       expect(typeof state?.encryptedPkceVerifier).toBe("string");
       const verifier = decryptEnvironmentValue(rawKey, state!.encryptedPkceVerifier as string);
@@ -474,7 +477,7 @@ describe("connections routes", () => {
       expect(location).toContain("providerDomain=mcp.example.com");
 
       expect(as.tokenRequests).toHaveLength(1);
-      expect(as.tokenRequests[0]!.get("resource")).toBe(mcp.url);
+      expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
       expect(as.tokenRequests[0]!.get("redirect_uri")).toBe("https://api.opengeni.test/v1/integrations/oauth/callback");
       expect(as.tokenRequests[0]!.get("code_verifier")).toBe(verifier);
       expect(as.tokenRequests[0]!.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
@@ -487,12 +490,68 @@ describe("connections routes", () => {
       expect(loaded?.credential).toMatchObject({
         access_token: "mcp-access-token",
         refresh_token: "mcp-refresh-token",
-        resource: mcp.url,
+        resource: "urn:test:mcp",
+        mcp_url: mcp.url,
         token_endpoint: `${as.url}/token`,
         client_id: "https://api.opengeni.test/v1/integrations/oauth/client-metadata.json",
       });
       expect(loaded?.metadata.authorizationServerIssuer).toBe(as.url);
+      expect(loaded?.metadata.resource).toBe("urn:test:mcp");
+      expect(loaded?.metadata.mcpUrl).toBe(mcp.url);
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({ status: "ok" });
       expect(loaded?.metadata.mcpTools).toEqual(expect.arrayContaining([expect.objectContaining({ name: "search_documents" })]));
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth uses protected-resource metadata resource as token audience while connecting to the MCP endpoint", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      clientIdMetadataDocumentSupported: true,
+      tokenAccessToken: (body) => `token-for-${body.get("resource")}`,
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer token-for-urn:test:mcp",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource"`,
+    });
+    try {
+      const response = await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providerDomain: "linear.app",
+          mcpUrl: mcp.url,
+          returnPath: "/integrations?connect_item=linear",
+        }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { state: string; authorizationUrl: string };
+      expect(new URL(body.authorizationUrl).searchParams.get("resource")).toBe("urn:test:mcp");
+
+      const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(callback.headers.get("location")).not.toContain("verification=failed");
+      expect(as.tokenRequests).toHaveLength(1);
+      expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
+
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "linear.app",
+        kind: "oauth2",
+      });
+      expect(loaded?.credential).toMatchObject({
+        access_token: "token-for-urn:test:mcp",
+        resource: "urn:test:mcp",
+        mcp_url: mcp.url,
+      });
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({ status: "ok" });
     } finally {
       mcp.close();
       as.close();
@@ -696,7 +755,7 @@ describe("connections routes", () => {
     }
   });
 
-  test("oauth callback verifies MCP tools through guarded fetch redirects", async () => {
+  test("oauth callback records non-fatal tools/list verification failure after guarded fetch redirects", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const originalFetch = globalThis.fetch;
@@ -750,9 +809,20 @@ describe("connections routes", () => {
       const response = await publicApp(client.db, { environment: "production" })
         .request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(state)}`);
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toContain("reason=tools_list_failed");
+      expect(response.headers.get("location")).toContain("integration_oauth=success");
+      expect(response.headers.get("location")).toContain("verification=failed");
       expect(hits).toEqual(["https://1.1.1.1/token", "https://1.1.1.1/mcp"]);
       expect(privateHopHits).toBe(0);
+      const loaded = await loadConnectionCredentialForBroker(client.db, settings, {
+        workspaceId: workspace.workspaceId,
+        providerDomain: "verify-redirect.example.com",
+        kind: "oauth2",
+      });
+      expect(loaded?.credential).toMatchObject({ access_token: "mcp-access-token" });
+      expect(loaded?.metadata.mcpToolsVerification).toMatchObject({
+        status: "failed",
+        reason: "tools_list_failed",
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/docs/integrations-design.md
+++ b/docs/integrations-design.md
@@ -104,7 +104,8 @@ DISCOVER   probe server URL unauthenticated
            → REQUIRE code_challenge_methods_supported ∋ S256, else abort with clear error
 REGISTER   priority: (1) operator pre-registered creds for this AS
            (2) CIMD if client_id_metadata_document_supported — client_id is our hosted
-               metadata URL (§5.3)
+               metadata URL (§5.3), unless this AS is in the DCR-compatibility
+               override set
            (3) DCR (RFC 7591) if registration_endpoint — minted client_id stored per AS
            (4) manual client-credential entry in UI
 AUTHORIZE  authorize URL: PKCE S256, state = signed payload (§5.2),
@@ -130,6 +131,8 @@ The callback route must NOT call `requireAccessGrant` — a browser redirect car
 ### 5.2.1 Authorization-server clients
 
 DCR-minted OAuth clients are deployment-wide authorization-server identity, not per-workspace user credentials. They live in `integration_oauth_clients`, keyed by AS issuer, with `client_secret` encrypted under the environments key when present. This keeps one DCR client reusable across many workspace connections to the same AS, while the actual access/refresh tokens remain in workspace-scoped `connections.credential_encrypted`. Operator pre-registered clients are read from `OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON` and are not copied into Postgres.
+
+Some authorization servers advertise both CIMD and DCR but only issue MCP-accepted tokens to DCR clients. Linear's MCP server (`https://mcp.linear.app`) is in this compatibility set: operator credentials still win when configured, otherwise OpenGeni dynamically registers and reuses a DCR client even though Linear's metadata also says `client_id_metadata_document_supported=true`.
 
 ### 5.3 Our client identity (CIMD)
 

--- a/packages/core/src/domain/capabilities.ts
+++ b/packages/core/src/domain/capabilities.ts
@@ -436,7 +436,7 @@ export async function validateMcpCapabilityConnection(
     };
   } catch (error) {
     throw new HTTPException(422, {
-      message: `MCP capability "${item.name}" could not be enabled because OpenGeni could not initialize ${item.endpointUrl}: ${mcpProbeErrorMessage(error)}`,
+      message: `MCP capability "${item.name}" could not be enabled because ${mcpProbeErrorMessage(error, item.endpointUrl)}`,
     });
   }
 }
@@ -461,9 +461,16 @@ async function probeStreamableHttpMcpServer(input: McpCapabilityProbeInput): Pro
   }
 }
 
-function mcpProbeErrorMessage(error: unknown): string {
+function mcpProbeErrorMessage(error: unknown, endpointUrl: string): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\s+/g, " ").trim().slice(0, 500) || "unknown error";
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (
+    /404|405|not found|unexpected token|not valid json|invalid json|failed to parse|streamable http error|unable to connect|fetch failed|econnrefused|enotfound|timeout|aborted/i
+      .test(normalized)
+  ) {
+    return `OpenGeni could not reach a valid Streamable HTTP MCP server at ${endpointUrl}. Check the endpoint URL or choose a different catalog entry.`;
+  }
+  return `OpenGeni could not initialize ${endpointUrl}: ${normalized.slice(0, 500) || "unknown error"}`;
 }
 
 export async function disableCapability(input: {


### PR DESCRIPTION
## Summary

Fixes Linear MCP OAuth connections by preferring Dynamic Client Registration for Linear's MCP authorization server (`https://mcp.linear.app`) even though its metadata also advertises Client ID Metadata Documents.

## Root cause

Linear's MCP endpoint rejects the access token minted to OpenGeni's CIMD client (`client_id=https://app.opengeni.ai/v1/integrations/oauth/client-metadata.json`) with `401 invalid_token`. The token was loaded through the exact broker path and sent directly to `https://mcp.linear.app/mcp`, so this is not a verify-vs-runtime discrepancy.

Current live Linear metadata advertises both:

- `client_id_metadata_document_supported: true`
- `registration_endpoint: https://mcp.linear.app/register`

OpenGeni followed the MCP 2025-11-25 default priority and chose CIMD before DCR. Linear's own MCP docs, however, describe the Streamable HTTP endpoint as using OAuth 2.1 with Dynamic Client Registration. That means Linear is a provider-compatibility exception: it advertises CIMD, but tokens accepted by its MCP resource must be issued to a dynamically registered client.

## Changes

- Add a narrow DCR-preferred authorization-server compatibility set containing `https://mcp.linear.app`.
- Keep operator pre-registered clients as the first priority.
- Reuse stored DCR clients per issuer, or dynamically register and persist one if absent.
- Add a regression test for Linear-shaped metadata: CIMD supported, DCR endpoint present, Linear issuer. The test proves the authorize URL, signed state, and token request use the DCR client id rather than OpenGeni's metadata-document URL.
- Update `docs/integrations-design.md` to document the compatibility override.

## Verification

- `bun test apps/api/test/connections-routes.test.ts`
- `bun run typecheck`

## Rollout note

Existing Linear connections minted via CIMD will still hold rejected tokens. Users need to reconnect/re-consent once after deploy so OpenGeni obtains a new token through the Linear DCR client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client registration, token audience, and callback persistence paths; mis-handling resource vs mcpUrl or DCR selection could break third-party MCP connects, though behavior is covered by expanded integration tests.
> 
> **Overview**
> Fixes **Linear MCP OAuth** by preferring **dynamic client registration** for `https://mcp.linear.app` even when metadata advertises CIMD, so tokens are minted to a DCR client the MCP endpoint accepts. Operator-configured clients still win; existing Linear CIMD connections need a reconnect after deploy.
> 
> **OAuth resource vs MCP URL:** Discovery and post-callback **tools/list** use the canonical **MCP endpoint** (`mcpUrl` in signed state and stored credentials as `mcp_url`). **Authorize and token** requests use the **protected-resource metadata `resource`** (RFC 8707 audience, including non-URL values like `urn:test:mcp`) when PRM provides it.
> 
> **Callback behavior:** **tools/list** verification after token exchange is **non-fatal**—failed probes log a warning, persist `mcpToolsVerification` on the connection, and can add `verification=failed` on an otherwise successful redirect instead of failing the whole callback.
> 
> **UX:** MCP capability enable probes surface clearer copy when the catalog URL is not a valid Streamable HTTP MCP server (e.g. 404). Design doc updated for the Linear DCR override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb118d4487e394ca6cbae1f6d434dde309232056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->