### PR TITLE
Fix Linear MCP OAuth token binding

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -12,7 +12,9 @@ import {
   encryptEnvironmentValue,
   getConnectionMetadata,
   isPrivateAddress,
+  listConnectionsMetadata,
   loadIntegrationOAuthClient,
+  replaceIntegrationOAuthClient,
   storeIntegrationOAuthClient,
   updateConnection,
   type Database,
@@ -27,8 +29,12 @@ import { canonicalProviderDomain } from "./provider-domain";
 
 export const oauthStateTtlMs = 10 * 60 * 1000;
 const dcrPreferredAuthorizationServers = new Set([
-  // Linear advertises CIMD, but its MCP docs and runtime behavior require
-  // dynamic client registration for tokens accepted by https://mcp.linear.app/mcp.
+  "https://mcp.linear.app",
+]);
+const confidentialDcrAuthorizationServers = new Set([
+  // Linear's token endpoint will issue opaque tokens to public DCR clients, but
+  // the MCP resource rejects those tokens. Register a confidential DCR client,
+  // matching known-working MCP SDK clients that request a client_secret method.
   "https://mcp.linear.app",
 ]);
 
@@ -70,6 +76,7 @@ type AuthorizationServerMetadata = {
   tokenEndpoint: string;
   registrationEndpoint?: string;
   clientIdMetadataDocumentSupported: boolean;
+  tokenEndpointAuthMethodsSupported: string[];
   codeChallengeMethodsSupported: string[];
   raw: Record<string, unknown>;
 };
@@ -139,18 +146,21 @@ export async function startMcpOAuth(
   const baseUrl = integrationBaseUrl(settings.publicBaseUrl, context.requestUrl);
   const redirectUri = `${baseUrl}/v1/integrations/oauth/callback`;
   const metadataUrl = `${baseUrl}/v1/integrations/oauth/client-metadata.json`;
-  const existing = context.payload.connectionId
-    ? await getConnectionMetadata(db, context.workspaceId, context.payload.connectionId, context.subjectId)
-    : null;
+  const existing = await existingOAuthConnectionForStart(db, {
+    workspaceId: context.workspaceId,
+    subjectId: context.subjectId,
+    providerDomain,
+    connectionId: context.payload.connectionId,
+  });
   if (context.payload.connectionId && !existing) {
     throw new HTTPException(404, { message: "connection not found" });
   }
 
   const discovery = await discoverMcpOAuth(mcpUrl, settings);
   const resource = discovery.prm.resource ? canonicalOAuthResource(discovery.prm.resource) : mcpUrl;
-  const client = await registerOAuthClient(db, settings, discovery.as, metadataUrl, redirectUri);
   const verifier = randomPkceVerifier();
   const authorizeScopes = chooseAuthorizeScopes(context.payload.requestedScopes, discovery.challenge.scope, discovery.prm.scopesSupported);
+  const client = await registerOAuthClient(db, settings, discovery.as, metadataUrl, redirectUri, authorizeScopes);
   const key = requireEnvironmentEncryption(settings);
   const state = createSignedState(requireIntegrationsStateSecret(settings), {
     accountId: context.accountId,
@@ -400,6 +410,7 @@ async function discoverAuthorizationServerMetadata(authorizationServer: string, 
       authorizationEndpoint,
       tokenEndpoint,
       clientIdMetadataDocumentSupported: payload.client_id_metadata_document_supported === true,
+      tokenEndpointAuthMethodsSupported: stringArray(payload.token_endpoint_auth_methods_supported),
       codeChallengeMethodsSupported: stringArray(payload.code_challenge_methods_supported),
       raw: payload,
       ...(stringValue(payload.registration_endpoint) ? { registrationEndpoint: stringValue(payload.registration_endpoint)! } : {}),
@@ -414,13 +425,14 @@ async function registerOAuthClient(
   as: AuthorizationServerMetadata,
   metadataUrl: string,
   redirectUri: string,
+  scopes: string[],
 ): Promise<OAuthClientRegistration> {
   const operator = operatorClientForAs(settings, as);
   if (operator) {
     return operator;
   }
   if (prefersDynamicClientRegistration(as)) {
-    return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri);
+    return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
   }
   if (as.clientIdMetadataDocumentSupported) {
     return {
@@ -431,7 +443,7 @@ async function registerOAuthClient(
       tokenEndpointAuthMethod: "none",
     };
   }
-  return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri);
+  return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
 }
 
 async function getOrCreateDynamicClientRegistration(
@@ -439,9 +451,11 @@ async function getOrCreateDynamicClientRegistration(
   settings: Settings,
   as: AuthorizationServerMetadata,
   redirectUri: string,
+  scopes: string[],
 ): Promise<OAuthClientRegistration> {
+  const requiredAuthMethod = requiredDcrTokenEndpointAuthMethod(as);
   const storedClient = await loadIntegrationOAuthClient(db, settings, as.issuer);
-  if (storedClient) {
+  if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, requiredAuthMethod, scopes)) {
     return {
       method: "dcr",
       issuer: storedClient.issuer,
@@ -456,19 +470,19 @@ async function getOrCreateDynamicClientRegistration(
       message: "manual OAuth client credentials are required for this authorization server",
     });
   }
-  const dcr = await dynamicClientRegistration(settings, as, redirectUri);
+  const dcr = await dynamicClientRegistration(settings, as, redirectUri, scopes, requiredAuthMethod);
   const key = dcr.clientSecret ? requireEnvironmentEncryption(settings) : null;
-  const storedWinner = await storeIntegrationOAuthClient(db, {
+  const storeInput = {
     issuer: as.issuer,
     authorizationServer: as.authorizationServer,
     clientId: dcr.clientId,
     clientSecretEncrypted: dcr.clientSecret && key ? encryptEnvironmentValue(key, dcr.clientSecret) : null,
     tokenEndpointAuthMethod: dcr.tokenEndpointAuthMethod,
-    metadata: {
-      registrationEndpoint: as.registrationEndpoint,
-      registeredAt: new Date().toISOString(),
-    },
-  });
+    metadata: registrationMetadata(as, scopes),
+  };
+  const storedWinner = requiredAuthMethod
+    ? await replaceIntegrationOAuthClient(db, storeInput)
+    : await storeIntegrationOAuthClient(db, storeInput);
   if (storedWinner.clientId !== dcr.clientId) {
     const winner = await loadIntegrationOAuthClient(db, settings, as.issuer);
     if (!winner) {
@@ -481,6 +495,50 @@ async function getOrCreateDynamicClientRegistration(
 
 function prefersDynamicClientRegistration(as: AuthorizationServerMetadata): boolean {
   return [as.issuer, as.authorizationServer].some((candidate) => dcrPreferredAuthorizationServers.has(normalizedIssuerKey(candidate)));
+}
+
+function requiresConfidentialDynamicClient(as: AuthorizationServerMetadata): boolean {
+  return [as.issuer, as.authorizationServer].some((candidate) => confidentialDcrAuthorizationServers.has(normalizedIssuerKey(candidate)));
+}
+
+function requiredDcrTokenEndpointAuthMethod(as: AuthorizationServerMetadata): OAuthClientRegistration["tokenEndpointAuthMethod"] | null {
+  if (!requiresConfidentialDynamicClient(as)) {
+    return null;
+  }
+  if (as.tokenEndpointAuthMethodsSupported.includes("client_secret_basic")) {
+    return "client_secret_basic";
+  }
+  if (as.tokenEndpointAuthMethodsSupported.includes("client_secret_post")) {
+    return "client_secret_post";
+  }
+  throw new HTTPException(422, { message: "authorization server requires confidential DCR but does not advertise a supported client secret auth method" });
+}
+
+function storedDcrClientSatisfiesPolicy(
+  stored: { clientSecret: string | null; tokenEndpointAuthMethod: string; metadata: Record<string, unknown> },
+  requiredAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"] | null,
+  scopes: string[],
+): boolean {
+  if (!registeredScopesMatch(stored.metadata, scopes)) {
+    return false;
+  }
+  return requiredAuthMethod ? Boolean(stored.clientSecret) && stored.tokenEndpointAuthMethod === requiredAuthMethod : true;
+}
+
+function registeredScopesMatch(metadata: Record<string, unknown>, scopes: string[]): boolean {
+  return stableScopeKey(stringArray(metadata.registeredScopes)) === stableScopeKey(scopes);
+}
+
+function stableScopeKey(scopes: string[]): string {
+  return uniqueStrings(scopes).sort().join(" ");
+}
+
+function registrationMetadata(as: AuthorizationServerMetadata, scopes: string[]): Record<string, unknown> {
+  return {
+    registrationEndpoint: as.registrationEndpoint,
+    registeredAt: new Date().toISOString(),
+    registeredScopes: uniqueStrings(scopes),
+  };
 }
 
 function dcrRegistrationFromStored(stored: {
@@ -544,6 +602,8 @@ async function dynamicClientRegistration(
   settings: Settings,
   as: AuthorizationServerMetadata,
   redirectUri: string,
+  scopes: string[],
+  tokenEndpointAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"] | null,
 ): Promise<OAuthClientRegistration> {
   if (!as.registrationEndpoint) {
     throw new HTTPException(422, { message: "authorization server does not support dynamic client registration" });
@@ -555,9 +615,10 @@ async function dynamicClientRegistration(
     body: JSON.stringify({
       client_name: "OpenGeni",
       redirect_uris: [redirectUri],
-      token_endpoint_auth_method: "none",
+      token_endpoint_auth_method: tokenEndpointAuthMethod ?? "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
+      ...(scopes.length ? { scope: scopes.join(" ") } : {}),
     }),
   });
   if (!response.ok) {
@@ -577,6 +638,27 @@ async function dynamicClientRegistration(
     ...(clientSecret ? { clientSecret } : {}),
     tokenEndpointAuthMethod: tokenAuthMethod(stringValue(payload.token_endpoint_auth_method), Boolean(clientSecret)),
   };
+}
+
+async function existingOAuthConnectionForStart(
+  db: Database,
+  input: {
+    workspaceId: string;
+    subjectId: string;
+    providerDomain: string;
+    connectionId?: string | undefined;
+  },
+) {
+  if (input.connectionId) {
+    return await getConnectionMetadata(db, input.workspaceId, input.connectionId, input.subjectId);
+  }
+  const visible = await listConnectionsMetadata(db, input.workspaceId, input.subjectId);
+  return visible.find((connection) =>
+    connection.subjectId === null &&
+    connection.kind === "oauth2" &&
+    connection.status === "active" &&
+    connection.providerDomain === input.providerDomain
+  ) ?? null;
 }
 
 function buildAuthorizationUrl(input: {
@@ -698,12 +780,14 @@ async function exchangeAuthorizationCode(
   body.set("redirect_uri", input.redirectUri);
   body.set("code_verifier", input.verifier);
   body.set("resource", input.resource);
-  body.set("client_id", input.client.clientId);
   const headers: Record<string, string> = { "content-type": "application/x-www-form-urlencoded", accept: "application/json" };
   if (input.client.clientSecret && input.client.tokenEndpointAuthMethod === "client_secret_post") {
+    body.set("client_id", input.client.clientId);
     body.set("client_secret", input.client.clientSecret);
   } else if (input.client.clientSecret && input.client.tokenEndpointAuthMethod === "client_secret_basic") {
     headers.authorization = `Basic ${Buffer.from(`${input.client.clientId}:${input.client.clientSecret}`).toString("base64")}`;
+  } else {
+    body.set("client_id", input.client.clientId);
   }
   const response = await fetchOAuth(input.tokenEndpoint, settings, { method: "POST", headers, body });
   if (!response.ok) {

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
 import { randomBytes } from "node:crypto";
 import type { Settings } from "@opengeni/config";
 import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
@@ -8,6 +9,8 @@ import {
   encryptEnvironmentValue,
   getConnectionMetadata,
   loadConnectionCredentialForBroker,
+  loadIntegrationOAuthClient,
+  replaceIntegrationOAuthClient,
   type DbClient,
 } from "@opengeni/db";
 import { createSignedState, readSignedState } from "@opengeni/github";
@@ -145,6 +148,7 @@ function requestHeaderValue(headers: HeadersInit | undefined, name: string): str
 type FakeAuthorizationServer = {
   url: string;
   tokenRequests: URLSearchParams[];
+  tokenRequestAuthHeaders: Array<string | null>;
   registrations: Record<string, unknown>[];
   close: () => void;
 };
@@ -152,6 +156,7 @@ type FakeAuthorizationServer = {
 function startFakeAuthorizationServer(options: {
   scopesSupported?: string[];
   codeChallengeMethods?: string[];
+  tokenEndpointAuthMethodsSupported?: string[];
   clientIdMetadataDocumentSupported?: boolean;
   issuer?: string;
   dcr?: boolean;
@@ -160,6 +165,7 @@ function startFakeAuthorizationServer(options: {
   tokenError?: string;
 } = {}): FakeAuthorizationServer {
   const tokenRequests: URLSearchParams[] = [];
+  const tokenRequestAuthHeaders: Array<string | null> = [];
   const registrations: Record<string, unknown>[] = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -180,20 +186,25 @@ function startFakeAuthorizationServer(options: {
           authorization_endpoint: `${origin}/authorize`,
           token_endpoint: `${origin}/token`,
           code_challenge_methods_supported: options.codeChallengeMethods ?? ["S256"],
+          token_endpoint_auth_methods_supported: options.tokenEndpointAuthMethodsSupported ?? ["none"],
           client_id_metadata_document_supported: options.clientIdMetadataDocumentSupported ?? true,
           ...(options.dcr ? { registration_endpoint: `${origin}/register` } : {}),
         });
       }
       if (url.pathname === "/register") {
-        registrations.push(await request.json() as Record<string, unknown>);
+        const registration = await request.json() as Record<string, unknown>;
+        registrations.push(registration);
+        const authMethod = typeof registration.token_endpoint_auth_method === "string" ? registration.token_endpoint_auth_method : "none";
         return Response.json({
           client_id: `${origin}/registered-client/${registrations.length}`,
-          token_endpoint_auth_method: "none",
+          ...(authMethod === "client_secret_basic" || authMethod === "client_secret_post" ? { client_secret: `secret-${registrations.length}` } : {}),
+          token_endpoint_auth_method: authMethod,
         }, { status: 201 });
       }
       if (url.pathname === "/token") {
         const body = new URLSearchParams(await request.text());
         tokenRequests.push(body);
+        tokenRequestAuthHeaders.push(request.headers.get("authorization"));
         if (options.tokenStatus && options.tokenStatus >= 400) {
           return Response.json({
             error: options.tokenError ?? "invalid_client",
@@ -216,6 +227,7 @@ function startFakeAuthorizationServer(options: {
   return {
     url: `http://127.0.0.1:${server.port}`,
     tokenRequests,
+    tokenRequestAuthHeaders,
     registrations,
     close: () => server.stop(true),
   };
@@ -700,6 +712,7 @@ describe("connections routes", () => {
         client_name: "OpenGeni",
         redirect_uris: ["https://api.opengeni.test/v1/integrations/oauth/callback"],
         token_endpoint_auth_method: "none",
+        scope: "documents:read",
       });
       const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
       expect(callback.status).toBe(302);
@@ -718,6 +731,7 @@ describe("connections routes", () => {
       clientIdMetadataDocumentSupported: true,
       dcr: true,
       scopesSupported: ["read", "write"],
+      tokenEndpointAuthMethodsSupported: ["client_secret_basic", "client_secret_post", "none"],
     });
     const mcp = startTestMcpServer({
       requiredAuthorization: "Bearer mcp-access-token",
@@ -743,7 +757,8 @@ describe("connections routes", () => {
       expect(as.registrations[0]).toMatchObject({
         client_name: "OpenGeni",
         redirect_uris: ["https://api.opengeni.test/v1/integrations/oauth/callback"],
-        token_endpoint_auth_method: "none",
+        token_endpoint_auth_method: "client_secret_basic",
+        scope: "read write",
       });
 
       const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
@@ -754,8 +769,65 @@ describe("connections routes", () => {
       expect(callback.status).toBe(302);
       expect(callback.headers.get("location")).toContain("integration_oauth=success");
       expect(as.tokenRequests).toHaveLength(1);
-      expect(as.tokenRequests[0]!.get("client_id")).toBe(`${as.url}/registered-client/1`);
+      expect(as.tokenRequests[0]!.has("client_id")).toBe(false);
+      expect(as.tokenRequests[0]!.has("client_secret")).toBe(false);
+      expect(as.tokenRequestAuthHeaders[0]).toBe(`Basic ${Buffer.from(`${as.url}/registered-client/1:secret-1`).toString("base64")}`);
       expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
+
+      const loadedClient = await loadIntegrationOAuthClient(client.db, settings, "https://mcp.linear.app");
+      expect(loadedClient).toMatchObject({
+        clientId: `${as.url}/registered-client/1`,
+        clientSecret: "secret-1",
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+      expect(loadedClient?.metadata.registeredScopes).toEqual(["read", "write"]);
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth start replaces a stored Linear DCR client missing required auth method or scopes", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    await replaceIntegrationOAuthClient(client.db, {
+      issuer: "https://mcp.linear.app",
+      authorizationServer: "https://mcp.linear.app",
+      clientId: "public-linear-client",
+      tokenEndpointAuthMethod: "none",
+      metadata: { registrationEndpoint: "https://mcp.linear.app/register", registeredAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const as = startFakeAuthorizationServer({
+      issuer: "https://mcp.linear.app",
+      clientIdMetadataDocumentSupported: true,
+      dcr: true,
+      scopesSupported: ["read", "write"],
+      tokenEndpointAuthMethodsSupported: ["client_secret_basic", "client_secret_post", "none"],
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource", scope="read write"`,
+    });
+    try {
+      const response = await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ providerDomain: "linear.app", mcpUrl: mcp.url, returnPath: "/integrations?connect_item=linear" }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { authorizationUrl: string };
+      expect(new URL(body.authorizationUrl).searchParams.get("client_id")).toBe(`${as.url}/registered-client/1`);
+
+      const loadedClient = await loadIntegrationOAuthClient(client.db, settings, "https://mcp.linear.app");
+      expect(loadedClient).toMatchObject({
+        clientId: `${as.url}/registered-client/1`,
+        clientSecret: "secret-1",
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+      expect(loadedClient?.metadata.registeredScopes).toEqual(["read", "write"]);
     } finally {
       mcp.close();
       as.close();

--- a/docs/integrations-design.md
+++ b/docs/integrations-design.md
@@ -107,6 +107,7 @@ REGISTER   priority: (1) operator pre-registered creds for this AS
                metadata URL (§5.3), unless this AS is in the DCR-compatibility
                override set
            (3) DCR (RFC 7591) if registration_endpoint — minted client_id stored per AS
+               and registered with the same resolved scope used for authorization
            (4) manual client-credential entry in UI
 AUTHORIZE  authorize URL: PKCE S256, state = signed payload (§5.2),
            resource = canonical MCP server URI (RFC 8707, ALWAYS sent),
@@ -132,7 +133,7 @@ The callback route must NOT call `requireAccessGrant` — a browser redirect car
 
 DCR-minted OAuth clients are deployment-wide authorization-server identity, not per-workspace user credentials. They live in `integration_oauth_clients`, keyed by AS issuer, with `client_secret` encrypted under the environments key when present. This keeps one DCR client reusable across many workspace connections to the same AS, while the actual access/refresh tokens remain in workspace-scoped `connections.credential_encrypted`. Operator pre-registered clients are read from `OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON` and are not copied into Postgres.
 
-Some authorization servers advertise both CIMD and DCR but only issue MCP-accepted tokens to DCR clients. Linear's MCP server (`https://mcp.linear.app`) is in this compatibility set: operator credentials still win when configured, otherwise OpenGeni dynamically registers and reuses a DCR client even though Linear's metadata also says `client_id_metadata_document_supported=true`.
+Some authorization servers advertise both CIMD and DCR but only issue MCP-accepted tokens to DCR clients. Linear's MCP server (`https://mcp.linear.app`) is in this compatibility set: operator credentials still win when configured, otherwise OpenGeni dynamically registers and reuses a confidential DCR client with Linear's resolved `read write` MCP scope even though Linear's metadata also says `client_id_metadata_document_supported=true`. Stale Linear DCR clients registered before that policy are replaced on the next connect attempt.
 
 ### 5.3 Our client identity (CIMD)
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1281,6 +1281,8 @@ export type StoreIntegrationOAuthClientInput = {
   metadata?: Record<string, unknown>;
 };
 
+export type ReplaceIntegrationOAuthClientInput = StoreIntegrationOAuthClientInput;
+
 export type ConsumeOAuthStateNonceInput = {
   accountId: string;
   workspaceId: string;
@@ -2419,6 +2421,34 @@ export async function storeIntegrationOAuthClient(
     throw new Error(`OAuth client registration conflict winner not found for issuer ${input.issuer}`);
   }
   return mapStoredIntegrationOAuthClient(winner);
+}
+
+export async function replaceIntegrationOAuthClient(
+  db: Database,
+  input: ReplaceIntegrationOAuthClientInput,
+): Promise<StoredIntegrationOAuthClient> {
+  const [row] = await db.insert(schema.integrationOauthClients).values({
+    issuer: input.issuer,
+    authorizationServer: input.authorizationServer,
+    clientId: input.clientId,
+    clientSecretEncrypted: input.clientSecretEncrypted ?? null,
+    tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? "none",
+    metadata: input.metadata ?? {},
+  }).onConflictDoUpdate({
+    target: schema.integrationOauthClients.issuer,
+    set: {
+      authorizationServer: input.authorizationServer,
+      clientId: input.clientId,
+      clientSecretEncrypted: input.clientSecretEncrypted ?? null,
+      tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? "none",
+      metadata: input.metadata ?? {},
+      updatedAt: new Date(),
+    },
+  }).returning();
+  if (!row) {
+    throw new Error(`OAuth client registration replacement failed for issuer ${input.issuer}`);
+  }
+  return mapStoredIntegrationOAuthClient(row);
 }
 
 function mapStoredIntegrationOAuthClient(row: typeof schema.integrationOauthClients.$inferSelect): StoredIntegrationOAuthClient {


### PR DESCRIPTION
## Summary

Fixes the Linear MCP OAuth flow after #297 proved that DCR-vs-CIMD alone was not sufficient.

## Root cause evidence

The new deployed DCR connection still produced an opaque Linear access token that Linear's MCP resource rejected with `401 invalid_token`, so the failure was not simply CIMD vs DCR.

The actual request delta is in how the DCR client is registered and later authenticated:

- Linear's docs say `https://mcp.linear.app/mcp` uses OAuth 2.1 with dynamic client registration.
- Linear's live metadata advertises token endpoint auth methods `client_secret_basic`, `client_secret_post`, and `none`.
- Probing `https://mcp.linear.app/register` shows Linear honors the requested client auth method:
  - when registered with `token_endpoint_auth_method: none`, Linear returns no `client_secret`;
  - when registered with `client_secret_basic` or `client_secret_post`, Linear returns a `client_secret` and echoes the method.
- The official MCP TypeScript SDK registers DCR clients with the resolved MCP scope, and uses the registered client auth method for token exchange. For `client_secret_basic`, it sends HTTP Basic auth and does not duplicate `client_id` in the token body.
- OpenGeni's previous Linear DCR path registered a public client (`none`), did not include the resolved MCP scope in the DCR registration, and reused that deployment-wide client registration.

That combination can mint an opaque token from Linear's token endpoint, but the MCP resource rejects it. This PR makes OpenGeni match the working MCP client shape: Linear gets a confidential DCR client registered with the resolved `read write` MCP scope, and the token exchange authenticates exactly with the registered method.

## Changes

- Keep Linear in the DCR-preferred compatibility set.
- Add Linear to a confidential-DCR policy:
  - choose `client_secret_basic` when advertised, else `client_secret_post`;
  - request that method at DCR registration;
  - persist the returned client secret and auth method.
- Include the resolved OAuth scope in the DCR registration body and persist `registeredScopes` in registration metadata.
- Replace stale Linear DCR registrations on next connect if they lack the required confidential auth method or the registered scope metadata.
- Make token exchange match MCP SDK behavior:
  - `client_secret_basic`: HTTP Basic only, no body `client_id`/`client_secret`;
  - `client_secret_post`: body `client_id` + `client_secret`;
  - public client: body `client_id`.
- Fix duplicate connections: OAuth start without `connectionId` now reuses the active shared workspace OAuth connection for the provider instead of creating a second active row.

## Verification

- `bun test apps/api/test/connections-routes.test.ts`
- `bun run typecheck`

## Rollout / validation

Existing Linear tokens and the old deployment-wide DCR client are not salvageable. After deploy, the user must reconnect Linear once. On that connect, OpenGeni will replace the stale Linear DCR registration, obtain a new token through the confidential scoped DCR client, and update the existing active `linear.app` connection rather than minting a duplicate.

Validation step after deploy: reconnect Linear, then load that same connection through `loadConnectionCredentialForBroker` and POST MCP `initialize` to `https://mcp.linear.app/mcp` with `Authorization: Bearer <new token>`, `accept: application/json, text/event-stream`, and `mcp-protocol-version: 2025-06-18`. Expected result: not `401 invalid_token`; then tool listing should succeed through the normal MCP client path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth client registration, token exchange, and connection deduplication for integrations—security-sensitive but scoped with tests and Linear-specific policy.
> 
> **Overview**
> Fixes **Linear MCP OAuth** so tokens are accepted by the resource: Linear now gets a **confidential DCR client** (`client_secret_basic` when advertised) registered with the **same resolved authorize scopes** as the browser flow, and token exchange follows MCP SDK rules (Basic auth for `client_secret_basic`, no duplicate `client_id` in the body).
> 
> **DCR policy:** Stored deployment-wide clients are reused only when they match required auth method and `registeredScopes` metadata; otherwise Linear triggers **`replaceIntegrationOAuthClient`** (upsert by issuer) instead of keeping stale public registrations. Generic DCR still includes scope in the registration body and persists `registeredScopes`.
> 
> **OAuth start:** Without `connectionId`, start **reuses** the active workspace-shared `oauth2` connection for the provider domain so reconnect does not create duplicate rows.
> 
> Docs and API tests cover Linear confidential registration, token auth headers, and stale client replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645c82df64578ce6df3f4694875b5b2515d573e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->