### PR TITLE
Inline reconnect card for lapsed connections

### DIFF
--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -33,6 +33,7 @@ import {
   createInputFromCatalogItem,
   filterCapabilityCatalogItems,
   isMissingCredentialsError,
+  normalizeProviderDomain,
   oauthResumeAction,
   registryResultsForQuery,
   resolveSheetItem,
@@ -348,6 +349,31 @@ export function CapabilitiesRoute({ workspaceId, initialSection }: { workspaceId
       } else {
         toast.error("Connection failed", { description: reason ?? undefined });
       }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, items]);
+
+  // Deep-link from an in-session reconnect card for an api-key connection:
+  // ?reconnect_domain=<domain> opens the connect sheet for the enabled item on
+  // that provider so the credential can be re-entered. Runs after the catalog
+  // loads (it resolves the item by connectionRef domain); a miss just seeds the
+  // search so the user can find it. Stripped from the URL after one read.
+  const reconnectHandled = useRef(false);
+  useEffect(() => {
+    if (reconnectHandled.current || loading) return;
+    const params = new URLSearchParams(window.location.search);
+    const domain = params.get("reconnect_domain");
+    if (!domain) return;
+    reconnectHandled.current = true;
+    window.history.replaceState(null, "", window.location.pathname);
+    const target = normalizeProviderDomain(domain);
+    const item = items.find(
+      (candidate) => candidate.enabled && candidate.connectionRef && normalizeProviderDomain(candidate.connectionRef.providerDomain) === target,
+    );
+    if (item) {
+      setSelected({ id: item.id, registry: false, snapshotFallback: false, snapshot: item });
+    } else {
+      setQuery(domain);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, items]);

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -13,13 +13,14 @@ import {
   useSessionEvents,
   useTurnQueue,
   type AgentMessageItem,
+  type AuthNeededItem,
   type PendingApproval,
   type TimelineItem,
   type UserMessageItem,
 } from "@opengeni/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { CheckIcon, Loader2Icon, MessagesSquareIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { isApiErrorStatus } from "@/api";
@@ -49,7 +50,7 @@ import { useAppContext } from "@/context";
 import { useCodexModels } from "@/lib/use-codex-models";
 import { isTerminalSessionStatus, projectSessionTimeline, summarizeSessionFailure } from "@/lib/events";
 import { buildTools } from "@/lib/session-tools";
-import type { Session, SessionEvent } from "@/types";
+import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
 
 export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; sessionId: string }) {
   const context = useAppContext();
@@ -141,6 +142,55 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     }
   }, [loadError]);
 
+  // A reconnect OAuth round-trip lands back here (the reconnect card set
+  // returnPath to this session). The connection is refreshed server-side, so we
+  // just acknowledge it and strip the params — the user retries their message.
+  const oauthReturnHandled = useRef(false);
+  useEffect(() => {
+    if (oauthReturnHandled.current) {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const outcome = params.get("integration_oauth");
+    if (!outcome) {
+      return;
+    }
+    oauthReturnHandled.current = true;
+    window.history.replaceState(null, "", window.location.pathname);
+    if (outcome === "success") {
+      toast.success("Reconnected", { description: "Send your message again to continue." });
+    } else {
+      toast.error("Reconnect failed", { description: params.get("reason") ?? undefined });
+    }
+  }, []);
+
+  // Start the recovery flow for a lapsed connection surfaced inline in the
+  // timeline. OAuth connections reconnect in place (reuse the connectionId) and
+  // return to this session; api-key ones can't OAuth, so hand off to credential
+  // re-entry on the capabilities sheet for that provider. Throwing bubbles a
+  // calm inline error on the reconnect card.
+  const onReconnect = useCallback(async (item: AuthNeededItem) => {
+    const connections = await context.client.listConnections(workspaceId).catch(() => [] as ConnectionMetadata[]);
+    const connection = item.connectionId ? connections.find((candidate) => candidate.id === item.connectionId) ?? null : null;
+    if (connection?.kind === "api_key") {
+      window.location.assign(
+        `/workspaces/${encodeURIComponent(workspaceId)}/capabilities?reconnect_domain=${encodeURIComponent(item.providerDomain)}`,
+      );
+      return;
+    }
+    const returnPath = `${window.location.pathname}${window.location.search}`;
+    const response = await context.client.startConnectionOAuth(workspaceId, {
+      providerDomain: item.providerDomain,
+      ...(item.connectionId ? { connectionId: item.connectionId } : {}),
+      ...(item.resource ? { resource: item.resource } : {}),
+      returnPath,
+    });
+    if (!response.authorizationUrl) {
+      throw new Error("The provider did not return an authorization link.");
+    }
+    window.location.assign(response.authorizationUrl);
+  }, [context.client, workspaceId]);
+
   if (loading || !session) {
     if (loadError) {
       return isApiErrorStatus(loadError, 404) ? (
@@ -177,6 +227,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       onNewSession={() => void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } })}
       onApprove={(approvalId) => approve(approvalId, "approve")}
       onReject={(approvalId) => approve(approvalId, "reject")}
+      onReconnect={onReconnect}
     />
   );
 
@@ -287,6 +338,7 @@ function SessionChatPane(props: {
   onNewSession: () => void;
   onApprove: (approvalId: string) => Promise<void>;
   onReject: (approvalId: string) => Promise<void>;
+  onReconnect: (item: AuthNeededItem) => void | Promise<void>;
 }) {
   const context = useAppContext();
   const codexModels = useCodexModels(props.session.workspaceId);
@@ -405,6 +457,7 @@ function SessionChatPane(props: {
               status={props.session.status}
               renderMessageText={renderMessageText}
               onOpenSession={props.onOpenSession}
+              onReconnect={props.onReconnect}
               hasOlder={props.hasOlder}
               loadingOlder={props.loadingOlder}
               onLoadOlder={() => void props.onLoadOlder()}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -48,6 +48,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { WorkspaceDock, type WorkspaceTab } from "@opengeni/react";
 import { useAppContext } from "@/context";
 import { useCodexModels } from "@/lib/use-codex-models";
+import { normalizeProviderDomain } from "@/lib/capabilities";
 import { isTerminalSessionStatus, projectSessionTimeline, summarizeSessionFailure } from "@/lib/events";
 import { buildTools } from "@/lib/session-tools";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
@@ -191,6 +192,53 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     window.location.assign(response.authorizationUrl);
   }, [context.client, workspaceId]);
 
+  // Self-hosted provider logos for any inline reconnect card. A domain resolves
+  // to a logo only through the workspace catalog (logoAssetPath), so fetch it
+  // lazily — once an auth-needed card is actually in view — and serve the image
+  // from our own catalog-assets route via `catalogAssetUrl`, never an off-origin
+  // favicon (the CSP forbids it and it would leak which providers are connected).
+  const hasAuthNeeded = useMemo(() => timeline.some((item) => item.kind === "auth-needed"), [timeline]);
+  const [providerLogos, setProviderLogos] = useState<Map<string, string>>(() => new Map());
+  const logosRequestedRef = useRef(false);
+  useEffect(() => {
+    if (!hasAuthNeeded || logosRequestedRef.current) {
+      return;
+    }
+    logosRequestedRef.current = true;
+    let cancelled = false;
+    void context.client.listCapabilities(workspaceId)
+      .then((catalog) => {
+        if (cancelled) {
+          return;
+        }
+        const map = new Map<string, string>();
+        for (const cap of catalog.items) {
+          const domain = cap.providerDomain ?? cap.connectionRef?.providerDomain ?? null;
+          const url = context.client.catalogAssetUrl(cap.logoAssetPath);
+          if (domain && url) {
+            const key = normalizeProviderDomain(domain);
+            if (!map.has(key)) {
+              map.set(key, url);
+            }
+          }
+        }
+        setProviderLogos(map);
+      })
+      .catch(() => {
+        // Leave the card on its monogram fallback and allow a later retry.
+        if (!cancelled) {
+          logosRequestedRef.current = false;
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasAuthNeeded, context.client, workspaceId]);
+  const resolveProviderLogo = useCallback(
+    (domain: string) => providerLogos.get(normalizeProviderDomain(domain)) ?? null,
+    [providerLogos],
+  );
+
   if (loading || !session) {
     if (loadError) {
       return isApiErrorStatus(loadError, 404) ? (
@@ -228,6 +276,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       onApprove={(approvalId) => approve(approvalId, "approve")}
       onReject={(approvalId) => approve(approvalId, "reject")}
       onReconnect={onReconnect}
+      resolveProviderLogo={resolveProviderLogo}
     />
   );
 
@@ -339,6 +388,7 @@ function SessionChatPane(props: {
   onApprove: (approvalId: string) => Promise<void>;
   onReject: (approvalId: string) => Promise<void>;
   onReconnect: (item: AuthNeededItem) => void | Promise<void>;
+  resolveProviderLogo: (providerDomain: string) => string | null;
 }) {
   const context = useAppContext();
   const codexModels = useCodexModels(props.session.workspaceId);
@@ -458,6 +508,7 @@ function SessionChatPane(props: {
               renderMessageText={renderMessageText}
               onOpenSession={props.onOpenSession}
               onReconnect={props.onReconnect}
+              resolveProviderLogo={props.resolveProviderLogo}
               hasOlder={props.hasOlder}
               loadingOlder={props.loadingOlder}
               onLoadOlder={() => void props.onLoadOlder()}

--- a/packages/react/demo/timeline-fixtures.ts
+++ b/packages/react/demo/timeline-fixtures.ts
@@ -584,6 +584,49 @@ export function completedTurnEvents(): SessionEvent[] {
   return log.events;
 }
 
+/**
+ * A turn paused on a lapsed connection: a Linear tool call trips the broker's
+ * reauth path (`tool.auth_needed`), and a second provider needs wider scope.
+ * Each projects to a clean inline reconnect card — no `turn.completed`, because
+ * the turn is genuinely waiting on the user.
+ */
+export function authNeededEvents(): SessionEvent[] {
+  const log = new EventLog();
+  const turn = "turn-reconnect";
+  log.push("user.message", { text: "File a Linear issue for the flaky test, then log the same in Notion." });
+  log.push(
+    "agent.reasoning.delta",
+    { text: "I'll create the Linear issue first, then mirror it into the Notion database." },
+    turn,
+  );
+  log.push(
+    "tool.auth_needed",
+    {
+      serverId: "mcp-linear",
+      toolName: "create_issue",
+      providerDomain: "linear.app",
+      connectionId: "conn-linear-1",
+      reason: "refresh_failed",
+      scopes: ["issues:write"],
+      resource: "https://mcp.linear.app/sse",
+    },
+    turn,
+  );
+  log.push(
+    "tool.auth_needed",
+    {
+      serverId: "mcp-notion",
+      toolName: "create_page",
+      providerDomain: "notion.so",
+      connectionId: "conn-notion-1",
+      reason: "insufficient_scope",
+      scopes: ["databases.write"],
+    },
+    turn,
+  );
+  return log.events;
+}
+
 export function failedTurnEvents(): SessionEvent[] {
   const log = new EventLog();
   const turn = "turn-fail";

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -39,6 +39,16 @@ import "./styles.css";
 /** One overline/eyebrow recipe, used for every uppercase section label. */
 const EYEBROW = "text-og-xs font-medium uppercase tracking-[0.1em] text-og-fg-subtle";
 
+/** Demo-only stand-in for the app's catalog-asset logos (an inline data-URI so
+    the harness needs no network). The real app resolves these via catalogAssetUrl. */
+const DEMO_PROVIDER_LOGOS: Record<string, string> = {
+  "linear.app":
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="24" fill="#5e6ad2"/><g stroke="#fff" stroke-width="7" stroke-linecap="round"><line x1="24" y1="62" x2="62" y2="24"/><line x1="24" y1="44" x2="44" y2="24"/><line x1="38" y1="76" x2="76" y2="38"/></g></svg>`,
+    ),
+};
+
 /**
  * A demo section. The `hint` is intentionally ONE short line (never a wrapping
  * paragraph) so the gallery reads as a sleek component showcase, not docs
@@ -144,9 +154,17 @@ function Harness() {
 
             <Section
               title="Reconnect — a lapsed connection, inline"
-              hint="tool.auth_needed → a clean card: provider logo, one human line, a Reconnect button."
+              hint="tool.auth_needed → a clean card: self-hosted logo (or monogram), one human line, a Reconnect button."
             >
-              <MessageTimeline events={authNeededEvents()} onReconnect={() => new Promise(() => {})} className="max-h-none" />
+              {/* In the app the logo URL comes from our own catalog assets; here
+                  a fixture resolver serves one provider (logo) and lets the other
+                  fall back to its monogram — both states in one shot. */}
+              <MessageTimeline
+                events={authNeededEvents()}
+                onReconnect={() => new Promise(() => {})}
+                resolveProviderLogo={(domain) => DEMO_PROVIDER_LOGOS[domain] ?? null}
+                className="max-h-none"
+              />
             </Section>
 
             <Section title="Interrupted turn — cancelled mid-run">

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -13,6 +13,7 @@ import {
   type TimelineGroup,
 } from "../src/index";
 import {
+  authNeededEvents,
   cancelledTurnEvents,
   completedTurnEvents,
   failedTurnEvents,
@@ -139,6 +140,13 @@ function Harness() {
 
             <Section title="Failed turn — folds, but the error is never hidden" hint="Failed turns start open so the error and folded context stay visible.">
               <MessageTimeline events={failedTurnEvents()} className="max-h-none" />
+            </Section>
+
+            <Section
+              title="Reconnect — a lapsed connection, inline"
+              hint="tool.auth_needed → a clean card: provider logo, one human line, a Reconnect button."
+            >
+              <MessageTimeline events={authNeededEvents()} onReconnect={() => new Promise(() => {})} className="max-h-none" />
             </Section>
 
             <Section title="Interrupted turn — cancelled mid-run">

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -6,6 +6,7 @@ import {
   PauseIcon,
   PencilLineIcon,
   PlayIcon,
+  RefreshCwIcon,
   TargetIcon,
   TriangleAlertIcon,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import {
   LightboxProvider,
   type ActivityItem,
   type AgentMessageItem,
+  type AuthNeededItem,
   type GoalItem,
   type NoticeItem,
   type TimelineGroup,
@@ -45,6 +47,14 @@ export type MessageTimelineProps = {
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   /** Drill into a spawned worker session. */
   onOpenSession?: ((sessionId: string) => void) | undefined;
+  /**
+   * Start the reconnect flow when a tool needs its connection reauthorized. The
+   * app supplies this (it owns the SDK client + workspace): it typically kicks
+   * off `startConnectionOAuth` and redirects, or routes to credential entry.
+   * Rejecting surfaces a calm inline error on the card; the library never draws
+   * a Reconnect button without a handler to run it.
+   */
+  onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
   /**
    * The tool-renderer registry that resolves how each tool call is drawn.
    * Defaults to {@link defaultToolRegistry}; pass a registry from
@@ -75,6 +85,7 @@ export function MessageTimeline({
   status,
   renderMessageText,
   onOpenSession,
+  onReconnect,
   toolRegistry = defaultToolRegistry,
   autoFollow = true,
   hasOlder = false,
@@ -285,6 +296,7 @@ export function MessageTimeline({
               group={group}
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
+              onReconnect={onReconnect}
               toolRegistry={toolRegistry}
               foldLiveCluster={isAgentProgress(groups[index + 1])}
             />
@@ -349,6 +361,7 @@ function TimelineGroupView({
   group,
   renderMessageText,
   onOpenSession,
+  onReconnect,
   toolRegistry,
   insideTurn = false,
   foldLiveCluster = false,
@@ -356,6 +369,7 @@ function TimelineGroupView({
   group: TimelineGroup;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
+  onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
   toolRegistry: ToolRegistry;
   /** A completed cluster of a still-RUNNING turn (not the live tail) folds
       behind a neutral chip — the one place activity without an outcome still
@@ -399,6 +413,7 @@ function TimelineGroupView({
                 group={child}
                 renderMessageText={renderMessageText}
                 onOpenSession={onOpenSession}
+                onReconnect={onReconnect}
                 toolRegistry={toolRegistry}
                 insideTurn
               />
@@ -408,7 +423,7 @@ function TimelineGroupView({
       );
     }
     case "item":
-      return <TimelineRow item={group.item} renderMessageText={renderMessageText} />;
+      return <TimelineRow item={group.item} renderMessageText={renderMessageText} onReconnect={onReconnect} />;
   }
 }
 
@@ -478,9 +493,11 @@ function durationBetween(startedAt: string, endedAt: string): number | undefined
 export function TimelineRow({
   item,
   renderMessageText,
+  onReconnect,
 }: {
   item: TimelineItem;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
+  onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
 }) {
   switch (item.kind) {
     case "user-message":
@@ -493,6 +510,8 @@ export function TimelineRow({
       return <GoalRow item={item} />;
     case "notice":
       return <NoticeRow item={item} />;
+    case "auth-needed":
+      return <AuthNeededRow item={item} onReconnect={onReconnect} />;
     default:
       return null;
   }
@@ -639,4 +658,137 @@ function NoticeRow({ item }: { item: NoticeItem }) {
       ) : null}
     </div>
   );
+}
+
+/**
+ * The inline reconnect card: a lapsed connection surfaces as a calm, tappable
+ * affordance — provider logo, one human line, one primary Reconnect button —
+ * instead of a raw "linear.app needs to be reconnected." string. The `reason`
+ * only shapes the helper copy; no domain or enum code is shown as a label.
+ * `onReconnect` (from the app, which owns the SDK client) runs the flow; without
+ * it, a pre-minted authorization link is offered, or the card stays informative.
+ */
+function AuthNeededRow({
+  item,
+  onReconnect,
+}: {
+  item: AuthNeededItem;
+  onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+}) {
+  const enter = useEntranceAnimation();
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const provider = providerLabel(item.providerDomain);
+
+  const start = async () => {
+    if (!onReconnect || busy) {
+      return;
+    }
+    setBusy(true);
+    setFailed(false);
+    try {
+      // On success the app redirects to consent (or routes to credential entry),
+      // so this row unmounts; a resolve without navigation just relaxes the button.
+      await onReconnect(item);
+      setBusy(false);
+    } catch {
+      setFailed(true);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={cn(enter && "animate-og-enter", "flex flex-col gap-2")} role="status">
+      <div className="flex flex-col gap-3 rounded-og-lg border border-og-border bg-og-surface-1 px-3.5 py-3 sm:flex-row sm:items-center">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <AuthProviderLogo domain={item.providerDomain} label={provider} />
+          <div className="min-w-0">
+            <p className="truncate text-og-md font-medium text-og-fg">Reconnect {provider}</p>
+            <p className="truncate text-og-sm text-og-fg-subtle">{authReasonLine(item.reason)}</p>
+          </div>
+        </div>
+        {onReconnect ? (
+          <button
+            type="button"
+            onClick={() => void start()}
+            disabled={busy}
+            className={cn(
+              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-sm font-medium text-og-accent-fg sm:w-auto",
+              "transition-colors hover:bg-og-accent-strong disabled:opacity-70 pointer-coarse:min-h-9",
+            )}
+          >
+            <RefreshCwIcon className={cn("size-3.5", busy && "animate-og-spin")} aria-hidden />
+            {busy ? "Reconnecting…" : "Reconnect"}
+          </button>
+        ) : item.authorizationUrl ? (
+          <a
+            href={item.authorizationUrl}
+            rel="noreferrer"
+            target="_blank"
+            className={cn(
+              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-sm font-medium text-og-accent-fg sm:w-auto",
+              "transition-colors hover:bg-og-accent-strong pointer-coarse:min-h-9",
+            )}
+          >
+            <RefreshCwIcon className="size-3.5" aria-hidden />
+            Reconnect
+          </a>
+        ) : null}
+      </div>
+      {failed ? (
+        <p className="px-1 text-og-xs text-og-status-failed">Couldn't start reconnecting {provider}. Try again.</p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The provider's favicon in a rounded tile, with a calm letter monogram fallback
+ * when there's no domain or the icon fails to load — so the card never shows a
+ * broken-image glyph. Favicons come from a public icon service keyed on the
+ * registrable domain; a strict-CSP host simply gets the monogram.
+ */
+function AuthProviderLogo({ domain, label }: { domain: string; label: string }) {
+  const [failed, setFailed] = useState(false);
+  const host = domain.trim().replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0] ?? "";
+  const src = host && !failed ? `https://icons.duckduckgo.com/ip3/${host}.ico` : null;
+  return (
+    <span
+      className="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-og-md border border-og-border bg-og-surface-2 text-sm font-semibold text-og-fg-muted"
+      aria-hidden
+    >
+      {src ? (
+        <img src={src} alt="" loading="lazy" decoding="async" className="size-full object-contain p-1.5" onError={() => setFailed(true)} />
+      ) : (
+        <span>{label.charAt(0).toUpperCase() || "?"}</span>
+      )}
+    </span>
+  );
+}
+
+/** "linear.app" -> "Linear": the first domain label, capitalized. A calm human
+    name for the provider — never the raw domain shown as a label. */
+function providerLabel(domain: string): string {
+  const host = domain.trim().replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0] ?? "";
+  const first = host.split(".")[0] ?? host;
+  if (!first) {
+    return "this service";
+  }
+  return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+/** A calm, human helper line per reauth reason — the `reason` informs the copy
+    but is never rendered as a raw enum/code. */
+function authReasonLine(reason: AuthNeededItem["reason"]): string {
+  switch (reason) {
+    case "insufficient_scope":
+      return "It needs additional access to continue.";
+    case "missing_connection":
+      return "It isn't connected yet.";
+    case "expired":
+    case "refresh_failed":
+      return "Its access expired.";
+    default:
+      return "Its connection needs attention.";
+  }
 }

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -56,6 +56,14 @@ export type MessageTimelineProps = {
    */
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
   /**
+   * Resolve a provider domain (from a reconnect card) to a logo URL the host
+   * serves itself — the app maps it through its catalog + `catalogAssetUrl`.
+   * Return null/undefined to fall back to a calm monogram. The library never
+   * fetches an off-origin favicon (CSP + privacy); an unresolved logo is a
+   * monogram, not an external image.
+   */
+  resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
+  /**
    * The tool-renderer registry that resolves how each tool call is drawn.
    * Defaults to {@link defaultToolRegistry}; pass a registry from
    * `createDefaultToolRegistry({ entries })` to add custom tool renderers.
@@ -86,6 +94,7 @@ export function MessageTimeline({
   renderMessageText,
   onOpenSession,
   onReconnect,
+  resolveProviderLogo,
   toolRegistry = defaultToolRegistry,
   autoFollow = true,
   hasOlder = false,
@@ -297,6 +306,7 @@ export function MessageTimeline({
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
               onReconnect={onReconnect}
+              resolveProviderLogo={resolveProviderLogo}
               toolRegistry={toolRegistry}
               foldLiveCluster={isAgentProgress(groups[index + 1])}
             />
@@ -362,6 +372,7 @@ function TimelineGroupView({
   renderMessageText,
   onOpenSession,
   onReconnect,
+  resolveProviderLogo,
   toolRegistry,
   insideTurn = false,
   foldLiveCluster = false,
@@ -370,6 +381,7 @@ function TimelineGroupView({
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
   toolRegistry: ToolRegistry;
   /** A completed cluster of a still-RUNNING turn (not the live tail) folds
       behind a neutral chip — the one place activity without an outcome still
@@ -414,6 +426,7 @@ function TimelineGroupView({
                 renderMessageText={renderMessageText}
                 onOpenSession={onOpenSession}
                 onReconnect={onReconnect}
+                resolveProviderLogo={resolveProviderLogo}
                 toolRegistry={toolRegistry}
                 insideTurn
               />
@@ -423,7 +436,14 @@ function TimelineGroupView({
       );
     }
     case "item":
-      return <TimelineRow item={group.item} renderMessageText={renderMessageText} onReconnect={onReconnect} />;
+      return (
+        <TimelineRow
+          item={group.item}
+          renderMessageText={renderMessageText}
+          onReconnect={onReconnect}
+          resolveProviderLogo={resolveProviderLogo}
+        />
+      );
   }
 }
 
@@ -494,10 +514,12 @@ export function TimelineRow({
   item,
   renderMessageText,
   onReconnect,
+  resolveProviderLogo,
 }: {
   item: TimelineItem;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
 }) {
   switch (item.kind) {
     case "user-message":
@@ -511,7 +533,7 @@ export function TimelineRow({
     case "notice":
       return <NoticeRow item={item} />;
     case "auth-needed":
-      return <AuthNeededRow item={item} onReconnect={onReconnect} />;
+      return <AuthNeededRow item={item} onReconnect={onReconnect} resolveProviderLogo={resolveProviderLogo} />;
     default:
       return null;
   }
@@ -671,9 +693,11 @@ function NoticeRow({ item }: { item: NoticeItem }) {
 function AuthNeededRow({
   item,
   onReconnect,
+  resolveProviderLogo,
 }: {
   item: AuthNeededItem;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
+  resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
 }) {
   const enter = useEntranceAnimation();
   const [busy, setBusy] = useState(false);
@@ -701,7 +725,7 @@ function AuthNeededRow({
     <div className={cn(enter && "animate-og-enter", "flex flex-col gap-2")} role="status">
       <div className="flex flex-col gap-3 rounded-og-lg border border-og-border bg-og-surface-1 px-3.5 py-3 sm:flex-row sm:items-center">
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <AuthProviderLogo domain={item.providerDomain} label={provider} />
+          <AuthProviderLogo src={resolveProviderLogo?.(item.providerDomain) ?? null} label={provider} />
           <div className="min-w-0">
             <p className="truncate text-og-md font-medium text-og-fg">Reconnect {provider}</p>
             <p className="truncate text-og-sm text-og-fg-subtle">{authReasonLine(item.reason)}</p>
@@ -743,27 +767,43 @@ function AuthNeededRow({
 }
 
 /**
- * The provider's favicon in a rounded tile, with a calm letter monogram fallback
- * when there's no domain or the icon fails to load — so the card never shows a
- * broken-image glyph. Favicons come from a public icon service keyed on the
- * registrable domain; a strict-CSP host simply gets the monogram.
+ * The provider's logo in a rounded tile, from a URL the HOST serves itself
+ * (resolved via `resolveProviderLogo` → the app's catalog assets). A missing or
+ * failed image falls back to a calm letter monogram — same as the rest of the
+ * app — so the card never shows a broken-image glyph and never reaches off-origin
+ * for a favicon (CSP + privacy).
  */
-function AuthProviderLogo({ domain, label }: { domain: string; label: string }) {
+function AuthProviderLogo({ src, label }: { src: string | null; label: string }) {
   const [failed, setFailed] = useState(false);
-  const host = domain.trim().replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0] ?? "";
-  const src = host && !failed ? `https://icons.duckduckgo.com/ip3/${host}.ico` : null;
+  // A resolver that only returns the URL after a lazy catalog fetch means `src`
+  // can arrive on a later render; reset the error latch so it gets its attempt.
+  useEffect(() => setFailed(false), [src]);
+  const showImage = src && !failed;
   return (
     <span
       className="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-og-md border border-og-border bg-og-surface-2 text-sm font-semibold text-og-fg-muted"
       aria-hidden
     >
-      {src ? (
+      {showImage ? (
         <img src={src} alt="" loading="lazy" decoding="async" className="size-full object-contain p-1.5" onError={() => setFailed(true)} />
       ) : (
-        <span>{label.charAt(0).toUpperCase() || "?"}</span>
+        <span>{monogram(label)}</span>
       )}
     </span>
   );
+}
+
+/** First one or two initials for the monogram fallback — mirrors the app's
+    `capabilityMonogram` so the reconnect tile reads like every other logo tile. */
+function monogram(label: string): string {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return "?";
+  }
+  if (words.length === 1) {
+    return words[0]!.slice(0, 2).toUpperCase();
+  }
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
 }
 
 /** "linear.app" -> "Linear": the first domain label, capitalized. A calm human

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -100,6 +100,7 @@ export {
 export type {
   ActivityItem,
   AgentMessageItem,
+  AuthNeededItem,
   GoalItem,
   NoticeItem,
   ReasoningItem,

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -22,6 +22,7 @@ export { buildTimeline, creditExhaustedFromEvents, extractSessionRef, groupTimel
 export type {
   ActivityItem,
   AgentMessageItem,
+  AuthNeededItem,
   GoalItem,
   NoticeItem,
   ReasoningItem,

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -3,6 +3,7 @@ import { CREDIT_EXHAUSTION_MESSAGE, humanizeFailureReason, isCreditExhaustion, t
 import type {
   AgentMessageItem,
   ActivityItem,
+  AuthNeededItem,
   GoalItem,
   SandboxItem,
   SessionStatusItem,
@@ -322,14 +323,22 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "tool.auth_needed": {
+        // Keep the whole structured payload — the renderer turns it into a clean
+        // inline reconnect card, and the app starts the recovery flow off the
+        // connectionId/resource. Losing it to a plain-text notice was the ugly
+        // "linear.app needs to be reconnected." line users complained about.
         closeStreamingTail();
-        const authorizationUrl = typeof payload.authorizationUrl === "string" ? payload.authorizationUrl : null;
         items.push({
-          kind: "notice",
+          kind: "auth-needed",
           id: event.id,
-          tone: "waiting",
-          text: authNeededNoticeText(payload),
-          ...(authorizationUrl ? { action: { label: "Connect", url: authorizationUrl } } : {}),
+          turnId,
+          providerDomain: typeof payload.providerDomain === "string" ? payload.providerDomain : "",
+          connectionId: typeof payload.connectionId === "string" ? payload.connectionId : null,
+          reason: authNeededReason(payload.reason),
+          scopes: stringList(payload.scopes),
+          resource: typeof payload.resource === "string" ? payload.resource : null,
+          toolName: typeof payload.toolName === "string" ? payload.toolName : null,
+          authorizationUrl: typeof payload.authorizationUrl === "string" ? payload.authorizationUrl : null,
           occurredAt: event.occurredAt,
         });
         break;
@@ -885,20 +894,14 @@ function goalText(payload: Record<string, unknown>): string | null {
   return null;
 }
 
-function authNeededNoticeText(payload: Record<string, unknown>): string {
-  const provider =
-    typeof payload.providerDomain === "string" && payload.providerDomain.trim().length > 0 ? payload.providerDomain.trim() : "This service";
-  const scopes = Array.isArray(payload.scopes)
-    ? payload.scopes.filter((scope): scope is string => typeof scope === "string" && scope.trim().length > 0)
-    : [];
+const AUTH_NEEDED_REASONS: ReadonlySet<string> = new Set(["missing_connection", "expired", "insufficient_scope", "refresh_failed"]);
 
-  if (payload.reason === "insufficient_scope") {
-    return scopes.length > 0 ? `${provider} needs additional access (${scopes.join(", ")}).` : `${provider} needs additional access.`;
-  }
-  if (payload.reason === "expired" || payload.reason === "refresh_failed") {
-    return `${provider} needs to be reconnected.`;
-  }
-  return `${provider} needs a connection.`;
+function authNeededReason(value: unknown): AuthNeededItem["reason"] {
+  return typeof value === "string" && AUTH_NEEDED_REASONS.has(value) ? (value as AuthNeededItem["reason"]) : null;
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0) : [];
 }
 
 function reasoningText(payload: unknown): string {

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -120,6 +120,35 @@ export type NoticeItem = {
   occurredAt: string;
 };
 
+/**
+ * A tool call hit a connection whose credential lapsed — the broker asked the
+ * user to reconnect the provider before the turn can continue. Carries the
+ * structured `tool.auth_needed` payload so the renderer can draw a clean inline
+ * reconnect affordance (provider logo + one human line + a Reconnect button)
+ * and the app can start the right recovery flow (OAuth reconnect for the
+ * surviving connection, or credential re-entry for an api-key one). The `reason`
+ * shapes the human copy but is never shown raw.
+ */
+export type AuthNeededItem = {
+  kind: "auth-needed";
+  id: string;
+  turnId: string | null;
+  /** The connection's registrable domain, e.g. "linear.app". */
+  providerDomain: string;
+  /** The lapsed connection to reconnect, when the row survived. */
+  connectionId: string | null;
+  reason: "missing_connection" | "expired" | "insufficient_scope" | "refresh_failed" | null;
+  /** Scopes the provider now needs; may inform the copy, never shown as a raw label. */
+  scopes: string[];
+  /** The OAuth `resource` (RFC 8707) the reconnect should target, when supplied. */
+  resource: string | null;
+  /** The tool whose call triggered the reauth, for context. */
+  toolName: string | null;
+  /** A pre-minted authorization URL, when the broker already produced one. */
+  authorizationUrl: string | null;
+  occurredAt: string;
+};
+
 export type TurnOutcome = "complete" | "failed" | "cancelled";
 
 export type TurnEndItem = {
@@ -141,6 +170,7 @@ export type TimelineItem =
   | SessionStatusItem
   | GoalItem
   | NoticeItem
+  | AuthNeededItem
   | TurnEndItem;
 
 /** Activity items cluster between chat messages (reasoning, tools, workers, sandbox). */

--- a/packages/react/test/golden/serialize.ts
+++ b/packages/react/test/golden/serialize.ts
@@ -97,6 +97,20 @@ function serializeItem(item: TimelineItem): Record<string, unknown> {
         tone: item.tone,
         text: item.text,
       };
+    case "auth-needed":
+      return {
+        kind: item.kind,
+        id: item.id,
+        turnId: item.turnId,
+        occurredAt: item.occurredAt,
+        providerDomain: item.providerDomain,
+        connectionId: item.connectionId,
+        reason: item.reason,
+        scopes: stableValue(item.scopes),
+        resource: item.resource,
+        toolName: item.toolName,
+        authorizationUrl: item.authorizationUrl,
+      };
     case "turn-end":
       return {
         kind: item.kind,

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -666,22 +666,46 @@ describe("buildTimeline", () => {
     expect(items[0]).toMatchObject({ kind: "notice", tone: "waiting" });
   });
 
-  test("tool.auth_needed becomes a waiting notice with a connect action", () => {
+  test("tool.auth_needed becomes a structured auth-needed item carrying the full payload", () => {
     reset();
     const items = buildTimeline([
       event("tool.auth_needed", {
+        serverId: "mcp-linear",
+        toolName: "create_issue",
         providerDomain: "linear.app",
-        reason: "insufficient_scope",
+        connectionId: "conn-1",
+        reason: "refresh_failed",
         scopes: ["issues:write"],
+        resource: "https://mcp.linear.app/sse",
         authorizationUrl: "https://linear.app/oauth/authorize",
-      }),
+      }, { turnId: "turn-1" }),
     ]);
     expect(items).toHaveLength(1);
     expect(items[0]).toMatchObject({
-      kind: "notice",
-      tone: "waiting",
-      text: "linear.app needs additional access (issues:write).",
-      action: { label: "Connect", url: "https://linear.app/oauth/authorize" },
+      kind: "auth-needed",
+      turnId: "turn-1",
+      providerDomain: "linear.app",
+      connectionId: "conn-1",
+      reason: "refresh_failed",
+      scopes: ["issues:write"],
+      resource: "https://mcp.linear.app/sse",
+      toolName: "create_issue",
+      authorizationUrl: "https://linear.app/oauth/authorize",
+    });
+  });
+
+  test("tool.auth_needed tolerates a sparse payload and drops an unknown reason", () => {
+    reset();
+    const items = buildTimeline([event("tool.auth_needed", { providerDomain: "supabase.com", reason: "who_knows" })]);
+    expect(items[0]).toMatchObject({
+      kind: "auth-needed",
+      providerDomain: "supabase.com",
+      connectionId: null,
+      reason: null,
+      scopes: [],
+      resource: null,
+      toolName: null,
+      authorizationUrl: null,
     });
   });
 


### PR DESCRIPTION
## What

When an MCP tool call needs its connection reauthorized mid-session, the chat showed a raw text line — **"linear.app needs to be reconnected."** — because the projection flattened the broker's structured `tool.auth_needed` event to a plain notice string and threw away everything useful. This replaces that with a clean, tappable inline **Reconnect** card.

## Before → After

**Before:** a waiting notice reading `linear.app needs to be reconnected.` (raw domain, no action beyond a generic "Connect" link when an authorizationUrl happened to be present).

**After:** a calm card — provider logo, one human line, a primary **Reconnect** button that starts the real recovery flow and returns to the session.

## Changes

- **Projection** (`packages/react/src/timeline/{types,projection}.ts`): `tool.auth_needed` now projects a structured `auth-needed` item carrying `providerDomain`, `connectionId`, `reason`, `scopes`, `resource`, `toolName`, and any `authorizationUrl`. Pure + unit-tested (unknown reasons drop to `null`; sparse payloads tolerated).
- **Renderer** (`packages/react/.../message-timeline.tsx`): a new `AuthNeededRow` — provider favicon with a calm letter-monogram fallback, a human line (`Reconnect Linear` / `Its access expired.` — never the raw domain or enum code), and a primary Reconnect button. Responsive: single row on desktop, button stacks full-width on mobile. Handles busy/redirecting + a calm inline error if the flow can't start. Wired via a new `onReconnect` callback prop (same extension pattern as `onOpenSession`).
- **App wiring** (`apps/web/src/routes/session.tsx`): supplies `onReconnect` — OAuth connections reconnect in place (reuse `connectionId`, `returnPath` back to this session) and land back with a "Reconnected" toast; api-key connections deep-link to credential re-entry on the capabilities sheet (`?reconnect_domain`, handled in `capabilities.tsx`).
- **Demo**: a "Reconnect" section in the timeline harness over a real-shaped `auth_needed` fixture (Linear + Notion).

## Verification

- `packages/react`: `tsc --noEmit` clean, 445 tests pass (incl. two new projection tests for the structured item).
- `apps/web`: `tsc --noEmit` clean.
- Visual: rendered the real `MessageTimeline` against an `auth_needed` fixture and screenshotted the card at desktop + mobile widths in dark + light, plus the busy state — clean in all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG9aDFjDS5jR4XR4zKaUUt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth redirects and connection recovery in live sessions; changes are UI-heavy with bounded auth flow wiring rather than server credential logic.
> 
> **Overview**
> **Mid-session MCP reauth** no longer shows a raw domain string in a waiting notice. `tool.auth_needed` now projects to a structured **`auth-needed`** timeline item, and **`MessageTimeline`** renders an inline **Reconnect** card (human copy, catalog-hosted logo or monogram, busy/error states) via new **`onReconnect`** and **`resolveProviderLogo`** props.
> 
> **`apps/web`** implements recovery: OAuth reconnect reuses **`connectionId`** and returns to the session with a success toast; API-key connections deep-link to capabilities with **`?reconnect_domain`**, which opens the connect sheet for the matching enabled integration (or seeds search). Provider logos load lazily from the workspace catalog through **`catalogAssetUrl`**.
> 
> Tests, golden serialization, and the timeline demo harness add **`authNeededEvents`** and a Reconnect gallery section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c157e862a1caeeadba68f09b31f17dce08f22bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->