### PR TITLE
De-box the expanded timeline: thread, not boxes

### DIFF
--- a/apps/web/src/components/session/goal-surface.tsx
+++ b/apps/web/src/components/session/goal-surface.tsx
@@ -49,7 +49,9 @@ type GoalPillMeta = {
 const GOAL_PILL_META: Record<GoalPillState, GoalPillMeta> = {
   pursuing: { label: "Pursuing goal", icon: ZapIcon, tint: "text-brand", ring: "border-brand/40" },
   paused: { label: "Goal paused", icon: PauseIcon, tint: "text-status-waiting", ring: "border-status-waiting/40" },
-  attention: { label: "Needs attention", icon: TriangleAlertIcon, tint: "text-status-waiting", ring: "border-status-waiting/45" },
+  // "Needs attention" wears the warning/amber hue, not paused's purple — the two
+  // states were near-indistinguishable when both leaned on status-waiting.
+  attention: { label: "Needs attention", icon: TriangleAlertIcon, tint: "text-status-running", ring: "border-status-running/50" },
   completed: { label: "Goal completed", icon: CheckCircle2Icon, tint: "text-status-idle", ring: "border-status-idle/40" },
 };
 
@@ -232,7 +234,12 @@ export function GoalSurface({
             sideOffset={8}
             collisionPadding={12}
             className={cn(
-              "z-50 w-[min(24rem,calc(100vw-2rem))] rounded-xl border border-border bg-surface shadow-lg outline-none",
+              // Anchored directly above the composer, the panel opens UPWARD. On a
+              // short viewport it caps at the space available above the pill and
+              // scrolls inside itself (subagent trees can get tall) rather than
+              // overflowing off-screen or flipping down over the composer.
+              "z-50 flex max-h-[min(30rem,var(--radix-popover-content-available-height))] w-[min(24rem,calc(100vw-2rem))] flex-col overflow-y-auto overscroll-contain",
+              "rounded-xl border border-border bg-surface shadow-lg outline-none",
               "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
               "data-[side=top]:slide-in-from-bottom-1",
             )}
@@ -293,7 +300,7 @@ function GoalDetail({ goal, state }: { goal: UseGoalResult; state: GoalPillState
         <MetaChip dot={record.noProgressStreak >= 2 ? "waiting" : undefined}>
           {record.noProgressStreak} stalled check{record.noProgressStreak === 1 ? "" : "s"}
         </MetaChip>
-        <MetaChip>version {record.version}</MetaChip>
+        <MetaChip>v{record.version}</MetaChip>
       </div>
 
       {record.status !== "completed" ? (

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -212,37 +212,41 @@ function RawRail({ events }: { events: ReturnType<typeof tourEvents> }) {
   );
 }
 
-function RawGroup({ group }: { group: TimelineGroup }) {
+function RawGroup({ group, insideTurn = false }: { group: TimelineGroup; insideTurn?: boolean }) {
   switch (group.kind) {
     case "activity":
       return group.outcome ? (
         <TurnSummary
           items={group.items}
           outcome={group.outcome}
-          failureText={group.failureText}
-          defaultOpen={group.outcome === "failed" ? true : undefined}
+          failureText={insideTurn ? undefined : group.failureText}
+          defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
+          bare={insideTurn}
         >
-          <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} />
+          <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} bare={insideTurn} />
         </TurnSummary>
       ) : (
-        <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} />
+        <ActivityRail items={group.items} onOpenSession={(id) => window.alert(`Open session ${id}`)} bare={insideTurn} />
       );
-    case "turn":
+    case "turn": {
+      const body = group.groups.map((child) => <RawGroup key={rawGroupKey(child)} group={child} insideTurn />);
       return (
         <TurnSummary
           items={flattenActivities(group.groups)}
           outcome={group.outcome}
           failureText={group.failureText}
           durationMs={durationBetween(group.startedAt, group.endedAt)}
-          defaultOpen={group.outcome === "failed" ? true : undefined}
+          defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
+          bare={insideTurn}
         >
-          <div className="flex flex-col gap-4">
-            {group.groups.map((child) => (
-              <RawGroup key={rawGroupKey(child)} group={child} />
-            ))}
-          </div>
+          {insideTurn ? (
+            <div className="flex flex-col gap-4">{body}</div>
+          ) : (
+            <div className="flex flex-col gap-4 border-l-2 border-og-border pl-3 sm:pl-4">{body}</div>
+          )}
         </TurnSummary>
       );
+    }
     case "item":
       return <TimelineRow item={group.item} onOpenSession={(id) => window.alert(`Open session ${id}`)} />;
   }

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -434,7 +434,10 @@ function TimelineGroupView({
         <TurnSummary
           items={activityItems}
           outcome={group.outcome}
-          failureText={group.failureText}
+          // One loud error at the top; nested sub-turn chips stay calm — the
+          // parent already renders the failure reason, so clear it here exactly
+          // as the nested activity-cluster case does.
+          failureText={insideTurn ? undefined : group.failureText}
           durationMs={durationBetween(group.startedAt, group.endedAt)}
           defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
           bare={insideTurn}

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -407,38 +407,47 @@ function TimelineGroupView({
           outcome={group.outcome}
           failureText={insideTurn ? undefined : group.failureText}
           defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
+          bare={insideTurn}
         >
-          <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
+          <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} bare={insideTurn} />
         </TurnSummary>
       ) : (
-        <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} />
+        // A nested live cluster hangs on the turn's rail (bare); a top-level one
+        // owns its own rail.
+        <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} bare={insideTurn} />
       );
     case "turn": {
       const activityItems = flattenActivityItems(group.groups);
+      const body = group.groups.map((child) => (
+        <TimelineGroupView
+          key={timelineGroupKey(child)}
+          group={child}
+          renderMessageText={renderMessageText}
+          onOpenSession={onOpenSession}
+          onReconnect={onReconnect}
+          resolveProviderLogo={resolveProviderLogo}
+          toolRegistry={toolRegistry}
+          insideTurn
+        />
+      ));
       return (
         <TurnSummary
           items={activityItems}
           outcome={group.outcome}
           failureText={group.failureText}
           durationMs={durationBetween(group.startedAt, group.endedAt)}
-          defaultOpen={group.outcome === "failed" ? true : undefined}
+          defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
+          bare={insideTurn}
         >
-          {/* The body wears the timeline's rail language (matching ActivityRail)
-              so nested chips read as contained by the turn, not as siblings. */}
-          <div className="flex flex-col gap-4 border-l-2 border-og-border pl-3 sm:pl-4">
-            {group.groups.map((child) => (
-              <TimelineGroupView
-                key={timelineGroupKey(child)}
-                group={child}
-                renderMessageText={renderMessageText}
-                onOpenSession={onOpenSession}
-                onReconnect={onReconnect}
-                resolveProviderLogo={resolveProviderLogo}
-                toolRegistry={toolRegistry}
-                insideTurn
-              />
-            ))}
-          </div>
+          {insideTurn ? (
+            // A nested turn is already on an ancestor rail — its body just stacks
+            // flush (the bare-node body already indents it), so no second rule.
+            <div className="flex flex-col gap-4">{body}</div>
+          ) : (
+            // The top-level turn draws THE rail: one thin continuous rule that
+            // every nested node and step hangs off of.
+            <div className="flex flex-col gap-4 border-l-2 border-og-border pl-3 sm:pl-4">{body}</div>
+          )}
         </TurnSummary>
       );
     }
@@ -619,20 +628,21 @@ type WorkerCompletionMeta = {
   label: string;
   icon: ComponentType<{ className?: string }>;
   iconClass: string;
-  cardClass: string;
+  /** The 2px left-accent hue — color spent only on the exceptional outcomes. */
+  accentClass: string;
 };
 
 function workerCompletionMeta(item: WorkerCompletionItem): WorkerCompletionMeta {
   if (item.childStatus === "failed") {
-    return { label: "Worker failed", icon: XCircleIcon, iconClass: "text-og-status-failed", cardClass: "border-og-status-failed/40" };
+    return { label: "Worker failed", icon: XCircleIcon, iconClass: "text-og-status-failed", accentClass: "border-og-status-failed/60" };
   }
   if (item.goalStatus === "paused") {
-    return { label: "Worker paused", icon: PauseCircleIcon, iconClass: "text-og-status-waiting", cardClass: "border-og-status-waiting/35" };
+    return { label: "Worker paused", icon: PauseCircleIcon, iconClass: "text-og-status-waiting", accentClass: "border-og-status-waiting/50" };
   }
   if (item.goalStatus === "completed") {
-    return { label: "Worker completed", icon: CheckCircle2Icon, iconClass: "text-og-status-idle", cardClass: "border-og-border" };
+    return { label: "Worker completed", icon: CheckCircle2Icon, iconClass: "text-og-status-idle", accentClass: "border-og-status-idle/45" };
   }
-  return { label: "Worker reported back", icon: BotIcon, iconClass: "text-og-accent", cardClass: "border-og-border" };
+  return { label: "Worker reported back", icon: BotIcon, iconClass: "text-og-accent", accentClass: "border-og-border-strong" };
 }
 
 function WorkerCompletionRow({
@@ -660,7 +670,9 @@ function WorkerCompletionRow({
   const hasDetails = details.length > 0;
   return (
     <div className={cn(enter && "animate-og-enter", "min-w-0")}>
-      <div className={cn("flex flex-col gap-2 rounded-og-md border bg-og-surface-1 p-3", meta.cardClass)}>
+      {/* An inbound result, not a bubble: a 2px left accent carries the outcome —
+          no full frame, no surface fill. The report unfolds flush beneath. */}
+      <div className={cn("flex flex-col gap-2 border-l-2 pl-3", meta.accentClass)}>
         <div className="flex items-start gap-2.5">
           <span className={cn("mt-0.5 shrink-0", meta.iconClass)}>
             <Icon className="size-4" />

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -161,20 +161,15 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
             : cancelled
               ? "Worker interrupted"
               : "Worker messaged";
+  // A worker is a first-class actor but still a STEP on the rail — a borderless
+  // row (no card), aligned to its sibling tool rows: the chevron column is an
+  // empty spacer (a worker doesn't expand), then the bot glyph, then the title
+  // with a quiet prompt/id beneath, and one right-gutter affordance.
   return (
-    <div
-      className={cn(
-        "my-0.5 flex items-start gap-3 rounded-og-md border bg-og-surface-1 p-3",
-        failed ? "border-og-status-failed/40" : "border-og-border",
-      )}
-    >
-      <span
-        className={cn(
-          "mt-0.5 inline-flex size-7 shrink-0 items-center justify-center",
-          failed ? "text-og-status-failed" : "text-og-accent",
-        )}
-      >
-        <BotIcon className="size-4" />
+    <div className="flex items-start gap-2 px-1.5 py-1.5">
+      <span className="size-3.5 shrink-0" aria-hidden />
+      <span className={cn("mt-px shrink-0", failed ? "text-og-status-failed" : "text-og-accent")}>
+        <BotIcon className="size-3.5" />
       </span>
       <div className="min-w-0 flex-1">
         {/* In-flight state is carried ONLY by the shimmering title (no detached
@@ -188,7 +183,8 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
         ) : null}
       </div>
       {/* Right gutter: failed gets a red chip; cancelled gets a calm "interrupted"
-          chip (no dot, no red); a live complete worker shows an "Open session" button. */}
+          chip (no dot, no red); a live complete worker shows a quiet "Open session"
+          affordance (borderless, matching the worker-completion deep-link). */}
       {failed ? (
         <span className="inline-flex shrink-0 self-center items-center gap-1.5 font-og-mono text-og-xs leading-none text-og-status-failed">
           <span className="size-1.5 rounded-full bg-og-status-failed" />
@@ -203,8 +199,8 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
           type="button"
           onClick={() => item.workerSessionId && onOpenSession(item.workerSessionId)}
           className={cn(
-            "shrink-0 self-center rounded-og-sm border border-og-border px-2.5 py-1 text-og-sm font-medium text-og-fg-muted pointer-coarse:py-2",
-            "outline-none transition-colors duration-150 hover:border-og-border-strong hover:text-og-fg",
+            "-my-0.5 -mr-1 inline-flex shrink-0 self-center items-center gap-1 rounded-og-sm px-2 py-1 text-og-sm font-medium text-og-fg-muted pointer-coarse:py-2",
+            "outline-none transition-colors duration-150 hover:bg-og-surface-1 hover:text-og-fg",
             "focus-visible:ring-2 focus-visible:ring-og-accent",
           )}
         >

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -270,6 +270,7 @@ export function TermBlock({
   output,
   live,
   tailLines = 12,
+  failed,
 }: {
   /**
    * The command shown in the prompt header. Pass `null` when the row title
@@ -282,6 +283,8 @@ export function TermBlock({
   /** The FULL output. TermBlock owns the tail/full slicing internally. */
   output: string;
   live?: boolean | undefined;
+  /** A non-zero exit / failed call — tints the left accent red (the one hue). */
+  failed?: boolean | undefined;
   /**
    * When the output exceeds the tail window, only the last `tailLines` are shown
    * with a "show full output" toggle. The component holds the full text, so the
@@ -297,10 +300,19 @@ export function TermBlock({
   const showMore = big && !full;
   const showHeader = command != null || workdir != null;
 
+  // No frame, no fill: a quiet monospace run flush on the page, marked only by a
+  // 2px left accent so it reads as terminal output at a glance without becoming
+  // yet another nested box. Color is spent only on the exception — a settled run
+  // gets a calm neutral rule, a live one the running hue, a failed one the red.
   return (
-    <div className="min-w-0 overflow-hidden rounded-og-sm border border-og-border bg-og-bg/70">
+    <div
+      className={cn(
+        "min-w-0 border-l-2 pl-3",
+        failed ? "border-og-status-failed/50" : live ? "border-og-status-running/50" : "border-og-border",
+      )}
+    >
       {showHeader ? (
-        <div className="flex items-center gap-2 border-b border-og-border/70 px-2.5 py-1.5">
+        <div className="flex items-center gap-2 pb-1">
           <span className="select-none text-og-status-idle">$</span>
           {command != null ? (
             <span className="min-w-0 flex-1 truncate font-og-mono text-og-sm text-og-fg-muted">{command}</span>
@@ -311,9 +323,9 @@ export function TermBlock({
         </div>
       ) : null}
       {empty ? (
-        <p className="px-2.5 py-2 font-og-mono text-og-xs italic text-og-fg-subtle">(no output)</p>
+        <p className="font-og-mono text-og-xs italic text-og-fg-subtle">(no output)</p>
       ) : (
-        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-all px-2.5 py-2 font-og-mono text-og-xs leading-5 text-og-fg-muted">
+        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-all font-og-mono text-og-xs leading-5 text-og-fg-muted">
           {shown}
           {live ? <span className="ml-px inline-block h-[1em] w-[2px] translate-y-[2px] animate-og-blink bg-og-accent align-middle" /> : null}
         </pre>
@@ -322,7 +334,7 @@ export function TermBlock({
         <button
           type="button"
           onClick={() => setFull(true)}
-          className="w-full border-t border-og-border/70 px-2.5 py-1.5 text-left text-og-xs text-og-fg-subtle transition-colors hover:text-og-fg"
+          className="mt-1 text-left text-og-xs text-og-fg-subtle transition-colors hover:text-og-fg"
         >
           show full output ({lines.length} lines)
         </button>
@@ -338,15 +350,16 @@ export function PayloadBlock({ label, value, failed }: { label: string; value: u
   if (!text || text.trim() === "") {
     return null;
   }
+  // Flush on the page, no frame — a labelled monospace run marked only by a 2px
+  // left accent (red when the call failed, otherwise a calm neutral rule), so a
+  // payload reads as detail hanging off the row, never a nested card.
   return (
-    <div className="min-w-0">
+    <div className={cn("min-w-0 border-l-2 pl-3", failed ? "border-og-status-failed/50" : "border-og-border")}>
       <p className="mb-1 text-og-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle">{label}</p>
       <pre
         className={cn(
-          "max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-og-sm border p-2.5 font-og-mono text-og-xs leading-5",
-          failed
-            ? "border-og-status-failed/30 bg-og-status-failed/5 text-og-status-failed"
-            : "border-og-border bg-og-bg/60 text-og-fg-muted",
+          "max-h-64 overflow-auto whitespace-pre-wrap break-all font-og-mono text-og-xs leading-5",
+          failed ? "text-og-status-failed" : "text-og-fg-muted",
         )}
       >
         {text}
@@ -358,8 +371,10 @@ export function PayloadBlock({ label, value, failed }: { label: string; value: u
 /** A quiet inline note inside an expanded body (lost output, empty frame, …). */
 export function BodyNote({ children, tone }: { children: ReactNode; tone?: "error" | "muted" | undefined }) {
   if (tone === "error") {
+    // A quiet error run marked by a 2px red accent — the same flush, frameless
+    // language as the payload/output blocks, not a filled callout box.
     return (
-      <div className="rounded-og-sm border border-og-status-failed/30 bg-og-status-failed/5 px-2.5 py-2 font-og-mono text-og-xs leading-5 text-og-status-failed">
+      <div className="border-l-2 border-og-status-failed/50 pl-3 font-og-mono text-og-xs leading-5 text-og-status-failed">
         {children}
       </div>
     );

--- a/packages/react/src/timeline/tool-diff.tsx
+++ b/packages/react/src/timeline/tool-diff.tsx
@@ -67,7 +67,7 @@ export function RawPatch({ diff }: { diff: string }) {
       <p className="mb-1 text-og-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle">
         raw patch (could not parse hunks)
       </p>
-      <pre className="max-h-72 overflow-auto rounded-og-sm border border-og-border bg-og-bg/60 p-2.5 font-og-mono text-og-xs leading-5">
+      <pre className="max-h-72 overflow-auto border-l-2 border-og-border pl-3 font-og-mono text-og-xs leading-5">
         {diff.split("\n").map((line, index) => (
           <span
             key={index}

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -178,7 +178,7 @@ function ExecRenderer({ item }: ToolRendererProps) {
       cancelled={item.status === "cancelled"}
       preview={truncated ? `⋯ truncated · ${preview}` : preview}
     >
-      <TermBlock command={null} workdir={workdir} output={body} />
+      <TermBlock command={null} workdir={workdir} output={body} failed={item.status === "failed" || (exitCode != null && exitCode !== 0)} />
       {bgSession != null ? (
         <BodyNote>↳ session {bgSession} — a later write_stdin can target this PTY.</BodyNote>
       ) : null}

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -36,11 +36,18 @@ export type TurnSummaryProps = {
   durationMs?: number | undefined;
   /** Start expanded. */
   defaultOpen?: boolean | undefined;
+  /**
+   * A nested fold — a cluster or sub-turn INSIDE an already-expanded turn. It
+   * drops the bordered/filled chip and renders as a plain disclosure node on the
+   * parent's rail (chevron + glyph + facets), so expanding a turn reveals a thread
+   * of nodes, never a stack of boxes-in-boxes. The top-level fold stays a chip.
+   */
+  bare?: boolean | undefined;
   /** The rendered activity rail revealed on expand. */
   children: React.ReactNode;
 };
 
-export function TurnSummary({ items, outcome, failureText, durationMs, defaultOpen, children }: TurnSummaryProps) {
+export function TurnSummary({ items, outcome, failureText, durationMs, defaultOpen, bare, children }: TurnSummaryProps) {
   // An explicit `defaultOpen` always wins; otherwise an ancestor may seed it
   // (screenshot instrumentation); otherwise the turn starts folded.
   const forcedDefaultOpen = useForcedDefaultOpen();
@@ -49,18 +56,26 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
   const facets = summarizeTurn(items, durationMs);
 
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen} className={enter ? "animate-og-enter" : undefined}>
+    <Collapsible.Root open={open} onOpenChange={setOpen} className={enter && !bare ? "animate-og-enter" : undefined}>
       <Collapsible.Trigger
         className={cn(
-          "group flex w-full items-center gap-2.5 rounded-og-md border px-3 py-2 text-left text-og-base transition-colors",
-          // A folded turn is a touch target on coarse pointers: grow the row so
-          // it clears the 40px minimum without disturbing the calm desktop rhythm.
-          "pointer-coarse:py-2.5",
-          // Only a failed turn earns the one filled/tinted card in the timeline;
-          // complete and cancelled stay flat and calm.
-          outcome === "failed"
-            ? "border-og-status-failed/30 bg-og-status-failed/[0.06] hover:border-og-status-failed/50"
-            : "border-og-border bg-og-surface-1/50 hover:border-og-border-strong",
+          "group flex w-full items-center text-left text-og-base transition-colors",
+          bare
+            ? // A nested node: no border, no fill — a plain rail row. It sits at the
+              // same weight as the tool rows it groups (hover tint only), so the turn
+              // body reads as one continuous thread instead of nested cards.
+              "gap-2 rounded-og-sm px-1.5 py-1.5 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:py-2.5"
+            : cn(
+                "gap-2.5 rounded-og-md border px-3 py-2",
+                // A folded turn is a touch target on coarse pointers: grow the row so
+                // it clears the 40px minimum without disturbing the calm desktop rhythm.
+                "pointer-coarse:py-2.5",
+                // Only a failed turn earns the one filled/tinted card in the timeline;
+                // complete and cancelled stay flat and calm.
+                outcome === "failed"
+                  ? "border-og-status-failed/30 bg-og-status-failed/[0.06] hover:border-og-status-failed/50"
+                  : "border-og-border bg-og-surface-1/50 hover:border-og-border-strong",
+              ),
         )}
       >
         {/* Disclosure grammar matches the rows: chevron leads (far left), then the
@@ -68,14 +83,21 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
         <ChevronRightIcon className="size-3.5 shrink-0 text-og-fg-subtle transition-transform duration-150 group-data-[state=open]:rotate-90" />
         {/* Only the exceptional outcomes earn a filled tinted circle. A clean
             (complete) run draws a bare muted check — zero colored fills, so the
-            eye is pulled only to a turn that needs attention. */}
+            eye is pulled only to a turn that needs attention. A nested node keeps
+            the glyph unfilled (it is a rail node, not a card) — the hue alone
+            carries an exceptional outcome. */}
         <span
           className={cn(
-            "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+            "inline-flex shrink-0 items-center justify-center rounded-full",
+            bare ? "size-3.5" : "size-5",
             outcome === "failed"
-              ? "bg-og-status-failed/15 text-og-status-failed"
+              ? bare
+                ? "text-og-status-failed"
+                : "bg-og-status-failed/15 text-og-status-failed"
               : outcome === "cancelled"
-                ? "bg-og-fg-subtle/15 text-og-fg-subtle"
+                ? bare
+                  ? "text-og-fg-subtle"
+                  : "bg-og-fg-subtle/15 text-og-fg-subtle"
                 : "text-og-fg-subtle",
           )}
         >
@@ -84,12 +106,12 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
           ) : outcome === "cancelled" ? (
             <CircleSlashIcon className="size-3" />
           ) : outcome === "complete" ? (
-            <CheckIcon className="size-3.5" />
+            <CheckIcon className={bare ? "size-3" : "size-3.5"} />
           ) : (
             <span className="size-1.5 animate-og-pulse rounded-full bg-og-fg-subtle" />
           )}
         </span>
-        <span className="min-w-0 flex-1 truncate text-og-fg-muted">
+        <span className={cn("min-w-0 flex-1 truncate", bare ? "text-og-sm" : "text-og-fg-muted")}>
           {facets}
           {outcome === "failed" && failureText ? (
             <span className="text-og-status-failed"> · {failureText}</span>
@@ -113,7 +135,9 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
         </span>
       </Collapsible.Trigger>
       <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-og-collapse data-[state=open]:animate-og-expand">
-        <div className="pt-2">{children}</div>
+        {/* A nested node indents its revealed rows under the glyph (thread nesting
+            off the parent rail); the top-level turn body owns its own rail. */}
+        <div className={bare ? "pt-1 pl-5" : "pt-2"}>{children}</div>
       </Collapsible.Content>
     </Collapsible.Root>
   );

--- a/packages/react/test/timeline-worker-completion.test.tsx
+++ b/packages/react/test/timeline-worker-completion.test.tsx
@@ -80,22 +80,20 @@ describe("MessageTimeline — worker completions", () => {
   });
 
   test("deep-links into the child session on click", async () => {
-    let opened: string | null = null;
+    const opened: string[] = [];
     const events = [
       completionEvent({
         text: "done",
         childCompletion: { childSessionId: CHILD_ID, status: "idle", goal: { status: "completed", text: "ship it" } },
       }),
     ];
-    const r = await renderComponent(<MessageTimeline events={events} onOpenSession={(id) => { opened = id; }} />);
+    const r = await renderComponent(<MessageTimeline events={events} onOpenSession={(id) => { opened.push(id); }} />);
     const viewButton = Array.from(r.container.querySelectorAll("button")).find((b) => /View session/.test(b.textContent ?? ""));
     await act(async () => {
       viewButton!.click();
       await flush();
     });
-    // TS narrows `opened` to null here (it cannot see the callback write);
-    // widen for the matcher without weakening the runtime assertion.
-    expect(opened as string | null).toBe(CHILD_ID);
+    expect(opened).toEqual([CHILD_ID]);
   });
 
   test("a failed child reads as a failure, a paused goal as paused", async () => {


### PR DESCRIPTION
Reviewer feedback: the boxes that expand to show steps — the outer layer and the inner layers of each step — "are a little bit ugly… make those not kind of boxes in that kind of way, make it more beautiful, better flow."

## The change: containment → thread

Before, expanding a turn opened a bordered rectangle; each step inside was another bordered/filled rectangle; step output was a third. Boxes in boxes in boxes. Now an expanded turn is one continuous thread down a single left rail:

- **Nested cluster/sub-turn chips** → plain disclosure nodes hanging on the turn's rail (chevron + status glyph + facet line, no border, no fill); their steps reveal indented flush beneath. No second border inside a turn.
- **Command output / payloads / error notes / raw patches** → quiet monospace runs marked only by a 2px left accent (neutral at rest, running hue while live, red on failure — color spent only on the exception). No separate background rectangle.
- **Worker rows** → borderless rail rows aligned with sibling tool rows; deep-link is a quiet borderless button.
- **Worker-completion cards** → full tinted-border box → 2px left-accent treatment (green completed / waiting paused / red failed), report unfolds flush beneath.

Kept deliberately: the **top-level turn fold chip** (per the direction — the collapsed chip works; it's now the single frame in the expanded view rather than the head of a box hierarchy) and the **code-diff viewer** (shared with the Files tab; a framed diff with line numbers is a real code surface, the GitHub-Actions-log reference, not a step box).

## Bundled goal-surface taste fixes
1. "Needs attention" now wears an amber/warning hue (was purple, indistinguishable from paused).
2. The goal detail panel opens **upward** from the pill, capped to the space above it, scrolling internally on short viewports (verified at 420×560).
3. Autonomy counters show a quiet "v4" chip instead of "version 4".

## Verification
- packages/react: typecheck clean, 453 tests pass (golden grammar included — visual-only, no serialized output changed, no regeneration).
- apps/web: typecheck clean, 179 tests pass.
- Before/after screenshots (dark + light, completed/failed/live turns, workers, completions, goal panel) in `.agent/screenshots/` in the worktree.
- Animation hardening (reveal-at-bottom, capture-at-mount, expand/collapse eases) intact; no projection/data/fold-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and component props in timeline and goal UI; no projection, API, or data-path changes, with existing tests still passing.
> 
> **Overview**
> **Reframes expanded timeline UI from nested boxes to one continuous left-rail thread**, while keeping the **top-level turn fold chip** as the only framed summary.
> 
> **Timeline (`@opengeni/react`):** Nested activity clusters and sub-turns use a new **`bare`** mode on `TurnSummary` and `ActivityRail`—plain disclosure rows on the parent rail (no inner bordered chips). Only the outermost turn draws the **`border-l-2`** rail; nested bodies stack flush without a second rule. **Failure text** and **auto-open on failed** apply at the top level only so nested nodes stay quiet.
> 
> **Detail blocks** (`TermBlock`, `PayloadBlock`, error `BodyNote`, raw patches) drop filled/bordered rectangles for **2px left-accent** monospace runs (neutral / running / red on failure). **Worker** rows and **worker-completion** cards follow the same language (borderless rail rows; completions use left accent instead of full cards). Exec output passes **`failed`** into `TermBlock` for non-zero exits.
> 
> **Goal surface (`apps/web`):** “Needs attention” uses **amber/warning** tokens so it’s distinct from paused purple. The goal detail **popover** is height-capped above the pill with **internal scroll**. Autonomy chip shows **`v{n}`** instead of “version n”.
> 
> Demo harness mirrors the nested **`insideTurn` / `bare`** wiring; one worker-completion test uses an array for the open-session callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f031a1b1d1b6f2294fe356b54edb94c2c260f4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->