### PR TITLE
fix(api): send canonical Bearer auth scheme (Linear MCP token acceptance)

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -14,6 +14,7 @@ import {
   isPrivateAddress,
   listConnectionsMetadata,
   loadIntegrationOAuthClient,
+  normalizeBearerScheme,
   replaceIntegrationOAuthClient,
   storeIntegrationOAuthClient,
   updateConnection,
@@ -900,7 +901,7 @@ async function verifyMcpToolsList(settings: Settings, resource: string, token: T
   try {
     const transport = new StreamableHTTPClientTransport(new URL(resource), {
       requestInit: {
-        headers: { authorization: `${token.tokenType} ${token.accessToken}` },
+        headers: { authorization: `${normalizeBearerScheme(token.tokenType)} ${token.accessToken}` },
       },
       fetch: (url, init) => fetchOAuth(url.toString(), settings, init),
     });

--- a/packages/db/src/connection-token-resolver.ts
+++ b/packages/db/src/connection-token-resolver.ts
@@ -263,6 +263,16 @@ function missingRequestedScopes(requested: string[] | undefined, granted: string
   return requested.filter((scope) => !grantedSet.has(scope));
 }
 
+/**
+ * Normalizes an OAuth token_type into the Authorization scheme to send. RFC 6750
+ * says the scheme is case-insensitive, but some MCP servers (e.g. Linear) reject
+ * a lowercase `bearer` — so a `bearer`/`BEARER` (or absent) token_type is sent as
+ * the canonical `Bearer`. A non-bearer scheme is passed through unchanged.
+ */
+export function normalizeBearerScheme(tokenType: string | null | undefined): string {
+  return !tokenType || /^bearer$/i.test(tokenType) ? "Bearer" : tokenType;
+}
+
 function headersForCredential(cred: ConnectionCredentialForBroker): Record<string, string> | null {
   if (cred.kind === "api_key") {
     return stringRecord((cred.credential as { headers?: unknown }).headers);
@@ -272,8 +282,7 @@ function headersForCredential(cred: ConnectionCredentialForBroker): Record<strin
     if (!accessToken) {
       return null;
     }
-    const tokenType = stringValue((cred.credential as { token_type?: unknown }).token_type) || "Bearer";
-    return { authorization: `${tokenType} ${accessToken}` };
+    return { authorization: `${normalizeBearerScheme(stringValue((cred.credential as { token_type?: unknown }).token_type))} ${accessToken}` };
   }
   return stringRecord((cred.credential as { headers?: unknown }).headers);
 }

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -6,6 +6,7 @@ import postgres from "postgres";
 import {
   buildConnectionTokenResolver,
   ConnectionRefreshHttpError,
+  normalizeBearerScheme,
   createConnection,
   createDb,
   consumeIntegrationOAuthStateNonce,
@@ -697,5 +698,18 @@ describe("buildConnectionTokenResolver", () => {
     });
     expect(result).toMatchObject({ status: "auth_needed", reason: "refresh_failed", connectionId: "conn_oauth" });
     expect(counts.status).toBe(1);
+  });
+});
+
+describe("normalizeBearerScheme", () => {
+  test("canonicalizes a lowercase/absent bearer scheme to \"Bearer\" (Linear MCP rejects lowercase)", () => {
+    expect(normalizeBearerScheme("bearer")).toBe("Bearer");
+    expect(normalizeBearerScheme("BEARER")).toBe("Bearer");
+    expect(normalizeBearerScheme("Bearer")).toBe("Bearer");
+    expect(normalizeBearerScheme(null)).toBe("Bearer");
+    expect(normalizeBearerScheme("")).toBe("Bearer");
+  });
+  test("passes a non-bearer scheme through unchanged", () => {
+    expect(normalizeBearerScheme("DPoP")).toBe("DPoP");
   });
 });


### PR DESCRIPTION
**The real root cause of Linear MCP connect failing.** Linear's token endpoint returns token_type `bearer` (lowercase); the broker sent `Authorization: bearer <token>` verbatim; Linear's MCP is case-sensitive and 401'd it. Proven empirically against the live persisted token: `bearer <t>` → 401, `Bearer <t>` → 200. The prior CIMD/DCR/confidential-client theories were all red herrings — the token was always valid. `normalizeBearerScheme()` canonicalizes a bearer/absent scheme to `Bearer` at both header-construction sites (runtime broker + callback verify). **No reconnect required** — existing Linear tokens work once deployed. Regression test added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Authorization header formatting for OAuth2; low blast radius with regression tests and no credential or auth-flow logic changes beyond scheme casing.
> 
> **Overview**
> Fixes MCP OAuth calls failing when providers return `token_type: bearer` (lowercase) but the resource server only accepts `Authorization: Bearer <token>`.
> 
> Introduces **`normalizeBearerScheme()`** in `@opengeni/db`: maps missing or case-insensitive `bearer` to `Bearer`, and leaves other schemes (e.g. `DPoP`) unchanged. It is used when building OAuth2 headers in the **connection token broker** and in the API’s **post-callback MCP tools/list verification** (`verifyMcpToolsList`).
> 
> Existing stored tokens should work after deploy—no reconnect required. Unit tests cover the helper’s bearer canonicalization and non-bearer passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212bc1d0e1b6814ede467c8651a4e0f297e5ed4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->