### PR TITLE
fix(web): clean human labels on message capability chips

### DIFF
--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { MarkdownText } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/context";
+import { capabilityChipLabel } from "@/lib/capabilities";
 import type { SessionFailureSummary } from "@/lib/events";
 import { formatTimestamp } from "@/lib/format";
 import { repositoryDisplayName } from "@/lib/session-tools";
@@ -235,8 +236,8 @@ export function UserMessageBody({ workspaceId, item }: { workspaceId: string; it
               key={`${tool.kind}:${tool.id}`}
               className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg-muted"
             >
-              <WrenchIcon className="size-3.5" />
-              <span>{tool.id}</span>
+              <WrenchIcon className="size-3.5 shrink-0" />
+              <span className="truncate">{capabilityChipLabel(tool.id)}</span>
             </span>
           ))}
         </div>

--- a/apps/web/src/lib/capabilities.ts
+++ b/apps/web/src/lib/capabilities.ts
@@ -2,6 +2,40 @@ import type { CapabilityCatalogItem, CapabilityKind, CapabilitySource, Connectio
 
 export type CapabilityFilter = "all" | CapabilityKind;
 
+/** Nice labels for the built-in (first-party) MCP servers. */
+const FIRST_PARTY_MCP_LABELS: Record<string, string> = {
+  opengeni: "OpenGeni",
+  files: "Files",
+  docs: "Docs",
+};
+
+// domain-slug suffixes that are really a TLD glued on by the slugifier
+// (linear.app -> "linear-app"); dropped so the chip reads "Linear", not "Linear App".
+const DOMAIN_TLD_SUFFIX = /-(app|com|io|org|dev|ai|co|net|so|xyz|cloud|sh)$/i;
+
+/**
+ * Human label for an MCP tool/capability id shown on a message chip. Built-in
+ * servers get their proper name; catalog-imported ids
+ * (`cap-integrations-sh-linear-app-<hash>-<hash>`) are stripped of their
+ * prefix + trailing hash segments and title-cased to the provider ("Linear").
+ * Best-effort by design — a value we can't parse is returned as-is rather than
+ * shown as raw id soup where avoidable.
+ */
+export function capabilityChipLabel(id: string): string {
+  if (FIRST_PARTY_MCP_LABELS[id]) return FIRST_PARTY_MCP_LABELS[id];
+  let slug = id.replace(/^(cap|mcp)-/, "").replace(/^integrations-sh-/, "");
+  // drop the trailing opaque hash segments the id builder appends
+  slug = slug.replace(/(-[a-z0-9]{5,}){1,3}$/i, "");
+  slug = slug.replace(DOMAIN_TLD_SUFFIX, "");
+  const label = slug
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+    .trim();
+  return label || id;
+}
+
 // Human copy for every taxonomy value that used to leak enum slugs into the UI
 // (doctrine: no internal taxonomy in user-facing labels). Codes appear at most
 // as fallbacks for values we don't recognize.


### PR DESCRIPTION
User-message capability chips showed raw MCP server ids (`cap-integrations-sh-linear-app-<hash>`, `opengeni`). `capabilityChipLabel()` renders the provider name instead (Linear / Notion / OpenGeni). Best-effort string clean; a proper catalog-name lookup is the follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label formatting in session message UI; no auth, API, or data-path changes.
> 
> **Overview**
> User-message **tool/capability chips** no longer show raw ids like `cap-integrations-sh-linear-app-<hash>` or `opengeni`. They now render through **`capabilityChipLabel()`**, which maps first-party MCP ids to fixed names (OpenGeni, Files, Docs) and heuristically strips catalog prefixes, hash suffixes, and domain TLD slug noise so imported integrations read as provider names (e.g. **Linear**).
> 
> Chip layout is aligned with repo chips: the wrench icon is **`shrink-0`** and the label **`truncate`**s so long ids don’t blow out the bubble.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f14e13cd929756c87ee167be3091bd7ce61af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->