### PR TITLE
fix(sandbox): file-resource download is POSIX-safe + non-fatal (no more session death)

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -52,8 +52,11 @@ import {
   summarizeForCompaction,
   ensureModalRegistryImage,
   findCompactionNeededError,
+  materializeSandboxFileDownloads,
+  sandboxFileDownloadFailureNote,
   SUMMARY_BUFFER_TOKENS,
   type SandboxFileDownload,
+  type SandboxFileDownloadFailure,
   type OpenGeniRuntime,
   type ComputerToolMode,
 } from "@opengeni/runtime";
@@ -1513,6 +1516,25 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           console.error("context compaction failed (turn proceeds un-compacted)", compactError);
         }
       }
+      let fileMaterializationFailures: SandboxFileDownloadFailure[] = [];
+      let fileDownloadsMaterializedForRun = false;
+      if (
+        resolvedSandbox
+        && setupBoxSession
+        && activeSandboxBackend !== "selfhosted"
+        && fileResourceDownloads.length > 0
+      ) {
+        const runAs = sandboxRunAs(runSettings);
+        const materialized = await materializeSandboxFileDownloads(setupBoxSession as any, fileResourceDownloads, {
+          onRuntimeEvent: async (event) => {
+            await publish!([{ type: event.type, payload: event.payload }], true);
+          },
+          ...(runAs ? { runAs } : {}),
+        });
+        fileMaterializationFailures = materialized.failures;
+        fileDownloadsMaterializedForRun = true;
+      }
+      const unavailableSandboxFilesNote = sandboxFileDownloadFailureNote(fileMaterializationFailures);
       // Cross-account reasoning strip: pass THIS turn's codex account so every
       // history read path (items + run-state replay) drops reasoning produced by
       // a DIFFERENT codex account. effectiveCodexCredentialId is the resolved
@@ -1534,6 +1556,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           trigger,
           runSettings,
           { currentCodexCredentialId: effectiveCodexCredentialId },
+          unavailableSandboxFilesNote ? { unavailableSandboxFilesNote } : {},
         );
         runInput = prepared.input;
         // Slice index = the length of the model-facing (active) history this turn
@@ -1615,6 +1638,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 // established box — never through the routing proxy, which would
                 // re-route those execs onto a machine swapped in mid-turn.
                 ...(setupBoxSession ? { setupSession: setupBoxSession } : {}),
+                ...(fileDownloadsMaterializedForRun ? { fileDownloadsMaterialized: true } : {}),
               },
             }
             : {}),
@@ -2049,6 +2073,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         activityError = error;
         await flushRuntimeBatcher();
         if (preemptTurnId) {
+          await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+            turnId: preemptTurnId,
+            type: "turn.cancelled",
+            payload: {
+              triggerEventId: input.triggerEventId,
+              reason: error.message || "activity_cancelled",
+            },
+          }]).catch(() => undefined);
           await finishTurn(db, input.workspaceId, preemptTurnId, "cancelled").catch(() => undefined);
           turnMetricOutcome = "cancelled";
         }

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -134,6 +134,10 @@ export type PreparedTurnInput = {
   modelHistoryFromItems: boolean;
 };
 
+export type TurnInputOptions = {
+  unavailableSandboxFilesNote?: string;
+};
+
 export async function turnInput(
   db: Database,
   runtime: OpenGeniRuntime,
@@ -141,6 +145,7 @@ export async function turnInput(
   trigger: Awaited<ReturnType<typeof getSessionEvent>>,
   settings?: Settings,
   current: TurnCodexAccount = NON_CODEX_TURN,
+  options: TurnInputOptions = {},
 ): Promise<PreparedTurnInput> {
   if (!trigger) {
     throw new Error("Missing trigger event");
@@ -156,7 +161,7 @@ export async function turnInput(
       payload.text,
       Array.isArray(payload.resources) ? payload.resources as ResourceRef[] : [],
     );
-    return await messageInput(db, runtime, agent, trigger, text, settings, current);
+    return await messageInput(db, runtime, agent, trigger, withUnavailableSandboxFilesNote(text, options.unavailableSandboxFilesNote), settings, current);
   }
   if (trigger.type === "goal.continuation") {
     const payload = trigger.payload as { text?: unknown };
@@ -165,7 +170,7 @@ export async function turnInput(
     }
     // Threading the stored conversation keeps the agent's full context across
     // continuations — this is what makes "keep working" coherent.
-    return await messageInput(db, runtime, agent, trigger, payload.text, settings, current);
+    return await messageInput(db, runtime, agent, trigger, withUnavailableSandboxFilesNote(payload.text, options.unavailableSandboxFilesNote), settings, current);
   }
   if (trigger.type === "turn.preempted") {
     const payload = trigger.payload as { text?: unknown };
@@ -175,7 +180,7 @@ export async function turnInput(
     // A turn re-entering after a graceful worker shutdown checkpointed it
     // mid-flight: thread the stored conversation (which includes the turn's
     // original input and its progress so far) behind a resume notice.
-    return await messageInput(db, runtime, agent, trigger, payload.text, settings, current);
+    return await messageInput(db, runtime, agent, trigger, withUnavailableSandboxFilesNote(payload.text, options.unavailableSandboxFilesNote), settings, current);
   }
   if (trigger.type === "user.approvalDecision") {
     const payload = trigger.payload as {
@@ -208,6 +213,11 @@ export async function turnInput(
     };
   }
   throw new Error(`Unsupported trigger event type: ${trigger.type}`);
+}
+
+export function withUnavailableSandboxFilesNote(text: string, note?: string): string {
+  const trimmed = note?.trim();
+  return trimmed ? [text, "", trimmed].join("\n") : text;
 }
 
 /**

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -5,6 +5,7 @@ import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
 import { classifyContextWindowOverflowError, computerToolModeForTurn, ensureTurnModalRegistryImage, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 import { settingsWithPackSandboxImage } from "../src/activities/packs";
+import { withUnavailableSandboxFilesNote } from "../src/activities/run-input";
 
 // Item shapes mirror the SDK history representation persisted into
 // session_history_items (type discriminator, camelCase callId).
@@ -477,6 +478,24 @@ describe("worker shutdown preemption", () => {
   test("resume notice tells the agent to verify in-flight side effects", () => {
     expect(WORKER_SHUTDOWN_RESUME_TEXT).toContain("TURN RESUMED AFTER WORKER RESTART");
     expect(WORKER_SHUTDOWN_RESUME_TEXT).toContain("check whether it already happened");
+  });
+});
+
+describe("sandbox file materialization note", () => {
+  test("appends unavailable attachment details to model-facing text", () => {
+    const text = withUnavailableSandboxFilesNote(
+      "Analyze the attachment",
+      [
+        "The following attached files could not be loaded into the sandbox and are unavailable this turn:",
+        "- report.csv (Sandbox file resource download file-1 failed with exit code 2)",
+        "Continue without them or tell the user.",
+      ].join("\n"),
+    );
+
+    expect(text).toContain("Analyze the attachment");
+    expect(text).toContain("report.csv");
+    expect(text).toContain("failed with exit code 2");
+    expect(text).toContain("Continue without them or tell the user.");
   });
 });
 

--- a/apps/worker/test/session-state-cancel.test.ts
+++ b/apps/worker/test/session-state-cancel.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const appendedEvents: Array<{ type: string; turnId?: string | null; payload: any }> = [];
+const finishedTurns: Array<{ turnId: string; status: string }> = [];
+const statuses: Array<{ sessionId: string; status: string; activeTurnId: string | null }> = [];
+
+mock.module("@opengeni/db", () => ({
+  claimNextQueuedTurn: mock(async () => null),
+  countQueuedTurns: mock(async () => 0),
+  countTurnSessionHistoryItems: mock(async () => 0),
+  finishTurn: mock(async (_db: unknown, _workspaceId: string, turnId: string, status: string) => {
+    finishedTurns.push({ turnId, status });
+  }),
+  getSessionEvent: mock(async () => ({ id: "event-1", type: "user.message", payload: { text: "stop" } })),
+  getSessionTurn: mock(async () => null),
+  incrementTurnWorkerDeathRedispatches: mock(async () => 1),
+  requeuePreemptedTurn: mock(async () => undefined),
+  requireSession: mock(async () => ({
+    id: "session-1",
+    status: "running",
+    activeTurnId: "turn-1",
+  })),
+  setSessionStatus: mock(async (_db: unknown, _workspaceId: string, sessionId: string, status: string, activeTurnId: string | null) => {
+    statuses.push({ sessionId, status, activeTurnId });
+  }),
+}));
+
+mock.module("@opengeni/events", () => ({
+  appendAndPublishEvents: mock(async (_db: unknown, _bus: unknown, _workspaceId: string, _sessionId: string, events: any[]) => {
+    appendedEvents.push(...events);
+    return events.map((event, index) => ({ id: `event-${index + 1}`, ...event }));
+  }),
+}));
+
+mock.module("../src/activities/goals", () => ({
+  isSteerInterrupt: () => false,
+  pauseActiveGoalOnInterrupt: mock(async () => undefined),
+}));
+
+mock.module("../src/activities/parent-wake", () => ({
+  notifyParentOfChildTerminal: mock(async () => undefined),
+}));
+
+mock.module("../src/observability-metrics", () => ({
+  recordTurnsQueuedGauge: mock(() => undefined),
+}));
+
+describe("session-state cancellation", () => {
+  beforeEach(() => {
+    appendedEvents.length = 0;
+    finishedTurns.length = 0;
+    statuses.length = 0;
+  });
+
+  test("emits turn.cancelled when cancelling an active turn", async () => {
+    const { createSessionStateActivities } = await import("../src/activities/session-state");
+    const activities = createSessionStateActivities(async () => ({
+      db: {},
+      bus: {},
+      settings: {},
+      observability: {},
+      wakeSessionWorkflow: mock(async () => undefined),
+    } as any));
+
+    await activities.interruptActiveTurn({
+      accountId: "account-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      triggerEventId: "event-1",
+      workflowId: "workflow-1",
+      turnId: "turn-1",
+    });
+
+    expect(appendedEvents.map((event) => event.type)).toEqual(["turn.cancelled", "session.status.changed"]);
+    expect(appendedEvents[0]).toMatchObject({
+      type: "turn.cancelled",
+      turnId: "turn-1",
+      payload: { triggerEventId: "event-1" },
+    });
+    expect(finishedTurns).toEqual([{ turnId: "turn-1", status: "cancelled" }]);
+    expect(statuses).toEqual([{ sessionId: "session-1", status: "queued", activeTurnId: null }]);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -287,6 +287,19 @@ export type SandboxFileDownload = {
   sizeBytes?: number;
 };
 
+export type SandboxFileDownloadFailure = {
+  fileId: string;
+  filename: string;
+  path: string;
+  reason: string;
+  exitCode?: number;
+  output?: string;
+};
+
+export type SandboxFileDownloadMaterializationResult = {
+  failures: SandboxFileDownloadFailure[];
+};
+
 let runtimeMetricsHooks: RuntimeMetricsHooks | null = null;
 
 export function configureRuntimeMetricsHooks(hooks: RuntimeMetricsHooks | null | undefined): void {
@@ -2199,6 +2212,9 @@ export type RunAgentStreamOptions = {
     // follow a swap onto a connected machine (the user's real computer), so it
     // runs against this pinned handle instead. Absent -> falls back to `session`.
     setupSession?: unknown;
+    // True when the caller already ran file-resource materialization for this
+    // provided session and threaded any failures into the model input.
+    fileDownloadsMaterialized?: boolean;
   };
   // A per-turn model-input filter chained AFTER the provider-item-id strip.
   // Used by the genesis-title injection to prepend a hidden, NON-PERSISTED
@@ -2434,11 +2450,12 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
       // command is idempotent (skips an existing file) and atomic (tmp + rename),
       // so the per-turn re-run is safe; the turn re-signs URLs each run, so a
       // re-warmed box always gets fresh links.
-      if (fileDownloads.length > 0) {
-        await materializeSandboxFileDownloads(setupSession, fileDownloads, {
+      if (fileDownloads.length > 0 && !overrides.ownedSandbox.fileDownloadsMaterialized) {
+        const materialized = await materializeSandboxFileDownloads(setupSession, fileDownloads, {
           ...(overrides.onRuntimeEvent ? { onRuntimeEvent: overrides.onRuntimeEvent } : {}),
           ...(runAs ? { runAs } : {}),
         });
+        appendSandboxFileDownloadFailureNote(prepared, materialized.failures);
       }
     } else {
       // SELFHOSTED TOOLSPACE (parity): the platform setup hooks (repository clone,
@@ -2555,6 +2572,23 @@ export async function runAgentStream(agent: Agent<any, any>, input: PreparedAgen
     } as SandboxRunConfig;
   }
   return await runScopedRunner(settings).run(agent, prepared.input, runOptions);
+}
+
+function appendSandboxFileDownloadFailureNote(input: PreparedAgentInput, failures: SandboxFileDownloadFailure[]): void {
+  const note = sandboxFileDownloadFailureNote(failures);
+  if (!note) {
+    return;
+  }
+  if (typeof input.input === "string") {
+    input.input = [input.input, "", note].join("\n");
+    return;
+  }
+  if (Array.isArray(input.input)) {
+    input.input = [
+      ...input.input,
+      { type: "message", role: "user", content: note } as AgentInputItem,
+    ];
+  }
 }
 
 /**
@@ -2858,14 +2892,12 @@ export async function materializeSandboxFileDownloads(
   session: SandboxSessionLike,
   downloads: SandboxFileDownload[],
   context: Pick<SandboxLifecycleHookContext, "onRuntimeEvent" | "runAs"> = {},
-): Promise<void> {
+): Promise<SandboxFileDownloadMaterializationResult> {
   const normalizedDownloads = normalizeSandboxFileDownloads(downloads);
   if (normalizedDownloads.length === 0) {
-    return;
+    return { failures: [] };
   }
-  if (!session.exec && !session.execCommand) {
-    throw new Error("Sandbox file download materialization requires command execution support");
-  }
+  const failures: SandboxFileDownloadFailure[] = [];
   for (const download of normalizedDownloads) {
     const targetPath = sandboxDownloadTargetPath(download);
     const payload = {
@@ -2875,8 +2907,22 @@ export async function materializeSandboxFileDownloads(
       expiresAt: download.expiresAt ? new Date(download.expiresAt).toISOString() : null,
     };
     await context.onRuntimeEvent?.({ type: "sandbox.operation.started", payload: { name: "file-resource-download", ...payload } });
+    if (!session.exec && !session.execCommand) {
+      const failure = sandboxFileDownloadFailure(download, targetPath, "Sandbox file download materialization requires command execution support");
+      failures.push(failure);
+      await context.onRuntimeEvent?.({
+        type: "sandbox.operation.failed",
+        payload: {
+          name: "file-resource-download",
+          ...payload,
+          error: failure.reason,
+        },
+      });
+      continue;
+    }
+    let result: unknown;
     try {
-      const result = session.exec
+      result = session.exec
         ? await session.exec({
           cmd: sandboxFileDownloadCommand(download, targetPath),
           workdir: "/workspace",
@@ -2894,17 +2940,50 @@ export async function materializeSandboxFileDownloads(
       assertSandboxCommandSucceeded(result, `Sandbox file resource download ${download.fileId}`);
       await context.onRuntimeEvent?.({ type: "sandbox.operation.completed", payload: { name: "file-resource-download", ...payload } });
     } catch (error) {
+      const failure = sandboxFileDownloadFailure(download, targetPath, error, result);
+      failures.push(failure);
       await context.onRuntimeEvent?.({
         type: "sandbox.operation.failed",
         payload: {
           name: "file-resource-download",
           ...payload,
-          error: error instanceof Error ? error.message : String(error),
+          error: failure.reason,
+          ...(failure.exitCode !== undefined ? { exitCode: failure.exitCode } : {}),
+          ...(failure.output ? { output: failure.output } : {}),
         },
       });
-      throw error;
     }
   }
+  return { failures };
+}
+
+function sandboxFileDownloadFailure(
+  download: SandboxFileDownload,
+  targetPath: string,
+  error: unknown,
+  result?: unknown,
+): SandboxFileDownloadFailure {
+  const exitCode = sandboxCommandExitCode(result);
+  const output = sandboxCommandOutput(result);
+  return {
+    fileId: download.fileId,
+    filename: download.filename,
+    path: targetPath,
+    reason: error instanceof Error ? error.message : String(error),
+    ...(exitCode !== null ? { exitCode } : {}),
+    ...(output ? { output } : {}),
+  };
+}
+
+export function sandboxFileDownloadFailureNote(failures: SandboxFileDownloadFailure[]): string {
+  if (failures.length === 0) {
+    return "";
+  }
+  return [
+    "The following attached files could not be loaded into the sandbox and are unavailable this turn:",
+    ...failures.map((failure) => `- ${failure.filename} (${failure.reason})`),
+    "Continue without them or tell the user.",
+  ].join("\n");
 }
 
 export function sandboxFileDownloadsForAgent(agent: unknown): SandboxFileDownload[] {
@@ -3367,7 +3446,7 @@ function sandboxFileDownloadCommand(download: SandboxFileDownload, targetPath: s
   const targetDir = posixPath.dirname(targetPath);
   const tmpPath = `${targetPath}.opengeni-download-$$`;
   return [
-    "set -euo pipefail",
+    "set -eu",
     `mkdir -p -- ${shellQuote(targetDir)}`,
     `if [ ! -f ${shellQuote(targetPath)} ]; then`,
     `  tmp=${shellQuote(tmpPath)}`,
@@ -3885,6 +3964,10 @@ export function sandboxCommandExitCode(result: unknown): number | null {
 }
 
 export function sandboxCommandOutput(result: unknown): string {
+  if (typeof result === "string") {
+    const outputIndex = result.indexOf("Output:");
+    return outputIndex >= 0 ? result.slice(outputIndex + "Output:".length).trim() : result.trim();
+  }
   if (!result || typeof result !== "object") {
     return "";
   }
@@ -3905,7 +3988,7 @@ function assertSandboxCommandSucceeded(result: unknown, operation: string): void
   }
   const exitCode = sandboxCommandExitCode(result);
   if (exitCode !== null && exitCode !== 0) {
-    throw new Error(output || `${operation} failed with exit code ${exitCode}`);
+    throw new Error(`${operation} failed with exit code ${exitCode}${output ? `:\n${output}` : ""}`);
   }
   if (exitCode === null) {
     throw new Error(output || `${operation} did not return a command exit code`);

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -978,11 +978,47 @@ describe("runtime event normalization", () => {
     });
 
     expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain("set -eu");
+    expect(commands[0]).not.toContain("pipefail");
     expect(commands[0]).toContain("curl --fail");
     expect(commands[0]).toContain("chmod a-w");
     expect(commands[0]).toContain("https://storage.example/input.txt?sig=secret");
     expect(events.join("\n")).not.toContain("sig=secret");
     expect(events.join("\n")).toContain("file-resource-download");
+  });
+
+  test("reports signed file download failures without throwing", async () => {
+    const events: Array<{ type: string; payload: any }> = [];
+    const result = await materializeSandboxFileDownloads({
+      state: { manifest: new Manifest({ root: "/workspace" }) },
+      execCommand: async () => [
+        "Chunk ID: abc123",
+        "Wall time: 0.0000 seconds",
+        "Process exited with code 2",
+        "Output:",
+        "/bin/sh: 1: set: Illegal option -o pipefail",
+      ].join("\n"),
+    } as any, [{
+      fileId: "file-1",
+      mountPath: "files/file-1",
+      filename: "input.txt",
+      url: "https://storage.example/input.txt?sig=secret",
+      sizeBytes: 5,
+    }], {
+      onRuntimeEvent: (event) => {
+        events.push(event as any);
+      },
+    });
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.filename).toBe("input.txt");
+    expect(result.failures[0]?.exitCode).toBe(2);
+    expect(result.failures[0]?.reason).toContain("failed with exit code 2");
+    expect(result.failures[0]?.reason).toContain("Illegal option");
+    expect(events.map((event) => event.type)).toEqual(["sandbox.operation.started", "sandbox.operation.failed"]);
+    expect(events[1]?.payload.exitCode).toBe(2);
+    expect(events[1]?.payload.error).toContain("Illegal option");
+    expect(JSON.stringify(events)).not.toContain("sig=secret");
   });
 
   test("wraps sandbox clients with signed file downloads on create and resume", async () => {


### PR DESCRIPTION
Incident: a session died terminally on "Sandbox file resource download <id> failed with exit code 2". The file was healthy (fresh SAS, blob present) — it failed in 560ms before curl ran because `sandboxFileDownloadCommand` opened with `set -euo pipefail` and dash (POSIX /bin/sh, self-hosted machines) rejects `-o pipefail` with exit 2. There is no pipe in the script, so pipefail was pointless. `assertSandboxCommandSucceeded` then threw at turn setup and killed the whole session.

Four fixes:
1. POSIX `set -eu` (no pipefail).
2. Failures now carry exit code + captured stderr/output (previously dropped) — into the thrown error and the sandbox.operation.failed event; SAS URL never leaked into events.
3. **Non-fatal**: materialization returns collected failures instead of throwing; the worker injects a legible model-facing note listing unavailable attachments + reasons and the turn PROCEEDS. A broken attachment can never kill a session again.
4. Missing `turn.cancelled` on the activity cancellation path is now always emitted (fixes the stuck in-flight tool spinner, e.g. sandboxes_list "running" forever).

Gates: typecheck clean; runtime 562 pass / 0 fail; worker 222 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-setup behavior for all sandbox file attachments and model input text; low risk for cancellation events, but materialization path affects every turn with file resources on non-selfhosted sandboxes.
> 
> **Overview**
> Fixes terminal session failures when sandbox file-resource downloads failed during turn setup (e.g. dash rejecting `pipefail` with exit 2 before `curl` ran).
> 
> **Sandbox file materialization** now uses POSIX-safe `set -eu` (drops `pipefail`), collects per-file failures with exit code and captured output instead of throwing, and emits richer `sandbox.operation.failed` events without leaking signed URLs. The worker materializes downloads early on the pinned setup session, threads `fileDownloadsMaterialized` into the runtime to avoid double work, and appends a model-facing note via `withUnavailableSandboxFilesNote` / `turnInput` so the turn continues without broken attachments.
> 
> **Cancellation UX**: the agent-turn activity `CancelledFailure` path now publishes `turn.cancelled` before finishing the turn (covers cases where interrupt did not go through session-state). Tests cover the unavailable-files note and session-state `turn.cancelled` emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc9d9e22c2567087f20598546b52b5633594553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->