### PR TITLE
refactor(api): drop Linear DCR/confidential OAuth special-casing (CIMD works)

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -29,15 +29,6 @@ import { HTTPException } from "hono/http-exception";
 import { canonicalProviderDomain } from "./provider-domain";
 
 export const oauthStateTtlMs = 10 * 60 * 1000;
-const dcrPreferredAuthorizationServers = new Set([
-  "https://mcp.linear.app",
-]);
-const confidentialDcrAuthorizationServers = new Set([
-  // Linear's token endpoint will issue opaque tokens to public DCR clients, but
-  // the MCP resource rejects those tokens. Register a confidential DCR client,
-  // matching known-working MCP SDK clients that request a client_secret method.
-  "https://mcp.linear.app",
-]);
 
 type OAuthClientDeps = {
   db: Database;
@@ -432,9 +423,6 @@ async function registerOAuthClient(
   if (operator) {
     return operator;
   }
-  if (prefersDynamicClientRegistration(as)) {
-    return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
-  }
   if (as.clientIdMetadataDocumentSupported) {
     return {
       method: "cimd",
@@ -454,9 +442,8 @@ async function getOrCreateDynamicClientRegistration(
   redirectUri: string,
   scopes: string[],
 ): Promise<OAuthClientRegistration> {
-  const requiredAuthMethod = requiredDcrTokenEndpointAuthMethod(as);
   const storedClient = await loadIntegrationOAuthClient(db, settings, as.issuer);
-  if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, requiredAuthMethod, scopes)) {
+  if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, scopes)) {
     return {
       method: "dcr",
       issuer: storedClient.issuer,
@@ -471,7 +458,7 @@ async function getOrCreateDynamicClientRegistration(
       message: "manual OAuth client credentials are required for this authorization server",
     });
   }
-  const dcr = await dynamicClientRegistration(settings, as, redirectUri, scopes, requiredAuthMethod);
+  const dcr = await dynamicClientRegistration(settings, as, redirectUri, scopes);
   const key = dcr.clientSecret ? requireEnvironmentEncryption(settings) : null;
   const storeInput = {
     issuer: as.issuer,
@@ -481,9 +468,7 @@ async function getOrCreateDynamicClientRegistration(
     tokenEndpointAuthMethod: dcr.tokenEndpointAuthMethod,
     metadata: registrationMetadata(as, scopes),
   };
-  const storedWinner = requiredAuthMethod
-    ? await replaceIntegrationOAuthClient(db, storeInput)
-    : await storeIntegrationOAuthClient(db, storeInput);
+  const storedWinner = await storeIntegrationOAuthClient(db, storeInput);
   if (storedWinner.clientId !== dcr.clientId) {
     const winner = await loadIntegrationOAuthClient(db, settings, as.issuer);
     if (!winner) {
@@ -494,36 +479,11 @@ async function getOrCreateDynamicClientRegistration(
   return dcr;
 }
 
-function prefersDynamicClientRegistration(as: AuthorizationServerMetadata): boolean {
-  return [as.issuer, as.authorizationServer].some((candidate) => dcrPreferredAuthorizationServers.has(normalizedIssuerKey(candidate)));
-}
-
-function requiresConfidentialDynamicClient(as: AuthorizationServerMetadata): boolean {
-  return [as.issuer, as.authorizationServer].some((candidate) => confidentialDcrAuthorizationServers.has(normalizedIssuerKey(candidate)));
-}
-
-function requiredDcrTokenEndpointAuthMethod(as: AuthorizationServerMetadata): OAuthClientRegistration["tokenEndpointAuthMethod"] | null {
-  if (!requiresConfidentialDynamicClient(as)) {
-    return null;
-  }
-  if (as.tokenEndpointAuthMethodsSupported.includes("client_secret_basic")) {
-    return "client_secret_basic";
-  }
-  if (as.tokenEndpointAuthMethodsSupported.includes("client_secret_post")) {
-    return "client_secret_post";
-  }
-  throw new HTTPException(422, { message: "authorization server requires confidential DCR but does not advertise a supported client secret auth method" });
-}
-
 function storedDcrClientSatisfiesPolicy(
-  stored: { clientSecret: string | null; tokenEndpointAuthMethod: string; metadata: Record<string, unknown> },
-  requiredAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"] | null,
+  stored: { metadata: Record<string, unknown> },
   scopes: string[],
 ): boolean {
-  if (!registeredScopesMatch(stored.metadata, scopes)) {
-    return false;
-  }
-  return requiredAuthMethod ? Boolean(stored.clientSecret) && stored.tokenEndpointAuthMethod === requiredAuthMethod : true;
+  return registeredScopesMatch(stored.metadata, scopes);
 }
 
 function registeredScopesMatch(metadata: Record<string, unknown>, scopes: string[]): boolean {
@@ -604,7 +564,6 @@ async function dynamicClientRegistration(
   as: AuthorizationServerMetadata,
   redirectUri: string,
   scopes: string[],
-  tokenEndpointAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"] | null,
 ): Promise<OAuthClientRegistration> {
   if (!as.registrationEndpoint) {
     throw new HTTPException(422, { message: "authorization server does not support dynamic client registration" });
@@ -616,7 +575,7 @@ async function dynamicClientRegistration(
     body: JSON.stringify({
       client_name: "OpenGeni",
       redirect_uris: [redirectUri],
-      token_endpoint_auth_method: tokenEndpointAuthMethod ?? "none",
+      token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       ...(scopes.length ? { scope: scopes.join(" ") } : {}),

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -723,7 +723,7 @@ describe("connections routes", () => {
     }
   });
 
-  test("oauth start prefers DCR for Linear even when CIMD is advertised", async () => {
+  test("oauth start uses CIMD for Linear when CIMD is advertised", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const as = startFakeAuthorizationServer({
@@ -749,45 +749,33 @@ describe("connections routes", () => {
       expect(response.status).toBe(200);
       const body = await response.json() as { state: string; authorizationUrl: string };
       const authUrl = new URL(body.authorizationUrl);
-      expect(authUrl.searchParams.get("client_id")).toBe(`${as.url}/registered-client/1`);
-      expect(authUrl.searchParams.get("client_id")).not.toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
+      expect(authUrl.searchParams.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
       expect(authUrl.searchParams.get("resource")).toBe("urn:test:mcp");
       expect(authUrl.searchParams.get("scope")).toBe("read write");
-      expect(as.registrations).toHaveLength(1);
-      expect(as.registrations[0]).toMatchObject({
-        client_name: "OpenGeni",
-        redirect_uris: ["https://api.opengeni.test/v1/integrations/oauth/callback"],
-        token_endpoint_auth_method: "client_secret_basic",
-        scope: "read write",
-      });
+      expect(as.registrations).toHaveLength(0);
 
       const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
-      expect(state?.clientRegistrationMethod).toBe("dcr");
-      expect(state?.clientId).toBe(`${as.url}/registered-client/1`);
+      expect(state?.clientRegistrationMethod).toBe("cimd");
+      expect(state?.clientId).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
 
       const callback = await publicApp(client.db).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`);
       expect(callback.status).toBe(302);
       expect(callback.headers.get("location")).toContain("integration_oauth=success");
       expect(as.tokenRequests).toHaveLength(1);
-      expect(as.tokenRequests[0]!.has("client_id")).toBe(false);
+      expect(as.tokenRequests[0]!.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
       expect(as.tokenRequests[0]!.has("client_secret")).toBe(false);
-      expect(as.tokenRequestAuthHeaders[0]).toBe(`Basic ${Buffer.from(`${as.url}/registered-client/1:secret-1`).toString("base64")}`);
+      expect(as.tokenRequestAuthHeaders[0]).toBeNull();
       expect(as.tokenRequests[0]!.get("resource")).toBe("urn:test:mcp");
 
       const loadedClient = await loadIntegrationOAuthClient(client.db, settings, "https://mcp.linear.app");
-      expect(loadedClient).toMatchObject({
-        clientId: `${as.url}/registered-client/1`,
-        clientSecret: "secret-1",
-        tokenEndpointAuthMethod: "client_secret_basic",
-      });
-      expect(loadedClient?.metadata.registeredScopes).toEqual(["read", "write"]);
+      expect(loadedClient).toBeNull();
     } finally {
       mcp.close();
       as.close();
     }
   });
 
-  test("oauth start replaces a stored Linear DCR client missing required auth method or scopes", async () => {
+  test("oauth start ignores stored Linear DCR client when CIMD is advertised", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     await replaceIntegrationOAuthClient(client.db, {
@@ -819,15 +807,15 @@ describe("connections routes", () => {
       });
       expect(response.status).toBe(200);
       const body = await response.json() as { authorizationUrl: string };
-      expect(new URL(body.authorizationUrl).searchParams.get("client_id")).toBe(`${as.url}/registered-client/1`);
+      expect(new URL(body.authorizationUrl).searchParams.get("client_id")).toBe("https://api.opengeni.test/v1/integrations/oauth/client-metadata.json");
+      expect(as.registrations).toHaveLength(0);
 
       const loadedClient = await loadIntegrationOAuthClient(client.db, settings, "https://mcp.linear.app");
       expect(loadedClient).toMatchObject({
-        clientId: `${as.url}/registered-client/1`,
-        clientSecret: "secret-1",
-        tokenEndpointAuthMethod: "client_secret_basic",
+        clientId: "public-linear-client",
+        clientSecret: null,
+        tokenEndpointAuthMethod: "none",
       });
-      expect(loadedClient?.metadata.registeredScopes).toEqual(["read", "write"]);
     } finally {
       mcp.close();
       as.close();


### PR DESCRIPTION
The Linear MCP rejection was purely the Authorization header casing (fixed in #303 via normalizeBearerScheme). Empirically confirmed: a CIMD-client token lists all 52 Linear tools with the corrected `Bearer` header. So the DCR-preferred + confidential-DCR machinery (#297/#298) was never needed — and its ~24h `client_secret` expiry would have broken Linear on token refresh. This removes the Linear allowlists + dead confidential-DCR code; Linear falls back to default CIMD (no secret, durable). Keeps normalizeBearerScheme + connection dedup. **Provider audit:** both `token_type` header sites use normalizeBearerScheme; all other Authorization headers hardcode `Bearer`. Typecheck clean, 20/20 api tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth start/callback and token exchange for providers like Linear, but behavior aligns with the standard CIMD-first path and removes short-lived confidential DCR that could break refresh.
> 
> **Overview**
> **Removes Linear-only OAuth client registration rules** that forced dynamic client registration (DCR) ahead of client ID metadata documents (CIMD) and required confidential DCR with `client_secret_*` token auth.
> 
> `registerOAuthClient` now follows the default order: configured operator client, then **CIMD when `clientIdMetadataDocumentSupported`**, then DCR. Linear with CIMD advertised no longer hits DCR, does not register at `/register`, and does not persist integration OAuth clients for that flow.
> 
> **Simplifies DCR**: new registrations always request `token_endpoint_auth_method: "none"`; reuse of stored DCR clients is gated only on matching registered scopes (not secret/auth-method policy); persistence always uses `storeIntegrationOAuthClient` instead of replacing clients for confidential upgrades.
> 
> Connection route tests for Linear are updated to expect CIMD `client_id`, public token exchange, no DCR registration, and unchanged legacy stored DCR rows when CIMD is chosen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71611c4b245f8954010fee0fd469203b32633647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->