### PR TITLE
Resolve real capability names for user-message tool chips

### DIFF
--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -170,7 +170,12 @@ function isImageAsset(asset: FileAsset | null | undefined): boolean {
 }
 
 /** Attachment previews/chips + repository/tool chips + markdown body inside the user bubble. */
-export function UserMessageBody({ workspaceId, item }: { workspaceId: string; item: UserMessageItem }) {
+export function UserMessageBody({ workspaceId, item, resolveCapabilityName }: {
+  workspaceId: string;
+  item: UserMessageItem;
+  /** Real capability name for a tool chip (from the workspace catalog), or null. */
+  resolveCapabilityName?: (mcpServerId: string) => string | null;
+}) {
   const fileResources = item.resources.filter((resource): resource is FileResource => resource.kind === "file");
   const repositoryResources = item.resources.filter((resource): resource is Extract<ResourceRef, { kind: "repository" }> => resource.kind === "repository");
   const { assets, ready } = useFileAssets(workspaceId, fileResources);
@@ -237,7 +242,7 @@ export function UserMessageBody({ workspaceId, item }: { workspaceId: string; it
               className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg-muted"
             >
               <WrenchIcon className="size-3.5 shrink-0" />
-              <span className="truncate">{capabilityChipLabel(tool.id)}</span>
+              <span className="truncate">{resolveCapabilityName?.(tool.id) ?? capabilityChipLabel(tool.id)}</span>
             </span>
           ))}
         </div>

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -192,51 +192,73 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     window.location.assign(response.authorizationUrl);
   }, [context.client, workspaceId]);
 
-  // Self-hosted provider logos for any inline reconnect card. A domain resolves
-  // to a logo only through the workspace catalog (logoAssetPath), so fetch it
-  // lazily — once an auth-needed card is actually in view — and serve the image
-  // from our own catalog-assets route via `catalogAssetUrl`, never an off-origin
-  // favicon (the CSP forbids it and it would leak which providers are connected).
+  // One lazy catalog fetch feeds two timeline resolvers: provider logos for any
+  // inline reconnect card, and real capability names for the tool chips on user
+  // messages. Both resolve only through the workspace catalog, so fetch it once —
+  // when EITHER an auth-needed card OR a message carrying tool chips is in view —
+  // and reuse the single response. Logos serve from our own catalog-assets route
+  // via `catalogAssetUrl`, never an off-origin favicon (the CSP forbids it and it
+  // would leak which providers are connected).
   const hasAuthNeeded = useMemo(() => timeline.some((item) => item.kind === "auth-needed"), [timeline]);
+  const hasToolChips = useMemo(
+    () => timeline.some((item) => item.kind === "user-message" && item.tools.length > 0),
+    [timeline],
+  );
   const [providerLogos, setProviderLogos] = useState<Map<string, string>>(() => new Map());
-  const logosRequestedRef = useRef(false);
+  // mcpServerId -> human capability name, so a chip reads "Linear" instead of a
+  // best-effort parse of the raw server id.
+  const [capabilityNames, setCapabilityNames] = useState<Map<string, string>>(() => new Map());
+  const catalogRequestedRef = useRef(false);
   useEffect(() => {
-    if (!hasAuthNeeded || logosRequestedRef.current) {
+    if ((!hasAuthNeeded && !hasToolChips) || catalogRequestedRef.current) {
       return;
     }
-    logosRequestedRef.current = true;
+    catalogRequestedRef.current = true;
     let cancelled = false;
     void context.client.listCapabilities(workspaceId)
       .then((catalog) => {
         if (cancelled) {
           return;
         }
-        const map = new Map<string, string>();
+        const logos = new Map<string, string>();
+        const names = new Map<string, string>();
         for (const cap of catalog.items) {
           const domain = cap.providerDomain ?? cap.connectionRef?.providerDomain ?? null;
           const url = context.client.catalogAssetUrl(cap.logoAssetPath);
           if (domain && url) {
             const key = normalizeProviderDomain(domain);
-            if (!map.has(key)) {
-              map.set(key, url);
+            if (!logos.has(key)) {
+              logos.set(key, url);
             }
           }
+          // A chip's tool.id IS the capability's runtime mcpServerId — map it to
+          // the item's human name so the chip resolves to the real label.
+          const mcpServerId = cap.runtime.mcpServerId;
+          if (mcpServerId && cap.name && !names.has(mcpServerId)) {
+            names.set(mcpServerId, cap.name);
+          }
         }
-        setProviderLogos(map);
+        setProviderLogos(logos);
+        setCapabilityNames(names);
       })
       .catch(() => {
-        // Leave the card on its monogram fallback and allow a later retry.
+        // Leave the card on its monogram fallback and the chips on their
+        // best-effort labels, and allow a later retry.
         if (!cancelled) {
-          logosRequestedRef.current = false;
+          catalogRequestedRef.current = false;
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [hasAuthNeeded, context.client, workspaceId]);
+  }, [hasAuthNeeded, hasToolChips, context.client, workspaceId]);
   const resolveProviderLogo = useCallback(
     (domain: string) => providerLogos.get(normalizeProviderDomain(domain)) ?? null,
     [providerLogos],
+  );
+  const resolveCapabilityName = useCallback(
+    (mcpServerId: string) => capabilityNames.get(mcpServerId) ?? null,
+    [capabilityNames],
   );
 
   if (loading || !session) {
@@ -278,6 +300,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       onReject={(approvalId) => approve(approvalId, "reject")}
       onReconnect={onReconnect}
       resolveProviderLogo={resolveProviderLogo}
+      resolveCapabilityName={resolveCapabilityName}
     />
   );
 
@@ -392,6 +415,8 @@ function SessionChatPane(props: {
   onReject: (approvalId: string) => Promise<void>;
   onReconnect: (item: AuthNeededItem) => void | Promise<void>;
   resolveProviderLogo: (providerDomain: string) => string | null;
+  /** Real capability name for a user-message tool chip, resolved from the catalog. */
+  resolveCapabilityName: (mcpServerId: string) => string | null;
 }) {
   const context = useAppContext();
   const codexModels = useCodexModels(props.session.workspaceId);
@@ -471,14 +496,14 @@ function SessionChatPane(props: {
 
   const renderMessageText = useCallback((text: string, item: AgentMessageItem | UserMessageItem) => {
     if (item.kind === "user-message") {
-      return <UserMessageBody workspaceId={props.session.workspaceId} item={item} />;
+      return <UserMessageBody workspaceId={props.session.workspaceId} item={item} resolveCapabilityName={props.resolveCapabilityName} />;
     }
     return (
       <div data-testid="assistant-markdown">
         <MarkdownText text={text} streaming={item.streaming} />
       </div>
     );
-  }, [props.session.workspaceId]);
+  }, [props.session.workspaceId, props.resolveCapabilityName]);
 
   return (
     <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">


### PR DESCRIPTION
## What

User-message capability chips now show the **real** capability name resolved from the workspace catalog, instead of a best-effort string-parse of the raw MCP server id.

Before, chips called `capabilityChipLabel(tool.id)` which string-cleaned the raw `mcpServerId` (`cap-integrations-sh-1password-com-<hash>` → `1password`, wrong case; multi-word providers guessed). Now they resolve the item's human `name` from the catalog.

## How

- A chip's `tool.id` **is** the capability's `runtime.mcpServerId`. `session.tsx` already fetches the catalog once (lazy, ref-guarded) to resolve reconnect-card provider logos. That same single fetch now also builds an `mcpServerId → name` map, and its gate is widened to fire when **either** an auth-needed card **or** a tool-chip-carrying user message is in view. No second request.
- A new `resolveCapabilityName(mcpServerId) => string | null` is threaded down to `UserMessageBody` exactly the way `resolveProviderLogo` is threaded (route → `SessionChatPane` → `renderMessageText` → `UserMessageBody`).
- The chip renders `resolveCapabilityName(tool.id) ?? capabilityChipLabel(tool.id)` — resolved catalog name first, else the existing best-effort helper (kept as fallback, never the raw id). First-party built-ins (`opengeni` → OpenGeni, `files`, `docs`) stay correct via that fallback even when the catalog omits them.

Same-origin only, no new fetch layer, no external calls.

## Verify

- `apps/web` `bun run typecheck` clean.
- Rendered the real `UserMessageBody` in isolation with a fixture message carrying Linear + `opengeni` + 1Password chips. With the resolver: **1Password** (correct case, from catalog `name`) vs the old best-effort **1password** (wrong case); `opengeni` correctly falls back to **OpenGeni**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only timeline labeling with no changes to auth, sends, or API contracts beyond reusing an existing catalog fetch.
> 
> **Overview**
> User-message **tool chips** now prefer the workspace catalog’s human **capability name** (e.g. **1Password**) instead of only `capabilityChipLabel`’s parsed MCP server id.
> 
> The session route’s existing lazy **`listCapabilities`** fetch now also builds an **`mcpServerId → name`** map and runs when the timeline has **auth-needed cards or user messages with tools**, still a single request. **`resolveCapabilityName`** is passed through to **`UserMessageBody`**, which renders **`resolveCapabilityName(tool.id) ?? capabilityChipLabel(tool.id)`** so catalog misses keep the prior best-effort labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7975014cf27dc66201d7ef08ecc394a2874624fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->