### PR TITLE
feat(runtime): set stable prompt_cache_key per session (improve cache-hit routing)

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -577,6 +577,28 @@ export function computerToolModeForTurn(
 }
 
 /**
+ * Decide whether THIS turn may send OpenAI's `prompt_cache_key` request field.
+ *
+ * Accepted transports:
+ *   - legacy/built-in OpenAI or Azure Responses fallback (resolvedModel null);
+ *   - resolved built-in OpenAI/Azure providers;
+ *   - ChatGPT/Codex subscription backend (its strict allowlist permits the field).
+ *
+ * Registry API-key providers are intentionally excluded. Fireworks' prompt-cache
+ * docs prescribe `user` or `x-session-affinity`, not `prompt_cache_key`; Z.AI/GLM
+ * documents automatic context caching plus `user_id`. Sending OpenAI-only fields
+ * to unknown OpenAI-compatible providers risks unsupported-parameter 400s.
+ */
+export function acceptsPromptCacheKeyForTurn(
+  resolvedModel: { provider: { kind: RegistryProviderKind; builtin?: boolean } } | null,
+): boolean {
+  if (!resolvedModel) {
+    return true;
+  }
+  return resolvedModel.provider.builtin === true || resolvedModel.provider.kind === "codex-subscription";
+}
+
+/**
  * SELF-HEAL helper for the all-capped rotation idle (invariant 4: BOUNDED, no thrash).
  * The turn hot path never refreshes Codex usage — only the usage API route does — so a
  * window that has actually reset still reads OVER-threshold from the stale cache, which
@@ -1447,6 +1469,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // trigger is goal.continuation/turn.preempted).
       const isGenesisTurn = triggerType === "user.message"
         && (await countSessionHistoryItems(db, input.workspaceId, input.sessionId)) === 0;
+      const promptCacheKey = acceptsPromptCacheKeyForTurn(resolvedModel) ? input.sessionId : undefined;
       // Clone-onto-real-disk hazard (Case B). A session keeps its CLOUD HOME
       // backend (runSettings.sandboxBackend, e.g. "modal") but its ACTIVE sandbox
       // may have been swapped to a connected machine (active_sandbox_id → a
@@ -1519,12 +1542,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // responses → hosted) so the runtime never string-sniffs the model instance's
             // constructor name. See {@link computerToolModeForTurn}.
             computerToolMode: computerToolModeForTurn(resolvedModel),
+            ...(promptCacheKey ? { promptCacheKey } : {}),
           }
           // LEGACY global-client fallback (resolveTurnModel returned null → the model
           // is not in the registry, served by the built-in OpenAI/Azure Responses
           // client). That backend has real hosted support, so pin computerToolMode to
           // "hosted" EXPLICITLY rather than leaving the runtime to sniff the instance.
-          : { computerToolMode: computerToolModeForTurn(null) }),
+          : {
+            computerToolMode: computerToolModeForTurn(null),
+            promptCacheKey: input.sessionId,
+          }),
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(workspaceAgentInstructions ? { instructionsTemplate: workspaceAgentInstructions } : {}),
         // Per-session persona tier (session > workspace > deployment default).
@@ -1548,8 +1575,15 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             model: resolvedModel.configured.id,
             maxOutputTokens: SUMMARY_BUFFER_TOKENS,
             ...(o?.maxTranscriptTokens ? { maxTranscriptTokens: o.maxTranscriptTokens } : {}),
+            ...(promptCacheKey ? { promptCacheKey } : {}),
           }))
-        : undefined;
+        : promptCacheKey
+          ? ((s: Settings, m: Array<Record<string, unknown>>, o?: { maxTranscriptTokens?: number }) => summarizeForCompaction(s, m, {
+              maxOutputTokens: SUMMARY_BUFFER_TOKENS,
+              ...(o?.maxTranscriptTokens ? { maxTranscriptTokens: o.maxTranscriptTokens } : {}),
+              promptCacheKey,
+            }))
+          : undefined;
       // Pre-turn client-side context compaction (Azure path). When the
       // resolved mode is "client" and the single Codex-parity threshold is
       // crossed, this summarizes the current active history and rebuilds active
@@ -1573,7 +1607,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // Provider-aware summarizer: when the turn's model resolved to a
             // registry provider, summarize on THAT provider's client + wire API
             // (a chat provider can't summarize through OpenAI/Azure). Null
-            // resolution keeps the default built-in Responses summarizer.
+            // resolution uses the built-in Responses summarizer with the same
+            // session prompt-cache key as the main model calls.
             compactSummarizer,
             forced ? { force: true } : {},
           );

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -3,7 +3,7 @@ import { CancelledFailure } from "@temporalio/activity";
 import type { Settings } from "@opengeni/config";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
-import { classifyContextWindowOverflowError, computerToolModeForTurn, emitModelCallUsage, ensureTurnModalRegistryImage, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { acceptsPromptCacheKeyForTurn, classifyContextWindowOverflowError, computerToolModeForTurn, emitModelCallUsage, ensureTurnModalRegistryImage, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 import { settingsWithPackSandboxImage } from "../src/activities/packs";
 import { withUnavailableSandboxFilesNote } from "../src/activities/run-input";
 
@@ -614,6 +614,25 @@ describe("computerToolModeForTurn (explicit computer-use transport derivation)",
 
   test("the LEGACY global-client fallback (resolveTurnModel → null) → hosted EXPLICITLY", () => {
     expect(computerToolModeForTurn(null)).toBe("hosted");
+  });
+});
+
+describe("acceptsPromptCacheKeyForTurn", () => {
+  const resolved = (kind: RegistryProviderKind, api: ModelProviderApi, builtin = false) =>
+    ({ provider: { kind, api, builtin } }) as Parameters<typeof acceptsPromptCacheKeyForTurn>[0];
+
+  test("accepts the legacy built-in OpenAI/Azure fallback", () => {
+    expect(acceptsPromptCacheKeyForTurn(null)).toBe(true);
+  });
+
+  test("accepts built-in OpenAI/Azure providers and the codex backend", () => {
+    expect(acceptsPromptCacheKeyForTurn(resolved("api-key", "responses", true))).toBe(true);
+    expect(acceptsPromptCacheKeyForTurn(resolved("codex-subscription", "responses"))).toBe(true);
+  });
+
+  test("excludes registry providers such as Fireworks or Z.AI/GLM", () => {
+    expect(acceptsPromptCacheKeyForTurn(resolved("api-key", "chat"))).toBe(false);
+    expect(acceptsPromptCacheKeyForTurn(resolved("api-key", "responses"))).toBe(false);
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -665,7 +665,7 @@ function recordModelCallMetric(provider: string, outcome: "completed" | "failed"
 export async function summarizeForCompaction(
   settings: Settings,
   input: Array<Record<string, unknown>>,
-  options: { client?: OpenAI; api?: ModelProviderApi; maxOutputTokens?: number; model?: string; maxTranscriptTokens?: number } = {},
+  options: { client?: OpenAI; api?: ModelProviderApi; maxOutputTokens?: number; model?: string; maxTranscriptTokens?: number; promptCacheKey?: string } = {},
 ): Promise<string | null> {
   const client = options.client ?? buildOpenAIClientFromSettings(settings);
   const api = options.api ?? "responses";
@@ -683,6 +683,7 @@ export async function summarizeForCompaction(
         model,
         max_tokens: maxTokens,
         messages: [{ role: "user", content: transcript }],
+        ...(options.promptCacheKey ? { prompt_cache_key: options.promptCacheKey } : {}),
       } as any);
       const text = (completion as { choices?: Array<{ message?: { content?: unknown } }> }).choices?.[0]?.message?.content;
       const trimmed = typeof text === "string" ? text.trim() : "";
@@ -696,6 +697,7 @@ export async function summarizeForCompaction(
       ...(settings.openaiProvider === "azure" ? {} : { store: false }),
       max_output_tokens: maxTokens,
       input: transcript,
+      ...(options.promptCacheKey ? { prompt_cache_key: options.promptCacheKey } : {}),
     } as any);
     const text = extractResponseOutputText(response);
     const trimmed = text.trim();
@@ -803,6 +805,11 @@ export type BuildAgentOptions = {
   // the account's ACTUALLY-connected sources (codex-rs parity). Only meaningful
   // on the codex tool-search path.
   codexConnectorNamespaces?: ReadonlySet<string>;
+  // Stable per-session routing key for provider-side prompt prefix caches. The
+  // worker passes this only for transports whose docs/API surface accept
+  // prompt_cache_key; registry providers that use a different affinity field stay
+  // unset to avoid unknown-parameter 400s.
+  promptCacheKey?: string;
   sandboxEnvironment?: Record<string, string>;
   // The EFFECTIVE/active compute backend for this turn. `settings.sandboxBackend`
   // is the session's HOME backend (the default cloud group box it was created
@@ -1037,6 +1044,10 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
   const hostedWebSearch = options.hostedWebSearch ?? settings.webSearchEnabled;
   const encryptedReasoning = options.encryptedReasoning ?? settings.openaiReasoningEncryptedContent;
   const contextWindowTokens = options.contextWindowTokens ?? settings.contextWindowTokens;
+  const providerData = {
+    ...(encryptedReasoning ? { include: ["reasoning.encrypted_content"] } : {}),
+    ...(options.promptCacheKey ? { prompt_cache_key: options.promptCacheKey } : {}),
+  };
   // Native hosted tools attached to every constructed agent. webSearchEnabled
   // is ON by default and provider-unconditional on the built-in path (the live
   // Azure Responses path executes the hosted web_search tool); a registry model
@@ -1100,9 +1111,7 @@ export function buildOpenGeniAgent(settings: Settings, resources: ResourceRef[],
       // function tools, which contribute none. Gated on the resolved
       // encryptedReasoning flag: the chat wire API has no encrypted_content
       // field, so registry "chat" providers turn it off.
-      ...(encryptedReasoning
-        ? { providerData: { include: ["reasoning.encrypted_content"] } }
-        : {}),
+      ...(Object.keys(providerData).length > 0 ? { providerData } : {}),
     },
     // Explicit hosted tools (web_search when enabled). Threaded into BOTH the
     // `new Agent(baseConfig)` path (sandboxBackend === "none") and the

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -232,6 +232,27 @@ describe("provider-proof compaction transcript", () => {
     expect(seenInput).not.toContain("callId");
   });
 
+  test("passes prompt_cache_key through summarizer Responses calls when provided", async () => {
+    let seenKey: unknown;
+    const fakeClient = {
+      responses: {
+        create: async (request: { prompt_cache_key?: unknown }) => {
+          seenKey = request.prompt_cache_key;
+          return { output_text: "rendered summary" };
+        },
+      },
+    };
+
+    const summary = await summarizeForCompaction(
+      testSettings({ openaiProvider: "azure", contextCompactionMode: "client" }),
+      buildCompactionPromptInput([user("deploy it")]),
+      { client: fakeClient as any, api: "responses", model: "scripted-model", promptCacheKey: "session-123" },
+    );
+
+    expect(summary).toBe("rendered summary");
+    expect(seenKey).toBe("session-123");
+  });
+
   test("hard-trimmed transcript drops oldest items and keeps the checkpoint prompt", () => {
     const rendered = renderCompactionPromptInputForChat(
       buildCompactionPromptInput([

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -178,6 +178,36 @@ describe("multi-provider gating in buildOpenGeniAgent", () => {
     expect((agent as { modelSettings: { store?: unknown } }).modelSettings.store).toBe(false);
   });
 
+  test("an accepted responses transport carries the stable session prompt_cache_key", () => {
+    const settings = multiProviderSettings();
+    const resolved = resolveTurnModel(settings, "gpt-5.5")!;
+    const agent = buildOpenGeniAgent(settings, [], {
+      model: resolved.model,
+      compactionMode: resolved.provider.compactionMode,
+      hostedWebSearch: resolved.configured.hostedWebSearch,
+      encryptedReasoning: resolved.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+      contextWindowTokens: resolved.configured.contextWindowTokens,
+      promptCacheKey: "session-123",
+    });
+    expect((agent as { modelSettings: { providerData?: unknown } }).modelSettings.providerData).toEqual({
+      include: ["reasoning.encrypted_content"],
+      prompt_cache_key: "session-123",
+    });
+  });
+
+  test("an excluded registry chat transport does not carry prompt_cache_key when no key is passed", () => {
+    const settings = multiProviderSettings();
+    const resolved = resolveTurnModel(settings, FIREWORKS_MODEL)!;
+    const agent = buildOpenGeniAgent(settings, [], {
+      model: resolved.model,
+      compactionMode: resolved.provider.compactionMode,
+      hostedWebSearch: resolved.configured.hostedWebSearch,
+      encryptedReasoning: resolved.provider.api === "responses" && settings.openaiReasoningEncryptedContent,
+      contextWindowTokens: resolved.configured.contextWindowTokens,
+    });
+    expect((agent as { modelSettings: { providerData?: Record<string, unknown> } }).modelSettings.providerData?.prompt_cache_key).toBeUndefined();
+  });
+
   test("resolveModelProvider/configuredProviders agree on the registry provider's client gating", () => {
     // Cross-check the config layer the runtime builds on: the resolved provider
     // for the Fireworks model is the chat/client provider, and the built-in


### PR DESCRIPTION
Prompt caching is automatic server-side prefix caching; we keep the prefix stable (elision removed in #306) but never set a routing key, so under load repeat requests can hit a different backend and miss a warm cache. This sets `prompt_cache_key = sessionId` on every model call for the transports that accept it.

Provider matrix (verified before enabling): OpenAI Responses+chat, Azure Responses+chat, and the Codex/ChatGPT backend all accept prompt_cache_key → applied (incl. compaction summarizer calls). Fireworks and GLM/Z.AI **excluded defensively** — their docs use `user`/`x-session-affinity`/`user_id` for affinity, not prompt_cache_key, and it's unverified whether they'd ignore or 400 it. No provider 400 encountered. Injected via modelSettings.providerData; key source input.sessionId.

Observable via the #306 agent.model.usage cachedTokens telemetry.

Gates: typecheck clean; 786 pass / 1 skip / 0 fail across runtime+worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive request metadata on already-supported transports with defensive exclusion of registry providers; no auth or billing path changes.
> 
> **Overview**
> Improves provider-side prompt cache hit rates by sending a **stable routing key** (`prompt_cache_key` = `sessionId`) on each turn’s model traffic, so repeat requests in a session are more likely to land on a backend that already holds a warm prefix cache.
> 
> **Worker:** New `acceptsPromptCacheKeyForTurn` enables the field only for the legacy built-in OpenAI/Azure path, built-in providers, and Codex subscription—not registry API-key providers (Fireworks, Z.AI/GLM), where OpenAI-only parameters could cause 400s. The key is passed into `buildAgent` and into compaction summarizers (including the legacy null-model path).
> 
> **Runtime:** `BuildAgentOptions` and `summarizeForCompaction` accept optional `promptCacheKey`; agent calls set `modelSettings.providerData.prompt_cache_key`, and summarizer chat/responses requests forward it when present.
> 
> Tests cover the provider gate and propagation through agent `providerData` and compaction API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff8a49704da2387be385cd1d5e3d82b63509198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->