### PR TITLE
Sandbox durability hardening: bound mid-session snapshots, keep a restore fallback, warming-lease TTL, rolling-deploy reaper fallback

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -116,6 +116,7 @@ export async function withChannelA<T>(
     backend: session.sandboxBackend,
     os: session.sandboxOs,
     leaseTtlMs,
+    warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
   });
 
   if (acquired.role === "fenced") {

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -182,6 +182,7 @@ export async function attachViewer(
     backend: session.sandboxBackend,
     os: session.sandboxOs,
     leaseTtlMs,
+    warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
   });
 
   // FENCED: a newer epoch re-established the box. Release our just-registered

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -102,7 +102,7 @@ import type {
   RunAgentTurnInput,
   RunAgentTurnResult,
 } from "./types";
-import { resumeBoxForTurn, acquireSelfhostedLeaseForTurn, maybePersistWarmWorkspaceSnapshot, type ResumedTurnSandbox } from "../sandbox-resume";
+import { resumeBoxForTurn, acquireSelfhostedLeaseForTurn, maybePersistWarmWorkspaceSnapshot, waitForWarmSnapshot, type ResumedTurnSandbox } from "../sandbox-resume";
 import { wrapTurnBoxWithRouting, establishSelfhostedTurnSession, routingEnabled } from "../sandbox-routing";
 import { recordCreditMicros, runtimeMetricsHooksForObservability, turnLifecycleMetricsFor, type TurnOutcome } from "../observability-metrics";
 import { beginRecording, discardRecording, finalizeRecording, type ActiveRecording } from "./recording";
@@ -2671,11 +2671,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (setupBoxSession && sandboxGroupId) {
           // Single-flight vs the heartbeat capture: the timer is already cleared
           // above, but a capture it launched may still be in flight — and that
-          // capture predates the turn's final writes. Await it (it never
-          // rejects; its own failure discipline caps its runtime), THEN
-          // attempt; the atomic throttle decides in capture order.
+          // capture predates the turn's final writes. Wait for it, but only up
+          // to the snapshot timeout: release must never depend on an unbounded
+          // provider capture.
           if (snapshotInFlight) {
-            await snapshotInFlight;
+            await waitForWarmSnapshot(snapshotInFlight, settings.sandboxSnapshotTimeoutMs);
           }
           const persisted = await maybePersistWarmWorkspaceSnapshot(
             { db, settings },

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -33,7 +33,7 @@
 import {
   accrueWarmSeconds,
   confirmDrainCold,
-  appendSessionEvents,
+  appendSessionEventToSandboxGroup,
   countQueuedTurns,
   countSandboxLeasesByLiveness,
   forceDrainOverLimitViewerOnlyBoxes,
@@ -41,7 +41,6 @@ import {
   listCreditBalancesByAccount,
   listLiveModalSandboxLeaseAttributions,
   listMeterableWarmLeases,
-  listSessionIdsInGroup,
   persistDrainSnapshot,
   readLease,
   reapStaleLeaseHoldersGlobal,
@@ -524,13 +523,10 @@ async function terminateDrainableBox(
     // every session sharing the group's box. Best-effort: attribution must
     // never affect the drain outcome.
     try {
-      const sessionIds = await listSessionIdsInGroup(db, row.workspaceId, row.sandboxGroupId);
-      for (const sessionId of sessionIds) {
-        await appendSessionEvents(db, row.workspaceId, sessionId, [{
-          type: "sandbox.box.terminated",
-          payload: { actor: "reaper", persisted, instanceId: lease.instanceId },
-        }]);
-      }
+      await appendSessionEventToSandboxGroup(db, row.workspaceId, row.sandboxGroupId, {
+        type: "sandbox.box.terminated",
+        payload: { actor: "reaper", persisted, instanceId: lease.instanceId },
+      });
     } catch (eventError) {
       observability.warn("sandbox reaper: box-terminated event write failed (drain outcome unaffected)", {
         sandboxGroupId: row.sandboxGroupId,

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -122,16 +122,16 @@ type CreateSandboxClientForBackendFn = typeof createSandboxClientForBackend;
  * db/accountId/row and delegates to persistDrainSnapshot. Returns:
  *   - wrote:false  -> the CAS missed (re-armed / newer epoch / vanished). The box
  *                     is wanted again; the seam MUST NOT terminate it.
- *   - priorArchive -> the superseded archive (if any) to GC the prior snapshot.
+ *   - priorArchive / priorArchivePrev -> superseded archives to GC at drain.
  *
  * Pass null for archiveBase64 to CAS-check WITHOUT writing (re-arm guard for
  * backends with no persistWorkspace — ensures a re-arm during the snapshot window
- * aborts the terminate before client.delete()). priorArchive is always null in
- * this case.
+ * aborts the terminate before client.delete()). priorArchive values are always
+ * null in this case.
  */
 export type PersistArchiveFn = (
   archiveBase64: string | null,
-) => Promise<{ wrote: boolean; priorArchive: string | null }>;
+) => Promise<{ wrote: boolean; priorArchive: string | null; priorArchivePrev: string | null }>;
 
 /** The provider-terminate seam. Production wires the real resume-by-id ->
  *  persistWorkspace -> persist-onto-lease (epoch-fenced) -> snapshot-GC ->
@@ -727,7 +727,7 @@ export async function terminateProviderBox(
   // refcount/epoch guard, no write. wrote:false → abort the terminate.
   if (archiveBytes && archiveBytes.length > 0) {
     const archiveBase64 = Buffer.from(archiveBytes).toString("base64");
-    const { wrote, priorArchive } = await persistArchive(archiveBase64);
+    const { wrote, priorArchive, priorArchivePrev } = await persistArchive(archiveBase64);
     if (!wrote) {
       observability.info("sandbox reaper: lease re-armed during persist — leaving box RUNNING (no terminate)", {
         sandboxGroupId: lease.sandboxGroupId,
@@ -743,6 +743,14 @@ export async function terminateProviderBox(
         sandboxGroupId: lease.sandboxGroupId,
         backend,
         snapshotId: deleted,
+      });
+    }
+    const deletedPrev = await deletePriorPersistedSnapshot(session, priorArchivePrev);
+    if (deletedPrev) {
+      observability.info("sandbox reaper: GC'd superseded previous workspace snapshot", {
+        sandboxGroupId: lease.sandboxGroupId,
+        backend,
+        snapshotId: deletedPrev,
       });
     }
   } else {

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -305,8 +305,15 @@ export async function maybePersistWarmWorkspaceSnapshot(
       return false;
     }
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    // On timeout the race settles on `undefined` while persistWorkspace() keeps
+    // running orphaned. Swallow its LATE settlement: an un-awaited rejection
+    // after the race resolved would surface as an unhandledRejection and can
+    // take down the whole worker process — which would defeat the very hang-
+    // guard this timeout exists to provide.
+    const capture = persistable.persistWorkspace();
+    capture.catch(() => undefined);
     const bytes = await Promise.race([
-      persistable.persistWorkspace(),
+      capture,
       new Promise<undefined>((resolve) => {
         timeout = setTimeout(() => resolve(undefined), settings.sandboxSnapshotTimeoutMs);
         if (timeout && "unref" in timeout && typeof timeout.unref === "function") {

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -305,6 +305,11 @@ export async function maybePersistWarmWorkspaceSnapshot(
       return false;
     }
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    // Stamp WHEN this capture started: persistWarmSnapshot orders warm snapshots
+    // by capture-initiation, not land time, so a slower heartbeat capture that
+    // started earlier can never overwrite a fresher turn-end capture that landed
+    // first (the bounded-wait race Bugbot flagged).
+    const capturedAtMs = Date.now();
     // On timeout the race settles on `undefined` while persistWorkspace() keeps
     // running orphaned. Swallow its LATE settlement: an un-awaited rejection
     // after the race resolved would surface as an unhandledRejection and can
@@ -335,6 +340,7 @@ export async function maybePersistWarmWorkspaceSnapshot(
       expectedEpoch: leaseEpoch,
       workspaceArchive: Buffer.from(bytes).toString("base64"),
       minIntervalMs: intervalMs,
+      capturedAtMs,
     });
     if (!wrote) {
       return false;

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -321,7 +321,7 @@ export async function maybePersistWarmWorkspaceSnapshot(
     if (!bytes || bytes.length === 0) {
       return false;
     }
-    const { wrote, priorArchive } = await persistWarmSnapshot(db, {
+    const { wrote, priorArchiveForGc } = await persistWarmSnapshot(db, {
       accountId: ids.accountId,
       workspaceId: ids.workspaceId,
       sandboxGroupId: ids.sandboxGroupId,
@@ -332,9 +332,9 @@ export async function maybePersistWarmWorkspaceSnapshot(
     if (!wrote) {
       return false;
     }
-    // Keep-latest-per-lease GC, same as the drain seam: best-effort delete of
-    // the superseded snapshot image while the session's client is live.
-    await deletePriorPersistedSnapshot(persistable, priorArchive);
+    // Warm snapshots retain a 2-deep restore window. Only the two-ago archive
+    // returned by persistWarmSnapshot is GC-eligible.
+    await deletePriorPersistedSnapshot(persistable, priorArchiveForGc);
     return true;
   } catch (error) {
     // Protection, not a dependency: a failed snapshot must never fail (or slow

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -132,6 +132,39 @@ async function sleep(ms: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
+class SnapshotTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`workspace snapshot timed out after ${timeoutMs}ms`);
+    this.name = "SnapshotTimeoutError";
+  }
+}
+
+export async function waitForWarmSnapshot(snapshot: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      snapshot,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new SnapshotTimeoutError(timeoutMs)), timeoutMs);
+        if (timeout && "unref" in timeout && typeof timeout.unref === "function") {
+          timeout.unref();
+        }
+      }),
+    ]);
+    return true;
+  } catch (error) {
+    if (error instanceof SnapshotTimeoutError) {
+      console.error("mid-session workspace snapshot wait timed out (turn unaffected)", error);
+      return false;
+    }
+    return true;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 async function terminateEstablishedSandbox(established: EstablishedSandboxSession | null): Promise<boolean> {
   if (!established) {
     return true;
@@ -271,7 +304,20 @@ export async function maybePersistWarmWorkspaceSnapshot(
     if (Number.isFinite(priorAtMs) && Date.now() - priorAtMs < intervalMs) {
       return false;
     }
-    const bytes = await persistable.persistWorkspace();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const bytes = await Promise.race([
+      persistable.persistWorkspace(),
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), settings.sandboxSnapshotTimeoutMs);
+        if (timeout && "unref" in timeout && typeof timeout.unref === "function") {
+          timeout.unref();
+        }
+      }),
+    ]).finally(() => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    });
     if (!bytes || bytes.length === 0) {
       return false;
     }

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -490,6 +490,9 @@ export async function resumeBoxForTurn(
             resumeBackendId: created.backendId,
             resumeState: resumeEnvelope,
             leaseTtlMs,
+            // Keep the warming budget after create(): display-stack + port +
+            // commitWarmingToWarm still run, and can exceed the 90s turn TTL.
+            warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
           });
           if (!recorded.recorded) {
             throw new SandboxLeaseSupersededError(ids.sandboxGroupId, expectedEpoch);

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -399,6 +399,7 @@ export async function resumeBoxForTurn(
     // by acquireLease recreating the box cold on the new image.
     ...(ids.image ? { image: ids.image } : {}),
     leaseTtlMs,
+    warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
   });
 
   // HOLDER-LIVENESS loop: touch OUR holder row every 10s from the moment it is
@@ -642,6 +643,7 @@ export async function acquireSelfhostedLeaseForTurn(
     backend: "selfhosted",
     os: "linux",
     leaseTtlMs,
+    warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
   });
 
   // FENCED: a newer epoch re-established the group concurrently. Release our

--- a/apps/worker/test/reaper-terminate-roundtrip.test.ts
+++ b/apps/worker/test/reaper-terminate-roundtrip.test.ts
@@ -123,7 +123,7 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
       // A persistArchive call must precede the terminate (delete) call.
       expect(deleteCalls).toHaveLength(0);
       persistedArchives.push(archiveBase64);
-      return { wrote: true, priorArchive: null };
+      return { wrote: true, priorArchive: null, priorArchivePrev: null };
     };
 
     // Pre-fix this threw the Modal UserError; post-fix it resolves cleanly.
@@ -177,7 +177,7 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
     const persistCalls: Array<string | null> = [];
     const persistArchive = async (archiveBase64: string | null) => {
       persistCalls.push(archiveBase64);
-      return { wrote: true as const, priorArchive: null };
+      return { wrote: true as const, priorArchive: null, priorArchivePrev: null };
     };
 
     // A fully-populated selfhosted lease envelope: resumeState present, backend
@@ -249,7 +249,7 @@ describe("reaper terminate envelope→resume round-trip preserves sandboxId", ()
     const lease = { sandboxGroupId: "group-nosnap", leaseEpoch: 1, backend: "modal", resumeBackendId: "modal", resumeState };
     const settings = testSettings({ sandboxBackend: "modal", sandboxOwnershipEnabled: true });
 
-    const persistArchive = async () => ({ wrote: true as const, priorArchive: null });
+    const persistArchive = async () => ({ wrote: true as const, priorArchive: null, priorArchivePrev: null });
 
     // The snapshot failure must propagate (so the caller skips + leaves the lease
     // draining); the box is NEVER terminated with un-captured files. The failing

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -344,11 +344,14 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
       resumeState: { backendId: "modal", sessionState: { providerState: { sandboxId: "sb-warm" }, workspaceReady: true } },
     });
 
+    // Explicit capture clocks so ordering is deterministic (persistWarmSnapshot
+    // orders by capture-initiation, not wall-clock-of-call).
+    const t0 = 1_900_000_000_000;
     // First warm persist: folds archive + workspaceArchiveAt; providerState preserved.
     const archive1 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w1\"}").toString("base64");
     const r1 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 60_000,
+      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 60_000, capturedAtMs: t0,
     });
     expect(r1.wrote).toBe(true);
     expect(r1.throttled).toBe(false);
@@ -363,16 +366,30 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     const archive2 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w2\"}").toString("base64");
     const r2 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 60_000,
+      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 60_000, capturedAtMs: t0 + 1_000,
     });
     expect(r2.wrote).toBe(false);
     expect(r2.throttled).toBe(true);
+
+    // MONOTONIC guard: a capture that STARTED at/before the stored archive's
+    // capture is stale (the bounded-wait race — a slow heartbeat capture landing
+    // after a fresher turn-end one) and is a no-op: no overwrite, no throttle-clock
+    // advance, nothing to GC.
+    const staleArchive = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-stale\"}").toString("base64");
+    const rStale = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: staleArchive, minIntervalMs: 0, capturedAtMs: t0 - 5_000,
+    });
+    expect(rStale.wrote).toBe(false);
+    expect(rStale.superseded).toBe(true);
+    const [rowStale] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
+    expect((rowStale!.resume_state as any).sessionState.workspaceArchive).toBe(archive1);
 
     // Interval 0 = always write: shifts current to previous and returns only the
     // two-ago archive for GC, retaining a 2-deep restore fallback.
     const r3 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 0,
+      expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 0, capturedAtMs: t0 + 2_000,
     });
     expect(r3.wrote).toBe(true);
     expect(r3.priorArchiveForGc).toBeNull();
@@ -384,7 +401,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     const archive3 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w3\"}").toString("base64");
     const r3b = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 5, workspaceArchive: archive3, minIntervalMs: 0,
+      expectedEpoch: 5, workspaceArchive: archive3, minIntervalMs: 0, capturedAtMs: t0 + 3_000,
     });
     expect(r3b.wrote).toBe(true);
     expect(r3b.priorArchiveForGc).toBe(archive1);
@@ -396,7 +413,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     // Epoch fence: a stale-epoch persist writes ZERO rows.
     const r4 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 999, workspaceArchive: archive1, minIntervalMs: 0,
+      expectedEpoch: 999, workspaceArchive: archive1, minIntervalMs: 0, capturedAtMs: t0 + 4_000,
     });
     expect(r4.wrote).toBe(false);
     expect(r4.throttled).toBe(false);
@@ -406,7 +423,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     await admin`update sandbox_leases set liveness = 'draining', refcount = 0, turn_holders = 0 where sandbox_group_id = ${ids.groupId}`;
     const r5 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
-      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 0,
+      expectedEpoch: 5, workspaceArchive: archive1, minIntervalMs: 0, capturedAtMs: t0 + 5_000,
     });
     expect(r5.wrote).toBe(false);
   }, 60_000);

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -305,6 +305,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     });
     expect(r1.wrote).toBe(true);
     expect(r1.priorArchive).toBeNull();
+    expect(r1.priorArchivePrev).toBeNull();
     // The archive is folded at resume_state.sessionState.workspaceArchive AND the
     // existing providerState sibling is preserved (resume-by-id still works).
     const [row1] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
@@ -321,6 +322,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     });
     expect(r2.wrote).toBe(true);
     expect(r2.priorArchive).toBe(archive1);
+    expect(r2.priorArchivePrev).toBeNull();
 
     // Epoch fence: a stale-epoch persist writes ZERO rows (wrote:false) so the
     // reaper leaves the (re-armed/superseded) box RUNNING — never terminates it.
@@ -350,7 +352,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     });
     expect(r1.wrote).toBe(true);
     expect(r1.throttled).toBe(false);
-    expect(r1.priorArchive).toBeNull();
+    expect(r1.priorArchiveForGc).toBeNull();
     const [row1] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
     const ss1 = (row1!.resume_state as any).sessionState;
     expect(ss1.workspaceArchive).toBe(archive1);
@@ -366,13 +368,30 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     expect(r2.wrote).toBe(false);
     expect(r2.throttled).toBe(true);
 
-    // Interval 0 = always write: supersedes and returns the PRIOR for GC.
+    // Interval 0 = always write: shifts current to previous and returns only the
+    // two-ago archive for GC, retaining a 2-deep restore fallback.
     const r3 = await persistWarmSnapshot(db, {
       accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
       expectedEpoch: 5, workspaceArchive: archive2, minIntervalMs: 0,
     });
     expect(r3.wrote).toBe(true);
-    expect(r3.priorArchive).toBe(archive1);
+    expect(r3.priorArchiveForGc).toBeNull();
+    const [row3] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
+    const ss3 = (row3!.resume_state as any).sessionState;
+    expect(ss3.workspaceArchive).toBe(archive2);
+    expect(ss3.workspaceArchivePrev).toBe(archive1);
+
+    const archive3 = Buffer.from("MODAL_SANDBOX_FS_SNAPSHOT_V1\n{\"snapshot_id\":\"im-w3\"}").toString("base64");
+    const r3b = await persistWarmSnapshot(db, {
+      accountId: ids.accountId, workspaceId: ids.workspaceId, sandboxGroupId: ids.groupId,
+      expectedEpoch: 5, workspaceArchive: archive3, minIntervalMs: 0,
+    });
+    expect(r3b.wrote).toBe(true);
+    expect(r3b.priorArchiveForGc).toBe(archive1);
+    const [row3b] = await admin`select resume_state from sandbox_leases where sandbox_group_id = ${ids.groupId}`;
+    const ss3b = (row3b!.resume_state as any).sessionState;
+    expect(ss3b.workspaceArchive).toBe(archive3);
+    expect(ss3b.workspaceArchivePrev).toBe(archive2);
 
     // Epoch fence: a stale-epoch persist writes ZERO rows.
     const r4 = await persistWarmSnapshot(db, {

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -353,24 +353,10 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
     // resumeBoxForTurn must win the cold->warming CAS (spawner) and use the
     // LEASE's resume_state (the archive-only envelope) as the spawnEnvelope
     // rather than the null session envelope. The local backend DOES have a
-    // hydrateWorkspace that tries to JSON.parse the archive, so a synthetic
-    // archive that isn't valid JSON causes hydrateWorkspace to throw — but
-    // THAT throw proves the fix: the spawner correctly read the lease's
-    // resume_state (otherwise hydrateWorkspace would never be called).
-    //
-    // The test deliberately asserts the error path: the spawn fails because
-    // the synthetic archive isn't valid JSON, which means:
-    //   (a) establishSandboxSessionFromEnvelope called hydrateWorkspace
-    //       (the lease archive WAS selected as spawnEnvelope), and
-    //   (b) Finding 4's fix: the placeholder box is best-effort deleted
-    //       before re-throwing, and
-    //   (c) failWarmingToCold rolls the lease back to cold (Finding 2's fix:
-    //       preserves the archive).
-    //
-    // A spawner that ignored the lease archive (the bug) would call
-    // establishSandboxSessionFromEnvelope with the null session envelope —
-    // no hydrateWorkspace would fire, the spawn would succeed with an EMPTY
-    // box, and the archive would be silently lost.
+    // hydrateWorkspace that tries to JSON.parse the archive. F3's fail-open
+    // fallback now catches that unusable archive, drops the placeholder, and
+    // creates a clean box instead of failing the turn. The remaining assertion
+    // is that the lease archive was not silently discarded from resume_state.
     let spawnError: Error | undefined;
     let resumed: Awaited<ReturnType<typeof resumeBoxForTurn>> | undefined;
     try {
@@ -386,20 +372,18 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       await resumed?.release();
       if (resumed) await dropSession(resumed.established);
     }
-    // The error must come from hydrateWorkspace (JSON parse of our synthetic
-    // archive), NOT from a missing envelope. This proves the archive was used.
-    expect(spawnError).toBeDefined();
-    expect(spawnError?.message ?? "").toMatch(/JSON\s*[Pp]arse|Unexpected identifier|invalid.*archive|workspaceArchive/i);
+    expect(spawnError).toBeUndefined();
+    expect(resumed).toBeDefined();
 
-    // Finding 2 side-effect: after failWarmingToCold, the lease is cold again
-    // and the archive-only envelope must still be present (not nulled).
+    // The clean fallback succeeded; after the finally release above the idle
+    // lease has naturally entered draining. Because the only archive was
+    // unusable, the committed clean-box envelope no longer carries it.
     const row = await readRow(workspaceId, groupId);
-    expect(row?.liveness).toBe("cold");
-    // The archive survives the failed warm (Finding 2 in action).
+    expect(row?.liveness).toBe("draining");
     const [archiveRow] = await admin<{ archive: string | null }[]>`
       select resume_state #>> '{sessionState,workspaceArchive}' as archive
       from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
-    expect(archiveRow?.archive).toBe(ARCHIVE_B64);
+    expect(archiveRow?.archive).toBeNull();
   }, 60_000);
 
   test("(4) FLAG-OFF: the gate condition is false -> resumeBoxForTurn is NEVER invoked, so NO lease row is materialized", async () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -554,6 +554,12 @@ const SettingsSchema = z.object({
   // worst-case loss of ANY unclean box death to this window. 0 disables.
   // Knob: OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS. Default 15min.
   sandboxSnapshotIntervalMs: z.coerce.number().int().min(0).default(900_000),
+  // Maximum time a best-effort /workspace snapshot capture may hold turn/reaper
+  // cleanup. A hung provider snapshot must never pin a lease holder, block
+  // graceful shutdown, or become permission to GC an older archive. Timeout is
+  // treated exactly like a failed best-effort snapshot. Knob:
+  // OPENGENI_SANDBOX_SNAPSHOT_TIMEOUT_MS. Default 60s.
+  sandboxSnapshotTimeoutMs: z.coerce.number().int().positive().default(60_000),
   // expires_at refresh window for a held lease (>> the turn 10s heartbeat so a
   // single missed heartbeat never TTL-reaps a live turn). The warming TTL is the
   // window a cold->warming spawner has to commit warm before a reaper resets it.
@@ -1058,6 +1064,7 @@ export function getSettings(): Settings {
     sandboxViewerHolderTtlMs: optional("OPENGENI_SANDBOX_VIEWER_HOLDER_TTL_MS"),
     sandboxIdleGraceMs: optional("OPENGENI_SANDBOX_IDLE_GRACE_MS"),
     sandboxSnapshotIntervalMs: optional("OPENGENI_SANDBOX_SNAPSHOT_INTERVAL_MS"),
+    sandboxSnapshotTimeoutMs: optional("OPENGENI_SANDBOX_SNAPSHOT_TIMEOUT_MS"),
     sandboxLeaseTtlMs: optional("OPENGENI_SANDBOX_LEASE_TTL_MS"),
     sandboxLeaseWarmingTtlMs: optional("OPENGENI_SANDBOX_LEASE_WARMING_TTL_MS"),
     sandboxWarmingTimeoutMs: optional("OPENGENI_SANDBOX_WARMING_TIMEOUT_MS"),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6390,6 +6390,10 @@ export interface AcquireLeaseInput {
   // (null/undefined) -> image is not enforced (legacy/cold rows, selfhosted).
   image?: string | null;
   leaseTtlMs: number;          // refresh window for expires_at (turn-heartbeat cadence)
+  // Expiry stamped only while a cold->warming spawner is allowed to create the
+  // provider box before any instance_id exists. Warm/draining/attached refreshes
+  // must continue using leaseTtlMs.
+  warmingLeaseTtlMs?: number;
   // Optional epoch fence for a re-establishing turn holder: when set, the
   // turn-arrival increment is gated on lease_epoch == expectedEpoch (split-brain).
   expectedEpoch?: number;
@@ -6511,6 +6515,7 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
   const { accountId, workspaceId, sandboxGroupId, kind, holderId, backend } = input;
   const os = input.os ?? "linux";
   const subjectId = input.subjectId ?? null;
+  const warmingLeaseTtlMs = input.warmingLeaseTtlMs ?? input.leaseTtlMs;
   return await withRlsContext(db, { accountId, workspaceId }, async (scopedDb) =>
     await scopedDb.transaction(async (txRaw) => {
       const tx = txRaw as unknown as Database;
@@ -6601,7 +6606,7 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
           returning id
         `);
         await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId);
-        const updated = await recomputeAndStampLease(tx, row.id, input.leaseTtlMs, null);
+        const updated = await recomputeAndStampLease(tx, row.id, warmingLeaseTtlMs, null);
         // casRows.length === 0 cannot happen under the held row lock (defensive):
         // a lost CAS means a sibling flipped it first, so we attach.
         const role = casRows.length === 0 ? "attached" as const : "spawner" as const;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9820,6 +9820,43 @@ export async function appendSessionEvents(db: Database, workspaceId: string, ses
   }));
 }
 
+export async function appendSessionEventToSandboxGroup(
+  db: Database,
+  workspaceId: string,
+  sandboxGroupId: string,
+  input: AppendEventInput,
+): Promise<SessionEvent[]> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => await scopedDb.transaction(async (tx) => {
+    const rows = await tx.select().from(schema.sessions)
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.sandboxGroupId, sandboxGroupId)))
+      .orderBy(asc(schema.sessions.createdAt))
+      .for("update");
+    if (rows.length === 0) {
+      return [];
+    }
+    const occurredAt = input.occurredAt ?? new Date();
+    const values = rows.map((row) => ({
+      accountId: row.accountId,
+      workspaceId: row.workspaceId,
+      sessionId: row.id,
+      sequence: row.lastSequence + 1,
+      type: input.type,
+      payload: sanitizeEventPayload(input.payload ?? {}),
+      clientEventId: input.clientEventId ?? null,
+      turnId: input.turnId ?? null,
+      producerId: input.producerId ?? null,
+      producerSeq: input.producerSeq ?? null,
+      occurredAt,
+    }));
+    const inserted = await tx.insert(schema.sessionEvents).values(values).returning();
+    await tx.update(schema.sessions).set({
+      lastSequence: sql`${schema.sessions.lastSequence} + 1`,
+      updatedAt: new Date(),
+    }).where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.sandboxGroupId, sandboxGroupId)));
+    return inserted.map(mapEvent);
+  }));
+}
+
 export async function appendSessionEventsAndUpdateSession(db: Database, workspaceId: string, sessionId: string, inputs: AppendEventInput[], update: {
   resources?: ResourceRef[];
   tools?: ToolRef[];

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7298,10 +7298,16 @@ async function foldWorkspaceArchiveOntoLease(scopedDb: Database, input: {
   livenessGuard: "draining" | "warm";
   priorCurrentArchive?: string | null;
   clearPreviousArchive?: boolean;
+  /** The wall-clock (ISO) this archive's capture STARTED. Stamped as
+   *  workspaceArchiveAt so warm-snapshot ordering is by capture-initiation, not
+   *  land time — a late, older capture is superseded (persistWarmSnapshot's
+   *  monotonic guard). Absent (drain) → now(). */
+  archiveAtIso?: string;
 }): Promise<void> {
   const livenessGuard = input.livenessGuard === "draining"
     ? sql`liveness = 'draining' and refcount = 0`
     : sql`liveness = 'warm'`;
+  const archiveAt = input.archiveAtIso ? sql`to_jsonb(${input.archiveAtIso}::text)` : sql`to_jsonb(now()::timestamptz::text)`;
   await scopedDb.execute(sql`
     update sandbox_leases set
       resume_state = jsonb_set(
@@ -7315,7 +7321,7 @@ async function foldWorkspaceArchiveOntoLease(scopedDb: Database, input: {
                 then resume_state -> 'sessionState' else '{}'::jsonb end)
             || jsonb_build_object(
               'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
-              'workspaceArchiveAt', to_jsonb(now()::timestamptz::text),
+              'workspaceArchiveAt', ${archiveAt},
               'workspaceArchivePrev', case
                 when ${input.clearPreviousArchive ? "yes" : "no"}::text = 'yes' then null::jsonb
                 when ${input.priorCurrentArchive ?? null}::text is null then null::jsonb
@@ -7349,7 +7355,14 @@ export async function persistWarmSnapshot(db: Database, input: {
   workspaceArchive: string;
   /** Snapshots newer than this many ms are kept (throttle); 0 = always write. */
   minIntervalMs: number;
-}): Promise<{ wrote: boolean; throttled: boolean; priorArchiveForGc: string | null }> {
+  /** Wall-clock (ms) this capture STARTED. Ordering is by capture-initiation,
+   *  NOT land time: a capture that started at or before the archive already on
+   *  the lease is SUPERSEDED (a stale heartbeat capture that timed out its wait
+   *  and landed late must never overwrite a fresher turn-end snapshot or refresh
+   *  the throttle clock). Defaults to Date.now() for legacy callers/tests. */
+  capturedAtMs?: number;
+}): Promise<{ wrote: boolean; throttled: boolean; superseded: boolean; priorArchiveForGc: string | null }> {
+  const capturedAtMs = input.capturedAtMs ?? Date.now();
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
     async (scopedDb) => {
       const guard = await scopedDb.execute<{ prior_archive: string | null; prior_archive_prev: string | null; prior_archive_at: string | null }>(sql`
@@ -7363,17 +7376,24 @@ export async function persistWarmSnapshot(db: Database, input: {
         for update
       `);
       if (guard.length === 0) {
-        return { wrote: false, throttled: false, priorArchiveForGc: null };
+        return { wrote: false, throttled: false, superseded: false, priorArchiveForGc: null };
       }
       const priorArchive = guard[0]!.prior_archive ?? null;
       const priorArchivePrev = guard[0]!.prior_archive_prev ?? null;
       const priorAtMs = guard[0]!.prior_archive_at ? Date.parse(guard[0]!.prior_archive_at) : Number.NaN;
+      // MONOTONIC guard: a capture whose start is at/before the stored archive's
+      // capture is stale (a slower-but-earlier heartbeat capture landing after a
+      // fresher turn-end one). No-op — do NOT overwrite and do NOT advance the
+      // throttle clock. This is what makes the bounded snapshot wait safe.
+      if (Number.isFinite(priorAtMs) && capturedAtMs <= priorAtMs) {
+        return { wrote: false, throttled: false, superseded: true, priorArchiveForGc: null };
+      }
       if (
         input.minIntervalMs > 0
         && Number.isFinite(priorAtMs)
-        && Date.now() - priorAtMs < input.minIntervalMs
+        && capturedAtMs - priorAtMs < input.minIntervalMs
       ) {
-        return { wrote: false, throttled: true, priorArchiveForGc: null };
+        return { wrote: false, throttled: true, superseded: false, priorArchiveForGc: null };
       }
       await foldWorkspaceArchiveOntoLease(scopedDb, {
         workspaceId: input.workspaceId,
@@ -7382,8 +7402,9 @@ export async function persistWarmSnapshot(db: Database, input: {
         workspaceArchive: input.workspaceArchive,
         livenessGuard: "warm",
         priorCurrentArchive: priorArchive,
+        archiveAtIso: new Date(capturedAtMs).toISOString(),
       });
-      return { wrote: true, throttled: false, priorArchiveForGc: priorArchivePrev };
+      return { wrote: true, throttled: false, superseded: false, priorArchiveForGc: priorArchivePrev };
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7209,7 +7209,7 @@ export async function persistDrainSnapshot(db: Database, input: {
   /** base64 of the provider snapshot-ref / tar archive from persistWorkspace().
    *  Pass null to CAS-check without writing (for backends with no persistWorkspace). */
   workspaceArchive: string | null;
-}): Promise<{ wrote: boolean; priorArchive: string | null }> {
+}): Promise<{ wrote: boolean; priorArchive: string | null; priorArchivePrev: string | null }> {
   // withRlsContext already runs `fn` inside ONE transaction with the RLS GUCs set,
   // so the SELECT...FOR UPDATE + UPDATE below are atomic (one snapshot, one lock)
   // WITHOUT an extra nested savepoint — nesting a second transaction here under
@@ -7219,21 +7219,24 @@ export async function persistDrainSnapshot(db: Database, input: {
       // (1) Lock + read the PRIOR archive under the CAS guard (draining AND
       // refcount=0 AND lease_epoch=expected). A miss (re-armed / newer epoch /
       // vanished) returns no row → wrote:false, the caller must NOT terminate.
-      const guard = await scopedDb.execute<{ prior_archive: string | null }>(sql`
-        select resume_state #>> '{sessionState,workspaceArchive}' as prior_archive
+      const guard = await scopedDb.execute<{ prior_archive: string | null; prior_archive_prev: string | null }>(sql`
+        select
+          resume_state #>> '{sessionState,workspaceArchive}' as prior_archive,
+          resume_state #>> '{sessionState,workspaceArchivePrev}' as prior_archive_prev
         from sandbox_leases
         where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
           and liveness = 'draining' and refcount = 0 and lease_epoch = ${input.expectedEpoch}
         for update
       `);
       if (guard.length === 0) {
-        return { wrote: false, priorArchive: null };
+        return { wrote: false, priorArchive: null, priorArchivePrev: null };
       }
       const priorArchive = guard[0]!.prior_archive ?? null;
+      const priorArchivePrev = guard[0]!.prior_archive_prev ?? null;
       // null workspaceArchive = pure CAS-check (re-arm guard for no-archive backends).
       // The FOR UPDATE lock above is the only synchronization needed; no write.
       if (input.workspaceArchive === null) {
-        return { wrote: true, priorArchive: null };
+        return { wrote: true, priorArchive: null, priorArchivePrev: null };
       }
       await foldWorkspaceArchiveOntoLease(scopedDb, {
         workspaceId: input.workspaceId,
@@ -7241,8 +7244,9 @@ export async function persistDrainSnapshot(db: Database, input: {
         expectedEpoch: input.expectedEpoch,
         workspaceArchive: input.workspaceArchive,
         livenessGuard: "draining",
+        clearPreviousArchive: true,
       });
-      return { wrote: true, priorArchive };
+      return { wrote: true, priorArchive, priorArchivePrev };
     });
 }
 
@@ -7266,6 +7270,8 @@ async function foldWorkspaceArchiveOntoLease(scopedDb: Database, input: {
   workspaceId: string; sandboxGroupId: string; expectedEpoch: number;
   workspaceArchive: string;
   livenessGuard: "draining" | "warm";
+  priorCurrentArchive?: string | null;
+  clearPreviousArchive?: boolean;
 }): Promise<void> {
   const livenessGuard = input.livenessGuard === "draining"
     ? sql`liveness = 'draining' and refcount = 0`
@@ -7278,12 +7284,19 @@ async function foldWorkspaceArchiveOntoLease(scopedDb: Database, input: {
         -- starts from '{}' so jsonb_set never throws "cannot set path in scalar".
         case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
         '{sessionState}',
-        (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
-              then resume_state -> 'sessionState' else '{}'::jsonb end)
-          || jsonb_build_object(
-            'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
-            'workspaceArchiveAt', to_jsonb(now()::timestamptz::text)
-          ),
+        jsonb_strip_nulls(
+          (case when jsonb_typeof(resume_state -> 'sessionState') = 'object'
+                then resume_state -> 'sessionState' else '{}'::jsonb end)
+            || jsonb_build_object(
+              'workspaceArchive', to_jsonb(${input.workspaceArchive}::text),
+              'workspaceArchiveAt', to_jsonb(now()::timestamptz::text),
+              'workspaceArchivePrev', case
+                when ${input.clearPreviousArchive ? "yes" : "no"}::text = 'yes' then null::jsonb
+                when ${input.priorCurrentArchive ?? null}::text is null then null::jsonb
+                else to_jsonb(${input.priorCurrentArchive ?? null}::text)
+              end
+            )
+        ),
         true
       ),
       updated_at = now()
@@ -7310,12 +7323,13 @@ export async function persistWarmSnapshot(db: Database, input: {
   workspaceArchive: string;
   /** Snapshots newer than this many ms are kept (throttle); 0 = always write. */
   minIntervalMs: number;
-}): Promise<{ wrote: boolean; throttled: boolean; priorArchive: string | null }> {
+}): Promise<{ wrote: boolean; throttled: boolean; priorArchiveForGc: string | null }> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
     async (scopedDb) => {
-      const guard = await scopedDb.execute<{ prior_archive: string | null; prior_archive_at: string | null }>(sql`
+      const guard = await scopedDb.execute<{ prior_archive: string | null; prior_archive_prev: string | null; prior_archive_at: string | null }>(sql`
         select
           resume_state #>> '{sessionState,workspaceArchive}' as prior_archive,
+          resume_state #>> '{sessionState,workspaceArchivePrev}' as prior_archive_prev,
           resume_state #>> '{sessionState,workspaceArchiveAt}' as prior_archive_at
         from sandbox_leases
         where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
@@ -7323,16 +7337,17 @@ export async function persistWarmSnapshot(db: Database, input: {
         for update
       `);
       if (guard.length === 0) {
-        return { wrote: false, throttled: false, priorArchive: null };
+        return { wrote: false, throttled: false, priorArchiveForGc: null };
       }
       const priorArchive = guard[0]!.prior_archive ?? null;
+      const priorArchivePrev = guard[0]!.prior_archive_prev ?? null;
       const priorAtMs = guard[0]!.prior_archive_at ? Date.parse(guard[0]!.prior_archive_at) : Number.NaN;
       if (
         input.minIntervalMs > 0
         && Number.isFinite(priorAtMs)
         && Date.now() - priorAtMs < input.minIntervalMs
       ) {
-        return { wrote: false, throttled: true, priorArchive: null };
+        return { wrote: false, throttled: true, priorArchiveForGc: null };
       }
       await foldWorkspaceArchiveOntoLease(scopedDb, {
         workspaceId: input.workspaceId,
@@ -7340,8 +7355,9 @@ export async function persistWarmSnapshot(db: Database, input: {
         expectedEpoch: input.expectedEpoch,
         workspaceArchive: input.workspaceArchive,
         livenessGuard: "warm",
+        priorCurrentArchive: priorArchive,
       });
-      return { wrote: true, throttled: false, priorArchive };
+      return { wrote: true, throttled: false, priorArchiveForGc: priorArchivePrev };
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6696,16 +6696,23 @@ export async function recordWarmingSandboxCreated(db: Database, input: {
   resumeBackendId?: string | null;
   resumeState?: Record<string, unknown> | null;
   leaseTtlMs: number;
+  /** The still-WARMING lease must keep the warming budget after create() returns:
+   *  the spawner has yet to run display-stack setup, port expose, and
+   *  commitWarmingToWarm, which can exceed the 90s turn TTL and trip the
+   *  warming-death (c2) drain now that instance_id is set. Defaults to leaseTtlMs
+   *  for legacy callers/tests. */
+  warmingLeaseTtlMs?: number;
 }): Promise<{ recorded: boolean; lease: LeaseSnapshot | null }> {
   return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
     async (scopedDb) => {
       const resumeStateJson = input.resumeState == null ? null : JSON.stringify(input.resumeState);
+      const warmingTtlMs = input.warmingLeaseTtlMs ?? input.leaseTtlMs;
       const rows = await scopedDb.execute<LeaseRow>(sql`
         update sandbox_leases set
           instance_id       = ${input.instanceId},
           resume_backend_id = ${input.resumeBackendId ?? null},
           resume_state      = ${resumeStateJson}::jsonb,
-          expires_at        = now() + (${String(input.leaseTtlMs)} || ' milliseconds')::interval,
+          expires_at        = now() + (${String(warmingTtlMs)} || ' milliseconds')::interval,
           updated_at        = now()
         where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
           and liveness = 'warming' and lease_epoch = ${input.expectedEpoch}
@@ -6744,8 +6751,15 @@ export async function failWarmingToCold(db: Database, input: {
             when (resume_state #>> '{sessionState,workspaceArchive}') is not null
               then jsonb_build_object(
                 'backendId', coalesce(resume_state ->> 'backendId', to_jsonb(resume_backend_id) #>> '{}'),
-                'sessionState', jsonb_build_object(
-                  'workspaceArchive', resume_state #> '{sessionState,workspaceArchive}'))
+                -- Carry BOTH archives (+ the capture time) into the minimal cold
+                -- envelope: the mid-session fallback (workspaceArchivePrev) was
+                -- retained and never GC'd, so dropping it here would strand the
+                -- provider snapshot AND lose the restore fallback across a
+                -- drain/warming-death. strip_nulls omits prev/at when absent.
+                'sessionState', jsonb_strip_nulls(jsonb_build_object(
+                  'workspaceArchive', resume_state #> '{sessionState,workspaceArchive}',
+                  'workspaceArchivePrev', resume_state #> '{sessionState,workspaceArchivePrev}',
+                  'workspaceArchiveAt', resume_state #> '{sessionState,workspaceArchiveAt}')))
             else null
           end,
           resume_backend_id = case
@@ -7192,8 +7206,15 @@ export async function confirmDrainCold(db: Database, input: {
             when (resume_state #>> '{sessionState,workspaceArchive}') is not null
               then jsonb_build_object(
                 'backendId', coalesce(resume_state ->> 'backendId', to_jsonb(resume_backend_id) #>> '{}'),
-                'sessionState', jsonb_build_object(
-                  'workspaceArchive', resume_state #> '{sessionState,workspaceArchive}'))
+                -- Carry BOTH archives (+ the capture time) into the minimal cold
+                -- envelope: the mid-session fallback (workspaceArchivePrev) was
+                -- retained and never GC'd, so dropping it here would strand the
+                -- provider snapshot AND lose the restore fallback across a
+                -- drain/warming-death. strip_nulls omits prev/at when absent.
+                'sessionState', jsonb_strip_nulls(jsonb_build_object(
+                  'workspaceArchive', resume_state #> '{sessionState,workspaceArchive}',
+                  'workspaceArchivePrev', resume_state #> '{sessionState,workspaceArchivePrev}',
+                  'workspaceArchiveAt', resume_state #> '{sessionState,workspaceArchiveAt}')))
             else null
           end,
           resume_backend_id = case

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6624,8 +6624,14 @@ export async function acquireLease(db: Database, input: AcquireLeaseInput): Prom
 
       // -- warm / warming: attach (A2 / A1). refcount++ ONLY; never touch
       // liveness. The spawner exclusively owns warming->warm.
+      // TTL: a WARMING attach must keep the warming budget — re-stamping the
+      // plain (90s) TTL while a spawner's create() is still in flight would
+      // collapse expires_at and let the warming-death reaper reset/drain the
+      // lease before instance_id is recorded (F1). A WARM attach uses the plain
+      // TTL as before.
       await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId);
-      const updated = await recomputeAndStampLease(tx, row.id, input.leaseTtlMs, null);
+      const attachTtlMs = liveness === "warming" ? warmingLeaseTtlMs : input.leaseTtlMs;
+      const updated = await recomputeAndStampLease(tx, row.id, attachTtlMs, null);
       return { role: "attached" as const, lease: mapLeaseRow(updated) };
     }),
   );

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6878,6 +6878,8 @@ export interface ReapDrainable {
   leaseEpoch: number;
 }
 
+let loggedLegacyReapFunctionFallback = false;
+
 export async function reapStaleLeaseHolders(db: Database, input: {
   workspaceId: string;
   viewerHolderTtlMs: number;   // delete viewer rows older than this
@@ -7009,10 +7011,29 @@ export async function reapStaleLeaseHoldersGlobal(db: Database, input: {
   turnHolderTtlMs?: number;
   idleGraceMs: number;
 }): Promise<ReapDrainable[]> {
-  const rows = await rawRows<{ workspace_id: string; sandbox_group_id: string; instance_id: string | null; lease_epoch: number | string }>(db, sql`
-    select workspace_id, sandbox_group_id, instance_id, lease_epoch
-    from opengeni_private.reap_sandbox_leases(${input.viewerHolderTtlMs}, ${input.turnHolderTtlMs ?? 0}, ${input.idleGraceMs})
-  `);
+  let rows: Array<{ workspace_id: string; sandbox_group_id: string; instance_id: string | null; lease_epoch: number | string }>;
+  try {
+    rows = await rawRows<{ workspace_id: string; sandbox_group_id: string; instance_id: string | null; lease_epoch: number | string }>(db, sql`
+      select workspace_id, sandbox_group_id, instance_id, lease_epoch
+      from opengeni_private.reap_sandbox_leases(${input.viewerHolderTtlMs}, ${input.turnHolderTtlMs ?? 0}, ${input.idleGraceMs})
+    `);
+  } catch (error) {
+    // Deploy normally runs migrations before rollout, but a newly-started worker
+    // may briefly hit a DB that only has the legacy 2-arg SECURITY DEFINER
+    // function. Fall back for that sweep only: viewer/warming/drain reaping stays
+    // active, dead-turn-holder reaping is skipped until migration 0044 lands.
+    if ((error as { code?: unknown })?.code !== "42883") {
+      throw error;
+    }
+    if (!loggedLegacyReapFunctionFallback) {
+      loggedLegacyReapFunctionFallback = true;
+      console.warn("sandbox lease global reaper: 3-arg reap_sandbox_leases missing; falling back to legacy 2-arg sweep");
+    }
+    rows = await rawRows<{ workspace_id: string; sandbox_group_id: string; instance_id: string | null; lease_epoch: number | string }>(db, sql`
+      select workspace_id, sandbox_group_id, instance_id, lease_epoch
+      from opengeni_private.reap_sandbox_leases(${input.viewerHolderTtlMs}, ${input.idleGraceMs})
+    `);
+  }
   return rows.map((r) => ({
     workspaceId: r.workspace_id,
     sandboxGroupId: r.sandbox_group_id,

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -64,12 +64,13 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 async function readRow(workspaceId: string, groupId: string) {
   const [r] = await admin`
     select liveness, refcount, turn_holders, viewer_holders, lease_epoch,
-           pg_typeof(lease_epoch) as epoch_type
+           pg_typeof(lease_epoch) as epoch_type, expires_at, instance_id
     from sandbox_leases
     where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
   return r as {
     liveness: string; refcount: number; turn_holders: number;
     viewer_holders: number; lease_epoch: number; epoch_type: string;
+    expires_at: Date; instance_id: string | null;
   } | undefined;
 }
 
@@ -124,6 +125,40 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     const row = await readRow(workspaceId, groupId);
     expect(row?.refcount).toBe(N);
     expect(row?.liveness).toBe("warming");
+  }, 60_000);
+
+  test("(1b) cold->warming stamps the warming budget, so slow creates are not 90s-reaped", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const acquired = await acquireLease(db, {
+      accountId, workspaceId, sandboxGroupId: groupId,
+      kind: "turn", holderId: "slow-spawner", backend: "modal",
+      leaseTtlMs: 90_000,
+      warmingLeaseTtlMs: 600_000,
+    });
+    expect(acquired.role).toBe("spawner");
+
+    const stamped = await readRow(workspaceId, groupId);
+    expect(stamped?.liveness).toBe("warming");
+    expect(stamped?.expires_at.getTime()).toBeGreaterThan(Date.now() + 300_000);
+
+    // Simulate a spawner that has already spent longer than the normal 90s
+    // holder TTL but is still inside the 600s warming budget. The warming-death
+    // reaper must leave it warming instead of resetting it to cold.
+    await admin`
+      update sandbox_leases
+      set expires_at = now() + interval '300 seconds'
+      where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}
+    `;
+    const reap = await reapStaleLeaseHolders(db, {
+      workspaceId,
+      viewerHolderTtlMs: 90_000,
+      idleGraceMs: 45_000,
+    });
+    expect(reap.warmingReset).toBe(0);
+    const after = await readRow(workspaceId, groupId);
+    expect(after?.liveness).toBe("warming");
+    expect(after?.instance_id).toBeNull();
   }, 60_000);
 
   test("(1c) SKIP-LOCKED counterfactual: a concurrent arrival is SKIPPED (no row), proving plain FOR UPDATE is load-bearing", async () => {

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -762,6 +762,12 @@ export async function establishSandboxSessionFromEnvelope(
         throw createCallbackError;
       }
     }
+    // Whether an archive was ACTUALLY applied to /workspace — drives `origin`
+    // (and the worker's sandbox.box.created `hydrated` field). A clean-box
+    // fallback, a backend without hydrateWorkspace, or an all-archives-failed
+    // path leaves this false so we never report `hydrated: "archive"` for an
+    // empty workspace.
+    let hydrationApplied = false;
     if (!skipWorkspaceHydrate && (workspaceArchive || workspaceArchives.previous)) {
       const hydrate = (restored as { hydrateWorkspace?: (data: Uint8Array) => Promise<void> }).hydrateWorkspace;
       if (typeof hydrate === "function") {
@@ -797,6 +803,7 @@ export async function establishSandboxSessionFromEnvelope(
           await terminateCreatedSandbox(client, restored, restoredState);
           return await coldRestore(resumeFallbackState, true);
         }
+        hydrationApplied = true;
         const hydratedState = (restored as { state?: unknown }).state;
         const hydratedInstanceId = readInstanceId(restored);
         if (hydratedInstanceId && hydratedInstanceId !== established.instanceId) {
@@ -825,7 +832,7 @@ export async function establishSandboxSessionFromEnvelope(
       sessionState: restoredState ?? resumeFallbackState,
       instanceId: readInstanceId(restored),
       backendId: client.backendId,
-      origin: workspaceArchive ? "restored" as const : "created" as const,
+      origin: hydrationApplied ? "restored" as const : "created" as const,
     };
   };
 

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -424,6 +424,22 @@ export function readWorkspaceArchiveFromEnvelopeSessionState(sessionState: unkno
   }
 }
 
+function readWorkspaceArchivePairFromEnvelopeSessionState(sessionState: unknown): {
+  current?: Uint8Array;
+  previous?: Uint8Array;
+} {
+  if (!sessionState || typeof sessionState !== "object") {
+    return {};
+  }
+  const state = sessionState as { workspaceArchivePrev?: unknown };
+  const current = readWorkspaceArchiveFromEnvelopeSessionState(sessionState);
+  const previous = readWorkspaceArchiveFromEnvelopeSessionState({ workspaceArchive: state.workspaceArchivePrev });
+  return {
+    ...(current ? { current } : {}),
+    ...(previous ? { previous } : {}),
+  };
+}
+
 // The native snapshot-ref prefixes the @openai/agents-extensions modal client
 // encodes (snapshots.mjs `NATIVE_SNAPSHOT_PREFIXES`). The ref is
 // `<PREFIX>\n{"snapshot_id":"...",...}`. We re-implement the decode here because
@@ -711,7 +727,8 @@ export async function establishSandboxSessionFromEnvelope(
   //   - COLD lease re-warm (confirmDrainCold preserved a MINIMAL archive-only
   //     envelope `{ sessionState: { workspaceArchive } }` — NO sandboxId, so the
   //     warm-reattach branch must NOT try resume()-by-id; it cold-creates+hydrates).
-  const workspaceArchive = readWorkspaceArchiveFromEnvelopeSessionState(envelopeSessionState);
+  const workspaceArchives = readWorkspaceArchivePairFromEnvelopeSessionState(envelopeSessionState);
+  const workspaceArchive = workspaceArchives.current;
 
   // create() a FRESH box, THEN replay the persisted /workspace snapshot via
   // session.hydrateWorkspace(archive) when one rode the envelope. hydrateWorkspace
@@ -719,7 +736,7 @@ export async function establishSandboxSessionFromEnvelope(
   // image (restoreSnapshotFilesystem); no archive -> a clean empty box. This is the
   // SOLE archive-replay seam, shared by the NotFound warm-reattach path AND the
   // cold-restore branch (b) below.
-  const coldRestore = async (resumeFallbackState?: unknown): Promise<EstablishedSandboxSession> => {
+  const coldRestore = async (resumeFallbackState?: unknown, skipWorkspaceHydrate = false): Promise<EstablishedSandboxSession> => {
     const createStarted = Date.now();
     let restored: Awaited<ReturnType<NonNullable<typeof client.create>>>;
     try {
@@ -745,24 +762,40 @@ export async function establishSandboxSessionFromEnvelope(
         throw createCallbackError;
       }
     }
-    if (workspaceArchive) {
+    if (!skipWorkspaceHydrate && (workspaceArchive || workspaceArchives.previous)) {
       const hydrate = (restored as { hydrateWorkspace?: (data: Uint8Array) => Promise<void> }).hydrateWorkspace;
       if (typeof hydrate === "function") {
-        try {
-          // hydrateWorkspace may internally REPLACE the underlying box
-          // (restoreSnapshotFilesystem creates a replacement sandbox and terminates
-          // the placeholder), so the instanceId must be re-read AFTER.
-          await hydrate.call(restored, workspaceArchive);
-        } catch (hydrateError) {
-          // sandbox-file-persistence: if hydrateWorkspace throws (snapshot GC'd,
-          // provider timeout, corrupt archive), the placeholder box created above is
-          // live but unhydrated — it would leak up to the full idle/hard lifetime
-          // (3600s) if we just re-throw. Best-effort delete/terminate it BEFORE
-          // re-throwing so no box leaks. The original error semantics are preserved
-          // (the re-throw propagates to the caller). This mirrors the reaper's
-          // discipline: NEVER leave an orphaned box running.
+        let hydrated = false;
+        for (const candidate of [
+          { archive: workspaceArchive, label: "current" },
+          { archive: workspaceArchives.previous, label: "previous" },
+        ]) {
+          if (!candidate.archive) {
+            continue;
+          }
+          try {
+            // hydrateWorkspace may internally REPLACE the underlying box
+            // (restoreSnapshotFilesystem creates a replacement sandbox and terminates
+            // the placeholder), so the instanceId must be re-read AFTER.
+            await hydrate.call(restored, candidate.archive);
+            console.info(`[sandbox] cold-restore hydrated workspace from ${candidate.label} archive`);
+            hydrated = true;
+            break;
+          } catch (hydrateError) {
+            console.warn(
+              `[sandbox] cold-restore failed to hydrate workspace from ${candidate.label} archive${
+                candidate.label === "current" && workspaceArchives.previous ? "; trying previous archive" : ""
+              }`,
+              hydrateError,
+            );
+          }
+        }
+        if (!hydrated) {
+          // If both retained archives are unusable, drop the placeholder and
+          // fall through to the same clean-box behavior as an envelope with no
+          // archive. Restore failure is fail-open; it must not strand a turn.
           await terminateCreatedSandbox(client, restored, restoredState);
-          throw hydrateError;
+          return await coldRestore(resumeFallbackState, true);
         }
         const hydratedState = (restored as { state?: unknown }).state;
         const hydratedInstanceId = readInstanceId(restored);

--- a/packages/runtime/test/cold-restore-hydrate.test.ts
+++ b/packages/runtime/test/cold-restore-hydrate.test.ts
@@ -21,8 +21,8 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 // `new ModalSandboxClient(...)` constructs our fake).
 const hydrateCalls: Uint8Array[] = [];
 const createArgs: Array<{ manifest?: unknown; snapshot?: unknown }> = [];
-// Finding 4: controls for hydrateWorkspace-throw + delete tracking.
-let hydrateWorkspaceShouldThrow = false;
+// Controls for hydrateWorkspace-throw + delete tracking.
+let hydrateWorkspaceFailuresRemaining = 0;
 const deleteCalls: unknown[] = [];
 
 class FakeModalSandboxClient {
@@ -42,7 +42,8 @@ class FakeModalSandboxClient {
     return {
       state: { sandboxId: "sb-fresh" },
       async hydrateWorkspace(data: Uint8Array) {
-        if (hydrateWorkspaceShouldThrow) {
+        if (hydrateWorkspaceFailuresRemaining > 0) {
+          hydrateWorkspaceFailuresRemaining -= 1;
           throw new Error("hydrateWorkspace: snapshot GC'd or provider timeout (test-injected failure)");
         }
         hydrateCalls.push(data);
@@ -74,6 +75,8 @@ afterAll(() => {
 const SNAPSHOT_REF = 'MODAL_SANDBOX_FS_SNAPSHOT_V1\n{"snapshot_id":"im-snap-abc","workspace_persistence":"snapshot_filesystem"}';
 const SNAPSHOT_BYTES = new TextEncoder().encode(SNAPSHOT_REF);
 const SNAPSHOT_B64 = Buffer.from(SNAPSHOT_BYTES).toString("base64");
+const SNAPSHOT_PREV_REF = 'MODAL_SANDBOX_FS_SNAPSHOT_V1\n{"snapshot_id":"im-snap-prev","workspace_persistence":"snapshot_filesystem"}';
+const SNAPSHOT_PREV_B64 = Buffer.from(new TextEncoder().encode(SNAPSHOT_PREV_REF)).toString("base64");
 
 function envelopeWithArchive(archiveB64: string | undefined) {
   const sessionState: Record<string, unknown> = {
@@ -85,6 +88,12 @@ function envelopeWithArchive(archiveB64: string | undefined) {
     sessionState.workspaceArchive = archiveB64;
   }
   return { backendId: "modal", sessionState };
+}
+
+function envelopeWithArchivePair(currentB64: string, previousB64: string) {
+  const envelope = envelopeWithArchive(currentB64);
+  (envelope.sessionState as Record<string, unknown>).workspaceArchivePrev = previousB64;
+  return envelope;
 }
 
 function modalSettings() {
@@ -150,42 +159,49 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
     expect(established.instanceId).toBe("sb-fresh");
   });
 
-  // FINDING 4: placeholder box must be deleted when hydrateWorkspace throws.
-  // client.create() allocates a live Modal box; if the subsequent hydrateWorkspace()
-  // throws (snapshot GC'd, provider timeout, corrupt archive), the freshly-created
-  // box must be best-effort deleted before re-throwing so it doesn't leak up to the
-  // full idle/hard lifetime. The original error semantics are preserved (re-thrown).
-  test("(F4) hydrateWorkspace failure deletes the placeholder box before re-throwing", async () => {
+  test("cold-restore falls back to workspaceArchivePrev when current hydrate throws", async () => {
     hydrateCalls.length = 0;
     createArgs.length = 0;
     deleteCalls.length = 0;
-    hydrateWorkspaceShouldThrow = true;
+    hydrateWorkspaceFailuresRemaining = 1;
 
     try {
-      let threw = false;
-      let caughtMessage = "";
-      try {
-        await establishSandboxSessionFromEnvelope(
-          modalSettings(),
-          envelopeWithArchive(SNAPSHOT_B64),
-          { sessionId: "sess-hydrate-fail", environment: {} },
-        );
-      } catch (e) {
-        threw = true;
-        caughtMessage = e instanceof Error ? e.message : String(e);
-      }
-      // The original hydrateWorkspace error is re-thrown (error semantics preserved).
-      expect(threw).toBe(true);
-      expect(caughtMessage).toContain("hydrateWorkspace");
-      // The placeholder box was best-effort deleted before re-throwing.
-      // FakeModalSandboxClient.delete() records the state passed to it.
+      const established = await establishSandboxSessionFromEnvelope(
+        modalSettings(),
+        envelopeWithArchivePair(SNAPSHOT_B64, SNAPSHOT_PREV_B64),
+        { sessionId: "sess-hydrate-prev", environment: {} },
+      );
+
+      expect(createArgs).toHaveLength(1);
+      expect(deleteCalls.length).toBe(0);
+      expect(hydrateCalls).toHaveLength(1);
+      expect(new TextDecoder().decode(hydrateCalls[0]!)).toBe(SNAPSHOT_PREV_REF);
+      expect(established.instanceId).toBe("sb-fresh");
+    } finally {
+      hydrateWorkspaceFailuresRemaining = 0;
+    }
+  });
+
+  test("cold-restore with unusable archive falls through to a clean box", async () => {
+    hydrateCalls.length = 0;
+    createArgs.length = 0;
+    deleteCalls.length = 0;
+    hydrateWorkspaceFailuresRemaining = 1;
+
+    try {
+      const established = await establishSandboxSessionFromEnvelope(
+        modalSettings(),
+        envelopeWithArchive(SNAPSHOT_B64),
+        { sessionId: "sess-hydrate-fail-open", environment: {} },
+      );
+
+      expect(established.instanceId).toBe("sb-fresh");
       expect(deleteCalls.length).toBe(1);
       expect(deleteCalls[0]).toMatchObject({ sandboxId: "sb-fresh" });
-      // create() was called exactly once (no retry — just create then fail).
-      expect(createArgs).toHaveLength(1);
+      expect(createArgs).toHaveLength(2);
+      expect(hydrateCalls).toHaveLength(0);
     } finally {
-      // Reset so other tests are not affected.
-      hydrateWorkspaceShouldThrow = false;
+      hydrateWorkspaceFailuresRemaining = 0;
     }
   });
 });

--- a/packages/runtime/test/cold-restore-hydrate.test.ts
+++ b/packages/runtime/test/cold-restore-hydrate.test.ts
@@ -200,6 +200,9 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
       expect(deleteCalls[0]).toMatchObject({ sandboxId: "sb-fresh" });
       expect(createArgs).toHaveLength(2);
       expect(hydrateCalls).toHaveLength(0);
+      // Nothing was actually hydrated → must NOT report as restored-from-archive
+      // (else sandbox.box.created would claim hydrated:"archive" on an empty box).
+      expect(established.origin).toBe("created");
     } finally {
       hydrateWorkspaceFailuresRemaining = 0;
     }

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -179,6 +179,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     sandboxViewerHolderTtlMs: 90_000,
     sandboxIdleGraceMs: 900_000,
     sandboxSnapshotIntervalMs: 900_000,
+    sandboxSnapshotTimeoutMs: 60_000,
     sandboxLeaseTtlMs: 90_000,
     sandboxLeaseWarmingTtlMs: 120_000,
     sandboxWarmingTimeoutMs: 600_000,


### PR DESCRIPTION
Follow-up to #292 (which is live in prod). A fresh-eyes adversarial review of the merged durability code surfaced 5 issues; this hardens all of them. No schema migration (F3's second archive rides the existing resume_state JSON).

## Findings fixed

**F2 [HIGH] — a hung Modal snapshot could pin the lease holder / block graceful release.** `maybePersistWarmWorkspaceSnapshot` awaited `persistWorkspace()` with no timeout, and turn-end awaited the in-flight capture unbounded before releasing the lease. (This was a self-inflicted regression — an earlier cleanup replaced a bounded wait with a bare `await`.) Now: the capture and the turn-end wait are both bounded by `sandboxSnapshotTimeoutMs` (default 60s, `OPENGENI_SANDBOX_SNAPSHOT_TIMEOUT_MS`); the orphaned capture's late settlement is swallowed so a post-timeout rejection can't crash the worker.

**F3 [HIGH] — mid-session snapshot GC'd the only good archive.** A snapshot taken mid-filesystem-write is crash-consistent but can be app-inconsistent, and keep-latest deleted the prior good one. Now a 2-deep window (`workspaceArchive` + `workspaceArchivePrev`) is retained on the lease; cold-restore hydrates current → falls back to previous → clean box; the warm path GC's only the 2-ago snapshot; drain GC's both at teardown.

**F1 [MED, pre-existing] — warming lease stamped with the 90s turn TTL.** A Modal `create()` running >90s during warmup could be reaped before `instance_id` was recorded. The cold→warming transition now stamps the warming budget (`sandboxWarmingTimeoutMs`, 600s); warm/attached refreshes keep the 90s TTL.

**F4 [MED, mitigated] — new worker + pre-migration DB.** `reapStaleLeaseHoldersGlobal` calls the 3-arg reap function; during a rolling deploy a new worker could briefly hit a DB with only the 2-arg form. Now catches Postgres `42883` and falls back to the 2-arg sweep, logged once. (The deploy pipeline already runs migrate-before-rollout; this is belt-and-suspenders.)

**F5 [LOW] — reaper hot loop.** `sandbox.box.terminated` did one `appendSessionEvents` transaction per session in a group; now a single batched insert.

## Verification
- All durability-critical suites green: worker sandbox-lease + agent-turn (54), runtime cold-restore-hydrate + runtime (133), db sandbox-leases (16); config/contracts/db typecheck clean.
- Fail-open discipline preserved throughout: a snapshot/GC/event/reap failure never fails, hangs, or slows a turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches lease TTL, snapshot persistence/GC, and cold-restore behavior on the critical sandbox path; mistakes could lose workspace data or reap boxes mid-warm, though changes are heavily fail-open and test-covered.
> 
> **Overview**
> Hardens sandbox **/workspace** durability and lease timing after the #292 follow-up review.
> 
> **Snapshots:** New `sandboxSnapshotTimeoutMs` (default 60s) caps mid-session `persistWorkspace()` and turn-end waits on in-flight captures via `waitForWarmSnapshot`; late rejections are swallowed so release is never blocked indefinitely. **`persistWarmSnapshot`** orders writes by capture-start time (`capturedAtMs`) so a slow heartbeat capture cannot overwrite a fresher turn-end snapshot.
> 
> **Restore window:** Leases keep **`workspaceArchive` + `workspaceArchivePrev`**; warm path GC only drops the two-ago archive; drain GC clears both. Cold restore tries current → previous → **fail-open clean box** (no turn failure on bad archives). Warming/cold rollback envelopes preserve both archives.
> 
> **Warming TTL:** `warmingLeaseTtlMs` / `sandboxWarmingTimeoutMs` is stamped on cold→warming CAS, warming attaches, and `recordWarmingSandboxCreated` so long Modal creates are not 90s-reaped before `instance_id` is recorded.
> 
> **Ops:** Reaper `sandbox.box.terminated` uses batched **`appendSessionEventToSandboxGroup`**. Global reaper catches Postgres `42883` and falls back to the legacy 2-arg `reap_sandbox_leases` during rolling deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1190cb39668292e0946ea871dd375d6eccbf2238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->