### PR TITLE
fix(sandbox): materialize file resources once per box, not every turn

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -37,6 +37,8 @@ import {
   sumUsageQuantity,
   heartbeatLeaseHolder,
   accrueWarmSeconds,
+  getMaterializedSandboxFileResources,
+  markSandboxFileResourcesMaterialized,
   SandboxLeaseSupersededError,
   buildConnectionTokenResolver,
   type AppendEventInput,
@@ -134,6 +136,16 @@ export function selectCodexCredentialForTurn(args: {
     return active;
   }
   return null;
+}
+
+export function filterUnmaterializedSandboxFileDownloads(
+  downloads: SandboxFileDownload[],
+  materializedFileIds: Set<string>,
+): SandboxFileDownload[] {
+  if (downloads.length === 0 || materializedFileIds.size === 0) {
+    return downloads;
+  }
+  return downloads.filter((download) => !materializedFileIds.has(download.fileId));
 }
 
 // Resume notice fed to the model when a turn re-enters after a graceful
@@ -1628,14 +1640,42 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         && activeSandboxBackend !== "selfhosted"
         && fileResourceDownloads.length > 0
       ) {
-        const runAs = sandboxRunAs(runSettings);
-        const materialized = await materializeSandboxFileDownloads(setupBoxSession as any, fileResourceDownloads, {
-          onRuntimeEvent: async (event) => {
-            await publish!([{ type: event.type, payload: event.payload }], true);
-          },
-          ...(runAs ? { runAs } : {}),
+        const boxInstanceId = resolvedSandbox.established.instanceId;
+        const alreadyMaterialized = await getMaterializedSandboxFileResources(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sandboxGroupId: session.sandboxGroupId,
+          expectedEpoch: resolvedSandbox.leaseEpoch,
+          instanceId: boxInstanceId,
         });
-        fileMaterializationFailures = materialized.failures;
+        const downloadsToMaterialize = filterUnmaterializedSandboxFileDownloads(
+          fileResourceDownloads,
+          alreadyMaterialized,
+        );
+        const runAs = sandboxRunAs(runSettings);
+        if (downloadsToMaterialize.length > 0) {
+          const materialized = await materializeSandboxFileDownloads(setupBoxSession as any, downloadsToMaterialize, {
+            onRuntimeEvent: async (event) => {
+              await publish!([{ type: event.type, payload: event.payload }], true);
+            },
+            ...(runAs ? { runAs } : {}),
+          });
+          fileMaterializationFailures = materialized.failures;
+          const failedFileIds = new Set(materialized.failures.map((failure) => failure.fileId));
+          const succeededFileIds = downloadsToMaterialize
+            .map((download) => download.fileId)
+            .filter((fileId) => !failedFileIds.has(fileId));
+          if (succeededFileIds.length > 0) {
+            await markSandboxFileResourcesMaterialized(db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sandboxGroupId: session.sandboxGroupId,
+              expectedEpoch: resolvedSandbox.leaseEpoch,
+              instanceId: boxInstanceId,
+              fileIds: succeededFileIds,
+            });
+          }
+        }
         fileDownloadsMaterializedForRun = true;
       }
       const unavailableSandboxFilesNote = sandboxFileDownloadFailureNote(fileMaterializationFailures);

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -3,7 +3,7 @@ import { CancelledFailure } from "@temporalio/activity";
 import type { Settings } from "@opengeni/config";
 import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
-import { acceptsPromptCacheKeyForTurn, classifyContextWindowOverflowError, computerToolModeForTurn, emitModelCallUsage, ensureTurnModalRegistryImage, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
+import { acceptsPromptCacheKeyForTurn, classifyContextWindowOverflowError, computerToolModeForTurn, emitModelCallUsage, ensureTurnModalRegistryImage, filterUnmaterializedSandboxFileDownloads, historyRowsToAppend, isWorkerShutdownCancellation, modelUsageSourceKey, resolveActiveSandboxBackend, shouldStartOnTurnRecording, WORKER_SHUTDOWN_RESUME_TEXT } from "../src/activities/agent-turn";
 import { settingsWithPackSandboxImage } from "../src/activities/packs";
 import { withUnavailableSandboxFilesNote } from "../src/activities/run-input";
 
@@ -544,6 +544,16 @@ describe("worker shutdown preemption", () => {
 });
 
 describe("sandbox file materialization note", () => {
+  test("filters downloads already materialized on the current box", () => {
+    const downloads = [
+      { fileId: "file-1", mountPath: "files/file-1", filename: "one.txt", url: "https://example.com/1" },
+      { fileId: "file-2", mountPath: "files/file-2", filename: "two.txt", url: "https://example.com/2" },
+    ];
+
+    expect(filterUnmaterializedSandboxFileDownloads(downloads, new Set(["file-1"]))).toEqual([downloads[1]]);
+    expect(filterUnmaterializedSandboxFileDownloads(downloads, new Set())).toBe(downloads);
+  });
+
   test("appends unavailable attachment details to model-facing text", () => {
     const text = withUnavailableSandboxFilesNote(
       "Analyze the attachment",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6492,6 +6492,90 @@ export async function persistWarmSnapshot(db: Database, input: {
         livenessGuard: "warm",
       });
       return { wrote: true, throttled: false, priorArchive };
+  });
+}
+
+export async function getMaterializedSandboxFileResources(db: Database, input: {
+  accountId: string; workspaceId: string; sandboxGroupId: string;
+  expectedEpoch: number;
+  instanceId: string;
+}): Promise<Set<string>> {
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const rows = await scopedDb.execute<{ file_ids: unknown }>(sql`
+        select coalesce(
+          jsonb_path_query_array(
+            resume_state,
+            '$.opengeniFileMaterialization[*] ? (@.instanceId == $instanceId).fileIds[*]',
+            jsonb_build_object('instanceId', to_jsonb(${input.instanceId}::text))
+          ),
+          '[]'::jsonb
+        ) as file_ids
+        from sandbox_leases
+        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
+          and liveness = 'warm' and lease_epoch = ${input.expectedEpoch}
+          and instance_id = ${input.instanceId}
+        limit 1
+      `);
+      const raw = rows[0]?.file_ids;
+      const values = Array.isArray(raw) ? raw : [];
+      return new Set(values.filter((value): value is string => typeof value === "string"));
+    });
+}
+
+export async function markSandboxFileResourcesMaterialized(db: Database, input: {
+  accountId: string; workspaceId: string; sandboxGroupId: string;
+  expectedEpoch: number;
+  instanceId: string;
+  fileIds: string[];
+}): Promise<{ wrote: boolean }> {
+  const fileIds = [...new Set(input.fileIds.filter((fileId) => fileId.length > 0))];
+  if (fileIds.length === 0) {
+    return { wrote: false };
+  }
+  return await withRlsContext(db, { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const rows = await scopedDb.execute<{ id: string }>(sql`
+        update sandbox_leases set
+          resume_state = jsonb_set(
+            case when jsonb_typeof(resume_state) = 'object' then resume_state else '{}'::jsonb end,
+            '{opengeniFileMaterialization}',
+            (
+              select jsonb_agg(entry order by entry ->> 'instanceId')
+              from (
+                select jsonb_build_object(
+                  'instanceId', ${input.instanceId}::text,
+                  'fileIds', (
+                    select jsonb_agg(distinct value order by value)
+                    from jsonb_array_elements_text(
+                      coalesce(
+                        (
+                          select existing -> 'fileIds'
+                          from jsonb_array_elements(coalesce(resume_state -> 'opengeniFileMaterialization', '[]'::jsonb)) existing
+                          where existing ->> 'instanceId' = ${input.instanceId}
+                          limit 1
+                        ),
+                        '[]'::jsonb
+                      )
+                      || ${JSON.stringify(fileIds)}::jsonb
+                    ) as merged(value)
+                  )
+                ) as entry
+                union all
+                select existing as entry
+                from jsonb_array_elements(coalesce(resume_state -> 'opengeniFileMaterialization', '[]'::jsonb)) existing
+                where existing ->> 'instanceId' <> ${input.instanceId}
+              ) entries
+            ),
+            true
+          ),
+          updated_at = now()
+        where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}
+          and liveness = 'warm' and lease_epoch = ${input.expectedEpoch}
+          and instance_id = ${input.instanceId}
+        returning id
+      `);
+      return { wrote: rows.length > 0 };
     });
 }
 

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -6,7 +6,9 @@ import {
   commitWarmingToWarm,
   confirmDrainCold,
   createDb,
+  getMaterializedSandboxFileResources,
   heartbeatLeaseHolder,
+  markSandboxFileResourcesMaterialized,
   persistDrainSnapshot,
   reapStaleLeaseHolders,
   reapStaleLeaseHoldersGlobal,
@@ -221,6 +223,45 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
       kind: "turn", holderId: "turn-1", leaseTtlMs: 45_000, expectedEpoch: s2Epoch,
     });
     expect(freshAccepted).toBe(true);
+  }, 60_000);
+
+  test("(2b) file materialization markers are keyed by warm box instance and epoch", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    await acquireLease(db, {
+      accountId, workspaceId, sandboxGroupId: groupId,
+      kind: "turn", holderId: "turn-files", backend: "modal", leaseTtlMs: 45_000,
+    });
+    const committed = await commitWarmingToWarm(db, {
+      accountId, workspaceId, sandboxGroupId: groupId,
+      expectedEpoch: 0, instanceId: "box-files-1", leaseTtlMs: 45_000,
+      resumeState: { backendId: "modal", sessionState: { providerState: { sandboxId: "box-files-1" } } },
+    });
+    const epoch = committed.lease!.leaseEpoch;
+
+    expect(await getMaterializedSandboxFileResources(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch, instanceId: "box-files-1",
+    })).toEqual(new Set());
+
+    expect(await markSandboxFileResourcesMaterialized(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch, instanceId: "box-files-1",
+      fileIds: ["file-a", "file-b", "file-a"],
+    })).toEqual({ wrote: true });
+    expect(await markSandboxFileResourcesMaterialized(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch, instanceId: "box-files-1",
+      fileIds: ["file-c"],
+    })).toEqual({ wrote: true });
+
+    expect(await getMaterializedSandboxFileResources(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch, instanceId: "box-files-1",
+    })).toEqual(new Set(["file-a", "file-b", "file-c"]));
+    expect(await markSandboxFileResourcesMaterialized(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch - 1, instanceId: "box-files-1",
+      fileIds: ["stale-epoch"],
+    })).toEqual({ wrote: false });
+    expect(await getMaterializedSandboxFileResources(db, {
+      accountId, workspaceId, sandboxGroupId: groupId, expectedEpoch: epoch, instanceId: "box-files-2",
+    })).toEqual(new Set());
   }, 60_000);
 
   test("(3) refcount->0 drives warm->draining (turn_holders=0 guard) then the reaper surfaces it", async () => {


### PR DESCRIPTION
User caught it: an attached image re-runs the file-download step on EVERY turn. session.resources merges into every turn → sandboxFileDownloadsForRun re-mints a signed URL and runs the download command each turn. On persistent /workspace the curl no-ops (`if [ ! -f ]`) but the per-turn SAS mint + sandbox exec + UI step still happen; on a fresh/self-hosted box it genuinely re-downloads the same file every turn (and was the crash path).

Fix: materialize a given file at most once per warm box. A successful download is marked in the sandbox lease `resume_state`, fenced by (workspaceId, sandboxGroupId, leaseEpoch, instanceId). Later turns on the same box skip materialization entirely — no SAS mint, no exec, no UI step. A box churn/swap (new epoch/instance) re-materializes (the file isn't there). Failed downloads are NOT marked, so they retry next turn. Builds on #305 (non-fatal + POSIX); selfhosted still excluded from platform file materialization as before.

Gates: typecheck clean; targeted worker + real-Postgres lease tests 57 pass / 0 fail. (Pre-existing unrelated full-suite failures in desktop-stream/UUID-fixture/toolspace areas are not touched by this change and are non-gating — same debt present when #309 merged green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the agent-turn sandbox setup path and mutates lease `resume_state` JSON with epoch/instance fencing; behavior is well-tested but incorrect fencing could skip needed downloads or leave stale markers.
> 
> **Overview**
> **Stops re-downloading the same session file attachments on every turn** when the warm sandbox box already has them. Previously merged session resources triggered signed-URL minting, sandbox exec, and UI steps each turn even when `/workspace` already held the file.
> 
> The worker now reads **which `fileId`s were successfully materialized** for the current lease (`workspaceId`, `sandboxGroupId`, `leaseEpoch`, `instanceId`) from `sandbox_leases.resume_state` (`opengeniFileMaterialization`), runs `materializeSandboxFileDownloads` only for the remainder, and **records successes** after download. Failed files are not marked so they retry next turn; a new box epoch/instance re-materializes because the file is not on disk. Self-hosted platform materialization stays excluded as before.
> 
> New helpers: `getMaterializedSandboxFileResources`, `markSandboxFileResourcesMaterialized` in `@opengeni/db`, plus `filterUnmaterializedSandboxFileDownloads` and unit/integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e66072b86bdd3406c83ddb9da24040af024b08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->