### PR TITLE
UI feedback batch: de-box fold chips, delete goal, resizable sidebar, spawn deep-link, file-download noise, + lineage/review fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ For a map of every app, package, and how the parts fit together, start at [`docs
 - Public clients talk only to the API.
 - Domain/access/billing helpers now live in `@opengeni/core` under `packages/core/src`; `apps/api` routes are HTTP adapters over them.
 - Browser streaming uses `GET /v1/workspaces/:workspaceId/sessions/:id/events/stream` with SSE.
+- Session goals support `GET`, `PATCH(status paused|active)`, and idempotent `DELETE` clear on `/v1/workspaces/:workspaceId/sessions/:id/goal`; clearing removes the goal row and emits `goal.cleared`.
 - Core NATS is the realtime bus between producers and API instances.
 - Postgres is the durable event store and replay source.
 - Temporal is orchestration only. Token streams do not go through workflow history.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -33,6 +33,7 @@ import {
 import { resolveContextCompactionMode, streamTokenDegraded } from "@opengeni/config";
 import {
   cancelQueuedSessionTurn,
+  clearSessionGoal,
   clearSessionContext,
   closePtySession,
   getOpenPtySession,
@@ -234,6 +235,22 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       await workflowClient.wakeSessionWorkflow({ accountId: grant.accountId, workspaceId, sessionId, workflowId: workflowIdForSession(sessionId) });
     }
     return c.json(goal);
+  });
+
+  app.delete("/v1/workspaces/:workspaceId/sessions/:sessionId/goal", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
+    const { event } = await clearSessionGoal(db, workspaceId, sessionId);
+    if (event) {
+      try {
+        await bus.publish(workspaceId, sessionId, [event]);
+      } catch (error) {
+        console.warn(`[api] live publish failed for cleared goal ${workspaceId}/${sessionId}; event is durable and reconciles on replay`, error);
+      }
+    }
+    return c.body(null, 204);
   });
 
   // Operator context controls (slash-command palette: /clear, /compact). These

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -144,6 +144,16 @@ describe("rail session grouping", () => {
     expect(forest.grouped.flatMap((bucket) => bucket.sessions).map((node) => node.session.id)).toEqual(["orphan"]);
   });
 
+  test("buildRailForest keeps sessions in a parent cycle visible at the root", () => {
+    const forest = buildRailForest([
+      railSession({ id: "a", parentSessionId: "b", updatedAt: "2026-06-19T10:00:00.000Z" }),
+      railSession({ id: "b", parentSessionId: "a", updatedAt: "2026-06-19T11:00:00.000Z" }),
+    ], NOW);
+    const roots = forest.grouped.flatMap((bucket) => bucket.sessions);
+    expect(roots.map((node) => node.session.id)).toEqual(["b", "a"]);
+    expect(roots.flatMap((node) => node.children)).toEqual([]);
+  });
+
   test("buildRailForest pins a manager whose only activity is a live child", () => {
     const forest = buildRailForest([
       railSession({ id: "manager", status: "idle", updatedAt: "2026-06-01T10:00:00.000Z" }),

--- a/apps/web/src/components/rail/rail-context.tsx
+++ b/apps/web/src/components/rail/rail-context.tsx
@@ -7,8 +7,20 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import { useAppContext } from "@/context";
 
 const RAIL_COLLAPSED_KEY = "opengeni.rail.collapsed";
+const RAIL_WIDTH_KEY = "opengeni.rail.width";
 /** Below this viewport width the rail is an overlay drawer, not a fixed column. */
 export const RAIL_DRAWER_BREAKPOINT = 1024;
+/** Resize bounds for the expanded desktop rail (px). */
+export const RAIL_MIN_WIDTH = 220;
+export const RAIL_MAX_WIDTH = 480;
+export const RAIL_DEFAULT_WIDTH = 260;
+
+function clampRailWidth(width: number): number {
+  if (!Number.isFinite(width)) {
+    return RAIL_DEFAULT_WIDTH;
+  }
+  return Math.min(RAIL_MAX_WIDTH, Math.max(RAIL_MIN_WIDTH, Math.round(width)));
+}
 
 export type RailContextValue = {
   workspaceId: string;
@@ -16,6 +28,10 @@ export type RailContextValue = {
   collapsed: boolean;
   setCollapsed: (collapsed: boolean) => void;
   toggleCollapsed: () => void;
+  /** User-chosen expanded-rail width (px), clamped to [RAIL_MIN, RAIL_MAX]. */
+  width: number;
+  /** Set the expanded-rail width; persisted to localStorage (clamped). */
+  setWidth: (width: number) => void;
   /** Whether the viewport is narrow enough to use the overlay drawer. */
   isMobile: boolean;
   /** Mobile overlay-drawer open state. */
@@ -52,10 +68,23 @@ function readStoredCollapsed(): boolean {
   }
 }
 
+function readStoredWidth(): number {
+  if (typeof window === "undefined") {
+    return RAIL_DEFAULT_WIDTH;
+  }
+  try {
+    const raw = window.localStorage.getItem(RAIL_WIDTH_KEY);
+    return raw ? clampRailWidth(Number.parseInt(raw, 10)) : RAIL_DEFAULT_WIDTH;
+  } catch {
+    return RAIL_DEFAULT_WIDTH;
+  }
+}
+
 export function RailProvider({ workspaceId, children }: { workspaceId: string; children: ReactNode }) {
   const navigate = useNavigate();
   const appContext = useAppContext();
   const [collapsed, setCollapsedState] = useState<boolean>(() => readStoredCollapsed());
+  const [width, setWidthState] = useState<number>(() => readStoredWidth());
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isMobile, setIsMobile] = useState<boolean>(() =>
     typeof window !== "undefined" ? window.innerWidth < RAIL_DRAWER_BREAKPOINT : false,
@@ -82,6 +111,16 @@ export function RailProvider({ workspaceId, children }: { workspaceId: string; c
   }, []);
 
   const toggleCollapsed = useCallback(() => setCollapsed(!collapsed), [collapsed, setCollapsed]);
+
+  const setWidth = useCallback((next: number) => {
+    const clamped = clampRailWidth(next);
+    setWidthState(clamped);
+    try {
+      window.localStorage.setItem(RAIL_WIDTH_KEY, String(clamped));
+    } catch {
+      // localStorage may be unavailable (private mode); keep the in-memory value.
+    }
+  }, []);
 
   const openWorkspace = useCallback((nextWorkspaceId: string) => {
     appContext.resetSessionView();
@@ -117,6 +156,8 @@ export function RailProvider({ workspaceId, children }: { workspaceId: string; c
     collapsed: isMobile ? false : collapsed,
     setCollapsed,
     toggleCollapsed,
+    width,
+    setWidth,
     isMobile,
     drawerOpen,
     setDrawerOpen,
@@ -124,7 +165,7 @@ export function RailProvider({ workspaceId, children }: { workspaceId: string; c
     openOrg,
     openSession,
     startNewSession,
-  }), [workspaceId, collapsed, isMobile, drawerOpen, setCollapsed, toggleCollapsed, openWorkspace, openOrg, openSession, startNewSession]);
+  }), [workspaceId, collapsed, width, setWidth, isMobile, drawerOpen, setCollapsed, toggleCollapsed, openWorkspace, openOrg, openSession, startNewSession]);
 
   return <RailContext.Provider value={value}>{children}</RailContext.Provider>;
 }

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -8,11 +8,11 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import { LockIcon, MenuIcon, PanelRightIcon, PencilIcon } from "lucide-react";
 
 import { BrandMark } from "@/components/brand-mark";
-import { useEffect, useRef, type ReactNode, type RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from "react";
 
 import { ConnectionPill } from "@/components/common";
 import { RailFooter } from "@/components/rail/rail-footer";
-import { useRail } from "@/components/rail/rail-context";
+import { RAIL_DEFAULT_WIDTH, RAIL_MAX_WIDTH, RAIL_MIN_WIDTH, useRail } from "@/components/rail/rail-context";
 import { CollapsedSessionsButton, SessionList } from "@/components/rail/session-list";
 import { SwitcherBlock } from "@/components/rail/switcher-block";
 import { SessionSandboxSwitcher } from "@/components/session/sandbox-switcher";
@@ -64,6 +64,35 @@ function RailBody() {
   );
 }
 
+/**
+ * The drag handle on the expanded rail's right edge. A quiet, wide-ish hit area
+ * straddling the border: at rest it's invisible (the border is the only line);
+ * on hover it thickens into a stronger line, and while dragging it wears the
+ * brand tint. Double-click snaps back to the default width. Keyboard users get
+ * the collapse toggle elsewhere; this is a pointer affordance (hidden from the
+ * a11y tree beyond its separator role + label).
+ */
+function RailResizeHandle({ onStart, active }: { onStart: (event: ReactPointerEvent) => void; active: boolean }) {
+  const rail = useRail();
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      onPointerDown={onStart}
+      onDoubleClick={() => rail.setWidth(RAIL_DEFAULT_WIDTH)}
+      className="group absolute inset-y-0 -right-1 z-20 w-2 cursor-col-resize touch-none select-none"
+    >
+      <span
+        className={cn(
+          "absolute inset-y-0 right-1 w-px transition-[width,background-color] duration-150",
+          active ? "w-0.5 bg-brand/70" : "bg-transparent group-hover:w-0.5 group-hover:bg-border-strong",
+        )}
+      />
+    </div>
+  );
+}
+
 export function RailShell({ children }: { children: ReactNode }) {
   const rail = useRail();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -71,6 +100,36 @@ export function RailShell({ children }: { children: ReactNode }) {
   // controlled Sheet with no in-tree trigger, so radix can't restore focus on
   // its own — we point it back at the hamburger that opened it.
   const hamburgerRef = useRef<HTMLButtonElement>(null);
+
+  // Live width while the reader drags the resize handle. Held locally (not in
+  // context) so we don't write localStorage on every pointer move — the chosen
+  // width is committed once on pointer-up. `null` means "not resizing".
+  const [liveWidth, setLiveWidth] = useState<number | null>(null);
+  const resizing = liveWidth !== null;
+  const startResize = useCallback((event: ReactPointerEvent) => {
+    // Ignore anything but a primary-button / touch drag.
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = rail.width;
+    const clamp = (w: number) => Math.min(RAIL_MAX_WIDTH, Math.max(RAIL_MIN_WIDTH, Math.round(w)));
+    setLiveWidth(startWidth);
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+    const onMove = (moveEvent: PointerEvent) => setLiveWidth(clamp(startWidth + (moveEvent.clientX - startX)));
+    const onUp = (upEvent: PointerEvent) => {
+      rail.setWidth(clamp(startWidth + (upEvent.clientX - startX)));
+      setLiveWidth(null);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }, [rail]);
 
   // Close the mobile drawer on route change.
   useEffect(() => {
@@ -101,17 +160,24 @@ export function RailShell({ children }: { children: ReactNode }) {
   return (
     <TooltipProvider delayDuration={300}>
       <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden">
-        {/* Fixed desktop rail. */}
+        {/* Fixed desktop rail — user-resizable when expanded. */}
         {!rail.isMobile ? (
           <nav
             aria-label="Primary"
             data-collapsed={rail.collapsed}
+            style={rail.collapsed ? undefined : { width: resizing ? liveWidth! : rail.width }}
             className={cn(
-              "motion-safe:transition-[width] motion-safe:duration-150 shrink-0 border-r border-border",
-              rail.collapsed ? "w-[56px]" : "w-[260px]",
+              "relative shrink-0 border-r border-border",
+              // Animate the collapse/expand toggle, but never while dragging — a
+              // transition there would lag the handle behind the pointer.
+              !resizing && "motion-safe:transition-[width] motion-safe:duration-150",
+              rail.collapsed && "w-[56px]",
             )}
           >
             <RailBody />
+            {/* The drag handle only exists on the expanded desktop rail; the
+                collapsed strip and the mobile drawer are fixed-width. */}
+            {!rail.collapsed ? <RailResizeHandle onStart={startResize} active={resizing} /> : null}
           </nav>
         ) : null}
 

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -106,6 +106,11 @@ export function RailShell({ children }: { children: ReactNode }) {
   // width is committed once on pointer-up. `null` means "not resizing".
   const [liveWidth, setLiveWidth] = useState<number | null>(null);
   const resizing = liveWidth !== null;
+  // Teardown for an in-progress drag (remove window listeners + reset body
+  // styles). Held in a ref so an unmount / route change MID-DRAG can run it —
+  // otherwise the listeners and the col-resize cursor / no-select body styles
+  // linger until an unrelated pointer release elsewhere.
+  const endResizeRef = useRef<(() => void) | null>(null);
   const startResize = useCallback((event: ReactPointerEvent) => {
     // Ignore anything but a primary-button / touch drag.
     if (event.button !== 0) {
@@ -119,17 +124,25 @@ export function RailShell({ children }: { children: ReactNode }) {
     document.body.style.userSelect = "none";
     document.body.style.cursor = "col-resize";
     const onMove = (moveEvent: PointerEvent) => setLiveWidth(clamp(startWidth + (moveEvent.clientX - startX)));
+    const teardown = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      endResizeRef.current = null;
+    };
     const onUp = (upEvent: PointerEvent) => {
       rail.setWidth(clamp(startWidth + (upEvent.clientX - startX)));
       setLiveWidth(null);
-      document.body.style.userSelect = "";
-      document.body.style.cursor = "";
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
+      teardown();
     };
+    endResizeRef.current = teardown;
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
   }, [rail]);
+  // Unmount / route-change mid-drag: run the drag teardown so listeners and
+  // body styles never leak.
+  useEffect(() => () => endResizeRef.current?.(), []);
 
   // Close the mobile drawer on route change.
   useEffect(() => {

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -342,7 +342,9 @@ function SessionRow(props: {
   const rename = useInlineRename(props.session, props.onRename);
   const hasChildren = props.childCount > 0;
   // Indent nested rows; the leading affordance is a chevron for parents, else a
-  // spacer that keeps every dot in the same column as its parent's chevron.
+  // spacer of the same width — reserved at every depth (root included) so every
+  // status dot sits in one column and the left edge is even whether a row is a
+  // leaf or a parent.
   const indentStyle = props.depth > 0 ? { paddingLeft: props.depth * 14 } : undefined;
 
   const rowClassName = cn(
@@ -369,9 +371,9 @@ function SessionRow(props: {
         >
           <ChevronRightIcon className={cn("size-3 transition-transform", props.expanded && "rotate-90")} />
         </button>
-      ) : props.depth > 0 ? (
+      ) : (
         <span className="size-4" />
-      ) : null}
+      )}
     </span>
   );
 

--- a/apps/web/src/components/session/goal-surface.tsx
+++ b/apps/web/src/components/session/goal-surface.tsx
@@ -20,6 +20,7 @@ import {
   Loader2Icon,
   PauseIcon,
   PlayIcon,
+  Trash2Icon,
   TriangleAlertIcon,
   ZapIcon,
 } from "lucide-react";
@@ -49,21 +50,33 @@ type GoalPillMeta = {
 const GOAL_PILL_META: Record<GoalPillState, GoalPillMeta> = {
   pursuing: { label: "Pursuing goal", icon: ZapIcon, tint: "text-brand", ring: "border-brand/40" },
   paused: { label: "Goal paused", icon: PauseIcon, tint: "text-status-waiting", ring: "border-status-waiting/40" },
-  // "Needs attention" wears the warning/amber hue, not paused's purple — the two
-  // states were near-indistinguishable when both leaned on status-waiting.
-  attention: { label: "Needs attention", icon: TriangleAlertIcon, tint: "text-status-running", ring: "border-status-running/50" },
+  // "Needs attention" is the requires_action state — the SAME state the subagent
+  // rows paint with the doctrine "waiting" dot (status-waiting/purple). It wears
+  // that one hue too, so a session that needs you reads as one colour across the
+  // pill and the lineage; its triangle glyph + label set it apart from paused.
+  attention: { label: "Needs attention", icon: TriangleAlertIcon, tint: "text-status-waiting", ring: "border-status-waiting/50" },
   completed: { label: "Goal completed", icon: CheckCircle2Icon, tint: "text-status-idle", ring: "border-status-idle/40" },
 };
+
+/** A session lifecycle state where the goal is NOT actively being pursued — the
+    agent is waiting on input, or the session has failed or been cancelled. In
+    all three the goal clock must freeze and the pill drops "Pursuing" for an
+    attention cue rather than a live-ticking one under a failure banner. */
+function isSessionStalled(status: SessionStatus): boolean {
+  return status === "requires_action" || status === "failed" || status === "cancelled";
+}
 
 function goalPillState(goalStatus: "active" | "paused" | "completed", sessionStatus: SessionStatus): GoalPillState {
   if (goalStatus === "completed") {
     return "completed";
   }
-  if (goalStatus === "active" && sessionStatus === "requires_action") {
-    return "attention";
-  }
   if (goalStatus === "paused") {
     return "paused";
+  }
+  // An active goal on a stalled session (needs input / failed / cancelled) is
+  // not "pursuing" — surface it as attention, never a live-ticking pursuit.
+  if (goalStatus === "active" && isSessionStalled(sessionStatus)) {
+    return "attention";
   }
   return "pursuing";
 }
@@ -148,15 +161,20 @@ export function GoalSurface({
   const children = lineage.lineage?.children ?? [];
   const record = goal.goal;
   // All hooks run unconditionally (the null-goal early return is below): the
-  // elapsed clock ticks only while the goal is actively being pursued.
-  const live = record?.status === "active" && session.status !== "requires_action";
+  // elapsed clock ticks only while the goal is actively being pursued AND the
+  // session is genuinely moving. A session that needs input, has failed, or was
+  // cancelled must NOT keep a clock ticking under its banner.
+  const live = record?.status === "active" && !isSessionStalled(session.status);
   const elapsed = useLiveElapsed(
     record?.createdAt,
     Boolean(live),
-    // Freeze the clock for BOTH terminal-ish states: completed shows its final
-    // duration, paused shows time spent up to the pause (updatedAt is bumped by
-    // the pause write) — never a clock that kept counting through the pause.
-    record?.status === "completed" || record?.status === "paused" ? record.updatedAt : null,
+    // Freeze the clock whenever it stops ticking: a completed goal shows its
+    // final duration; a paused one the time up to the pause; a stalled session
+    // (needs input / failed / cancelled) freezes at the goal's last update —
+    // never a clock that kept counting past the moment work stopped.
+    record?.status === "completed" || record?.status === "paused" || isSessionStalled(session.status)
+      ? record?.updatedAt
+      : null,
   );
 
   // Hidden entirely when the session has no goal — the pill is a goal surface,
@@ -197,7 +215,10 @@ export function GoalSurface({
               </>
             ) : null}
 
-            {canToggle ? (
+            {/* The inline pause/resume toggle lives on the COLLAPSED pill only —
+                once the panel is open, its labeled Pause/Resume button owns the
+                action, so showing both would be a duplicate control. */}
+            {canToggle && !open ? (
               <button
                 type="button"
                 aria-label={record.status === "paused" ? "Resume goal" : "Pause goal"}
@@ -303,21 +324,23 @@ function GoalDetail({ goal, state }: { goal: UseGoalResult; state: GoalPillState
         <MetaChip>v{record.version}</MetaChip>
       </div>
 
-      {record.status !== "completed" ? (
-        <div className="mt-3 flex justify-end">
-          {record.status === "active" ? (
-            <Button type="button" variant="ghost" size="xs" disabled={goal.updating} onClick={() => void goal.pause("Paused from the console")}>
-              {goal.updating ? <Loader2Icon className="size-3 animate-spin" /> : <PauseIcon className="size-3" />}
-              Pause goal
-            </Button>
-          ) : (
-            <Button type="button" size="xs" disabled={goal.updating} onClick={() => void goal.resume()}>
-              {goal.updating ? <Loader2Icon className="size-3 animate-spin" /> : <PlayIcon className="size-3" />}
-              Resume goal
-            </Button>
-          )}
-        </div>
-      ) : null}
+      {/* Delete lives on the left (a quiet destructive action), pause/resume on
+          the right. Delete is available in every state, including a completed
+          goal the user wants to clear off the session. */}
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <DeleteGoalButton goal={goal} />
+        {record.status === "active" ? (
+          <Button type="button" variant="ghost" size="xs" disabled={goal.updating} onClick={() => void goal.pause("Paused from the console")}>
+            {goal.updating ? <Loader2Icon className="size-3 animate-spin" /> : <PauseIcon className="size-3" />}
+            Pause goal
+          </Button>
+        ) : record.status === "paused" ? (
+          <Button type="button" size="xs" disabled={goal.updating} onClick={() => void goal.resume()}>
+            {goal.updating ? <Loader2Icon className="size-3 animate-spin" /> : <PlayIcon className="size-3" />}
+            Resume goal
+          </Button>
+        ) : null}
+      </div>
 
       {goal.mutationError ? (
         <div className="mt-2">
@@ -325,6 +348,45 @@ function GoalDetail({ goal, state }: { goal: UseGoalResult; state: GoalPillState
         </div>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * A quiet destructive "Delete goal" action with a lightweight two-step confirm
+ * (it's destructive but low-stakes — the loop stops and the pill hides, no data
+ * beyond the goal record is lost, so a full modal would be overkill). On confirm
+ * it calls `deleteGoal`; the goal becomes null, which unmounts the whole surface.
+ */
+function DeleteGoalButton({ goal }: { goal: UseGoalResult }) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (confirming) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-fg-muted">
+        <span className="pl-1">Delete goal?</span>
+        <Button type="button" variant="ghost" size="xs" disabled={goal.updating} onClick={() => setConfirming(false)}>
+          Cancel
+        </Button>
+        <Button type="button" variant="destructive" size="xs" disabled={goal.updating} onClick={() => void goal.deleteGoal()}>
+          {goal.updating ? <Loader2Icon className="size-3 animate-spin" /> : null}
+          Delete
+        </Button>
+      </span>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      className="text-fg-subtle hover:text-destructive"
+      disabled={goal.updating}
+      onClick={() => setConfirming(true)}
+    >
+      <Trash2Icon className="size-3" />
+      Delete goal
+    </Button>
   );
 }
 

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -161,6 +161,25 @@ export function buildRailForest(sessions: Session[], now: Date = new Date()): Se
   };
 
   const rootNodes = roots.map((session) => build(session, new Set()));
+  const reachable = new Set<string>();
+  const markReachable = (node: SessionTreeNode): void => {
+    if (reachable.has(node.session.id)) {
+      return;
+    }
+    reachable.add(node.session.id);
+    for (const child of node.children) {
+      markReachable(child);
+    }
+  };
+  for (const node of rootNodes) {
+    markReachable(node);
+  }
+  for (const session of sessions) {
+    if (!reachable.has(session.id)) {
+      rootNodes.push({ session, children: [], hasActiveDescendant: false });
+      reachable.add(session.id);
+    }
+  }
   const running = rootNodes
     .filter((node) => nodeIsActive(node))
     .sort((a, b) => sessionActivityTime(b.session) - sessionActivityTime(a.session));

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -29,7 +29,8 @@ A goal is `active`, `paused`, or `completed`.
   replaced.
 
 Every transition lands on the session timeline as `goal.set`, `goal.updated`,
-`goal.completed`, `goal.paused`, `goal.resumed`, or `goal.continuation` events.
+`goal.completed`, `goal.paused`, `goal.resumed`, `goal.cleared`, or
+`goal.continuation` events.
 
 ## The continuation loop
 
@@ -97,6 +98,9 @@ previous-continuation pointers are cleared together.
   and wakes the session workflow — resume works even on a fully idle session
   because `signalWithStart` restarts a completed workflow. Invalid transitions
   (e.g. resuming a completed goal) return 409.
+- `DELETE /v1/workspaces/:id/sessions/:sessionId/goal` clears the session's
+  active goal (`sessions:control`). It deletes the goal row, emits
+  `goal.cleared` when a goal existed, and is idempotent when no goal exists.
 
 ## Scheduled tasks
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2535,6 +2535,7 @@ export const SessionEventType = z.enum([
   "goal.completed",
   "goal.paused",
   "goal.resumed",
+  "goal.cleared",
   "goal.continuation",
   // Channel-B desktop pixel-plane signals (07-channel-b §1.2). The pixel socket
   // carries opaque RFB and cannot carry a control message the client can act on,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2497,6 +2497,7 @@ export const LineageNode: z.ZodType<LineageNode> = z.lazy(() => z.object({
 export const SessionLineageResponse = z.object({
   ancestors: z.array(Session),
   children: z.array(LineageNode),
+  truncated: z.boolean().default(false),
 });
 export type SessionLineageResponse = z.infer<typeof SessionLineageResponse>;
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4358,6 +4358,7 @@ export async function listSessions(db: Database, workspaceId: string, limitOrOpt
 export type SessionLineage = {
   ancestors: Session[];
   children: LineageNode[];
+  truncated: boolean;
 };
 
 type LineageIdRow = {
@@ -4371,9 +4372,10 @@ type LineageIdRow = {
  * Read the full lineage slice around a session. Every recursive step carries
  * workspace_id as a hard predicate; a foreign parent/child id is invisible even
  * before RLS is considered. Ancestors are capped at 10 and returned root-first.
- * Descendants are capped at depth 5 and returned as a nested tree.
+ * Descendants are capped at depth 5 and 200 total rows, returned as a nested tree.
  */
 export async function getSessionLineage(db: Database, workspaceId: string, sessionId: string): Promise<SessionLineage | null> {
+  const descendantLimit = 200;
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     // Existence check on the ALREADY-SCOPED connection — never a nested
     // withWorkspaceRls (getSession opens its own scoped transaction, which
@@ -4425,12 +4427,15 @@ export async function getSessionLineage(db: Database, workspaceId: string, sessi
       select id, parent_session_id as "parentSessionId", depth, path
       from descendants
       order by path
+      limit ${descendantLimit + 1}
     `) as LineageIdRow[];
+    const truncated = childRows.length > descendantLimit;
+    const descendantRows = truncated ? childRows.slice(0, descendantLimit) : childRows;
 
-    const lineageRows = [...ancestorRows, ...childRows];
+    const lineageRows = [...ancestorRows, ...descendantRows];
     const ids = [...new Set(lineageRows.map((row) => row.id))];
     if (ids.length === 0) {
-      return { ancestors: [], children: [] };
+      return { ancestors: [], children: [], truncated: false };
     }
     const rows = await scopedDb.select().from(schema.sessions)
       .where(and(eq(schema.sessions.workspaceId, workspaceId), inArray(schema.sessions.id, ids)));
@@ -4442,14 +4447,14 @@ export async function getSessionLineage(db: Database, workspaceId: string, sessi
       .filter((session): session is Session => Boolean(session));
 
     const nodesById = new Map<string, LineageNode>();
-    for (const row of childRows) {
+    for (const row of descendantRows) {
       const session = sessionsById.get(row.id);
       if (session) {
         nodesById.set(row.id, { session, children: [] });
       }
     }
     const children: LineageNode[] = [];
-    for (const row of childRows) {
+    for (const row of descendantRows) {
       const node = nodesById.get(row.id);
       if (!node) continue;
       if (row.parentSessionId === sessionId) {
@@ -4458,7 +4463,7 @@ export async function getSessionLineage(db: Database, workspaceId: string, sessi
         nodesById.get(row.parentSessionId ?? "")?.children.push(node);
       }
     }
-    return { ancestors, children };
+    return { ancestors, children, truncated };
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8028,6 +8028,45 @@ export async function getSessionGoal(db: Database, workspaceId: string, sessionI
   });
 }
 
+export async function clearSessionGoal(db: Database, workspaceId: string, sessionId: string): Promise<{ cleared: boolean; goal: SessionGoal | null; event: SessionEvent | null }> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => await scopedDb.transaction(async (tx) => {
+    const [existing] = await tx.select().from(schema.sessionGoals)
+      .where(and(eq(schema.sessionGoals.workspaceId, workspaceId), eq(schema.sessionGoals.sessionId, sessionId)))
+      .for("update")
+      .limit(1);
+    if (!existing) {
+      return { cleared: false, goal: null, event: null };
+    }
+    await tx.delete(schema.sessionGoals).where(eq(schema.sessionGoals.id, existing.id));
+    const [session] = await tx.select().from(schema.sessions)
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)))
+      .for("update")
+      .limit(1);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const sequence = session.lastSequence + 1;
+    const [event] = await tx.insert(schema.sessionEvents).values({
+      accountId: session.accountId,
+      workspaceId: session.workspaceId,
+      sessionId,
+      sequence,
+      type: "goal.cleared",
+      payload: sanitizeEventPayload({
+        goalId: existing.id,
+        text: existing.text,
+        version: existing.version,
+      }),
+    }).returning();
+    await tx.update(schema.sessions).set({ lastSequence: sequence, updatedAt: new Date() })
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)));
+    if (!event) {
+      throw new Error("Failed to append goal.cleared event");
+    }
+    return { cleared: true, goal: mapSessionGoal(existing), event: mapEvent(event) };
+  }));
+}
+
 /**
  * goal_set semantics: insert, or replace the existing goal in place. A replace
  * re-activates the goal (even when paused or completed), bumps the version,

--- a/packages/db/test/reactive-rotation-boundedness.test.ts
+++ b/packages/db/test/reactive-rotation-boundedness.test.ts
@@ -2,9 +2,12 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
 import {
+  clearSessionGoal,
   countConsecutiveReactiveRotations,
   createDb,
   evaluateGoalContinuation,
+  getSessionGoal,
+  listSessionEvents,
   type Database,
   type DbClient,
 } from "../src/index";
@@ -147,6 +150,28 @@ describe("Finding 1b — countConsecutiveReactiveRotations", () => {
     await appendEvent(ws, sessionId, "turn.failed", { rotated: true });
     await appendEvent(ws, sessionId, "turn.completed", { output: "done" });
     expect(await countConsecutiveReactiveRotations(db, ws.workspaceId, sessionId)).toBe(0);
+  });
+});
+
+describe("session goal clearing", () => {
+  test("deletes the goal row, appends goal.cleared once, and is idempotent", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const sessionId = await seedSession(ws);
+    await admin`
+      insert into session_goals (account_id, workspace_id, session_id, status, text)
+      values (${ws.accountId}, ${ws.workspaceId}, ${sessionId}, 'active', 'ship it')`;
+
+    const first = await clearSessionGoal(db, ws.workspaceId, sessionId);
+    expect(first.cleared).toBe(true);
+    expect(first.goal?.text).toBe("ship it");
+    expect(first.event?.type).toBe("goal.cleared");
+    expect(await getSessionGoal(db, ws.workspaceId, sessionId)).toBeNull();
+
+    const second = await clearSessionGoal(db, ws.workspaceId, sessionId);
+    expect(second).toEqual({ cleared: false, goal: null, event: null });
+    const events = await listSessionEvents(db, ws.workspaceId, sessionId);
+    expect(events.map((event) => event.type)).toEqual(["goal.cleared"]);
   });
 });
 

--- a/packages/db/test/session-lineage.test.ts
+++ b/packages/db/test/session-lineage.test.ts
@@ -24,6 +24,14 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
   return { accountId: a!.id, workspaceId: w!.id };
 }
 
+type TestLineageNode = {
+  children: TestLineageNode[];
+};
+
+function countLineageNodes(nodes: TestLineageNode[]): number {
+  return nodes.reduce((total, node) => total + 1 + countLineageNodes(node.children), 0);
+}
+
 beforeAll(async () => {
   shared = await acquireSharedTestDatabase("session-lineage");
   if (!shared) {
@@ -98,11 +106,37 @@ describe("session lineage", () => {
     const lineage = await getSessionLineage(db, workspaceId, child.id);
     expect(lineage?.ancestors.map((s) => s.id)).toEqual([root.id]);
     expect(lineage?.children.map((n) => n.session.id)).toEqual([grandchild.id]);
+    expect(lineage?.truncated).toBe(false);
 
     const rootLineage = await getSessionLineage(db, workspaceId, root.id);
     expect(rootLineage?.ancestors).toEqual([]);
     expect(rootLineage?.children.map((n) => n.session.id).sort()).toEqual([child.id, sibling.id].sort());
     const childNode = rootLineage?.children.find((n) => n.session.id === child.id);
     expect(childNode?.children.map((n) => n.session.id)).toEqual([grandchild.id]);
+    expect(rootLineage?.truncated).toBe(false);
   }, 60_000);
+
+  test("getSessionLineage caps descendants and reports truncation", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const root = await createSession(db, {
+      accountId, workspaceId, initialMessage: "root", resources: [], metadata: {}, model: "gpt", sandboxBackend: "none",
+    });
+    for (let i = 0; i < 201; i += 1) {
+      await createSession(db, {
+        accountId,
+        workspaceId,
+        initialMessage: `child ${i}`,
+        resources: [],
+        metadata: {},
+        model: "gpt",
+        sandboxBackend: "none",
+        parentSessionId: root.id,
+      });
+    }
+
+    const lineage = await getSessionLineage(db, workspaceId, root.id);
+    expect(lineage?.truncated).toBe(true);
+    expect(countLineageNodes(lineage?.children ?? [])).toBeLessThanOrEqual(200);
+  }, 120_000);
 });

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -313,6 +313,14 @@ export class MockOpenGeniClient implements SessionClientLike {
     return { ...goal };
   }
 
+  async deleteGoal(_workspaceId: string, sessionId: string): Promise<void> {
+    const goal = this.goals.get(sessionId);
+    this.goals.delete(sessionId);
+    if (goal) {
+      this.bus(sessionId).append("goal.cleared", { goalId: goal.id });
+    }
+  }
+
   async clearSessionContext(_workspaceId: string, sessionId: string): Promise<void> {
     this.bus(sessionId).append("session.context.cleared", { clearedBy: "api" });
   }

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -150,7 +150,7 @@ export class MockOpenGeniClient implements SessionClientLike {
     const children = sessionId === MANAGER_SESSION_ID
       ? [{ session: this.fabricateSession(WORKER_SESSION_ID, "running", "Worker session"), children: [] }]
       : [];
-    return { ancestors: [], children };
+    return { ancestors: [], children, truncated: false };
   }
 
   async updateSession(_workspaceId: string, sessionId: string, request: UpdateSessionRequest): Promise<Session> {

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -28,6 +28,7 @@ export type SessionClientLike = Pick<
   // Goal
   | "getGoal"
   | "updateGoal"
+  | "deleteGoal"
   // Operator context controls (/clear, /compact)
   | "clearSessionContext"
   | "compactSessionContext"

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -12,6 +12,7 @@ import {
   PlayIcon,
   RefreshCwIcon,
   TargetIcon,
+  Trash2Icon,
   TriangleAlertIcon,
   XCircleIcon,
 } from "lucide-react";
@@ -781,6 +782,7 @@ const GOAL_META: Record<GoalItem["action"], GoalMeta> = {
   completed: { label: "Goal completed", pill: "border-og-status-idle/30 bg-og-status-idle/10 text-og-status-idle", icon: CheckIcon },
   paused: { label: "Goal paused", pill: "border-og-status-waiting/35 bg-og-status-waiting/10 text-og-status-waiting", icon: PauseIcon },
   resumed: { label: "Goal resumed", pill: NEUTRAL_PILL, icon: PlayIcon },
+  cleared: { label: "Goal cleared", pill: NEUTRAL_PILL, icon: Trash2Icon },
   continuation: { label: "Continuing toward the goal", pill: NEUTRAL_PILL, icon: ArrowRightIcon },
 };
 

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -153,8 +153,20 @@ export function useGoal(sessionId: string | null | undefined, options: UseGoalOp
     if (!sessionId) {
       return;
     }
-    await mutation.run(() => client.deleteGoal(workspaceId, sessionId));
-    setGoal(null);
+    // deleteGoal resolves void, so distinguish success (a truthy sentinel) from
+    // mutation.run's null-on-failure. Only a SUCCESSFUL delete hides the goal:
+    // a failed one leaves the pill up so its mutationError renders. And invalidate
+    // any in-flight load first so a slower getGoal started before the delete can't
+    // commit and repopulate the just-cleared goal.
+    const ok = await mutation.run(async () => {
+      await client.deleteGoal(workspaceId, sessionId);
+      return true as const;
+    });
+    if (ok) {
+      generation.current += 1;
+      setGoal(null);
+      setError(null);
+    }
   }, [client, workspaceId, sessionId, mutation.run]);
 
   return {

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -27,7 +27,11 @@ export type UseGoalResult = {
   pause: (rationale?: string) => Promise<SessionGoal | null>;
   /** Resume a paused goal: resets counters and re-arms continuations. */
   resume: () => Promise<SessionGoal | null>;
-  /** True while a pause/resume is in flight. */
+  /** Clear the session goal; goal-less sessions remain a successful no-op. */
+  clearGoal: () => Promise<void>;
+  /** Alias for `clearGoal`. */
+  deleteGoal: () => Promise<void>;
+  /** True while a pause/resume/clear is in flight. */
   updating: boolean;
   mutationError: Error | null;
   clearMutationError: () => void;
@@ -145,6 +149,14 @@ export function useGoal(sessionId: string | null | undefined, options: UseGoalOp
     return result;
   }, [client, workspaceId, sessionId, mutation.run]);
 
+  const clearGoal = useCallback(async (): Promise<void> => {
+    if (!sessionId) {
+      return;
+    }
+    await mutation.run(() => client.deleteGoal(workspaceId, sessionId));
+    setGoal(null);
+  }, [client, workspaceId, sessionId, mutation.run]);
+
   return {
     goal,
     isActive: goal?.status === "active",
@@ -155,6 +167,8 @@ export function useGoal(sessionId: string | null | undefined, options: UseGoalOp
     refresh: load,
     pause,
     resume,
+    clearGoal,
+    deleteGoal: clearGoal,
     updating: mutation.mutating,
     mutationError: mutation.mutationError,
     clearMutationError: mutation.clearMutationError,

--- a/packages/react/src/hooks/use-session-lineage.ts
+++ b/packages/react/src/hooks/use-session-lineage.ts
@@ -1,5 +1,5 @@
 import type { SessionEvent, SessionLineageResponse } from "@opengeni/sdk";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { useDebouncedCallback, usePolledValue, useSessionEventTrigger } from "./internal";
 
@@ -22,15 +22,24 @@ export function isLineageRefreshEvent(event: SessionEvent): boolean {
     return true;
   }
   // A child's creation never appears on the PARENT's stream as session.created —
-  // the parent sees its own spawn as an agent.toolCall.* for session_create. The
-  // output event is when the child exists server-side; refreshing on created too
-  // keeps the "N agents" chip live while the spawn is still running.
-  if (event.type === "agent.toolCall.created" || event.type === "agent.toolCall.output") {
+  // the parent sees its own spawn as an agent.toolCall.* for session_create.
+  // Created events are handled separately so they can refresh immediately and
+  // once after the child row has had time to commit.
+  if (event.type === "agent.toolCall.output") {
     const payload = event.payload as { name?: unknown; toolName?: unknown } | null | undefined;
     const name = typeof payload?.name === "string" ? payload.name : typeof payload?.toolName === "string" ? payload.toolName : "";
     return name === "session_create" || name.endsWith("__session_create");
   }
   return false;
+}
+
+function isSessionCreateToolCallCreated(event: SessionEvent): boolean {
+  if (event.type !== "agent.toolCall.created") {
+    return false;
+  }
+  const payload = event.payload as { name?: unknown; toolName?: unknown } | null | undefined;
+  const name = typeof payload?.name === "string" ? payload.name : typeof payload?.toolName === "string" ? payload.toolName : "";
+  return name === "session_create" || name.endsWith("__session_create");
 }
 
 /** Read the ancestors + descendant tree for one session. Data-only; no UI state. */
@@ -43,6 +52,24 @@ export function useSessionLineage(sessionId: string | null | undefined, options:
   );
   const state = usePolledValue(load, { pollIntervalMs: options.pollIntervalMs, enabled });
   const refreshSoon = useDebouncedCallback(() => void state.refresh(), 150);
+  const delayedChildRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (delayedChildRefreshRef.current !== null) {
+        clearTimeout(delayedChildRefreshRef.current);
+      }
+    };
+  }, []);
+  const refreshAfterChildCreate = useCallback(() => {
+    void state.refresh();
+    if (delayedChildRefreshRef.current !== null) {
+      clearTimeout(delayedChildRefreshRef.current);
+    }
+    delayedChildRefreshRef.current = setTimeout(() => {
+      delayedChildRefreshRef.current = null;
+      void state.refresh();
+    }, 2500);
+  }, [state]);
   useSessionEventTrigger(
     client,
     workspaceId,
@@ -53,6 +80,14 @@ export function useSessionLineage(sessionId: string | null | undefined, options:
     // open its OWN streamEvents tail — a second live SSE connection next to the
     // session route's useSessionEvents. A caller with no feed opts into polling
     // (pollIntervalMs), never a duplicate stream.
+    { events: options.events, enabled: enabled && options.events !== undefined },
+  );
+  useSessionEventTrigger(
+    client,
+    workspaceId,
+    sessionId,
+    isSessionCreateToolCallCreated,
+    refreshAfterChildCreate,
     { events: options.events, enabled: enabled && options.events !== undefined },
   );
   return { lineage: state.data, loading: state.loading, error: state.error, refresh: state.refresh };

--- a/packages/react/src/hooks/use-session-lineage.ts
+++ b/packages/react/src/hooks/use-session-lineage.ts
@@ -53,13 +53,17 @@ export function useSessionLineage(sessionId: string | null | undefined, options:
   const state = usePolledValue(load, { pollIntervalMs: options.pollIntervalMs, enabled });
   const refreshSoon = useDebouncedCallback(() => void state.refresh(), 150);
   const delayedChildRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Clear a pending delayed refresh on session/workspace SWITCH (not just
+  // unmount): otherwise a timer scheduled for the previous session can fire
+  // ~2.5s later and commit that session's lineage onto the new one.
   useEffect(() => {
     return () => {
       if (delayedChildRefreshRef.current !== null) {
         clearTimeout(delayedChildRefreshRef.current);
+        delayedChildRefreshRef.current = null;
       }
     };
-  }, []);
+  }, [sessionId, workspaceId]);
   const refreshAfterChildCreate = useCallback(() => {
     void state.refresh();
     if (delayedChildRefreshRef.current !== null) {

--- a/packages/react/src/hooks/use-session-lineage.ts
+++ b/packages/react/src/hooks/use-session-lineage.ts
@@ -47,7 +47,7 @@ export function useSessionLineage(sessionId: string | null | undefined, options:
   const { client, workspaceId } = useOpenGeni(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
   const load = useCallback(
-    async () => sessionId ? await client.getSessionLineage(workspaceId, sessionId) : { ancestors: [], children: [] },
+    async () => sessionId ? await client.getSessionLineage(workspaceId, sessionId) : { ancestors: [], children: [], truncated: false },
     [client, workspaceId, sessionId],
   );
   const state = usePolledValue(load, { pollIntervalMs: options.pollIntervalMs, enabled });

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -1,4 +1,4 @@
-import { BotIcon, BrainIcon, SquareTerminalIcon } from "lucide-react";
+import { ArrowRightIcon, BotIcon, BrainIcon, SquareTerminalIcon } from "lucide-react";
 import { cn } from "../lib/cn";
 import { truncate } from "../lib/format";
 import { defaultToolRegistry } from "./tool-renderers";
@@ -164,9 +164,18 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
   // A worker is a first-class actor but still a STEP on the rail — a borderless
   // row (no card), aligned to its sibling tool rows: the chevron column is an
   // empty spacer (a worker doesn't expand), then the bot glyph, then the title
-  // with a quiet prompt/id beneath, and one right-gutter affordance.
-  return (
-    <div className="flex items-start gap-2 px-1.5 py-1.5">
+  // with a quiet prompt beneath, and one right-gutter affordance.
+  //
+  // Once the worker's session id is known, the WHOLE row is a clean, clickable
+  // deep-link into that child session (a trailing arrow brightens on hover) —
+  // the spawn moment itself is the affordance, not a small side button. A
+  // still-in-flight spawn (no id yet) or a failed/cancelled worker is inert, so
+  // there is never a dead click target. The gutter mirrors the worker-completion
+  // card's calm language: red chip on failure, "interrupted" on cancel.
+  const sessionId = item.workerSessionId;
+  const deepLink = Boolean(sessionId) && Boolean(onOpenSession) && !failed && !cancelled;
+  const inner = (
+    <>
       <span className="size-3.5 shrink-0" aria-hidden />
       <span className={cn("mt-px shrink-0", failed ? "text-og-status-failed" : "text-og-accent")}>
         <BotIcon className="size-3.5" />
@@ -178,13 +187,7 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
           {title}
         </span>
         {item.prompt ? <p className="mt-0.5 truncate text-og-sm text-og-fg-muted">{truncate(item.prompt, 140)}</p> : null}
-        {item.workerSessionId ? (
-          <p className="mt-1 font-og-mono text-og-xs text-og-fg-subtle">{item.workerSessionId.slice(0, 8)}</p>
-        ) : null}
       </div>
-      {/* Right gutter: failed gets a red chip; cancelled gets a calm "interrupted"
-          chip (no dot, no red); a live complete worker shows a quiet "Open session"
-          affordance (borderless, matching the worker-completion deep-link). */}
       {failed ? (
         <span className="inline-flex shrink-0 self-center items-center gap-1.5 font-og-mono text-og-xs leading-none text-og-status-failed">
           <span className="size-1.5 rounded-full bg-og-status-failed" />
@@ -194,19 +197,29 @@ function WorkerRow({ item, onOpenSession }: { item: WorkerItem; onOpenSession?: 
         <span className="og-cancelled-chip shrink-0 self-center font-og-mono text-og-xs leading-none text-og-fg-subtle">
           interrupted
         </span>
-      ) : item.workerSessionId && onOpenSession ? (
-        <button
-          type="button"
-          onClick={() => item.workerSessionId && onOpenSession(item.workerSessionId)}
-          className={cn(
-            "-my-0.5 -mr-1 inline-flex shrink-0 self-center items-center gap-1 rounded-og-sm px-2 py-1 text-og-sm font-medium text-og-fg-muted pointer-coarse:py-2",
-            "outline-none transition-colors duration-150 hover:bg-og-surface-1 hover:text-og-fg",
-            "focus-visible:ring-2 focus-visible:ring-og-accent",
-          )}
-        >
-          Open session
-        </button>
+      ) : deepLink ? (
+        <ArrowRightIcon
+          aria-hidden
+          className="mt-0.5 size-3.5 shrink-0 text-og-fg-subtle transition-[transform,color] duration-150 group-hover/worker:translate-x-0.5 group-hover/worker:text-og-fg"
+        />
       ) : null}
-    </div>
+    </>
   );
+
+  if (deepLink && sessionId && onOpenSession) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenSession(sessionId)}
+        className={cn(
+          "group/worker -mx-1.5 flex w-full items-start gap-2 rounded-og-sm px-1.5 py-1.5 text-left",
+          "outline-none transition-colors duration-150 hover:bg-og-surface-1 focus-visible:ring-2 focus-visible:ring-og-accent",
+          "pointer-coarse:py-2.5",
+        )}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return <div className="flex items-start gap-2 px-1.5 py-1.5">{inner}</div>;
 }

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -870,7 +870,13 @@ function workerCompletionPayload(value: unknown): {
   pausedReason: string | null;
 } | null {
   const payload = asRecord(value);
-  if (typeof payload.childSessionId !== "string" || typeof payload.status !== "string") {
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (
+    typeof payload.childSessionId !== "string"
+    || !uuidPattern.test(payload.childSessionId)
+    || typeof payload.status !== "string"
+    || payload.status.trim() === ""
+  ) {
     return null;
   }
   const goal = asRecord(payload.goal);

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -441,6 +441,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "goal.completed":
       case "goal.paused":
       case "goal.resumed":
+      case "goal.cleared":
       case "goal.continuation": {
         items.push({
           kind: "goal",

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -254,12 +254,17 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "sandbox.operation.failed": {
         const name = typeof payload.name === "string" ? payload.name : "sandbox";
         const status = event.type.endsWith(".failed") ? "failed" : event.type.endsWith(".completed") ? "complete" : "running";
-        // Routine repository-clone operations are per-turn platform plumbing (an
-        // idempotent clone check + off-manifest token re-seed runs before EVERY
-        // turn on a repo-attached session) — rendering them reads as the agent
-        // redoing work each turn. Only failures surface, and they surface loudly:
-        // the failed event below creates its own item even without a started row.
-        if (name === "repository-clone" && status !== "failed") {
+        // Routine per-turn platform plumbing that runs before EVERY turn to
+        // guarantee box contents survive a re-warm — NOT the agent redoing work:
+        //   - repository-clone: idempotent clone check + off-manifest token re-seed;
+        //   - file-resource-download: idempotent `if [ ! -f ] then curl` (skips
+        //     when the attached file is already on the box — see
+        //     sandboxFileDownloadCommand), so an uploaded image is not re-fetched;
+        //     the operation still emits every turn even when it does nothing.
+        // Rendering either every turn reads as churn. Only FAILURES surface, and
+        // they surface loudly — the failed event below creates its own item even
+        // without a started row.
+        if ((name === "repository-clone" || name === "file-resource-download") && status !== "failed") {
           break;
         }
         const existing = findOpenSandbox(items, name);

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -59,46 +59,39 @@ export function TurnSummary({ items, outcome, failureText, durationMs, defaultOp
     <Collapsible.Root open={open} onOpenChange={setOpen} className={enter && !bare ? "animate-og-enter" : undefined}>
       <Collapsible.Trigger
         className={cn(
-          "group flex w-full items-center text-left text-og-base transition-colors",
+          // Both the top-level turn fold and a nested cluster fold render as a
+          // FLAT rail row — chevron + glyph + facets on the page background, no
+          // border, no fill. Only a hover tint hints the row is expandable, so a
+          // collapsed turn never reads as a boxed card. The top-level row is a
+          // touch larger (base text, size-5 glyph, wider gap) so it still reads
+          // as a turn landmark above the nested cluster rows it groups.
+          "group flex w-full items-center rounded-og-sm text-left transition-colors",
+          // A folded turn is a touch target on coarse pointers: grow the row so it
+          // clears the 40px minimum without disturbing the calm desktop rhythm.
+          "pointer-coarse:py-2.5",
           bare
-            ? // A nested node: no border, no fill — a plain rail row. It sits at the
-              // same weight as the tool rows it groups (hover tint only), so the turn
-              // body reads as one continuous thread instead of nested cards.
-              "gap-2 rounded-og-sm px-1.5 py-1.5 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:py-2.5"
-            : cn(
-                "gap-2.5 rounded-og-md border px-3 py-2",
-                // A folded turn is a touch target on coarse pointers: grow the row so
-                // it clears the 40px minimum without disturbing the calm desktop rhythm.
-                "pointer-coarse:py-2.5",
-                // Only a failed turn earns the one filled/tinted card in the timeline;
-                // complete and cancelled stay flat and calm.
-                outcome === "failed"
-                  ? "border-og-status-failed/30 bg-og-status-failed/[0.06] hover:border-og-status-failed/50"
-                  : "border-og-border bg-og-surface-1/50 hover:border-og-border-strong",
-              ),
+            ? "gap-2 px-1.5 py-1.5 text-og-sm text-og-fg-muted"
+            : "-mx-2 gap-2.5 px-2 py-1.5 text-og-base text-og-fg-muted",
+          // A failed fold keeps its red accent (glyph + inline reason below) and a
+          // faint red hover wash so attention still lands there; every other
+          // outcome gets the neutral surface hover.
+          outcome === "failed"
+            ? "hover:bg-og-status-failed/[0.06] hover:text-og-fg"
+            : "hover:bg-og-surface-1 hover:text-og-fg",
         )}
       >
         {/* Disclosure grammar matches the rows: chevron leads (far left), then the
             outcome glyph, then the facets — one expand affordance side everywhere. */}
         <ChevronRightIcon className="size-3.5 shrink-0 text-og-fg-subtle transition-transform duration-150 group-data-[state=open]:rotate-90" />
-        {/* Only the exceptional outcomes earn a filled tinted circle. A clean
-            (complete) run draws a bare muted check — zero colored fills, so the
-            eye is pulled only to a turn that needs attention. A nested node keeps
-            the glyph unfilled (it is a rail node, not a card) — the hue alone
-            carries an exceptional outcome. */}
+        {/* The outcome glyph carries the state by hue alone — no filled circle, no
+            card. A clean (complete) run draws a bare muted check; a failed one a
+            red triangle; a cancelled one a muted slash; a still-running cluster a
+            quiet pulse dot in the glyph's place so alignment holds. */}
         <span
           className={cn(
-            "inline-flex shrink-0 items-center justify-center rounded-full",
+            "inline-flex shrink-0 items-center justify-center",
             bare ? "size-3.5" : "size-5",
-            outcome === "failed"
-              ? bare
-                ? "text-og-status-failed"
-                : "bg-og-status-failed/15 text-og-status-failed"
-              : outcome === "cancelled"
-                ? bare
-                  ? "text-og-fg-subtle"
-                  : "bg-og-fg-subtle/15 text-og-fg-subtle"
-                : "text-og-fg-subtle",
+            outcome === "failed" ? "text-og-status-failed" : "text-og-fg-subtle",
           )}
         >
           {outcome === "failed" ? (

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -120,7 +120,7 @@ export type SessionStatusItem = {
 export type GoalItem = {
   kind: "goal";
   id: string;
-  action: "set" | "updated" | "completed" | "paused" | "resumed" | "continuation";
+  action: "set" | "updated" | "completed" | "paused" | "resumed" | "cleared" | "continuation";
   text: string | null;
   occurredAt: string;
 };

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -379,6 +379,32 @@ describe("useGoal", () => {
     await hook.unmount();
   });
 
+  test("a FAILED clearGoal keeps the goal (and surfaces the error), never hides the pill", async () => {
+    const client = fakeClient({
+      getGoal: async () => fakeGoal(),
+      deleteGoal: async () => {
+        throw new Error("server 5xx");
+      },
+    });
+    const hook = await renderHook(
+      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      undefined,
+    );
+    await flush();
+    // Populate the goal (shared-feed skips the initial auto-load).
+    await flushing(async () => {
+      await hook.result.current.refresh();
+    });
+    expect(hook.result.current.goal).not.toBeNull();
+    await flushing(async () => {
+      await hook.result.current.clearGoal();
+    });
+    // The delete failed → the goal must remain so the panel's mutationError renders.
+    expect(hook.result.current.goal).not.toBeNull();
+    expect(hook.result.current.mutationError).not.toBeNull();
+    await hook.unmount();
+  });
+
   test("goal.* events on a shared log refetch the goal", async () => {
     let reads = 0;
     const client = fakeClient({

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -22,14 +22,14 @@ import { useWorkspaces } from "../src/hooks/use-workspaces";
 
 registerDom();
 
-function makeEvent(sequence: number, type: string): SessionEvent {
+function makeEvent(sequence: number, type: string, payload: Record<string, unknown> = {}): SessionEvent {
   return {
     id: `00000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
     workspaceId: WORKSPACE_ID,
     sessionId: SESSION_ID,
     sequence,
     type,
-    payload: {},
+    payload,
     occurredAt: new Date().toISOString(),
   };
 }
@@ -240,6 +240,37 @@ describe("useSessionLineage", () => {
     await flush(250);
     expect(reads).toBe(2);
     expect(hook.result.current.lineage?.children[0]?.session.id).toBe("child-2");
+    await hook.unmount();
+  });
+
+  test("refreshes immediately and once later when a child session create tool starts", async () => {
+    let reads = 0;
+    const client = fakeClient({
+      getSessionLineage: async () => {
+        reads += 1;
+        return {
+          ancestors: [],
+          children: [{ session: { id: `child-${reads}` }, children: [] }],
+        } as never;
+      },
+    });
+    const hook = await renderHook(
+      (events: SessionEvent[]) => useSessionLineage(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events }),
+      [] as SessionEvent[],
+    );
+    await flush();
+    expect(reads).toBe(1);
+
+    await hook.rerender([
+      makeEvent(1, "agent.toolCall.created", { name: "session_create" }),
+    ]);
+    await flush(50);
+    expect(reads).toBe(2);
+    expect(hook.result.current.lineage?.children[0]?.session.id).toBe("child-2");
+
+    await flush(2700);
+    expect(reads).toBe(3);
+    expect(hook.result.current.lineage?.children[0]?.session.id).toBe("child-3");
     await hook.unmount();
   });
 });

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -357,6 +357,28 @@ describe("useGoal", () => {
     await hook.unmount();
   });
 
+  test("clearGoal DELETEs the goal and clears local state", async () => {
+    let deletes = 0;
+    const client = fakeClient({
+      getGoal: async () => fakeGoal(),
+      deleteGoal: async () => {
+        deletes += 1;
+      },
+    });
+    const hook = await renderHook(
+      () => useGoal(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      undefined,
+    );
+    await flush();
+    await flushing(async () => {
+      await hook.result.current.clearGoal();
+    });
+    expect(deletes).toBe(1);
+    expect(hook.result.current.goal).toBeNull();
+    expect(hook.result.current.isActive).toBe(false);
+    await hook.unmount();
+  });
+
   test("goal.* events on a shared log refetch the goal", async () => {
     let reads = 0;
     const client = fakeClient({

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -224,6 +224,7 @@ describe("useSessionLineage", () => {
         return {
           ancestors: [],
           children: [{ session: { id: `child-${reads}` }, children: [] }],
+          truncated: false,
         } as never;
       },
     });
@@ -251,6 +252,7 @@ describe("useSessionLineage", () => {
         return {
           ancestors: [],
           children: [{ session: { id: `child-${reads}` }, children: [] }],
+          truncated: false,
         } as never;
       },
     });

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -737,6 +737,12 @@ describe("buildTimeline", () => {
     expect(items[0]).toMatchObject({ kind: "goal", action: "set", text: "Keep staging green" });
   });
 
+  test("goal.cleared is tolerated as a goal landmark", () => {
+    reset();
+    const items = buildTimeline([event("goal.cleared", { goalId: "goal-1" })]);
+    expect(items[0]).toMatchObject({ kind: "goal", action: "cleared", text: null });
+  });
+
   test("session.requiresAction becomes a waiting notice", () => {
     reset();
     const items = buildTimeline([event("session.requiresAction", { approvals: [] })]);

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -508,6 +508,30 @@ describe("buildTimeline", () => {
     expect(sandbox?.output).toContain("authentication failed");
   });
 
+  test("routine file-resource-download operations never render", () => {
+    // Per-turn plumbing: an idempotent `if [ ! -f ] then curl` re-materializes
+    // an attached file after a box re-warm and emits its operation every turn
+    // even when the file is already present — it must not read as re-downloading.
+    reset();
+    const items = buildTimeline([
+      event("sandbox.operation.started", { name: "file-resource-download", fileId: "f1", path: "files/photo.png" }),
+      event("sandbox.operation.completed", { name: "file-resource-download", fileId: "f1", path: "files/photo.png" }),
+    ]);
+    expect(items.filter((item) => item.kind === "sandbox")).toHaveLength(0);
+  });
+
+  test("failed file-resource-download operations still surface loudly", () => {
+    reset();
+    const items = buildTimeline([
+      event("sandbox.operation.started", { name: "file-resource-download", fileId: "f1" }),
+      event("sandbox.operation.failed", { name: "file-resource-download", fileId: "f1", error: "signed URL expired" }),
+    ]);
+    const sandbox = items.find((item): item is SandboxItem => item.kind === "sandbox");
+    expect(sandbox?.name).toBe("file-resource-download");
+    expect(sandbox?.status).toBe("failed");
+    expect(sandbox?.output).toContain("signed URL expired");
+  });
+
   test("sandbox durability lifecycle events are ignored by the projection", () => {
     // sandbox.box.* / sandbox.env.drift are observability spine events —
     // tolerant reader: they must never render or disturb the timeline.

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -132,6 +132,18 @@ describe("buildTimeline", () => {
     expect((items[0] as UserMessageItem).text).toBe("Still readable");
   });
 
+  test("leaves invalid childCompletion session ids as plain user messages", () => {
+    reset();
+    const items = buildTimeline([
+      event("user.message", {
+        text: "Still readable",
+        childCompletion: { childSessionId: "not-a-uuid", status: "idle" },
+      }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["user-message"]);
+    expect((items[0] as UserMessageItem).text).toBe("Still readable");
+  });
+
   test("accumulates streaming deltas into one agent message and finalizes on completed", () => {
     reset();
     const items = buildTimeline([

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -570,6 +570,10 @@ export class OpenGeniClient {
     return await this.requestJson<SessionGoal>("PATCH", `/v1/workspaces/${workspaceId}/sessions/${sessionId}/goal`, request);
   }
 
+  async deleteGoal(workspaceId: string, sessionId: string): Promise<void> {
+    await this.requestVoid("DELETE", `/v1/workspaces/${workspaceId}/sessions/${sessionId}/goal`);
+  }
+
   /** Pause the goal loop: the session stops self-continuing until resumed. */
   async pauseGoal(workspaceId: string, sessionId: string, options: { rationale?: string } = {}): Promise<SessionGoal> {
     return await this.updateGoal(workspaceId, sessionId, {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -394,6 +394,7 @@ export type LineageNode = {
 export type SessionLineageResponse = {
   ancestors: SessionSummary[];
   children: LineageNode[];
+  truncated: boolean;
 };
 
 export type SessionTurnStatus =

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -463,6 +463,7 @@ export const SESSION_EVENT_TYPES = [
   "goal.completed",
   "goal.paused",
   "goal.resumed",
+  "goal.cleared",
   "goal.continuation",
   // Channel-B desktop pixel-plane signals (mirror of contracts SessionEventType;
   // the contract-parity test asserts sorted equality).

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -296,6 +296,13 @@ describe("OpenGeniClient goals", () => {
     expect(JSON.parse(requests[0]!.body!)).toEqual({ status: "paused", rationale: "manual review" });
     expect(JSON.parse(requests[1]!.body!)).toEqual({ status: "active" });
   });
+
+  test("deleteGoal DELETEs the session goal route", async () => {
+    const { client, requests } = makeClient(() => new Response(null, { status: 204 }));
+    await client.deleteGoal(WORKSPACE_ID, SESSION_ID);
+    expect(requests[0]!.method).toBe("DELETE");
+    expect(requests[0]!.url).toBe(`https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/goal`);
+  });
 });
 
 describe("OpenGeniClient access + workspaces", () => {


### PR DESCRIPTION
Reviewer feedback on the just-shipped lineage/goal/de-box UI, plus the fixes from the fresh-eyes review of #300/#302.

## Review items
- **De-box the COLLAPSED fold chips** (`b09425f`) — the "N steps · Xs" turn/cluster summary was a bordered filled box; now a flat rail row (chevron + glyph + facets on the page background, hover tint only). Collapsed now matches the de-boxed expanded thread. Failed folds keep the red glyph + inline reason so the error still draws the eye. (This is the box the reviewer actually meant — I'd kept it in #302 by mistake.)
- **Delete a goal** (`2429691`) — quiet destructive "Delete goal" in the expanded goal panel with a two-step inline confirm (no modal); calls the new `deleteGoal()` → pill hides.
- **Resizable left sidebar** (`432d7ca`) — drag the right-edge handle (220–480px), persisted to localStorage, double-click resets. Collapsed strip + mobile drawer keep fixed widths.
- **Spawn deep-link** (`42a8241`) — once the child session id is known, the whole spawned-worker row deep-links into it; an in-flight or failed spawn stays inert (no dead target). Dropped the raw id slug as noise.
- **File-download noise** (`f2fe2ca`) — routine `file-resource-download` operations no longer render every turn (it never re-downloads — the `if [ ! -f ] then curl` skips; it was just the missed sibling of the #292 repo-clone suppression). Failures still surface.

## Fresh-eyes review fixes
- Failed session no longer shows "Pursuing goal" with a live-ticking clock — clock freezes, pill switches to attention (`2429691`).
- "Needs attention" uses one consistent hue (purple, matching the status dots — amber is the running tone). Redundant pill toggle hidden when the panel is open. Rail chevron gutter reserved at depth 0 so status dots align (`e1e9c0d`).
- Lineage: child-refresh timing after a spawn, rail cycle-safety, lineage descendant width-cap + `truncated` flag, worker-completion `childSessionId` UUID validation (`9cd2c48`, `b2cc62a`, `414be67`, `bce83fd`).
- Goal-clear plumbing: DELETE route + `goal.cleared` event + SDK `deleteGoal` (`5cb0042`).

## Verification
packages/react 459 tests + apps/web 180 tests pass; both typecheck clean; golden grammar untouched (DOM-only). Screenshots (fold-chip before/after both themes, goal pill states incl. failed-frozen, delete confirm, spawn deep-link) in the worktree `.agent/screenshots/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Goal DELETE mutates durable state and the continuation loop; changes are transactional and tested, but operators can stop long-running goal loops. Remaining risk is mostly UI/timeline projection and lineage refresh timing.
> 
> **Overview**
> **Goal lifecycle:** Adds idempotent `DELETE` on session goals (DB `clearSessionGoal`, `goal.cleared` event, SDK/React `deleteGoal`), plus console **Delete goal** with inline confirm. Goal pill behavior tightens: elapsed clock stops on stalled sessions (`requires_action` / `failed` / `cancelled`), **Needs attention** uses the waiting (purple) tone, and the collapsed pill hides duplicate pause/resume when the panel is open.
> 
> **Rail & session list:** Desktop left rail is **user-resizable** (220–480px, `localStorage`, double-click reset). Session rows reserve chevron gutter at every depth for aligned status dots. `buildRailForest` surfaces unreachable/cyclic parent links as extra roots.
> 
> **Lineage:** Descendant queries cap at **200** rows with a **`truncated`** flag on API/contracts/SDK. `useSessionLineage` refreshes immediately and again ~2.5s after `session_create` tool starts, with timer cleanup on session switch.
> 
> **Timeline / activity:** Turn fold chips are **flat rail rows** (no bordered cards). Worker spawn rows become full-row deep links when a child session id exists. Routine `file-resource-download` sandbox ops are hidden like repo-clone (failures still show). `childCompletion` requires a valid UUID before promoting to a worker item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2690cdc2e4751ed2020b7935af5df2d5343426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->