### PR TITLE
fix(sandbox): lazy createEditor returns a non-null lazy editor

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1766,19 +1766,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               ...(lazyGitTokens ? { gitTokenSeedsOverride: lazyGitTokens } : {}),
             },
           );
-          const runFacing = lazyOwnedSandbox
-            ? {
-              ...provisioned,
-              established: {
-                ...provisioned.established,
-                session: lazyOwnedSandbox.session,
-              },
-            }
-            : provisioned;
-          resolvedSandbox = runFacing;
-          startLeaseHeartbeat(runFacing, activeSandboxBackend ?? groupBoxBackend);
-          await maybeStartOnTurnRecording(runFacing, activeSandboxBackend);
-          return runFacing;
+          // Return the REAL established box (NOT a copy whose session is the routing
+          // proxy). resolveActiveBackend dispatches ops to `provisioned.established.session`;
+          // if that were the proxy itself, proxy.exec -> dispatch -> resolve ->
+          // provisioner.get() -> proxy.exec -> ... loops forever (an async infinite
+          // recursion that HANGS the turn — caught live on staging 2026-07-08). The SDK
+          // already holds the proxy directly (injected as lazyOwnedSandbox.session), so it
+          // gets per-op routing; the worker-side handle (resolvedSandbox: release,
+          // heartbeat, on-turn recording) wants the real box, unproxied.
+          resolvedSandbox = provisioned;
+          startLeaseHeartbeat(provisioned, activeSandboxBackend ?? groupBoxBackend);
+          await maybeStartOnTurnRecording(provisioned, activeSandboxBackend);
+          return provisioned;
         }, {
           onStarted: async () => {
             await publish?.([{ type: "sandbox.operation.started", payload: { name: "sandbox.provision" } }], true);

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -257,6 +257,16 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     }
     const fromEpoch = this.cachedEpoch ?? pointer.activeEpoch;
     const resolved = await this.deps.resolveActiveBackend(pointer);
+    // Re-entrancy guard: a resolver that returns THIS proxy as the active backend
+    // makes every op (exec/readFile/…) dispatch back into resolve() -> the same
+    // backend -> forever (a silent async infinite recursion that HANGS the turn,
+    // not a stack overflow). Fail loud instead — a wiring bug must surface as a
+    // legible error, never a hung turn.
+    if ((resolved.session as unknown) === this) {
+      throw new Error(
+        "RoutingSandboxSession.resolveActiveBackend returned the proxy itself as the active backend (re-entrancy) — the resolver must return the underlying box session, not the routing proxy.",
+      );
+    }
     this.cachedEpoch = pointer.activeEpoch;
     this.cached = resolved;
     this.lastResolved = resolved;

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -417,12 +417,34 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     return Boolean(s?.supportsPty?.());
   }
 
-  /** createEditor is a synchronous factory in the SDK surface; it binds to the
-   *  last-resolved backend's editor (or the default backend before the first op).
-   *  Returns undefined when the active backend has no editor (channel-a falls back
-   *  to its exec-based write path). */
+  /** createEditor is a synchronous factory in the SDK surface. The SDK's filesystem
+   *  capability calls it ONCE at tool-BIND time — `FilesystemCapability.tools()`,
+   *  every turn, before any tool runs — and throws "Filesystem sandbox sessions must
+   *  provide createEditor()" if it returns falsy. When a backend is already resolved
+   *  (eager/selfhosted routing) we bind to its editor directly, byte-for-byte as
+   *  before. But under LAZY provisioning the backend is not established yet
+   *  (defaultResolved is the synthetic unprovisioned session with no editor), so a
+   *  direct delegate returns undefined and every lazy turn would die at bind. Return a
+   *  LAZY EDITOR PROXY instead: a non-null editor whose async ops resolve the active
+   *  backend (establishing the box on first use, via `dispatch`) and delegate to its
+   *  real editor — mirroring how this proxy defers exec/readFile. */
   createEditor(runAs?: string): unknown {
-    return (this.lastResolved ?? this.deps.defaultResolved)?.session.createEditor?.(runAs);
+    const eager = (this.lastResolved ?? this.deps.defaultResolved)?.session.createEditor?.(runAs);
+    if (eager) {
+      return eager;
+    }
+    const op = (name: "createFile" | "updateFile" | "deleteFile") =>
+      (operation: unknown, context?: unknown): Promise<unknown> =>
+        this.dispatch(`editor.${name}`, async (s) => {
+          const editor = s.createEditor?.(runAs) as
+            | Record<string, (operation: unknown, context?: unknown) => Promise<unknown>>
+            | undefined;
+          if (!editor?.[name]) {
+            throw new RoutingUnsupportedError(`editor.${name}`, this.cached?.kind ?? "unknown");
+          }
+          return editor[name](operation, context);
+        });
+    return { createFile: op("createFile"), updateFile: op("updateFile"), deleteFile: op("deleteFile") };
   }
 
   async resolveExposedPort(port: number): Promise<ExposedPortEndpoint> {

--- a/packages/runtime/test/lazy-provisioning.test.ts
+++ b/packages/runtime/test/lazy-provisioning.test.ts
@@ -88,4 +88,60 @@ describe("lazy provisioning synthetic manifest", () => {
     expect(events.filter((event) => event.type === "sandbox.env.drift")).toEqual([]);
     expect(await manifestEnv((agent as { defaultManifest: never }).defaultManifest)).toEqual(environment);
   });
+
+  // REGRESSION (caught live on staging 2026-07-08): the SDK's FilesystemCapability
+  // calls session.createEditor() SYNCHRONOUSLY at tool-BIND time (every turn, before
+  // any tool runs) and throws "Filesystem sandbox sessions must provide createEditor()"
+  // if it returns falsy. Under lazy provisioning the default backend is the synthetic
+  // unprovisioned session with NO editor, so a direct delegate returned undefined and
+  // EVERY lazy turn died at bind — even chat-only turns. createEditor must return a
+  // non-null lazy editor whose ops resolve (establish) the backend on first use.
+  test("createEditor returns a non-null lazy editor before establish; editor ops resolve the backend", async () => {
+    let resolveCount = 0;
+    const realEditorCalls: Array<{ op: string; operation: unknown }> = [];
+    const realBackend: RoutableBackendSession = {
+      state: { manifest: {} },
+      createEditor: () => ({
+        createFile: async (operation: unknown) => {
+          realEditorCalls.push({ op: "createFile", operation });
+          return { output: "created" };
+        },
+        updateFile: async (operation: unknown) => {
+          realEditorCalls.push({ op: "updateFile", operation });
+          return { output: "updated" };
+        },
+        deleteFile: async (operation: unknown) => {
+          realEditorCalls.push({ op: "deleteFile", operation });
+          return { output: "deleted" };
+        },
+      }),
+    } as unknown as RoutableBackendSession;
+    const proxy = new RoutingSandboxSession({
+      // Synthetic unprovisioned default: NO createEditor (this is what broke bind).
+      defaultResolved: { session: { state: { manifest: {} } }, sandboxId: null, kind: "unprovisioned" },
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 1 }),
+      resolveActiveBackend: async () => {
+        resolveCount += 1;
+        return { session: realBackend, sandboxId: null, kind: "modal" };
+      },
+    });
+
+    // The exact SDK bind-time check: createEditor() must be non-null. Before this
+    // fix it returned undefined (the synthetic backend had no editor) and threw.
+    const editor = proxy.createEditor("root") as {
+      createFile: (op: unknown) => Promise<unknown>;
+      updateFile: (op: unknown) => Promise<unknown>;
+      deleteFile: (op: unknown) => Promise<unknown>;
+    };
+    expect(editor).toBeTruthy();
+    expect(typeof editor.createFile).toBe("function");
+    // No backend resolved yet: returning the editor must NOT have established a box.
+    expect(resolveCount).toBe(0);
+
+    // The editor op establishes the backend (resolve) on first use and delegates.
+    const result = await editor.createFile({ type: "create_file", path: "/workspace/x", diff: "+hi" });
+    expect(resolveCount).toBe(1);
+    expect(result).toEqual({ output: "created" });
+    expect(realEditorCalls).toEqual([{ op: "createFile", operation: { type: "create_file", path: "/workspace/x", diff: "+hi" } }]);
+  });
 });

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -245,6 +245,23 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
     expect(modal.calls).toEqual(["x"]);
     expect(selfhosted.calls).toEqual(["y"]);
   });
+
+  // REGRESSION (caught live on staging 2026-07-08): the lazy wiring returned the
+  // proxy ITSELF as the resolved backend, so every op re-dispatched into resolve()
+  // forever — a silent async infinite recursion that HUNG the turn (box created, exec
+  // never returned). The guard must fail loud instead of looping.
+  test("(5) re-entrancy guard: a resolver returning the proxy itself throws, never hangs", async () => {
+    let proxy: RoutingSandboxSession;
+    proxy = new RoutingSandboxSession({
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 1 }),
+      resolveActiveBackend: async (): Promise<ResolvedActiveBackend> => ({
+        session: proxy as unknown as RoutableBackendSession,
+        sandboxId: null,
+        kind: "unprovisioned",
+      }),
+    });
+    await expect(proxy.exec({ cmd: "x" })).rejects.toThrow(/re-entrancy|proxy itself/i);
+  });
 });
 
 describe("makeActiveBackendResolver — heterogeneous default/modal/selfhosted dispatch", () => {


### PR DESCRIPTION
Caught by a **live staging drill** of #315: with `OPENGENI_SANDBOX_LAZY_PROVISION` on, **every** turn (even chat-only) failed at agent-prep with `Filesystem sandbox sessions must provide createEditor()`.

The SDK's `FilesystemCapability.tools()` calls `session.createEditor()` synchronously at tool-**bind** time (every turn, before any tool runs) and throws if it returns falsy. Under lazy provisioning the default backend is the synthetic unprovisioned session with no editor, so the routing proxy's `createEditor` delegated to it and returned undefined.

**Fix:** when no backend editor exists yet (the lazy/synthetic case), `createEditor` returns a lazy editor proxy whose `createFile`/`updateFile`/`deleteFile` route through `dispatch()` — resolving (and thus establishing) the active backend on first use and delegating to its real editor. The eager/selfhosted path is unchanged. Regression test drives the exact bind-time contract + first-op establish.

Flag is off in all envs (disabled on staging on discovery) — no active incident, fix-forward. Re-drilled live on staging before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lazy-provision and routing hot path where staging saw hangs and bind failures; fixes are narrow with regression tests but affect every lazy turn’s sandbox lifecycle.
> 
> **Overview**
> Fixes two **lazy sandbox provisioning** bugs found on staging: turns could hang forever or fail before any model work.
> 
> **Lazy `createEditor`:** Under lazy provisioning the routing proxy’s default backend is a synthetic unprovisioned session with no editor. The SDK calls `createEditor()` synchronously at filesystem tool bind (every turn) and throws if it’s falsy — so even chat-only turns died at prep. When no eager editor exists yet, `createEditor` now returns a **lazy editor proxy** whose `createFile` / `updateFile` / `deleteFile` go through `dispatch()` and establish the real box on first use (same pattern as deferred `exec`).
> 
> **Provisioner wiring:** The lazy provisioner no longer returns a handle whose `established.session` is the routing proxy. If `resolveActiveBackend` pointed at that proxy, ops looped `proxy.exec → resolve → provisioner → proxy.exec` and **hung the turn**. Worker lease heartbeat, recording, and release now use the **unproxied** `provisioned` box; the SDK still gets the proxy via `lazyOwnedSandbox.session`.
> 
> **Safety net:** `RoutingSandboxSession.resolve()` throws if the resolver returns the proxy itself (re-entrancy), instead of looping silently. Regression tests cover bind-time `createEditor` and the re-entrancy guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873c0f27114cc8eff7e35434a0e0918037628014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->