### PR TITLE
Decouple the subagent view from goals: chip-expand popover + Agents dock tab

### DIFF
--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -296,7 +296,7 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
           <div className="flex shrink-0 items-center gap-1.5">
             {/* Sessions that spawned workers surface an "N agents" chip opening
                 the shared subagent lineage panel. */}
-            <SessionAgentsChip workspaceId={context.session.workspaceId} nodes={childNodes} loading={lineage.loading} />
+            <SessionAgentsChip workspaceId={context.session.workspaceId} nodes={childNodes} />
             <ConnectionPill state={context.connectionState} />
             <SessionStatusBadge status={context.session.status} />
             {context.keyAuthRequired ? (

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -17,7 +17,7 @@ import { CollapsedSessionsButton, SessionList } from "@/components/rail/session-
 import { SwitcherBlock } from "@/components/rail/switcher-block";
 import { SessionSandboxSwitcher } from "@/components/session/sandbox-switcher";
 import { CodexAccountIndicator } from "@/components/session/codex-account-indicator";
-import { SessionAgentsChip, SpawnedByBreadcrumb } from "@/components/session/goal-surface";
+import { SessionAgentsChip, SpawnedByBreadcrumb } from "@/components/session/subagents";
 import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent } from "@/components/ui/sheet";

--- a/apps/web/src/components/session/goal-surface.tsx
+++ b/apps/web/src/components/session/goal-surface.tsx
@@ -1,22 +1,18 @@
 // The goal surface: ONE slim floating pill above the composer (Codex-style)
 // that carries the active goal at a glance — state, truncated title, live
 // elapsed — and expands to a panel with the full goal detail, autonomy
-// counters, pause/resume, and the spawned-subagent tree. The same subagent
-// panel backs the header "N agents" chip (see SessionAgentsChip), so the
-// session's lineage is one component reused in two places.
+// counters, and pause/resume. The goal is its own concern: the spawned-subagent
+// tree is DECOUPLED into ./subagents.tsx (the "Agents" dock tab + header chip),
+// so nothing here reaches for the session's lineage.
 //
 // Copy doctrine: human language only. Internal status slugs (requires_action,
 // active, …) are translated to plain labels at this boundary; no enum leaks
 // into a rendered string.
 import type { UseGoalResult } from "@opengeni/react";
-import { useSessionLineage } from "@opengeni/react";
-import type { LineageNode, SessionEvent, SessionStatus, SessionSummary } from "@opengeni/sdk";
-import { Link } from "@tanstack/react-router";
+import type { SessionStatus } from "@opengeni/sdk";
 import {
-  BotIcon,
   CheckCircle2Icon,
   ChevronDownIcon,
-  ChevronRightIcon,
   Loader2Icon,
   PauseIcon,
   PlayIcon,
@@ -24,13 +20,12 @@ import {
   TriangleAlertIcon,
   ZapIcon,
 } from "lucide-react";
-import { Collapsible, Popover } from "radix-ui";
-import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react";
+import { Popover } from "radix-ui";
+import { useEffect, useState, type ComponentType } from "react";
 
 import { Button } from "@/components/ui/button";
 import { MetaChip } from "@/components/ui/meta-chip";
 import { Notice } from "@/components/ui/notice";
-import { STATUS_META, StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
 
@@ -81,24 +76,6 @@ function goalPillState(goalStatus: "active" | "paused" | "completed", sessionSta
   return "pursuing";
 }
 
-/** Map a session lifecycle status onto the six-tone status language. */
-export function sessionStatusTone(status: SessionStatus): StatusTone {
-  switch (status) {
-    case "requires_action":
-      return "waiting";
-    case "running":
-      return "running";
-    case "queued":
-      return "queued";
-    case "failed":
-      return "failed";
-    case "cancelled":
-      return "cancelled";
-    default:
-      return "idle";
-  }
-}
-
 /* --- elapsed clock ---------------------------------------------------------- */
 
 function formatCoarseElapsed(ms: number): string {
@@ -147,18 +124,11 @@ function useLiveElapsed(startIso: string | null | undefined, live: boolean, endI
 export function GoalSurface({
   session,
   goal,
-  events,
-  onNavigate,
 }: {
   session: Session;
   goal: UseGoalResult;
-  events: SessionEvent[];
-  /** Called before navigating into a subagent, so the host can e.g. close panels. */
-  onNavigate?: (() => void) | undefined;
 }) {
   const [open, setOpen] = useState(false);
-  const lineage = useSessionLineage(session.id, { events });
-  const children = lineage.lineage?.children ?? [];
   const record = goal.goal;
   // All hooks run unconditionally (the null-goal early return is below): the
   // elapsed clock ticks only while the goal is actively being pursued AND the
@@ -257,8 +227,8 @@ export function GoalSurface({
             className={cn(
               // Anchored directly above the composer, the panel opens UPWARD. On a
               // short viewport it caps at the space available above the pill and
-              // scrolls inside itself (subagent trees can get tall) rather than
-              // overflowing off-screen or flipping down over the composer.
+              // scrolls inside itself rather than overflowing off-screen or
+              // flipping down over the composer.
               "z-50 flex max-h-[min(30rem,var(--radix-popover-content-available-height))] w-[min(24rem,calc(100vw-2rem))] flex-col overflow-y-auto overscroll-contain",
               "rounded-xl border border-border bg-surface shadow-lg outline-none",
               "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
@@ -266,17 +236,6 @@ export function GoalSurface({
             )}
           >
             <GoalDetail goal={goal} state={state} />
-            <div className="border-t border-border/70 p-3">
-              <SubagentSection
-                workspaceId={session.workspaceId}
-                lineage={children}
-                loading={lineage.loading && children.length === 0}
-                onNavigate={() => {
-                  setOpen(false);
-                  onNavigate?.();
-                }}
-              />
-            </div>
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>
@@ -387,191 +346,5 @@ function DeleteGoalButton({ goal }: { goal: UseGoalResult }) {
       <Trash2Icon className="size-3" />
       Delete goal
     </Button>
-  );
-}
-
-/* --- subagent tree (shared by the pill panel and the header chip) ----------- */
-
-export function SubagentSection({
-  workspaceId,
-  lineage,
-  loading,
-  onNavigate,
-}: {
-  workspaceId: string;
-  lineage: LineageNode[];
-  loading: boolean;
-  onNavigate?: (() => void) | undefined;
-}) {
-  const count = lineage.length;
-  return (
-    <div className="min-w-0">
-      <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
-        <BotIcon className="size-3.5" />
-        Subagents
-        {count > 0 ? <span className="text-fg-subtle/80">· {count}</span> : null}
-      </div>
-      {loading ? (
-        <p className="mt-2 flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
-          <Loader2Icon className="size-3.5 animate-spin" />
-          Loading lineage
-        </p>
-      ) : count === 0 ? (
-        <p className="mt-2 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned</p>
-      ) : (
-        <ul className="mt-1.5 flex flex-col gap-px">
-          {lineage.map((node) => (
-            <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-function SubagentRow({
-  node,
-  workspaceId,
-  depth,
-  onNavigate,
-}: {
-  node: LineageNode;
-  workspaceId: string;
-  depth: number;
-  onNavigate?: (() => void) | undefined;
-}) {
-  const [open, setOpen] = useState(false);
-  const childCount = node.children.length;
-  const title = node.session.title?.trim() || node.session.initialMessage?.trim() || "Untitled session";
-  const tone = sessionStatusTone(node.session.status);
-  const live = node.session.status === "running" || node.session.status === "queued" || node.session.status === "requires_action";
-
-  const row = (
-    <div
-      className="group/agent flex h-8 items-center gap-2 rounded-md pl-1.5 pr-1 text-left text-xs text-fg-muted transition-colors hover:bg-surface-2"
-      style={depth > 0 ? { marginLeft: depth * 12 } : undefined}
-    >
-      {childCount > 0 ? (
-        <Collapsible.Trigger asChild>
-          <button
-            type="button"
-            aria-label={open ? "Collapse" : "Expand"}
-            onClick={(event) => event.stopPropagation()}
-            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle outline-none hover:text-fg focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <ChevronRightIcon className={cn("size-3 transition-transform", open && "rotate-90")} />
-          </button>
-        </Collapsible.Trigger>
-      ) : (
-        <span className="size-4 shrink-0" />
-      )}
-      <StatusDot tone={tone} pulse={live} className="size-1.5" />
-      <Link
-        to="/workspaces/$workspaceId/sessions/$sessionId"
-        params={{ workspaceId, sessionId: node.session.id }}
-        onClick={() => onNavigate?.()}
-        title={title}
-        className="min-w-0 flex-1 truncate outline-none hover:text-fg focus-visible:text-fg focus-visible:underline"
-      >
-        {title}
-      </Link>
-      {childCount > 0 ? (
-        <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{childCount}</span>
-      ) : null}
-    </div>
-  );
-
-  if (childCount === 0) {
-    return <li>{row}</li>;
-  }
-  return (
-    <li>
-      <Collapsible.Root open={open} onOpenChange={setOpen}>
-        {row}
-        <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-          <ul className="mt-px flex flex-col gap-px">
-            {node.children.map((child) => (
-              <SubagentRow key={child.session.id} node={child} workspaceId={workspaceId} depth={depth + 1} onNavigate={onNavigate} />
-            ))}
-          </ul>
-        </Collapsible.Content>
-      </Collapsible.Root>
-    </li>
-  );
-}
-
-/* --- header "N agents" chip (session header, shares the subagent panel) ----- */
-
-export function SessionAgentsChip({
-  workspaceId,
-  nodes,
-  loading = false,
-}: {
-  workspaceId: string;
-  /** Direct children; presentational — the header owns the single lineage read. */
-  nodes: LineageNode[];
-  loading?: boolean | undefined;
-}) {
-  const [open, setOpen] = useState(false);
-  const count = nodes.length;
-  if (count === 0) {
-    return null;
-  }
-  return (
-    <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-0.5 text-2xs font-medium text-fg-muted",
-            "outline-none transition-colors hover:border-border-strong hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:text-fg",
-          )}
-        >
-          <BotIcon className="size-3" />
-          {count} agent{count === 1 ? "" : "s"}
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          side="bottom"
-          align="end"
-          sideOffset={8}
-          collisionPadding={12}
-          className={cn(
-            "z-50 w-[min(24rem,calc(100vw-2rem))] rounded-xl border border-border bg-surface p-3 shadow-lg outline-none",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-          )}
-        >
-          <SubagentSection workspaceId={workspaceId} lineage={nodes} loading={loading} onNavigate={() => setOpen(false)} />
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}
-
-/* --- "spawned by" breadcrumb (child sessions link back to their parent) ----- */
-
-export function SpawnedByBreadcrumb({
-  workspaceId,
-  parent,
-}: {
-  workspaceId: string;
-  /** The direct parent (last ancestor), or null when this session has none. */
-  parent: SessionSummary | null;
-}): ReactNode {
-  if (!parent) {
-    return null;
-  }
-  const label = parent.title?.trim() || parent.initialMessage?.trim() || "manager session";
-  return (
-    <Link
-      to="/workspaces/$workspaceId/sessions/$sessionId"
-      params={{ workspaceId, sessionId: parent.id }}
-      title={`Spawned by ${label}`}
-      className="inline-flex min-w-0 items-center gap-1 text-2xs text-fg-subtle outline-none transition-colors hover:text-fg-muted focus-visible:text-fg-muted"
-    >
-      <ChevronRightIcon className="size-3 shrink-0 rotate-180" />
-      <span className="min-w-0 truncate">spawned by {label}</span>
-    </Link>
   );
 }

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -1,25 +1,37 @@
 // The subagent-lineage surface: everything that renders a session's spawned
 // workers. It is deliberately DECOUPLED from goals — a session's agent tree is
-// orthogonal to whether it carries a goal, so this lives in its own module and
-// backs three homes:
-//   - AgentsPanel     — the first-class "Agents" dock tab (the primary home)
-//   - SessionAgentsChip — the header "N agents" chip + popover
-//   - SubagentSection / SubagentRow — the shared tree the two reuse
-// plus SpawnedByBreadcrumb, the inverse link a child session shows back to the
-// manager that spawned it.
+// orthogonal to whether it carries a goal — and one compact tree component backs
+// two sibling homes:
+//   - SessionAgentsChip — the header "N agents" chip that EXPANDS into a floating
+//     panel, mirroring the goal pill's click-to-expand interaction + elevated
+//     visual family (the glanceable, quick-jump hero).
+//   - AgentsPanel — the persistent, roomy "Agents" right-dock tab (the deep view
+//     a manager watches while orchestrating many workers).
+// Both render {@link SubagentTree}: the compact form in the popover, the
+// full-height form in the dock. SpawnedByBreadcrumb is the inverse link a child
+// session shows back to the manager that spawned it.
+//
+// Design language: one dense line per agent — a single status-tone dot + a
+// truncated title + a quiet relative-time hint — the whole row a hover-lit
+// deep-link. Grandchildren thread off a hairline rail (one level, expandable),
+// never boxes. Calm at rest; the chevron affordance lifts on hover.
 //
 // Copy doctrine: human language only. Internal status slugs (requires_action,
-// active, …) are translated to plain labels at this boundary; no enum leaks
-// into a rendered string.
+// active, …) never leak into a rendered string.
+import { formatRelativeTime } from "@opengeni/react";
 import type { LineageNode, SessionStatus, SessionSummary } from "@opengeni/sdk";
 import { Link } from "@tanstack/react-router";
 import { BotIcon, ChevronRightIcon, Loader2Icon } from "lucide-react";
-import { Collapsible, Popover } from "radix-ui";
+import { Popover } from "radix-ui";
 import { useState, type ReactNode } from "react";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { cn } from "@/lib/utils";
+
+/** Children (depth 0) plus one level of grandchildren (depth 1) — the tree goes
+    exactly one level deeper, so a depth-1 row never draws its own expander. */
+const MAX_DEPTH = 1;
 
 /** Map a session lifecycle status onto the six-tone status language. */
 export function sessionStatusTone(status: SessionStatus): StatusTone {
@@ -39,42 +51,28 @@ export function sessionStatusTone(status: SessionStatus): StatusTone {
   }
 }
 
-/* --- subagent tree (shared by the dock panel and the header chip) ----------- */
+function isLiveStatus(status: SessionStatus): boolean {
+  return status === "running" || status === "queued" || status === "requires_action";
+}
 
-export function SubagentSection({
+/* --- the shared compact tree ------------------------------------------------ */
+
+/** The lineage tree, shared verbatim by the chip popover and the dock tab. */
+export function SubagentTree({
   workspaceId,
-  lineage,
-  loading,
+  nodes,
   onNavigate,
 }: {
   workspaceId: string;
-  lineage: LineageNode[];
-  loading: boolean;
+  nodes: LineageNode[];
   onNavigate?: (() => void) | undefined;
 }) {
-  const count = lineage.length;
   return (
-    <div className="min-w-0">
-      <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
-        <BotIcon className="size-3.5" />
-        Subagents
-        {count > 0 ? <span className="text-fg-subtle/80">· {count}</span> : null}
-      </div>
-      {loading ? (
-        <p className="mt-2 flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
-          <Loader2Icon className="size-3.5 animate-spin" />
-          Loading lineage
-        </p>
-      ) : count === 0 ? (
-        <p className="mt-2 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned</p>
-      ) : (
-        <ul className="mt-1.5 flex flex-col gap-px">
-          {lineage.map((node) => (
-            <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
-          ))}
-        </ul>
-      )}
-    </div>
+    <ul className="flex flex-col gap-px">
+      {nodes.map((node) => (
+        <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
+      ))}
+    </ul>
   );
 }
 
@@ -90,74 +88,84 @@ function SubagentRow({
   onNavigate?: (() => void) | undefined;
 }) {
   const [open, setOpen] = useState(false);
-  const childCount = node.children.length;
   const title = node.session.title?.trim() || node.session.initialMessage?.trim() || "Untitled session";
   const tone = sessionStatusTone(node.session.status);
-  const live = node.session.status === "running" || node.session.status === "queued" || node.session.status === "requires_action";
+  const live = isLiveStatus(node.session.status);
+  const rel = formatRelativeTime(node.session.updatedAt);
+  const canExpand = depth < MAX_DEPTH && node.children.length > 0;
 
-  const row = (
-    <div
-      className="group/agent flex h-8 items-center gap-2 rounded-md pl-1.5 pr-1 text-left text-xs text-fg-muted transition-colors hover:bg-surface-2"
-      style={depth > 0 ? { marginLeft: depth * 12 } : undefined}
-    >
-      {childCount > 0 ? (
-        <Collapsible.Trigger asChild>
+  return (
+    <li>
+      {/* The container owns the hover wash + focus ring so the WHOLE row lights
+          as one target; the Link inside covers dot→title→time (the nav hit
+          area), the chevron toggles without navigating. */}
+      <div className="group/row flex h-7 items-center gap-1.5 rounded-md pr-1.5 transition-colors hover:bg-surface-2 has-[a:focus-visible]:bg-surface-2">
+        {canExpand ? (
           <button
             type="button"
             aria-label={open ? "Collapse" : "Expand"}
-            onClick={(event) => event.stopPropagation()}
-            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle outline-none hover:text-fg focus-visible:ring-1 focus-visible:ring-ring"
+            onClick={() => setOpen((prev) => !prev)}
+            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
           >
             <ChevronRightIcon className={cn("size-3 transition-transform", open && "rotate-90")} />
           </button>
-        </Collapsible.Trigger>
-      ) : (
-        <span className="size-4 shrink-0" />
-      )}
-      <StatusDot tone={tone} pulse={live} className="size-1.5" />
-      <Link
-        to="/workspaces/$workspaceId/sessions/$sessionId"
-        params={{ workspaceId, sessionId: node.session.id }}
-        onClick={() => onNavigate?.()}
-        title={title}
-        className="min-w-0 flex-1 truncate outline-none hover:text-fg focus-visible:text-fg focus-visible:underline"
-      >
-        {title}
-      </Link>
-      {childCount > 0 ? (
-        <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{childCount}</span>
+        ) : (
+          <span className="size-4 shrink-0" aria-hidden />
+        )}
+        <Link
+          to="/workspaces/$workspaceId/sessions/$sessionId"
+          params={{ workspaceId, sessionId: node.session.id }}
+          onClick={() => onNavigate?.()}
+          title={title}
+          className="flex min-w-0 flex-1 items-center gap-2 text-xs text-fg-muted outline-none group-hover/row:text-fg"
+        >
+          <StatusDot tone={tone} pulse={live} className="size-1.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">{title}</span>
+          {rel ? <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{rel}</span> : null}
+        </Link>
+      </div>
+      {canExpand && open ? (
+        // Grandchildren thread off a hairline rail aligned under the parent's
+        // chevron column — a descending line, not a box.
+        <ul className="ml-2 mt-px flex flex-col gap-px border-l border-border/60 pl-2.5">
+          {node.children.map((child) => (
+            <SubagentRow key={child.session.id} node={child} workspaceId={workspaceId} depth={depth + 1} onNavigate={onNavigate} />
+          ))}
+        </ul>
       ) : null}
-    </div>
-  );
-
-  if (childCount === 0) {
-    return <li>{row}</li>;
-  }
-  return (
-    <li>
-      <Collapsible.Root open={open} onOpenChange={setOpen}>
-        {row}
-        <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-          <ul className="mt-px flex flex-col gap-px">
-            {node.children.map((child) => (
-              <SubagentRow key={child.session.id} node={child} workspaceId={workspaceId} depth={depth + 1} onNavigate={onNavigate} />
-            ))}
-          </ul>
-        </Collapsible.Content>
-      </Collapsible.Root>
     </li>
   );
 }
 
-/* --- the Agents dock tab (first-class, decoupled home for the lineage) ------- */
+/** The quiet section label both homes wear above the tree. */
+function SubagentsLabel({ count }: { count: number }) {
+  return (
+    <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
+      <BotIcon className="size-3.5" />
+      Subagents
+      {count > 0 ? <span className="text-fg-subtle/70">· {count}</span> : null}
+    </div>
+  );
+}
+
+function LineageLoading() {
+  return (
+    <p className="flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
+      <Loader2Icon className="size-3.5 animate-spin" />
+      Loading lineage
+    </p>
+  );
+}
+
+/* --- the Agents dock tab (persistent, full-height home) --------------------- */
 
 /**
- * The full-height lineage tree for the right dock's "Agents" tab — the primary,
- * goal-independent place to see and deep-link into the workers a session spawned.
- * Presentational: the dock owns the single {@link useSessionLineage} read (so the
- * tab count and this panel stay one source of truth) and feeds children in. The
- * tab is hidden when a session has no children, so the empty state here is a
- * belt-and-suspenders fallback that should not normally be reached.
+ * The full-height lineage tree for the right dock's "Agents" tab — the deep,
+ * goal-independent workspace for a manager actively orchestrating workers, live
+ * as agents spawn and change status. Presentational: the dock owns the single
+ * {@link useSessionLineage} read (so the tab count and this panel stay one
+ * source of truth) and feeds children in. The tab is hidden when a session has
+ * no children, so the empty state here is a belt-and-suspenders fallback.
  */
 export function AgentsPanel({
   workspaceId,
@@ -173,35 +181,25 @@ export function AgentsPanel({
   const count = nodes.length;
   return (
     <ScrollArea className="h-full min-w-0">
-      <div className="min-w-0 p-3">
-        <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
-          <BotIcon className="size-3.5" />
-          Agents spawned
-          {count > 0 ? <span className="text-fg-subtle/80">· {count}</span> : null}
-        </div>
-        <p className="mt-1 text-xs leading-5 text-fg-subtle">
-          Workers this session spawned. Open one to follow its own run.
-        </p>
+      <div className="min-w-0 p-2.5">
+        <SubagentsLabel count={count} />
         {loading && count === 0 ? (
-          <p className="mt-3 flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
-            <Loader2Icon className="size-3.5 animate-spin" />
-            Loading lineage
-          </p>
+          <div className="mt-2">
+            <LineageLoading />
+          </div>
         ) : count === 0 ? (
-          <p className="mt-3 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned yet.</p>
+          <p className="mt-2 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned yet.</p>
         ) : (
-          <ul className="mt-2.5 flex flex-col gap-px">
-            {nodes.map((node) => (
-              <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
-            ))}
-          </ul>
+          <div className="mt-2">
+            <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={onNavigate} />
+          </div>
         )}
       </div>
     </ScrollArea>
   );
 }
 
-/* --- header "N agents" chip (session header, shares the subagent panel) ----- */
+/* --- header "N agents" chip → expands into the goal-pill-family panel -------- */
 
 export function SessionAgentsChip({
   workspaceId,
@@ -225,7 +223,7 @@ export function SessionAgentsChip({
           type="button"
           className={cn(
             "inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-0.5 text-2xs font-medium text-fg-muted",
-            "outline-none transition-colors hover:border-border-strong hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:text-fg",
+            "outline-none transition-colors hover:border-border-strong hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:border-border-strong data-[state=open]:text-fg",
           )}
         >
           <BotIcon className="size-3" />
@@ -239,11 +237,27 @@ export function SessionAgentsChip({
           sideOffset={8}
           collisionPadding={12}
           className={cn(
-            "z-50 w-[min(24rem,calc(100vw-2rem))] rounded-xl border border-border bg-surface p-3 shadow-lg outline-none",
+            // Same elevated family as the goal-pill panel (rounded-xl / border /
+            // shadow-lg / surface), just opening DOWNWARD from the header; a tall
+            // lineage scrolls inside rather than overflowing the viewport.
+            "z-50 flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto overscroll-contain",
+            "rounded-xl border border-border bg-surface shadow-lg outline-none",
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[side=bottom]:slide-in-from-top-1",
           )}
         >
-          <SubagentSection workspaceId={workspaceId} lineage={nodes} loading={loading} onNavigate={() => setOpen(false)} />
+          <div className="p-2.5">
+            <SubagentsLabel count={count} />
+            {loading && count === 0 ? (
+              <div className="mt-2">
+                <LineageLoading />
+              </div>
+            ) : (
+              <div className="mt-2">
+                <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={() => setOpen(false)} />
+              </div>
+            )}
+          </div>
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -1,0 +1,278 @@
+// The subagent-lineage surface: everything that renders a session's spawned
+// workers. It is deliberately DECOUPLED from goals — a session's agent tree is
+// orthogonal to whether it carries a goal, so this lives in its own module and
+// backs three homes:
+//   - AgentsPanel     — the first-class "Agents" dock tab (the primary home)
+//   - SessionAgentsChip — the header "N agents" chip + popover
+//   - SubagentSection / SubagentRow — the shared tree the two reuse
+// plus SpawnedByBreadcrumb, the inverse link a child session shows back to the
+// manager that spawned it.
+//
+// Copy doctrine: human language only. Internal status slugs (requires_action,
+// active, …) are translated to plain labels at this boundary; no enum leaks
+// into a rendered string.
+import type { LineageNode, SessionStatus, SessionSummary } from "@opengeni/sdk";
+import { Link } from "@tanstack/react-router";
+import { BotIcon, ChevronRightIcon, Loader2Icon } from "lucide-react";
+import { Collapsible, Popover } from "radix-ui";
+import { useState, type ReactNode } from "react";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
+import { cn } from "@/lib/utils";
+
+/** Map a session lifecycle status onto the six-tone status language. */
+export function sessionStatusTone(status: SessionStatus): StatusTone {
+  switch (status) {
+    case "requires_action":
+      return "waiting";
+    case "running":
+      return "running";
+    case "queued":
+      return "queued";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "idle";
+  }
+}
+
+/* --- subagent tree (shared by the dock panel and the header chip) ----------- */
+
+export function SubagentSection({
+  workspaceId,
+  lineage,
+  loading,
+  onNavigate,
+}: {
+  workspaceId: string;
+  lineage: LineageNode[];
+  loading: boolean;
+  onNavigate?: (() => void) | undefined;
+}) {
+  const count = lineage.length;
+  return (
+    <div className="min-w-0">
+      <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
+        <BotIcon className="size-3.5" />
+        Subagents
+        {count > 0 ? <span className="text-fg-subtle/80">· {count}</span> : null}
+      </div>
+      {loading ? (
+        <p className="mt-2 flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
+          <Loader2Icon className="size-3.5 animate-spin" />
+          Loading lineage
+        </p>
+      ) : count === 0 ? (
+        <p className="mt-2 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned</p>
+      ) : (
+        <ul className="mt-1.5 flex flex-col gap-px">
+          {lineage.map((node) => (
+            <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SubagentRow({
+  node,
+  workspaceId,
+  depth,
+  onNavigate,
+}: {
+  node: LineageNode;
+  workspaceId: string;
+  depth: number;
+  onNavigate?: (() => void) | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  const childCount = node.children.length;
+  const title = node.session.title?.trim() || node.session.initialMessage?.trim() || "Untitled session";
+  const tone = sessionStatusTone(node.session.status);
+  const live = node.session.status === "running" || node.session.status === "queued" || node.session.status === "requires_action";
+
+  const row = (
+    <div
+      className="group/agent flex h-8 items-center gap-2 rounded-md pl-1.5 pr-1 text-left text-xs text-fg-muted transition-colors hover:bg-surface-2"
+      style={depth > 0 ? { marginLeft: depth * 12 } : undefined}
+    >
+      {childCount > 0 ? (
+        <Collapsible.Trigger asChild>
+          <button
+            type="button"
+            aria-label={open ? "Collapse" : "Expand"}
+            onClick={(event) => event.stopPropagation()}
+            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle outline-none hover:text-fg focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <ChevronRightIcon className={cn("size-3 transition-transform", open && "rotate-90")} />
+          </button>
+        </Collapsible.Trigger>
+      ) : (
+        <span className="size-4 shrink-0" />
+      )}
+      <StatusDot tone={tone} pulse={live} className="size-1.5" />
+      <Link
+        to="/workspaces/$workspaceId/sessions/$sessionId"
+        params={{ workspaceId, sessionId: node.session.id }}
+        onClick={() => onNavigate?.()}
+        title={title}
+        className="min-w-0 flex-1 truncate outline-none hover:text-fg focus-visible:text-fg focus-visible:underline"
+      >
+        {title}
+      </Link>
+      {childCount > 0 ? (
+        <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{childCount}</span>
+      ) : null}
+    </div>
+  );
+
+  if (childCount === 0) {
+    return <li>{row}</li>;
+  }
+  return (
+    <li>
+      <Collapsible.Root open={open} onOpenChange={setOpen}>
+        {row}
+        <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+          <ul className="mt-px flex flex-col gap-px">
+            {node.children.map((child) => (
+              <SubagentRow key={child.session.id} node={child} workspaceId={workspaceId} depth={depth + 1} onNavigate={onNavigate} />
+            ))}
+          </ul>
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </li>
+  );
+}
+
+/* --- the Agents dock tab (first-class, decoupled home for the lineage) ------- */
+
+/**
+ * The full-height lineage tree for the right dock's "Agents" tab — the primary,
+ * goal-independent place to see and deep-link into the workers a session spawned.
+ * Presentational: the dock owns the single {@link useSessionLineage} read (so the
+ * tab count and this panel stay one source of truth) and feeds children in. The
+ * tab is hidden when a session has no children, so the empty state here is a
+ * belt-and-suspenders fallback that should not normally be reached.
+ */
+export function AgentsPanel({
+  workspaceId,
+  nodes,
+  loading,
+  onNavigate,
+}: {
+  workspaceId: string;
+  nodes: LineageNode[];
+  loading: boolean;
+  onNavigate?: (() => void) | undefined;
+}) {
+  const count = nodes.length;
+  return (
+    <ScrollArea className="h-full min-w-0">
+      <div className="min-w-0 p-3">
+        <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
+          <BotIcon className="size-3.5" />
+          Agents spawned
+          {count > 0 ? <span className="text-fg-subtle/80">· {count}</span> : null}
+        </div>
+        <p className="mt-1 text-xs leading-5 text-fg-subtle">
+          Workers this session spawned. Open one to follow its own run.
+        </p>
+        {loading && count === 0 ? (
+          <p className="mt-3 flex items-center gap-2 px-0.5 py-1 text-xs text-fg-subtle">
+            <Loader2Icon className="size-3.5 animate-spin" />
+            Loading lineage
+          </p>
+        ) : count === 0 ? (
+          <p className="mt-3 px-0.5 py-1 text-xs text-fg-subtle">No agents spawned yet.</p>
+        ) : (
+          <ul className="mt-2.5 flex flex-col gap-px">
+            {nodes.map((node) => (
+              <SubagentRow key={node.session.id} node={node} workspaceId={workspaceId} depth={0} onNavigate={onNavigate} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+/* --- header "N agents" chip (session header, shares the subagent panel) ----- */
+
+export function SessionAgentsChip({
+  workspaceId,
+  nodes,
+  loading = false,
+}: {
+  workspaceId: string;
+  /** Direct children; presentational — the header owns the single lineage read. */
+  nodes: LineageNode[];
+  loading?: boolean | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  const count = nodes.length;
+  if (count === 0) {
+    return null;
+  }
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-0.5 text-2xs font-medium text-fg-muted",
+            "outline-none transition-colors hover:border-border-strong hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:text-fg",
+          )}
+        >
+          <BotIcon className="size-3" />
+          {count} agent{count === 1 ? "" : "s"}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          side="bottom"
+          align="end"
+          sideOffset={8}
+          collisionPadding={12}
+          className={cn(
+            "z-50 w-[min(24rem,calc(100vw-2rem))] rounded-xl border border-border bg-surface p-3 shadow-lg outline-none",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        >
+          <SubagentSection workspaceId={workspaceId} lineage={nodes} loading={loading} onNavigate={() => setOpen(false)} />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/* --- "spawned by" breadcrumb (child sessions link back to their parent) ----- */
+
+export function SpawnedByBreadcrumb({
+  workspaceId,
+  parent,
+}: {
+  workspaceId: string;
+  /** The direct parent (last ancestor), or null when this session has none. */
+  parent: SessionSummary | null;
+}): ReactNode {
+  if (!parent) {
+    return null;
+  }
+  const label = parent.title?.trim() || parent.initialMessage?.trim() || "manager session";
+  return (
+    <Link
+      to="/workspaces/$workspaceId/sessions/$sessionId"
+      params={{ workspaceId, sessionId: parent.id }}
+      title={`Spawned by ${label}`}
+      className="inline-flex min-w-0 items-center gap-1 text-2xs text-fg-subtle outline-none transition-colors hover:text-fg-muted focus-visible:text-fg-muted"
+    >
+      <ChevronRightIcon className="size-3 shrink-0 rotate-180" />
+      <span className="min-w-0 truncate">spawned by {label}</span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -26,7 +26,7 @@ import { Popover } from "radix-ui";
 import { useState, type ReactNode } from "react";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
+import { STATUS_META, StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { cn } from "@/lib/utils";
 
 /** Children (depth 0) plus one level of grandchildren (depth 1) — the tree goes
@@ -91,27 +91,41 @@ function SubagentRow({
   const title = node.session.title?.trim() || node.session.initialMessage?.trim() || "Untitled session";
   const tone = sessionStatusTone(node.session.status);
   const live = isLiveStatus(node.session.status);
-  const rel = formatRelativeTime(node.session.updatedAt);
   const canExpand = depth < MAX_DEPTH && node.children.length > 0;
+
+  // The trailing hint stays calm and compact for the common case (relative
+  // time), and turns loud ONLY for the two rows a manager must act on: a failed
+  // agent and one waiting on you spell the word out in their own status tone, so
+  // they don't hide behind a color dot in a long list.
+  const attentionWord =
+    node.session.status === "failed" ? "Failed" : node.session.status === "requires_action" ? "Needs you" : null;
+  const hint = attentionWord ?? formatRelativeTime(node.session.updatedAt);
+  const hintClass = attentionWord ? cn(STATUS_META[tone].text, "font-medium") : "text-fg-subtle";
 
   return (
     <li>
       {/* The container owns the hover wash + focus ring so the WHOLE row lights
-          as one target; the Link inside covers dot→title→time (the nav hit
+          as one target; the Link inside covers dot→title→hint (the nav hit
           area), the chevron toggles without navigating. */}
       <div className="group/row flex h-7 items-center gap-1.5 rounded-md pr-1.5 transition-colors hover:bg-surface-2 has-[a:focus-visible]:bg-surface-2">
-        {canExpand ? (
-          <button
-            type="button"
-            aria-label={open ? "Collapse" : "Expand"}
-            onClick={() => setOpen((prev) => !prev)}
-            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
-          >
-            <ChevronRightIcon className={cn("size-3 transition-transform", open && "rotate-90")} />
-          </button>
-        ) : (
-          <span className="size-4 shrink-0" aria-hidden />
-        )}
+        {/* Lead cluster: the expand chevron + child-count grouped as the "has N
+            children" affordance, at a fixed width so every dot column lines up
+            whether or not a row has children. */}
+        <span className="flex w-7 shrink-0 items-center gap-0.5">
+          {canExpand ? (
+            <>
+              <button
+                type="button"
+                aria-label={open ? "Collapse" : "Expand"}
+                onClick={() => setOpen((prev) => !prev)}
+                className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
+              >
+                <ChevronRightIcon className={cn("size-3 transition-transform", open && "rotate-90")} />
+              </button>
+              <span className="text-2xs leading-none tabular-nums text-fg-subtle/60">{node.children.length}</span>
+            </>
+          ) : null}
+        </span>
         <Link
           to="/workspaces/$workspaceId/sessions/$sessionId"
           params={{ workspaceId, sessionId: node.session.id }}
@@ -121,7 +135,7 @@ function SubagentRow({
         >
           <StatusDot tone={tone} pulse={live} className="size-1.5 shrink-0" />
           <span className="min-w-0 flex-1 truncate">{title}</span>
-          {rel ? <span className="shrink-0 text-2xs tabular-nums text-fg-subtle">{rel}</span> : null}
+          {hint ? <span className={cn("shrink-0 text-2xs tabular-nums", hintClass)}>{hint}</span> : null}
         </Link>
       </div>
       {canExpand && open ? (

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -218,12 +218,12 @@ export function AgentsPanel({
 export function SessionAgentsChip({
   workspaceId,
   nodes,
-  loading = false,
 }: {
   workspaceId: string;
-  /** Direct children; presentational — the header owns the single lineage read. */
+  /** Direct children; presentational — the header owns the single lineage read.
+   *  The chip only renders when there ARE children (count>0), so it has no
+   *  loading/empty state of its own. */
   nodes: LineageNode[];
-  loading?: boolean | undefined;
 }) {
   const [open, setOpen] = useState(false);
   const count = nodes.length;
@@ -262,15 +262,11 @@ export function SessionAgentsChip({
         >
           <div className="p-2.5">
             <SubagentsLabel count={count} />
-            {loading && count === 0 ? (
-              <div className="mt-2">
-                <LineageLoading />
-              </div>
-            ) : (
-              <div className="mt-2">
-                <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={() => setOpen(false)} />
-              </div>
-            )}
+            {/* count > 0 here (the chip/popover only renders with children), so
+                the tree always has rows — no loading/empty branch to guard. */}
+            <div className="mt-2">
+              <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={() => setOpen(false)} />
+            </div>
           </div>
         </Popover.Content>
       </Popover.Portal>

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -11,6 +11,7 @@ import {
   useGoal,
   useSession,
   useSessionEvents,
+  useSessionLineage,
   useTurnQueue,
   type AgentMessageItem,
   type AuthNeededItem,
@@ -41,6 +42,7 @@ import { GoalSurface } from "@/components/session/goal-surface";
 import { SessionInspector } from "@/components/session/inspector";
 import { QueueRail } from "@/components/session/queue-rail";
 import { useSandboxWorkspaceTabs } from "@/components/session/sandbox-workspace";
+import { AgentsPanel } from "@/components/session/subagents";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Notice } from "@/components/ui/notice";
@@ -359,6 +361,13 @@ function SessionDock(props: {
     filesActive: !props.dockCollapsed && activeTab === "files",
   });
 
+  // The decoupled home for spawned workers: one live lineage read (shared-feed
+  // via the dock's own event stream, no extra poll) gates the "Agents" tab and
+  // feeds its panel. The tab is present only once the session has children, so a
+  // goal-less session still surfaces its agents here.
+  const lineage = useSessionLineage(props.sessionId, { events: props.events });
+  const childNodes = lineage.lineage?.children ?? [];
+
   const tabs: WorkspaceTab[] = [
     {
       id: "run",
@@ -373,6 +382,26 @@ function SessionDock(props: {
         </ScrollArea>
       ),
     },
+    ...(childNodes.length > 0
+      ? [
+          {
+            id: "agents",
+            label: "Agents",
+            badge: (
+              <span className="rounded-sm bg-og-accent-soft px-1 text-2xs text-og-fg-muted">
+                {childNodes.length}
+              </span>
+            ),
+            content: (
+              <AgentsPanel
+                workspaceId={props.workspaceId}
+                nodes={childNodes}
+                loading={lineage.loading && childNodes.length === 0}
+              />
+            ),
+          } satisfies WorkspaceTab,
+        ]
+      : []),
     ...sandboxTabs,
     {
       id: "debug",
@@ -589,12 +618,7 @@ function SessionChatPane(props: {
       {/* The floating goal pill hovers just above the composer (hidden when the
           session has no goal). */}
       {!terminal ? (
-        <GoalSurface
-          session={props.session}
-          goal={props.goal}
-          events={props.events}
-          onNavigate={() => undefined}
-        />
+        <GoalSurface session={props.session} goal={props.goal} />
       ) : null}
 
       <div className="shrink-0 px-4 pb-4 pt-1 sm:px-6">


### PR DESCRIPTION
Reviewer feedback: the subagent view was only reachable via the goal panel — "the sub-agent view shouldn't be coupled to the goal stuff." It literally lived inside `goal-surface.tsx`. This gives subagents a first-class home, fully decoupled.

## What changed
- **New `apps/web/src/components/session/subagents.tsx`** owns all subagent-lineage UI (moved out of `goal-surface.tsx`): the header chip, the tree (`SubagentTree`/`SubagentRow`), `SpawnedByBreadcrumb`, and `sessionStatusTone`. The goal module no longer touches lineage.
- **Two sibling surfaces, one shared tree, neither goal-coupled:**
  1. **Header "N agents" chip → expands into a popover** mirroring the goal-pill's click-to-expand interaction and visual family — the glanceable, quick-jump primary.
  2. **"Agents · N" right-dock tab** (after Run) — persistent, roomy, live-updating (`useSessionLineage(sessionId, { events })`, shared-feed), shown only when the session has children.
- **Goal panel decoupled:** the Subagents section is removed from the GoalSurface expanded panel; it's goal-only now (call site simplified to `<GoalSurface session goal />`).

## Design (compact / clean bar)
Each agent is one dense line: status-tone dot (color = state, pulse = live) + truncated title + trailing hint; whole row is a hover-lit deep-link into that child session; chevron toggles without navigating. Grandchildren (one level, expandable) thread off a **hairline rail**, not boxes — same language as the de-boxed timeline. Trailing hint stays calm (relative time: now/12m/2h) for the common case, but **actionable states read loud**: `requires_action` → "Needs you" (attention tone), failed → "Failed" (red) — because surfacing "which agent needs me / failed" is the whole point. Parent child-count sits by the chevron; dot columns aligned. Theme-aware (light + dark).

## Verification
apps/web + packages/react typecheck clean; `bun test apps/web/src packages/react/test` → 641 pass, 0 fail; golden grammar untouched (no projection change). Screenshots (chip popover both themes, dock tab both themes, the actionable-states view, and the goal panel with no subagents) in the worktree `.agent/screenshots/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session UI refactor with no API or auth changes; lineage still comes from the same `useSessionLineage` hook with slightly different refresh behavior in the rail header (poll) vs the dock (events).
> 
> **Overview**
> Subagent lineage UI moves out of `goal-surface.tsx` into **`subagents.tsx`**, so spawned workers are no longer tied to opening the goal pill.
> 
> **`GoalSurface`** is goal-only: the expanded panel drops the subagents section and no longer takes `events` / `onNavigate` or calls `useSessionLineage`.
> 
> **Two first-class surfaces** share **`SubagentTree`**: the header **“N agents”** chip (popover, imports updated in `rail-shell`) and a new **Agents** right-dock tab (after Run) when the session has children, fed by `useSessionLineage` on the session event stream in `session.tsx`. The tree UI is refreshed—one-level expandable grandchildren on a hairline rail, relative-time hints, and explicit **“Needs you”** / **“Failed”** labels for actionable states.
> 
> **`SessionAgentsChip`** no longer accepts a `loading` prop (the chip only appears when children exist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9e6c6d364098201f9962029eeacb2c0a564b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->