### PR TITLE
fix(worker): re-dispatch a turn the dying attempt stamped `cancelled`

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -3,6 +3,7 @@ import {
   createTurn,
   applyCreditDebitUpToBalance,
   finishTurn,
+  cancelTurnFromDyingDispatch,
   getBillingBalance,
   getSandbox,
   readActiveSandbox,
@@ -753,6 +754,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let turnMetricOutcome: TurnOutcome | null = null;
     let activityError: unknown;
     let turnId: string | undefined;
+    // Worker-death redispatch counter observed when THIS dispatch claimed the
+    // turn. If a dying-attempt cancel later fences on this and the turn's
+    // current value differs, recovery already re-queued/re-dispatched the turn
+    // and the zombie must not clobber it.
+    let redispatchesAtDispatch = 0;
     let heartbeatTimer: ReturnType<typeof startActivityHeartbeat> | undefined;
     // P1.2 ownership inversion: when sandboxOwnershipEnabled, the turn resolves
     // the one box by id from the group lease and injects it NON-OWNED into the
@@ -1072,6 +1078,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         throw new Error(`Session turn not found for trigger: ${input.triggerEventId}`);
       }
       turnId = turn.id;
+      redispatchesAtDispatch = Number((turn.metadata as { workerDeathRedispatches?: number } | null)?.workerDeathRedispatches ?? 0);
       turnLifecycleMetricsFor(observability).start(turnId);
       // Canonical codex-billed predicate (codex/<slug> + feature enabled + active
       // workspace credential). Computed once and threaded through every billing
@@ -2485,16 +2492,26 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         activityError = error;
         await flushRuntimeBatcher();
         if (preemptTurnId) {
-          await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
-            turnId: preemptTurnId,
-            type: "turn.cancelled",
-            payload: {
-              triggerEventId: input.triggerEventId,
-              reason: error.message || "activity_cancelled",
-            },
-          }]).catch(() => undefined);
-          await finishTurn(db, input.workspaceId, preemptTurnId, "cancelled").catch(() => undefined);
-          turnMetricOutcome = "cancelled";
+          // FENCED settle: a heartbeat-timeout death lands here too (it is a
+          // CancelledFailure that is not WORKER_SHUTDOWN), and its zombie must
+          // NOT overwrite a turn worker-death recovery already re-queued or
+          // re-dispatched — that reintroduces the exact orphan stall this
+          // change fixes, in the reverse event order. cancelTurnFromDyingDispatch
+          // only settles a still-live turn whose redispatch counter is unchanged
+          // since this dispatch claimed it; a deliberate user interrupt (turn
+          // still running, counter unchanged) still settles as before.
+          const settled = await cancelTurnFromDyingDispatch(db, input.workspaceId, preemptTurnId, redispatchesAtDispatch).catch(() => false);
+          if (settled) {
+            await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [{
+              turnId: preemptTurnId,
+              type: "turn.cancelled",
+              payload: {
+                triggerEventId: input.triggerEventId,
+                reason: error.message || "activity_cancelled",
+              },
+            }]).catch(() => undefined);
+            turnMetricOutcome = "cancelled";
+          }
         }
         throw error;
       }

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -180,12 +180,18 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
       );
     } catch (requeueError) {
       // The zombie attempt can settle the turn between the status check above
-      // and this requeue (it keeps executing until it notices the timeout).
-      // A settled turn means its recorded outcome is the truth: report stale
-      // so the workflow continues instead of failing the session over a lost
-      // race. Anything else is a real persistence failure — rethrow.
+      // and this requeue (it keeps executing until it notices the timeout). If
+      // the turn is now GENUINELY settled (completed/failed/idle) or already
+      // re-queued by a concurrent actor, that outcome is the truth: report
+      // stale so the workflow continues. But if the turn is STILL in a
+      // requeue-able state — running/requires_action, or a death-artifact
+      // `cancelled` (which this path re-dispatches) — then the requeue hit a
+      // REAL persistence error, so rethrow to retry rather than silently drop
+      // the turn as stale (the exact idle-stall this change fixes).
       const current = await getSessionTurn(db, input.workspaceId, input.turnId);
-      if (current && current.status !== "running" && current.status !== "requires_action") {
+      const stillRequeueable = current
+        && (current.status === "running" || current.status === "requires_action" || current.status === "cancelled");
+      if (!stillRequeueable) {
         return { action: "stale" };
       }
       throw requeueError;

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -121,10 +121,20 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
   async function requeueTurnAfterWorkerDeath(input: RequeueTurnAfterWorkerDeathInput): Promise<RequeueTurnAfterWorkerDeathResult> {
     const { settings, db, bus, observability } = await services();
     const turn = await getSessionTurn(db, input.workspaceId, input.turnId);
-    if (!turn || (turn.status !== "running" && turn.status !== "requires_action")) {
-      // The timed-out attempt was a zombie that actually settled the turn
-      // (completed/failed/cancelled it) after the server gave up on its
-      // heartbeats. Whatever it recorded is the truth; nothing to redo.
+    // Reaching this activity PROVES the session workflow classified the turn's
+    // failure as a WORKER DEATH (heartbeat / schedule-to-start timeout): a
+    // deliberate user interrupt never gets here — it resolves the workflow's
+    // interrupt branch and runs interruptActiveTurn instead. So the only ways
+    // the turn is already terminal here are:
+    //   • completed / failed — the zombie genuinely finished (or errored) the
+    //     work after the server gave up on its heartbeats. That outcome is the
+    //     truth; nothing to redo.
+    //   • cancelled — the zombie's OWN CancelledFailure cleanup (agent-turn's
+    //     generic-cancel catch) marked it as it died. That IS the death, not a
+    //     real settle. Requeue it, or the turn — and any goal awaiting it — is
+    //     orphaned until a human intervenes (the 76e2f2ee/Vern 16h stall).
+    const deathArtifactCancel = turn?.status === "cancelled";
+    if (!turn || (turn.status !== "running" && turn.status !== "requires_action" && !deathArtifactCancel)) {
       return { action: "stale" };
     }
     const redispatches = await incrementTurnWorkerDeathRedispatches(db, input.workspaceId, input.turnId);
@@ -158,7 +168,16 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
       },
     ]);
     try {
-      await requeuePreemptedTurn(db, input.workspaceId, turn.id, resumeWithNotice && preemptedEvent ? preemptedEvent.id : input.triggerEventId);
+      // Worker-death redispatch may reset a turn the dying attempt already
+      // stamped `cancelled` (death artifact, see above), so the reset must
+      // match that status too — not only running/requires_action.
+      await requeuePreemptedTurn(
+        db,
+        input.workspaceId,
+        turn.id,
+        resumeWithNotice && preemptedEvent ? preemptedEvent.id : input.triggerEventId,
+        ["running", "requires_action", "cancelled"],
+      );
     } catch (requeueError) {
       // The zombie attempt can settle the turn between the status check above
       // and this requeue (it keeps executing until it notices the timeout).

--- a/apps/worker/src/workflows/activities.ts
+++ b/apps/worker/src/workflows/activities.ts
@@ -6,7 +6,14 @@ export const activity = proxyActivities<typeof activities>({
   // sessions). Dead workers are detected by the heartbeat, not this timeout,
   // so it is deliberately generous rather than a pacing bound.
   startToCloseTimeout: "30 days",
-  heartbeatTimeout: "30 seconds",
+  // 2 min (not 30s): the heartbeat timer fires every 10s but the Temporal SDK
+  // throttles forwarded heartbeats to ~80% of this timeout, and it shares the
+  // turn's event loop — a 30s timeout left only ~6s of slack, so a GC pause or
+  // synchronous work assembling a large-context model request tripped a FALSE
+  // worker-death (then a full redispatch, capped → could fail the session).
+  // A real dead worker is still detected within 2 min, immaterial for turns
+  // that legitimately run for days.
+  heartbeatTimeout: "2 minutes",
   retry: { maximumAttempts: 1 },
 });
 

--- a/apps/worker/test/session-state-worker-death.test.ts
+++ b/apps/worker/test/session-state-worker-death.test.ts
@@ -13,6 +13,7 @@ const fakeDb = {};
 const fakeBus = { publish: async () => undefined };
 
 let currentTurn: { id: string; status: string } | null = null;
+let requeueOverride: (() => void) | null = null;
 const appendedEvents: Array<{ type: string; turnId?: string | null; payload: any }> = [];
 const requeueCalls: Array<{ turnId: string; triggerEventId: string; fromStatuses?: string[] }> = [];
 const statuses: string[] = [];
@@ -30,6 +31,10 @@ mock.module("@opengeni/db", () => ({
   countTurnSessionHistoryItems: mock(async () => 0),
   countQueuedTurns: mock(async () => 0),
   requeuePreemptedTurn: mock(async (_db: unknown, _ws: string, turnId: string, triggerEventId: string, fromStatuses?: string[]) => {
+    if (requeueOverride) {
+      requeueOverride();
+      return;
+    }
     // Mirror the DB guard: the reset only matches a turn whose status is in
     // fromStatuses (defaults to the live-turn set). If a caller tries to
     // requeue a `cancelled` turn without opting it in, that is the bug.
@@ -92,6 +97,7 @@ describe("requeueTurnAfterWorkerDeath: death-artifact cancel", () => {
     requeueCalls.length = 0;
     statuses.length = 0;
     currentTurn = null;
+    requeueOverride = null;
   });
 
   test("re-dispatches a turn the dying attempt stamped `cancelled`", async () => {
@@ -145,5 +151,28 @@ describe("requeueTurnAfterWorkerDeath: death-artifact cancel", () => {
 
     expect(result).toEqual({ action: "stale" });
     expect(requeueCalls).toHaveLength(0);
+  });
+
+  test("rethrows (does NOT go stale) on a real persistence error while the turn is still cancelled", async () => {
+    // The turn stays `cancelled` (still re-dispatchable), and the reset fails
+    // for a real reason — this must retry, not silently drop the turn.
+    currentTurn = { id: "turn-1", status: "cancelled" };
+    requeueOverride = () => { throw new Error("db connection reset"); };
+
+    await expect(runRequeue()).rejects.toThrow("db connection reset");
+  });
+
+  test("reports stale when a racing actor genuinely settled the turn during requeue", async () => {
+    // Turn was re-dispatchable at the guard, but a racing zombie completed it
+    // before the reset landed → its recorded outcome is the truth.
+    currentTurn = { id: "turn-1", status: "cancelled" };
+    requeueOverride = () => {
+      currentTurn = { id: "turn-1", status: "completed" };
+      throw new Error("Preemptible session turn not found: turn-1");
+    };
+
+    const result = await runRequeue();
+
+    expect(result).toEqual({ action: "stale" });
   });
 });

--- a/apps/worker/test/session-state-worker-death.test.ts
+++ b/apps/worker/test/session-state-worker-death.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Regression: a worker that dies mid-turn (heartbeat timeout) can have its
+// dying attempt stamp the turn `cancelled` in the generic CancelledFailure
+// cleanup. requeueTurnAfterWorkerDeath must treat that `cancelled` as a DEATH
+// ARTIFACT and re-dispatch — not honor it as a deliberate settle and drop it
+// (the 76e2f2ee/Vern 16h stall). A genuinely settled `completed`/`failed`
+// turn still stays `stale`. A deliberate user interrupt never reaches this
+// activity (it takes the workflow's interrupt branch), so `cancelled` here is
+// unambiguously the death.
+
+const fakeDb = {};
+const fakeBus = { publish: async () => undefined };
+
+let currentTurn: { id: string; status: string } | null = null;
+const appendedEvents: Array<{ type: string; turnId?: string | null; payload: any }> = [];
+const requeueCalls: Array<{ turnId: string; triggerEventId: string; fromStatuses?: string[] }> = [];
+const statuses: string[] = [];
+
+const realDb = await import("@opengeni/db");
+const realEvents = await import("@opengeni/events");
+const realParentWake = await import("../src/activities/parent-wake");
+const realObservability = await import("../src/observability-metrics");
+
+mock.module("@opengeni/db", () => ({
+  ...realDb,
+  getSessionTurn: mock(async () => currentTurn),
+  incrementTurnWorkerDeathRedispatches: mock(async () => 1),
+  getSessionEvent: mock(async () => ({ id: "trigger-1", type: "goal.continuation", payload: {} })),
+  countTurnSessionHistoryItems: mock(async () => 0),
+  countQueuedTurns: mock(async () => 0),
+  requeuePreemptedTurn: mock(async (_db: unknown, _ws: string, turnId: string, triggerEventId: string, fromStatuses?: string[]) => {
+    // Mirror the DB guard: the reset only matches a turn whose status is in
+    // fromStatuses (defaults to the live-turn set). If a caller tries to
+    // requeue a `cancelled` turn without opting it in, that is the bug.
+    const allowed = fromStatuses ?? ["running", "requires_action"];
+    if (!currentTurn || !allowed.includes(currentTurn.status)) {
+      throw new Error(`Preemptible session turn not found: ${turnId}`);
+    }
+    requeueCalls.push({ turnId, triggerEventId, fromStatuses });
+    currentTurn = { ...currentTurn, status: "queued" };
+  }),
+  setSessionStatus: mock(async (_db: unknown, _ws: string, _sid: string, status: string) => {
+    statuses.push(status);
+  }),
+}));
+
+mock.module("@opengeni/events", () => ({
+  ...realEvents,
+  appendAndPublishEvents: mock(async (_db: unknown, _bus: any, _ws: string, _sid: string, events: any[]) => {
+    appendedEvents.push(...events);
+    return events.map((event, index) => ({ id: `event-${index + 1}`, sequence: index + 1, ...event }));
+  }),
+}));
+
+mock.module("../src/activities/parent-wake", () => ({
+  ...realParentWake,
+  notifyParentOfChildTerminal: mock(async () => undefined),
+}));
+
+mock.module("../src/observability-metrics", () => ({
+  ...realObservability,
+  recordTurnsQueuedGauge: mock(() => undefined),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+async function runRequeue() {
+  const { createSessionStateActivities } = await import("../src/activities/session-state");
+  const activities = createSessionStateActivities(async () => ({
+    db: fakeDb,
+    bus: fakeBus,
+    settings: { sessionHistorySource: "items", openaiReasoningEffort: "medium" },
+    observability: {},
+    wakeSessionWorkflow: mock(async () => undefined),
+  } as any));
+  return activities.requeueTurnAfterWorkerDeath({
+    accountId: "account-1",
+    workspaceId: "workspace-1",
+    sessionId: "session-1",
+    triggerEventId: "trigger-1",
+    workflowId: "workflow-1",
+    turnId: "turn-1",
+  } as any);
+}
+
+describe("requeueTurnAfterWorkerDeath: death-artifact cancel", () => {
+  beforeEach(() => {
+    appendedEvents.length = 0;
+    requeueCalls.length = 0;
+    statuses.length = 0;
+    currentTurn = null;
+  });
+
+  test("re-dispatches a turn the dying attempt stamped `cancelled`", async () => {
+    currentTurn = { id: "turn-1", status: "cancelled" };
+
+    const result = await runRequeue();
+
+    expect(result).toMatchObject({ action: "requeued" });
+    // It must opt `cancelled` into the requeue reset, else the DB guard drops it.
+    expect(requeueCalls).toHaveLength(1);
+    expect(requeueCalls[0].fromStatuses).toEqual(["running", "requires_action", "cancelled"]);
+    // Emits the worker-death preemption so the loop re-claims it.
+    const preempted = appendedEvents.find((event) => event.type === "turn.preempted");
+    expect(preempted?.payload).toMatchObject({ reason: "worker_death" });
+    expect(statuses).toContain("queued");
+  });
+
+  test("still re-dispatches a normal running turn (unchanged happy path)", async () => {
+    currentTurn = { id: "turn-1", status: "running" };
+
+    const result = await runRequeue();
+
+    expect(result).toMatchObject({ action: "requeued" });
+    expect(requeueCalls).toHaveLength(1);
+    expect(requeueCalls[0].fromStatuses).toEqual(["running", "requires_action", "cancelled"]);
+  });
+
+  test("leaves a genuinely COMPLETED turn as stale (respects the real outcome)", async () => {
+    currentTurn = { id: "turn-1", status: "completed" };
+
+    const result = await runRequeue();
+
+    expect(result).toEqual({ action: "stale" });
+    expect(requeueCalls).toHaveLength(0);
+    expect(appendedEvents).toHaveLength(0);
+  });
+
+  test("leaves a genuinely FAILED turn as stale", async () => {
+    currentTurn = { id: "turn-1", status: "failed" };
+
+    const result = await runRequeue();
+
+    expect(result).toEqual({ action: "stale" });
+    expect(requeueCalls).toHaveLength(0);
+  });
+
+  test("a missing turn is stale", async () => {
+    currentTurn = null;
+
+    const result = await runRequeue();
+
+    expect(result).toEqual({ action: "stale" });
+    expect(requeueCalls).toHaveLength(0);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9720,7 +9720,16 @@ export async function finishTurn(db: Database, workspaceId: string, turnId: stri
  * without a fresh claim, so the row still carries the approval-wait status
  * while the rerun activity executes.
  */
-export async function requeuePreemptedTurn(db: Database, workspaceId: string, turnId: string, triggerEventId: string): Promise<void> {
+export async function requeuePreemptedTurn(
+  db: Database,
+  workspaceId: string,
+  turnId: string,
+  triggerEventId: string,
+  // Prior statuses the reset is allowed to match. Defaults to the live-turn
+  // set; the worker-death redispatch also passes "cancelled" so it can reset a
+  // turn the dying attempt stamped `cancelled` in its CancelledFailure cleanup.
+  fromStatuses: string[] = ["running", "requires_action"],
+): Promise<void> {
   await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [row] = await scopedDb.update(schema.sessionTurns).set({
       status: "queued",
@@ -9728,7 +9737,7 @@ export async function requeuePreemptedTurn(db: Database, workspaceId: string, tu
       startedAt: null,
       finishedAt: null,
       updatedAt: new Date(),
-    }).where(and(eq(schema.sessionTurns.workspaceId, workspaceId), eq(schema.sessionTurns.id, turnId), inArray(schema.sessionTurns.status, ["running", "requires_action"]))).returning({ id: schema.sessionTurns.id });
+    }).where(and(eq(schema.sessionTurns.workspaceId, workspaceId), eq(schema.sessionTurns.id, turnId), inArray(schema.sessionTurns.status, fromStatuses))).returning({ id: schema.sessionTurns.id });
     if (!row) {
       throw new Error(`Preemptible session turn not found: ${turnId}`);
     }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9773,6 +9773,37 @@ export async function incrementTurnWorkerDeathRedispatches(db: Database, workspa
   });
 }
 
+/**
+ * Settle a turn `cancelled` from a DYING attempt (the generic CancelledFailure
+ * cleanup of a worker that lost its heartbeat), fenced so a zombie can never
+ * clobber a turn that worker-death recovery has already moved on. It only
+ * writes when BOTH hold:
+ *   • the turn is still live (running / requires_action) — not a turn recovery
+ *     already reset to `queued`; and
+ *   • the redispatch counter is unchanged since this dispatch started —
+ *     requeueTurnAfterWorkerDeath bumps it BEFORE re-queuing, so a mismatch
+ *     means a successor dispatch owns the turn now (do not touch it).
+ * Returns true when it actually settled (caller emits turn.cancelled only then).
+ */
+export async function cancelTurnFromDyingDispatch(
+  db: Database,
+  workspaceId: string,
+  turnId: string,
+  expectedRedispatches: number,
+): Promise<boolean> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.execute(sql`
+      update session_turns
+      set status = 'cancelled', finished_at = now(), updated_at = now()
+      where workspace_id = ${workspaceId} and id = ${turnId}
+        and status in ('running', 'requires_action')
+        and coalesce((metadata->>'workerDeathRedispatches')::int, 0) = ${expectedRedispatches}
+      returning id
+    `);
+    return rows.length > 0;
+  });
+}
+
 export async function getSessionTurn(db: Database, workspaceId: string, turnId: string): Promise<SessionTurn | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [row] = await scopedDb.select().from(schema.sessionTurns).where(and(eq(schema.sessionTurns.workspaceId, workspaceId), eq(schema.sessionTurns.id, turnId))).limit(1);

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -57,6 +57,8 @@ import {
   listScheduledTaskRuns,
   listScheduledTasks,
   getSessionTurn,
+  cancelTurnFromDyingDispatch,
+  incrementTurnWorkerDeathRedispatches,
   listSessionEvents,
   requeuePreemptedTurn,
   saveRunState,
@@ -423,6 +425,68 @@ describe("DB integration", () => {
     // Terminal turns cannot be preempt-requeued.
     await finishTurn(dbClient.db, grant.workspaceId, turn.id, "idle");
     await expect(requeuePreemptedTurn(dbClient.db, grant.workspaceId, turn.id, resumeTrigger!.id)).rejects.toThrow("Preemptible session turn not found");
+  });
+
+  test("dying-attempt cancel is fenced against worker-death recovery", async () => {
+    const grant = await testGrant(dbClient.db);
+    const session = await createSession(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "long task",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const [trigger] = await appendSessionEvents(dbClient.db, grant.workspaceId, session.id, [
+      { type: "user.message", payload: { text: "long task" } },
+    ]);
+    const enqueue = () => enqueueSessionTurn(dbClient.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      triggerEventId: trigger!.id,
+      temporalWorkflowId: "wf-fence-db",
+      source: "user",
+      prompt: "long task",
+      resources: [],
+      tools: [],
+      model: "scripted-model",
+      reasoningEffort: "low",
+      sandboxBackend: "none",
+      metadata: {},
+    });
+
+    // Ordering A — zombie cancels a live turn BEFORE recovery runs: the fence
+    // (counter unchanged since this dispatch claimed) lets it settle.
+    const turnA = await enqueue();
+    await claimNextQueuedTurn(dbClient.db, grant.workspaceId, session.id, "wf-fence-db");
+    expect(await cancelTurnFromDyingDispatch(dbClient.db, grant.workspaceId, turnA.id, 0)).toBe(true);
+    expect((await getSessionTurn(dbClient.db, grant.workspaceId, turnA.id))?.status).toBe("cancelled");
+    // requeuing that death-artifact cancel (the recovery side) resurrects it.
+    await requeuePreemptedTurn(dbClient.db, grant.workspaceId, turnA.id, trigger!.id, ["running", "requires_action", "cancelled"]);
+    expect((await getSessionTurn(dbClient.db, grant.workspaceId, turnA.id))?.status).toBe("queued");
+    // Retire turnA so it does not shadow turnB in the per-session claim queue.
+    await finishTurn(dbClient.db, grant.workspaceId, turnA.id, "idle");
+
+    // Orderings B & C — recovery has ALREADY advanced (counter bumped, then the
+    // turn is either queued or re-claimed to running): a stale zombie that
+    // captured the pre-death counter must NOT clobber it.
+    const turnB = await enqueue();
+    await claimNextQueuedTurn(dbClient.db, grant.workspaceId, session.id, "wf-fence-db");
+    const bumped = await incrementTurnWorkerDeathRedispatches(dbClient.db, grant.workspaceId, turnB.id); // recovery bumps BEFORE requeue
+    expect(bumped).toBe(1);
+    await requeuePreemptedTurn(dbClient.db, grant.workspaceId, turnB.id, trigger!.id, ["running", "requires_action", "cancelled"]);
+    // (B) turn is `queued`; stale zombie captured 0.
+    expect(await cancelTurnFromDyingDispatch(dbClient.db, grant.workspaceId, turnB.id, 0)).toBe(false);
+    expect((await getSessionTurn(dbClient.db, grant.workspaceId, turnB.id))?.status).toBe("queued");
+    // (C) a successor re-claims -> running again, but the counter is still 1.
+    await claimNextQueuedTurn(dbClient.db, grant.workspaceId, session.id, "wf-fence-db-2");
+    expect(await cancelTurnFromDyingDispatch(dbClient.db, grant.workspaceId, turnB.id, 0)).toBe(false);
+    expect((await getSessionTurn(dbClient.db, grant.workspaceId, turnB.id))?.status).toBe("running");
+    // The successor's OWN dispatch (captured counter 1) can still settle its turn.
+    expect(await cancelTurnFromDyingDispatch(dbClient.db, grant.workspaceId, turnB.id, 1)).toBe(true);
+    expect((await getSessionTurn(dbClient.db, grant.workspaceId, turnB.id))?.status).toBe("cancelled");
   });
 
   test("persists scheduled tasks and run history", async () => {


### PR DESCRIPTION
## Problem
A worker that dies mid-turn (activity **heartbeat timeout**) can have its zombie attempt mark the turn `cancelled` in the generic `CancelledFailure` cleanup. `requeueTurnAfterWorkerDeath` then saw a terminal turn and returned `{action:"stale"}` — **dropping it**. If a goal was `paused` awaiting that worker, the session went idle and **stalled indefinitely** until a human hit "continue".

Real incident: geni/Vern manager session `76e2f2ee`, ~16h stall on 2026-07-07→08. Durable proof: Temporal run `117068a9` history shows `ACTIVITY_TASK_TIMED_OUT{HEARTBEAT}` → `requeueTurnAfterWorkerDeath` → `{action:"stale"}` → `markSessionIdle`.

## Why the fix is safe
Reaching `requeueTurnAfterWorkerDeath` **proves** the workflow classified the failure as a worker death (heartbeat / schedule-to-start timeout). A deliberate user interrupt resolves the workflow's *interrupt* branch and runs `interruptActiveTurn` — it never reaches here. So a `cancelled` turn at this point is unambiguously the zombie's **death artifact**, not a real settle → re-dispatch it. A genuinely settled `completed`/`failed` turn still stays `stale`. Bounded by the existing `WORKER_DEATH_MAX_REDISPATCHES` cap (deterministic re-death → `failSession`, a loud escalation, not a silent stall).

## Changes
- **session-state** `requeueTurnAfterWorkerDeath`: treat a death-artifact `cancelled` turn as re-dispatchable.
- **db** `requeuePreemptedTurn`: optional `fromStatuses` so the reset can match a `cancelled` row (default unchanged for every existing caller).
- **activities** `heartbeatTimeout` **30s → 2min**: the 10s heartbeat timer shares the turn's event loop and the SDK throttles forwarded heartbeats to ~80% of timeout, so 30s left only ~6s slack — a GC pause / large-context request assembly tripped **false** worker-deaths. A real dead worker is still caught within 2 min (immaterial for turns that run for days).

## Tests
`session-state-worker-death.test.ts`: re-dispatches a `cancelled` turn (with cancelled-inclusive `fromStatuses` + `turn.preempted{worker_death}`), keeps `completed`/`failed`/missing as `stale`. Typecheck + adjacent worker unit suites green.

## Follow-ups (not in this PR)
- Un-starvable heartbeat (emit off the work event loop) + context-size discipline (root of the false-death).
- Paused-goal reconciler (weaker second net; this race fix already covers the incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4tzoxgyduFnVme3sAtceZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn lifecycle, worker-death recovery, and Temporal heartbeat semantics; incorrect fencing could still orphan turns or clobber re-queued work, though behavior is bounded and covered by new tests.
> 
> **Overview**
> Fixes **indefinite session stalls** when a worker dies mid-turn: the zombie’s `CancelledFailure` cleanup could mark the turn `cancelled`, and worker-death recovery then treated that as a real terminal outcome (`stale`) instead of re-queuing.
> 
> **Worker-death recovery** (`requeueTurnAfterWorkerDeath`) now treats `cancelled` as a death artifact (only on this path—user interrupts never reach it), requeues via `requeuePreemptedTurn` with `fromStatuses` including `cancelled`, and **rethrows** on persistence errors while the turn is still requeueable instead of silently going stale.
> 
> **Zombie vs recovery races**: `cancelTurnFromDyingDispatch` fences dying-attempt cancels on unchanged `workerDeathRedispatches` and live turn status; `runAgentTurn` records the counter at dispatch and uses this instead of unconditionally `finishTurn` on generic `CancelledFailure`.
> 
> **False worker deaths**: agent activity `heartbeatTimeout` is **30s → 2 minutes** to absorb GC / large-context assembly on the shared event loop.
> 
> Regression tests cover death-artifact requeue and DB fencing orderings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db3a2a05d67beaf3ada18d345e20e92ab399c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->