### PR TITLE
feat(memory): first-class memory writes in the timeline + optional deep-link

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -146,6 +146,11 @@ const workspaceSchedulesRoute = createRoute({
 const workspaceDocumentsRoute = createRoute({
   getParentRoute: () => workspaceRoute,
   path: "documents",
+  // `?memory=<id>` deep-links a memory record (from a timeline memory step): the
+  // Documents page reveals + highlights that memory even when the filters would
+  // otherwise hide it. Unknown values are ignored.
+  validateSearch: (search: Record<string, unknown>): { memory?: string } =>
+    typeof search.memory === "string" ? { memory: search.memory } : {},
   component: Documents,
 });
 const workspaceSettingsRoute = createRoute({
@@ -272,7 +277,8 @@ function Schedules() {
 
 function Documents() {
   const { workspaceId } = workspaceDocumentsRoute.useParams();
-  return <DocumentsRoute workspaceId={workspaceId} />;
+  const { memory } = workspaceDocumentsRoute.useSearch();
+  return <DocumentsRoute workspaceId={workspaceId} focusMemoryId={memory} />;
 }
 
 function WorkspaceSettings() {

--- a/apps/web/src/components/knowledge/memory-pane.tsx
+++ b/apps/web/src/components/knowledge/memory-pane.tsx
@@ -296,6 +296,31 @@ export function MemoryPane({
     }
   }
 
+  const renderMemoryCard = (memory: KnowledgeMemory) => (
+    <MemoryCard
+      key={memory.id}
+      workspaceId={workspaceId}
+      memory={memory}
+      highlighted={focusedId === memory.id}
+      innerRef={(el) => {
+        const map = cardRefs.current;
+        if (el) map.set(memory.id, el);
+        else map.delete(memory.id);
+      }}
+      busy={busyIds.has(memory.id)}
+      editing={editingId === memory.id}
+      editText={editText}
+      onEditTextChange={setEditText}
+      onStartEdit={() => { setEditingId(memory.id); setEditText(memory.text); }}
+      onCancelEdit={() => setEditingId(null)}
+      onSaveEdit={() => void saveEdit(memory)}
+      onTogglePin={() => void runUpdate(memory, { pinned: !memory.pinned }, memory.pinned ? "Unpinned" : "Pinned", false)}
+      onArchive={() => void runUpdate(memory, { status: "archived" }, "Memory archived", true)}
+      onApprove={() => void runUpdate(memory, { status: "approved" }, "Memory approved", true)}
+      onReject={() => void runUpdate(memory, { status: "rejected" }, "Memory rejected", true)}
+    />
+  );
+
   return (
     <div className="mt-6 border-t border-[color:var(--color-border)] pt-4">
       <div className="flex items-center justify-between gap-2">
@@ -446,45 +471,30 @@ export function MemoryPane({
                 <Loader2Icon className="size-3.5 animate-spin" />
                 Loading memory
               </div>
-            ) : error ? (
-              <Notice
-                tone="failed"
-                title="Couldn't load memory"
-                action={<Button type="button" variant="ghost" size="xs" onClick={() => void refresh()}>Retry</Button>}
-              >
-                {error.message}
-              </Notice>
-            ) : memories.length > 0 ? (
-              memories.map((memory) => (
-                <MemoryCard
-                  key={memory.id}
-                  workspaceId={workspaceId}
-                  memory={memory}
-                  highlighted={focusedId === memory.id}
-                  innerRef={(el) => {
-                    const map = cardRefs.current;
-                    if (el) map.set(memory.id, el);
-                    else map.delete(memory.id);
-                  }}
-                  busy={busyIds.has(memory.id)}
-                  editing={editingId === memory.id}
-                  editText={editText}
-                  onEditTextChange={setEditText}
-                  onStartEdit={() => { setEditingId(memory.id); setEditText(memory.text); }}
-                  onCancelEdit={() => setEditingId(null)}
-                  onSaveEdit={() => void saveEdit(memory)}
-                  onTogglePin={() => void runUpdate(memory, { pinned: !memory.pinned }, memory.pinned ? "Unpinned" : "Pinned", false)}
-                  onArchive={() => void runUpdate(memory, { status: "archived" }, "Memory archived", true)}
-                  onApprove={() => void runUpdate(memory, { status: "approved" }, "Memory approved", true)}
-                  onReject={() => void runUpdate(memory, { status: "rejected" }, "Memory rejected", true)}
-                />
-              ))
             ) : (
-              <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-4 text-xs leading-5 text-[color:var(--color-fg-muted)]">
-                {statusFilter === "active"
-                  ? "No memory yet. Agents add facts as they work, or seed one with the + above."
-                  : `No ${STATUS_LABEL[statusFilter].toLowerCase()} memory${kindFilter ? ` of this kind` : ""}.`}
-              </div>
+              <>
+                {/* A list error is a banner, not a takeover: cards below still
+                    render — so a deep-linked record (injected even when the
+                    browse list fails) still mounts, scrolls, and highlights. */}
+                {error ? (
+                  <Notice
+                    tone="failed"
+                    title="Couldn't load memory"
+                    action={<Button type="button" variant="ghost" size="xs" onClick={() => void refresh()}>Retry</Button>}
+                  >
+                    {error.message}
+                  </Notice>
+                ) : null}
+                {memories.length > 0 ? (
+                  memories.map(renderMemoryCard)
+                ) : error ? null : (
+                  <div className="rounded-lg border border-dashed border-[color:var(--color-border)] p-4 text-xs leading-5 text-[color:var(--color-fg-muted)]">
+                    {statusFilter === "active"
+                      ? "No memory yet. Agents add facts as they work, or seed one with the + above."
+                      : `No ${STATUS_LABEL[statusFilter].toLowerCase()} memory${kindFilter ? ` of this kind` : ""}.`}
+                  </div>
+                )}
+              </>
             )}
           </div>
         </>

--- a/apps/web/src/components/knowledge/memory-pane.tsx
+++ b/apps/web/src/components/knowledge/memory-pane.tsx
@@ -20,7 +20,7 @@ import {
   SearchIcon,
   XCircleIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -72,7 +72,16 @@ function sortMemories(memories: KnowledgeMemory[]): KnowledgeMemory[] {
   });
 }
 
-export function MemoryPane({ workspaceId, memoryEnabled }: { workspaceId: string; memoryEnabled: boolean }) {
+export function MemoryPane({
+  workspaceId,
+  memoryEnabled,
+  focusMemoryId,
+}: {
+  workspaceId: string;
+  memoryEnabled: boolean;
+  /** A memory record to reveal + highlight, deep-linked from a timeline memory step (`?memory=<id>`). */
+  focusMemoryId?: string | undefined;
+}) {
   const client = useAppContext().client;
 
   const [memories, setMemories] = useState<KnowledgeMemory[]>([]);
@@ -80,6 +89,15 @@ export function MemoryPane({ workspaceId, memoryEnabled }: { workspaceId: string
   const [error, setError] = useState<Error | null>(null);
   const [statusFilter, setStatusFilter] = useState<KnowledgeMemoryStatus>("active");
   const [kindFilter, setKindFilter] = useState<KnowledgeMemoryKind | "">("");
+
+  // Deep-link focus (from `?memory=<id>`): reveal the record even when the
+  // filters would hide it, scroll it into view, and ring it briefly. `pending`
+  // is the id awaiting reveal; `focusedId` drives the transient highlight;
+  // `fallback` is the fetched record we inject if it lands outside the list.
+  const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [focusFallback, setFocusFallback] = useState<KnowledgeMemory | null>(null);
+  const cardRefs = useRef(new Map<string, HTMLDivElement>());
 
   const [query, setQuery] = useState("");
   const [searching, setSearching] = useState(false);
@@ -103,6 +121,58 @@ export function MemoryPane({ workspaceId, memoryEnabled }: { workspaceId: string
     setEditingId(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, statusFilter, kindFilter]);
+
+  // A deep-link arrived: leave any search, fetch the record to learn its
+  // status/kind, and align the browse filters so it comes into view. Filter
+  // changes ride the effect above (which refetches the list).
+  useEffect(() => {
+    if (!focusMemoryId) return;
+    let cancelled = false;
+    setSearchResults(null);
+    setPendingFocusId(focusMemoryId);
+    void (async () => {
+      try {
+        const record = await client.getKnowledgeMemory(workspaceId, focusMemoryId);
+        if (cancelled) return;
+        setFocusFallback(record);
+        setKindFilter((current) => (current && current !== record.kind ? "" : current));
+        setStatusFilter((current) => (current !== record.status ? record.status : current));
+      } catch {
+        // Not found / no access — drop the pending focus so nothing dead-highlights.
+        if (!cancelled) setPendingFocusId(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusMemoryId, workspaceId]);
+
+  // Once the list has settled, scroll the focused card into view and ring it. If
+  // the record fell outside the (filtered, capped) list, inject the fetched copy
+  // so the deep-link never dead-ends, then this effect re-runs and reveals it.
+  useEffect(() => {
+    if (!pendingFocusId || loading || searchResults !== null) return;
+    const node = cardRefs.current.get(pendingFocusId);
+    if (node) {
+      node.scrollIntoView({ behavior: "smooth", block: "center" });
+      setFocusedId(pendingFocusId);
+      setPendingFocusId(null);
+      return;
+    }
+    if (focusFallback && focusFallback.id === pendingFocusId) {
+      setMemories((current) =>
+        current.some((item) => item.id === pendingFocusId) ? current : sortMemories([focusFallback, ...current]),
+      );
+    }
+  }, [pendingFocusId, loading, memories, searchResults, focusFallback]);
+
+  // The highlight ring is transient — fade it after ~2s.
+  useEffect(() => {
+    if (!focusedId) return;
+    const timer = setTimeout(() => setFocusedId(null), 2000);
+    return () => clearTimeout(timer);
+  }, [focusedId]);
 
   async function refresh() {
     setLoading(true);
@@ -381,6 +451,12 @@ export function MemoryPane({ workspaceId, memoryEnabled }: { workspaceId: string
                   key={memory.id}
                   workspaceId={workspaceId}
                   memory={memory}
+                  highlighted={focusedId === memory.id}
+                  innerRef={(el) => {
+                    const map = cardRefs.current;
+                    if (el) map.set(memory.id, el);
+                    else map.delete(memory.id);
+                  }}
                   busy={busyIds.has(memory.id)}
                   editing={editingId === memory.id}
                   editText={editText}
@@ -412,6 +488,10 @@ function MemoryCard(props: {
   workspaceId: string;
   memory: KnowledgeMemory;
   score?: number;
+  /** Ring the card briefly — set while it is the deep-link's focused record. */
+  highlighted?: boolean;
+  /** Registers the card node so the pane can scroll it into view on a deep-link. */
+  innerRef?: (el: HTMLDivElement | null) => void;
   busy: boolean;
   editing: boolean;
   editText: string;
@@ -429,7 +509,15 @@ function MemoryCard(props: {
   const canArchive = memory.status === "active" || memory.status === "approved" || memory.status === "proposed";
 
   return (
-    <div className={cn("rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3", faded && "opacity-70")}>
+    <div
+      ref={props.innerRef}
+      className={cn(
+        "scroll-mt-4 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)]/35 p-3 transition-shadow duration-300",
+        faded && "opacity-70",
+        props.highlighted &&
+          "ring-2 ring-[color:var(--color-brand)] ring-offset-2 ring-offset-[color:var(--color-bg)]",
+      )}
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           {memory.pinned ? <PinIcon className="size-3 shrink-0 text-[color:var(--color-brand)]" /> : null}

--- a/apps/web/src/components/knowledge/memory-pane.tsx
+++ b/apps/web/src/components/knowledge/memory-pane.tsx
@@ -126,10 +126,17 @@ export function MemoryPane({
   // status/kind, and align the browse filters so it comes into view. Filter
   // changes ride the effect above (which refetches the list).
   useEffect(() => {
-    if (!focusMemoryId) return;
+    if (!focusMemoryId) {
+      // The deep-link was cleared (or we switched workspace): drop any pending
+      // focus so a stale id can't highlight or inject into the new list.
+      setPendingFocusId(null);
+      setFocusFallback(null);
+      return;
+    }
     let cancelled = false;
     setSearchResults(null);
     setPendingFocusId(focusMemoryId);
+    setFocusFallback(null);
     void (async () => {
       try {
         const record = await client.getKnowledgeMemory(workspaceId, focusMemoryId);
@@ -160,12 +167,14 @@ export function MemoryPane({
       setPendingFocusId(null);
       return;
     }
-    if (focusFallback && focusFallback.id === pendingFocusId) {
+    // Inject the fetched copy only when it belongs to THIS workspace — guard
+    // against a fallback fetched for a workspace we've since navigated away from.
+    if (focusFallback && focusFallback.id === pendingFocusId && focusFallback.workspaceId === workspaceId) {
       setMemories((current) =>
         current.some((item) => item.id === pendingFocusId) ? current : sortMemories([focusFallback, ...current]),
       );
     }
-  }, [pendingFocusId, loading, memories, searchResults, focusFallback]);
+  }, [pendingFocusId, loading, memories, searchResults, focusFallback, workspaceId]);
 
   // The highlight ring is transient — fade it after ~2s.
   useEffect(() => {

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -18,7 +18,7 @@ import type { DocumentBase, DocumentSearchMode, DocumentSearchResult, IndexedDoc
 
 const sourceKindOptions: KnowledgeSourceKind[] = ["manual_upload", "meeting_transcript", "repository", "email", "chat", "document", "web", "other"];
 
-export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
+export function DocumentsRoute({ workspaceId, focusMemoryId }: { workspaceId: string; focusMemoryId?: string | undefined }) {
   const context = useAppContext();
   const client = context.client;
   const fileUploadsEnabled = context.clientConfig.fileUploads.enabled === true;
@@ -544,7 +544,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
               )}
             </div>
 
-            <MemoryPane workspaceId={workspaceId} memoryEnabled={memoryEnabled} />
+            <MemoryPane workspaceId={workspaceId} memoryEnabled={memoryEnabled} focusMemoryId={focusMemoryId} />
           </aside>
         </div>
       </section>

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -295,6 +295,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       onLoadOlder={loadOlder}
       onClearView={clearView}
       onOpenSession={(nextSessionId) => void navigate({ to: "/workspaces/$workspaceId/sessions/$sessionId", params: { workspaceId, sessionId: nextSessionId } })}
+      onMemoryClick={(memoryId) => void navigate({ to: "/workspaces/$workspaceId/documents", params: { workspaceId }, search: { memory: memoryId } })}
       onNewSession={() => void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } })}
       onApprove={(approvalId) => approve(approvalId, "approve")}
       onReject={(approvalId) => approve(approvalId, "reject")}
@@ -410,6 +411,8 @@ function SessionChatPane(props: {
   /** Reset the local timeline view (the /clear-view command target). */
   onClearView: () => void;
   onOpenSession: (sessionId: string) => void;
+  /** Deep-link a timeline memory step to its record in the Documents memory pane. */
+  onMemoryClick: (memoryId: string) => void;
   onNewSession: () => void;
   onApprove: (approvalId: string) => Promise<void>;
   onReject: (approvalId: string) => Promise<void>;
@@ -529,6 +532,7 @@ function SessionChatPane(props: {
               status={props.session.status}
               renderMessageText={renderMessageText}
               onOpenSession={props.onOpenSession}
+              onMemoryClick={props.onMemoryClick}
               onReconnect={props.onReconnect}
               resolveProviderLogo={props.resolveProviderLogo}
               hasOlder={props.hasOlder}

--- a/packages/react/demo/timeline-fixtures.ts
+++ b/packages/react/demo/timeline-fixtures.ts
@@ -631,6 +631,68 @@ export function completedTurnEvents(): SessionEvent[] {
 }
 
 /**
+ * A settled turn in which the agent writes to workspace memory: it saves two new
+ * memories and corrects two existing ones (one superseded with a replacement, one
+ * updated in place). Folds to a chip whose summary carries the memory facets
+ * ("… · 2 memories saved · 2 memories updated"); expanded, each write is a calm
+ * neutral memory row (a supersede shows old → new; an in-place update shows the
+ * live text). `memory.saved` / `memory.corrected` payloads mirror the shapes the
+ * MCP server emits (apps/api/src/mcp/server.ts).
+ */
+export function memoryTurnEvents(): SessionEvent[] {
+  const log = new EventLog();
+  const turn = "turn-memory";
+  log.push("user.message", { text: "Note our deploy conventions for next time, and fix that stale database note — I checked and it's wrong now." });
+  log.push(
+    "agent.reasoning.delta",
+    { text: "I'll record the standing conventions as workspace memory, then correct the two facts that have drifted so future sessions don't repeat them." },
+    turn,
+  );
+  log.tool(
+    {
+      name: "exec_command",
+      id: "mem-0",
+      arguments: { cmd: "cat infra/README.md", workdir: "/workspace" },
+      output: "Chunk ID: 909\nWall time: 0.3\nProcess exited with code 0\nOutput:\nDeploys: staging from main only, via opengeni-ops.\n",
+    },
+    turn,
+  );
+  log.push("memory.saved", {
+    memoryId: "aa11bb22-0000-4000-8000-000000000001",
+    kind: "preference",
+    preview: "Prefer Terraform over Pulumi for all new infrastructure in this workspace.",
+    deduped: false,
+  }, turn);
+  log.push("memory.saved", {
+    memoryId: "aa11bb22-0000-4000-8000-000000000002",
+    kind: "semantic",
+    preview: "Staging deploys run from the main branch only, via the opengeni-ops workflow.",
+    deduped: false,
+  }, turn);
+  log.push("memory.corrected", {
+    memoryId: "aa11bb22-0000-4000-8000-000000000003",
+    kind: "semantic",
+    preview: "The staging database is walrus-primary and lives in the neu region.",
+    action: "superseded",
+    reason: "Verified in-session: the instance was migrated and renamed.",
+    replacementMemoryId: "aa11bb22-0000-4000-8000-000000000004",
+    replacementPreview: "The staging database is walrus-2 (Postgres 16) in the neu region; walrus-primary was retired.",
+  }, turn);
+  log.push("memory.corrected", {
+    memoryId: "aa11bb22-0000-4000-8000-000000000005",
+    kind: "procedural",
+    preview: "Run database migrations with `make db-migrate` before every deploy.",
+    action: "updated",
+    reason: "The command moved under the ops wrapper.",
+  }, turn);
+  log.push("agent.message.completed", {
+    text: "Saved the Terraform preference and the staging-deploy rule, corrected the database note (walrus-primary → walrus-2), and updated the migration command in place. Future sessions will start with the right picture.",
+  }, turn);
+  log.push("turn.completed", {}, turn);
+  return log.events;
+}
+
+/**
  * A turn paused on a lapsed connection: a Linear tool call trips the broker's
  * reauth path (`tool.auth_needed`), and a second provider needs wider scope.
  * Each projects to a clean inline reconnect card — no `turn.completed`, because

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -18,6 +18,7 @@ import {
   completedTurnEvents,
   failedTurnEvents,
   liveTurnEvents,
+  memoryTurnEvents,
   tourEvents,
   workerCompletionEvents,
   workerGoalEvents,
@@ -158,6 +159,16 @@ function Harness() {
 
             <Section title="Failed turn — folds, but the error is never hidden" hint="Failed turns start open so the error and folded context stay visible.">
               <MessageTimeline events={failedTurnEvents()} className="max-h-none" />
+            </Section>
+
+            <Section
+              title="Memory writes — a first-class step, saved & corrected"
+              hint="memory.saved / memory.corrected fold into the chip summary ('… · 2 memories saved · 2 memories updated'); expanded, each is a calm neutral row (supersede = old → new, in-place = live text). With a host onMemoryClick, expanding reveals a 'View in memory' deep-link.">
+              <MessageTimeline
+                events={memoryTurnEvents()}
+                onMemoryClick={(id) => window.alert(`Open memory ${id}`)}
+                className="max-h-none"
+              />
             </Section>
 
             <Section

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -56,6 +56,15 @@ export type MessageTimelineProps = {
   /** Drill into a spawned worker session. */
   onOpenSession?: ((sessionId: string) => void) | undefined;
   /**
+   * Deep-link a memory row (a `memory.saved` / `memory.corrected` step) to its
+   * record in the host's memory pane. Opt-in, exactly like `onReconnect`: the
+   * library draws no "View in memory" affordance without a handler — the memory
+   * row is then non-interactive rich content. This is the switch that makes the
+   * deep-link a first-party OpenGeni capability without other SDK consumers
+   * opting into it. The app supplies it (it owns routing to the memory pane).
+   */
+  onMemoryClick?: ((memoryId: string) => void) | undefined;
+  /**
    * Start the reconnect flow when a tool needs its connection reauthorized. The
    * app supplies this (it owns the SDK client + workspace): it typically kicks
    * off `startConnectionOAuth` and redirects, or routes to credential entry.
@@ -101,6 +110,7 @@ export function MessageTimeline({
   status,
   renderMessageText,
   onOpenSession,
+  onMemoryClick,
   onReconnect,
   resolveProviderLogo,
   toolRegistry = defaultToolRegistry,
@@ -313,6 +323,7 @@ export function MessageTimeline({
               group={group}
               renderMessageText={renderMessageText}
               onOpenSession={onOpenSession}
+              onMemoryClick={onMemoryClick}
               onReconnect={onReconnect}
               resolveProviderLogo={resolveProviderLogo}
               toolRegistry={toolRegistry}
@@ -379,6 +390,7 @@ function TimelineGroupView({
   group,
   renderMessageText,
   onOpenSession,
+  onMemoryClick,
   onReconnect,
   resolveProviderLogo,
   toolRegistry,
@@ -388,6 +400,7 @@ function TimelineGroupView({
   group: TimelineGroup;
   renderMessageText?: ((text: string, item: AgentMessageItem | UserMessageItem) => ReactNode) | undefined;
   onOpenSession?: ((sessionId: string) => void) | undefined;
+  onMemoryClick?: ((memoryId: string) => void) | undefined;
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
   resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
   toolRegistry: ToolRegistry;
@@ -410,12 +423,12 @@ function TimelineGroupView({
           defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
           bare={insideTurn}
         >
-          <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} bare={insideTurn} />
+          <ActivityRail items={group.items} onOpenSession={onOpenSession} onMemoryClick={onMemoryClick} toolRegistry={toolRegistry} bare={insideTurn} />
         </TurnSummary>
       ) : (
         // A nested live cluster hangs on the turn's rail (bare); a top-level one
         // owns its own rail.
-        <ActivityRail items={group.items} onOpenSession={onOpenSession} toolRegistry={toolRegistry} bare={insideTurn} />
+        <ActivityRail items={group.items} onOpenSession={onOpenSession} onMemoryClick={onMemoryClick} toolRegistry={toolRegistry} bare={insideTurn} />
       );
     case "turn": {
       const activityItems = flattenActivityItems(group.groups);
@@ -425,6 +438,7 @@ function TimelineGroupView({
           group={child}
           renderMessageText={renderMessageText}
           onOpenSession={onOpenSession}
+          onMemoryClick={onMemoryClick}
           onReconnect={onReconnect}
           resolveProviderLogo={resolveProviderLogo}
           toolRegistry={toolRegistry}
@@ -498,6 +512,10 @@ function clusterIsSettled(group: Extract<TimelineGroup, { kind: "activity" }>): 
   return group.items.every((item) => {
     if (item.kind === "reasoning") {
       return !item.streaming;
+    }
+    // A memory write is a discrete, already-settled event — it has no running state.
+    if (item.kind === "memory") {
+      return true;
     }
     return item.status !== "running";
   });

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -179,8 +179,15 @@ function MemoryRow({ item, onMemoryClick }: { item: MemoryItem; onMemoryClick?: 
           <p className="whitespace-pre-wrap text-og-sm leading-6 text-og-fg-subtle line-through">{item.preview}</p>
           <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.replacementPreview}</p>
         </div>
+      ) : corrected && item.action === "updated" ? (
+        // Edited in place, no replacement record: the memory is still live, so
+        // show its current text — NOT the archived treatment.
+        <>
+          <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.preview}</p>
+          <BodyNote tone="muted">Updated in place.</BodyNote>
+        </>
       ) : corrected ? (
-        // A correction with no replacement archived the record.
+        // A correction with no replacement (and not an in-place update) archived the record.
         <BodyNote tone="muted">Archived.</BodyNote>
       ) : (
         <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.preview}</p>

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -1,12 +1,12 @@
-import { ArrowRightIcon, BotIcon, BrainIcon, SquareTerminalIcon } from "lucide-react";
+import { ArrowRightIcon, BotIcon, BrainCircuitIcon, BrainIcon, SquareTerminalIcon } from "lucide-react";
 import { cn } from "../lib/cn";
 import { truncate } from "../lib/format";
 import { defaultToolRegistry } from "./tool-renderers";
 import { useEntranceAnimation } from "./entrance";
 import type { ToolRegistry } from "./registry";
-import { PayloadBlock, ActivityDisclosure } from "./shared";
+import { BodyNote, PayloadBlock, ActivityDisclosure } from "./shared";
 import { toolDisplayName } from "./projection";
-import type { ActivityItem, ReasoningItem, SandboxItem, WorkerItem } from "./types";
+import type { ActivityItem, MemoryItem, ReasoningItem, SandboxItem, WorkerItem } from "./types";
 
 /* ----------------------------------------------------------------------------
    Activity rail
@@ -25,6 +25,12 @@ export type ActivityRailProps = {
   toolRegistry?: ToolRegistry | undefined;
   /** Drill into a spawned worker session. */
   onOpenSession?: ((sessionId: string) => void) | undefined;
+  /**
+   * Deep-link a memory row to its record in the host's memory pane. Opt-in: the
+   * library draws no "View in memory" affordance without a handler (the memory
+   * row is then non-interactive rich content). See {@link MessageTimelineProps}.
+   */
+  onMemoryClick?: ((memoryId: string) => void) | undefined;
   /** Drop the left rule + indent (used inside a folded turn summary). */
   bare?: boolean | undefined;
   className?: string | undefined;
@@ -42,7 +48,7 @@ function familyOf(item: ActivityItem): string {
   return item.kind;
 }
 
-export function ActivityRail({ items, toolRegistry = defaultToolRegistry, onOpenSession, bare, className }: ActivityRailProps) {
+export function ActivityRail({ items, toolRegistry = defaultToolRegistry, onOpenSession, onMemoryClick, bare, className }: ActivityRailProps) {
   const enter = useEntranceAnimation();
   return (
     <div
@@ -58,7 +64,7 @@ export function ActivityRail({ items, toolRegistry = defaultToolRegistry, onOpen
     >
       {items.map((item, index) => {
         const newFamily = index > 0 && familyOf(item) !== familyOf(items[index - 1]!);
-        const row = renderActivity(item, toolRegistry, onOpenSession);
+        const row = renderActivity(item, toolRegistry, onOpenSession, onMemoryClick);
         return (
           <div key={item.id} className={cn(newFamily && "mt-3")}>
             {row}
@@ -78,6 +84,7 @@ function renderActivity(
   item: ActivityItem,
   toolRegistry: ToolRegistry,
   onOpenSession: ((sessionId: string) => void) | undefined,
+  onMemoryClick: ((memoryId: string) => void) | undefined,
 ) {
   switch (item.kind) {
     case "reasoning":
@@ -90,6 +97,8 @@ function renderActivity(
       return <WorkerRow item={item} onOpenSession={onOpenSession} />;
     case "sandbox":
       return <SandboxRow item={item} />;
+    case "memory":
+      return <MemoryRow item={item} onMemoryClick={onMemoryClick} />;
     default:
       return assertNever(item);
   }
@@ -113,6 +122,83 @@ function ReasoningRow({ item }: { item: ReasoningItem }) {
       preview={truncate(item.text, 110)}
     >
       <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.text}</p>
+    </ActivityDisclosure>
+  );
+}
+
+/**
+ * Human labels for the memory kinds, translated at the SDK boundary so a raw
+ * enum slug never renders as UI. Kept local to the library (the app has its own
+ * `KIND_LABEL`); an unknown kind simply omits the chip rather than showing a slug.
+ */
+const MEMORY_KIND_LABEL: Record<string, string> = {
+  preference: "Preference",
+  semantic: "Fact",
+  procedural: "Procedure",
+  decision: "Decision",
+  episodic: "History",
+};
+
+/**
+ * A memory write the agent made mid-turn. A calm, NEUTRAL step (a successful save
+ * is ordinary progress, never an exceptional state, so no accent/color): a brain-
+ * circuit glyph, "Saved to memory" / "Updated memory", a human kind chip, and the
+ * memory text. Expanding reveals the full text; a supersede shows the old text
+ * struck through above the new one. When the host opts in with `onMemoryClick`,
+ * a quiet "View in memory" affordance deep-links to the LIVE record.
+ */
+function MemoryRow({ item, onMemoryClick }: { item: MemoryItem; onMemoryClick?: ((memoryId: string) => void) | undefined }) {
+  const corrected = item.variant === "corrected";
+  const kindLabel = MEMORY_KIND_LABEL[item.memoryKind];
+  // A supersede carries both the old text (`preview`) and the new (`replacementPreview`);
+  // an in-place update / archive carries only `preview`.
+  const superseded = corrected && Boolean(item.replacementPreview);
+  // Link to the LIVE record: a supersede's replacement when present, else the memory itself.
+  const targetId = corrected ? (item.replacementMemoryId ?? item.memoryId) : item.memoryId;
+  const deepLink = Boolean(onMemoryClick);
+  return (
+    <ActivityDisclosure
+      icon={<BrainCircuitIcon className="size-3.5" />}
+      iconTone="muted"
+      title={
+        <span className="inline-flex min-w-0 items-center gap-2">
+          <span className="shrink-0">{corrected ? "Updated memory" : "Saved to memory"}</span>
+          {kindLabel ? (
+            <span className="shrink-0 rounded-og-xs bg-og-surface-2 px-1.5 py-px text-og-xs font-normal leading-tight text-og-fg-subtle">
+              {kindLabel}
+            </span>
+          ) : null}
+        </span>
+      }
+      preview={superseded ? item.replacementPreview : item.preview}
+    >
+      {superseded ? (
+        // The correction as a before → after: the old memory struck through and
+        // dimmed, the new text in the ordinary body weight below it.
+        <div className="flex flex-col gap-1.5">
+          <p className="whitespace-pre-wrap text-og-sm leading-6 text-og-fg-subtle line-through">{item.preview}</p>
+          <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.replacementPreview}</p>
+        </div>
+      ) : corrected ? (
+        // A correction with no replacement archived the record.
+        <BodyNote tone="muted">Archived.</BodyNote>
+      ) : (
+        <p className="whitespace-pre-wrap text-og-base leading-6 text-og-fg-muted">{item.preview}</p>
+      )}
+      {item.deduped ? <BodyNote tone="muted">Merged into an existing memory.</BodyNote> : null}
+      {deepLink ? (
+        <button
+          type="button"
+          onClick={() => onMemoryClick?.(targetId)}
+          className={cn(
+            "group/memlink -mx-1 inline-flex w-fit items-center gap-1 rounded-og-sm px-1 py-0.5 text-left text-og-sm text-og-fg-subtle",
+            "outline-none transition-colors duration-150 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent",
+          )}
+        >
+          View in memory
+          <ArrowRightIcon className="size-3.5 transition-transform duration-150 group-hover/memlink:translate-x-0.5" />
+        </button>
+      ) : null}
     </ActivityDisclosure>
   );
 }

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -24,6 +24,7 @@ export type {
   AgentMessageItem,
   AuthNeededItem,
   GoalItem,
+  MemoryItem,
   NoticeItem,
   ReasoningItem,
   SandboxItem,

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -984,6 +984,7 @@ function memoryItem(
   }
   const replacementPreview = typeof payload.replacementPreview === "string" ? payload.replacementPreview : undefined;
   const replacementMemoryId = typeof payload.replacementMemoryId === "string" ? payload.replacementMemoryId : undefined;
+  const action = typeof payload.action === "string" ? payload.action : undefined;
   return {
     kind: "memory",
     id,
@@ -993,6 +994,7 @@ function memoryItem(
     preview: typeof payload.preview === "string" ? payload.preview : "",
     ...(payload.deduped === true ? { deduped: true } : {}),
     ...(replacementPreview ? { replacementPreview } : {}),
+    ...(action ? { action } : {}),
     memoryId,
     ...(replacementMemoryId ? { replacementMemoryId } : {}),
     occurredAt,

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -5,6 +5,7 @@ import type {
   ActivityItem,
   AuthNeededItem,
   GoalItem,
+  MemoryItem,
   SandboxItem,
   SessionStatusItem,
   TimelineGroup,
@@ -436,6 +437,19 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         break;
       }
 
+      case "memory.saved":
+      case "memory.corrected": {
+        // A first-party memory write is a discrete step, not streamed text, so it
+        // ends whatever was streaming (mirrors tool/sandbox pushes). A payload
+        // missing the memory id is malformed and dropped rather than shown blank.
+        const memory = memoryItem(event.id, event.type, turnId, payload, event.occurredAt);
+        if (memory) {
+          closeStreamingTail();
+          items.push(memory);
+        }
+        break;
+      }
+
       case "goal.set":
       case "goal.updated":
       case "goal.completed":
@@ -520,6 +534,7 @@ function isActivityItem(item: TimelineItem): item is ActivityItem {
     case "tool-call":
     case "worker":
     case "sandbox":
+    case "memory":
       return true;
     default:
       return false;
@@ -949,6 +964,39 @@ function goalText(payload: Record<string, unknown>): string | null {
     return payload.prompt;
   }
   return null;
+}
+
+/**
+ * Fold a `memory.saved` / `memory.corrected` event into a {@link MemoryItem}.
+ * Reads DEFENSIVELY (the payload is untyped `unknown`, no Zod schema): a missing
+ * memory id means a malformed event, so we return null and the case drops it.
+ */
+function memoryItem(
+  id: string,
+  type: string,
+  turnId: string | null,
+  payload: Record<string, unknown>,
+  occurredAt: string,
+): MemoryItem | null {
+  const memoryId = typeof payload.memoryId === "string" && payload.memoryId ? payload.memoryId : null;
+  if (!memoryId) {
+    return null;
+  }
+  const replacementPreview = typeof payload.replacementPreview === "string" ? payload.replacementPreview : undefined;
+  const replacementMemoryId = typeof payload.replacementMemoryId === "string" ? payload.replacementMemoryId : undefined;
+  return {
+    kind: "memory",
+    id,
+    turnId,
+    variant: type === "memory.corrected" ? "corrected" : "saved",
+    memoryKind: typeof payload.kind === "string" ? payload.kind : "",
+    preview: typeof payload.preview === "string" ? payload.preview : "",
+    ...(payload.deduped === true ? { deduped: true } : {}),
+    ...(replacementPreview ? { replacementPreview } : {}),
+    memoryId,
+    ...(replacementMemoryId ? { replacementMemoryId } : {}),
+    occurredAt,
+  };
 }
 
 const AUTH_NEEDED_REASONS: ReadonlySet<string> = new Set(["missing_connection", "expired", "insufficient_scope", "refresh_failed"]);

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -141,7 +141,19 @@ function summarizeTurn(items: ActivityItem[], durationMs?: number): string {
   let files = 0;
   let commands = 0;
   let screenshots = 0;
+  let memoriesSaved = 0;
+  let memoriesUpdated = 0;
   for (const item of items) {
+    if (item.kind === "memory") {
+      // A memory write is a first-class facet — the "wrote 1 memory" signal the
+      // fold should make prominent — counted saved vs updated separately.
+      if (item.variant === "corrected") {
+        memoriesUpdated += 1;
+      } else {
+        memoriesSaved += 1;
+      }
+      continue;
+    }
     if (item.kind !== "tool-call") {
       continue;
     }
@@ -165,6 +177,12 @@ function summarizeTurn(items: ActivityItem[], durationMs?: number): string {
   }
   if (screenshots) {
     parts.push(`${screenshots} ${screenshots === 1 ? "screenshot" : "screenshots"}`);
+  }
+  if (memoriesSaved) {
+    parts.push(`${memoriesSaved} ${memoriesSaved === 1 ? "memory" : "memories"} saved`);
+  }
+  if (memoriesUpdated) {
+    parts.push(`${memoriesUpdated} ${memoriesUpdated === 1 ? "memory" : "memories"} updated`);
   }
   const duration = formatDurationFacet(durationMs);
   if (duration) {

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -132,6 +132,13 @@ export type MemoryItem = {
   deduped?: boolean;
   /** The NEW text when a correction superseded the memory with a replacement; absent = updated-in-place or archived. */
   replacementPreview?: string;
+  /**
+   * What a `memory.corrected` did: `"superseded"` (replaced by a new record, see
+   * `replacementPreview`), `"updated"` (edited in place — the record lives on), or
+   * `"archived"` (retired). Distinguishes updated-in-place from archived when there
+   * is no replacement. Corrected variant only; read defensively (may be absent).
+   */
+  action?: string;
   /** The saved / corrected memory's id — the deep-link target for a save. */
   memoryId: string;
   /** The replacement memory's id when a correction produced one — the LIVE record the deep-link targets. */

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -110,6 +110,35 @@ export type SandboxItem = {
   occurredAt: string;
 };
 
+/**
+ * A first-party workspace-memory write the agent made mid-turn — a `memory.saved`
+ * (it committed a new preference / fact / procedure / decision / history) or a
+ * `memory.corrected` (it updated or archived an existing one). A settled save is
+ * ordinary progress, not an exceptional state, so it renders as a calm NEUTRAL
+ * step on the rail (never accent/color). When the host app supplies an
+ * `onMemoryClick` handler the row also deep-links to the record in its memory
+ * pane; without one it is non-interactive rich content.
+ */
+export type MemoryItem = {
+  kind: "memory";
+  id: string;
+  turnId: string | null;
+  variant: "saved" | "corrected";
+  /** The memory's kind enum (`"preference" | "semantic" | …`); mapped to a human label at render. */
+  memoryKind: string;
+  /** The memory text, ellipsized to ≤120 chars server-side. For a supersede this is the OLD text. */
+  preview: string;
+  /** The save collapsed into an existing memory (no new row was written). Saved variant only. */
+  deduped?: boolean;
+  /** The NEW text when a correction superseded the memory with a replacement; absent = updated-in-place or archived. */
+  replacementPreview?: string;
+  /** The saved / corrected memory's id — the deep-link target for a save. */
+  memoryId: string;
+  /** The replacement memory's id when a correction produced one — the LIVE record the deep-link targets. */
+  replacementMemoryId?: string;
+  occurredAt: string;
+};
+
 export type SessionStatusItem = {
   kind: "session-status";
   id: string;
@@ -186,10 +215,11 @@ export type TimelineItem =
   | GoalItem
   | NoticeItem
   | AuthNeededItem
+  | MemoryItem
   | TurnEndItem;
 
-/** Activity items cluster between chat messages (reasoning, tools, workers, sandbox). */
-export type ActivityItem = ReasoningItem | ToolCallItem | WorkerItem | SandboxItem;
+/** Activity items cluster between chat messages (reasoning, tools, workers, sandbox, memory). */
+export type ActivityItem = ReasoningItem | ToolCallItem | WorkerItem | SandboxItem | MemoryItem;
 
 export type TimelineGroup =
   | { kind: "item"; item: TimelineItem }

--- a/packages/react/test/golden/serialize.ts
+++ b/packages/react/test/golden/serialize.ts
@@ -114,6 +114,7 @@ function serializeItem(item: TimelineItem): Record<string, unknown> {
         preview: item.preview,
         deduped: item.deduped === true,
         replacementPreview: item.replacementPreview ?? null,
+        action: item.action ?? null,
         memoryId: item.memoryId,
         replacementMemoryId: item.replacementMemoryId ?? null,
       };

--- a/packages/react/test/golden/serialize.ts
+++ b/packages/react/test/golden/serialize.ts
@@ -103,6 +103,20 @@ function serializeItem(item: TimelineItem): Record<string, unknown> {
         action: item.action,
         text: item.text,
       };
+    case "memory":
+      return {
+        kind: item.kind,
+        id: item.id,
+        turnId: item.turnId,
+        occurredAt: item.occurredAt,
+        variant: item.variant,
+        memoryKind: item.memoryKind,
+        preview: item.preview,
+        deduped: item.deduped === true,
+        replacementPreview: item.replacementPreview ?? null,
+        memoryId: item.memoryId,
+        replacementMemoryId: item.replacementMemoryId ?? null,
+      };
     case "notice":
       return {
         kind: item.kind,

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -3,7 +3,7 @@ import type { SessionEvent } from "@opengeni/sdk";
 import { act } from "react";
 import { registerDom, renderComponent, flush } from "./render-hook";
 import { defaultToolRegistry, ActivityRail } from "../src/timeline";
-import type { ToolCallItem, SandboxItem } from "../src/timeline";
+import type { MemoryItem, ToolCallItem, SandboxItem } from "../src/timeline";
 import { MessageTimeline } from "../src";
 
 /* ----------------------------------------------------------------------------
@@ -841,6 +841,146 @@ describe("SandboxRow — failed chip", () => {
     // No failure chip for a successful op.
     expect(text.toLowerCase()).not.toContain("failed");
 
+    await r.unmount();
+  });
+});
+
+function memoryItem(overrides: Partial<MemoryItem>): MemoryItem {
+  return {
+    kind: "memory",
+    id: "mem-item-1",
+    turnId: "turn-1",
+    variant: "saved",
+    memoryKind: "preference",
+    preview: "Prefers concise prose.",
+    memoryId: "mem-1",
+    occurredAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("MemoryRow", () => {
+  test("renders a neutral saved row with a human kind chip and the memory text on expand", async () => {
+    const r = await renderComponent(<ActivityRail items={[memoryItem({})]} />);
+    await flush();
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Saved to memory");
+    // Human kind label, never the raw enum slug.
+    expect(text).toContain("Preference");
+    expect(text).not.toContain("preference");
+    // A save is ordinary progress — no failure affordance.
+    expect(text.toLowerCase()).not.toContain("failed");
+    await r.unmount();
+  });
+
+  test("without an onMemoryClick handler the row draws no deep-link affordance", async () => {
+    const r = await renderComponent(<ActivityRail items={[memoryItem({})]} />);
+    await flush();
+    // Expand the row so any body affordance would be present.
+    const row = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(r.container.textContent ?? "").not.toContain("View in memory");
+    await r.unmount();
+  });
+
+  test("with a handler, expanding shows 'View in memory' and clicking it links the saved record", async () => {
+    const clicked: string[] = [];
+    const r = await renderComponent(
+      <ActivityRail items={[memoryItem({ memoryId: "mem-saved" })]} onMemoryClick={(id) => clicked.push(id)} />,
+    );
+    await flush();
+    const row = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    const link = Array.from(r.container.querySelectorAll("button")).find((button) =>
+      (button.textContent ?? "").includes("View in memory"),
+    );
+    expect(link).toBeTruthy();
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(clicked).toEqual(["mem-saved"]);
+    await r.unmount();
+  });
+
+  test("a supersede shows old text struck vs new and deep-links the LIVE replacement record", async () => {
+    const clicked: string[] = [];
+    const item = memoryItem({
+      variant: "corrected",
+      preview: "Deploy from the release branch.",
+      replacementPreview: "Deploy from main after staging.",
+      memoryId: "mem-old",
+      replacementMemoryId: "mem-new",
+    });
+    const r = await renderComponent(<ActivityRail items={[item]} onMemoryClick={(id) => clicked.push(id)} />);
+    await flush();
+    expect(r.container.textContent ?? "").toContain("Updated memory");
+    const row = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Deploy from the release branch.");
+    expect(text).toContain("Deploy from main after staging.");
+    const link = Array.from(r.container.querySelectorAll("button")).find((button) =>
+      (button.textContent ?? "").includes("View in memory"),
+    );
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    // Links to the replacement (the live record), never the archived original.
+    expect(clicked).toEqual(["mem-new"]);
+    await r.unmount();
+  });
+});
+
+describe("turn fold — memory facet", () => {
+  async function foldedTrigger(events: SessionEvent[]) {
+    const r = await renderComponent(<MessageTimeline events={events} />);
+    await flush();
+    return { r, trigger: turnSummaryTrigger(r.container) };
+  }
+
+  test("one saved memory reads '1 memory saved'", async () => {
+    resetTimelineEvents();
+    const { r, trigger } = await foldedTrigger([
+      timelineEvent("user.message", { text: "note it" }),
+      timelineEvent("memory.saved", { memoryId: "mem-1", kind: "preference", preview: "A preference." }),
+      timelineEvent("turn.completed", {}),
+    ]);
+    expect(trigger?.textContent).toContain("1 memory saved");
+    expect(trigger?.textContent).not.toContain("memories saved");
+    await r.unmount();
+  });
+
+  test("multiple saved memories pluralize to 'N memories saved'", async () => {
+    resetTimelineEvents();
+    const { r, trigger } = await foldedTrigger([
+      timelineEvent("user.message", { text: "note them" }),
+      timelineEvent("memory.saved", { memoryId: "mem-1", kind: "preference", preview: "One." }),
+      timelineEvent("memory.saved", { memoryId: "mem-2", kind: "semantic", preview: "Two." }),
+      timelineEvent("turn.completed", {}),
+    ]);
+    expect(trigger?.textContent).toContain("2 memories saved");
+    await r.unmount();
+  });
+
+  test("a correction reads '1 memory updated'", async () => {
+    resetTimelineEvents();
+    const { r, trigger } = await foldedTrigger([
+      timelineEvent("user.message", { text: "fix it" }),
+      timelineEvent("memory.corrected", { memoryId: "mem-1", kind: "decision", preview: "Old.", action: "archived" }),
+      timelineEvent("turn.completed", {}),
+    ]);
+    expect(trigger?.textContent).toContain("1 memory updated");
     await r.unmount();
   });
 });

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -940,6 +940,47 @@ describe("MemoryRow", () => {
     expect(clicked).toEqual(["mem-new"]);
     await r.unmount();
   });
+
+  test("an in-place update (corrected, action 'updated', no replacement) shows the live text, not 'Archived'", async () => {
+    const item = memoryItem({
+      variant: "corrected",
+      action: "updated",
+      preview: "Prefers dark mode.",
+      memoryId: "mem-upd",
+    });
+    const r = await renderComponent(<ActivityRail items={[item]} />);
+    await flush();
+    const row = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Prefers dark mode.");
+    expect(text).toContain("Updated in place.");
+    expect(text).not.toContain("Archived");
+    await r.unmount();
+  });
+
+  test("an archive (corrected, action 'archived', no replacement) shows the archived note", async () => {
+    const item = memoryItem({
+      variant: "corrected",
+      action: "archived",
+      preview: "Tried the beta once.",
+      memoryId: "mem-arc",
+    });
+    const r = await renderComponent(<ActivityRail items={[item]} />);
+    await flush();
+    const row = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Archived.");
+    expect(text).not.toContain("Updated in place.");
+    await r.unmount();
+  });
 });
 
 describe("turn fold — memory facet", () => {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -9,6 +9,7 @@ import {
   sessionStatusFromEvents,
   toolDisplayName,
   type AgentMessageItem,
+  type MemoryItem,
   type SandboxItem,
   type TimelineGroup,
   type TurnEndItem,
@@ -1238,3 +1239,85 @@ function collectActivityGroups(groups: ReturnType<typeof groupTimeline>) {
   }
   return out;
 }
+
+describe("buildTimeline — memory writes", () => {
+  test("projects memory.saved into a neutral MemoryItem carrying id, kind, preview", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.saved", {
+        memoryId: "mem-1",
+        kind: "preference",
+        preview: "Prefers concise prose over bullet lists.",
+        deduped: false,
+      }),
+    ]);
+    expect(items.map((item) => item.kind)).toEqual(["memory"]);
+    const memory = items[0] as MemoryItem;
+    expect(memory.variant).toBe("saved");
+    expect(memory.memoryKind).toBe("preference");
+    expect(memory.preview).toBe("Prefers concise prose over bullet lists.");
+    expect(memory.memoryId).toBe("mem-1");
+    expect(memory.deduped).toBeUndefined();
+    expect(memory.replacementPreview).toBeUndefined();
+  });
+
+  test("carries a deduped flag through only when the save collapsed into an existing memory", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.saved", { memoryId: "mem-2", kind: "semantic", preview: "Ships on Fridays.", deduped: true }),
+    ]);
+    expect((items[0] as MemoryItem).deduped).toBe(true);
+  });
+
+  test("projects memory.corrected supersede into a MemoryItem with old preview, new replacement, and both ids", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.corrected", {
+        memoryId: "mem-old",
+        kind: "decision",
+        preview: "Deploy from the release branch.",
+        action: "superseded",
+        replacementMemoryId: "mem-new",
+        replacementPreview: "Deploy from main after a green staging run.",
+      }),
+    ]);
+    const memory = items[0] as MemoryItem;
+    expect(memory.kind).toBe("memory");
+    expect(memory.variant).toBe("corrected");
+    expect(memory.preview).toBe("Deploy from the release branch.");
+    expect(memory.replacementPreview).toBe("Deploy from main after a green staging run.");
+    expect(memory.memoryId).toBe("mem-old");
+    expect(memory.replacementMemoryId).toBe("mem-new");
+  });
+
+  test("projects an archive (corrected, no replacement) with only the preview", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.corrected", { memoryId: "mem-3", kind: "episodic", preview: "Tried the beta once.", action: "archived" }),
+    ]);
+    const memory = items[0] as MemoryItem;
+    expect(memory.variant).toBe("corrected");
+    expect(memory.replacementPreview).toBeUndefined();
+    expect(memory.replacementMemoryId).toBeUndefined();
+  });
+
+  test("drops a malformed memory event with no memory id rather than rendering a blank row", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.saved", { kind: "preference", preview: "no id here" }),
+    ]);
+    expect(items).toEqual([]);
+  });
+
+  test("clusters memory writes as activity steps alongside tool calls", () => {
+    reset();
+    const groups = groupTimeline(buildTimeline([
+      event("agent.toolCall.created", { id: "call-1", name: "memory_save", arguments: {} }),
+      event("agent.toolCall.output", { id: "call-1", output: "ok" }),
+      event("memory.saved", { memoryId: "mem-1", kind: "preference", preview: "A preference." }),
+    ]));
+    const activities = collectActivityGroups(groups);
+    expect(activities).toHaveLength(1);
+    expect(activities[0]!.items.map((item) => item.kind)).toEqual(["tool-call", "memory"]);
+  });
+});

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1290,15 +1290,27 @@ describe("buildTimeline — memory writes", () => {
     expect(memory.replacementMemoryId).toBe("mem-new");
   });
 
-  test("projects an archive (corrected, no replacement) with only the preview", () => {
+  test("projects an archive (corrected, no replacement) carrying the archived action", () => {
     reset();
     const items = buildTimeline([
       event("memory.corrected", { memoryId: "mem-3", kind: "episodic", preview: "Tried the beta once.", action: "archived" }),
     ]);
     const memory = items[0] as MemoryItem;
     expect(memory.variant).toBe("corrected");
+    expect(memory.action).toBe("archived");
     expect(memory.replacementPreview).toBeUndefined();
     expect(memory.replacementMemoryId).toBeUndefined();
+  });
+
+  test("projects an in-place update (corrected, no replacement) carrying the updated action", () => {
+    reset();
+    const items = buildTimeline([
+      event("memory.corrected", { memoryId: "mem-4", kind: "preference", preview: "Prefers dark mode.", action: "updated" }),
+    ]);
+    const memory = items[0] as MemoryItem;
+    expect(memory.variant).toBe("corrected");
+    expect(memory.action).toBe("updated");
+    expect(memory.replacementPreview).toBeUndefined();
   });
 
   test("drops a malformed memory event with no memory id rather than rendering a blank row", () => {


### PR DESCRIPTION
Follow-up to Workspace Memory V1 (#313). Makes agent memory writes visible and prominent in the session timeline — they were previously dropped entirely by the projection (`default: break`, rendered nowhere).

## What

- **Prominence in the fold.** `memory.saved` / `memory.corrected` now project to a first-class `MemoryItem` activity kind, so they count as a step and get their own facet in the collapsed turn-chip summary: e.g. `6 steps · 1 command · 2 memories saved · 2 memories updated · 8s` (the Claude-Code "wrote 1 memory" signal).
- **Beautiful expanded rendering.** A dedicated `MemoryRow` on the shared `ActivityDisclosure` primitive: brain-circuit glyph, **neutral tone** (a successful save is ordinary progress, not an exceptional state — respects the timeline's failure-only color doctrine), a human kind chip (Preference / Fact / Procedure / Decision / History), and the memory text as prose. A supersede renders old → new (old struck-through); an in-place `updated` shows the live text with an "Updated in place." note; a genuine archive shows "Archived."
- **Optional deep-link.** New optional `onMemoryClick?: (memoryId) => void` on `MessageTimeline`, threaded like `onOpenSession`. When the host provides it, the expanded row shows a quiet "View in memory →" that targets the LIVE record (a correction's replacement when present). **The prop's presence is the opt-in** — OpenGeni's web app wires it to `/workspaces/$id/documents?memory=<id>`; other `@opengeni/react` consumers omit it and the row is inert rich content.
- **Web side.** `?memory=<id>` search param on the documents route; `MemoryPane` reveals the target (fetch-by-id + filter-align if it's outside the current view), scrolls to it, and rings it for ~2s.
- **Demo coverage.** A memory-writes scenario added to the timeline demo (the real `buildTimeline` pipeline) covering saved / superseded / updated-in-place.

## Screenshots
Rendered via the component demo (real pipeline, fixture events). Folded chip shows the memory facets; expanded shows the neutral rows, the old→new supersede, the "Updated in place." note, and the "View in memory →" deep-link. (Attached in the PR conversation.)

## Verification
- Full `bun run typecheck` (18 pkgs) exit 0; `bun test packages/react` 477 pass (+13 new: projection/clustering, MemoryRow render for saved/superseded/updated-in-place/archived, deep-link click, fold-facet strings); `apps/web` typecheck + build clean; `App.test.ts` 89 pass.
- No-memory turns fold byte-identically (golden snapshots unchanged) — the summary invariant holds.
- Backend/contracts/db untouched; other SDK consumers' behavior unchanged (deep-link opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRR4H31cd5J1T9qUu3qRo1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and timeline projection only; deep-link is opt-in for SDK consumers, with no API or auth changes.
> 
> **Overview**
> Agent **memory writes** (`memory.saved` / `memory.corrected`) are now visible in the session timeline instead of being dropped by projection.
> 
> **`@opengeni/react`:** Events project to a new **`MemoryItem`** activity kind, cluster with tools/reasoning, and add **saved/updated** facets on folded turn chips (e.g. `2 memories saved · 2 memories updated`). Expanded turns use a neutral **`MemoryRow`** (kind chip, preview text, supersede old→new, in-place update vs archived). Optional **`onMemoryClick(memoryId)`** on `MessageTimeline` shows **View in memory** and targets the live record (replacement id on supersede); hosts that omit the prop get non-interactive rows.
> 
> **Web app:** Session view wires `onMemoryClick` to **`/workspaces/$id/documents?memory=<id>`**. **`MemoryPane`** accepts `focusMemoryId`, fetches the record, aligns filters, injects it if missing from the capped list, scrolls, and briefly highlights. List errors no longer block deep-linked cards from rendering.
> 
> Demo fixtures, harness section, and tests cover projection, rendering, fold facets, and deep-link clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e8f381197452eb26d680f24ceaa9e373361c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->