### PR TITLE
chore(toolchain): bun cleanup + toolchain docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ Thanks for considering a contribution.
 bun run dev
 ```
 
+## Toolchain
+
+Package manager is Bun everywhere (one intentional npm exception for release publishing).
+Typecheck runs on tsgo, not `tsc`. See [`docs/toolchain.md`](docs/toolchain.md) for what runs
+typecheck/lint/format and why.
+
 ## Checks
 
 Run the normal PR check before opening a pull request:

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ This map defines who each doc tier serves and where volatile facts belong.
 | MCP surface selection | `docs/mcp-surfaces.md` | `docs/architecture.md`, `docs/capabilities.md`, `docs/session-mcp-servers.md` should link. |
 | Toolspace programmatic tool access | `docs/mcp-surfaces.md`, `docs/architecture.md`; record design in `docs/design/toolspace.md` | Runtime/API/worker comments should link instead of restating security invariants. |
 | Client/server compatibility policy | `docs/architecture.md` §3.10 | `packages/sdk/README.md` links; release notes should link. |
+| Typecheck/lint/format toolchain | `docs/toolchain.md` | `CONTRIBUTING.md` links; other docs should not restate tool choice or version. |
 
 ## Rules
 

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -1,0 +1,51 @@
+# Toolchain
+
+The fast path for contributors: what runs typecheck, lint, and format, and why.
+
+## Package manager & runtime
+
+**Bun** end to end — install, run, test, and script execution. There is no `npm`/`pnpm`/`yarn`
+lockfile in this repo; use `bun install`, `bun run <script>`, `bun test`. Libraries build with
+`tsup` (esbuild); `apps/web` builds with Vite.
+
+The one intentional exception is the publish step: `bun run release:publish`
+(`scripts/release-publish.sh`) shells out to `npx changeset publish`, which falls back to
+`npm publish` for the actual registry push. That's deliberate — `bun publish` cannot emit npm
+provenance attestations, so the release workflow (`.github/workflows/release.yml`) sets up Node
+and the npm registry for that one step only. Don't "fix" this to use bun; provenance is the reason
+it exists.
+
+## Typecheck: tsgo
+
+Typecheck runs on **tsgo** (`@typescript/native-preview`, the native-Go TypeScript 7 compiler),
+not `tsc`. `bun run typecheck` invokes `bun scripts/typecheck.ts`, which runs `tsgo --noEmit`
+sequentially over every project's `tsconfig.json` (one process at a time, fail-fast). This
+replaced an 18-step chain of per-package `tsc --noEmit` calls that used to be the dominant cost of
+local verification, both in wall time and peak memory.
+
+`typescript@6` is still a dependency, but only as `tsup`'s internal `.d.ts` emitter for
+publishable packages (`dts: true`) — it is never invoked as a gating typecheck. If you see a
+`tsc`-shaped error during a package build, that's the dts emit path, not the typecheck gate.
+
+CI runs the same `bun run typecheck` step (`.github/workflows/ci.yml`), so there is nothing
+special to configure locally beyond `bun install`.
+
+## Lint: oxlint (landing in a follow-up PR)
+
+**oxlint** is the planned linter — there is no ESLint/Prettier/Biome config in this repo today, so
+this is a greenfield add rather than a migration. It is not wired up yet; when it lands, `bun run
+lint` will run it and CI will gate on it. See `docs/architecture.md` for where package boundaries
+live if you're setting up per-package lint scope.
+
+## Format: oxfmt (landing in a follow-up PR)
+
+**oxfmt** is the planned formatter (Prettier-compatible output). Also not wired up yet; when it
+lands, `bun run format` / `bun run format:check` will run it and CI will gate on `format:check`.
+The initial adoption reformats the whole repo in one dedicated commit (large, mechanical diff) —
+don't hand-format ahead of that landing to avoid fighting it.
+
+## Where this fits
+
+For the full local check sequence contributors run before opening a PR, see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#checks). This doc is intentionally narrow: it explains
+*which tool* does typecheck/lint/format and why, not the day-to-day contributor workflow.


### PR DESCRIPTION
## Summary
- Audited the repo for `npx`/`npm` usage: the only hit outside the intentional npm-provenance publish path (`scripts/release-publish.sh`, `.github/workflows/release.yml`) is that provenance path itself — left untouched per the toolchain program's binding decision #8.
- Confirmed the orphaned `packages/sdk/tsconfig.build.json` / `packages/react/tsconfig.build.json` are already gone (deleted in the tsgo migration, #317).
- Adds `docs/toolchain.md`: documents the current tsgo typecheck gate (`typescript@6` kept only as tsup's internal `.d.ts` emitter) and marks oxlint/oxfmt as landing in follow-up PRs (not wired up yet). Linked from `CONTRIBUTING.md` and added to the `docs/README.md` canonical-homes table.

## Test plan
- [x] `bun scripts/check-docs-refs.ts` passes (new doc + all path references resolve)
- [x] No functional script/workflow changes — docs-only diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, CI script, or workflow edits in the diff.
> 
> **Overview**
> Introduces **`docs/toolchain.md`** as the canonical place for typecheck, lint, and format tooling: Bun for day-to-day work, the intentional **`npx changeset publish` / npm provenance** exception on release, **tsgo** as the gating typecheck (with `typescript@6` only for tsup `.d.ts` emit), and **oxlint/oxfmt** noted as follow-up work not wired yet.
> 
> **`CONTRIBUTING.md`** gains a short **Toolchain** section pointing contributors at that doc instead of restating commands. **`docs/README.md`** registers the new file in the canonical-homes table so other docs link there rather than duplicating tool choices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f826834e5aa732efa1a2bdf21ee376d6219086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->