### PR TITLE
Polish: session header (light), calmer focus ring, agents indicator above the composer

### DIFF
--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -3,29 +3,26 @@
 // overlay drawer (<1024px), and the slim canvas top strip that carries
 // session-contextual actions on session routes. The rail itself is composed
 // from the brand, switcher, workspace nav, session list, and footer sections.
-import { SessionStatus as SessionStatusBadge, useSessionLineage } from "@opengeni/react";
+import { useSessionLineage } from "@opengeni/react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { LockIcon, MenuIcon, PanelRightIcon, PencilIcon } from "lucide-react";
+import { MenuIcon } from "lucide-react";
 
 import { BrandMark } from "@/components/brand-mark";
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from "react";
 
-import { ConnectionPill } from "@/components/common";
 import { RailFooter } from "@/components/rail/rail-footer";
+import { SessionHeader } from "@/components/rail/session-header";
 import { RAIL_DEFAULT_WIDTH, RAIL_MAX_WIDTH, RAIL_MIN_WIDTH, useRail } from "@/components/rail/rail-context";
 import { CollapsedSessionsButton, SessionList } from "@/components/rail/session-list";
 import { SwitcherBlock } from "@/components/rail/switcher-block";
 import { SessionSandboxSwitcher } from "@/components/session/sandbox-switcher";
 import { CodexAccountIndicator } from "@/components/session/codex-account-indicator";
-import { SessionAgentsChip, SpawnedByBreadcrumb } from "@/components/session/subagents";
 import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
-import { SESSION_TITLE_MAX_LENGTH, sessionDisplayTitle, useInlineRename } from "@/lib/session-rename";
 import { cn } from "@/lib/utils";
-import type { Session } from "@/types";
 
 /** The rail body — shared between the fixed desktop column and the mobile drawer. */
 function RailBody() {
@@ -234,13 +231,12 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const isSessionRoute = /\/sessions\/[^/]+/.test(pathname);
   const showSessionActions = Boolean(context.session) && isSessionRoute;
-  // One lineage read for the whole header — shared by the "N agents" chip and
-  // the "spawned by" breadcrumb (disabled when there is no session). The header
-  // lives outside the session route's event feed, so spawn events can't trigger
-  // a refresh here (the goal pill's panel gets that via `events`); a modest poll
-  // keeps the agent count honest without threading the stream into the rail.
+  // A lineage read for the header's "spawned by" breadcrumb (disabled when there
+  // is no session). The header lives outside the session route's event feed, so
+  // spawn events can't trigger a refresh here; a modest poll keeps the ancestor
+  // link honest without threading the stream into the rail. (The child-agents
+  // count moved to the composer pill, which reads lineage off the live feed.)
   const lineage = useSessionLineage(context.session?.id ?? null, { pollIntervalMs: 30_000 });
-  const childNodes = lineage.lineage?.children ?? [];
   const ancestors = lineage.lineage?.ancestors ?? [];
   const parentSession = ancestors.length > 0 ? ancestors[ancestors.length - 1]! : null;
 
@@ -249,157 +245,59 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
     return null;
   }
 
-  return (
-    <header
-      className={cn(
-        "flex shrink-0 items-center gap-3 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4",
-        // The session strip carries a two-line block (title + meta) — it gets
-        // breathing room; the plain mobile brand strip stays slim.
-        showSessionActions ? "h-14" : "h-12",
-      )}
+  const hamburger = rail.isMobile ? (
+    <Button
+      ref={hamburgerRef}
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Open navigation"
+      onClick={() => rail.setDrawerOpen(true)}
     >
-      {rail.isMobile ? (
-        <Button
-          ref={hamburgerRef}
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Open navigation"
-          onClick={() => rail.setDrawerOpen(true)}
-        >
-          <MenuIcon className="size-4" />
-        </Button>
-      ) : null}
+      <MenuIcon className="size-4" />
+    </Button>
+  ) : null;
 
-      {showSessionActions && context.session ? (
-        <>
-          <div className="flex min-w-0 flex-1 flex-col justify-center gap-px">
-            {/* Child sessions link back to the manager that spawned them. */}
-            <SpawnedByBreadcrumb workspaceId={context.session.workspaceId} parent={parentSession} />
-            <SessionTitleEditor session={context.session} onRename={context.updateSessionTitle} />
-            {/* One quiet metadata voice: no label-colon grammar, no separator
-                soup — the model·effort token, then the sandbox pill (its own
-                shape, no interposed dot), then the codex indicator. */}
-            <div className="flex min-w-0 items-center gap-1.5 text-2xs leading-4 text-fg-subtle">
-              <span className="shrink-0">
-                {context.session.model} · {String(context.session.metadata.reasoningEffort ?? "low")}
-              </span>
-              <SessionSandboxSwitcher workspaceId={context.session.workspaceId} sessionId={context.session.id} />
-              {/* Codex-prefix-gated inside the component: absent for host-credit sessions. */}
-              <CodexAccountIndicator
-                workspaceId={context.session.workspaceId}
-                sessionId={context.session.id}
-                model={context.session.model}
-              />
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1.5">
-            {/* Sessions that spawned workers surface an "N agents" chip opening
-                the shared subagent lineage panel. */}
-            <SessionAgentsChip workspaceId={context.session.workspaceId} nodes={childNodes} />
-            <ConnectionPill state={context.connectionState} />
-            <SessionStatusBadge status={context.session.status} />
-            {context.keyAuthRequired ? (
-              <Button type="button" variant="ghost" size="icon-sm" onClick={context.forgetAccessKey} aria-label="Clear access key">
-                <LockIcon className="size-4" />
-              </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant={context.inspectorOpen ? "secondary" : "ghost"}
-              size="icon-sm"
-              onClick={() => context.setInspectorOpen((open) => !open)}
-              aria-label={context.inspectorOpen ? "Hide session panel" : "Show session panel"}
-            >
-              <PanelRightIcon className="size-4" />
-            </Button>
-          </div>
-        </>
-      ) : rail.isMobile ? (
-        <Link
-          to="/workspaces/$workspaceId/sessions"
-          params={{ workspaceId: rail.workspaceId }}
-          className="flex items-center gap-2 text-sm font-semibold"
-        >
-          <span className="flex size-5 items-center justify-center rounded bg-brand-strong/20 text-brand">
-            <BrandMark className="size-3.5" />
-          </span>
-          OpenGeni
-        </Link>
-      ) : null}
-    </header>
-  );
-}
-
-/**
- * The session header title — display by default, click the title (or the
- * always-visible pencil) to rename inline. Prefers the durable session.title
- * (agent- or user-set), falling back to the initial message / "Untitled
- * session" exactly like the rail list. Enter saves, Esc cancels, blur saves; an
- * empty/unchanged value is a no-op cancel. The live title (context.session)
- * flows in through the session.title_set SSE event the react useSession hook
- * applies, so cross-client renames and agent titling reflect here without a
- * reload. The shared `useInlineRename` hook keeps this behaviour identical to
- * the rail row's rename.
- */
-function SessionTitleEditor(props: {
-  session: Session;
-  onRename: (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
-}) {
-  const display = sessionDisplayTitle(props.session);
-  const rename = useInlineRename(props.session, props.onRename);
-
-  if (rename.editing) {
+  // Session route: the full identity + status header (its own bar). The live
+  // sandbox switcher and codex indicator flow in as slots so the header stays a
+  // pure, screenshot-testable component.
+  if (showSessionActions && context.session) {
+    const session = context.session;
     return (
-      // A calm in-place edit: same size and position as the display title, a
-      // soft surface tint + hairline instead of a loud focus ring. The global
-      // focus-ring rule is what painted the old blue box; opting out here keeps
-      // the rename feeling like editing the text, not filling in a form field.
-      <input
-        ref={rename.inputRef}
-        value={rename.draft}
-        onChange={(event) => rename.setDraft(event.target.value)}
-        onBlur={() => void rename.commit()}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            void rename.commit();
-          } else if (event.key === "Escape") {
-            event.preventDefault();
-            rename.cancel();
-          }
-        }}
-        maxLength={SESSION_TITLE_MAX_LENGTH}
-        aria-label="Session title"
-        className="-mx-1.5 w-full truncate rounded-md bg-surface-2/70 px-1.5 text-sm font-medium leading-5 outline-none ring-1 ring-border-strong focus:outline-none focus-visible:outline-none"
-        style={{ outline: "none" }}
+      <SessionHeader
+        session={session}
+        parent={parentSession}
+        connectionState={context.connectionState}
+        status={session.status}
+        keyAuthRequired={context.keyAuthRequired}
+        onForgetAccessKey={context.forgetAccessKey}
+        inspectorOpen={context.inspectorOpen}
+        onToggleInspector={() => context.setInspectorOpen((open) => !open)}
+        onRename={context.updateSessionTitle}
+        leading={hamburger}
+        sandboxSlot={<SessionSandboxSwitcher workspaceId={session.workspaceId} sessionId={session.id} />}
+        // Codex-prefix-gated inside the component: absent for host-credit sessions.
+        codexSlot={<CodexAccountIndicator workspaceId={session.workspaceId} sessionId={session.id} model={session.model} />}
+        // The "N agents" indicator now lives above the composer (front and
+        // center) as ComposerAgentsPill, not in this header — see session.tsx.
       />
     );
   }
 
+  // Mobile, off a session route: the slim brand strip.
   return (
-    <div className="group/title flex min-w-0 items-center gap-0.5">
-      <button
-        type="button"
-        onClick={rename.startEditing}
-        title={`${display} · click to rename`}
-        className="min-w-0 shrink truncate rounded-sm text-left text-sm font-medium leading-5 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
+    <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border bg-bg/75 px-3 backdrop-blur sm:px-4">
+      {hamburger}
+      <Link
+        to="/workspaces/$workspaceId/sessions"
+        params={{ workspaceId: rail.workspaceId }}
+        className="flex items-center gap-2 text-sm font-semibold"
       >
-        {display}
-      </button>
-      {/* The pencil earns its pixels only when relevant: hidden at rest,
-          revealed on hover/focus, always present on coarse pointers where
-          hover doesn't exist. */}
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-xs"
-        onClick={rename.startEditing}
-        aria-label="Rename session"
-        className="shrink-0 text-fg-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover/title:opacity-100 pointer-coarse:opacity-100"
-      >
-        <PencilIcon className="size-3" />
-      </Button>
-    </div>
+        <span className="flex size-5 items-center justify-center rounded bg-brand-strong/20 text-brand">
+          <BrandMark className="size-3.5" />
+        </span>
+        OpenGeni
+      </Link>
+    </header>
   );
 }

--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -1,0 +1,175 @@
+// The session header bar — the slim canvas top strip's contents on a session
+// route. Split out of rail-shell as a PURE, presentational component: it takes
+// plain session data + callbacks and renders the two-line identity block
+// (breadcrumb → title → model·effort · sandbox · codex) on the left and the
+// live-status cluster (connection, status, lock, panel toggle) on the right.
+// The live children that need their own hooks — the sandbox switcher and the
+// codex account indicator — arrive as slots so the whole bar can be rendered
+// (and screenshotted) in isolation. `CanvasTopStrip` in rail-shell owns the
+// data wiring and passes the real slots.
+import { SessionStatus as SessionStatusBadge } from "@opengeni/react";
+import type { SessionEventsConnectionState } from "@opengeni/react";
+import type { SessionSummary } from "@opengeni/sdk";
+import { LockIcon, PanelRightIcon, PencilIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { ConnectionPill } from "@/components/common";
+import { SpawnedByBreadcrumb } from "@/components/session/subagents";
+import { Button } from "@/components/ui/button";
+import { SESSION_TITLE_MAX_LENGTH, sessionDisplayTitle, useInlineRename } from "@/lib/session-rename";
+import { cn } from "@/lib/utils";
+import type { Session } from "@/types";
+
+export function SessionHeader({
+  session,
+  parent,
+  connectionState,
+  status,
+  keyAuthRequired,
+  onForgetAccessKey,
+  inspectorOpen,
+  onToggleInspector,
+  onRename,
+  sandboxSlot,
+  codexSlot,
+  agentsSlot,
+  leading,
+}: {
+  session: Session;
+  /** The direct parent (last ancestor), or null when this session has none. */
+  parent: SessionSummary | null;
+  connectionState: SessionEventsConnectionState;
+  status: Session["status"];
+  keyAuthRequired: boolean;
+  onForgetAccessKey: () => void;
+  inspectorOpen: boolean;
+  onToggleInspector: () => void;
+  onRename: (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
+  /** The "Run on <machine>" control — a live component in production. */
+  sandboxSlot?: ReactNode;
+  /** The codex-account indicator — absent for host-credit sessions. */
+  codexSlot?: ReactNode;
+  /** Legacy header home for the "N agents" chip (moved above the composer). */
+  agentsSlot?: ReactNode;
+  /** Leading control (the mobile hamburger); absent on desktop. */
+  leading?: ReactNode;
+}) {
+  return (
+    // An elevated band, not just canvas-with-a-hairline: reading as a real top
+    // bar was the light-theme fix — a near-white header on a near-white canvas
+    // needs its own surface + a crisp divider to look intentional (and it lifts
+    // the dark bar a touch above the canvas too).
+    <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border bg-surface/80 px-3.5 backdrop-blur supports-[backdrop-filter]:bg-surface/65 sm:px-5">
+      {leading}
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
+        {/* Child sessions link back to the manager that spawned them. */}
+        <SpawnedByBreadcrumb workspaceId={session.workspaceId} parent={parent} />
+        <SessionTitleEditor session={session} onRename={onRename} />
+        {/* One quiet metadata voice: no label-colon grammar, no separator
+            soup — the model·effort token (the model earns a touch more weight,
+            the effort stays quiet), then the sandbox pill (its own shape, no
+            interposed dot), then the codex indicator. */}
+        <div className="flex min-w-0 items-center gap-2 text-2xs leading-4 text-fg-subtle">
+          <span className="shrink-0 font-medium text-fg-muted">
+            {session.model}
+            <span className="font-normal text-fg-subtle"> · {String(session.metadata.reasoningEffort ?? "low")}</span>
+          </span>
+          {sandboxSlot}
+          {codexSlot}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {agentsSlot}
+        <ConnectionPill state={connectionState} />
+        <SessionStatusBadge status={status} />
+        {keyAuthRequired ? (
+          <Button type="button" variant="ghost" size="icon-sm" onClick={onForgetAccessKey} aria-label="Clear access key">
+            <LockIcon className="size-4" />
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant={inspectorOpen ? "secondary" : "ghost"}
+          size="icon-sm"
+          onClick={onToggleInspector}
+          aria-label={inspectorOpen ? "Hide session panel" : "Show session panel"}
+        >
+          <PanelRightIcon className="size-4" />
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+/**
+ * The session header title — display by default, click the title (or the
+ * always-visible pencil) to rename inline. Prefers the durable session.title
+ * (agent- or user-set), falling back to the initial message / "Untitled
+ * session" exactly like the rail list. Enter saves, Esc cancels, blur saves; an
+ * empty/unchanged value is a no-op cancel. The live title (context.session)
+ * flows in through the session.title_set SSE event the react useSession hook
+ * applies, so cross-client renames and agent titling reflect here without a
+ * reload. The shared `useInlineRename` hook keeps this behaviour identical to
+ * the rail row's rename.
+ */
+function SessionTitleEditor(props: {
+  session: Session;
+  onRename: (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
+}) {
+  const display = sessionDisplayTitle(props.session);
+  const rename = useInlineRename(props.session, props.onRename);
+
+  if (rename.editing) {
+    return (
+      // A calm in-place edit: same size and position as the display title, a
+      // soft surface tint + hairline instead of a loud focus ring. The global
+      // focus-ring rule is what painted the old blue box; opting out here keeps
+      // the rename feeling like editing the text, not filling in a form field.
+      <input
+        ref={rename.inputRef}
+        value={rename.draft}
+        onChange={(event) => rename.setDraft(event.target.value)}
+        onBlur={() => void rename.commit()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            void rename.commit();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            rename.cancel();
+          }
+        }}
+        maxLength={SESSION_TITLE_MAX_LENGTH}
+        aria-label="Session title"
+        className="-mx-1.5 w-full truncate rounded-md bg-surface-2/70 px-1.5 text-[15px] font-semibold leading-6 tracking-[-0.01em] outline-none ring-1 ring-border-strong focus:outline-none focus-visible:outline-none"
+        style={{ outline: "none" }}
+      />
+    );
+  }
+
+  return (
+    <div className="group/title flex min-w-0 items-center gap-0.5">
+      <button
+        type="button"
+        onClick={rename.startEditing}
+        title={`${display} · click to rename`}
+        className="min-w-0 shrink truncate rounded-sm text-left text-[15px] font-semibold leading-6 tracking-[-0.01em] text-fg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
+      >
+        {display}
+      </button>
+      {/* The pencil earns its pixels only when relevant: hidden at rest,
+          revealed on hover/focus, always present on coarse pointers where
+          hover doesn't exist. */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onClick={rename.startEditing}
+        aria-label="Rename session"
+        className="shrink-0 text-fg-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover/title:opacity-100 pointer-coarse:opacity-100"
+      >
+        <PencilIcon className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/composer-agents-pill.tsx
+++ b/apps/web/src/components/session/composer-agents-pill.tsx
@@ -1,0 +1,104 @@
+// The composer-anchored subagent pill: a compact floating pill that sits above
+// the composer (a sibling of the goal pill), front-and-center, and expands
+// UPWARD into the shared subagent lineage popover. It replaces the old header
+// "N agents" chip — a manager watches the same tree from the input, not the far
+// top corner.
+//
+// State language: calm at rest ("3 agents") and live when any worker is running
+// (a pulsing running-tone dot + "1 running"), so a glance at the composer tells
+// you whether the fleet is working. Clicking opens the same {@link SubagentTree}
+// the header chip and the Agents dock tab render — one source of truth.
+//
+// Copy doctrine: human language only; no status enum leaks into a label.
+import type { LineageNode } from "@opengeni/sdk";
+import { BotIcon } from "lucide-react";
+import { Popover } from "radix-ui";
+import { useState } from "react";
+
+import { SubagentTree, SubagentsLabel } from "@/components/session/subagents";
+import { cn } from "@/lib/utils";
+
+export function ComposerAgentsPill({
+  workspaceId,
+  nodes,
+}: {
+  workspaceId: string;
+  /** Direct children; presentational — the caller owns the single lineage read.
+   *  Renders nothing when there are no children. */
+  nodes: LineageNode[];
+}) {
+  const [open, setOpen] = useState(false);
+  const count = nodes.length;
+  if (count === 0) {
+    return null;
+  }
+  const runningCount = nodes.filter((n) => n.session.status === "running").length;
+  const live = runningCount > 0;
+
+  return (
+    <div className="mx-auto mb-2 flex w-full max-w-3xl justify-start px-4 sm:px-6">
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            data-testid="composer-agents-pill"
+            className={cn(
+              // Same elevated floating family as the goal pill (rounded-full /
+              // border / surface-2 / shadow-md / backdrop-blur), and matched to
+              // its height + left inset so the two read as siblings when stacked.
+              "inline-flex h-8 max-w-full items-center gap-2 rounded-full border bg-surface-2/90 pl-3 pr-3.5 text-xs shadow-md backdrop-blur",
+              "supports-[backdrop-filter]:bg-surface-2/75 outline-none transition-colors",
+              "hover:border-border-strong focus-visible:ring-2 focus-visible:ring-ring/40 data-[state=open]:border-border-strong",
+              live ? "border-status-running/40" : "border-border",
+            )}
+          >
+            {/* Leading glyph: a live pulsing dot when work is running, else the
+                calm bot icon. */}
+            {live ? (
+              <span className="relative flex size-3.5 shrink-0 items-center justify-center">
+                <span className="absolute inline-flex size-2 rounded-full bg-status-running opacity-70 motion-safe:animate-ping" />
+                <span className="relative inline-flex size-2 rounded-full bg-status-running" />
+              </span>
+            ) : (
+              <BotIcon className="size-3.5 shrink-0 text-fg-subtle" />
+            )}
+            <span className="shrink-0 font-medium text-fg">
+              {count} agent{count === 1 ? "" : "s"}
+            </span>
+            {live ? (
+              <>
+                <span aria-hidden className="shrink-0 text-fg-subtle">·</span>
+                <span className="shrink-0 font-medium text-status-running">{runningCount} running</span>
+              </>
+            ) : null}
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            side="top"
+            align="start"
+            sideOffset={8}
+            collisionPadding={12}
+            className={cn(
+              // Anchored above the composer, opening UPWARD — the same panel
+              // family + scroll behaviour as the goal pill's detail panel.
+              "z-50 flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto overscroll-contain",
+              "rounded-xl border border-border bg-surface shadow-lg outline-none",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              "data-[side=top]:slide-in-from-bottom-1",
+            )}
+          >
+            <div className="p-2.5">
+              <SubagentsLabel count={count} />
+              {/* count > 0 here (the pill only renders with children), so the
+                  tree always has rows — no loading/empty branch to guard. */}
+              <div className="mt-2">
+                <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={() => setOpen(false)} />
+              </div>
+            </div>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/goal-surface.tsx
+++ b/apps/web/src/components/session/goal-surface.tsx
@@ -194,7 +194,7 @@ export function GoalSurface({
                 aria-label={record.status === "paused" ? "Resume goal" : "Pause goal"}
                 disabled={goal.updating}
                 onClick={() => void (record.status === "paused" ? goal.resume() : goal.pause("Paused from the console"))}
-                className="ml-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full text-fg-subtle outline-none transition-colors hover:bg-surface-3 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                className="ml-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full text-fg-subtle outline-none transition-colors hover:bg-surface-3 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 disabled:opacity-60"
               >
                 {goal.updating ? (
                   <Loader2Icon className="size-3.5 animate-spin" />
@@ -210,7 +210,7 @@ export function GoalSurface({
               <button
                 type="button"
                 aria-label={open ? "Hide goal detail" : "Show goal detail"}
-                className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-fg-subtle outline-none transition-colors hover:bg-surface-3 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-surface-3 data-[state=open]:text-fg"
+                className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-fg-subtle outline-none transition-colors hover:bg-surface-3 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 data-[state=open]:bg-surface-3 data-[state=open]:text-fg"
               >
                 <ChevronDownIcon className="size-3.5 transition-transform data-[state=open]:rotate-180" />
               </button>

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -1,15 +1,15 @@
-// The subagent-lineage surface: everything that renders a session's spawned
-// workers. It is deliberately DECOUPLED from goals — a session's agent tree is
-// orthogonal to whether it carries a goal — and one compact tree component backs
-// two sibling homes:
-//   - SessionAgentsChip — the header "N agents" chip that EXPANDS into a floating
-//     panel, mirroring the goal pill's click-to-expand interaction + elevated
-//     visual family (the glanceable, quick-jump hero).
+// The subagent-lineage surface: the shared pieces that render a session's
+// spawned workers. It is deliberately DECOUPLED from goals — a session's agent
+// tree is orthogonal to whether it carries a goal — and one compact tree
+// component ({@link SubagentTree}) backs every home:
+//   - ComposerAgentsPill (./composer-agents-pill.tsx) — the floating "N agents"
+//     pill above the composer that EXPANDS upward into the lineage popover (the
+//     glanceable, front-and-center hero); reuses {@link SubagentTree} +
+//     {@link SubagentsLabel} from here.
 //   - AgentsPanel — the persistent, roomy "Agents" right-dock tab (the deep view
 //     a manager watches while orchestrating many workers).
-// Both render {@link SubagentTree}: the compact form in the popover, the
-// full-height form in the dock. SpawnedByBreadcrumb is the inverse link a child
-// session shows back to the manager that spawned it.
+// SpawnedByBreadcrumb is the inverse link a child session shows back to the
+// manager that spawned it.
 //
 // Design language: one dense line per agent — a single status-tone dot + a
 // truncated title + a quiet relative-time hint — the whole row a hover-lit
@@ -22,7 +22,6 @@ import { formatRelativeTime } from "@opengeni/react";
 import type { LineageNode, SessionStatus, SessionSummary } from "@opengeni/sdk";
 import { Link } from "@tanstack/react-router";
 import { BotIcon, ChevronRightIcon, Loader2Icon } from "lucide-react";
-import { Popover } from "radix-ui";
 import { useState, type ReactNode } from "react";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -152,7 +151,7 @@ function SubagentRow({
 }
 
 /** The quiet section label both homes wear above the tree. */
-function SubagentsLabel({ count }: { count: number }) {
+export function SubagentsLabel({ count }: { count: number }) {
   return (
     <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-fg-subtle">
       <BotIcon className="size-3.5" />
@@ -210,67 +209,6 @@ export function AgentsPanel({
         )}
       </div>
     </ScrollArea>
-  );
-}
-
-/* --- header "N agents" chip → expands into the goal-pill-family panel -------- */
-
-export function SessionAgentsChip({
-  workspaceId,
-  nodes,
-}: {
-  workspaceId: string;
-  /** Direct children; presentational — the header owns the single lineage read.
-   *  The chip only renders when there ARE children (count>0), so it has no
-   *  loading/empty state of its own. */
-  nodes: LineageNode[];
-}) {
-  const [open, setOpen] = useState(false);
-  const count = nodes.length;
-  if (count === 0) {
-    return null;
-  }
-  return (
-    <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-surface-2/60 px-2 py-0.5 text-2xs font-medium text-fg-muted",
-            "outline-none transition-colors hover:border-border-strong hover:text-fg focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:border-border-strong data-[state=open]:text-fg",
-          )}
-        >
-          <BotIcon className="size-3" />
-          {count} agent{count === 1 ? "" : "s"}
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          side="bottom"
-          align="end"
-          sideOffset={8}
-          collisionPadding={12}
-          className={cn(
-            // Same elevated family as the goal-pill panel (rounded-xl / border /
-            // shadow-lg / surface), just opening DOWNWARD from the header; a tall
-            // lineage scrolls inside rather than overflowing the viewport.
-            "z-50 flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto overscroll-contain",
-            "rounded-xl border border-border bg-surface shadow-lg outline-none",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-            "data-[side=bottom]:slide-in-from-top-1",
-          )}
-        >
-          <div className="p-2.5">
-            <SubagentsLabel count={count} />
-            {/* count > 0 here (the chip/popover only renders with children), so
-                the tree always has rows — no loading/empty branch to guard. */}
-            <div className="mt-2">
-              <SubagentTree workspaceId={workspaceId} nodes={nodes} onNavigate={() => setOpen(false)} />
-            </div>
-          </div>
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
   );
 }
 

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -264,6 +264,13 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     (mcpServerId: string) => capabilityNames.get(mcpServerId) ?? null,
     [capabilityNames],
   );
+  // One lineage read for the whole session view: it gates the dock's "Agents"
+  // tab AND feeds the composer-anchored agents pill, so both stay a single
+  // source of truth (event-derived off the shared feed — no extra poll). Must
+  // sit above the loading/error early-returns — it's a hook, so it has to run
+  // unconditionally on every render.
+  const lineage = useSessionLineage(sessionId, { events });
+  const agentNodes = lineage.lineage?.children ?? [];
 
   if (loading || !session) {
     if (loadError) {
@@ -283,12 +290,6 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     }
     return <LoadingPanel label="Opening session" />;
   }
-
-  // One lineage read for the whole session view: it gates the dock's "Agents"
-  // tab AND feeds the composer-anchored agents pill, so both stay a single
-  // source of truth (event-derived off the shared feed — no extra poll).
-  const lineage = useSessionLineage(sessionId, { events });
-  const agentNodes = lineage.lineage?.children ?? [];
 
   const chatPane = (
     <SessionChatPane

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -266,10 +266,12 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
   );
   // One lineage read for the whole session view: it gates the dock's "Agents"
   // tab AND feeds the composer-anchored agents pill, so both stay a single
-  // source of truth (event-derived off the shared feed — no extra poll). Must
-  // sit above the loading/error early-returns — it's a hook, so it has to run
-  // unconditionally on every render.
-  const lineage = useSessionLineage(sessionId, { events });
+  // source of truth. Events refresh it instantly on spawn/worker-completion, and
+  // a 30s poll (matching the old header chip) is the fallback so the pill's
+  // "running" count doesn't go stale on CHILD-side status changes that emit no
+  // event on this parent's feed. Must sit above the loading/error early-returns
+  // — it's a hook, so it has to run unconditionally on every render.
+  const lineage = useSessionLineage(sessionId, { events, pollIntervalMs: 30_000 });
   const agentNodes = lineage.lineage?.children ?? [];
 
   if (loading || !session) {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -38,6 +38,7 @@ import {
   TerminalSessionBanner,
   UserMessageBody,
 } from "@/components/session/banners";
+import { ComposerAgentsPill } from "@/components/session/composer-agents-pill";
 import { GoalSurface } from "@/components/session/goal-surface";
 import { SessionInspector } from "@/components/session/inspector";
 import { QueueRail } from "@/components/session/queue-rail";
@@ -53,6 +54,7 @@ import { useCodexModels } from "@/lib/use-codex-models";
 import { normalizeProviderDomain } from "@/lib/capabilities";
 import { isTerminalSessionStatus, projectSessionTimeline, summarizeSessionFailure } from "@/lib/events";
 import { buildTools } from "@/lib/session-tools";
+import type { LineageNode } from "@opengeni/sdk";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
 
 export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; sessionId: string }) {
@@ -282,6 +284,12 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
     return <LoadingPanel label="Opening session" />;
   }
 
+  // One lineage read for the whole session view: it gates the dock's "Agents"
+  // tab AND feeds the composer-anchored agents pill, so both stay a single
+  // source of truth (event-derived off the shared feed — no extra poll).
+  const lineage = useSessionLineage(sessionId, { events });
+  const agentNodes = lineage.lineage?.children ?? [];
+
   const chatPane = (
     <SessionChatPane
       session={session}
@@ -292,6 +300,7 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
       failure={failure}
       creditExhausted={creditExhausted}
       goal={goal}
+      agentNodes={agentNodes}
       hasOlder={hasOlder}
       loadingOlder={loadingOlder}
       onLoadOlder={loadOlder}
@@ -317,6 +326,8 @@ export function SessionRoute({ workspaceId, sessionId }: { workspaceId: string; 
         queue={queue}
         goal={goal}
         connectionState={connectionState}
+        agentNodes={agentNodes}
+        agentsLoading={lineage.loading}
         primary={chatPane}
         dockCollapsed={!context.inspectorOpen}
         onDockCollapsedChange={(collapsed) => context.setInspectorOpen(!collapsed)}
@@ -347,6 +358,9 @@ function SessionDock(props: {
   queue: ReturnType<typeof useTurnQueue>;
   goal: ReturnType<typeof useGoal>;
   connectionState: ReturnType<typeof useSessionEvents>["connectionState"];
+  /** Spawned-worker lineage — read once by SessionRoute, shared here + the pill. */
+  agentNodes: LineageNode[];
+  agentsLoading: boolean;
   primary: React.ReactNode;
   dockCollapsed: boolean;
   onDockCollapsedChange: (collapsed: boolean) => void;
@@ -373,13 +387,13 @@ function SessionDock(props: {
     content: <SessionInspector session={props.session} events={props.events} connectionState={props.connectionState} />,
   };
 
-  // The decoupled home for spawned workers (#318): one live lineage read (shared-
-  // feed via the dock's own event stream, no extra poll) gates the "Agents" tab
-  // and feeds its panel. The tab is present only once the session has children,
-  // so a goal-less session still surfaces its agents here. Injected right after
-  // Run (before the package's sandbox tabs) to preserve #318's dock order.
-  const lineage = useSessionLineage(props.sessionId, { events: props.events });
-  const childNodes = lineage.lineage?.children ?? [];
+  // The decoupled home for spawned workers (#318): SessionRoute owns the single
+  // lineage read and passes the children in (props.agentNodes), so the "Agents"
+  // tab AND the composer-anchored pill stay one source of truth. The tab is
+  // present only once the session has children, so a goal-less session still
+  // surfaces its agents here. Injected right after Run (before the package's
+  // sandbox tabs) to preserve #318's dock order.
+  const childNodes = props.agentNodes;
   const agentsTab: WorkspaceTab | null =
     childNodes.length > 0
       ? {
@@ -394,7 +408,7 @@ function SessionDock(props: {
             <AgentsPanel
               workspaceId={props.workspaceId}
               nodes={childNodes}
-              loading={lineage.loading && childNodes.length === 0}
+              loading={props.agentsLoading && childNodes.length === 0}
             />
           ),
         }
@@ -426,6 +440,8 @@ function SessionChatPane(props: {
   /** The last turn ended budget_exhausted — the workspace is out of credits. */
   creditExhausted: boolean;
   goal: ReturnType<typeof useGoal>;
+  /** Spawned-worker lineage children — feeds the composer-anchored agents pill. */
+  agentNodes: LineageNode[];
   hasOlder: boolean;
   loadingOlder: boolean;
   onLoadOlder: () => Promise<boolean>;
@@ -611,10 +627,15 @@ function SessionChatPane(props: {
         </div>
       ) : null}
 
-      {/* The floating goal pill hovers just above the composer (hidden when the
-          session has no goal). */}
+      {/* Front-and-center floating pills above the composer: the agents pill
+          (spawned workers, with a live running indicator) stacks over the goal
+          pill. Each hides when it has nothing to show, so they degrade to
+          whichever one is present — or neither. */}
       {!terminal ? (
-        <GoalSurface session={props.session} goal={props.goal} />
+        <>
+          <ComposerAgentsPill workspaceId={props.session.workspaceId} nodes={props.agentNodes} />
+          <GoalSurface session={props.session} goal={props.goal} />
+        </>
       ) : null}
 
       <div className="shrink-0 px-4 pb-4 pt-1 sm:px-6">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -149,13 +149,19 @@ body {
   background: transparent;
 }
 
-/* Focus ring. The composer textarea is excluded: its wrapper already shows a
-   whole-composer focus affordance (focus-within border + soft glow), and a
-   per-textarea outline here painted a second highlight bounded to the textarea
-   box (the top half, stopping above the toolbar). Scoping it out of `.og-root`
-   leaves every other control's focus ring intact. */
-:where(button, a, input, textarea, [role="button"], [tabindex]):focus-visible:not(.og-root textarea) {
-  outline: 2px solid var(--color-brand);
+/* Focus ring. One calm, intentional treatment: a soft brand-tinted ring set off
+   from the control by a 2px gap (never a harsh full-chroma hairline hugging the
+   edge). Kept clearly visible for keyboard users while reading as designed, not
+   as a default browser outline.
+
+   Two exclusions:
+   - the composer textarea (`.og-root textarea`) already shows a whole-composer
+     focus affordance (focus-within border + soft glow), so a second outline
+     bounded to the textarea box would double it;
+   - shadcn buttons (`[data-slot="button"]`) carry their own offset ring in
+     button.tsx — excluding them here avoids stacking two rings on one control. */
+:where(button, a, input, textarea, [role="button"], [tabindex]):focus-visible:not(.og-root textarea):not([data-slot="button"]) {
+  outline: 2px solid color-mix(in oklch, var(--color-ring) 55%, transparent);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
 }


### PR DESCRIPTION
Three founder-flagged UI fixes (all verified in BOTH themes via a throwaway apps/web harness; rebased onto #322 Workbench v2).

## 1 — Session header polish (light theme was broken)
In light mode the header was a near-white strip on near-white canvas with only a faint hairline — read as unfinished, title undersized, metadata weak. Extracted the header markup into a pure `SessionHeader` (screenshot-testable) and polished: a subtle elevated band (`bg-surface/80` + backdrop-blur + crisp divider) so it reads as a bar in light and lifts slightly in dark (no dark regression); title → 15px semibold tighter tracking; model token → muted/medium; more breathing room.

## 2 — Calmer focus ring
Buttons stacked a tight `border-ring` blue hug + a 3px ring + a 2nd full-chroma global outline — a harsh doubled blue outline. Now one treatment: a soft `ring-2 ring-ring/40` with `ring-offset-2` (the Linear/Stripe offset ring), global outline softened to `color-mix(ring 55%, transparent)`, shadcn buttons excluded so nothing stacks. Keyboard focus stays clearly visible (a11y).

## 3 — "N agents" indicator moved above the composer
Was a chip tucked in the top-right header next to the status pill. Now a floating pill **above the composer, sibling to the goal pill** (stacked, agents on top): calm = "3 agents"; running = a pulsing running-tone dot + "1 running" (derived from lineage children). Click expands the SAME subagent tree popover, re-anchored to open UPWARD. `SessionRoute` owns the single `useSessionLineage` read and passes children to BOTH the Agents dock tab and the pill (one source of truth, no 2nd network read). The persistent Agents dock tab is unchanged. Removed the old header chip.

## Verify
apps/web + packages/react typecheck clean (tsgo); full unit tests green (180 web + 477 react). Screenshots (header/focus/pill/popover, before+after, both themes) in the worktree `apps/web/.agent/screenshots/`.

## Note / open question
No in-app light/dark toggle exists in the code — the only light mechanism is the `data-og-theme="light"` attribute (what the react demos read). Fixes are token-based so they're correct regardless of how light is triggered, but we should confirm how users actually land in light (and possibly add a real toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1BYTN91Gqkbpx3QPRhK1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI refactor and styling; lineage data is consolidated but behavior stays the same with no security or API changes.
> 
> **Overview**
> **Session header** is extracted into a presentational `SessionHeader` (slots for sandbox/codex) with a clearer elevated bar in light mode, stronger title/metadata typography, and `CanvasTopStrip` wiring only breadcrumb lineage (no child count in the rail).
> 
> The **“N agents” control** moves from the header chip to **`ComposerAgentsPill`** stacked above the goal pill: floating pill styling, live “X running” when workers are active, and the same `SubagentTree` popover opening upward. **`SessionRoute`** owns one `useSessionLineage` (events + 30s poll) shared by the dock **Agents** tab and the pill; **`SessionAgentsChip`** is removed.
> 
> **Focus styling** is unified: shadcn buttons use a softer offset ring; the global outline is muted and excludes `[data-slot="button"]` and the composer textarea; goal pill icon buttons use `ring-ring/40`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecac7533fdbca7d3b4f19a1bc94a04afec9777d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->