### PR TITLE
fix(workbench): gate cold prewarm to intent + capture-driven default tab

### DIFF
--- a/packages/react/src/components/code-editor.tsx
+++ b/packages/react/src/components/code-editor.tsx
@@ -106,6 +106,10 @@ export type CodeEditorProps = {
   initialContents: string;
   /** Persist the current buffer. Resolves when the write lands; rejects to surface an error. */
   onSave: (contents: string) => Promise<unknown>;
+  /** Fired once when the buffer FIRST diverges from its baseline (the first real
+   *  keystroke) — the wake-on-edit intent. The host warms the box on this so the
+   *  eventual save lands fast; merely opening the file for reading never fires it. */
+  onEditIntent?: (() => void) | undefined;
   /** Read-only mode (e.g. a truncated/too-large file shown for reference only). */
   readOnly?: boolean | undefined;
   themeType?: "dark" | "light" | undefined;
@@ -132,6 +136,7 @@ export function CodeEditor({
   path,
   initialContents,
   onSave,
+  onEditIntent,
   readOnly = false,
   themeType = "dark",
   loading,
@@ -155,17 +160,34 @@ export function CodeEditor({
   // Reload the buffer when the file identity changes. Guard on initialContents
   // too so an external refresh of the SAME path (e.g. fs.changed re-read) reseeds
   // a clean buffer — but only when the user hasn't got unsaved edits in flight.
+  // Fire the wake-on-edit intent at most once per opened file — reset on re-seed.
+  const editIntentFiredRef = useRef(false);
   const lastSeed = useRef<{ path: string; contents: string }>({ path, contents: initialContents });
   useEffect(() => {
     const seedChanged =
       lastSeed.current.path !== path || lastSeed.current.contents !== initialContents;
     if (!seedChanged) return;
     lastSeed.current = { path, contents: initialContents };
+    editIntentFiredRef.current = false;
     setValue(initialContents);
     setBaseline(initialContents);
     setSaveError(null);
     setSavedTick(false);
   }, [path, initialContents]);
+
+  // Record a buffer change: the FIRST divergence from the baseline is the edit
+  // intent that warms the box (idempotent — latched per opened file).
+  const noteEdit = useCallback(
+    (next: string) => {
+      setValue(next);
+      setSavedTick(false);
+      if (!editIntentFiredRef.current && next !== baseline) {
+        editIntentFiredRef.current = true;
+        onEditIntent?.();
+      }
+    },
+    [baseline, onEditIntent],
+  );
 
   // Resolve the lazy bundle (editor + keymap/Prec helpers + language grammar)
   // once, re-resolving the grammar when the file's language class changes.
@@ -261,10 +283,7 @@ export function CodeEditor({
           <PlainTextarea
             value={value}
             readOnly={readOnly}
-            onChange={(next) => {
-              setValue(next);
-              setSavedTick(false);
-            }}
+            onChange={noteEdit}
           />
         )}
       </div>
@@ -348,14 +367,7 @@ export function CodeEditor({
             extensions={cmExtensions}
             height="100%"
             className="og-cm-editor min-h-full text-og-sm"
-            onChange={
-              readOnly
-                ? undefined
-                : (next: string) => {
-                    setValue(next);
-                    setSavedTick(false);
-                  }
-            }
+            onChange={readOnly ? undefined : noteEdit}
           />
         </Suspense>
       </div>

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -23,6 +23,10 @@ export type SandboxFilesProps = {
   /** Allow in-place editing of tree files (CodeMirror). Default true. When false
    *  the surface is review-only: every text file opens in the read-only viewer. */
   editable?: boolean | undefined;
+  /** Fired once when the user first edits an open file (wake-on-edit intent). The
+   *  dock warms the box on this so the save lands fast; opening/reading never fires
+   *  it. Browsing the tree/diff must not warm a box. */
+  onEditIntent?: (() => void) | undefined;
   themeType?: "dark" | "light" | undefined;
   className?: string | undefined;
 };
@@ -40,6 +44,7 @@ export function SandboxFiles({
   fileSystemAvailable = true,
   usePierre = true,
   editable = true,
+  onEditIntent,
   themeType,
   className,
 }: SandboxFilesProps) {
@@ -159,6 +164,7 @@ export function SandboxFiles({
                   initialContents={fileView.content}
                   themeType={resolvedTheme}
                   onSave={(contents) => files.writeFile(viewPath, contents)}
+                  {...(onEditIntent ? { onEditIntent } : {})}
                   className="h-full"
                 />
               ) : fileView.error ? (

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -52,11 +52,16 @@ export const WORKBENCH_TAB_CHANGES = "changes";
 export const WORKBENCH_TAB_FILES = "files";
 
 /**
- * Decide the initial workspace tab BEFORE first paint from already-local data:
- * the newest `workspace.revision.captured` announce in the event log carries the
- * change surface stats, so "changes exist → Changes, else Files" is decided with
- * zero machine round-trips and no post-render tab switch (dossier §3 #6 / §12-D1).
- * A host `override` (e.g. a landing "run" tab) wins when supplied.
+ * Decide a workspace tab from an already-local event log: the newest
+ * `workspace.revision.captured` announce carries the change surface stats, so
+ * "changes exist → Changes, else Files" needs zero machine round-trips. A host
+ * `override` (e.g. a landing "run" tab) wins when supplied.
+ *
+ * NOTE: the dock no longer uses this for its default tab — `<SandboxWorkspace>`
+ * now derives the default from its OWN capture fetch (`useWorkspaceCapture`'s
+ * `fileCount`), so a pure embedder needs no events-at-mount contract (Refinement
+ * 2). This remains exported as a standalone helper for hosts that already hold
+ * the event log and want the same decision without the capture fetch.
  */
 export function initialWorkspaceTab(events: SessionEvent[] | undefined, override?: string | null): string {
   if (override) return override;
@@ -118,9 +123,9 @@ export type UseSandboxWorkspaceTabsOptions = ClientOverride & {
   sessionId: string;
   /** Live event log (usually `useSessionEvents().events`). */
   events: SessionEvent[];
-  /** Whether the Files tab is the one on screen. Drives the warm-box viewer
-   *  holder so Channel-A fs ops are ~100ms (warm) instead of ~5s (cold resume). */
-  filesActive?: boolean | undefined;
+  /** Override the capture-driven default tab (e.g. a host landing tab id). When
+   *  omitted the workbench picks Changes-vs-Files from its own capture fetch. */
+  initialTab?: string | null | undefined;
   /** Host-routed notifications (mutation errors, desktop-consent failures). The
    *  package never imports a toast library — the host decides how to surface. */
   onNotify?: ((notification: WorkspaceNotification) => void) | undefined;
@@ -129,9 +134,12 @@ export type UseSandboxWorkspaceTabsOptions = ClientOverride & {
 export type UseSandboxWorkspaceTabsResult = {
   /** Changes | Files | Terminal | Desktop (capability-gated where noted). */
   tabs: WorkspaceTab[];
-  /** The pre-paint default tab (Changes when the session has changes, else Files).
-   *  Frozen at mount so it never causes a post-render switch. */
-  defaultTab: string;
+  /** The capture-driven default tab: Changes when the session has changes, else
+   *  Files (a host `initialTab` overrides). null during the brief window before the
+   *  capture GET first resolves (and no host override was given) — consumers render
+   *  their dock's own first-tab fallback until it latches, which it does ONCE, so it
+   *  never causes a post-render switch. */
+  defaultTab: string | null;
   /** The machine-state model for the dock-header chip. */
   machine: WorkspaceMachine;
 };
@@ -143,12 +151,17 @@ export type UseSandboxWorkspaceTabsResult = {
  */
 export function useSandboxWorkspaceTabs(options: UseSandboxWorkspaceTabsOptions): UseSandboxWorkspaceTabsResult {
   const { client, workspaceId } = useOpenGeni(options);
-  const { sessionId, events, filesActive = false, onNotify } = options;
+  const { sessionId, events, onNotify } = options;
+  const initialTab = options.initialTab ?? null;
 
-  // Desktop watch consent (off by default) and terminal engagement (flips true on
-  // interact, never on mount) — the two interactions that warm the box.
+  // The three — and only three — box-warming INTENTS, each off by default and each
+  // flipped true by a genuine user action (never on mount, never on a passive
+  // capture glance): desktop watch consent, terminal engagement (`onActivate`), and
+  // the first wake-on-edit keystroke in the Files editor. Browsing capture-served
+  // Changes/Files warms nothing — that is the whole point of Refinement 1.
   const [watchDesktop, setWatchDesktop] = useState(false);
   const [warmTerminal, setWarmTerminal] = useState(false);
+  const [warmEdit, setWarmEdit] = useState(false);
 
   // The session's machine fleet + the active-sandbox pointer. Drives the header
   // chip (which machine + its connection state). Polls slowly — ambient context.
@@ -162,7 +175,9 @@ export function useSandboxWorkspaceTabs(options: UseSandboxWorkspaceTabsOptions)
     events,
     attachDesktop: watchDesktop,
     attachTerminal: warmTerminal,
-    attachFiles: filesActive,
+    // Edit intent only — NOT "the Files tab is open". A cold edit warms the box
+    // (that is the wake); a cold glance at the tree/diff does not.
+    attachFiles: warmEdit,
   });
   const capabilities = caps.capabilities;
   const liveness = capabilities?.liveness;
@@ -277,13 +292,27 @@ export function useSandboxWorkspaceTabs(options: UseSandboxWorkspaceTabsOptions)
     capabilitiesState: caps.state,
     activeMachineState: activeMachine?.state ?? null,
     activeIsSelfhosted: activeMachine?.kind === "selfhosted",
-    wantsWarm: warmTerminal || watchDesktop,
+    wantsWarm: warmTerminal || watchDesktop || warmEdit,
     capturedAt: captureState.capturedAt,
   });
 
-  // Freeze the pre-paint default tab at mount so live data can never switch it.
+  // The pre-paint default tab, decided from the workbench's OWN capture fetch — no
+  // embedder events-at-mount contract (Refinement 2). A host `initialTab` wins
+  // immediately; otherwise the default stays null until the capture GET first
+  // resolves, then latches Changes (changes exist) or Files, ONCE — live data can
+  // never switch it afterward. Committing at first-resolve — before the tab body's
+  // first CONTENT paint (both bodies show a connecting/loading state until the
+  // capture lands) — means the first real content is the correct tab, no switch. A
+  // pure embedder that never preloads events now gets the right default for free.
   const defaultTabRef = useRef<string | null>(null);
-  if (defaultTabRef.current === null) defaultTabRef.current = initialWorkspaceTab(events);
+  if (defaultTabRef.current === null) {
+    if (initialTab) {
+      defaultTabRef.current = initialTab;
+    } else if (captureState.fileCount !== null) {
+      defaultTabRef.current = captureState.fileCount > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
+    }
+  }
+  // null only during the brief pre-first-resolve window (no host override yet).
   const defaultTab = defaultTabRef.current;
 
   const tabs = useMemo(() => {
@@ -319,6 +348,9 @@ export function useSandboxWorkspaceTabs(options: UseSandboxWorkspaceTabsOptions)
           stagedGit={stagedGit}
           fileSystemAvailable={fileSystemOn || captureAvailable}
           editable={filesEditable}
+          // The first keystroke in the editor is the wake-on-edit INTENT: warm the
+          // box (even cold) so the write lands fast. Opening/reading files does not.
+          onEditIntent={() => setWarmEdit(true)}
           className="h-full"
         />
       ),
@@ -450,22 +482,22 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     className,
   } = props;
 
-  // The active tab is owned here (controlled on the dock) and seeded pre-paint so
-  // there is no post-render switch and no layout shift (D1). Frozen once.
-  const [activeTab, setActiveTab] = useState<string>(() => initialWorkspaceTab(events, initialTab));
-
-  // The Files surface holds the box warm only while it is actually on screen.
-  const isCollapsed = collapsed ?? false;
-  const filesActive = !isCollapsed && activeTab === WORKBENCH_TAB_FILES;
-
-  const { tabs: workbenchTabs, machine } = useSandboxWorkspaceTabs({
+  const { tabs: workbenchTabs, machine, defaultTab } = useSandboxWorkspaceTabs({
     ...(props.client ? { client: props.client } : {}),
     ...(props.workspaceId ? { workspaceId: props.workspaceId } : {}),
     sessionId,
     events,
-    filesActive,
+    ...(initialTab ? { initialTab } : {}),
     ...(onNotify ? { onNotify } : {}),
   });
+
+  // A user's tab click wins forever; before that we follow the capture-driven
+  // default. While it is still resolving (null, pure-embedder pre-first-resolve)
+  // we pass no controlled tab, so the dock renders its own first-tab fallback
+  // (Changes) — whose body is a connecting/loading state until the capture lands,
+  // so committing the real default at first-resolve produces no CONTENT switch.
+  const [selectedTab, setSelectedTab] = useState<string | null>(null);
+  const activeTab = selectedTab ?? defaultTab ?? undefined;
 
   const tabs: WorkspaceTab[] = [...(leadingTabs ?? []), ...workbenchTabs, ...(trailingTabs ?? [])];
 
@@ -473,8 +505,8 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     <WorkspaceDock
       primary={primary}
       tabs={tabs}
-      activeTab={activeTab}
-      onActiveTabChange={setActiveTab}
+      {...(activeTab !== undefined ? { activeTab } : {})}
+      onActiveTabChange={setSelectedTab}
       headerAccessory={
         <MachineStateChip
           chip={machine.chip}

--- a/packages/react/src/hooks/use-session-capabilities.ts
+++ b/packages/react/src/hooks/use-session-capabilities.ts
@@ -49,15 +49,18 @@ export type UseSessionCapabilitiesOptions = ClientOverride & {
    */
   attachTerminal?: boolean | undefined;
   /**
-   * Whether to acquire a viewer holder purely to KEEP THE BOX WARM while the
-   * structured Files surface is open. Shares the SAME viewer attach as the
-   * desktop/terminal (one warm box, one holder) and — like the terminal — needs
-   * NO un-redacted acknowledgment: listing/reading/writing files is the ordinary
-   * Channel-A control plane, not the pixel plane. Default false: the Files tab
-   * negotiates read-only and each op pays the cold-box resume (~5s). When true,
-   * the holder warms the box once and heartbeats it, so subsequent fs ops are
-   * ~100ms instead of re-resuming the box on every list/write. It folds NO live
-   * URL (files ride the stateless HTTP plane) — it only refcounts liveness.
+   * Whether to acquire a viewer holder to warm the box for a FILE WRITE — the
+   * wake-on-edit INTENT (a first keystroke in the editor), NOT passive browsing.
+   * Shares the SAME viewer attach as the desktop/terminal (one warm box, one
+   * holder) and — like the terminal — needs NO un-redacted acknowledgment:
+   * reading/writing files is the ordinary Channel-A control plane, not the pixel
+   * plane. It folds NO live URL (files ride the stateless HTTP plane) — it only
+   * refcounts liveness. Unlike desktop/terminal it warms even a COLD box: an edit
+   * legitimately cold-creates (that IS the wake), so the write lands ~100ms warm
+   * instead of paying the ~5s cold resume. Default false. IMPORTANT: merely
+   * opening/reading the Files tab must NOT set this — browsing capture-served
+   * trees/diffs needs no box, and warming one on a cold glance burns box-hours to
+   * serve reads the capture already answers for free.
    */
   attachFiles?: boolean | undefined;
   /** Hold off negotiating (e.g. the workbench panel is collapsed). Default true. */
@@ -281,16 +284,15 @@ export function useSessionCapabilities(
         // mint the URLs. Only a genuinely-unsupported reason suppresses the attach.
         const wantDesktopAttach = attachDesktop && desktopAttachable(caps.DesktopStream);
         const wantTerminalAttach = attachTerminal && terminalAttachable(caps.Terminal);
-        // The Files surface warms the box for fast Channel-A ops. It folds no live
-        // URL (files are stateless HTTP) — the attach is purely a liveness refcount.
-        // Under lazy provisioning it must only KEEP AN EXISTING box warm, never
-        // cold-CREATE one: merely opening the Files tab on a boxless session must
-        // not force a box (that would defeat lazy provisioning). So it's wanted only
-        // when the FileSystem cap is advertised AND a box already exists (liveness
-        // is anything but cold). A genuine warm action (desktop consent / terminal
-        // engage) still spins a cold box up — those are user-initiated, files-open
-        // is not.
-        const wantFilesAttach = attachFiles && caps.FileSystem.available && caps.liveness !== "cold";
+        // The Files attach warms the box for a file WRITE (wake-on-edit intent). It
+        // folds no live URL (files are stateless HTTP) — the attach is purely a
+        // liveness refcount. Unlike the previous "keep the box warm while the Files
+        // tab is on screen" wiring, this fires on genuine EDIT intent only, so it
+        // legitimately cold-CREATES: an edit is the wake, and the caller (the dock)
+        // never sets it for passive browsing. Gate solely on the FileSystem cap
+        // being advertised; liveness (cold included) does not suppress it — POST
+        // /viewers warms a cold box exactly as it does for a desktop/terminal engage.
+        const wantFilesAttach = attachFiles && caps.FileSystem.available;
         if (wantDesktopAttach || wantTerminalAttach || wantFilesAttach) {
           try {
             // Declare WHICH plane we're attaching for. `desktop:true` opts into the

--- a/packages/react/src/hooks/use-workspace-capture.ts
+++ b/packages/react/src/hooks/use-workspace-capture.ts
@@ -28,6 +28,12 @@ export type UseWorkspaceCaptureResult = {
   capturedAt: string | null;
   /** Whether a capture is available at all (the `{available:false}` discriminator). */
   available: boolean;
+  /** The changed-file count from the capture's stats, resolved on the FIRST GET
+   *  (from the response's top-level `stats`, before any manifest-URL hop). null
+   *  until that first resolve; 0 when no capture exists. This is the pre-paint
+   *  "changes exist?" signal the dock uses to pick its default tab with no
+   *  embedder events-at-mount contract. */
+  fileCount: number | null;
   /** A newer revision has been ANNOUNCED than the one currently loaded (a refresh
    *  is in flight or pending). M5's source badge can show a subtle "updating…". */
   isStale: boolean;
@@ -57,6 +63,9 @@ export function useWorkspaceCapture(
 
   const [capture, setCapture] = useState<WorkspaceCaptureManifest | null>(null);
   const [available, setAvailable] = useState(false);
+  // Resolved from the FIRST GET's top-level stats (before any manifest-URL hop),
+  // so the dock can pick its default tab as early as possible. null until then.
+  const [fileCount, setFileCount] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   // The highest revision ANNOUNCED on the event log — compared against the loaded
@@ -78,8 +87,12 @@ export function useWorkspaceCapture(
       if (!res.available) {
         setCapture(null);
         setAvailable(false);
+        setFileCount(0);
         return;
       }
+      // Resolve the changed-file count immediately from the response's stats — the
+      // default-tab signal must not wait on a >2MB manifest-URL hop.
+      setFileCount(res.stats.fileCount);
       // Exactly one of manifest / manifestUrl is non-null (M2 contract). The inline
       // manifest is the <200ms common case; a >2MB manifest is a signed URL hop.
       let manifest = res.manifest;
@@ -114,6 +127,7 @@ export function useWorkspaceCapture(
     if (!enabled) {
       setCapture(null);
       setAvailable(false);
+      setFileCount(null);
       setAnnouncedRevision(null);
       return;
     }
@@ -160,6 +174,7 @@ export function useWorkspaceCapture(
     revision: loadedRevision,
     capturedAt: capture?.capturedAt ?? null,
     available,
+    fileCount,
     isStale,
     loading,
     error,

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -231,6 +231,56 @@ describe("useSessionCapabilities", () => {
     await hook.unmount();
   });
 
+  test("attachFiles warms even a COLD box — wake-on-edit cold-creates (Refinement 1)", async () => {
+    // Edit intent legitimately spins a cold box up (that IS the wake). The old
+    // "keep-warm-only-if-already-warm" guard is gone: attachFiles now attaches on a
+    // cold lease, minting a holder with desktop:false (no un-redacted consent gate).
+    let attachCalls = 0;
+    let attachOpts: { desktop?: boolean } | null = null;
+    const client = fakeClient({
+      getStreamCapabilities: async () => fakeColdCapabilities(),
+      attachViewer: async (_w: string, _s: string, opts: { desktop?: boolean }) => {
+        attachCalls += 1;
+        attachOpts = opts;
+        return fakeAttachResponse();
+      },
+      heartbeatViewer: async () => ({ alive: true }),
+      detachViewer: async () => {},
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachFiles: true }),
+      undefined,
+    );
+    await flush();
+    expect(attachCalls).toBe(1);
+    expect(attachOpts).not.toBeNull();
+    expect((attachOpts as { desktop?: boolean }).desktop).toBe(false);
+    // A holder was minted → the box is live, not resting on the benign on-demand state.
+    expect(hook.result.current.state).toBe("ready");
+    await hook.unmount();
+  });
+
+  test("no attach intent: a cold session NEVER calls attachViewer — browsing is free (Refinement 1)", async () => {
+    // With no desktop/terminal/edit intent, a cold lease must warm nothing: reviewing
+    // capture-served Changes/Files costs zero Modal box-hours.
+    let attachCalls = 0;
+    const client = fakeClient({
+      getStreamCapabilities: async () => fakeColdCapabilities(),
+      attachViewer: async () => {
+        attachCalls += 1;
+        return fakeAttachResponse();
+      },
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, warmingPollMs: 20 }),
+      undefined,
+    );
+    await flush(80);
+    expect(attachCalls).toBe(0);
+    expect(hook.result.current.state).toBe("on-demand");
+    await hook.unmount();
+  });
+
   test("disabled hook stays idle (panel collapsed)", async () => {
     const client = fakeClient({ getStreamCapabilities: async () => fakeCapabilities() });
     const hook = await renderHook(

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -254,7 +254,7 @@ describe("useSessionCapabilities", () => {
     await flush();
     expect(attachCalls).toBe(1);
     expect(attachOpts).not.toBeNull();
-    expect((attachOpts as { desktop?: boolean }).desktop).toBe(false);
+    expect((attachOpts as unknown as { desktop?: boolean }).desktop).toBe(false);
     // A holder was minted → the box is live, not resting on the benign on-demand state.
     expect(hook.result.current.state).toBe("ready");
     await hook.unmount();

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -1,0 +1,319 @@
+/* ----------------------------------------------------------------------------
+   Workbench dock refinements.
+
+   Refinement 1 — the cold-session prewarm is gated to INTENT, not view: mounting
+   the dock / browsing capture-served Changes/Files warms NO Modal box; only a
+   genuine warm intent (terminal activate, desktop watch, first edit keystroke)
+   attaches a viewer. This closes a live prod cost (box-hours burned to serve reads
+   the capture already answers for free).
+
+   Refinement 2 — the default tab is decided from the workbench's OWN capture fetch
+   (`fileCount`) at first-resolve, with no embedder events-at-mount contract, and
+   with no post-paint CONTENT switch (the dock's first-tab fallback body is a
+   loader until the capture lands, so the committed default is the first real
+   content).
+   -------------------------------------------------------------------------- */
+import { describe, expect, test } from "bun:test";
+import { act, type ReactElement, type ReactNode } from "react";
+import type { GetWorkspaceCaptureResponse, WorkspaceCaptureManifest } from "@opengeni/sdk";
+import { registerDom, renderComponent, flush } from "./render-hook";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+import type { SessionClientLike } from "../src/client";
+import { fakeAttachResponse, fakeColdCapabilities } from "./sandbox-fixtures";
+import { OpenGeniProvider } from "../src/provider";
+import {
+  useSandboxWorkspaceTabs,
+  type UseSandboxWorkspaceTabsOptions,
+  type UseSandboxWorkspaceTabsResult,
+  SandboxWorkspace,
+  WORKBENCH_TAB_CHANGES,
+  WORKBENCH_TAB_FILES,
+} from "../src/components/sandbox-workspace";
+
+registerDom();
+
+const EMPTY_MACHINES = { activeSandboxId: null, activeEpoch: 0, machines: [] };
+
+/** The composite dock hook's sub-hooks resolve the client from context, so it
+ *  must run under a provider (unlike the leaf hooks). This renders it there and
+ *  exposes the latest return value. */
+async function renderTabsHook(
+  client: SessionClientLike,
+  options: Omit<UseSandboxWorkspaceTabsOptions, "client" | "workspaceId">,
+): Promise<{ result: { current: UseSandboxWorkspaceTabsResult }; unmount: () => Promise<void> }> {
+  const result = { current: undefined as unknown as UseSandboxWorkspaceTabsResult };
+  function Harness() {
+    result.current = useSandboxWorkspaceTabs(options);
+    return null;
+  }
+  const rendered = await renderComponent(withProvider(client, <Harness />));
+  return { result, unmount: rendered.unmount };
+}
+
+function withProvider(client: SessionClientLike, children: ReactNode): ReactElement {
+  return (
+    <OpenGeniProvider client={client} workspaceId={WORKSPACE_ID}>
+      {children}
+    </OpenGeniProvider>
+  );
+}
+
+// ── Capture fixtures ──────────────────────────────────────────────────────────
+
+function fakeManifest(fileCount: number): WorkspaceCaptureManifest {
+  const diff =
+    fileCount > 0
+      ? [
+          {
+            path: "app.py",
+            oldPath: null,
+            status: "modified" as const,
+            isBinary: false,
+            isImage: false,
+            additions: 2,
+            deletions: 1,
+            truncated: false,
+            hunks: [
+              {
+                oldStart: 1,
+                oldLines: 1,
+                newStart: 1,
+                newLines: 2,
+                header: "@@ -1 +1,2 @@",
+                lines: [{ type: "add" as const, oldNo: null, newNo: 2, text: "x" }],
+              },
+            ],
+          },
+        ]
+      : [];
+  return {
+    version: 1,
+    revision: 3,
+    capturedAt: "2026-07-08T12:00:00.000Z",
+    turnId: "turn-1",
+    leaseEpoch: 1,
+    treeIndex: {
+      name: "",
+      path: "",
+      type: "dir",
+      sizeBytes: null,
+      mtimeMs: null,
+      mode: null,
+      truncated: false,
+      children: [{ name: "app.py", path: "app.py", type: "file", sizeBytes: 10, mtimeMs: null, mode: null, truncated: false }],
+    },
+    treeTruncated: false,
+    repos: [{ root: "", head: "main", detached: false, upstream: null, ahead: 0, behind: 0, status: [], diff }],
+    files:
+      fileCount > 0
+        ? [{ path: "app.py", status: "modified", hash: "h1", baseHash: null, contentRef: "blob/h1", sizeBytes: 10, isBinary: false, tooLarge: false, deleted: false }]
+        : [],
+    stats: {
+      repoCount: 1,
+      fileCount,
+      additions: fileCount > 0 ? 2 : 0,
+      deletions: fileCount > 0 ? 1 : 0,
+      totalBytes: 10,
+      tooLargeCount: 0,
+      binaryCount: 0,
+      treeEntryCount: 1,
+      treeTruncated: false,
+      durationMs: 5,
+    },
+  };
+}
+
+function captureAvailable(manifest: WorkspaceCaptureManifest): GetWorkspaceCaptureResponse {
+  return {
+    available: true,
+    revision: manifest.revision,
+    capturedAt: manifest.capturedAt,
+    turnId: manifest.turnId,
+    leaseEpoch: manifest.leaseEpoch,
+    sizeBytes: 512,
+    stats: manifest.stats,
+    manifest,
+    manifestUrl: null,
+  };
+}
+
+/** A cold-lease client whose Files/Git surfaces seed from the given capture (no
+ *  live calls) and whose viewer attach is spied. */
+function coldClient(overrides: Partial<Parameters<typeof fakeClient>[0]> = {}) {
+  const spy = { attachCalls: 0 };
+  const client = fakeClient({
+    getStreamCapabilities: async () => fakeColdCapabilities(),
+    getWorkspaceCapture: async () => captureAvailable(fakeManifest(1)),
+    listMachines: async () => EMPTY_MACHINES,
+    attachViewer: async () => {
+      spy.attachCalls += 1;
+      return fakeAttachResponse();
+    },
+    heartbeatViewer: async () => ({ alive: true }),
+    detachViewer: async () => {},
+    ...overrides,
+  });
+  return { client, spy };
+}
+
+// ── Refinement 1: prewarm gated to intent ────────────────────────────────────
+
+describe("workbench prewarm gating (Refinement 1)", () => {
+  test("a cold dock mount browsing capture-served surfaces warms NO box", async () => {
+    const { client, spy } = coldClient();
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    // Well past the negotiate + capture GET: nothing asked for a box.
+    await flush(60);
+    expect(spy.attachCalls).toBe(0);
+    // Changes + Files are present (capture-backed), so review works with no box.
+    const ids = hook.result.current.tabs.map((t) => t.id);
+    expect(ids).toContain(WORKBENCH_TAB_CHANGES);
+    expect(ids).toContain(WORKBENCH_TAB_FILES);
+    await hook.unmount();
+  });
+
+  test("the FIRST edit keystroke warms the box (wake-on-edit intent)", async () => {
+    const { client, spy } = coldClient();
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush(60);
+    expect(spy.attachCalls).toBe(0);
+    // Reach the Files tab's onEditIntent (the editor's first-keystroke signal).
+    const filesTab = hook.result.current.tabs.find((t) => t.id === WORKBENCH_TAB_FILES);
+    const onEditIntent = (filesTab?.content as ReactElement).props.onEditIntent as () => void;
+    expect(typeof onEditIntent).toBe("function");
+    await act(async () => {
+      onEditIntent();
+    });
+    await flush(60);
+    // The edit intent flipped attachFiles → the box warmed via a viewer attach.
+    expect(spy.attachCalls).toBe(1);
+    await hook.unmount();
+  });
+
+  test("activating the terminal warms the box (interactive PTY intent)", async () => {
+    const { client, spy } = coldClient();
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush(60);
+    expect(spy.attachCalls).toBe(0);
+    const terminalTab = hook.result.current.tabs.find((t) => t.id === "terminal");
+    expect(terminalTab).toBeDefined();
+    // content = <div><SandboxTerminal onActivate=… /></div>
+    const inner = (terminalTab!.content as ReactElement).props.children as ReactElement;
+    const onActivate = inner.props.onActivate as () => void;
+    await act(async () => {
+      onActivate();
+    });
+    await flush(60);
+    expect(spy.attachCalls).toBe(1);
+    await hook.unmount();
+  });
+});
+
+// ── Refinement 2: capture-driven default tab ─────────────────────────────────
+
+describe("capture-driven default tab (Refinement 2)", () => {
+  test("changes present → default Changes; empty → default Files", async () => {
+    const withChanges = coldClient({ getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)) });
+    const changesHook = await renderTabsHook(withChanges.client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(changesHook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await changesHook.unmount();
+
+    const empty = coldClient({ getWorkspaceCapture: async () => captureAvailable(fakeManifest(0)) });
+    const emptyHook = await renderTabsHook(empty.client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(emptyHook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await emptyHook.unmount();
+  });
+
+  test("no capture at all → default Files (fileCount resolves 0)", async () => {
+    const { client } = coldClient({ getWorkspaceCapture: async () => ({ available: false }) });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await hook.unmount();
+  });
+
+  test("a host initialTab overrides the capture-driven default", async () => {
+    const { client } = coldClient({ getWorkspaceCapture: async () => captureAvailable(fakeManifest(5)) });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [], initialTab: "run" });
+    await flush();
+    // Even though the capture has changes, the host landing tab wins.
+    expect(hook.result.current.defaultTab).toBe("run");
+    await hook.unmount();
+  });
+
+  test("defaultTab is null until the capture GET first resolves (no premature commit)", async () => {
+    let resolveCapture: (value: GetWorkspaceCaptureResponse) => void = () => {};
+    const capturePromise = new Promise<GetWorkspaceCaptureResponse>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const { client } = coldClient({ getWorkspaceCapture: () => capturePromise });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    // The capture GET is still in flight — no default committed yet.
+    expect(hook.result.current.defaultTab).toBeNull();
+    await act(async () => {
+      resolveCapture(captureAvailable(fakeManifest(3)));
+    });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await hook.unmount();
+  });
+});
+
+// ── Refinement 2: no post-paint content switch (component level) ──────────────
+
+describe("SandboxWorkspace capture-driven default renders with no content switch", () => {
+  function selectedTabText(container: HTMLElement): string {
+    return container.querySelector('[role="tab"][aria-selected="true"]')?.textContent ?? "";
+  }
+
+  test("pure embedder, changes present: Changes is the selected tab before AND after resolve", async () => {
+    let resolveCapture: (value: GetWorkspaceCaptureResponse) => void = () => {};
+    const capturePromise = new Promise<GetWorkspaceCaptureResponse>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const { client } = coldClient({ getWorkspaceCapture: () => capturePromise });
+    const rendered = await renderComponent(
+      withProvider(
+        client,
+        <SandboxWorkspace
+          sessionId={SESSION_ID}
+          events={[]}
+          primary={<div>chat</div>}
+          autoSaveId="og.test.prewarm.changes"
+        />,
+      ),
+    );
+    await flush();
+    // Pending (capture unresolved): the dock falls back to its first tab (Changes);
+    // Files is NOT shown first. The body is a loader, not real content.
+    expect(selectedTabText(rendered.container)).toContain("Changes");
+    await act(async () => {
+      resolveCapture(captureAvailable(fakeManifest(2)));
+    });
+    await flush();
+    // Default resolved to Changes → the first REAL content paint is Changes: no switch.
+    expect(selectedTabText(rendered.container)).toContain("Changes");
+    await rendered.unmount();
+  });
+
+  test("pure embedder, empty capture: the default resolves to Files", async () => {
+    const { client } = coldClient({ getWorkspaceCapture: async () => captureAvailable(fakeManifest(0)) });
+    const rendered = await renderComponent(
+      withProvider(
+        client,
+        <SandboxWorkspace
+          sessionId={SESSION_ID}
+          events={[]}
+          primary={<div>chat</div>}
+          autoSaveId="og.test.prewarm.empty"
+        />,
+      ),
+    );
+    await flush();
+    expect(selectedTabText(rendered.container)).toContain("Files");
+    await rendered.unmount();
+  });
+});

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -152,7 +152,10 @@ function coldClient(overrides: Partial<Parameters<typeof fakeClient>[0]> = {}) {
     heartbeatViewer: async () => ({ alive: true }),
     detachViewer: async () => {},
     ...overrides,
-  });
+    // `listMachines` is served by the machines poll at runtime (the proxy needs
+    // it present) but isn't a member of the narrow SessionClientLike — assert past
+    // the excess-property check on this test mock.
+  } as Partial<SessionClientLike>);
   return { client, spy };
 }
 
@@ -179,7 +182,7 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     expect(spy.attachCalls).toBe(0);
     // Reach the Files tab's onEditIntent (the editor's first-keystroke signal).
     const filesTab = hook.result.current.tabs.find((t) => t.id === WORKBENCH_TAB_FILES);
-    const onEditIntent = (filesTab?.content as ReactElement).props.onEditIntent as () => void;
+    const onEditIntent = (filesTab?.content as ReactElement<{ onEditIntent: () => void }>).props.onEditIntent;
     expect(typeof onEditIntent).toBe("function");
     await act(async () => {
       onEditIntent();
@@ -198,8 +201,8 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     const terminalTab = hook.result.current.tabs.find((t) => t.id === "terminal");
     expect(terminalTab).toBeDefined();
     // content = <div><SandboxTerminal onActivate=… /></div>
-    const inner = (terminalTab!.content as ReactElement).props.children as ReactElement;
-    const onActivate = inner.props.onActivate as () => void;
+    const inner = (terminalTab!.content as ReactElement<{ children: ReactElement<{ onActivate: () => void }> }>).props.children;
+    const onActivate = inner.props.onActivate;
     await act(async () => {
       onActivate();
     });


### PR DESCRIPTION
Two small architectural refinements to the shipped Workbench v2 dock, both in `@opengeni/react`.

## Refinement 1 — prewarm gated to INTENT, not view (live prod cost)

Before, the dock kept a Modal box warm whenever the **Files tab was on screen** (`filesActive → attachFiles`, gated only to "not fully cold"). That still burned box-hours: a `warming`/`draining` box (e.g. just after a turn) was **held alive by a passive glance** at the capture-served tree/diff — the 90% review case that needs no box at all.

Now the box-warming intents are exactly three, each off by default and each flipped only by a genuine user action:
- **Terminal activate** (`onActivate` — needs a live PTY)
- **Desktop watch** (consent)
- **First wake-on-edit keystroke** in the Files editor (new `onEditIntent` signal from `CodeEditor` → `SandboxFiles` → dock)

Browsing capture-served Changes/Files warms **nothing**. The edit attach also drops the old "already-warm only" guard so a cold edit **cold-creates** the box (that *is* the wake), and the write lands ~100ms warm instead of ~5s cold. The WARM path, capability negotiation, and desktop/terminal consent are untouched.

**How prewarm gates now (fires-warm-on X):** terminal activate ✅, desktop watch ✅, first edit keystroke ✅ — dock mount ❌, viewing Changes ❌, viewing/reading Files ❌ (all previously could keep a non-cold box alive on view).

## Refinement 2 — default tab from the workbench's OWN capture fetch (embedder-contract-free)

`initialWorkspaceTab(events)` froze the default at mount from the `events` prop, so a pure embedder (cloudgeni #1577) that doesn't preload events defaulted to **Files even when changes exist**. The default is now derived from `useWorkspaceCapture().fileCount` (read from the GET response's top-level `stats`, before any >2MB manifest-URL hop), latched **once** at first capture-resolve.

- Changes exist → **Changes**; empty/no capture → **Files**.
- A host `initialTab` (apps/web passes `"run"`) still overrides — apps/web is unaffected.
- **No post-paint content switch:** while the capture GET is in flight the dock renders its own first-tab (Changes) fallback, whose body is a connecting/loading state — no real content — so committing the real default at first-resolve makes the first *content* paint the correct tab.
- **Documented residual (the tension):** for an *empty-capture pure embedder* the tab-bar *highlight* settles Changes→Files within the sub-200ms capture window (loader only, **no content flash**). This matches the stated "commit before the body's first content paint" mechanism; achieving zero *highlight* movement too would require a dock-shell "no active tab" mode (touching the shared, live-prod dock validity logic), which wasn't worth the risk for a surface only pure embedders hit.

## Tests (real behavior, not proxy)
- `sandbox-hooks`: attachFiles warms a **cold** box (edit cold-creates); no-intent cold session **never** calls `attachViewer`.
- `workbench-prewarm` (new): cold dock mount → **no** attachViewer; first edit keystroke → attach; terminal activate → attach; capture `fileCount>0` → Changes, `=0`/absent → Files, `initialTab` overrides, `defaultTab` null until first resolve; component-level no-switch (Changes stays selected across resolve, empty → Files).

## Gates (all green)
- `@opengeni/react` typecheck: 0 · `apps/web` typecheck: 0
- Targeted react tests: 91 pass (dock, capture-hooks, workbench-changes, sandbox-components, **golden unchanged**, new prewarm suite)
- publish-closure-guard: clean (16 pkgs, client bundle clean) · `demo:build`: ok

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when sandbox boxes spin up and which tab users see first—directly affects Modal cost and embedder UX—but behavior is covered by new hook and workbench tests and leaves desktop/terminal consent paths intact.
> 
> **Overview**
> Stops **passive** workbench use from keeping Modal boxes alive: viewer attach for files is no longer tied to having the Files tab open (`filesActive` removed). Warming is limited to **terminal activate**, **desktop watch**, and a new **wake-on-edit** path — `CodeEditor` fires `onEditIntent` once on the first keystroke that diverges from the baseline, plumbed through `SandboxFiles` into `useSandboxWorkspaceTabs` as `warmEdit` → `attachFiles`. `useSessionCapabilities` now treats `attachFiles` as edit intent only (can **cold-create** a box; no “already warm” gate).
> 
> **Default tab** no longer depends on embedders preloading `events` at mount: `useWorkspaceCapture` exposes early `fileCount` from the first capture GET stats; `SandboxWorkspace` latches Changes vs Files once, with optional `initialTab` override and uncontrolled dock tab until capture resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15fa2927b7614f28a5e79a6d17433511cc993c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->