### PR TITLE
fix(api): parallel machine liveness probes (fix machines-page hang)

### DIFF
--- a/apps/api/src/sandbox/machines.ts
+++ b/apps/api/src/sandbox/machines.ts
@@ -218,26 +218,28 @@ export async function listMachines(
   ]);
   const enrollmentById = new Map(enrollments.map((e) => [e.id, e]));
 
-  for (const sandbox of sandboxes) {
-    if (sandbox.kind !== "selfhosted" || !sandbox.enrollmentId) {
-      continue;
-    }
-    const enrollment = enrollmentById.get(sandbox.enrollmentId) ?? null;
-    if (!enrollment) {
-      continue;
-    }
-    const probe = await probeEnrollment(services, workspaceId, enrollment);
-    const state = machineStateFor(probe.state, probe.hasDisplay);
+  const machineViews = await Promise.all(
+    sandboxes.map(async (sandbox): Promise<MachineView | null> => {
+      if (sandbox.kind !== "selfhosted" || !sandbox.enrollmentId) {
+        return null;
+      }
+      const enrollment = enrollmentById.get(sandbox.enrollmentId) ?? null;
+      if (!enrollment) {
+        return null;
+      }
+      const [probe, lease] = await Promise.all([
+        probeEnrollment(services, workspaceId, enrollment),
+        readLease(db, workspaceId, sandbox.id),
+      ]);
+      const state = machineStateFor(probe.state, probe.hasDisplay);
 
-    // sharedSessionCount = the lease refcount for this machine's group. The
-    // selfhosted sandbox id IS the lease group key (maxSandboxes:1, N sessions
-    // share via refcount). No lease yet → 0 sessions sharing.
-    const lease = await readLease(db, workspaceId, sandbox.id);
-    const sharedSessionCount = lease?.refcount ?? 0;
+      // sharedSessionCount = the lease refcount for this machine's group. The
+      // selfhosted sandbox id IS the lease group key (maxSandboxes:1, N sessions
+      // share via refcount). No lease yet → 0 sessions sharing.
+      const sharedSessionCount = lease?.refcount ?? 0;
 
-    const metricsRow = metricsByEnrollment.get(enrollment.id) ?? null;
-    machines.push(
-      MachineView.parse({
+      const metricsRow = metricsByEnrollment.get(enrollment.id) ?? null;
+      return MachineView.parse({
         sandboxId: sandbox.id,
         enrollmentId: enrollment.id,
         name: sandbox.name,
@@ -253,9 +255,10 @@ export async function listMachines(
         sharedSessionCount,
         lastSeenAt: enrollment.lastSeenAt,
         metrics: metricsRow ? metricRowToSample(metricsRow) : null,
-      }),
-    );
-  }
+      });
+    }),
+  );
+  machines.push(...machineViews.filter((machine): machine is MachineView => machine !== null));
 
   return { activeSandboxId, activeEpoch, machines };
 }

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -13,6 +13,8 @@ import {
   createEnrollment,
   createSandbox,
   createSession,
+  listSandboxes,
+  revokeEnrollment,
   type Database,
   type DbClient,
 } from "@opengeni/db";
@@ -84,6 +86,42 @@ function busWithAgent(opts: {
     return ControlResponse.encode(res).finish();
   });
   return bus;
+}
+
+class SlowProbeBus extends MemoryEventBus {
+  startedSubjects: string[] = [];
+  completed = 0;
+  maxInFlight = 0;
+  private inFlight = 0;
+
+  constructor(private readonly delayMs: number) {
+    super();
+  }
+
+  getRequestConnection(): ReturnType<MemoryEventBus["getRequestConnection"]> {
+    return {
+      request: async (subject, payload) => {
+        this.startedSubjects.push(subject);
+        this.inFlight += 1;
+        this.maxInFlight = Math.max(this.maxInFlight, this.inFlight);
+        const { requestId } = ControlRequest.decode(payload);
+        await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs));
+        this.inFlight -= 1;
+        this.completed += 1;
+        return {
+          data: ControlResponse.encode({
+            requestId,
+            error: {
+              code: 4,
+              message: "probe timed out",
+              retryable: true,
+              detail: {},
+            },
+          }).finish(),
+        };
+      },
+    };
+  }
 }
 
 /** Build + emit a heartbeat AgentEvent carrying a metrics sample, driving the
@@ -352,6 +390,56 @@ describe("M10 GET /machines — dashboard list + states + metrics", () => {
       expect(body.machines[0]!.state).toBe("display_unavailable");
     }
   }, 120_000);
+
+  test("probes enrolled machines in parallel while preserving sandbox order", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const enrollments = [];
+    for (let i = 0; i < 4; i += 1) {
+      const enrollment = await createEnrollment(db, {
+        accountId,
+        workspaceId,
+        pubkey: `ed25519:${crypto.randomUUID()}`,
+        exposure: "whole-machine",
+        hasDisplay: true,
+        allowScreenControl: true,
+        os: "linux",
+        arch: "x86_64",
+      });
+      enrollments.push(enrollment);
+      await createSandbox(db, {
+        accountId,
+        workspaceId,
+        kind: "selfhosted",
+        name: `machine-${i}`,
+        enrollmentId: enrollment.id,
+      });
+    }
+    await revokeEnrollment(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: enrollments[3]!.id,
+    });
+
+    const expectedOrder = (await listSandboxes(db, workspaceId)).map((sandbox) => sandbox.id);
+    const bus = new SlowProbeBus(150);
+    const app = appFor(bus);
+    const auth = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
+
+    const startedAt = performance.now();
+    const res = await app.request(`/v1/workspaces/${workspaceId}/machines`, {
+      headers: { authorization: auth },
+    });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { machines: Array<{ sandboxId: string }> };
+    expect(body.machines.map((machine) => machine.sandboxId)).toEqual(expectedOrder);
+    expect(bus.startedSubjects.length).toBe(3);
+    expect(bus.completed).toBe(3);
+    expect(bus.maxInFlight).toBe(3);
+    expect(elapsedMs).toBeLessThan(450);
+  }, 30_000);
 });
 
 describe("M10 GET /machines/:enrollmentId/metrics/series", () => {


### PR DESCRIPTION
The machines dashboard probed each enrollment's liveness SERIALLY (await in a for-loop, 5s timeout each); dead/slow self-hosted machines each block → the page hangs (confirmed live on prod). Fix: ordered Promise.all so probe+lease run in parallel → total ≈ one 5s timeout, not N×. Order + all fields preserved; revoked/non-active still skip the ping. Regression test proves concurrent dispatch. typecheck clean; apps/api 369 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyi9t2w4tywBENfcRrsTdu