### PR TITLE
chore(agent): bump agent workspace version to 0.1.5

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "image",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "prost",
  "prost-build",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blake3",
  "hex",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the 0.1.5 agent release (durable keypair #331 + systemd unit fix).