### PR TITLE
fix(api): allow configured API key workspace access

### DIFF
--- a/apps/api/src/http/auth.ts
+++ b/apps/api/src/http/auth.ts
@@ -84,7 +84,12 @@ function isAuthorized(c: Context, expected: string | undefined): boolean {
     return false;
   }
   const explicit = c.req.header("x-opengeni-access-key");
-  return constantTimeEqual(explicit, expected);
+  if (constantTimeEqual(explicit, expected)) {
+    return true;
+  }
+  const authorization = c.req.header("authorization");
+  const bearer = authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : undefined;
+  return constantTimeEqual(bearer, expected);
 }
 
 function constantTimeEqual(actual: string | undefined, expected: string): boolean {

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -103,6 +103,10 @@ async function resolveAccessContext(c: Context, deps: AccessDeps): Promise<Acces
     if (delegated) {
       return delegated;
     }
+    const apiKey = await apiKeyAccessContext(c, deps, "configured");
+    if (apiKey) {
+      return apiKey;
+    }
     if (deps.settings.delegationSecret) {
       return null;
     }
@@ -124,39 +128,9 @@ async function resolveAccessContext(c: Context, deps: AccessDeps): Promise<Acces
     if (delegated) {
       return delegated;
     }
-    const apiKey = await findActiveApiKeyByHash(deps.db, await sha256Hex(bearer));
+    const apiKey = await apiKeyAccessContext(c, deps, "managed");
     if (apiKey) {
-      const accountPermissions = apiKey.workspaceId
-        ? apiKey.permissions.filter(
-            (permission) => permission === "billing:read" || permission === "billing:manage",
-          )
-        : apiKey.permissions;
-      return {
-        mode: "managed",
-        subjectId: `api_key:${apiKey.id}`,
-        subjectLabel: apiKey.name,
-        accountGrants: [
-          {
-            accountId: apiKey.accountId,
-            subjectId: `api_key:${apiKey.id}`,
-            subjectLabel: apiKey.name,
-            permissions: accountPermissions,
-          },
-        ],
-        workspaceGrants: apiKey.workspaceId
-          ? [
-              {
-                workspaceId: apiKey.workspaceId,
-                accountId: apiKey.accountId,
-                subjectId: `api_key:${apiKey.id}`,
-                subjectLabel: apiKey.name,
-                permissions: apiKey.permissions,
-              },
-            ]
-          : [],
-        defaultAccountId: apiKey.accountId,
-        defaultWorkspaceId: apiKey.workspaceId,
-      } satisfies AccessContext;
+      return apiKey;
     }
   }
 
@@ -172,6 +146,41 @@ async function resolveAccessContext(c: Context, deps: AccessDeps): Promise<Acces
   }
 
   return null;
+}
+
+async function apiKeyAccessContext(c: Context, deps: AccessDeps, mode: "configured" | "managed"): Promise<AccessContext | null> {
+  const bearer = bearerToken(c);
+  if (!bearer) {
+    return null;
+  }
+  const apiKey = await findActiveApiKeyByHash(deps.db, await sha256Hex(bearer));
+  if (!apiKey) {
+    return null;
+  }
+  const subjectId = `api_key:${apiKey.id}`;
+  const accountPermissions = apiKey.workspaceId
+    ? apiKey.permissions.filter((permission) => permission === "billing:read" || permission === "billing:manage")
+    : apiKey.permissions;
+  return {
+    mode,
+    subjectId,
+    subjectLabel: apiKey.name,
+    accountGrants: [{
+      accountId: apiKey.accountId,
+      subjectId,
+      subjectLabel: apiKey.name,
+      permissions: accountPermissions,
+    }],
+    workspaceGrants: apiKey.workspaceId ? [{
+      workspaceId: apiKey.workspaceId,
+      accountId: apiKey.accountId,
+      subjectId,
+      subjectLabel: apiKey.name,
+      permissions: apiKey.permissions,
+    }] : [],
+    defaultAccountId: apiKey.accountId,
+    defaultWorkspaceId: apiKey.workspaceId,
+  } satisfies AccessContext;
 }
 
 async function delegatedAccessContext(


### PR DESCRIPTION
Fix configured deployments where the browser is told to use bearer auth, but the API only accepted x-opengeni-access-key at the perimeter and rejected API-key workspace access when delegation is configured.\n\nValidation: bun run typecheck