### PR TITLE
fix(integrations): support manual OAuth clients for Slack

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -73,7 +73,7 @@ type AuthorizationServerMetadata = {
 };
 
 type OAuthClientRegistration = {
-  method: "operator" | "cimd" | "dcr";
+  method: "operator" | "manual" | "cimd" | "dcr";
   issuer: string;
   authorizationServer: string;
   clientId: string;
@@ -97,6 +97,7 @@ type OAuthStatePayload = {
   issuer: string;
   clientRegistrationMethod: OAuthClientRegistration["method"];
   tokenEndpointAuthMethod: OAuthClientRegistration["tokenEndpointAuthMethod"];
+  encryptedClientSecret?: string;
   returnPath: string;
   connectionId?: string;
   connectionVersion?: number;
@@ -164,6 +165,7 @@ export async function startMcpOAuth(
     metadataUrl,
     redirectUri,
     authorizeScopes,
+    context.payload.oauthClient,
   );
   const key = requireEnvironmentEncryption(settings);
   const state = createSignedState(requireIntegrationsStateSecret(settings), {
@@ -182,6 +184,9 @@ export async function startMcpOAuth(
     issuer: client.issuer,
     clientRegistrationMethod: client.method,
     tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+    ...(client.method === "manual" && client.clientSecret
+      ? { encryptedClientSecret: encryptEnvironmentValue(key, client.clientSecret) }
+      : {}),
     returnPath,
     ...(existing ? { connectionId: existing.id, connectionVersion: existing.version } : {}),
   });
@@ -470,6 +475,7 @@ async function registerOAuthClient(
   metadataUrl: string,
   redirectUri: string,
   scopes: string[],
+  manual: OAuthStartRequest["oauthClient"],
 ): Promise<OAuthClientRegistration> {
   const operator = operatorClientForAs(settings, as);
   if (operator) {
@@ -482,6 +488,19 @@ async function registerOAuthClient(
       authorizationServer: as.authorizationServer,
       clientId: metadataUrl,
       tokenEndpointAuthMethod: "none",
+    };
+  }
+  if (manual) {
+    return {
+      method: "manual",
+      issuer: as.issuer,
+      authorizationServer: as.authorizationServer,
+      clientId: manual.clientId,
+      ...(manual.clientSecret ? { clientSecret: manual.clientSecret } : {}),
+      tokenEndpointAuthMethod: tokenAuthMethod(
+        manual.tokenEndpointAuthMethod,
+        Boolean(manual.clientSecret),
+      ),
     };
   }
   return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
@@ -761,6 +780,9 @@ function readOAuthState(state: string, settings: Settings): OAuthStatePayload {
     issuer: requiredString(payload.issuer, "state.issuer"),
     clientRegistrationMethod: registrationMethod(payload.clientRegistrationMethod),
     tokenEndpointAuthMethod: tokenAuthMethod(stringValue(payload.tokenEndpointAuthMethod), false),
+    ...(stringValue(payload.encryptedClientSecret)
+      ? { encryptedClientSecret: stringValue(payload.encryptedClientSecret)! }
+      : {}),
     returnPath: safeReturnPath(stringValue(payload.returnPath) ?? "/integrations"),
     nonce: requiredString(payload.nonce, "state.nonce"),
     iat,
@@ -786,6 +808,19 @@ async function clientForState(
       authorizationServer: state.authorizationServer,
       clientId: state.clientId,
       tokenEndpointAuthMethod: "none",
+    };
+  }
+  if (state.clientRegistrationMethod === "manual") {
+    const key = requireEnvironmentEncryption(settings);
+    return {
+      method: "manual",
+      issuer: state.issuer,
+      authorizationServer: state.authorizationServer,
+      clientId: state.clientId,
+      ...(state.encryptedClientSecret
+        ? { clientSecret: decryptEnvironmentValue(key, state.encryptedClientSecret) }
+        : {}),
+      tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
     };
   }
   if (state.clientRegistrationMethod === "dcr") {
@@ -1271,7 +1306,7 @@ function tokenAuthMethod(
 }
 
 function registrationMethod(value: unknown): OAuthClientRegistration["method"] {
-  if (value === "operator" || value === "cimd" || value === "dcr") {
+  if (value === "operator" || value === "manual" || value === "cimd" || value === "dcr") {
     return value;
   }
   throw new HTTPException(400, { message: "invalid OAuth state" });

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -866,6 +866,136 @@ describe("connections routes", () => {
     }
   });
 
+  test("oauth start uses configured operator credentials for Slack-shaped authorization servers", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      issuer: "https://mcp.slack.com",
+      clientIdMetadataDocumentSupported: false,
+      tokenEndpointAuthMethodsSupported: ["client_secret_post"],
+      scopesSupported: ["search:read.public", "chat:write"],
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource", scope="search:read.public chat:write"`,
+    });
+    try {
+      const response = await app({
+        integrationsOauthClientsJson: JSON.stringify({
+          "https://mcp.slack.com": {
+            clientId: "slack-client-id",
+            clientSecret: "slack-client-secret",
+            tokenEndpointAuthMethod: "client_secret_post",
+          },
+        }),
+      }).request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providerDomain: "slack.com",
+          mcpUrl: mcp.url,
+          returnPath: "/capabilities?connect_item=slack",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { state: string; authorizationUrl: string };
+      const authUrl = new URL(body.authorizationUrl);
+      expect(authUrl.searchParams.get("client_id")).toBe("slack-client-id");
+      expect(authUrl.searchParams.get("scope")).toBe("search:read.public chat:write");
+
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
+      expect(state?.providerDomain).toBe("slack.com");
+      expect(state?.clientRegistrationMethod).toBe("operator");
+      expect(state?.clientId).toBe("slack-client-id");
+      expect(JSON.stringify(state)).not.toContain("slack-client-secret");
+
+      const callback = await publicApp(client.db, {
+        integrationsOauthClientsJson: JSON.stringify({
+          "https://mcp.slack.com": {
+            clientId: "slack-client-id",
+            clientSecret: "slack-client-secret",
+            tokenEndpointAuthMethod: "client_secret_post",
+          },
+        }),
+      }).request(
+        `/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`,
+      );
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(as.tokenRequests).toHaveLength(1);
+      expect(as.tokenRequests[0]!.get("client_id")).toBe("slack-client-id");
+      expect(as.tokenRequests[0]!.get("client_secret")).toBe("slack-client-secret");
+      expect(as.tokenRequestAuthHeaders[0]).toBeNull();
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth start uses one-time manual credentials for Slack-shaped authorization servers", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      issuer: "https://mcp.slack.com",
+      clientIdMetadataDocumentSupported: false,
+      tokenEndpointAuthMethodsSupported: ["client_secret_post"],
+      scopesSupported: ["search:read.public", "chat:write"],
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource", scope="search:read.public chat:write"`,
+    });
+    try {
+      const response = await app().request(
+        `/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`,
+        {
+          method: "POST",
+          headers: {
+            authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            providerDomain: "slack.com",
+            mcpUrl: mcp.url,
+            returnPath: "/capabilities?connect_item=slack",
+            oauthClient: {
+              clientId: "manual-slack-client-id",
+              clientSecret: "manual-slack-client-secret",
+              tokenEndpointAuthMethod: "client_secret_post",
+            },
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { state: string; authorizationUrl: string };
+      expect(new URL(body.authorizationUrl).searchParams.get("client_id")).toBe(
+        "manual-slack-client-id",
+      );
+      const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
+      expect(state?.clientRegistrationMethod).toBe("manual");
+      expect(state?.clientId).toBe("manual-slack-client-id");
+      expect(typeof state?.encryptedClientSecret).toBe("string");
+      expect(JSON.stringify(state)).not.toContain("manual-slack-client-secret");
+
+      const callback = await publicApp(client.db).request(
+        `/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(body.state)}`,
+      );
+      expect(callback.status).toBe(302);
+      expect(callback.headers.get("location")).toContain("integration_oauth=success");
+      expect(as.tokenRequests).toHaveLength(1);
+      expect(as.tokenRequests[0]!.get("client_id")).toBe("manual-slack-client-id");
+      expect(as.tokenRequests[0]!.get("client_secret")).toBe("manual-slack-client-secret");
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
   test("oauth start uses CIMD for Linear when CIMD is advertised", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();

--- a/apps/web/src/components/capabilities/capability-detail-sheet.tsx
+++ b/apps/web/src/components/capabilities/capability-detail-sheet.tsx
@@ -27,7 +27,15 @@ import type { CapabilityCatalogItem } from "@/types";
 
 export type ConnectAction =
   | { type: "enable"; item: CapabilityCatalogItem }
-  | { type: "oauth"; item: CapabilityCatalogItem }
+  | {
+      type: "oauth";
+      item: CapabilityCatalogItem;
+      oauthClient?: {
+        clientId: string;
+        clientSecret?: string;
+        tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+      };
+    }
   | { type: "api_key"; item: CapabilityCatalogItem; headers: Record<string, string> }
   // connectionId is the existing row to reuse, or null when the row was deleted
   // (reconnect then mints a fresh connection and re-enables with its ref).
@@ -242,20 +250,29 @@ function DetailBody({
               onSubmit={(next) => onAction({ type: "api_key", item, headers: next })}
             />
           ) : plan.mode === "oauth" ? (
-            <div className="space-y-2">
-              <Button
-                type="button"
-                className="w-full"
-                disabled={busy}
-                onClick={() => onAction({ type: "oauth", item })}
-              >
-                {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
-                Connect {item.name}
-              </Button>
-              <p className="text-center text-xs text-fg-subtle">
-                You'll authorize {item.name} in a new step, then return here.
-              </p>
-            </div>
+            plan.providerDomain === "slack.com" ? (
+              <OAuthClientForm
+                itemName={item.name}
+                keyPageUrl={keyPageUrl}
+                busy={busy}
+                onSubmit={(oauthClient) => onAction({ type: "oauth", item, oauthClient })}
+              />
+            ) : (
+              <div className="space-y-2">
+                <Button
+                  type="button"
+                  className="w-full"
+                  disabled={busy}
+                  onClick={() => onAction({ type: "oauth", item })}
+                >
+                  {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
+                  Connect {item.name}
+                </Button>
+                <p className="text-center text-xs text-fg-subtle">
+                  You'll authorize {item.name} in a new step, then return here.
+                </p>
+              </div>
+            )
           ) : (
             <Button
               type="button"
@@ -275,6 +292,87 @@ function DetailBody({
         </div>
       </div>
     </div>
+  );
+}
+
+function OAuthClientForm({
+  itemName,
+  keyPageUrl,
+  busy,
+  onSubmit,
+}: {
+  itemName: string;
+  keyPageUrl: string | null;
+  busy: boolean;
+  onSubmit: (oauthClient: {
+    clientId: string;
+    clientSecret: string;
+    tokenEndpointAuthMethod: "client_secret_post";
+  }) => void;
+}) {
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const ready = clientId.trim().length > 0 && clientSecret.trim().length > 0;
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!ready || busy) return;
+        onSubmit({
+          clientId: clientId.trim(),
+          clientSecret: clientSecret.trim(),
+          tokenEndpointAuthMethod: "client_secret_post",
+        });
+      }}
+    >
+      <Notice tone="muted">
+        {itemName} requires a Slack app OAuth client. Paste the client ID and client secret from
+        Slack, then you’ll authorize access in Slack.
+      </Notice>
+      <div className="space-y-1.5">
+        <Label htmlFor="oauth-client-id" className="text-xs text-fg-muted">
+          Client ID
+        </Label>
+        <Input
+          id="oauth-client-id"
+          type="text"
+          autoComplete="off"
+          value={clientId}
+          onChange={(event) => setClientId(event.target.value)}
+          placeholder="Paste your Slack client ID"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="oauth-client-secret" className="text-xs text-fg-muted">
+          Client secret
+        </Label>
+        <Input
+          id="oauth-client-secret"
+          type="password"
+          autoComplete="off"
+          value={clientSecret}
+          onChange={(event) => setClientSecret(event.target.value)}
+          placeholder="Paste your Slack client secret"
+        />
+      </div>
+      {keyPageUrl ? (
+        <a
+          href={keyPageUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
+        >
+          Open Slack app settings
+          <ExternalLinkIcon className="size-3" />
+        </a>
+      ) : null}
+      <Button type="submit" className="w-full" disabled={busy || !ready}>
+        {busy ? <Loader2Icon className="animate-spin" /> : <PlugIcon />}
+        Connect {itemName}
+      </Button>
+    </form>
   );
 }
 

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -315,6 +315,7 @@ export function CapabilitiesRoute({
         const response = await client.startConnectionOAuth(workspaceId, {
           ...(plan.mcpUrl ? { mcpUrl: plan.mcpUrl } : {}),
           ...(plan.providerDomain ? { providerDomain: plan.providerDomain } : {}),
+          ...(action.oauthClient ? { oauthClient: action.oauthClient } : {}),
           returnPath,
         });
         if (!response.authorizationUrl) {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2735,6 +2735,15 @@ export const OAuthStartRequest = z
     requestedScopes: z.array(z.string().min(1)).default([]),
     returnPath: z.string().min(1).optional(),
     connectionId: z.string().uuid().optional(),
+    oauthClient: z
+      .object({
+        clientId: z.string().min(1),
+        clientSecret: z.string().min(1).optional(),
+        tokenEndpointAuthMethod: z
+          .enum(["none", "client_secret_post", "client_secret_basic"])
+          .optional(),
+      })
+      .optional(),
   })
   .refine((value) => Boolean(value.mcpUrl ?? value.resource), {
     message: "mcpUrl is required",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -337,6 +337,13 @@ export type OAuthStartRequest = {
   requestedScopes?: string[] | undefined;
   returnPath?: string | undefined;
   connectionId?: string | undefined;
+  oauthClient?:
+    | {
+        clientId: string;
+        clientSecret?: string | undefined;
+        tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic" | undefined;
+      }
+    | undefined;
 };
 
 export type OAuthStartResponse = {


### PR DESCRIPTION
## Summary
- add one-time manual OAuth client support for MCP OAuth authorization servers without CIMD/DCR
- render a Slack client ID/secret prompt in the capability connect sheet
- keep manual client secrets encrypted in signed OAuth state and out of URLs/provider authorize params

## Verification
- bun run typecheck
- bun test packages/contracts/test/contracts.test.ts packages/sdk/test/contract-parity-coverage.test.ts packages/sdk/test/client-coverage.test.ts apps/api/test/connections-routes.test.ts --test-name-pattern 'OAuth|oauth|connection|Slack-shaped|manual credentials'

Note: apps/api/test/connections-routes.test.ts reports Docker unavailable in this sandbox, so DB-backed assertions are skipped locally; live staging/prod verification follows deployment.