### PR TITLE
Fix Codex GPT-5.6 catalog visibility

### DIFF
--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -90,10 +90,14 @@ function codexUsageJson(payload: CodexUsagePayload): {
 }
 
 export function codexModelsForPicker(
-  slugs: string[],
+  liveSlugs: readonly string[],
 ): Array<{ id: string; label: string; provider: string; providerLabel: string; api: "responses" }> {
-  const available = new Set(slugs);
-  return CODEX_FALLBACK_MODEL_SLUGS.filter((slug) => available.has(slug)).map((slug) => ({
+  const available = new Set(liveSlugs);
+  const missing = CODEX_FALLBACK_MODEL_SLUGS.filter((slug) => !available.has(slug));
+  if (missing.length > 0) {
+    throw new Error(`Codex catalog is missing required models: ${missing.join(", ")}`);
+  }
+  return CODEX_FALLBACK_MODEL_SLUGS.map((slug) => ({
     id: `${CODEX_MODEL_ID_PREFIX}${slug}`,
     label: slug.replace(/^gpt-/, "GPT-"),
     provider: CODEX_PROVIDER_ID,
@@ -264,7 +268,8 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
         }
       : null;
     let valid = false;
-    let models = codexModelsForPicker([...CODEX_FALLBACK_MODEL_SLUGS]); // offline fallback list
+    let models: ReturnType<typeof codexModelsForPicker> = [];
+    let catalogError: string | null = null;
     try {
       const cred = status.credentialId
         ? await loadCodexCredentialForRun(db, settings, workspaceId, status.credentialId)
@@ -276,20 +281,23 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
           isFedramp: cred.isFedramp,
           clientVersion: CODEX_CLIENT_VERSION,
         });
-        valid = live.ok;
-        if (live.ok && live.slugs.length > 0) {
-          models = codexModelsForPicker(live.slugs); // prefer the live catalog
+        if (live.ok) {
+          models = codexModelsForPicker(live.slugs);
+          valid = true;
+        } else {
+          catalogError = `Codex models request failed with status ${live.status}`;
         }
       }
-    } catch {
+    } catch (error) {
       valid = false;
+      catalogError = error instanceof Error ? error.message : String(error);
     }
     return c.json({
       connected: status.connected,
       plan: status.planType,
       valid,
       expiresAt: status.expiresAt,
-      lastError: status.lastError,
+      lastError: catalogError ?? status.lastError,
       models, // ClientModel[] the picker surfaces under the "no credits" group
       activeAccount, // the account a session runs on when unpinned (label for the indicator)
       accountCount: accounts.length,

--- a/apps/api/test/codex-model-catalog.test.ts
+++ b/apps/api/test/codex-model-catalog.test.ts
@@ -2,24 +2,30 @@ import { describe, expect, test } from "bun:test";
 import { codexModelsForPicker } from "../src/routes/codex";
 
 describe("Codex model catalog", () => {
-  test("exposes only GPT-5.6 Sol, Terra, and Luna from a broader live catalog", () => {
+  const expected = ["codex/gpt-5.6-sol", "codex/gpt-5.6-terra", "codex/gpt-5.6-luna"];
+
+  test("keeps exactly the three exact GPT-5.6 slugs from a broader live catalog", () => {
     const models = codexModelsForPicker([
-      "gpt-5.4",
       "gpt-5.6-luna",
-      "gpt-5.3-codex",
+      "gpt-5.5",
       "gpt-5.6-sol",
-      "o3-pro",
+      "gpt-5.4",
       "gpt-5.6-terra",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex-spark",
+      "codex-auto-review",
     ]);
 
-    expect(models.map((model) => model.id)).toEqual([
-      "codex/gpt-5.6-sol",
-      "codex/gpt-5.6-terra",
-      "codex/gpt-5.6-luna",
-    ]);
+    expect(models.map((model) => model.id)).toEqual(expected);
   });
 
-  test("does not fall back to older Codex models when GPT-5.6 is absent", () => {
-    expect(codexModelsForPicker(["gpt-5.3-codex", "gpt-5.2-codex"])).toEqual([]);
+  test("an unrelated catalog fails closed instead of exposing older models", () => {
+    expect(() =>
+      codexModelsForPicker(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "codex-auto-review"]),
+    ).toThrow("Codex catalog is missing required models");
+  });
+
+  test("an empty live catalog fails closed", () => {
+    expect(() => codexModelsForPicker([])).toThrow("Codex catalog is missing required models");
   });
 });

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -26,15 +26,14 @@ export const CODEX_PROVIDER_BASE_URL = "https://chatgpt.com/backend-api";
 export const CODEX_MODEL_ID_PREFIX = "codex/";
 
 // The only Codex subscription models OpenGeni exposes. The live GET /models
-// catalog is intersected with this list, never allowed to broaden it, so older
-// Codex/GPT models cannot reappear in the picker when the upstream catalog
-// includes them.
+// catalog must contain every exact slug; older or internal models never broaden
+// this product allowlist.
 export const CODEX_FALLBACK_MODEL_SLUGS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
 
-// Sent as the `version` header and inside the User-Agent. Confirmed live: the
-// backend accepts the current codex CLI version; an older value risks /models
-// min_client_version filtering. Keep in step with the codex CLI releases.
-export const CODEX_CLIENT_VERSION = "0.142.4";
+// Sent as the `version` header and inside the User-Agent. Staging-proven on
+// 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models, while the
+// official Codex 0.144.0 release returned all three exact slugs above.
+export const CODEX_CLIENT_VERSION = "0.144.0";
 
 export const CODEX_REFRESH_WINDOW_MS = 5 * 60 * 1000; // proactive refresh when within 5 min of exp (spec §1.1)
 export const CODEX_REFRESH_FALLBACK_MS = 8 * 24 * 60 * 60 * 1000; // 8 days when exp is unparseable

--- a/packages/codex/test/normalize.test.ts
+++ b/packages/codex/test/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildModelResolver, normalizeCodexRequestBody } from "../src";
+import { buildModelResolver, CODEX_FALLBACK_MODEL_SLUGS, normalizeCodexRequestBody } from "../src";
 
 const identity = (s: string): string => s;
 
@@ -199,6 +199,17 @@ describe("buildModelResolver", () => {
 
   test("unknown slug -> fallback", () => {
     expect(resolve("o3-pro")).toBe("gpt-5.6-sol");
+  });
+
+  test("all exposed Codex GPT-5.6 ids reach the exact upstream slug unchanged", () => {
+    const resolveExact = buildModelResolver(
+      CODEX_FALLBACK_MODEL_SLUGS,
+      CODEX_FALLBACK_MODEL_SLUGS[0],
+    );
+
+    for (const slug of CODEX_FALLBACK_MODEL_SLUGS) {
+      expect(resolveExact(`codex/${slug}`)).toBe(slug);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- update the Codex client header from 0.142.4 to official 0.144.0, which exposes the exact GPT-5.6 upstream slugs
- require all three exact GPT-5.6 slugs and fail closed if the live catalog omits any
- keep older/internal Codex models out of the picker and verify runtime slugs remain exact

## Validation
- focused Codex/API/worker tests
- full typecheck
- full unit suite: 0 failures