### PR TITLE
OPE-22: add safe operator session revival helper

### DIFF
--- a/.changeset/calm-operators-revive.md
+++ b/.changeset/calm-operators-revive.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+Add workspace-scoped operator session-revival admission helpers and pending-work guards for safe control-plane recovery tooling.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Per-session MCP servers | `docs/session-mcp-servers.md` | `docs/architecture.md`, SDK/client examples should link instead of restating credential semantics. |
 | Connected machines | `docs/connected-machines.md` | `README.md`, `AGENTS.md`, client docs and skills should link. |
 | Deployment | `docs/deployment.md` | `README.md`, `AGENTS.md`, Helm/Terraform notes should link. |
+| Operator session revival | `docs/operator-session-revival.md` | Incident notes should record stable IDs/statuses and link the reviewed runbook rather than copying volatile commands. |
 | Release/publishing | `CONTRIBUTING.md` § Release / Publishing, plus workflow files as executable truth | `README.md`, package READMEs, architecture release notes should link. |
 | Client/SDK integration | `packages/sdk/README.md` | `README.md`, `docs/embedding.md`, `@opengeni/react` docs should link. |
 | Credential taxonomy | `docs/credentials.md` | `docs/embedding.md`, `docs/capabilities.md`, route comments should link instead of re-listing token types. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -333,7 +333,7 @@ A Cargo workspace building the box-side binary for the `selfhosted` backend. `ag
 
 ### 6.5 Docs, scripts, test
 
-`docs/` (this map + topic docs, §14), `scripts/` (dev-stack, release mechanics, static guards, deployment CLIs, §11), `test/` (integration/e2e/live tiers + `source-hygiene.test.ts`).
+`docs/` (this map + topic docs, §14), `scripts/` (dev-stack, release mechanics, static guards, deployment CLIs, plus control-plane-only operator helpers under `scripts/operator/`, §11), `test/` (integration/e2e/live tiers + `source-hygiene.test.ts`).
 
 ### 6.6 The relay edge (BYO-compute data plane)
 
@@ -542,6 +542,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 | The Rust agent / wire proto | `agent/proto/opengeni_agent.proto`, `agent/scripts/codegen.sh` | `agent/README.md` |
 | Deployment (Helm/Terraform/profiles) | `packages/deployment/src/index.ts`, `deploy/helm/opengeni/` | [`deployment.md`](deployment.md) |
 | Build / test / release tooling | `package.json`, `.changeset/config.json`, `.github/workflows/` | [`../AGENTS.md`](../AGENTS.md) Verification |
+| Operator revival of an existing failed/idle session | `scripts/operator/revive-session.ts`, `packages/core/src/domain/sessions.ts` (`acceptSessionUserMessage`) | [`operator-session-revival.md`](operator-session-revival.md) |
 | The web console | `apps/web/src/App.tsx`, `apps/web/src/context.tsx` | [`command-palette.md`](command-palette.md) |
 
 ---
@@ -566,6 +567,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 | [`manager-session-robustness.md`](manager-session-robustness.md) | Manager-session failure modes and fixes (point-in-time; verification timestamps are historical). |
 | [`reliability-fixes.md`](reliability-fixes.md) | Reliability bugs/fixes (bounded Temporal history, orphan repair, scheduled-task/billing idempotency). |
 | [`deployment.md`](deployment.md) | Operator guide: profiles, preflight/stack plans, Helm/Terraform; the disposable-fixtures rule. |
+| [`operator-session-revival.md`](operator-session-revival.md) | Control-plane-only dry-run/apply procedure for reviving one exact session through shared message admission, including audit and no-delete rollback semantics. |
 | [`embedding.md`](embedding.md) | Host-app embedding guide: router mounting, direct core calls, ports/bindings, schema/RLS, worker, and EventBus. |
 | [`connected-machines.md`](connected-machines.md) | Integrator guide for targeting, swapping, enrolling, and operating Connected Machines. |
 | [`design/lazy-provisioning.md`](design/lazy-provisioning.md) | Point-in-time lazy sandbox provisioning design: first-op provisioner, synthetic manifest invariant, and failure contract. |

--- a/docs/operator-session-revival.md
+++ b/docs/operator-session-revival.md
@@ -1,0 +1,173 @@
+# Operator session revival
+
+This runbook covers one narrow recovery action: enqueueing a new user message
+onto one exact existing session through OpenGeni's normal control-plane
+admission path. It is intended for a session whose durable conversation remains
+valid but whose workflow needs a new message to revive it (normally `failed` or
+`idle`). It does not repair or rewrite session history.
+
+The helper is `scripts/operator/revive-session.ts`, exposed as:
+
+```bash
+bun run operator:revive-session --help
+```
+
+## Safety contract
+
+- **Dry-run is the default.** Only `--apply` enables writes.
+- `--workspace-id`, `--session-id`, and `--client-event-id` are mandatory,
+  canonical lowercase identifiers. The client event id must have this exact
+  deterministic form:
+
+  ```text
+  operator-revival:<workspace-id>:<session-id>:<stable-operation-key>
+  ```
+
+  Choose the final key once from the incident and recovery step, for example
+  `ope-22-revive-1`, and reuse it for every retry. Do not use a timestamp or a
+  newly generated UUID.
+- Apply additionally requires a non-empty `--message-file`, explicit `--model`,
+  and explicit `--reasoning-effort`. Message text is read from the file and is
+  never emitted by the helper.
+- The default queue policy rejects a session with `queued`, `running`, or
+  `requires_action` work. `--queue-policy append` is the only override; it
+  deliberately enqueues behind that work and does not cancel, bypass, approve,
+  or reorder anything.
+- A duplicate client event is refused and returns only the existing event ID.
+  The helper never assumes that one row proves every later enqueue/wake step
+  completed, and it never replays a partially completed admission automatically.
+- The helper emits only stable target/result IDs, statuses, and refusal codes.
+  It never emits message text, event payloads, session metadata, connection
+  details, credentials, or upstream error messages.
+
+## What apply does
+
+Apply composes the same production control-plane dependencies as the API:
+
+1. `createDb` with the configured search path and RLS strategy;
+2. the managed NATS event bus, using the existing control-plane authentication
+   configuration when present;
+3. a Temporal client that wakes the session with `signalWithStart`; and
+4. the shared `acceptSessionUserMessage` core function.
+
+The helper first reads the session, duplicate client event, and pending turns
+through workspace-scoped DB APIs. The core apply receives one synthetic grant
+with exactly:
+
+```json
+{
+  "workspaceId": "<requested workspace>",
+  "accountId": "<account from the workspace-scoped session row>",
+  "subjectId": "operator:session-revival",
+  "permissions": ["workspace:admin"]
+}
+```
+
+The grant is not accepted from CLI input. The requested workspace/session are
+checked again against the row returned under workspace RLS. With the default
+queue policy, the shared locked append path rechecks busy session/turn state so
+work that races with preflight causes a refusal rather than an accidental
+append.
+
+There is no raw SQL in the helper, no direct row edit, no history/run-state
+rewrite, no sandbox or provider call, and no cloud secret fetch. Apply uses only
+credentials already supplied to the normal OpenGeni control-plane process. It
+does not add a new credential, permission, or tenancy bypass.
+
+## Procedure
+
+Run this only from a reviewed OpenGeni revision in the deployment's
+control-plane environment, where the normal database, NATS, and Temporal
+settings are already injected. Do not copy production credentials into a shell
+history or pass them as CLI arguments.
+
+1. Prepare the approved recovery message in an operator-controlled file. Limit
+   access to the incident operators; the helper does not need the file after the
+   command exits.
+
+2. Set exact IDs and one deterministic operation identity:
+
+   ```bash
+   WORKSPACE_ID='<workspace-uuid>'
+   SESSION_ID='<session-uuid>'
+   CLIENT_EVENT_ID="operator-revival:${WORKSPACE_ID}:${SESSION_ID}:ope-22-revive-1"
+   ```
+
+3. Run the read-only preflight:
+
+   ```bash
+   bun run operator:revive-session -- \
+     --workspace-id "$WORKSPACE_ID" \
+     --session-id "$SESSION_ID" \
+     --client-event-id "$CLIENT_EVENT_ID"
+   ```
+
+   A normal revival target reports `mode: "dry_run"`, `status: "ready"`, the
+   session status, and an empty pending-turn list. `refused` exits with code 2.
+   Infrastructure errors exit with code 1 and intentionally omit upstream error
+   text; correlate using the stable IDs in normal control-plane logs.
+
+4. If preflight is approved, rerun the same identity with all apply fields:
+
+   ```bash
+   bun run operator:revive-session -- \
+     --workspace-id "$WORKSPACE_ID" \
+     --session-id "$SESSION_ID" \
+     --client-event-id "$CLIENT_EVENT_ID" \
+     --apply \
+     --message-file /operator-controlled/recovery-message.txt \
+     --model '<explicit-model-id>' \
+     --reasoning-effort '<none|minimal|low|medium|high|xhigh>'
+   ```
+
+   Do not add `--queue-policy append` merely to get past a refusal. Inspect the
+   listed turn IDs/statuses first. Select append only when the incident owner has
+   explicitly decided the recovery message should wait behind all current work:
+
+   ```bash
+   --queue-policy append
+   ```
+
+5. Save the JSON result in the incident evidence. `status: "accepted"` returns
+   the new durable `eventId`, `turnId`, and turn status. A retry with the same
+   client event is refused with `refusal: "duplicate_client_event"` and the
+   existing `eventId`; it performs no second write. Inspect the normal read-only
+   event/turn surfaces before deciding whether any separate recovery is needed.
+
+6. Verify through normal read-only session/event/turn surfaces that the returned
+   event and turn exist in the exact workspace/session, then observe the normal
+   run lifecycle. A failed or idle session should move through `queued`/`running`
+   and eventually settle according to the turn outcome. The helper's acceptance
+   proves admission, not model success.
+
+## Audit evidence
+
+Record all of the following in the incident/change record:
+
+- reviewed OpenGeni source/deployment revision;
+- exact workspace ID, session ID, and deterministic client event ID;
+- dry-run JSON result, including session and pending-turn statuses;
+- whether the default reject policy or explicit append policy was used, and the
+  incident-owner approval for append;
+- apply JSON result (`eventId`, `turnId`, and status only);
+- read-only post-apply verification and eventual turn/session outcome; and
+- the approved recovery-message artifact in access-controlled incident storage,
+  not in the CLI output or repository.
+
+## Rollback and no-delete semantics
+
+Dry-run writes nothing and needs no rollback. Apply is intentionally
+append-only: the durable user event is audit history and must not be deleted or
+edited, and this helper exposes no delete/rollback operation.
+
+If an accepted turn should not run:
+
+- while it is still queued, use the normal queued-turn cancellation API; that
+  records a `cancelled` state and event rather than deleting the row;
+- while it is running, use the normal session interrupt/stop control; and
+- if corrective context is needed, append a new corrective message with a new
+  deterministic operation key.
+
+Never roll back by editing `sessions`, `session_turns`, `session_events`,
+`session_history_items`, or Temporal state directly. Preserve the original
+event/turn IDs in the audit record.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:generate": "set -a; [ -f .env ] && . ./.env; set +a; cd packages/db && bun run generate",
     "catalog:refresh": "bun scripts/refresh-integrations-catalog.ts",
     "catalog:import": "set -a; [ -f .env ] && . ./.env; set +a; bun scripts/import-integrations-catalog.ts",
+    "operator:revive-session": "bun scripts/operator/revive-session.ts",
     "typecheck": "bun scripts/typecheck.ts",
     "lint": "oxlint",
     "format": "oxfmt",

--- a/packages/core/src/billing/limits.ts
+++ b/packages/core/src/billing/limits.ts
@@ -12,6 +12,8 @@ import {
 import { HTTPException } from "hono/http-exception";
 import type { ApiRouteDeps } from "../dependencies";
 
+export type LimitDependencies = Pick<ApiRouteDeps, "db" | "settings">;
+
 export type LimitCheckInput = {
   accountId: string;
   workspaceId?: string;
@@ -26,7 +28,7 @@ export type LimitCheckInput = {
   model?: string | null;
 };
 
-export async function requireLimit(deps: ApiRouteDeps, input: LimitCheckInput): Promise<void> {
+export async function requireLimit(deps: LimitDependencies, input: LimitCheckInput): Promise<void> {
   const decision = await checkLimit(deps, input);
   if (decision.allowed) {
     return;
@@ -37,7 +39,7 @@ export async function requireLimit(deps: ApiRouteDeps, input: LimitCheckInput): 
 }
 
 export async function checkLimit(
-  deps: ApiRouteDeps,
+  deps: LimitDependencies,
   input: LimitCheckInput,
 ): Promise<LimitDecision> {
   // Resolve the canonical codex-billed predicate ONCE. Returns false for any
@@ -62,7 +64,7 @@ export async function checkLimit(
 }
 
 async function checkCreditBalance(
-  deps: ApiRouteDeps,
+  deps: LimitDependencies,
   input: LimitCheckInput,
   codexBilled: boolean,
 ): Promise<LimitDecision> {
@@ -80,7 +82,7 @@ async function checkCreditBalance(
 }
 
 async function checkStaticCaps(
-  deps: ApiRouteDeps,
+  deps: LimitDependencies,
   input: LimitCheckInput,
   codexBilled: boolean,
 ): Promise<LimitDecision> {
@@ -201,7 +203,7 @@ async function checkStaticCaps(
 }
 
 export async function recordWorkspaceUsage(
-  deps: ApiRouteDeps,
+  deps: LimitDependencies,
   input: {
     accountId: string;
     workspaceId: string;
@@ -227,7 +229,7 @@ export async function recordWorkspaceUsage(
   });
 }
 
-function usesCreditLimits(deps: ApiRouteDeps): boolean {
+function usesCreditLimits(deps: LimitDependencies): boolean {
   return deps.settings.billingMode === "stripe" || deps.settings.usageLimitsMode === "managed";
 }
 

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -103,3 +103,18 @@ export type ApiRouteDeps = AppDependencies & {
   // resumeBoxById (it throws SandboxResumeError when sandboxBackend=none).
   resumeBoxById: (input: ResumeBoxByIdInput) => Promise<ResumedSandboxSession>;
 };
+
+/**
+ * The exact dependency slice used by `acceptSessionUserMessage`.
+ *
+ * Keeping this narrower than `ApiRouteDeps` lets control-plane callers reuse
+ * the canonical admission path without constructing unrelated HTTP, document,
+ * or sandbox services. The public API still passes its `ApiRouteDeps` superset.
+ */
+export type AcceptSessionUserMessageDependencies = Pick<
+  AppDependencies,
+  "settings" | "db" | "bus"
+> & {
+  workflowClient: Pick<SessionWorkflowClient, "wakeSessionWorkflow">;
+  objectStorage: ObjectStorageDependency;
+};

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -45,7 +45,11 @@ import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
 import { hasPermission, requirePermission } from "../access";
 import { recordWorkspaceUsage, requireLimit } from "../billing/limits";
-import type { ApiRouteDeps, SessionWorkflowClient } from "../dependencies";
+import type {
+  AcceptSessionUserMessageDependencies,
+  ApiRouteDeps,
+  SessionWorkflowClient,
+} from "../dependencies";
 import { swapActiveSandbox, type FleetContext } from "../sandbox/fleet";
 import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
 import { requireVariableSetEncryption, validateVariableSetAttachment } from "./environments";
@@ -603,7 +607,7 @@ export function reasoningEffortForSession(
 export async function postUserMessageTurn(input: {
   db: Database;
   bus: EventBus;
-  workflowClient: SessionWorkflowClient;
+  workflowClient: Pick<SessionWorkflowClient, "wakeSessionWorkflow">;
   settings: Settings;
   accountId: string;
   workspaceId: string;
@@ -615,6 +619,10 @@ export async function postUserMessageTurn(input: {
   reasoningEffort?: Settings["openaiReasoningEffort"] | null;
   clientEventId?: string;
   mcpCredentialUpdates?: UpdateSessionMcpServerCredentialsInput[];
+  // Default append preserves the public API/MCP queue semantics. The operator
+  // recovery helper opts into the locked reject policy so a preflight race
+  // cannot silently append behind newly-active work.
+  queuePolicy?: "append" | "reject_conflicts";
 }): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
   const { db, bus, workflowClient, settings, accountId, workspaceId, sessionId } = input;
   const requestedModel = input.model ?? null;
@@ -638,6 +646,19 @@ export async function postUserMessageTurn(input: {
         throw new HTTPException(409, {
           message: `session is ${lockedSession.status}; cannot accept a new user message`,
         });
+      }
+      if (input.queuePolicy === "reject_conflicts") {
+        const pendingTurns = await lockedUpdate.listPendingSessionTurns();
+        if (
+          pendingTurns.length > 0 ||
+          lockedSession.status === "queued" ||
+          lockedSession.status === "running" ||
+          lockedSession.status === "requires_action"
+        ) {
+          throw new HTTPException(409, {
+            message: "session has active or queued work; explicit append policy required",
+          });
+        }
       }
       const mcpCredentialUpdates = input.mcpCredentialUpdates?.length
         ? await lockedUpdate.updateSessionMcpServerCredentials(input.mcpCredentialUpdates)
@@ -1135,7 +1156,7 @@ export async function createSessionForRequest(
  * workspace's default capability MCP tools, matching an absent `tools` key.
  */
 export async function acceptSessionUserMessage(
-  deps: ApiRouteDeps,
+  deps: AcceptSessionUserMessageDependencies,
   grant: AccessGrant,
   workspaceId: string,
   sessionId: string,
@@ -1148,6 +1169,7 @@ export async function acceptSessionUserMessage(
     reasoningEffort?: ReasoningEffort | null;
     clientEventId?: string;
     mcpCredentialUpdates?: SessionMcpCredentialUpdateInput[];
+    queuePolicy?: "append" | "reject_conflicts";
   },
 ): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
@@ -1204,6 +1226,7 @@ export async function acceptSessionUserMessage(
     model: input.model ?? null,
     reasoningEffort: input.reasoningEffort ?? null,
     mcpCredentialUpdates,
+    queuePolicy: input.queuePolicy ?? "append",
     ...(input.clientEventId ? { clientEventId: input.clientEventId } : {}),
   });
   await recordWorkspaceUsage(deps, {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8329,6 +8329,33 @@ export async function getSessionEvent(
   });
 }
 
+/**
+ * Resolve a client-idempotent event inside one exact workspace/session scope.
+ * The three predicates are deliberate: a client event id is unique only within
+ * a session, while the workspace predicate remains the tenancy boundary.
+ */
+export async function getSessionEventByClientEventId(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+  clientEventId: string,
+): Promise<SessionEvent | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
+      .select()
+      .from(schema.sessionEvents)
+      .where(
+        and(
+          eq(schema.sessionEvents.workspaceId, workspaceId),
+          eq(schema.sessionEvents.sessionId, sessionId),
+          eq(schema.sessionEvents.clientEventId, clientEventId),
+        ),
+      )
+      .limit(1);
+    return row ? mapEvent(row) : null;
+  });
+}
+
 export async function getLatestRunState(
   db: Database,
   workspaceId: string,
@@ -14300,6 +14327,27 @@ export async function listSessionTurns(
   });
 }
 
+export async function listPendingSessionTurns(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionTurn[]> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb
+      .select()
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, workspaceId),
+          eq(schema.sessionTurns.sessionId, sessionId),
+          inArray(schema.sessionTurns.status, ["queued", "running", "requires_action"]),
+        ),
+      )
+      .orderBy(asc(schema.sessionTurns.position), asc(schema.sessionTurns.createdAt));
+    return rows.map(mapSessionTurn);
+  });
+}
+
 export async function updateQueuedSessionTurn(
   db: Database,
   workspaceId: string,
@@ -14600,6 +14648,7 @@ type LockedSessionUpdateContext = {
   updateSessionMcpServerCredentials: (
     updates: UpdateSessionMcpServerCredentialsInput[],
   ) => Promise<UpdateSessionMcpServerCredentialsResult>;
+  listPendingSessionTurns: () => Promise<SessionTurn[]>;
 };
 
 type LockedSessionUpdateResult = {
@@ -14646,6 +14695,20 @@ export async function appendSessionEventsWithLockedSessionUpdate(
               sessionId,
               updates,
             }),
+          listPendingSessionTurns: async () => {
+            const rows = await tx
+              .select()
+              .from(schema.sessionTurns)
+              .where(
+                and(
+                  eq(schema.sessionTurns.workspaceId, workspaceId),
+                  eq(schema.sessionTurns.sessionId, sessionId),
+                  inArray(schema.sessionTurns.status, ["queued", "running", "requires_action"]),
+                ),
+              )
+              .orderBy(asc(schema.sessionTurns.position), asc(schema.sessionTurns.createdAt));
+            return rows.map(mapSessionTurn);
+          },
         });
         if (built.events.length === 0) {
           return [];

--- a/scripts/operator/revive-session.test.ts
+++ b/scripts/operator/revive-session.test.ts
@@ -149,6 +149,61 @@ describe("operator session revival", () => {
     });
   });
 
+  test("a concurrent identical apply returns the winner event instead of conflicting work", async () => {
+    let currentSession = session("idle");
+    let currentEvent: SessionEvent | null = null;
+    let currentTurns: SessionTurn[] = [];
+    let acceptCalls = 0;
+    let durableWrites = 0;
+    let eventReads = 0;
+    const secondAcceptEntered = deferred<void>();
+    const winnerCommitted = deferred<void>();
+    const deps: OperatorSessionRevivalDependencies = {
+      getSession: async () => currentSession,
+      getEventByClientEventId: async () => {
+        eventReads += 1;
+        return currentEvent;
+      },
+      listPendingTurns: async () => currentTurns,
+      acceptUserMessage: async () => {
+        acceptCalls += 1;
+        if (acceptCalls === 1) {
+          await secondAcceptEntered.promise;
+          durableWrites += 1;
+          currentEvent = userMessageEvent();
+          currentTurns = [turn("queued")];
+          currentSession = session("queued");
+          winnerCommitted.resolve();
+          return { accepted: currentEvent, turn: currentTurns[0] as SessionTurn };
+        }
+        secondAcceptEntered.resolve();
+        await winnerCommitted.promise;
+        throw Object.assign(new Error("redacted"), { status: 409 });
+      },
+    };
+
+    const results = await Promise.all([
+      runOperatorSessionRevival(deps, applyInput()),
+      runOperatorSessionRevival(deps, applyInput()),
+    ]);
+
+    expect(results).toContainEqual(
+      expect.objectContaining({ status: "accepted", eventId, turnId }),
+    );
+    expect(results).toContainEqual(
+      expect.objectContaining({
+        status: "refused",
+        refusal: "duplicate_client_event",
+        eventId,
+      }),
+    );
+    expect(results).not.toContainEqual(expect.objectContaining({ refusal: "conflicting_work" }));
+    expect(acceptCalls).toBe(2);
+    expect(durableWrites).toBe(1);
+    expect(eventReads).toBe(3);
+    expect(currentTurns).toHaveLength(1);
+  });
+
   test("apply requires an explicit model and reasoning effort", () => {
     const { model: _model, ...withoutModel } = applyInput();
     expect(() => validateOperatorSessionRevivalInput(withoutModel)).toThrow();
@@ -296,4 +351,15 @@ function userMessageEvent(): SessionEvent {
     clientEventId,
     turnId: null,
   };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
 }

--- a/scripts/operator/revive-session.test.ts
+++ b/scripts/operator/revive-session.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+import type { Session, SessionEvent, SessionStatus, SessionTurn } from "@opengeni/contracts";
+import {
+  deterministicOperatorClientEventId,
+  runOperatorSessionRevival,
+  validateOperatorSessionRevivalInput,
+  type OperatorSessionRevivalDependencies,
+  type OperatorSessionRevivalInput,
+} from "./revive-session";
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const otherWorkspaceId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const sessionId = "22222222-2222-4222-8222-222222222222";
+const accountId = "33333333-3333-4333-8333-333333333333";
+const eventId = "44444444-4444-4444-8444-444444444444";
+const turnId = "55555555-5555-4555-8555-555555555555";
+const clientEventId = deterministicOperatorClientEventId(workspaceId, sessionId, "ope-22-revive-1");
+const message = "Resume the failed session from its durable conversation history.";
+const model = "codex/gpt-5.6-sol";
+const reasoningEffort = "xhigh";
+
+describe("operator session revival", () => {
+  test("dry-run preflights but never invokes the write/core port", async () => {
+    const harness = dependencies({ session: session("failed") });
+
+    const result = await runOperatorSessionRevival(harness.deps, dryRunInput());
+
+    expect(result).toMatchObject({
+      mode: "dry_run",
+      status: "ready",
+      workspaceId,
+      sessionId,
+      clientEventId,
+      sessionStatus: "failed",
+      pendingTurns: [],
+    });
+    expect(harness.accepted).toHaveLength(0);
+  });
+
+  test("a duplicate client event is refused with its stable event ID and no write", async () => {
+    const existingEvent = userMessageEvent();
+    const existingTurn = turn("queued");
+    const harness = dependencies({
+      session: session("queued"),
+      pendingTurns: [existingTurn],
+      existingEvent,
+    });
+
+    const result = await runOperatorSessionRevival(harness.deps, applyInput());
+
+    expect(result).toMatchObject({
+      status: "refused",
+      refusal: "duplicate_client_event",
+      eventId,
+    });
+    expect(harness.accepted).toHaveLength(0);
+  });
+
+  test("refuses a missing or mismatched workspace/session target", async () => {
+    const missing = dependencies({ session: null });
+    expect(await runOperatorSessionRevival(missing.deps, dryRunInput())).toMatchObject({
+      status: "refused",
+      refusal: "session_not_found_in_workspace",
+    });
+
+    const mismatched = dependencies({
+      session: { ...session("failed"), workspaceId: otherWorkspaceId },
+    });
+    expect(await runOperatorSessionRevival(mismatched.deps, dryRunInput())).toMatchObject({
+      status: "refused",
+      refusal: "scope_mismatch",
+    });
+    expect(missing.accepted).toHaveLength(0);
+    expect(mismatched.accepted).toHaveLength(0);
+  });
+
+  for (const status of ["queued", "running", "requires_action"] as const) {
+    test(`refuses ${status} work unless append is explicitly selected`, async () => {
+      const pendingTurn = turn(status);
+      const harness = dependencies({
+        session: session(status),
+        pendingTurns: [pendingTurn],
+      });
+
+      const refused = await runOperatorSessionRevival(harness.deps, applyInput());
+      expect(refused).toMatchObject({ status: "refused", refusal: "conflicting_work" });
+      expect(harness.accepted).toHaveLength(0);
+
+      const accepted = await runOperatorSessionRevival(harness.deps, {
+        ...applyInput(),
+        queuePolicy: "append",
+      });
+      expect(accepted).toMatchObject({ status: "accepted", eventId, turnId });
+      expect(harness.accepted).toHaveLength(1);
+      expect(harness.accepted[0]?.queuePolicy).toBe("append");
+    });
+  }
+
+  for (const status of ["failed", "idle"] as const) {
+    test(`${status} revival delegates to shared admission with the exact synthetic grant`, async () => {
+      const harness = dependencies({ session: session(status) });
+
+      const result = await runOperatorSessionRevival(harness.deps, applyInput());
+
+      expect(result).toMatchObject({
+        mode: "apply",
+        status: "accepted",
+        sessionStatus: status,
+        eventId,
+        turnId,
+      });
+      expect(harness.accepted).toHaveLength(1);
+      expect(harness.accepted[0]).toMatchObject({
+        workspaceId,
+        sessionId,
+        text: message,
+        model,
+        reasoningEffort,
+        clientEventId,
+        queuePolicy: "reject_conflicts",
+        grant: {
+          workspaceId,
+          accountId,
+          subjectId: "operator:session-revival",
+          permissions: ["workspace:admin"],
+        },
+      });
+      expect(harness.accepted[0]?.grant.permissions).toEqual(["workspace:admin"]);
+    });
+  }
+
+  test("an apply-time busy race is reported as a refusal instead of appending", async () => {
+    let pendingReads = 0;
+    const harness = dependencies({ session: session("idle") });
+    harness.deps.listPendingTurns = async () => {
+      pendingReads += 1;
+      return pendingReads === 1 ? [] : [turn("running")];
+    };
+    harness.deps.acceptUserMessage = async () => {
+      throw Object.assign(new Error("redacted"), { status: 409 });
+    };
+
+    const result = await runOperatorSessionRevival(harness.deps, applyInput());
+
+    expect(result).toMatchObject({
+      status: "refused",
+      refusal: "conflicting_work",
+      pendingTurns: [{ turnId, status: "running" }],
+    });
+  });
+
+  test("apply requires an explicit model and reasoning effort", () => {
+    const { model: _model, ...withoutModel } = applyInput();
+    expect(() => validateOperatorSessionRevivalInput(withoutModel)).toThrow();
+    const { reasoningEffort: _reasoningEffort, ...withoutReasoningEffort } = applyInput();
+    expect(() => validateOperatorSessionRevivalInput(withoutReasoningEffort)).toThrow();
+  });
+
+  test("requires a deterministic client event ID bound to the exact target", () => {
+    expect(() =>
+      validateOperatorSessionRevivalInput({
+        ...dryRunInput(),
+        clientEventId: "operator-revival:wrong-target",
+      }),
+    ).toThrow();
+    expect(clientEventId).toBe(`operator-revival:${workspaceId}:${sessionId}:ope-22-revive-1`);
+  });
+
+  test("never emits an accepted result returned outside the requested scope", async () => {
+    const harness = dependencies({ session: session("failed") });
+    harness.deps.acceptUserMessage = async () => ({
+      accepted: { ...userMessageEvent(), workspaceId: otherWorkspaceId },
+      turn: turn("queued"),
+    });
+
+    await expect(runOperatorSessionRevival(harness.deps, applyInput())).rejects.toThrow();
+  });
+});
+
+function dryRunInput(): OperatorSessionRevivalInput {
+  return {
+    workspaceId,
+    sessionId,
+    clientEventId,
+    apply: false,
+  };
+}
+
+function applyInput(): OperatorSessionRevivalInput {
+  return {
+    workspaceId,
+    sessionId,
+    clientEventId,
+    apply: true,
+    message,
+    model,
+    reasoningEffort,
+  };
+}
+
+function dependencies(options: {
+  session: Session | null;
+  pendingTurns?: SessionTurn[];
+  existingEvent?: SessionEvent | null;
+}): {
+  deps: OperatorSessionRevivalDependencies;
+  accepted: Parameters<OperatorSessionRevivalDependencies["acceptUserMessage"]>[0][];
+} {
+  const accepted: Parameters<OperatorSessionRevivalDependencies["acceptUserMessage"]>[0][] = [];
+  return {
+    accepted,
+    deps: {
+      getSession: async () => options.session,
+      getEventByClientEventId: async () => options.existingEvent ?? null,
+      listPendingTurns: async () => options.pendingTurns ?? [],
+      acceptUserMessage: async (input) => {
+        accepted.push(input);
+        return { accepted: userMessageEvent(), turn: turn("queued") };
+      },
+    },
+  };
+}
+
+function session(status: SessionStatus): Session {
+  return {
+    id: sessionId,
+    workspaceId,
+    accountId,
+    status,
+    initialMessage: "initial",
+    title: null,
+    titleSource: null,
+    instructions: null,
+    resources: [],
+    tools: [],
+    metadata: {},
+    model,
+    sandboxBackend: "modal",
+    sandboxOs: "linux",
+    sandboxGroupId: sessionId,
+    activeSandboxId: null,
+    activeEpoch: 0,
+    variableSetId: null,
+    environmentId: null,
+    rigId: null,
+    rigVersionId: null,
+    firstPartyMcpPermissions: null,
+    mcpServers: [],
+    parentSessionId: null,
+    createIdempotencyKey: null,
+    temporalWorkflowId: `session-${sessionId}`,
+    activeTurnId: status === "running" || status === "requires_action" ? turnId : null,
+    lastInputTokens: null,
+    lastSequence: 1,
+    codexPinnedCredentialId: null,
+    codexLastCredentialId: null,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+function turn(status: SessionTurn["status"]): SessionTurn {
+  return {
+    id: turnId,
+    workspaceId,
+    sessionId,
+    triggerEventId: eventId,
+    temporalWorkflowId: `session-${sessionId}`,
+    status,
+    source: "user",
+    position: 1,
+    prompt: message,
+    resources: [],
+    tools: [],
+    model,
+    reasoningEffort,
+    sandboxBackend: "modal",
+    sandboxOs: "linux",
+    metadata: {},
+    startedAt: status === "queued" ? null : "2026-07-10T00:00:01.000Z",
+    finishedAt: null,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+function userMessageEvent(): SessionEvent {
+  return {
+    id: eventId,
+    workspaceId,
+    sessionId,
+    sequence: 1,
+    type: "user.message",
+    payload: { text: message, model, reasoningEffort },
+    occurredAt: "2026-07-10T00:00:00.000Z",
+    clientEventId,
+    turnId: null,
+  };
+}

--- a/scripts/operator/revive-session.ts
+++ b/scripts/operator/revive-session.ts
@@ -1,0 +1,588 @@
+import {
+  dbSearchPath,
+  getSettings,
+  resolveNatsControlPlaneAuth,
+  type Settings,
+} from "@opengeni/config";
+import {
+  AccessGrant,
+  ReasoningEffort,
+  type Session,
+  type SessionEvent,
+  type SessionStatus,
+  type SessionTurn,
+  type SessionTurnStatus,
+} from "@opengeni/contracts";
+import {
+  acceptSessionUserMessage,
+  type AcceptSessionUserMessageDependencies,
+} from "@opengeni/core";
+import {
+  createDb,
+  getSession,
+  getSessionEventByClientEventId,
+  listPendingSessionTurns,
+  type Database,
+} from "@opengeni/db";
+import { createNatsEventBus, type EventBus } from "@opengeni/events";
+import { Client as TemporalClient, Connection as TemporalConnection } from "@temporalio/client";
+import { readFile } from "node:fs/promises";
+import { parseArgs as parseNodeArgs } from "node:util";
+
+const operatorSubjectId = "operator:session-revival";
+const deterministicClientEventPrefix = "operator-revival";
+const maxRecoveryMessageCharacters = 32_768;
+const canonicalUuid =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/;
+const clientEventOperationKey = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const busySessionStatuses = new Set<SessionStatus>(["queued", "running", "requires_action"]);
+
+export type OperatorQueuePolicy = "reject" | "append";
+
+export type OperatorSessionRevivalInput = {
+  workspaceId: string;
+  sessionId: string;
+  clientEventId: string;
+  apply: boolean;
+  queuePolicy?: OperatorQueuePolicy;
+  message?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+type SafePendingTurn = {
+  turnId: string;
+  status: SessionTurnStatus;
+};
+
+export type OperatorSessionRevivalResult = {
+  operation: "operator_session_revival";
+  mode: "dry_run" | "apply";
+  status: "ready" | "accepted" | "refused";
+  workspaceId: string;
+  sessionId: string;
+  clientEventId: string;
+  sessionStatus?: SessionStatus;
+  pendingTurns?: SafePendingTurn[];
+  eventId?: string;
+  turnId?: string;
+  turnStatus?: SessionTurnStatus;
+  refusal?:
+    | "session_not_found_in_workspace"
+    | "scope_mismatch"
+    | "cancelled_session"
+    | "conflicting_work"
+    | "duplicate_client_event";
+};
+
+export type OperatorSessionRevivalDependencies = {
+  getSession: (workspaceId: string, sessionId: string) => Promise<Session | null>;
+  getEventByClientEventId: (
+    workspaceId: string,
+    sessionId: string,
+    clientEventId: string,
+  ) => Promise<SessionEvent | null>;
+  listPendingTurns: (workspaceId: string, sessionId: string) => Promise<SessionTurn[]>;
+  acceptUserMessage: (input: {
+    grant: ReturnType<typeof AccessGrant.parse>;
+    workspaceId: string;
+    sessionId: string;
+    text: string;
+    model: string;
+    reasoningEffort: ReturnType<typeof ReasoningEffort.parse>;
+    clientEventId: string;
+    queuePolicy: "append" | "reject_conflicts";
+  }) => Promise<{ accepted: SessionEvent; turn: SessionTurn }>;
+};
+
+export function deterministicOperatorClientEventId(
+  workspaceId: string,
+  sessionId: string,
+  operationKey: string,
+): string {
+  requireCanonicalUuid("workspace ID", workspaceId);
+  requireCanonicalUuid("session ID", sessionId);
+  if (!clientEventOperationKey.test(operationKey)) {
+    throw new Error(
+      "operation key must be 1-64 lowercase alphanumeric, dot, underscore, or hyphen characters",
+    );
+  }
+  return `${deterministicClientEventPrefix}:${workspaceId}:${sessionId}:${operationKey}`;
+}
+
+export function validateOperatorSessionRevivalInput(input: OperatorSessionRevivalInput): void {
+  requireCanonicalUuid("workspace ID", input.workspaceId);
+  requireCanonicalUuid("session ID", input.sessionId);
+  const expectedPrefix = `${deterministicClientEventPrefix}:${input.workspaceId}:${input.sessionId}:`;
+  const operationKey = input.clientEventId.slice(expectedPrefix.length);
+  if (
+    !input.clientEventId.startsWith(expectedPrefix) ||
+    !clientEventOperationKey.test(operationKey)
+  ) {
+    throw new Error(
+      `client event ID must equal ${expectedPrefix}<stable-operation-key> using a 1-64 character lowercase safe key`,
+    );
+  }
+  if (!input.apply) {
+    return;
+  }
+  if (!input.message || input.message.trim().length === 0) {
+    throw new Error("apply requires a non-empty recovery message file");
+  }
+  if (input.message.length > maxRecoveryMessageCharacters) {
+    throw new Error(`recovery message exceeds ${maxRecoveryMessageCharacters} characters`);
+  }
+  if (!input.model || input.model.trim() !== input.model || input.model.length === 0) {
+    throw new Error("apply requires an explicit non-empty --model");
+  }
+  ReasoningEffort.parse(input.reasoningEffort);
+}
+
+/**
+ * Preflight and optionally revive one exact session through the shared message
+ * admission path. This function has no DB, NATS, Temporal, or environment
+ * construction so unit tests can prove dry-run performs no write.
+ */
+export async function runOperatorSessionRevival(
+  deps: OperatorSessionRevivalDependencies,
+  input: OperatorSessionRevivalInput,
+): Promise<OperatorSessionRevivalResult> {
+  validateOperatorSessionRevivalInput(input);
+  const mode: OperatorSessionRevivalResult["mode"] = input.apply ? "apply" : "dry_run";
+  const queuePolicy = input.queuePolicy ?? "reject";
+  const base = {
+    operation: "operator_session_revival" as const,
+    mode,
+    workspaceId: input.workspaceId,
+    sessionId: input.sessionId,
+    clientEventId: input.clientEventId,
+  };
+  const session = await deps.getSession(input.workspaceId, input.sessionId);
+  if (!session) {
+    return { ...base, status: "refused", refusal: "session_not_found_in_workspace" };
+  }
+  if (session.workspaceId !== input.workspaceId || session.id !== input.sessionId) {
+    return {
+      ...base,
+      status: "refused",
+      sessionStatus: session.status,
+      refusal: "scope_mismatch",
+    };
+  }
+
+  const [existingEvent, pendingTurns] = await Promise.all([
+    deps.getEventByClientEventId(input.workspaceId, input.sessionId, input.clientEventId),
+    deps.listPendingTurns(input.workspaceId, input.sessionId),
+  ]);
+  if (
+    pendingTurns.some(
+      (turn) => turn.workspaceId !== input.workspaceId || turn.sessionId !== input.sessionId,
+    )
+  ) {
+    return {
+      ...base,
+      status: "refused",
+      sessionStatus: session.status,
+      refusal: "scope_mismatch",
+    };
+  }
+  const safePendingTurns = pendingTurns
+    .map((turn) => ({ turnId: turn.id, status: turn.status }))
+    .sort((left, right) => left.turnId.localeCompare(right.turnId));
+  const preflight = {
+    ...base,
+    sessionStatus: session.status,
+    pendingTurns: safePendingTurns,
+  };
+
+  if (existingEvent) {
+    return duplicateClientEventResult(input, preflight, existingEvent);
+  }
+  if (session.status === "cancelled") {
+    return { ...preflight, status: "refused", refusal: "cancelled_session" };
+  }
+  if (
+    queuePolicy !== "append" &&
+    (busySessionStatuses.has(session.status) || safePendingTurns.length > 0)
+  ) {
+    return { ...preflight, status: "refused", refusal: "conflicting_work" };
+  }
+  if (!input.apply) {
+    return { ...preflight, status: "ready" };
+  }
+
+  const reasoningEffort = ReasoningEffort.parse(input.reasoningEffort);
+  const grant = AccessGrant.parse({
+    workspaceId: input.workspaceId,
+    accountId: session.accountId,
+    subjectId: operatorSubjectId,
+    permissions: ["workspace:admin"],
+  });
+  try {
+    const result = await deps.acceptUserMessage({
+      grant,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
+      text: input.message as string,
+      model: input.model as string,
+      reasoningEffort,
+      clientEventId: input.clientEventId,
+      queuePolicy: queuePolicy === "append" ? "append" : "reject_conflicts",
+    });
+    if (
+      result.accepted.workspaceId !== input.workspaceId ||
+      result.accepted.sessionId !== input.sessionId ||
+      result.turn.workspaceId !== input.workspaceId ||
+      result.turn.sessionId !== input.sessionId
+    ) {
+      throw new Error("shared admission returned a result outside the requested session scope");
+    }
+    return {
+      ...preflight,
+      status: "accepted",
+      eventId: result.accepted.id,
+      turnId: result.turn.id,
+      turnStatus: result.turn.status,
+    };
+  } catch (error) {
+    // Close the concurrent same-client-event race without masking any other
+    // core failure. postgres.js exposes SQLSTATE 23505 on unique violations.
+    if (isUniqueViolation(error)) {
+      const racedEvent = await deps.getEventByClientEventId(
+        input.workspaceId,
+        input.sessionId,
+        input.clientEventId,
+      );
+      if (!racedEvent) {
+        throw error;
+      }
+      return duplicateClientEventResult(input, preflight, racedEvent);
+    }
+    if (isConflict(error)) {
+      const [currentSession, currentPendingTurns] = await Promise.all([
+        deps.getSession(input.workspaceId, input.sessionId),
+        deps.listPendingTurns(input.workspaceId, input.sessionId),
+      ]);
+      if (
+        currentSession?.workspaceId === input.workspaceId &&
+        currentSession.id === input.sessionId
+      ) {
+        if (
+          currentPendingTurns.some(
+            (turn) => turn.workspaceId !== input.workspaceId || turn.sessionId !== input.sessionId,
+          )
+        ) {
+          return {
+            ...base,
+            status: "refused",
+            sessionStatus: currentSession.status,
+            refusal: "scope_mismatch",
+          };
+        }
+        const currentPreflight = {
+          ...base,
+          sessionStatus: currentSession.status,
+          pendingTurns: currentPendingTurns.map((turn) => ({
+            turnId: turn.id,
+            status: turn.status,
+          })),
+        };
+        if (currentSession.status === "cancelled") {
+          return { ...currentPreflight, status: "refused", refusal: "cancelled_session" };
+        }
+        if (
+          busySessionStatuses.has(currentSession.status) ||
+          currentPreflight.pendingTurns.length > 0
+        ) {
+          return { ...currentPreflight, status: "refused", refusal: "conflicting_work" };
+        }
+      }
+      return { ...preflight, status: "refused", refusal: "conflicting_work" };
+    }
+    throw error;
+  }
+}
+
+function duplicateClientEventResult(
+  input: OperatorSessionRevivalInput,
+  preflight: Omit<OperatorSessionRevivalResult, "status">,
+  event: SessionEvent,
+): OperatorSessionRevivalResult {
+  if (event.workspaceId !== input.workspaceId || event.sessionId !== input.sessionId) {
+    return { ...preflight, status: "refused", refusal: "scope_mismatch" };
+  }
+  return {
+    ...preflight,
+    status: "refused",
+    eventId: event.id,
+    refusal: "duplicate_client_event",
+  };
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "23505");
+}
+
+function isConflict(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "status" in error && error.status === 409);
+}
+
+function requireCanonicalUuid(label: string, value: string): void {
+  if (!canonicalUuid.test(value)) {
+    throw new Error(`${label} must be a canonical lowercase UUID`);
+  }
+}
+
+type ParsedCliArgs = OperatorSessionRevivalInput & {
+  messageFile?: string;
+  help: boolean;
+};
+
+export function parseOperatorSessionRevivalArgs(argv: string[]): ParsedCliArgs {
+  const { values, tokens } = parseNodeArgs({
+    args: argv,
+    allowPositionals: false,
+    strict: true,
+    tokens: true,
+    options: {
+      "workspace-id": { type: "string" },
+      "session-id": { type: "string" },
+      "client-event-id": { type: "string" },
+      "message-file": { type: "string" },
+      model: { type: "string" },
+      "reasoning-effort": { type: "string" },
+      "queue-policy": { type: "string" },
+      apply: { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+  });
+  const seen = new Set<string>();
+  for (const token of tokens) {
+    if (token.kind !== "option") continue;
+    if (seen.has(token.name)) {
+      throw new Error(`duplicate argument: --${token.name}`);
+    }
+    seen.add(token.name);
+  }
+
+  const workspaceId = values["workspace-id"];
+  const sessionId = values["session-id"];
+  const clientEventId = values["client-event-id"];
+  const messageFile = values["message-file"];
+  const model = values.model;
+  const reasoningEffort = values["reasoning-effort"];
+  const rawQueuePolicy = values["queue-policy"];
+  const apply = values.apply ?? false;
+  const help = values.help ?? false;
+  if (rawQueuePolicy !== undefined && rawQueuePolicy !== "append" && rawQueuePolicy !== "reject") {
+    throw new Error("--queue-policy must be reject or append");
+  }
+  const queuePolicy = rawQueuePolicy as OperatorQueuePolicy | undefined;
+  if (help) {
+    return {
+      workspaceId: workspaceId ?? "",
+      sessionId: sessionId ?? "",
+      clientEventId: clientEventId ?? "",
+      apply,
+      help,
+      ...(messageFile ? { messageFile } : {}),
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+      ...(queuePolicy ? { queuePolicy } : {}),
+    };
+  }
+  if (!workspaceId) throw new Error("missing --workspace-id");
+  if (!sessionId) throw new Error("missing --session-id");
+  if (!clientEventId) throw new Error("missing --client-event-id");
+  if (apply && !messageFile) throw new Error("--apply requires --message-file");
+  if (apply && !model) throw new Error("--apply requires --model");
+  if (apply && !reasoningEffort) throw new Error("--apply requires --reasoning-effort");
+  return {
+    workspaceId,
+    sessionId,
+    clientEventId,
+    apply,
+    help,
+    ...(messageFile ? { messageFile } : {}),
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(queuePolicy ? { queuePolicy } : {}),
+  };
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  bun run operator:revive-session --workspace-id <uuid> --session-id <uuid> \\
+    --client-event-id operator-revival:<workspace-id>:<session-id>:<stable-key>
+
+Dry-run is the default. Apply additionally requires:
+  --apply --message-file <path> --model <id> --reasoning-effort <effort>
+
+When active, queued, or requires-action work exists, the default policy refuses.
+Use --queue-policy append only after explicitly deciding to enqueue behind it.`);
+}
+
+function databaseReadDependencies(db: Database) {
+  return {
+    getSession: async (workspaceId: string, sessionId: string) =>
+      await getSession(db, workspaceId, sessionId),
+    getEventByClientEventId: async (
+      workspaceId: string,
+      sessionId: string,
+      clientEventId: string,
+    ) => await getSessionEventByClientEventId(db, workspaceId, sessionId, clientEventId),
+    listPendingTurns: async (workspaceId: string, sessionId: string) =>
+      await listPendingSessionTurns(db, workspaceId, sessionId),
+  };
+}
+
+async function createApplyDependencies(
+  settings: Settings,
+  db: Database,
+): Promise<{
+  bus: EventBus;
+  temporalConnection: TemporalConnection;
+  core: AcceptSessionUserMessageDependencies;
+}> {
+  const controlPlaneAuth = resolveNatsControlPlaneAuth(settings);
+  const bus = await createNatsEventBus(
+    settings.natsUrl,
+    controlPlaneAuth ? { user: controlPlaneAuth.user, pass: controlPlaneAuth.password } : undefined,
+  );
+  try {
+    const temporalConnection = await TemporalConnection.connect({ address: settings.temporalHost });
+    const temporal = new TemporalClient({
+      connection: temporalConnection,
+      namespace: settings.temporalNamespace,
+    });
+    return {
+      bus,
+      temporalConnection,
+      core: {
+        settings,
+        db,
+        bus,
+        objectStorage: null,
+        workflowClient: {
+          wakeSessionWorkflow: async ({ accountId, workspaceId, sessionId, workflowId }) => {
+            await temporal.workflow.signalWithStart("sessionWorkflow", {
+              taskQueue: settings.temporalTaskQueue,
+              workflowId,
+              workflowIdReusePolicy: "ALLOW_DUPLICATE",
+              args: [{ accountId, workspaceId, sessionId }],
+              signal: "queueChanged",
+            });
+          },
+        },
+      },
+    };
+  } catch (error) {
+    await bus.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  let parsed: ParsedCliArgs;
+  try {
+    parsed = parseOperatorSessionRevivalArgs(process.argv.slice(2));
+    if (parsed.help) {
+      printUsage();
+      return;
+    }
+  } catch {
+    console.error(
+      JSON.stringify({ operation: "operator_session_revival", status: "invalid_input" }),
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const input: OperatorSessionRevivalInput = {
+    workspaceId: parsed.workspaceId,
+    sessionId: parsed.sessionId,
+    clientEventId: parsed.clientEventId,
+    apply: parsed.apply,
+    ...(parsed.queuePolicy ? { queuePolicy: parsed.queuePolicy } : {}),
+    ...(parsed.model ? { model: parsed.model } : {}),
+    ...(parsed.reasoningEffort ? { reasoningEffort: parsed.reasoningEffort } : {}),
+  };
+  try {
+    if (parsed.messageFile) {
+      input.message = await readFile(parsed.messageFile, "utf8");
+    }
+    validateOperatorSessionRevivalInput(input);
+  } catch {
+    console.error(
+      JSON.stringify({ operation: "operator_session_revival", status: "invalid_input" }),
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  let dbClient: ReturnType<typeof createDb> | undefined;
+  let applyDeps: Awaited<ReturnType<typeof createApplyDependencies>> | undefined;
+  try {
+    const settings = getSettings();
+    const searchPath = dbSearchPath(settings);
+    dbClient = createDb(settings.databaseUrl, {
+      ...(searchPath ? { searchPath } : {}),
+      rlsStrategy: settings.rlsStrategy,
+    });
+    const db = dbClient.db;
+    const reads = databaseReadDependencies(db);
+    const deps: OperatorSessionRevivalDependencies = {
+      ...reads,
+      acceptUserMessage: async (request) => {
+        if (!applyDeps) {
+          applyDeps = await createApplyDependencies(settings, db);
+        }
+        return await acceptSessionUserMessage(
+          applyDeps.core,
+          request.grant,
+          request.workspaceId,
+          request.sessionId,
+          {
+            text: request.text,
+            resources: [],
+            tools: [],
+            toolsProvided: true,
+            model: request.model,
+            reasoningEffort: request.reasoningEffort,
+            clientEventId: request.clientEventId,
+            queuePolicy: request.queuePolicy,
+          },
+        );
+      },
+    };
+    const result = await runOperatorSessionRevival(deps, input);
+    console.log(JSON.stringify(result, null, 2));
+    if (result.status === "refused") {
+      process.exitCode = 2;
+    }
+  } catch {
+    // Never echo an upstream error: provider/database errors can contain
+    // connection details. The stable target ids are sufficient to correlate
+    // control-plane logs and the incident audit trail.
+    console.error(
+      JSON.stringify({
+        operation: "operator_session_revival",
+        status: "error",
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        clientEventId: input.clientEventId,
+      }),
+    );
+    process.exitCode = 1;
+  } finally {
+    await Promise.allSettled([
+      applyDeps?.temporalConnection.close(),
+      applyDeps?.bus.close(),
+      dbClient?.close(),
+    ]);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/operator/revive-session.ts
+++ b/scripts/operator/revive-session.ts
@@ -259,6 +259,20 @@ export async function runOperatorSessionRevival(
       return duplicateClientEventResult(input, preflight, racedEvent);
     }
     if (isConflict(error)) {
+      // The locked shared admission path checks for newly-active work before
+      // attempting the deterministic insert. Two identical callers can both
+      // pass the unlocked preflight, then the winner queues the session while
+      // the loser waits for the lock. In that case the loser receives 409
+      // rather than 23505, so give the exact client-event lookup precedence
+      // over generic busy-work classification.
+      const racedEvent = await deps.getEventByClientEventId(
+        input.workspaceId,
+        input.sessionId,
+        input.clientEventId,
+      );
+      if (racedEvent) {
+        return duplicateClientEventResult(input, preflight, racedEvent);
+      }
       const [currentSession, currentPendingTurns] = await Promise.all([
         deps.getSession(input.workspaceId, input.sessionId),
         deps.listPendingTurns(input.workspaceId, input.sessionId),

--- a/scripts/operator/tsconfig.json
+++ b/scripts/operator/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["./*.ts"]
+}

--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 // ~5x faster wall time and bounded per-process RSS. Keep this list in sync
 // with the per-package `typecheck` scripts.
 const projects = [
+  "scripts/operator",
   "packages/contracts",
   "packages/agent-proto",
   "packages/codex",


### PR DESCRIPTION
## Summary

- add a control-plane-only `operator:revive-session` helper with dry-run default and structured, redacted output
- require exact canonical workspace/session IDs plus a deterministic target-bound client event ID; require explicit message file, model, and reasoning effort for apply
- preflight duplicate client events and all queued/running/requires-action turns; default to refusal, with only an explicit `--queue-policy append` override
- close the preflight race through an additive locked `reject_conflicts` policy in the shared `acceptSessionUserMessage` path
- compose apply from `createDb`, the managed NATS event bus, Temporal `signalWithStart`, and an exact synthetic workspace-scoped `workspace:admin` grant
- document audit evidence, duplicate refusal, supported cancellation/interrupt correction, and strict no-direct-edit/no-delete semantics

## Safety / invariants

- no raw SQL or row mutation in the operator helper
- all reads remain workspace-RLS scoped and include the exact session predicate
- normal API/MCP queue behavior remains unchanged (`append` is still the core default)
- dry-run never calls the shared write port; NATS and Temporal are initialized lazily only after apply preflight passes
- helper output omits message text, payloads, metadata, credentials, connection details, and upstream errors
- no live DB, NATS, Temporal, session, cloud, model, merge, or deployment operation was performed during implementation

## Verification

- `bun test scripts/operator/revive-session.test.ts` — 12 pass, 0 fail
- `bun run typecheck` — all projects clean
- clean-pointer full unit run — 2623 pass, 4 gated-live skips, 0 fail across 197 files
  - only the rig-injected `OPENGENI_GIT_TOKEN_FILE`, `OPENGENI_GIT_CREDENTIALS_DIR`, and `OPENGENI_GIT_CLI_WRAPPER_DIR` pointer overrides were unset so lifecycle fallback tests match CI; no credential values were changed or printed
- `bun run check:docs-refs` — pass
- `bun run format:check` — pass
- `bun scripts/check-workspace-billing-static.ts` — pass
- `git diff --check` — pass
- `bun run lint` — 0 errors (repository currently reports 214 warnings)

## Delivery

- Linear: OPE-22
- Base: `88df9300e45c237ca7189eb61b1747f1b5654d3a`
- Commit: `332ac15b3e2d896804bceec0a0c04d9efed3abda`

Do not merge or deploy from this PR as part of this change; the incident owner controls release order and any live recovery action.
