### PR TITLE
fix(files): allow zero-credit attachment staging

### DIFF
--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -83,6 +83,13 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (!upload) {
       throw new HTTPException(404, { message: "file upload not found" });
     }
+    // A client can lose the response after the server commits completion, or two
+    // tabs can race the same completion request. A ready object is durable and
+    // safe to return again; forcing a retry to fail here would strand the
+    // attachment reference even though its storage work succeeded.
+    if (upload.status === "completed" && upload.file.status === "ready") {
+      return c.json(CompleteFileUploadResponse.parse({ file: upload.file }));
+    }
     if (upload.status !== "pending") {
       throw new HTTPException(409, { message: `file upload is ${upload.status}` });
     }

--- a/packages/core/src/billing/limits.ts
+++ b/packages/core/src/billing/limits.ts
@@ -235,10 +235,7 @@ function usesCreditLimits(deps: LimitDependencies): boolean {
 
 function isCostlyAction(action: LimitAction): boolean {
   return (
-    action === "agent_run:create" ||
-    action === "tokens:consume" ||
-    action === "file:upload" ||
-    action === "document:index"
+    action === "agent_run:create" || action === "tokens:consume" || action === "document:index"
   );
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1999,6 +1999,17 @@ export async function completeFileUpload(
         if (!fileRow) {
           throw new Error(`File not found for upload: ${uploadId}`);
         }
+        // The API route normally handles this fast path, but the second half of
+        // a concurrent finalize race can enter this transaction after the first
+        // caller committed. Locking makes the retry return the original ready
+        // asset rather than writing a second transition or failing a client that
+        // never received the first response.
+        if (uploadRow.status === "completed" && fileRow.status === "ready") {
+          return mapFile(fileRow);
+        }
+        if (uploadRow.status !== "pending") {
+          throw new Error(`File upload is ${uploadRow.status}: ${uploadId}`);
+        }
         const now = new Date();
         const [updatedFile] = await tx
           .update(schema.files)

--- a/test/e2e/browser.e2e.ts
+++ b/test/e2e/browser.e2e.ts
@@ -23,7 +23,10 @@ describe("browser e2e", () => {
   beforeAll(async () => {
     try {
       browser = await chromium.launch();
-      services = await startTestServices({ temporal: true });
+      // The attachment journey must exercise the actual direct-to-object-store
+      // path, not a mocked SDK upload. Keep the browser and API on their normal
+      // separate origins so CORS/signed-PUT behavior stays representative.
+      services = await startTestServices({ temporal: true, objectStorage: true });
       await services.migrate();
       apiPort = await freePort();
       webPort = await freePort();
@@ -130,6 +133,69 @@ describe("browser e2e", () => {
       .getByText("slow stream", { exact: false })
       .waitFor({ timeout: 15_000 });
   }, 120_000);
+
+  test("uploads an image from the composer, persists its resource, and survives refresh", async () => {
+    const page = await browser.newPage({ viewport: { width: 375, height: 740 } });
+    const image = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScL2GQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+    await page.goto(`http://127.0.0.1:${webPort}`);
+
+    // The control remains discoverable to assistive tech and accepts a normal
+    // picker selection. A narrow viewport must wrap the chip/control row,
+    // never introduce horizontal overflow.
+    await page.getByRole("button", { name: "Attach files" }).waitFor();
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "e2e screenshot.png",
+      mimeType: "image/png",
+      buffer: image,
+    });
+    await page.getByText("e2e screenshot.png", { exact: true }).waitFor({ timeout: 15_000 });
+    await waitFor(async () => (await page.locator('img[src^="blob:"]').count()) === 1, {
+      timeoutMs: 15_000,
+    });
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true);
+
+    await page.getByPlaceholder("Describe a task for the agent...").fill("inspect the screenshot");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await waitFor(() => /\/workspaces\/[^/]+\/sessions\/[^/]+$/.test(page.url()), {
+      timeoutMs: 15_000,
+    });
+    await page
+      .getByTestId("session-timeline")
+      .getByText("inspect the screenshot", { exact: true })
+      .waitFor({ timeout: 15_000 });
+
+    // The session API is the agent's durable resource source. Verify it has
+    // exactly one ready file reference before and after reconnect/replay.
+    const [workspaceId, sessionId] = page
+      .url()
+      .match(/workspaces\/([^/]+)\/sessions\/([^/]+)$/)!
+      .slice(1);
+    const resourceCount = async () =>
+      await page.evaluate(
+        async ({ apiPort, workspaceId, sessionId }) => {
+          const response = await fetch(
+            `http://127.0.0.1:${apiPort}/v1/workspaces/${workspaceId}/sessions/${sessionId}`,
+          );
+          const session = (await response.json()) as { resources?: Array<{ kind?: string }> };
+          return session.resources?.filter((resource) => resource.kind === "file").length ?? 0;
+        },
+        { apiPort, workspaceId, sessionId },
+      );
+    expect(await resourceCount()).toBe(1);
+
+    await page.reload();
+    await page
+      .getByTestId("session-timeline")
+      .getByText("inspect the screenshot", { exact: true })
+      .waitFor({ timeout: 15_000 });
+    expect(await resourceCount()).toBe(1);
+    await page.close();
+  }, 120_000);
 });
 
 function stackEnv(
@@ -150,6 +216,10 @@ function stackEnv(
     OPENGENI_OPENAI_MODEL: "scripted-model",
     OPENGENI_SANDBOX_BACKEND: "none",
     OPENGENI_SANDBOX_PREPARATION_PROFILES: "none",
+    OPENGENI_OBJECT_STORAGE_ENDPOINT: services.objectStorageEndpoint!,
+    OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT: services.objectStorageSandboxEndpoint!,
+    OPENGENI_OBJECT_STORAGE_ACCESS_KEY_ID: "minioadmin",
+    OPENGENI_OBJECT_STORAGE_SECRET_ACCESS_KEY: "minioadmin",
     OPENGENI_TEST_SCENARIO: scenario,
   };
 }

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -856,6 +856,164 @@ describe("API component integration", () => {
     );
   });
 
+  test("zero-credit attachment staging survives tenant checks, duplicate finalize, and a rejected turn", async () => {
+    const delegationSecret = "test-zero-credit-file-staging-secret";
+    const app = createApp({
+      settings: {
+        ...objectStorageSettings(services.databaseUrl, services.objectStorageEndpoint!),
+        productAccessMode: "managed",
+        usageLimitsMode: "managed",
+        delegationSecret,
+        betterAuthSecret: "test-better-auth-secret-32-bytes",
+        publicBaseUrl: "http://127.0.0.1:3000",
+      },
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const owner = await bootstrapWorkspace(dbClient.db, {
+      accountExternalSource: "test:zero-credit-file-owner",
+      accountExternalId: crypto.randomUUID(),
+      accountName: "Zero credit file owner",
+      workspaceExternalSource: "test:zero-credit-file-owner",
+      workspaceExternalId: crypto.randomUUID(),
+      workspaceName: "Zero credit file workspace",
+      subjectId: `test:zero-credit-file-owner:${crypto.randomUUID()}`,
+      accountPermissions: allAccountPermissions,
+      workspacePermissions: allWorkspacePermissions,
+    });
+    const otherTenant = await bootstrapWorkspace(dbClient.db, {
+      accountExternalSource: "test:zero-credit-file-other",
+      accountExternalId: crypto.randomUUID(),
+      accountName: "Other file account",
+      workspaceExternalSource: "test:zero-credit-file-other",
+      workspaceExternalId: crypto.randomUUID(),
+      workspaceName: "Other file workspace",
+      subjectId: `test:zero-credit-file-other:${crypto.randomUUID()}`,
+      accountPermissions: allAccountPermissions,
+      workspacePermissions: allWorkspacePermissions,
+    });
+    const ownerWorkspaceId = owner.defaultWorkspaceId!;
+    const otherWorkspaceId = otherTenant.defaultWorkspaceId!;
+    const ownerHeaders = {
+      authorization: `Bearer ${await signDelegatedAccessToken(delegationSecret, {
+        accountId: owner.defaultAccountId!,
+        workspaceId: ownerWorkspaceId,
+        subjectId: owner.subjectId,
+        permissions: [...allAccountPermissions, ...allWorkspacePermissions],
+        exp: Math.floor(Date.now() / 1000) + 60,
+      })}`,
+    };
+    const otherHeaders = {
+      authorization: `Bearer ${await signDelegatedAccessToken(delegationSecret, {
+        accountId: otherTenant.defaultAccountId!,
+        workspaceId: otherWorkspaceId,
+        subjectId: otherTenant.subjectId,
+        permissions: [...allAccountPermissions, ...allWorkspacePermissions],
+        exp: Math.floor(Date.now() / 1000) + 60,
+      })}`,
+    };
+    const image = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+    // Storage staging is not an inference purchase: no credit entry exists for
+    // this account, but prepare must issue a scoped signed PUT.
+    const begin = await app.request(workspacePath(ownerWorkspaceId, "/files/uploads"), {
+      method: "POST",
+      headers: { "content-type": "application/json", ...ownerHeaders },
+      body: JSON.stringify({
+        filename: "a very long screenshot name with spaces and _ punctuation.png",
+        contentType: "image/png",
+        sizeBytes: image.byteLength,
+      }),
+    });
+    expect(begin.status).toBe(201);
+    const upload = (await begin.json()) as {
+      fileId: string;
+      uploadId: string;
+      putUrl: string;
+      requiredHeaders: Record<string, string>;
+    };
+
+    // The upload id and asset are invisible outside their RLS workspace.
+    const wrongTenantComplete = await app.request(
+      workspacePath(otherWorkspaceId, `/files/uploads/${upload.uploadId}/complete`),
+      { method: "POST", headers: otherHeaders },
+    );
+    expect(wrongTenantComplete.status).toBe(404);
+    const wrongTenantRead = await app.request(
+      workspacePath(otherWorkspaceId, `/files/${upload.fileId}`),
+      { headers: otherHeaders },
+    );
+    expect(wrongTenantRead.status).toBe(404);
+
+    const put = await fetch(upload.putUrl, {
+      method: "PUT",
+      body: image,
+      headers: upload.requiredHeaders,
+    });
+    expect(put.ok).toBe(true);
+
+    // Two tabs (or a lost response retry) must converge on the one ready asset.
+    const complete = () =>
+      app.request(workspacePath(ownerWorkspaceId, `/files/uploads/${upload.uploadId}/complete`), {
+        method: "POST",
+        headers: ownerHeaders,
+      });
+    const [firstComplete, secondComplete] = await Promise.all([complete(), complete()]);
+    expect(firstComplete.status).toBe(200);
+    expect(secondComplete.status).toBe(200);
+    const firstFile = ((await firstComplete.json()) as { file: { id: string; status: string } })
+      .file;
+    const secondFile = ((await secondComplete.json()) as { file: { id: string; status: string } })
+      .file;
+    expect(firstFile).toEqual({ id: upload.fileId, status: "ready" });
+    expect(secondFile).toEqual(firstFile);
+
+    // A later model-turn admission still fails at zero balance, but cannot
+    // delete or orphan the already-finalized attachment reference.
+    const rejectedTurn = await app.request(workspacePath(ownerWorkspaceId, "/sessions"), {
+      method: "POST",
+      headers: { "content-type": "application/json", ...ownerHeaders },
+      body: JSON.stringify({
+        initialMessage: "inspect this screenshot",
+        resources: [{ kind: "file", fileId: upload.fileId }],
+      }),
+    });
+    expect(rejectedTurn.status).toBe(402);
+    expect(await rejectedTurn.text()).toContain("insufficient OpenGeni credits");
+    const preserved = await app.request(
+      workspacePath(ownerWorkspaceId, `/files/${upload.fileId}`),
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(preserved.status).toBe(200);
+    expect((await preserved.json()) as { status: string }).toMatchObject({ status: "ready" });
+
+    // Retrying after funds arrive attaches the same durable file rather than
+    // creating another object or requiring a re-upload.
+    await applyCreditLedgerEntry(dbClient.db, {
+      accountId: owner.defaultAccountId!,
+      type: "credit_topup",
+      amountMicros: 1_000_000,
+      sourceType: "test",
+      sourceId: "zero-credit-file-retry",
+      idempotencyKey: `test:zero-credit-file-retry:${owner.defaultAccountId!}`,
+    });
+    const retriedTurn = await app.request(workspacePath(ownerWorkspaceId, "/sessions"), {
+      method: "POST",
+      headers: { "content-type": "application/json", ...ownerHeaders },
+      body: JSON.stringify({
+        initialMessage: "inspect this screenshot",
+        resources: [{ kind: "file", fileId: upload.fileId }],
+      }),
+    });
+    expect(retriedTurn.status).toBe(202);
+    expect((await retriedTurn.json()) as { resources: unknown[] }).toMatchObject({
+      resources: [{ kind: "file", fileId: upload.fileId }],
+    });
+  });
+
   test("managed credit gate blocks document indexing before enqueueing work", async () => {
     const delegationSecret = "test-managed-document-credit-secret";
     const app = createApp({

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -966,7 +966,7 @@ describe("API component integration", () => {
       .file;
     const secondFile = ((await secondComplete.json()) as { file: { id: string; status: string } })
       .file;
-    expect(firstFile).toEqual({ id: upload.fileId, status: "ready" });
+    expect(firstFile).toMatchObject({ id: upload.fileId, status: "ready" });
     expect(secondFile).toEqual(firstFile);
 
     // A later model-turn admission still fails at zero balance, but cannot


### PR DESCRIPTION
## OPE-19 — zero-credit attachment staging

### Root cause and production evidence

Production API logs for workspace `c77bf2b8-3d09-4963-a40d-30588f5139f7` show repeated HTTP **402** responses at `POST /v1/workspaces/:workspaceId/files/uploads` around 2026-07-10 07:02 UTC. This occurs before the signed PUT, completion, session/draft update, or agent-turn admission.

The cause was `isCostlyAction()` classifying `file:upload` as an inference-credit action. That conflicts with the product invariant: storage staging is not an inference purchase.

### Change

- Removes `file:upload` from the prepaid inference-credit gate while retaining access grants, RLS, MIME/size/object-store verification, static `maxFileUploadBytes`, and object-store single-PUT limits.
- Makes a completed/ready upload finalize idempotent, including the locked concurrent-finalize path.
- Adds a real Postgres/RLS/MinIO integration test for zero-credit prepare → signed PUT → wrong-tenant denial → concurrent duplicate finalize → later turn 402 with ready asset preserved → funded retry using the same file.
- Extends Playwright E2E to run against MinIO and cover accessible composer selection, image preview, narrow-mobile no-overflow, durable file resource, and refresh/replay.

### Verification

- `bun run typecheck` (passed locally)
- `bun test packages/react/test/use-file-attachments.test.tsx packages/react/test/use-composer.test.ts apps/api/test/app.test.ts packages/core/test --timeout 30000` — **50 pass**
- Local Docker-backed integration/E2E could not start because this sandbox kernel rejects Docker bridge/NAT (`iptables ... Protocol not supported`); CI/staging must supply the real MinIO/Postgres/browser evidence.

No user message is sent by this change. The user’s separate streaming/render corruption remains uninvestigated pending a successful screenshot attachment.
