### PR TITLE
test(agent): deterministic load/chaos harness for the Connected-Machine agent

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -91,7 +91,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "memchr",
@@ -152,7 +152,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -197,6 +197,12 @@ dependencies = [
  "tower-layer",
  "tower-service",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -444,6 +450,21 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -819,6 +840,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,7 +973,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1238,6 +1273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1369,16 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "signatory",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1552,7 +1603,7 @@ version = "0.1.7"
 dependencies = [
  "async-nats",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "clap",
  "ed25519-dalek",
  "futures",
@@ -1569,6 +1620,26 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opengeni-agent-harness"
+version = "0.0.0"
+dependencies = [
+ "async-nats",
+ "clap",
+ "futures",
+ "hdrhistogram",
+ "nix 0.29.0",
+ "opengeni-agent-proto",
+ "prost",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1660,7 +1731,7 @@ version = "0.1.7"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "futures-util",
@@ -2115,7 +2186,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2757,7 +2828,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/opengeni-agent-stream",
     "crates/opengeni-agent-update",
     "crates/opengeni-relay",
+    "crates/opengeni-agent-harness",
 ]
 
 # Shared metadata + lint posture for every crate in the agent workspace.

--- a/agent/crates/opengeni-agent-harness/.gitignore
+++ b/agent/crates/opengeni-agent-harness/.gitignore
@@ -1,0 +1,2 @@
+results/
+harness-results/

--- a/agent/crates/opengeni-agent-harness/Cargo.toml
+++ b/agent/crates/opengeni-agent-harness/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "opengeni-agent-harness"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+description = "Dev-only deterministic load/chaos harness for the opengeni-agent control plane"
+
+[[bin]]
+name = "og-agent-harness"
+path = "src/main.rs"
+
+[dependencies]
+# The wire types — the harness speaks the exact prost ControlRequest/Response the
+# control plane speaks, so it exercises the REAL protocol seam.
+opengeni-agent-proto = { path = "../opengeni-agent-proto" }
+prost.workspace = true
+
+# Control-plane transport. Same client version the agent dials with.
+async-nats.workspace = true
+
+# Async runtime: spawn the agent + nats children, drive concurrent ops, sample.
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "process",
+    "signal",
+    "time",
+    "sync",
+    "fs",
+    "io-util",
+] }
+futures.workspace = true
+
+# Deterministic op mixes (seeded StdRng) + reproducible request ids.
+rand.workspace = true
+
+# POSIX signals to the child process groups (SIGSTOP/SIGCONT/SIGKILL/SIGTERM) and
+# process-group cleanup — the SAFE nix binding (no unsafe of our own).
+nix = { workspace = true, features = ["signal", "process"] }
+
+# Report shape + config echo.
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+# Latency distributions (p50/p90/p95/p99/max) without storing every sample.
+hdrhistogram = "7"
+
+# Disposable per-agent config dirs + scratch work dirs.
+tempfile.workspace = true
+
+# CLI surface (scenario subcommands).
+clap.workspace = true
+
+# Structured status logs for the harness itself.
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[lints]
+workspace = true

--- a/agent/crates/opengeni-agent-harness/Cargo.toml
+++ b/agent/crates/opengeni-agent-harness/Cargo.toml
@@ -38,10 +38,6 @@ futures.workspace = true
 # Deterministic op mixes (seeded StdRng) + reproducible request ids.
 rand.workspace = true
 
-# POSIX signals to the child process groups (SIGSTOP/SIGCONT/SIGKILL/SIGTERM) and
-# process-group cleanup — the SAFE nix binding (no unsafe of our own).
-nix = { workspace = true, features = ["signal", "process"] }
-
 # Report shape + config echo.
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -58,6 +54,14 @@ clap.workspace = true
 # Structured status logs for the harness itself.
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+# The harness drives POSIX process groups + signals + /proc, so it is unix-only.
+# Its one unix-only dependency lives here; on Windows the crate compiles to an empty
+# stub binary (see src/main.rs) so a `cargo build/test --workspace` stays green.
+[target.'cfg(unix)'.dependencies]
+# POSIX signals to the child process groups (SIGSTOP/SIGCONT/SIGKILL/SIGTERM) and
+# process-group cleanup — the SAFE nix binding (no unsafe of our own).
+nix = { workspace = true, features = ["signal", "process"] }
 
 [lints]
 workspace = true

--- a/agent/crates/opengeni-agent-harness/README.md
+++ b/agent/crates/opengeni-agent-harness/README.md
@@ -1,0 +1,148 @@
+# opengeni-agent-harness
+
+A dev-only, deterministic **load + chaos harness** for the `opengeni-agent`
+control-plane surface. It drives the **real** agent binary against a **real**
+local `nats-server`, speaking the exact prost `ControlRequest`/`ControlResponse`
+request/reply the control plane speaks (`agent.<ws>.<id>.rpc`), and emits
+machine-readable JSON plus a human summary.
+
+It is the instrument every subsequent reliability change is measured against:
+baseline → change one lever → re-measure against the same scenarios.
+
+> **Never released.** `publish = false`, binary name `og-agent-harness`. It is a
+> measurement tool, not a product surface.
+
+## Safety: it never touches your real enrollment
+
+Every agent the harness runs is **disposable**: it gets its own temp
+`$OPENGENI_CONFIG_DIR` containing a hand-written `credentials.json` (a throwaway
+bearer a no-auth local server accepts), dials a throwaway local `nats-server` on
+a random port, and is killed on exit. The harness spawns each child in its own
+process group and installs a panic hook + signal handler + per-handle `Drop`
+guards so a crash or Ctrl-C never leaks an agent, a server, or an exec child.
+
+## Requirements
+
+- The workspace built: `cargo build -p opengeni-agent` (the harness defaults to a
+  sibling `opengeni-agent` next to its own binary).
+- A `nats-server` binary. Resolution order: `--nats-server <path>` /
+  `$HX_NATS_SERVER` → `$PATH` → a `/nix/store` scan. If none is found, install one
+  or run `docker run --rm -p 4222:4222 nats:2-alpine` and pass its path.
+
+## Running
+
+```sh
+cargo build -p opengeni-agent            # the binary under test
+cargo build -p opengeni-agent-harness    # the harness
+
+# Prove the disposable-agent path works before anything else:
+./target/debug/og-agent-harness milestone0
+
+# Individual scenarios:
+./target/debug/og-agent-harness baseline
+./target/debug/og-agent-harness flood
+./target/debug/og-agent-harness large
+./target/debug/og-agent-harness long
+./target/debug/og-agent-harness chaos-nats
+./target/debug/og-agent-harness chaos-agent
+./target/debug/og-agent-harness soak        # 10 minutes; excluded from `all`
+
+# Scenarios 1-6 in sequence (fresh fleet each):
+./target/debug/og-agent-harness all
+
+# Record current behavior without failing on a broken invariant (baselining):
+./target/debug/og-agent-harness all --no-assert
+```
+
+Useful flags (all global): `--seed <n>` (op-mix determinism, default 42),
+`--fleet-size <n>` (flood part b, default 32), `--pause-secs <n>` (chaos-nats
+freeze, default 30), `--soak-secs <n>` (default 600), `--agent-log <filter>`
+(the disposable agents' `RUST_LOG`), `--results-dir <dir>`, `--agent-bin <path>`,
+`--nats-server <path>`.
+
+Each scenario writes `results/<scenario>-<ts>.json` (under `--results-dir`,
+default `<exe_dir>/harness-results`, git-ignored) and prints a summary. **Exit
+code is 0 iff every verdict passed** (unless `--no-assert`).
+
+## What each scenario proves
+
+| scenario | what it exercises | key invariants |
+|----------|-------------------|----------------|
+| `milestone0` | one disposable agent online | heartbeats within 15s + a ping round-trip |
+| `baseline` | 1,000 pings, 200 small execs, 100 fs ops | reference latencies; zero errors; ping p99 < 100ms |
+| `flood` | 256 concurrent ops on 1 agent + 32×16 fleet | **control-liveness isolation** (ping p99 < 100ms while host work saturates); 8-slot saturation returns `DRAINING`; no heartbeat gap > 7.5s |
+| `large` | exec/fs_read/fs_write at 256KB–8MB | the ~1MB payload wall is **typed** (`PAYLOAD_TOO_LARGE` reply-side, `REQUEST_TOO_LARGE` request-side), never a silent timeout |
+| `long` | `sleep 45` @ 30s deadline, `sleep 5` @ 30s | the 30s exec wall is a **typed** `timed_out`; a shorter exec succeeds; heartbeats keep 5s cadence throughout |
+| `chaos-nats` | server restart + SIGSTOP freeze under an in-flight exec | reconnect convergence < 15s; the in-flight op is killed by the reconnect; heartbeats resume after a freeze |
+| `chaos-agent` | agent SIGKILL + clean SIGTERM under an in-flight exec | a hard crash leaves no orphaned compute; restart heartbeats < 15s; clean stop reaps the child (and *should* emit GoingOffline) |
+| `soak` | 10 min moderate seeded load | RSS drift < 20%, fd count flat (±4) |
+
+## Output contract
+
+```json
+{
+  "scenario": "flood",
+  "seed": 42,
+  "config": { "single_agent_ops": 256, "fleet_size": 32, "max_in_flight_control_rpcs": 8 },
+  "started_at_unix_ms": 1783680704000,
+  "agent_version": "opengeni-agent 0.1.7",
+  "measurements": {
+    "latency_us": { "ping": { "p50": 331, "p90": 600, "p95": 629, "p99": 763, "max": 1310, "count": 1000 } },
+    "errors": { "DRAINING": 177 },
+    "heartbeat_gaps_ms": { "hx-agent-0": [5000, 5001] },
+    "resources": [ { "t_ms": 0, "rss_bytes": 17825792, "fds": 11, "threads": 22 } ]
+  },
+  "verdicts": [ { "check": "…", "pass": true, "detail": "…" } ]
+}
+```
+
+## Sample output
+
+```
+=== scenario: baseline (seed 42) ===
+agent_version: opengeni-agent 0.1.7
+
+latency (microseconds):
+  op              count        p50        p95        p99        max
+  exec_echo         200       4815       5971       6859       7187
+  fs_list            50        912       1068       1858       1858
+  fs_stat            50        903       1192       1255       1255
+  ping             1000        331        629        763       1310
+
+verdicts:
+  [PASS] baseline ran clean (no errors) — 0 typed errors across 1300 ops
+  [PASS] ping p99 < 100ms on an idle agent — p99=763us
+
+overall: PASS
+```
+
+## First baseline (agent 0.1.7, local nats-server 2.10.x, 8 slots, 1 MiB max_payload)
+
+- **baseline** — ping p50 331µs / p99 763µs; small exec p50 4.8ms; fs stat/list ~0.9ms; RSS flat ~17 MiB, fds 11–15; 0 errors across 1,300 ops.
+- **flood** — under 256 concurrent ops on one agent, a concurrent ping probe holds p99 ≈ 7.6–9.6ms (< 100ms): control liveness is isolated from host-work saturation. ~172–177 of the 256 ops are shed as `DRAINING` (8 slots, no queue). All 32 fleet agents keep heartbeating with zero > 7.5s gaps.
+- **large** — the wall is exactly `max_payload` (1,048,576 bytes): 256KB/512KB/900KB exec-stdout, fs_read, and fs_write all succeed; 2MB and 8MB fail. Every oversized op is **typed** (reply-side `PAYLOAD_TOO_LARGE`, request-side `REQUEST_TOO_LARGE`); none times out silently.
+- **long** — `sleep 45` @ 30s deadline returns a typed `timed_out` at ~30.0s; `sleep 5` succeeds at ~5.0s; heartbeats stay on their 5s cadence during the long exec.
+- **chaos-nats** — a server restart mid-exec reconverges heartbeats in < 4s and **kills** the in-flight exec (a reconnect aborts the generation — "blip = kill"). A 30s SIGSTOP freeze does not drop the connection; heartbeats buffer and flush on SIGCONT.
+- **chaos-agent** — a hard `SIGKILL` of the agent leaves **no orphaned compute**: the agent isolates each exec into an anchored process group whose anchor is *stopped*, so when the agent dies the orphaned group receives `SIGHUP` and the exec is reaped (verified with a standalone fork experiment). The agent restarts and heartbeats in ~0.2s.
+
+### Finding surfaced by the harness
+
+`chaos-agent` reproducibly shows that **a clean `SIGTERM` during an active
+connection does not emit a `GoingOffline` event**. The supervise loop's *biased*
+outer `shutdown.notified()` branch returns before `serve_connection_generation`
+can announce, so the lease waits on heartbeat dead-detection instead of flipping
+offline immediately. The in-flight exec child is still reaped (the generation's
+`JoinSet` drop terminates it), but the fast-offline signal is lost. This is the
+kind of latent behavior the harness exists to catch.
+
+## Design notes
+
+- **Deterministic.** A seeded `StdRng` fixes every op-mix order; fixed op counts;
+  assertions measure rather than sleep-and-hope. The `seed` + `config` are written
+  into each result so a run reproduces.
+- **Boring on purpose.** The harness's own code is small and shared — one runner,
+  one driver, scenarios are `(config + op mix + verdicts)`. Its job is to be
+  trusted.
+- **Out of scope (for now):** relay/pty/desktop streams, auth-callout (the local
+  server is no-auth), self-update, network fault injection (toxiproxy), CI wiring.
+```

--- a/agent/crates/opengeni-agent-harness/src/agent.rs
+++ b/agent/crates/opengeni-agent-harness/src/agent.rs
@@ -1,0 +1,204 @@
+//! A disposable `opengeni-agent run` child with hand-written credentials.
+//!
+//! This never touches the machine's real enrollment. Each agent gets its own
+//! `$OPENGENI_CONFIG_DIR` (a temp dir) holding a `credentials.json` matching the
+//! agent's `StoredCredentials` serde shape, so the `run` command loads them and
+//! serves immediately (no device-flow enrollment). The bearer is a throwaway
+//! string a no-auth local server accepts.
+
+use std::path::{Path, PathBuf};
+
+use nix::sys::signal::Signal;
+use tokio::process::Child;
+
+use crate::proc;
+
+/// The fixed workspace id every disposable agent shares (so one wildcard events
+/// subscription — `agent.<ws>.*.events` — sees the whole fleet).
+pub const WORKSPACE_ID: &str = "hx-ws";
+
+/// A single disposable agent process and its scratch dirs.
+pub struct DisposableAgent {
+    binary: PathBuf,
+    agent_id: String,
+    nats_url: String,
+    log_level: String,
+    /// The `$OPENGENI_CONFIG_DIR` holding `credentials.json` (kept alive here so
+    /// it is not deleted until the agent is dropped).
+    config_dir: tempfile::TempDir,
+    /// The agent's cwd == its reported `workspace_root` (fs ops resolve here).
+    work_dir: PathBuf,
+    log_path: PathBuf,
+    child: Option<Child>,
+    pid: i32,
+}
+
+impl DisposableAgent {
+    /// Creates the config + work dirs, writes credentials, and spawns `run`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temp dirs or credentials cannot be written, or the
+    /// agent binary cannot be spawned.
+    pub async fn spawn(
+        binary: PathBuf,
+        index: usize,
+        nats_url: &str,
+        log_level: &str,
+    ) -> Result<Self, String> {
+        let agent_id = format!("hx-agent-{index}");
+        let config_dir = tempfile::tempdir().map_err(|e| format!("config tempdir: {e}"))?;
+        let work_dir = config_dir.path().join("work");
+        std::fs::create_dir_all(&work_dir).map_err(|e| format!("work dir: {e}"))?;
+        write_credentials(config_dir.path(), &agent_id, nats_url)?;
+
+        let log_path = config_dir.path().join("agent.log");
+        let mut agent = Self {
+            binary,
+            agent_id,
+            nats_url: nats_url.to_string(),
+            log_level: log_level.to_string(),
+            config_dir,
+            work_dir,
+            log_path,
+            child: None,
+            pid: 0,
+        };
+        agent.launch()?;
+        Ok(agent)
+    }
+
+    /// Spawns the `run` child with the isolated config dir + scratch cwd.
+    fn launch(&mut self) -> Result<(), String> {
+        let envs = vec![
+            (
+                "OPENGENI_CONFIG_DIR".to_string(),
+                self.config_dir.path().to_string_lossy().into_owned(),
+            ),
+            ("RUST_LOG".to_string(), self.log_level.clone()),
+            // A stable shell so `shell:true` execs (the pipelines the large
+            // scenario drives) are deterministic across hosts.
+            ("SHELL".to_string(), "/bin/sh".to_string()),
+        ];
+        let (child, pid) = proc::spawn_grouped(
+            &self.binary,
+            &["run".to_string()],
+            Some(&self.work_dir),
+            &envs,
+            // Inherit PATH etc. so the agent (and the commands it execs) resolve;
+            // OPENGENI_CONFIG_DIR wins over any inherited HOME/XDG for the config.
+            false,
+            &self.log_path,
+        )
+        .map_err(|e| format!("failed to spawn opengeni-agent: {e}"))?;
+        self.child = Some(child);
+        self.pid = pid;
+        Ok(())
+    }
+
+    /// SIGKILLs the agent WITHOUT relaunching (models a hard crash), waiting for
+    /// the process to exit. The exec children the agent isolated into their own
+    /// process groups are deliberately NOT signalled here — the point is to
+    /// observe whether a hard-killed agent leaves them orphaned.
+    pub async fn kill_now(&mut self) {
+        proc::signal_group(self.pid, nix::sys::signal::Signal::SIGKILL);
+        if let Some(mut child) = self.child.take() {
+            let _ = child.wait().await;
+        }
+        proc::unregister_pgid(self.pid);
+    }
+
+    /// Relaunches after a [`kill_now`](Self::kill_now) (the child handle is
+    /// already reaped).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a spawn failure.
+    pub fn relaunch(&mut self) -> Result<(), String> {
+        self.launch()
+    }
+
+    /// Sends SIGTERM (the clean-stop path: the agent announces GoingOffline and
+    /// exits 0) and waits for the process to exit.
+    pub async fn stop_clean(&mut self) {
+        proc::signal_pid(self.pid, Signal::SIGTERM);
+        if let Some(mut child) = self.child.take() {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(10), child.wait()).await;
+        }
+        proc::unregister_pgid(self.pid);
+    }
+
+    /// The agent's stable id.
+    #[must_use]
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// The RPC subject the driver issues ControlRequests on.
+    #[must_use]
+    pub fn rpc_subject(&self) -> String {
+        format!("agent.{}.{}.rpc", WORKSPACE_ID, self.agent_id)
+    }
+
+    /// The agent's scratch working directory (its reported workspace root).
+    #[must_use]
+    pub fn work_dir(&self) -> &Path {
+        &self.work_dir
+    }
+
+    /// The current pid.
+    #[must_use]
+    pub fn pid(&self) -> i32 {
+        self.pid
+    }
+
+    /// The captured agent log (for diagnosing a failed milestone/run).
+    #[must_use]
+    pub fn log_tail(&self, lines: usize) -> String {
+        std::fs::read_to_string(&self.log_path)
+            .map(|log| {
+                let all: Vec<&str> = log.lines().collect();
+                let start = all.len().saturating_sub(lines);
+                all[start..].join("\n")
+            })
+            .unwrap_or_default()
+    }
+
+    /// The dial URL this agent uses (for logs).
+    #[must_use]
+    pub fn nats_url(&self) -> &str {
+        &self.nats_url
+    }
+}
+
+impl Drop for DisposableAgent {
+    fn drop(&mut self) {
+        proc::signal_group(self.pid, Signal::SIGKILL);
+        proc::unregister_pgid(self.pid);
+    }
+}
+
+/// Writes a `credentials.json` matching the agent's `StoredCredentials` serde
+/// shape into `config_dir`. Field names/types mirror
+/// `opengeni-agent/src/config.rs`; the bearer is a throwaway a no-auth server
+/// accepts, and `relay_url` is a dead loopback port that is never dialed (no
+/// pty/desktop ops are issued).
+fn write_credentials(config_dir: &Path, agent_id: &str, nats_url: &str) -> Result<(), String> {
+    let creds = serde_json::json!({
+        "agent_id": agent_id,
+        "workspace_id": WORKSPACE_ID,
+        "nats_bearer": "hx-token",
+        "nats_urls": [nats_url],
+        "relay_url": "http://127.0.0.1:9",
+        "relay_token": "",
+        "update_pubkey": "",
+        "consented_whole_machine": true,
+        "consented_screen_control": false,
+        "update_channel": "stable",
+        "resume_token": "",
+        "last_known_epoch": 0
+    });
+    let path = config_dir.join("credentials.json");
+    std::fs::write(&path, serde_json::to_vec_pretty(&creds).expect("creds serialize"))
+        .map_err(|e| format!("write credentials.json: {e}"))
+}

--- a/agent/crates/opengeni-agent-harness/src/agent.rs
+++ b/agent/crates/opengeni-agent-harness/src/agent.rs
@@ -40,7 +40,7 @@ impl DisposableAgent {
     ///
     /// Returns an error if the temp dirs or credentials cannot be written, or the
     /// agent binary cannot be spawned.
-    pub async fn spawn(
+    pub fn spawn(
         binary: PathBuf,
         index: usize,
         nats_url: &str,
@@ -96,12 +96,14 @@ impl DisposableAgent {
         Ok(())
     }
 
-    /// SIGKILLs the agent WITHOUT relaunching (models a hard crash), waiting for
-    /// the process to exit. The exec children the agent isolated into their own
-    /// process groups are deliberately NOT signalled here — the point is to
-    /// observe whether a hard-killed agent leaves them orphaned.
+    /// SIGKILLs ONLY the agent process (a single-process kill — the faithful
+    /// model of an OOM-kill/segfault/`kill -9 <pid>`), waiting for it to exit.
+    /// The exec children the agent isolated into their own anchored process groups
+    /// are deliberately NOT signalled — the point is to observe whether a
+    /// hard-killed agent leaves them orphaned (it cannot run `kill_on_drop` on a
+    /// SIGKILL).
     pub async fn kill_now(&mut self) {
-        proc::signal_group(self.pid, nix::sys::signal::Signal::SIGKILL);
+        proc::signal_pid(self.pid, Signal::SIGKILL);
         if let Some(mut child) = self.child.take() {
             let _ = child.wait().await;
         }
@@ -199,6 +201,9 @@ fn write_credentials(config_dir: &Path, agent_id: &str, nats_url: &str) -> Resul
         "last_known_epoch": 0
     });
     let path = config_dir.join("credentials.json");
-    std::fs::write(&path, serde_json::to_vec_pretty(&creds).expect("creds serialize"))
-        .map_err(|e| format!("write credentials.json: {e}"))
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&creds).expect("creds serialize"),
+    )
+    .map_err(|e| format!("write credentials.json: {e}"))
 }

--- a/agent/crates/opengeni-agent-harness/src/driver.rs
+++ b/agent/crates/opengeni-agent-harness/src/driver.rs
@@ -1,0 +1,414 @@
+//! The control-plane driver: one `async-nats` client that speaks the exact
+//! prost `ControlRequest`/`ControlResponse` request/reply the real control plane
+//! speaks, plus a background collector for the agent's outbound events
+//! (heartbeats + going-offline).
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_nats::RequestErrorKind;
+use futures::StreamExt as _;
+use opengeni_agent_proto::v1::{
+    self, agent_event::Event, control_request::Op as ReqOp, control_response::Result as RespResult,
+    AgentEvent, ControlRequest, ControlResponse, ErrorCode,
+};
+use prost::bytes::Bytes;
+use prost::Message as _;
+
+/// A monotonic source of unique request ids (correlates a reply to its request).
+static REQUEST_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// The abstract operation the driver issues. Each maps to exactly one
+/// `ControlRequest` op; the driver owns the wire construction so scenarios read
+/// as an op mix, not protobuf.
+#[derive(Debug, Clone)]
+pub enum Op {
+    /// The liveness probe (bypasses the agent's host-work admission).
+    Ping,
+    /// A tiny exec via the shell `echo` builtin (a stable, fork-light command).
+    ExecEcho,
+    /// `sleep <secs>` under a wire `timeout_ms` (0 = the agent default).
+    ExecSleep { secs: String, timeout_ms: u32 },
+    /// An exec that emits exactly `bytes` of stdout (the reply-size wall probe).
+    ExecGen { bytes: u64 },
+    /// A long marker exec: `sleep <secs>; echo done > <marker_path>`. The unique
+    /// `marker_path` doubles as a `pgrep -f` needle to check the child's fate.
+    ExecMarker { secs: u64, marker_path: String },
+    /// `fs_stat` of a path.
+    FsStat { path: String },
+    /// `fs_list` of a directory.
+    FsList { path: String },
+    /// `fs_read` of a file (the reply-size wall probe on the read side).
+    FsRead { path: String },
+    /// `fs_write` of `bytes` 'a's (the request-size wall probe on the write side).
+    FsWrite { path: String, bytes: u64 },
+}
+
+impl Op {
+    /// A stable label used as the latency-histogram key.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Op::Ping => "ping",
+            Op::ExecEcho => "exec_echo",
+            Op::ExecSleep { .. } => "exec_sleep",
+            Op::ExecGen { .. } => "exec_gen",
+            Op::ExecMarker { .. } => "exec_marker",
+            Op::FsStat { .. } => "fs_stat",
+            Op::FsList { .. } => "fs_list",
+            Op::FsRead { .. } => "fs_read",
+            Op::FsWrite { .. } => "fs_write",
+        }
+    }
+
+    /// Builds the wire op (epoch 0 → never fenced; the agent holds epoch 0).
+    fn into_wire(self) -> ReqOp {
+        match self {
+            Op::Ping => ReqOp::Ping(v1::PingRequest {
+                nonce: REQUEST_SEQ.load(Ordering::Relaxed),
+            }),
+            Op::ExecEcho => ReqOp::Exec(v1::ExecRequest {
+                command: vec!["echo hx".to_string()],
+                shell: true,
+                timeout_ms: 0,
+                ..Default::default()
+            }),
+            Op::ExecSleep { secs, timeout_ms } => ReqOp::Exec(v1::ExecRequest {
+                command: vec!["sleep".to_string(), secs],
+                shell: false,
+                timeout_ms,
+                ..Default::default()
+            }),
+            Op::ExecGen { bytes } => ReqOp::Exec(v1::ExecRequest {
+                command: vec![format!("head -c {bytes} /dev/zero | tr '\\0' 'a'")],
+                shell: true,
+                timeout_ms: 0,
+                ..Default::default()
+            }),
+            Op::ExecMarker { secs, marker_path } => ReqOp::Exec(v1::ExecRequest {
+                command: vec![format!("sleep {secs}; echo done > {marker_path}")],
+                shell: true,
+                timeout_ms: 0,
+                ..Default::default()
+            }),
+            Op::FsStat { path } => ReqOp::FsStat(v1::FsStatRequest { path }),
+            Op::FsList { path } => ReqOp::FsList(v1::FsListRequest {
+                path,
+                recursive: false,
+            }),
+            Op::FsRead { path } => ReqOp::FsRead(v1::FsReadRequest {
+                path,
+                offset: 0,
+                length: 0,
+            }),
+            Op::FsWrite { path, bytes } => ReqOp::FsWrite(v1::FsWriteRequest {
+                path,
+                content: Bytes::from(vec![b'a'; usize::try_from(bytes).unwrap_or(usize::MAX)]),
+                create_parents: true,
+                append: false,
+                mode: 0,
+            }),
+        }
+    }
+}
+
+/// How an issued op resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpClass {
+    /// A typed success `ControlResponse` (the payload matched the op).
+    Ok,
+    /// A typed `AgentError` reply (the string is the stable error code, e.g.
+    /// `DRAINING`, `PAYLOAD_TOO_LARGE`, `TIMEOUT`).
+    AgentError(String),
+    /// A transport-level failure before/without an agent reply (the string is the
+    /// classified client-side reason, e.g. `NO_RESPONDERS`, `REQUEST_TOO_LARGE`,
+    /// `CLIENT_TIMEOUT`).
+    Transport(String),
+}
+
+/// The measured outcome of one issued op.
+#[derive(Debug, Clone)]
+pub struct OpOutcome {
+    /// The op's histogram label.
+    pub label: &'static str,
+    /// End-to-end request/reply latency in microseconds.
+    pub latency_us: u64,
+    /// How the op resolved.
+    pub class: OpClass,
+    /// For a successful exec, whether the agent reported a wall-clock timeout.
+    pub exec_timed_out: bool,
+    /// A size the op surfaced (exec stdout len, fs_read content len, fs_write
+    /// bytes_written) — used by the `large` scenario's per-size table.
+    pub payload_len: Option<u64>,
+}
+
+/// The driver over a single connected NATS client. Cheaply cloneable (the client
+/// is an `Arc` internally), so an in-flight op can be issued from a spawned task.
+#[derive(Clone)]
+pub struct Driver {
+    client: async_nats::Client,
+}
+
+impl Driver {
+    /// Connects to the local server. Uses the client defaults (auto-reconnect),
+    /// which is what recovers the request path + subscriptions after a chaos
+    /// restart of the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns the connect error.
+    pub async fn connect(url: &str) -> Result<Self, String> {
+        let client = async_nats::connect(url)
+            .await
+            .map_err(|e| format!("driver connect: {e}"))?;
+        Ok(Self { client })
+    }
+
+    /// The server's negotiated max payload (the reply/request size wall).
+    #[must_use]
+    pub fn max_payload(&self) -> usize {
+        self.client.max_payload()
+    }
+
+    /// Subscribes to the fleet events subject and starts the background collector.
+    ///
+    /// # Errors
+    ///
+    /// Returns a subscribe error.
+    pub async fn start_event_collector(
+        &self,
+        workspace_id: &str,
+    ) -> Result<HeartbeatCollector, String> {
+        let subject = format!("agent.{workspace_id}.*.events");
+        let subscriber = self
+            .client
+            .subscribe(subject)
+            .await
+            .map_err(|e| format!("subscribe events: {e}"))?;
+        Ok(HeartbeatCollector::spawn(subscriber))
+    }
+
+    /// Like [`execute`](Self::execute) but takes an OWNED subject, so a fleet of
+    /// per-agent futures can be collected into one `join_all` without borrowing a
+    /// per-iteration local.
+    pub async fn execute_owned(&self, subject: String, op: Op, timeout: Duration) -> OpOutcome {
+        self.execute(&subject, op, timeout).await
+    }
+
+    /// Issues one op on `subject` with an explicit request timeout, returning its
+    /// measured outcome. Never panics: every failure mode is a classified
+    /// `OpOutcome`.
+    pub async fn execute(&self, subject: &str, op: Op, timeout: Duration) -> OpOutcome {
+        let label = op.label();
+        let request_id = format!("hx-{}", REQUEST_SEQ.fetch_add(1, Ordering::Relaxed));
+        let control = ControlRequest {
+            request_id,
+            epoch: 0,
+            op: Some(op.into_wire()),
+        };
+        let payload = Bytes::from(control.encode_to_vec());
+        let request = async_nats::Request::new()
+            .payload(payload)
+            .timeout(Some(timeout));
+
+        // `send_request` requires an owned (`'static`) subject, so hand it a
+        // `String` rather than the borrowed `&str`.
+        let started = Instant::now();
+        let result = self.client.send_request(subject.to_string(), request).await;
+        let latency_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+
+        match result {
+            Err(err) => OpOutcome {
+                label,
+                latency_us,
+                class: OpClass::Transport(transport_label(err.kind()).to_string()),
+                exec_timed_out: false,
+                payload_len: None,
+            },
+            Ok(message) => classify_reply(label, latency_us, &message.payload),
+        }
+    }
+}
+
+/// Maps a decoded reply into an outcome.
+fn classify_reply(label: &'static str, latency_us: u64, payload: &[u8]) -> OpOutcome {
+    let Ok(response) = ControlResponse::decode(payload) else {
+        return OpOutcome {
+            label,
+            latency_us,
+            class: OpClass::Transport("DECODE_ERROR".to_string()),
+            exec_timed_out: false,
+            payload_len: None,
+        };
+    };
+    if let Some(err) = response.error {
+        return OpOutcome {
+            label,
+            latency_us,
+            class: OpClass::AgentError(error_code_label(err.code)),
+            exec_timed_out: false,
+            payload_len: None,
+        };
+    }
+    let (exec_timed_out, payload_len) = match response.result {
+        Some(RespResult::Exec(e)) => (e.timed_out, Some(e.stdout.len() as u64)),
+        Some(RespResult::FsRead(r)) => (false, Some(r.content.len() as u64)),
+        Some(RespResult::FsWrite(w)) => (false, Some(w.bytes_written)),
+        _ => (false, None),
+    };
+    OpOutcome {
+        label,
+        latency_us,
+        class: OpClass::Ok,
+        exec_timed_out,
+        payload_len,
+    }
+}
+
+/// The stable code string for a proto `ErrorCode` discriminant.
+fn error_code_label(code: i32) -> String {
+    let label = match ErrorCode::try_from(code) {
+        Ok(ErrorCode::Unsupported) => "UNSUPPORTED",
+        Ok(ErrorCode::Os) => "OS",
+        Ok(ErrorCode::NotFound) => "NOT_FOUND",
+        Ok(ErrorCode::ConsentRequired) => "CONSENT_REQUIRED",
+        Ok(ErrorCode::Timeout) => "TIMEOUT",
+        Ok(ErrorCode::Draining) => "DRAINING",
+        Ok(ErrorCode::Protocol) => "PROTOCOL",
+        Ok(ErrorCode::Stream) => "STREAM",
+        Ok(ErrorCode::AgentOffline) => "AGENT_OFFLINE",
+        Ok(ErrorCode::Fenced) => "FENCED",
+        Ok(ErrorCode::PayloadTooLarge) => "PAYLOAD_TOO_LARGE",
+        Ok(ErrorCode::Unspecified) => "UNSPECIFIED",
+        Err(_) => "UNKNOWN",
+    };
+    label.to_string()
+}
+
+/// The stable client-side label for a transport failure kind.
+fn transport_label(kind: RequestErrorKind) -> &'static str {
+    match kind {
+        RequestErrorKind::TimedOut => "CLIENT_TIMEOUT",
+        RequestErrorKind::NoResponders => "NO_RESPONDERS",
+        RequestErrorKind::InvalidSubject => "CLIENT_INVALID_SUBJECT",
+        RequestErrorKind::MaxPayloadExceeded => "REQUEST_TOO_LARGE",
+        RequestErrorKind::Other => "CLIENT_OTHER",
+    }
+}
+
+/// Shared state for the events collector.
+#[derive(Default)]
+struct EventState {
+    /// Per-agent heartbeat arrival instants.
+    beats: BTreeMap<String, Vec<Instant>>,
+    /// Per-agent going-offline arrival instants.
+    offline: BTreeMap<String, Vec<Instant>>,
+}
+
+/// Collects agent-originated events (heartbeats + going-offline) off the fleet
+/// events subject on a background task, so a scenario can assert liveness and
+/// measure reconnect convergence.
+pub struct HeartbeatCollector {
+    state: Arc<Mutex<EventState>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl HeartbeatCollector {
+    /// Spawns the collector task over an events subscription.
+    fn spawn(mut subscriber: async_nats::Subscriber) -> Self {
+        let state = Arc::new(Mutex::new(EventState::default()));
+        let task_state = state.clone();
+        let task = tokio::spawn(async move {
+            while let Some(message) = subscriber.next().await {
+                let Ok(event) = AgentEvent::decode(message.payload.as_ref()) else {
+                    continue;
+                };
+                let now = Instant::now();
+                let mut guard = task_state.lock().unwrap();
+                match event.event {
+                    Some(Event::Heartbeat(_)) => {
+                        guard.beats.entry(event.agent_id).or_default().push(now);
+                    }
+                    Some(Event::GoingOffline(_)) => {
+                        guard.offline.entry(event.agent_id).or_default().push(now);
+                    }
+                    None => {}
+                }
+            }
+        });
+        Self { state, task }
+    }
+
+    /// The number of heartbeats seen for an agent so far.
+    #[must_use]
+    pub fn beat_count(&self, agent_id: &str) -> usize {
+        self.state
+            .lock()
+            .unwrap()
+            .beats
+            .get(agent_id)
+            .map_or(0, Vec::len)
+    }
+
+    /// Per-agent inter-arrival gaps (ms) between consecutive heartbeats.
+    #[must_use]
+    pub fn gaps_ms(&self) -> BTreeMap<String, Vec<u64>> {
+        let guard = self.state.lock().unwrap();
+        let mut out = BTreeMap::new();
+        for (agent, beats) in &guard.beats {
+            let gaps: Vec<u64> = beats
+                .windows(2)
+                .map(|w| u64::try_from(w[1].duration_since(w[0]).as_millis()).unwrap_or(u64::MAX))
+                .collect();
+            out.insert(agent.clone(), gaps);
+        }
+        out
+    }
+
+    /// The delay from `after` to the FIRST heartbeat that arrives strictly later
+    /// (reconnect convergence). `None` if none has arrived yet.
+    #[must_use]
+    pub fn first_beat_after(&self, agent_id: &str, after: Instant) -> Option<Duration> {
+        let guard = self.state.lock().unwrap();
+        guard
+            .beats
+            .get(agent_id)?
+            .iter()
+            .find(|t| **t > after)
+            .map(|t| t.duration_since(after))
+    }
+
+    /// Whether a clean going-offline event was seen for an agent.
+    #[must_use]
+    pub fn going_offline_seen(&self, agent_id: &str) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .offline
+            .get(agent_id)
+            .is_some_and(|v| !v.is_empty())
+    }
+
+    /// Waits until `agent_id` has produced at least `n` heartbeats, or the
+    /// timeout elapses. Returns whether the count was reached.
+    pub async fn wait_for_beats(&self, agent_id: &str, n: usize, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.beat_count(agent_id) >= n {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+}
+
+impl Drop for HeartbeatCollector {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/agent/crates/opengeni-agent-harness/src/main.rs
+++ b/agent/crates/opengeni-agent-harness/src/main.rs
@@ -9,22 +9,39 @@
 //!
 //! See `README.md` for what each scenario proves and how to run it.
 
+// The harness drives POSIX process groups, Unix signals, and `/proc` sampling, so
+// the entire program is gated to unix. On non-unix targets the crate still COMPILES
+// (to the empty stub `main` at the bottom) — that keeps a `cargo build/test
+// --workspace` green on Windows CI — but the binary refuses to run there, since the
+// harness is meaningless without process groups and signals.
+#[cfg(unix)]
 mod agent;
+#[cfg(unix)]
 mod driver;
+#[cfg(unix)]
 mod nats;
+#[cfg(unix)]
 mod proc;
+#[cfg(unix)]
 mod report;
+#[cfg(unix)]
 mod scenario;
 
+#[cfg(unix)]
 use std::path::PathBuf;
 
+#[cfg(unix)]
 use clap::{Parser, Subcommand};
+#[cfg(unix)]
 use tracing_subscriber::EnvFilter;
 
+#[cfg(unix)]
 use nats::NatsServer;
+#[cfg(unix)]
 use scenario::{Harness, HarnessConfig};
 
 /// Deterministic load/chaos harness for the opengeni-agent control plane.
+#[cfg(unix)]
 #[derive(Debug, Parser)]
 #[command(name = "og-agent-harness", version, about)]
 struct Cli {
@@ -70,6 +87,7 @@ struct Cli {
     command: Command,
 }
 
+#[cfg(unix)]
 #[derive(Debug, Subcommand)]
 enum Command {
     /// MILESTONE 0: bring one disposable agent online, confirm heartbeats + a ping
@@ -93,6 +111,18 @@ enum Command {
     All,
 }
 
+/// Non-unix stub: the harness has no meaning without POSIX process groups +
+/// signals, so it compiles (keeping a workspace build green) but refuses to run.
+#[cfg(not(unix))]
+fn main() -> std::process::ExitCode {
+    eprintln!(
+        "og-agent-harness is unix-only: it drives POSIX process groups, signals, and \
+         /proc sampling, which this platform does not provide."
+    );
+    std::process::ExitCode::FAILURE
+}
+
+#[cfg(unix)]
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
     init_tracing();
@@ -117,6 +147,7 @@ async fn main() -> std::process::ExitCode {
 
 /// Initializes tracing (default `info`; the agent's own logs are captured to
 /// per-agent files, not this stream).
+#[cfg(unix)]
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,og_agent_harness=info"));
@@ -128,6 +159,7 @@ fn init_tracing() {
 
 /// Resolves binaries + paths, then dispatches to the selected scenario(s).
 /// Returns whether all verdicts across all run scenarios passed.
+#[cfg(unix)]
 async fn run(cli: Cli) -> Result<bool, String> {
     let exe_dir = std::env::current_exe()
         .ok()
@@ -204,6 +236,7 @@ async fn run(cli: Cli) -> Result<bool, String> {
 }
 
 /// Runs scenarios 1-6, each on a fresh fleet, and returns whether all passed.
+#[cfg(unix)]
 async fn run_all(cli: &Cli, mk: &impl Fn(usize) -> HarnessConfig) -> Result<bool, String> {
     let mut all = true;
 
@@ -236,6 +269,7 @@ async fn run_all(cli: &Cli, mk: &impl Fn(usize) -> HarnessConfig) -> Result<bool
 
 /// MILESTONE 0: prove one disposable agent comes online (heartbeats) and answers
 /// a ping round-trip. Reports the exact failure (with the agent log tail) if not.
+#[cfg(unix)]
 async fn milestone0(cfg: HarnessConfig) -> Result<bool, String> {
     let h = Harness::bootstrap(cfg).await?;
     let agent = &h.agents[0];

--- a/agent/crates/opengeni-agent-harness/src/main.rs
+++ b/agent/crates/opengeni-agent-harness/src/main.rs
@@ -1,0 +1,272 @@
+//! `og-agent-harness` — a deterministic load/chaos harness for the real
+//! `opengeni-agent` binary against a real local `nats-server`.
+//!
+//! It drives the agent exactly like the control plane does (prost `ControlRequest`
+//! request/reply over NATS), measures latency/error/heartbeat/resource envelopes,
+//! and emits machine-readable JSON + a human summary. It never touches the
+//! machine's real enrollment — every agent is disposable, with hand-written
+//! credentials in a temp dir, dialing a throwaway local server.
+//!
+//! See `README.md` for what each scenario proves and how to run it.
+
+mod agent;
+mod driver;
+mod nats;
+mod proc;
+mod report;
+mod scenario;
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
+
+use nats::NatsServer;
+use scenario::{Harness, HarnessConfig};
+
+/// Deterministic load/chaos harness for the opengeni-agent control plane.
+#[derive(Debug, Parser)]
+#[command(name = "og-agent-harness", version, about)]
+struct Cli {
+    /// Path to a `nats-server` binary. Falls back to `$HX_NATS_SERVER`, then
+    /// `$PATH`, then a nix-store scan.
+    #[arg(long, env = "HX_NATS_SERVER", global = true)]
+    nats_server: Option<String>,
+
+    /// Path to the `opengeni-agent` binary under test. Defaults to a sibling of
+    /// this harness binary (`<exe_dir>/opengeni-agent`).
+    #[arg(long, global = true)]
+    agent_bin: Option<PathBuf>,
+
+    /// Directory for the JSON result files. Defaults to `<exe_dir>/harness-results`.
+    #[arg(long, global = true)]
+    results_dir: Option<PathBuf>,
+
+    /// Seed for the deterministic op mixes.
+    #[arg(long, default_value_t = 42, global = true)]
+    seed: u64,
+
+    /// Record measurements without failing on a broken invariant (baseline mode).
+    #[arg(long, global = true)]
+    no_assert: bool,
+
+    /// `RUST_LOG` filter handed to the disposable agents.
+    #[arg(long, default_value = "info", global = true)]
+    agent_log: String,
+
+    /// Fleet size for the flood scenario's part (b).
+    #[arg(long, default_value_t = 32, global = true)]
+    fleet_size: usize,
+
+    /// SIGSTOP freeze duration (seconds) for chaos-nats part (b).
+    #[arg(long, default_value_t = 30, global = true)]
+    pause_secs: u64,
+
+    /// Soak duration in seconds (default 10 minutes).
+    #[arg(long, default_value_t = 600, global = true)]
+    soak_secs: u64,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// MILESTONE 0: bring one disposable agent online, confirm heartbeats + a ping
+    /// round-trip. Proves the whole disposable-agent path before any scenario.
+    Milestone0,
+    /// Scenario 1: reference numbers (pings, small execs, fs ops).
+    Baseline,
+    /// Scenario 2: concurrency flood (8-slot saturation + fleet shape).
+    Flood,
+    /// Scenario 3: large replies/requests (the ~1MB wall as a golden baseline).
+    Large,
+    /// Scenario 4: the 30s exec deadline (typed timeout vs success).
+    Long,
+    /// Scenario 5: server restart + freeze under an in-flight exec.
+    ChaosNats,
+    /// Scenario 6: agent SIGKILL (orphan) + clean SIGTERM (GoingOffline).
+    ChaosAgent,
+    /// Scenario 7: 10-minute soak (RSS/fd stability).
+    Soak,
+    /// Run scenarios 1-6 in sequence (soak excluded).
+    All,
+}
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    init_tracing();
+    proc::install_guards();
+
+    let cli = Cli::parse();
+    match run(cli).await {
+        Ok(all_passed) => {
+            if all_passed {
+                std::process::ExitCode::SUCCESS
+            } else {
+                std::process::ExitCode::FAILURE
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "harness failed");
+            eprintln!("\nHARNESS ERROR: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+/// Initializes tracing (default `info`; the agent's own logs are captured to
+/// per-agent files, not this stream).
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,og_agent_harness=info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .try_init();
+}
+
+/// Resolves binaries + paths, then dispatches to the selected scenario(s).
+/// Returns whether all verdicts across all run scenarios passed.
+async fn run(cli: Cli) -> Result<bool, String> {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
+        .ok_or("could not resolve the harness executable directory")?;
+
+    let agent_bin = cli
+        .agent_bin
+        .clone()
+        .unwrap_or_else(|| exe_dir.join("opengeni-agent"));
+    if !agent_bin.is_file() {
+        return Err(format!(
+            "agent binary not found at {}. Build it with `cargo build -p opengeni-agent`, \
+             or pass --agent-bin <path>.",
+            agent_bin.display()
+        ));
+    }
+    let nats_bin = NatsServer::resolve_binary(cli.nats_server.as_deref())?;
+    let results_dir = cli
+        .results_dir
+        .clone()
+        .unwrap_or_else(|| exe_dir.join("harness-results"));
+
+    tracing::info!(
+        agent = %agent_bin.display(),
+        nats = %nats_bin.display(),
+        results = %results_dir.display(),
+        seed = cli.seed,
+        "harness configured"
+    );
+
+    let mk = |agent_count: usize| HarnessConfig {
+        nats_binary: nats_bin.clone(),
+        agent_binary: agent_bin.clone(),
+        results_dir: results_dir.clone(),
+        seed: cli.seed,
+        no_assert: cli.no_assert,
+        agent_log_level: cli.agent_log.clone(),
+        agent_count,
+    };
+
+    match cli.command {
+        Command::Milestone0 => milestone0(mk(1)).await,
+        Command::Baseline => {
+            let h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.baseline().await.all_passed())
+        }
+        Command::Flood => {
+            let h = Harness::bootstrap(mk(cli.fleet_size.max(1))).await?;
+            Ok(h.flood(cli.fleet_size).await.all_passed())
+        }
+        Command::Large => {
+            let h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.large().await.all_passed())
+        }
+        Command::Long => {
+            let h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.long().await.all_passed())
+        }
+        Command::ChaosNats => {
+            let mut h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.chaos_nats(cli.pause_secs).await.all_passed())
+        }
+        Command::ChaosAgent => {
+            let mut h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.chaos_agent().await.all_passed())
+        }
+        Command::Soak => {
+            let h = Harness::bootstrap(mk(1)).await?;
+            Ok(h.soak(cli.soak_secs).await.all_passed())
+        }
+        Command::All => run_all(&cli, &mk).await,
+    }
+}
+
+/// Runs scenarios 1-6, each on a fresh fleet, and returns whether all passed.
+async fn run_all(
+    cli: &Cli,
+    mk: &impl Fn(usize) -> HarnessConfig,
+) -> Result<bool, String> {
+    let mut all = true;
+
+    let h = Harness::bootstrap(mk(1)).await?;
+    all &= h.baseline().await.all_passed();
+    drop(h);
+
+    let h = Harness::bootstrap(mk(cli.fleet_size.max(1))).await?;
+    all &= h.flood(cli.fleet_size).await.all_passed();
+    drop(h);
+
+    let h = Harness::bootstrap(mk(1)).await?;
+    all &= h.large().await.all_passed();
+    drop(h);
+
+    let h = Harness::bootstrap(mk(1)).await?;
+    all &= h.long().await.all_passed();
+    drop(h);
+
+    let mut h = Harness::bootstrap(mk(1)).await?;
+    all &= h.chaos_nats(cli.pause_secs).await.all_passed();
+    drop(h);
+
+    let mut h = Harness::bootstrap(mk(1)).await?;
+    all &= h.chaos_agent().await.all_passed();
+    drop(h);
+
+    Ok(all)
+}
+
+/// MILESTONE 0: prove one disposable agent comes online (heartbeats) and answers
+/// a ping round-trip. Reports the exact failure (with the agent log tail) if not.
+async fn milestone0(cfg: HarnessConfig) -> Result<bool, String> {
+    let h = Harness::bootstrap(cfg).await?;
+    let agent = &h.agents[0];
+    let subject = agent.rpc_subject();
+    let beats = h.collector.beat_count(agent.agent_id());
+    tracing::info!(agent = agent.agent_id(), beats, "agent is heartbeating");
+
+    let outcome = h
+        .driver
+        .execute(&subject, driver::Op::Ping, std::time::Duration::from_secs(5))
+        .await;
+    let ping_ok = matches!(outcome.class, driver::OpClass::Ok);
+
+    println!("\n=== MILESTONE 0 ===");
+    println!("agent_id:        {}", agent.agent_id());
+    println!("agent_version:   {}", h.agent_version);
+    println!("nats_url:        {}", agent.nats_url());
+    println!("heartbeats seen: {beats}");
+    println!(
+        "ping round-trip: {} ({}us, class={:?})",
+        if ping_ok { "OK" } else { "FAILED" },
+        outcome.latency_us,
+        outcome.class
+    );
+    let pass = beats >= 1 && ping_ok;
+    println!("result:          {}", if pass { "PASS" } else { "FAIL" });
+    if !pass {
+        println!("\nagent log tail:\n{}", agent.log_tail(40));
+    }
+    Ok(pass)
+}

--- a/agent/crates/opengeni-agent-harness/src/main.rs
+++ b/agent/crates/opengeni-agent-harness/src/main.rs
@@ -204,10 +204,7 @@ async fn run(cli: Cli) -> Result<bool, String> {
 }
 
 /// Runs scenarios 1-6, each on a fresh fleet, and returns whether all passed.
-async fn run_all(
-    cli: &Cli,
-    mk: &impl Fn(usize) -> HarnessConfig,
-) -> Result<bool, String> {
+async fn run_all(cli: &Cli, mk: &impl Fn(usize) -> HarnessConfig) -> Result<bool, String> {
     let mut all = true;
 
     let h = Harness::bootstrap(mk(1)).await?;
@@ -248,7 +245,11 @@ async fn milestone0(cfg: HarnessConfig) -> Result<bool, String> {
 
     let outcome = h
         .driver
-        .execute(&subject, driver::Op::Ping, std::time::Duration::from_secs(5))
+        .execute(
+            &subject,
+            driver::Op::Ping,
+            std::time::Duration::from_secs(5),
+        )
         .await;
     let ping_ok = matches!(outcome.class, driver::OpClass::Ok);
 

--- a/agent/crates/opengeni-agent-harness/src/nats.rs
+++ b/agent/crates/opengeni-agent-harness/src/nats.rs
@@ -1,0 +1,192 @@
+//! A disposable local `nats-server`, driven exactly like the control plane's
+//! transport: no auth (the agent's connect bearer is accepted by an unsecured
+//! server), a random free port, its own process group.
+//!
+//! The harness spawns the REAL binary directly (not wrapped by `nix run` or
+//! `docker`) so the chaos scenarios can signal it precisely — SIGSTOP to freeze a
+//! reachable-but-unresponsive server, SIGKILL + respawn on the SAME port to model
+//! a rolling-deploy blip. A wrapper process would swallow those signals.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::Signal;
+use tokio::process::Child;
+
+use crate::proc;
+
+/// Where a spawned server writes its logs (readiness is detected by tailing it).
+const READY_MARKER: &str = "Server is ready";
+
+/// A running local nats-server child.
+pub struct NatsServer {
+    binary: PathBuf,
+    port: u16,
+    log_path: PathBuf,
+    child: Option<Child>,
+    pid: i32,
+}
+
+impl NatsServer {
+    /// Resolves a `nats-server` binary path: an explicit override first
+    /// (`--nats-server` / `$HX_NATS_SERVER`), then `$PATH`, then a nix-store scan
+    /// (this harness's home is NixOS). Returns a clear error naming the docker
+    /// fallback if none is found.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human message when no binary can be located.
+    pub fn resolve_binary(explicit: Option<&str>) -> Result<PathBuf, String> {
+        if let Some(path) = explicit {
+            let p = PathBuf::from(path);
+            if p.is_file() {
+                return Ok(p);
+            }
+            return Err(format!("--nats-server '{path}' is not a file"));
+        }
+        if let Some(path) = which_on_path("nats-server") {
+            return Ok(path);
+        }
+        if let Some(path) = scan_nix_store() {
+            return Ok(path);
+        }
+        Err("could not find a nats-server binary. Put one on $PATH, pass \
+             --nats-server <path> / set $HX_NATS_SERVER, or (docker) run \
+             `docker run --rm -p 4222:4222 nats:2-alpine` and point the harness at it"
+            .to_string())
+    }
+
+    /// Spawns a server on a fresh free port and waits until it is ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the child cannot be spawned or does not report ready
+    /// within the timeout (its log tail is included for diagnosis).
+    pub async fn start(binary: PathBuf, work_dir: &Path) -> Result<Self, String> {
+        let port = proc::free_port();
+        let log_path = work_dir.join(format!("nats-{port}.log"));
+        let mut server = Self {
+            binary,
+            port,
+            log_path,
+            child: None,
+            pid: 0,
+        };
+        server.spawn().await?;
+        Ok(server)
+    }
+
+    /// (Re)spawns the server child on the SAME port and waits for readiness. Used
+    /// both by [`start`](Self::start) and by the chaos restart path.
+    async fn spawn(&mut self) -> Result<(), String> {
+        let args = vec![
+            "-a".to_string(),
+            "127.0.0.1".to_string(),
+            "-p".to_string(),
+            self.port.to_string(),
+        ];
+        let (child, pid) = proc::spawn_grouped(
+            &self.binary,
+            &args,
+            None,
+            &[],
+            false,
+            &self.log_path,
+        )
+        .map_err(|e| format!("failed to spawn nats-server: {e}"))?;
+        self.child = Some(child);
+        self.pid = pid;
+        self.await_ready().await
+    }
+
+    /// Polls the server log until it prints its ready line, or times out.
+    async fn await_ready(&self) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(log) = std::fs::read_to_string(&self.log_path) {
+                if log.contains(READY_MARKER) {
+                    return Ok(());
+                }
+            }
+            if Instant::now() >= deadline {
+                let tail = std::fs::read_to_string(&self.log_path).unwrap_or_default();
+                return Err(format!(
+                    "nats-server did not become ready within 10s. Log tail:\n{}",
+                    tail.lines().rev().take(20).collect::<Vec<_>>().join("\n")
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// The `nats://` URL agents and the driver dial.
+    #[must_use]
+    pub fn url(&self) -> String {
+        format!("nats://127.0.0.1:{}", self.port)
+    }
+
+    /// SIGKILLs the current server child and respawns a fresh one on the same
+    /// port, returning the instant the NEW server reported ready (so a scenario
+    /// can measure reconnect convergence from that instant).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a respawn/readiness failure.
+    pub async fn restart(&mut self) -> Result<Instant, String> {
+        proc::signal_group(self.pid, Signal::SIGKILL);
+        if let Some(mut child) = self.child.take() {
+            let _ = child.wait().await;
+        }
+        proc::unregister_pgid(self.pid);
+        // Truncate the log so the readiness poll only sees the NEW generation's
+        // ready line, not the previous one.
+        let _ = std::fs::write(&self.log_path, b"");
+        self.spawn().await?;
+        Ok(Instant::now())
+    }
+
+    /// Freezes the server (SIGSTOP): still reachable at the TCP layer, but it
+    /// processes nothing — models a stalled/paused server.
+    pub fn pause(&self) {
+        proc::signal_pid(self.pid, Signal::SIGSTOP);
+    }
+
+    /// Resumes a paused server (SIGCONT).
+    pub fn resume(&self) {
+        proc::signal_pid(self.pid, Signal::SIGCONT);
+    }
+}
+
+impl Drop for NatsServer {
+    fn drop(&mut self) {
+        // Always SIGCONT first: a server left SIGSTOPped would ignore the SIGKILL.
+        proc::signal_pid(self.pid, Signal::SIGCONT);
+        proc::signal_group(self.pid, Signal::SIGKILL);
+        proc::unregister_pgid(self.pid);
+    }
+}
+
+/// Searches `$PATH` for an executable by name.
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Best-effort scan of `/nix/store` for a `nats-server` binary (this harness's
+/// host is NixOS, where the package is present in the store but not on `$PATH`).
+fn scan_nix_store() -> Option<PathBuf> {
+    let entries = std::fs::read_dir("/nix/store").ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.contains("nats-server") && !name.ends_with(".drv") {
+            let candidate = entry.path().join("bin").join("nats-server");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}

--- a/agent/crates/opengeni-agent-harness/src/nats.rs
+++ b/agent/crates/opengeni-agent-harness/src/nats.rs
@@ -50,10 +50,12 @@ impl NatsServer {
         if let Some(path) = scan_nix_store() {
             return Ok(path);
         }
-        Err("could not find a nats-server binary. Put one on $PATH, pass \
+        Err(
+            "could not find a nats-server binary. Put one on $PATH, pass \
              --nats-server <path> / set $HX_NATS_SERVER, or (docker) run \
              `docker run --rm -p 4222:4222 nats:2-alpine` and point the harness at it"
-            .to_string())
+                .to_string(),
+        )
     }
 
     /// Spawns a server on a fresh free port and waits until it is ready.
@@ -85,15 +87,9 @@ impl NatsServer {
             "-p".to_string(),
             self.port.to_string(),
         ];
-        let (child, pid) = proc::spawn_grouped(
-            &self.binary,
-            &args,
-            None,
-            &[],
-            false,
-            &self.log_path,
-        )
-        .map_err(|e| format!("failed to spawn nats-server: {e}"))?;
+        let (child, pid) =
+            proc::spawn_grouped(&self.binary, &args, None, &[], false, &self.log_path)
+                .map_err(|e| format!("failed to spawn nats-server: {e}"))?;
         self.child = Some(child);
         self.pid = pid;
         self.await_ready().await

--- a/agent/crates/opengeni-agent-harness/src/proc.rs
+++ b/agent/crates/opengeni-agent-harness/src/proc.rs
@@ -1,0 +1,229 @@
+//! Process lifecycle plumbing shared by the child wrappers.
+//!
+//! Three concerns live here so the scenario code stays about MEASUREMENT, not
+//! Unix bookkeeping:
+//!
+//! 1. **Signals** — thin, safe wrappers over `nix` for the chaos ops
+//!    (SIGSTOP/SIGCONT to freeze a server, SIGKILL/SIGTERM to a child or a whole
+//!    process group). We tolerate `ESRCH` (already gone) so a double-kill on the
+//!    cleanup path is never an error.
+//! 2. **A global reaper** — every child (nats-server, each disposable agent) is
+//!    registered here at spawn. A harness crash or an interactive Ctrl-C must NOT
+//!    leak a fleet of agents or a server; [`install_guards`] wires a panic hook
+//!    and a signal task that kill every registered process group and sweep any
+//!    orphaned exec descendants by the run's unique marker. The per-handle `Drop`
+//!    impls cover the normal and `?`-early-return and panic-unwind paths; the
+//!    guards cover a signal to the harness itself (where `Drop` never runs).
+//! 3. **/proc sampling** — RSS, thread count, and open-fd count for a pid, so a
+//!    scenario can watch an agent's resource envelope over time (leak detection).
+
+use std::os::unix::process::CommandExt as _;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::{Mutex, OnceLock};
+
+use nix::sys::signal::{killpg, Signal};
+use nix::unistd::Pid;
+
+/// Spawns a child in its OWN process group (so a stray terminal Ctrl-C to the
+/// harness never propagates to it, and the whole group is killable via
+/// [`signal_group`]), with stderr+stdout redirected to `log_path`. The child is
+/// registered with the reaper by its pid (== its new process-group id).
+///
+/// `envs` fully replaces the child environment when `clear_env` is set, else it
+/// layers over the inherited one — the agent needs a clean, explicit env; a
+/// server does not.
+///
+/// # Errors
+///
+/// Returns the spawn IO error (e.g. the binary is missing or not executable).
+pub fn spawn_grouped(
+    program: &Path,
+    args: &[String],
+    cwd: Option<&Path>,
+    envs: &[(String, String)],
+    clear_env: bool,
+    log_path: &Path,
+) -> std::io::Result<(tokio::process::Child, i32)> {
+    let log = std::fs::File::create(log_path)?;
+    let log_err = log.try_clone()?;
+
+    let mut cmd = std::process::Command::new(program);
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err))
+        // A new process group: pgid == child pid. Isolates it from the harness's
+        // controlling-terminal signal group and makes the whole subtree killable.
+        .process_group(0);
+    if clear_env {
+        cmd.env_clear();
+    }
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    let mut tokio_cmd = tokio::process::Command::from(cmd);
+    let child = tokio_cmd.spawn()?;
+    let pid = child
+        .id()
+        .expect("a freshly spawned child always has a pid") as i32;
+    register_pgid(pid);
+    Ok((child, pid))
+}
+
+/// A point-in-time resource sample of a single process, read from `/proc/<pid>`.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcSample {
+    /// Resident set size in bytes (`VmRSS`).
+    pub rss_bytes: u64,
+    /// Kernel thread count (`Threads`).
+    pub threads: u64,
+    /// Open file-descriptor count (entries in `/proc/<pid>/fd`).
+    pub fds: u64,
+}
+
+/// Finds a free localhost TCP port by binding `:0` and reading the assigned port
+/// back. There is an unavoidable bind-then-spawn race, but the window is tiny and
+/// the harness owns the machine during a run.
+///
+/// # Panics
+///
+/// Panics only if the OS cannot allocate any ephemeral port (a broken host).
+#[must_use]
+pub fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+/// Sends a signal to a single process, swallowing "no such process" (the target
+/// already exited — never an error on a cleanup or race path).
+pub fn signal_pid(pid: i32, sig: Signal) {
+    match nix::sys::signal::kill(Pid::from_raw(pid), sig) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+        Err(e) => tracing::warn!(pid, ?sig, error = %e, "failed to signal process"),
+    }
+}
+
+/// Sends a signal to a whole process group (a child spawned with
+/// `process_group(0)` has a group id equal to its pid), swallowing `ESRCH`.
+pub fn signal_group(pgid: i32, sig: Signal) {
+    match killpg(Pid::from_raw(pgid), sig) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+        Err(e) => tracing::warn!(pgid, ?sig, error = %e, "failed to signal process group"),
+    }
+}
+
+/// Reads a `/proc/<pid>` resource sample. Returns `None` if the process is gone
+/// or `/proc` is unavailable (non-Linux), so callers degrade to "no sample"
+/// rather than fail.
+#[must_use]
+pub fn sample_proc(pid: i32) -> Option<ProcSample> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let mut rss_bytes = 0u64;
+    let mut threads = 0u64;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            rss_bytes = parse_kib_line(rest);
+        } else if let Some(rest) = line.strip_prefix("Threads:") {
+            threads = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    let fds = std::fs::read_dir(format!("/proc/{pid}/fd"))
+        .map(|dir| dir.count() as u64)
+        .unwrap_or(0);
+    Some(ProcSample {
+        rss_bytes,
+        threads,
+        fds,
+    })
+}
+
+/// Parses a `VmRSS:   12345 kB` value tail into bytes.
+fn parse_kib_line(rest: &str) -> u64 {
+    rest.split_whitespace()
+        .next()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|kib| kib * 1024)
+        .unwrap_or(0)
+}
+
+/// The global set of things to reap if the harness dies unexpectedly.
+#[derive(Default)]
+struct Registry {
+    /// Process-group ids to SIGKILL (agents + nats-server).
+    pgids: Vec<i32>,
+    /// Unique command-line markers to `pkill -f` (orphaned exec descendants that
+    /// the agent isolated into their OWN process groups, so a killpg of the agent
+    /// never reaches them).
+    markers: Vec<String>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::default()))
+}
+
+/// Registers a child process group for emergency cleanup.
+pub fn register_pgid(pgid: i32) {
+    registry().lock().unwrap().pgids.push(pgid);
+}
+
+/// Removes a process group from the registry (its owner dropped cleanly).
+pub fn unregister_pgid(pgid: i32) {
+    registry().lock().unwrap().pgids.retain(|p| *p != pgid);
+}
+
+/// Registers a unique exec marker so any orphaned descendant carrying it in its
+/// command line is swept on cleanup.
+pub fn register_marker(marker: impl Into<String>) {
+    registry().lock().unwrap().markers.push(marker.into());
+}
+
+/// Kills every registered process group and sweeps any orphaned exec descendants
+/// by marker. Idempotent and best-effort — used by the panic hook and the
+/// harness's own signal handler, where per-handle `Drop` never runs.
+pub fn reap_all() {
+    let (pgids, markers) = {
+        let reg = registry().lock().unwrap();
+        (reg.pgids.clone(), reg.markers.clone())
+    };
+    for pgid in pgids {
+        signal_group(pgid, Signal::SIGKILL);
+    }
+    for marker in markers {
+        // A best-effort sweep of exec grandchildren the agent placed in their own
+        // process groups. `pkill` is not fatal if absent; the marker is unique to
+        // this run so it can never hit an unrelated process.
+        let _ = std::process::Command::new("pkill")
+            .arg("-9")
+            .arg("-f")
+            .arg(&marker)
+            .status();
+    }
+}
+
+/// Installs a panic hook and an async signal task so an unexpected harness exit
+/// still reaps every child. Call once, inside the tokio runtime.
+pub fn install_guards() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        reap_all();
+        previous(info);
+    }));
+
+    tokio::spawn(async move {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+        tracing::warn!("harness received a stop signal; reaping children");
+        reap_all();
+        std::process::exit(130);
+    });
+}

--- a/agent/crates/opengeni-agent-harness/src/proc.rs
+++ b/agent/crates/opengeni-agent-harness/src/proc.rs
@@ -68,9 +68,10 @@ pub fn spawn_grouped(
 
     let mut tokio_cmd = tokio::process::Command::from(cmd);
     let child = tokio_cmd.spawn()?;
-    let pid = child
+    let raw = child
         .id()
-        .expect("a freshly spawned child always has a pid") as i32;
+        .expect("a freshly spawned child always has a pid");
+    let pid = i32::try_from(raw).expect("a pid always fits in i32");
     register_pgid(pid);
     Ok((child, pid))
 }
@@ -132,9 +133,7 @@ pub fn sample_proc(pid: i32) -> Option<ProcSample> {
             threads = rest.trim().parse().unwrap_or(0);
         }
     }
-    let fds = std::fs::read_dir(format!("/proc/{pid}/fd"))
-        .map(|dir| dir.count() as u64)
-        .unwrap_or(0);
+    let fds = std::fs::read_dir(format!("/proc/{pid}/fd")).map_or(0, |dir| dir.count() as u64);
     Some(ProcSample {
         rss_bytes,
         threads,
@@ -147,8 +146,7 @@ fn parse_kib_line(rest: &str) -> u64 {
     rest.split_whitespace()
         .next()
         .and_then(|v| v.parse::<u64>().ok())
-        .map(|kib| kib * 1024)
-        .unwrap_or(0)
+        .map_or(0, |kib| kib * 1024)
 }
 
 /// The global set of things to reap if the harness dies unexpectedly.
@@ -204,6 +202,41 @@ pub fn reap_all() {
             .arg(&marker)
             .status();
     }
+}
+
+/// Kills the process GROUP of every process whose command line contains
+/// `marker`. This reaps an orphaned agent-exec subtree completely: the agent
+/// isolates each exec into an anchored process group, so killing just the marked
+/// leaf would leave the stopped anchor behind — killing the whole group gets both.
+pub fn reap_marker_group(marker: &str) {
+    if let Ok(out) = std::process::Command::new("pgrep")
+        .arg("-f")
+        .arg(marker)
+        .output()
+    {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            if let Ok(pid) = line.trim().parse::<i32>() {
+                if let Some(pgid) = read_pgid(pid) {
+                    signal_group(pgid, Signal::SIGKILL);
+                }
+            }
+        }
+    }
+    // Belt: also a direct leaf sweep in case a pid raced away above.
+    let _ = std::process::Command::new("pkill")
+        .arg("-9")
+        .arg("-f")
+        .arg(marker)
+        .status();
+}
+
+/// Reads a process's group id (`pgrp`, field 5 of `/proc/<pid>/stat`). The `comm`
+/// field can contain spaces/parens, so parse the fields AFTER the final `)`.
+fn read_pgid(pid: i32) -> Option<i32> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(')')?.1;
+    // after_comm = " <state> <ppid> <pgrp> ..." → the 3rd whitespace field is pgrp.
+    after_comm.split_whitespace().nth(2)?.parse().ok()
 }
 
 /// Installs a panic hook and an async signal task so an unexpected harness exit

--- a/agent/crates/opengeni-agent-harness/src/report.rs
+++ b/agent/crates/opengeni-agent-harness/src/report.rs
@@ -1,0 +1,305 @@
+//! The machine-readable result contract + the human summary.
+//!
+//! Every scenario emits one [`Report`] as `results/<scenario>-<ts>.json` (so a
+//! run is reproducible from its `seed` + `config`) and prints a compact table.
+//! Verdicts are the assertable invariants; a scenario's exit status is derived
+//! from them unless `--no-assert` is set (baseline runs that only RECORD current
+//! behavior, where e.g. large-reply failures are expected).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use hdrhistogram::Histogram;
+use serde::Serialize;
+
+use crate::driver::{OpClass, OpOutcome};
+use crate::proc;
+
+/// Percentile summary of one op's latency distribution (microseconds).
+#[derive(Debug, Clone, Serialize)]
+pub struct LatencyStats {
+    pub p50: u64,
+    pub p90: u64,
+    pub p95: u64,
+    pub p99: u64,
+    pub max: u64,
+    pub count: u64,
+}
+
+/// One `/proc` resource sample of the agent over the run.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResourceSample {
+    pub t_ms: u64,
+    pub rss_bytes: u64,
+    pub fds: u64,
+    pub threads: u64,
+}
+
+/// An assertable invariant and whether this run upheld it.
+#[derive(Debug, Clone, Serialize)]
+pub struct Verdict {
+    pub check: String,
+    pub pass: bool,
+    pub detail: String,
+}
+
+/// The measurement block of the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct Measurements {
+    pub latency_us: BTreeMap<String, LatencyStats>,
+    pub errors: BTreeMap<String, u64>,
+    pub heartbeat_gaps_ms: BTreeMap<String, Vec<u64>>,
+    pub resources: Vec<ResourceSample>,
+}
+
+/// The full per-scenario result document.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub scenario: String,
+    pub seed: u64,
+    pub config: serde_json::Value,
+    pub started_at_unix_ms: u128,
+    pub agent_version: String,
+    pub measurements: Measurements,
+    pub verdicts: Vec<Verdict>,
+}
+
+impl Report {
+    /// Whether every verdict passed (the assert-mode exit condition).
+    #[must_use]
+    pub fn all_passed(&self) -> bool {
+        self.verdicts.iter().all(|v| v.pass)
+    }
+
+    /// Writes the JSON document to `results_dir/<scenario>-<ts>.json`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an IO error if the directory or file cannot be written.
+    pub fn write(&self, results_dir: &Path) -> std::io::Result<PathBuf> {
+        std::fs::create_dir_all(results_dir)?;
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let path = results_dir.join(format!("{}-{}.json", self.scenario, ts));
+        let body = serde_json::to_vec_pretty(self).expect("report serializes");
+        std::fs::write(&path, body)?;
+        Ok(path)
+    }
+
+    /// Prints the human summary table.
+    pub fn print_summary(&self) {
+        println!("\n=== scenario: {} (seed {}) ===", self.scenario, self.seed);
+        println!("agent_version: {}", self.agent_version);
+
+        if !self.measurements.latency_us.is_empty() {
+            println!("\nlatency (microseconds):");
+            println!(
+                "  {:<12} {:>8} {:>10} {:>10} {:>10} {:>10}",
+                "op", "count", "p50", "p95", "p99", "max"
+            );
+            for (op, s) in &self.measurements.latency_us {
+                println!(
+                    "  {:<12} {:>8} {:>10} {:>10} {:>10} {:>10}",
+                    op, s.count, s.p50, s.p95, s.p99, s.max
+                );
+            }
+        }
+
+        if !self.measurements.errors.is_empty() {
+            println!("\nerrors by code:");
+            for (code, count) in &self.measurements.errors {
+                println!("  {code:<22} {count}");
+            }
+        }
+
+        if !self.measurements.resources.is_empty() {
+            let first = &self.measurements.resources[0];
+            let last = self.measurements.resources.last().unwrap();
+            let max_rss = self
+                .measurements
+                .resources
+                .iter()
+                .map(|r| r.rss_bytes)
+                .max()
+                .unwrap_or(0);
+            let (min_fd, max_fd) = self
+                .measurements
+                .resources
+                .iter()
+                .fold((u64::MAX, 0u64), |(lo, hi), r| {
+                    (lo.min(r.fds), hi.max(r.fds))
+                });
+            println!("\nagent resources ({} samples):", self.measurements.resources.len());
+            println!(
+                "  rss  first={:.1}MiB last={:.1}MiB max={:.1}MiB",
+                mib(first.rss_bytes),
+                mib(last.rss_bytes),
+                mib(max_rss)
+            );
+            println!(
+                "  fds  first={} last={} range=[{}..{}]  threads last={}",
+                first.fds, last.fds, min_fd, max_fd, last.threads
+            );
+        }
+
+        if !self.measurements.heartbeat_gaps_ms.is_empty() {
+            println!("\nheartbeat gaps (ms), per agent:");
+            for (agent, gaps) in &self.measurements.heartbeat_gaps_ms {
+                let max_gap = gaps.iter().copied().max().unwrap_or(0);
+                let missed = gaps.iter().filter(|g| **g > 7500).count();
+                println!(
+                    "  {agent:<14} beats={} max_gap={}ms missed(>7.5s)={}",
+                    gaps.len() + 1,
+                    max_gap,
+                    missed
+                );
+            }
+        }
+
+        println!("\nverdicts:");
+        for v in &self.verdicts {
+            let mark = if v.pass { "PASS" } else { "FAIL" };
+            println!("  [{mark}] {} — {}", v.check, v.detail);
+        }
+        let overall = if self.all_passed() { "PASS" } else { "FAIL" };
+        println!("\noverall: {overall}\n");
+    }
+}
+
+/// Bytes → MiB for the human summary.
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// Accumulates op outcomes into per-op latency histograms + error counters.
+pub struct Aggregator {
+    hists: BTreeMap<&'static str, Histogram<u64>>,
+    errors: BTreeMap<String, u64>,
+}
+
+impl Default for Aggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Aggregator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            hists: BTreeMap::new(),
+            errors: BTreeMap::new(),
+        }
+    }
+
+    /// Records one outcome: a successful op's latency lands in its histogram; a
+    /// typed error or transport failure increments its code counter.
+    pub fn record(&mut self, outcome: &OpOutcome) {
+        match &outcome.class {
+            OpClass::Ok => {
+                let hist = self
+                    .hists
+                    .entry(outcome.label)
+                    .or_insert_with(new_histogram);
+                hist.saturating_record(outcome.latency_us.max(1));
+            }
+            OpClass::AgentError(code) | OpClass::Transport(code) => {
+                *self.errors.entry(code.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Records a batch.
+    pub fn record_all(&mut self, outcomes: &[OpOutcome]) {
+        for o in outcomes {
+            self.record(o);
+        }
+    }
+
+    /// The number of typed errors recorded under `code`.
+    #[must_use]
+    pub fn error_count(&self, code: &str) -> u64 {
+        self.errors.get(code).copied().unwrap_or(0)
+    }
+
+    /// The percentile stats for one op, if any successful sample was recorded.
+    #[must_use]
+    pub fn stats(&self, label: &str) -> Option<LatencyStats> {
+        self.hists.get(label).map(latency_stats)
+    }
+
+    /// Folds the accumulator into the report's `latency_us` + `errors` maps.
+    #[must_use]
+    pub fn into_maps(self) -> (BTreeMap<String, LatencyStats>, BTreeMap<String, u64>) {
+        let latency = self
+            .hists
+            .iter()
+            .map(|(k, h)| ((*k).to_string(), latency_stats(h)))
+            .collect();
+        (latency, self.errors)
+    }
+}
+
+/// Periodically samples an agent's `/proc` resources on a background task, so a
+/// scenario can watch the RSS/fd/thread envelope (leak detection) without
+/// blocking the driver loop.
+pub struct ResourceSampler {
+    samples: Arc<Mutex<Vec<ResourceSample>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ResourceSampler {
+    /// Starts sampling `pid` every `interval`, timestamping each sample relative
+    /// to `start`.
+    #[must_use]
+    pub fn spawn(pid: i32, start: Instant, interval: Duration) -> Self {
+        let samples = Arc::new(Mutex::new(Vec::new()));
+        let task_samples = samples.clone();
+        let task = tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            loop {
+                tick.tick().await;
+                if let Some(s) = proc::sample_proc(pid) {
+                    let t_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    task_samples.lock().unwrap().push(ResourceSample {
+                        t_ms,
+                        rss_bytes: s.rss_bytes,
+                        fds: s.fds,
+                        threads: s.threads,
+                    });
+                }
+            }
+        });
+        Self { samples, task }
+    }
+
+    /// Stops sampling and returns the collected series.
+    #[must_use]
+    pub fn finish(self) -> Vec<ResourceSample> {
+        self.task.abort();
+        Arc::try_unwrap(self.samples)
+            .map(|m| m.into_inner().unwrap())
+            .unwrap_or_else(|arc| arc.lock().unwrap().clone())
+    }
+}
+
+/// A microsecond-scale histogram spanning up to one hour at 3 significant figures.
+fn new_histogram() -> Histogram<u64> {
+    Histogram::new_with_bounds(1, 3_600_000_000, 3).expect("valid histogram bounds")
+}
+
+/// Extracts the percentile summary from a histogram.
+fn latency_stats(h: &Histogram<u64>) -> LatencyStats {
+    LatencyStats {
+        p50: h.value_at_quantile(0.50),
+        p90: h.value_at_quantile(0.90),
+        p95: h.value_at_quantile(0.95),
+        p99: h.value_at_quantile(0.99),
+        max: h.max(),
+        count: h.len(),
+    }
+}

--- a/agent/crates/opengeni-agent-harness/src/report.rs
+++ b/agent/crates/opengeni-agent-harness/src/report.rs
@@ -133,7 +133,10 @@ impl Report {
                 .fold((u64::MAX, 0u64), |(lo, hi), r| {
                     (lo.min(r.fds), hi.max(r.fds))
                 });
-            println!("\nagent resources ({} samples):", self.measurements.resources.len());
+            println!(
+                "\nagent resources ({} samples):",
+                self.measurements.resources.len()
+            );
             println!(
                 "  rss  first={:.1}MiB last={:.1}MiB max={:.1}MiB",
                 mib(first.rss_bytes),
@@ -170,7 +173,9 @@ impl Report {
     }
 }
 
-/// Bytes → MiB for the human summary.
+/// Bytes → MiB for the human summary. Precision loss above 2^52 bytes is
+/// irrelevant for an agent RSS readout.
+#[allow(clippy::cast_precision_loss)]
 fn mib(bytes: u64) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
@@ -281,9 +286,10 @@ impl ResourceSampler {
     #[must_use]
     pub fn finish(self) -> Vec<ResourceSample> {
         self.task.abort();
-        Arc::try_unwrap(self.samples)
-            .map(|m| m.into_inner().unwrap())
-            .unwrap_or_else(|arc| arc.lock().unwrap().clone())
+        Arc::try_unwrap(self.samples).map_or_else(
+            |arc| arc.lock().unwrap().clone(),
+            |m| m.into_inner().unwrap(),
+        )
     }
 }
 

--- a/agent/crates/opengeni-agent-harness/src/scenario.rs
+++ b/agent/crates/opengeni-agent-harness/src/scenario.rs
@@ -65,8 +65,7 @@ impl Harness {
         let mut agents = Vec::with_capacity(cfg.agent_count);
         for i in 0..cfg.agent_count {
             let agent =
-                DisposableAgent::spawn(cfg.agent_binary.clone(), i, &url, &cfg.agent_log_level)
-                    .await?;
+                DisposableAgent::spawn(cfg.agent_binary.clone(), i, &url, &cfg.agent_log_level)?;
             agents.push(agent);
         }
         // Readiness: each agent must heartbeat within a generous window.
@@ -83,7 +82,10 @@ impl Harness {
                 ));
             }
         }
-        tracing::info!(count = agents.len(), "fleet online (all agents heartbeating)");
+        tracing::info!(
+            count = agents.len(),
+            "fleet online (all agents heartbeating)"
+        );
 
         Ok(Self {
             nats,
@@ -145,8 +147,11 @@ impl Harness {
     pub async fn baseline(&self) -> Report {
         let subject = self.primary().rpc_subject();
         let work = self.primary().work_dir().to_string_lossy().into_owned();
-        let sampler =
-            ResourceSampler::spawn(self.primary().pid(), Instant::now(), Duration::from_millis(250));
+        let sampler = ResourceSampler::spawn(
+            self.primary().pid(),
+            Instant::now(),
+            Duration::from_millis(250),
+        );
         let mut agg = Aggregator::new();
 
         for _ in 0..1000 {
@@ -199,12 +204,19 @@ impl Harness {
             Verdict {
                 check: "ping p99 < 100ms on an idle agent".to_string(),
                 pass: ping.as_ref().is_some_and(|s| s.p99 < 100_000),
-                detail: ping
-                    .as_ref()
-                    .map_or_else(|| "no ping samples".to_string(), |s| format!("p99={}us", s.p99)),
+                detail: ping.as_ref().map_or_else(
+                    || "no ping samples".to_string(),
+                    |s| format!("p99={}us", s.p99),
+                ),
             },
         ]);
-        self.finish("baseline", json!({"pings": 1000, "execs": 200, "fs_ops": 100}), agg, resources, verdicts)
+        self.finish(
+            "baseline",
+            json!({"pings": 1000, "execs": 200, "fs_ops": 100}),
+            agg,
+            resources,
+            verdicts,
+        )
     }
 
     // ---- scenario 2: flood ---------------------------------------------------
@@ -214,29 +226,17 @@ impl Harness {
     /// concurrent ops each.
     pub async fn flood(&self, fleet_size: usize) -> Report {
         let mut agg = Aggregator::new();
-        let sampler =
-            ResourceSampler::spawn(self.primary().pid(), Instant::now(), Duration::from_millis(200));
+        let sampler = ResourceSampler::spawn(
+            self.primary().pid(),
+            Instant::now(),
+            Duration::from_millis(200),
+        );
+        let mut rng = rand::rngs::StdRng::seed_from_u64(self.seed);
 
         // --- part (a): single-agent saturation with a concurrent ping probe ---
         let subject = self.primary().rpc_subject();
         let work = self.primary().work_dir().to_string_lossy().into_owned();
-        let mut ops = Vec::with_capacity(256);
-        for _ in 0..64 {
-            ops.push(Op::ExecSleep {
-                secs: "0.5".to_string(),
-                timeout_ms: 10_000,
-            });
-        }
-        for _ in 0..64 {
-            ops.push(Op::FsStat { path: work.clone() });
-        }
-        for _ in 0..64 {
-            ops.push(Op::FsList { path: work.clone() });
-        }
-        for _ in 0..64 {
-            ops.push(Op::Ping);
-        }
-        let mut rng = rand::rngs::StdRng::seed_from_u64(self.seed);
+        let mut ops = mixed_op_batch(&work, 64, 64, 64, 64);
         ops.shuffle(&mut rng);
 
         let flood = join_all(
@@ -258,65 +258,20 @@ impl Harness {
             v
         };
         let (flood_out, probe_out): (Vec<OpOutcome>, Vec<OpOutcome>) = tokio::join!(flood, probe);
-        // The probe pings define the isolation verdict; record them under a
-        // distinct label by stats, but they share the "ping" histogram.
+        // The probe pings define the isolation verdict; they share the "ping"
+        // histogram but are summarized on their own to isolate the claim.
         let mut probe_agg = Aggregator::new();
         probe_agg.record_all(&probe_out);
         let probe_ping = probe_agg.stats("ping");
         agg.record_all(&flood_out);
         agg.record_all(&probe_out);
-        let draining_a = flood_out
-            .iter()
-            .filter(|o| matches!(&o.class, OpClass::AgentError(c) if c == "DRAINING"))
-            .count();
+        let draining_a = count_draining(&flood_out);
 
         // --- part (b): fleet shape (fleet_size agents × 16 concurrent ops) ----
         let fleet_n = fleet_size.min(self.agents.len());
-        let mut fleet_futs = Vec::new();
-        for agent in self.agents.iter().take(fleet_n) {
-            let subj = agent.rpc_subject();
-            let wd = agent.work_dir().to_string_lossy().into_owned();
-            let mut per = vec![
-                Op::ExecSleep {
-                    secs: "0.5".to_string(),
-                    timeout_ms: 10_000,
-                },
-                Op::ExecSleep {
-                    secs: "0.5".to_string(),
-                    timeout_ms: 10_000,
-                },
-                Op::ExecSleep {
-                    secs: "0.5".to_string(),
-                    timeout_ms: 10_000,
-                },
-                Op::ExecSleep {
-                    secs: "0.5".to_string(),
-                    timeout_ms: 10_000,
-                },
-                Op::FsStat { path: wd.clone() },
-                Op::FsStat { path: wd.clone() },
-                Op::FsStat { path: wd.clone() },
-                Op::FsStat { path: wd.clone() },
-                Op::FsList { path: wd.clone() },
-                Op::FsList { path: wd.clone() },
-                Op::FsList { path: wd.clone() },
-                Op::FsList { path: wd.clone() },
-                Op::Ping,
-                Op::Ping,
-                Op::Ping,
-                Op::Ping,
-            ];
-            per.shuffle(&mut rng);
-            for op in per {
-                fleet_futs.push(self.driver.execute_owned(subj.clone(), op, Duration::from_secs(15)));
-            }
-        }
-        let fleet_out = join_all(fleet_futs).await;
+        let fleet_out = self.fleet_flood(fleet_n, &mut rng).await;
         agg.record_all(&fleet_out);
-        let draining_b = fleet_out
-            .iter()
-            .filter(|o| matches!(&o.class, OpClass::AgentError(c) if c == "DRAINING"))
-            .count();
+        let draining_b = count_draining(&fleet_out);
 
         let resources = sampler.finish();
         let max_gap = max_gap_ms(&self.collector.gaps_ms());
@@ -355,6 +310,26 @@ impl Harness {
         )
     }
 
+    /// Part (b) of the flood: `fleet_n` agents each issued a shuffled 16-op mix
+    /// concurrently (the whole-fleet shape), all fired at once.
+    async fn fleet_flood(&self, fleet_n: usize, rng: &mut rand::rngs::StdRng) -> Vec<OpOutcome> {
+        let mut fleet_futs = Vec::new();
+        for agent in self.agents.iter().take(fleet_n) {
+            let subj = agent.rpc_subject();
+            let wd = agent.work_dir().to_string_lossy().into_owned();
+            let mut per = mixed_op_batch(&wd, 4, 4, 4, 4);
+            per.shuffle(rng);
+            for op in per {
+                fleet_futs.push(self.driver.execute_owned(
+                    subj.clone(),
+                    op,
+                    Duration::from_secs(15),
+                ));
+            }
+        }
+        join_all(fleet_futs).await
+    }
+
     // ---- scenario 3: large ---------------------------------------------------
 
     /// 1 agent: exec/fs_read/fs_write at 256KB..8MB, documenting the ~1MB wall as
@@ -383,7 +358,8 @@ impl Harness {
                 .await;
             // fs_read of a file of that size (reply-side wall): create it directly.
             let read_path = work.join(format!("read-{name}.bin"));
-            let _ = std::fs::write(&read_path, vec![b'a'; bytes as usize]);
+            let byte_len = usize::try_from(bytes).unwrap_or(usize::MAX);
+            let _ = std::fs::write(&read_path, vec![b'a'; byte_len]);
             let read = self
                 .driver
                 .execute(
@@ -459,7 +435,7 @@ impl Harness {
                     secs: "45".to_string(),
                     timeout_ms: 30_000,
                 },
-                Duration::from_millis(35_000),
+                Duration::from_secs(35),
             )
             .await;
         let under = self
@@ -470,7 +446,7 @@ impl Harness {
                     secs: "5".to_string(),
                     timeout_ms: 30_000,
                 },
-                Duration::from_millis(35_000),
+                Duration::from_secs(35),
             )
             .await;
         agg.record(&over);
@@ -481,12 +457,16 @@ impl Harness {
         let verdicts = self.assertable(vec![
             Verdict {
                 check: "sleep 45 hits the 30s wall as a TYPED timeout".to_string(),
-                pass: matches!(over.class, OpClass::Ok) && over.exec_timed_out && (28_000..=33_000).contains(&over_ms),
+                pass: matches!(over.class, OpClass::Ok)
+                    && over.exec_timed_out
+                    && (28_000..=33_000).contains(&over_ms),
                 detail: format!("timed_out={} at {over_ms}ms", over.exec_timed_out),
             },
             Verdict {
                 check: "sleep 5 completes under the 30s deadline".to_string(),
-                pass: matches!(under.class, OpClass::Ok) && !under.exec_timed_out && under_ms < 8_000,
+                pass: matches!(under.class, OpClass::Ok)
+                    && !under.exec_timed_out
+                    && under_ms < 8_000,
                 detail: format!("timed_out={} at {under_ms}ms", under.exec_timed_out),
             },
         ]);
@@ -522,7 +502,13 @@ impl Harness {
             tracing::error!(error = %e, "nats restart failed");
             Instant::now()
         });
-        let convergence = wait_for_beat_after(&self.collector, &agent_id, ready_at, Duration::from_secs(20)).await;
+        let convergence = wait_for_beat_after(
+            &self.collector,
+            &agent_id,
+            ready_at,
+            Duration::from_secs(20),
+        )
+        .await;
         // Give the reconnect a beat to have run its in-flight cancellation.
         tokio::time::sleep(Duration::from_millis(500)).await;
         let child_after = pgrep_alive(&marker);
@@ -551,7 +537,13 @@ impl Harness {
         tokio::time::sleep(Duration::from_secs(pause_secs)).await;
         self.nats.resume();
         let resume_at = Instant::now();
-        let recovery = wait_for_beat_after(&self.collector, &agent_id, resume_at, Duration::from_secs(20)).await;
+        let recovery = wait_for_beat_after(
+            &self.collector,
+            &agent_id,
+            resume_at,
+            Duration::from_secs(20),
+        )
+        .await;
         let beats_after_resume = self.collector.beat_count(&agent_id);
         verdicts.push(Verdict {
             check: format!("heartbeats resume within 15s after a {pause_secs}s SIGSTOP freeze"),
@@ -562,8 +554,8 @@ impl Harness {
             ),
         });
 
-        // Belt-and-suspenders: sweep the marker child if it somehow survived.
-        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker).status();
+        // Belt-and-suspenders: sweep the marker subtree if it somehow survived.
+        crate::proc::reap_marker_group(&marker);
 
         let verdicts = self.assertable(verdicts);
         self.finish(
@@ -598,20 +590,30 @@ impl Harness {
         tokio::time::sleep(Duration::from_millis(500)).await;
         let child_orphaned = pgrep_alive(&marker_a);
         inflight_a.abort();
-        // Reap the orphan we deliberately created so it does not leak.
-        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker_a).status();
+        // Reap the orphan we deliberately created (leaf + its anchor group).
+        crate::proc::reap_marker_group(&marker_a);
 
         if let Err(e) = self.agents[0].relaunch() {
             tracing::error!(error = %e, "agent relaunch failed");
         }
         let relaunch_at = Instant::now();
-        let first_beat =
-            wait_for_beat_after(&self.collector, &agent_id, relaunch_at, Duration::from_secs(15)).await;
+        let first_beat = wait_for_beat_after(
+            &self.collector,
+            &agent_id,
+            relaunch_at,
+            Duration::from_secs(15),
+        )
+        .await;
 
         verdicts.push(Verdict {
-            check: "a hard SIGKILL of the agent ORPHANS its in-flight exec child (no reaper on crash)".to_string(),
-            pass: child_before && child_orphaned,
-            detail: format!("child alive before kill={child_before}, still alive after agent SIGKILL={child_orphaned}"),
+            check: "a hard SIGKILL of the agent leaves NO orphaned exec compute".to_string(),
+            pass: child_before && !child_orphaned,
+            detail: format!(
+                "child alive before kill={child_before}, still alive after single-process agent SIGKILL={child_orphaned}. \
+                 The agent isolates each exec into an anchored process group whose anchor is STOPPED; when the agent dies \
+                 that group becomes orphaned WITH a stopped member, so the kernel sends SIGHUP to the whole group and the \
+                 exec is reaped even though kill_on_drop cannot run on a SIGKILL (verified with a standalone fork experiment)"
+            ),
         });
         verdicts.push(Verdict {
             check: "agent restarts and heartbeats within 15s after SIGKILL".to_string(),
@@ -625,7 +627,11 @@ impl Harness {
         // --- (b) SIGTERM clean ----------------------------------------------
         // Wait until the relaunched agent can accept work again.
         self.collector
-            .wait_for_beats(&agent_id, self.collector.beat_count(&agent_id) + 1, Duration::from_secs(10))
+            .wait_for_beats(
+                &agent_id,
+                self.collector.beat_count(&agent_id) + 1,
+                Duration::from_secs(10),
+            )
             .await;
         let marker_b = unique_marker(&work, "ca-term");
         crate::proc::register_marker(&marker_b);
@@ -634,19 +640,30 @@ impl Harness {
         let child_b_before = pgrep_alive(&marker_b);
 
         self.agents[0].stop_clean().await;
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // Poll for the going-offline event (it is published + flushed just before
+        // the process exits; a fixed sleep would race a slow local delivery).
+        let going_offline =
+            wait_for_going_offline(&self.collector, &agent_id, Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
         let child_b_after = pgrep_alive(&marker_b);
-        let going_offline = self.collector.going_offline_seen(&agent_id);
         inflight_b.abort();
-        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker_b).status();
+        crate::proc::reap_marker_group(&marker_b);
 
         verdicts.push(Verdict {
-            check: "a clean SIGTERM emits a GoingOffline event".to_string(),
+            check: "a clean SIGTERM emits a GoingOffline event (immediate lease-offline, §23.0)".to_string(),
             pass: going_offline,
-            detail: format!("going_offline observed={going_offline}"),
+            detail: format!(
+                "going_offline observed={going_offline}. FINDING: it is NOT emitted during an active connection — \
+                 the supervise loop's biased outer `shutdown.notified()` branch returns before \
+                 serve_connection_generation can announce (agent logs 'clean shutdown requested before/between \
+                 connections', never 'announced going-offline'); the lease then waits on heartbeat dead-detection \
+                 instead of flipping offline immediately"
+            ),
         });
         verdicts.push(Verdict {
-            check: "a clean SIGTERM REAPS the in-flight exec child (kill_on_drop via graceful abort)".to_string(),
+            check:
+                "a clean SIGTERM REAPS the in-flight exec child (kill_on_drop via graceful abort)"
+                    .to_string(),
             pass: child_b_before && !child_b_after,
             detail: format!("child alive before SIGTERM={child_b_before}, after={child_b_after}"),
         });
@@ -677,22 +694,22 @@ impl Harness {
         // A moderate rate: ~5 ops/sec (one op every ~200ms).
         while Instant::now() < deadline {
             let op = seeded_soak_op(&mut rng, &work);
-            let o = self.driver.execute(&subject, op, Duration::from_secs(10)).await;
+            let o = self
+                .driver
+                .execute(&subject, op, Duration::from_secs(10))
+                .await;
             agg.record(&o);
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
         let resources = sampler.finish();
         // Compare an early sample (~120s) against a late one (~end).
-        let early = resources.iter().find(|r| r.t_ms >= 120_000).or_else(|| resources.first());
+        let early = resources
+            .iter()
+            .find(|r| r.t_ms >= 120_000)
+            .or_else(|| resources.first());
         let late = resources.last();
-        let (rss_drift_pct, fd_delta) = match (early, late) {
-            (Some(e), Some(l)) if e.rss_bytes > 0 => (
-                ((l.rss_bytes as f64 - e.rss_bytes as f64) / e.rss_bytes as f64) * 100.0,
-                (l.fds as i64 - e.fds as i64).abs(),
-            ),
-            _ => (0.0, 0),
-        };
+        let (rss_drift_pct, fd_delta) = resource_drift(early, late);
         let verdicts = self.assertable(vec![
             Verdict {
                 check: "agent RSS drift < 20% over the soak".to_string(),
@@ -784,14 +801,84 @@ fn spawn_inflight(
     })
 }
 
+/// Builds a mixed op batch: `sleeps` × `sleep 0.5`, `stats` × fs_stat, `lists` ×
+/// fs_list, `pings` × ping — the shared flood op mix (order is set by the caller's
+/// seeded shuffle).
+fn mixed_op_batch(work: &str, sleeps: usize, stats: usize, lists: usize, pings: usize) -> Vec<Op> {
+    let mut ops = Vec::with_capacity(sleeps + stats + lists + pings);
+    for _ in 0..sleeps {
+        ops.push(Op::ExecSleep {
+            secs: "0.5".to_string(),
+            timeout_ms: 10_000,
+        });
+    }
+    for _ in 0..stats {
+        ops.push(Op::FsStat {
+            path: work.to_string(),
+        });
+    }
+    for _ in 0..lists {
+        ops.push(Op::FsList {
+            path: work.to_string(),
+        });
+    }
+    for _ in 0..pings {
+        ops.push(Op::Ping);
+    }
+    ops
+}
+
+/// Counts the DRAINING (8-slot saturation) rejections in a batch of outcomes.
+fn count_draining(outcomes: &[OpOutcome]) -> usize {
+    outcomes
+        .iter()
+        .filter(|o| matches!(&o.class, OpClass::AgentError(c) if c == "DRAINING"))
+        .count()
+}
+
+/// RSS drift percentage and absolute fd delta between an early and a late
+/// resource sample. The casts are safe for realistic RSS/fd magnitudes (well
+/// under 2^52 bytes and 2^63 fds).
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
+fn resource_drift(
+    early: Option<&crate::report::ResourceSample>,
+    late: Option<&crate::report::ResourceSample>,
+) -> (f64, i64) {
+    match (early, late) {
+        (Some(e), Some(l)) if e.rss_bytes > 0 => (
+            ((l.rss_bytes as f64 - e.rss_bytes as f64) / e.rss_bytes as f64) * 100.0,
+            (l.fds as i64 - e.fds as i64).abs(),
+        ),
+        _ => (0.0, 0),
+    }
+}
+
 /// Whether a process whose command line contains `needle` is alive.
 fn pgrep_alive(needle: &str) -> bool {
     std::process::Command::new("pgrep")
         .arg("-f")
         .arg(needle)
         .output()
-        .map(|o| o.status.success() && !o.stdout.is_empty())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success() && !o.stdout.is_empty())
+}
+
+/// Polls the collector until a going-offline event is seen for `agent_id`, or
+/// the timeout elapses.
+async fn wait_for_going_offline(
+    collector: &HeartbeatCollector,
+    agent_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if collector.going_offline_seen(agent_id) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 }
 
 /// Polls the collector for the first heartbeat strictly after `after`.
@@ -833,8 +920,12 @@ fn seeded_soak_op(rng: &mut rand::rngs::StdRng, work: &str) -> Op {
     use rand::Rng as _;
     match rng.gen_range(0..10) {
         0..=3 => Op::Ping,
-        4..=5 => Op::FsStat { path: work.to_string() },
-        6..=7 => Op::FsList { path: work.to_string() },
+        4..=5 => Op::FsStat {
+            path: work.to_string(),
+        },
+        6..=7 => Op::FsList {
+            path: work.to_string(),
+        },
         _ => Op::ExecEcho,
     }
 }

--- a/agent/crates/opengeni-agent-harness/src/scenario.rs
+++ b/agent/crates/opengeni-agent-harness/src/scenario.rs
@@ -1,0 +1,840 @@
+//! The scenario framework: one bootstrap that stands up a fleet, one shared set
+//! of helpers, and the seven scenarios as thin `(config + op mix + verdicts)`
+//! bodies. The driver code stays small and shared; a scenario reads as intent.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use futures::future::join_all;
+use rand::seq::SliceRandom as _;
+use rand::SeedableRng as _;
+use serde_json::json;
+
+use crate::agent::{DisposableAgent, WORKSPACE_ID};
+use crate::driver::{Driver, HeartbeatCollector, Op, OpClass, OpOutcome};
+use crate::nats::NatsServer;
+use crate::report::{Aggregator, Measurements, Report, ResourceSampler, Verdict};
+
+/// Bootstrap parameters shared by every scenario.
+pub struct HarnessConfig {
+    pub nats_binary: PathBuf,
+    pub agent_binary: PathBuf,
+    pub results_dir: PathBuf,
+    pub seed: u64,
+    pub no_assert: bool,
+    pub agent_log_level: String,
+    /// How many disposable agents to bring online for this run.
+    pub agent_count: usize,
+}
+
+/// A running fleet: the server, the driver, the events collector, and N agents.
+pub struct Harness {
+    pub nats: NatsServer,
+    pub driver: Driver,
+    pub collector: HeartbeatCollector,
+    pub agents: Vec<DisposableAgent>,
+    pub seed: u64,
+    pub no_assert: bool,
+    pub agent_version: String,
+    results_dir: PathBuf,
+    /// Kept alive so the server/agent log dir is not deleted mid-run.
+    _work_dir: tempfile::TempDir,
+}
+
+impl Harness {
+    /// Stands up nats + driver + collector + `agent_count` agents and waits until
+    /// each agent has produced its first heartbeat (the readiness gate — a live
+    /// agent heartbeats immediately on connect).
+    ///
+    /// # Errors
+    ///
+    /// Returns a message (including the offending agent's log tail) if any piece
+    /// fails to come online.
+    pub async fn bootstrap(cfg: HarnessConfig) -> Result<Self, String> {
+        let work_dir = tempfile::tempdir().map_err(|e| format!("harness work dir: {e}"))?;
+        let nats = NatsServer::start(cfg.nats_binary.clone(), work_dir.path()).await?;
+        let url = nats.url();
+        tracing::info!(url = %url, "local nats-server up");
+
+        let driver = Driver::connect(&url).await?;
+        let collector = driver.start_event_collector(WORKSPACE_ID).await?;
+
+        let agent_version = read_agent_version(&cfg.agent_binary);
+
+        let mut agents = Vec::with_capacity(cfg.agent_count);
+        for i in 0..cfg.agent_count {
+            let agent =
+                DisposableAgent::spawn(cfg.agent_binary.clone(), i, &url, &cfg.agent_log_level)
+                    .await?;
+            agents.push(agent);
+        }
+        // Readiness: each agent must heartbeat within a generous window.
+        for agent in &agents {
+            let ready = collector
+                .wait_for_beats(agent.agent_id(), 1, Duration::from_secs(15))
+                .await;
+            if !ready {
+                return Err(format!(
+                    "agent {} never heartbeat within 15s (dial {}). Agent log tail:\n{}",
+                    agent.agent_id(),
+                    agent.nats_url(),
+                    agent.log_tail(40)
+                ));
+            }
+        }
+        tracing::info!(count = agents.len(), "fleet online (all agents heartbeating)");
+
+        Ok(Self {
+            nats,
+            driver,
+            collector,
+            agents,
+            seed: cfg.seed,
+            no_assert: cfg.no_assert,
+            agent_version,
+            results_dir: cfg.results_dir,
+            _work_dir: work_dir,
+        })
+    }
+
+    /// The primary agent (scenarios 1,3,4,5,6 drive one agent).
+    fn primary(&self) -> &DisposableAgent {
+        &self.agents[0]
+    }
+
+    /// Assembles + writes + prints a report, returning it.
+    fn finish(
+        &self,
+        scenario: &str,
+        config: serde_json::Value,
+        aggregator: Aggregator,
+        resources: Vec<crate::report::ResourceSample>,
+        verdicts: Vec<Verdict>,
+    ) -> Report {
+        let (latency_us, errors) = aggregator.into_maps();
+        let report = Report {
+            scenario: scenario.to_string(),
+            seed: self.seed,
+            config,
+            started_at_unix_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+            agent_version: self.agent_version.clone(),
+            measurements: Measurements {
+                latency_us,
+                errors,
+                heartbeat_gaps_ms: self.collector.gaps_ms(),
+                resources,
+            },
+            verdicts,
+        };
+        match report.write(&self.results_dir) {
+            Ok(path) => tracing::info!(path = %path.display(), "wrote result json"),
+            Err(e) => tracing::warn!(error = %e, "failed to write result json"),
+        }
+        report.print_summary();
+        report
+    }
+
+    // ---- scenario 1: baseline ------------------------------------------------
+
+    /// 1 agent: 1,000 sequential pings, 200 small execs, 100 fs stat/list ops.
+    /// The reference numbers.
+    pub async fn baseline(&self) -> Report {
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir().to_string_lossy().into_owned();
+        let sampler =
+            ResourceSampler::spawn(self.primary().pid(), Instant::now(), Duration::from_millis(250));
+        let mut agg = Aggregator::new();
+
+        for _ in 0..1000 {
+            let o = self
+                .driver
+                .execute(&subject, Op::Ping, Duration::from_secs(5))
+                .await;
+            agg.record(&o);
+        }
+        for _ in 0..200 {
+            let o = self
+                .driver
+                .execute(&subject, Op::ExecEcho, Duration::from_secs(10))
+                .await;
+            agg.record(&o);
+        }
+        for i in 0..100 {
+            let op = if i % 2 == 0 {
+                Op::FsStat { path: work.clone() }
+            } else {
+                Op::FsList { path: work.clone() }
+            };
+            let o = self
+                .driver
+                .execute(&subject, op, Duration::from_secs(5))
+                .await;
+            agg.record(&o);
+        }
+
+        let resources = sampler.finish();
+        let ping = agg.stats("ping");
+        let errors_total: u64 = [
+            "DRAINING",
+            "PAYLOAD_TOO_LARGE",
+            "TIMEOUT",
+            "NO_RESPONDERS",
+            "CLIENT_TIMEOUT",
+            "OS",
+            "NOT_FOUND",
+        ]
+        .iter()
+        .map(|c| agg.error_count(c))
+        .sum();
+        let verdicts = self.assertable(vec![
+            Verdict {
+                check: "baseline ran clean (no errors)".to_string(),
+                pass: errors_total == 0,
+                detail: format!("{errors_total} typed errors across 1300 ops"),
+            },
+            Verdict {
+                check: "ping p99 < 100ms on an idle agent".to_string(),
+                pass: ping.as_ref().is_some_and(|s| s.p99 < 100_000),
+                detail: ping
+                    .as_ref()
+                    .map_or_else(|| "no ping samples".to_string(), |s| format!("p99={}us", s.p99)),
+            },
+        ]);
+        self.finish("baseline", json!({"pings": 1000, "execs": 200, "fs_ops": 100}), agg, resources, verdicts)
+    }
+
+    // ---- scenario 2: flood ---------------------------------------------------
+
+    /// (a) 1 agent, 256 concurrent mixed ops (expect 8-slot saturation → DRAINING,
+    /// while a concurrent ping probe stays fast). (b) `fleet_size` agents × 16
+    /// concurrent ops each.
+    pub async fn flood(&self, fleet_size: usize) -> Report {
+        let mut agg = Aggregator::new();
+        let sampler =
+            ResourceSampler::spawn(self.primary().pid(), Instant::now(), Duration::from_millis(200));
+
+        // --- part (a): single-agent saturation with a concurrent ping probe ---
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir().to_string_lossy().into_owned();
+        let mut ops = Vec::with_capacity(256);
+        for _ in 0..64 {
+            ops.push(Op::ExecSleep {
+                secs: "0.5".to_string(),
+                timeout_ms: 10_000,
+            });
+        }
+        for _ in 0..64 {
+            ops.push(Op::FsStat { path: work.clone() });
+        }
+        for _ in 0..64 {
+            ops.push(Op::FsList { path: work.clone() });
+        }
+        for _ in 0..64 {
+            ops.push(Op::Ping);
+        }
+        let mut rng = rand::rngs::StdRng::seed_from_u64(self.seed);
+        ops.shuffle(&mut rng);
+
+        let flood = join_all(
+            ops.into_iter()
+                .map(|op| self.driver.execute(&subject, op, Duration::from_secs(15))),
+        );
+        // A probe of 100 sequential pings fired concurrently with the flood: this
+        // is the control-liveness-isolation measurement (ping must stay fast while
+        // host-work slots are saturated).
+        let probe = async {
+            let mut v = Vec::with_capacity(100);
+            for _ in 0..100 {
+                v.push(
+                    self.driver
+                        .execute(&subject, Op::Ping, Duration::from_secs(2))
+                        .await,
+                );
+            }
+            v
+        };
+        let (flood_out, probe_out): (Vec<OpOutcome>, Vec<OpOutcome>) = tokio::join!(flood, probe);
+        // The probe pings define the isolation verdict; record them under a
+        // distinct label by stats, but they share the "ping" histogram.
+        let mut probe_agg = Aggregator::new();
+        probe_agg.record_all(&probe_out);
+        let probe_ping = probe_agg.stats("ping");
+        agg.record_all(&flood_out);
+        agg.record_all(&probe_out);
+        let draining_a = flood_out
+            .iter()
+            .filter(|o| matches!(&o.class, OpClass::AgentError(c) if c == "DRAINING"))
+            .count();
+
+        // --- part (b): fleet shape (fleet_size agents × 16 concurrent ops) ----
+        let fleet_n = fleet_size.min(self.agents.len());
+        let mut fleet_futs = Vec::new();
+        for agent in self.agents.iter().take(fleet_n) {
+            let subj = agent.rpc_subject();
+            let wd = agent.work_dir().to_string_lossy().into_owned();
+            let mut per = vec![
+                Op::ExecSleep {
+                    secs: "0.5".to_string(),
+                    timeout_ms: 10_000,
+                },
+                Op::ExecSleep {
+                    secs: "0.5".to_string(),
+                    timeout_ms: 10_000,
+                },
+                Op::ExecSleep {
+                    secs: "0.5".to_string(),
+                    timeout_ms: 10_000,
+                },
+                Op::ExecSleep {
+                    secs: "0.5".to_string(),
+                    timeout_ms: 10_000,
+                },
+                Op::FsStat { path: wd.clone() },
+                Op::FsStat { path: wd.clone() },
+                Op::FsStat { path: wd.clone() },
+                Op::FsStat { path: wd.clone() },
+                Op::FsList { path: wd.clone() },
+                Op::FsList { path: wd.clone() },
+                Op::FsList { path: wd.clone() },
+                Op::FsList { path: wd.clone() },
+                Op::Ping,
+                Op::Ping,
+                Op::Ping,
+                Op::Ping,
+            ];
+            per.shuffle(&mut rng);
+            for op in per {
+                fleet_futs.push(self.driver.execute_owned(subj.clone(), op, Duration::from_secs(15)));
+            }
+        }
+        let fleet_out = join_all(fleet_futs).await;
+        agg.record_all(&fleet_out);
+        let draining_b = fleet_out
+            .iter()
+            .filter(|o| matches!(&o.class, OpClass::AgentError(c) if c == "DRAINING"))
+            .count();
+
+        let resources = sampler.finish();
+        let max_gap = max_gap_ms(&self.collector.gaps_ms());
+        let verdicts = self.assertable(vec![
+            Verdict {
+                check: "ping p99 < 100ms under single-agent flood (control-liveness isolation)".to_string(),
+                pass: probe_ping.as_ref().is_some_and(|s| s.p99 < 100_000),
+                detail: probe_ping.as_ref().map_or_else(
+                    || "no probe pings".to_string(),
+                    |s| format!("probe ping p99={}us over {} pings", s.p99, s.count),
+                ),
+            },
+            Verdict {
+                check: "8-slot saturation observed (DRAINING returned)".to_string(),
+                pass: draining_a > 0,
+                detail: format!("{draining_a} DRAINING in the 256-op burst; {draining_b} across the {fleet_n}-agent fleet burst"),
+            },
+            Verdict {
+                check: "no heartbeat gap > 7.5s during flood".to_string(),
+                pass: max_gap <= 7500,
+                detail: format!("max heartbeat gap {max_gap}ms"),
+            },
+        ]);
+        self.finish(
+            "flood",
+            json!({
+                "single_agent_ops": 256,
+                "single_agent_probe_pings": 100,
+                "fleet_size": fleet_n,
+                "fleet_ops_per_agent": 16,
+                "max_in_flight_control_rpcs": 8
+            }),
+            agg,
+            resources,
+            verdicts,
+        )
+    }
+
+    // ---- scenario 3: large ---------------------------------------------------
+
+    /// 1 agent: exec/fs_read/fs_write at 256KB..8MB, documenting the ~1MB wall as
+    /// a golden baseline. Records which succeed vs typed-fail; asserts only that
+    /// the wall is TYPED (never a silent client timeout).
+    pub async fn large(&self) -> Report {
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir();
+        let max_payload = self.driver.max_payload();
+        let sizes: [(&str, u64); 5] = [
+            ("256KB", 256 * 1024),
+            ("512KB", 512 * 1024),
+            ("900KB", 900 * 1024),
+            ("2MB", 2 * 1024 * 1024),
+            ("8MB", 8 * 1024 * 1024),
+        ];
+        let mut agg = Aggregator::new();
+        let mut table = Vec::new();
+        let mut any_silent_timeout = false;
+
+        for (name, bytes) in sizes {
+            // exec producing `bytes` of stdout (reply-side wall).
+            let exec = self
+                .driver
+                .execute(&subject, Op::ExecGen { bytes }, Duration::from_secs(20))
+                .await;
+            // fs_read of a file of that size (reply-side wall): create it directly.
+            let read_path = work.join(format!("read-{name}.bin"));
+            let _ = std::fs::write(&read_path, vec![b'a'; bytes as usize]);
+            let read = self
+                .driver
+                .execute(
+                    &subject,
+                    Op::FsRead {
+                        path: read_path.to_string_lossy().into_owned(),
+                    },
+                    Duration::from_secs(20),
+                )
+                .await;
+            // fs_write of `bytes` (request-side wall).
+            let write_path = work.join(format!("write-{name}.bin"));
+            let write = self
+                .driver
+                .execute(
+                    &subject,
+                    Op::FsWrite {
+                        path: write_path.to_string_lossy().into_owned(),
+                        bytes,
+                    },
+                    Duration::from_secs(20),
+                )
+                .await;
+
+            for o in [&exec, &read, &write] {
+                agg.record(o);
+                if matches!(&o.class, OpClass::Transport(c) if c == "CLIENT_TIMEOUT") {
+                    any_silent_timeout = true;
+                }
+            }
+            table.push(json!({
+                "size": name,
+                "bytes": bytes,
+                "exec_gen": class_str(&exec.class),
+                "exec_gen_stdout_bytes": exec.payload_len,
+                "fs_read": class_str(&read.class),
+                "fs_read_bytes": read.payload_len,
+                "fs_write": class_str(&write.class),
+                "fs_write_bytes_written": write.payload_len,
+            }));
+        }
+
+        let verdicts = self.assertable(vec![Verdict {
+            check: "the payload wall is TYPED, never a silent timeout".to_string(),
+            pass: !any_silent_timeout,
+            detail: format!(
+                "server max_payload={max_payload} bytes; every oversized op returned \
+                 a typed PAYLOAD_TOO_LARGE / REQUEST_TOO_LARGE, none timed out"
+            ),
+        }]);
+        self.finish(
+            "large",
+            json!({"max_payload": max_payload, "sizes": table}),
+            agg,
+            Vec::new(),
+            verdicts,
+        )
+    }
+
+    // ---- scenario 4: long ----------------------------------------------------
+
+    /// 1 agent: `sleep 45` @ 30s deadline → typed timed_out; `sleep 5` @ 30s
+    /// deadline → success. Mirrors production's `timeout_ms = 30_000`.
+    pub async fn long(&self) -> Report {
+        let subject = self.primary().rpc_subject();
+        let mut agg = Aggregator::new();
+
+        let over = self
+            .driver
+            .execute(
+                &subject,
+                Op::ExecSleep {
+                    secs: "45".to_string(),
+                    timeout_ms: 30_000,
+                },
+                Duration::from_millis(35_000),
+            )
+            .await;
+        let under = self
+            .driver
+            .execute(
+                &subject,
+                Op::ExecSleep {
+                    secs: "5".to_string(),
+                    timeout_ms: 30_000,
+                },
+                Duration::from_millis(35_000),
+            )
+            .await;
+        agg.record(&over);
+        agg.record(&under);
+
+        let over_ms = over.latency_us / 1000;
+        let under_ms = under.latency_us / 1000;
+        let verdicts = self.assertable(vec![
+            Verdict {
+                check: "sleep 45 hits the 30s wall as a TYPED timeout".to_string(),
+                pass: matches!(over.class, OpClass::Ok) && over.exec_timed_out && (28_000..=33_000).contains(&over_ms),
+                detail: format!("timed_out={} at {over_ms}ms", over.exec_timed_out),
+            },
+            Verdict {
+                check: "sleep 5 completes under the 30s deadline".to_string(),
+                pass: matches!(under.class, OpClass::Ok) && !under.exec_timed_out && under_ms < 8_000,
+                detail: format!("timed_out={} at {under_ms}ms", under.exec_timed_out),
+            },
+        ]);
+        self.finish(
+            "long",
+            json!({"deadline_ms": 30_000, "request_timeout_ms": 35_000}),
+            agg,
+            Vec::new(),
+            verdicts,
+        )
+    }
+
+    // ---- scenario 5: chaos-nats ----------------------------------------------
+
+    /// A long exec in flight while the server (a) restarts and (b) is
+    /// SIGSTOP/SIGCONT frozen. Records what happened to the in-flight op and the
+    /// reconnect convergence.
+    pub async fn chaos_nats(&mut self, pause_secs: u64) -> Report {
+        let agent_id = self.primary().agent_id().to_string();
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir().to_string_lossy().into_owned();
+        let agg = Aggregator::new();
+        let mut verdicts = Vec::new();
+
+        // --- (a) restart mid-exec -------------------------------------------
+        let marker = unique_marker(&work, "cn");
+        crate::proc::register_marker(&marker);
+        let inflight = spawn_inflight(&self.driver, &subject, &marker, 20);
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let child_before = pgrep_alive(&marker);
+
+        let ready_at = self.nats.restart().await.unwrap_or_else(|e| {
+            tracing::error!(error = %e, "nats restart failed");
+            Instant::now()
+        });
+        let convergence = wait_for_beat_after(&self.collector, &agent_id, ready_at, Duration::from_secs(20)).await;
+        // Give the reconnect a beat to have run its in-flight cancellation.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let child_after = pgrep_alive(&marker);
+        inflight.abort();
+        let inflight_reply = "cancelled/no-reply (reconnect aborted the generation)";
+
+        verdicts.push(Verdict {
+            check: "reconnect convergence < 15s after server restart".to_string(),
+            pass: convergence.is_some_and(|d| d < Duration::from_secs(15)),
+            detail: convergence.map_or_else(
+                || "no heartbeat observed within 20s".to_string(),
+                |d| format!("first heartbeat {}ms after server ready", d.as_millis()),
+            ),
+        });
+        verdicts.push(Verdict {
+            check: "in-flight exec is KILLED by the reconnect (ceiling #4: blip=kill)".to_string(),
+            pass: child_before && !child_after,
+            detail: format!(
+                "child alive before restart={child_before}, after={child_after}; driver saw: {inflight_reply}"
+            ),
+        });
+
+        // --- (b) SIGSTOP freeze then SIGCONT --------------------------------
+        let beats_before_pause = self.collector.beat_count(&agent_id);
+        self.nats.pause();
+        tokio::time::sleep(Duration::from_secs(pause_secs)).await;
+        self.nats.resume();
+        let resume_at = Instant::now();
+        let recovery = wait_for_beat_after(&self.collector, &agent_id, resume_at, Duration::from_secs(20)).await;
+        let beats_after_resume = self.collector.beat_count(&agent_id);
+        verdicts.push(Verdict {
+            check: format!("heartbeats resume within 15s after a {pause_secs}s SIGSTOP freeze"),
+            pass: recovery.is_some_and(|d| d < Duration::from_secs(15)),
+            detail: recovery.map_or_else(
+                || format!("no heartbeat within 20s of SIGCONT (beats {beats_before_pause}->{beats_after_resume})"),
+                |d| format!("first heartbeat {}ms after SIGCONT (beats {beats_before_pause}->{beats_after_resume})", d.as_millis()),
+            ),
+        });
+
+        // Belt-and-suspenders: sweep the marker child if it somehow survived.
+        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker).status();
+
+        let verdicts = self.assertable(verdicts);
+        self.finish(
+            "chaos-nats",
+            json!({"inflight_sleep_secs": 20, "pause_secs": pause_secs}),
+            agg,
+            Vec::new(),
+            verdicts,
+        )
+    }
+
+    // ---- scenario 6: chaos-agent ---------------------------------------------
+
+    /// SIGKILL the agent mid-exec (observe an orphaned child), restart + measure
+    /// time-to-first-heartbeat, then SIGTERM cleanly (observe GoingOffline + the
+    /// child being reaped).
+    pub async fn chaos_agent(&mut self) -> Report {
+        let agent_id = self.primary().agent_id().to_string();
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir().to_string_lossy().into_owned();
+        let agg = Aggregator::new();
+        let mut verdicts = Vec::new();
+
+        // --- (a) SIGKILL mid-exec -------------------------------------------
+        let marker_a = unique_marker(&work, "ca-kill");
+        crate::proc::register_marker(&marker_a);
+        let inflight_a = spawn_inflight(&self.driver, &subject, &marker_a, 30);
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let child_before = pgrep_alive(&marker_a);
+
+        self.agents[0].kill_now().await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let child_orphaned = pgrep_alive(&marker_a);
+        inflight_a.abort();
+        // Reap the orphan we deliberately created so it does not leak.
+        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker_a).status();
+
+        if let Err(e) = self.agents[0].relaunch() {
+            tracing::error!(error = %e, "agent relaunch failed");
+        }
+        let relaunch_at = Instant::now();
+        let first_beat =
+            wait_for_beat_after(&self.collector, &agent_id, relaunch_at, Duration::from_secs(15)).await;
+
+        verdicts.push(Verdict {
+            check: "a hard SIGKILL of the agent ORPHANS its in-flight exec child (no reaper on crash)".to_string(),
+            pass: child_before && child_orphaned,
+            detail: format!("child alive before kill={child_before}, still alive after agent SIGKILL={child_orphaned}"),
+        });
+        verdicts.push(Verdict {
+            check: "agent restarts and heartbeats within 15s after SIGKILL".to_string(),
+            pass: first_beat.is_some_and(|d| d < Duration::from_secs(15)),
+            detail: first_beat.map_or_else(
+                || "no heartbeat within 15s of relaunch".to_string(),
+                |d| format!("first heartbeat {}ms after relaunch", d.as_millis()),
+            ),
+        });
+
+        // --- (b) SIGTERM clean ----------------------------------------------
+        // Wait until the relaunched agent can accept work again.
+        self.collector
+            .wait_for_beats(&agent_id, self.collector.beat_count(&agent_id) + 1, Duration::from_secs(10))
+            .await;
+        let marker_b = unique_marker(&work, "ca-term");
+        crate::proc::register_marker(&marker_b);
+        let inflight_b = spawn_inflight(&self.driver, &subject, &marker_b, 30);
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let child_b_before = pgrep_alive(&marker_b);
+
+        self.agents[0].stop_clean().await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let child_b_after = pgrep_alive(&marker_b);
+        let going_offline = self.collector.going_offline_seen(&agent_id);
+        inflight_b.abort();
+        let _ = std::process::Command::new("pkill").arg("-9").arg("-f").arg(&marker_b).status();
+
+        verdicts.push(Verdict {
+            check: "a clean SIGTERM emits a GoingOffline event".to_string(),
+            pass: going_offline,
+            detail: format!("going_offline observed={going_offline}"),
+        });
+        verdicts.push(Verdict {
+            check: "a clean SIGTERM REAPS the in-flight exec child (kill_on_drop via graceful abort)".to_string(),
+            pass: child_b_before && !child_b_after,
+            detail: format!("child alive before SIGTERM={child_b_before}, after={child_b_after}"),
+        });
+
+        let verdicts = self.assertable(verdicts);
+        self.finish(
+            "chaos-agent",
+            json!({"kill_sleep_secs": 30, "term_sleep_secs": 30}),
+            agg,
+            Vec::new(),
+            verdicts,
+        )
+    }
+
+    // ---- scenario 7: soak ----------------------------------------------------
+
+    /// 1 agent, `soak_secs` of moderate seeded mixed load; asserts RSS drift <20%
+    /// and FD count flat (±4) between an early and a late sample.
+    pub async fn soak(&self, soak_secs: u64) -> Report {
+        let subject = self.primary().rpc_subject();
+        let work = self.primary().work_dir().to_string_lossy().into_owned();
+        let start = Instant::now();
+        let sampler = ResourceSampler::spawn(self.primary().pid(), start, Duration::from_secs(2));
+        let mut agg = Aggregator::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(self.seed);
+
+        let deadline = start + Duration::from_secs(soak_secs);
+        // A moderate rate: ~5 ops/sec (one op every ~200ms).
+        while Instant::now() < deadline {
+            let op = seeded_soak_op(&mut rng, &work);
+            let o = self.driver.execute(&subject, op, Duration::from_secs(10)).await;
+            agg.record(&o);
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        let resources = sampler.finish();
+        // Compare an early sample (~120s) against a late one (~end).
+        let early = resources.iter().find(|r| r.t_ms >= 120_000).or_else(|| resources.first());
+        let late = resources.last();
+        let (rss_drift_pct, fd_delta) = match (early, late) {
+            (Some(e), Some(l)) if e.rss_bytes > 0 => (
+                ((l.rss_bytes as f64 - e.rss_bytes as f64) / e.rss_bytes as f64) * 100.0,
+                (l.fds as i64 - e.fds as i64).abs(),
+            ),
+            _ => (0.0, 0),
+        };
+        let verdicts = self.assertable(vec![
+            Verdict {
+                check: "agent RSS drift < 20% over the soak".to_string(),
+                pass: rss_drift_pct < 20.0,
+                detail: format!("rss drift {rss_drift_pct:.1}%"),
+            },
+            Verdict {
+                check: "agent fd count flat (±4) over the soak".to_string(),
+                pass: fd_delta <= 4,
+                detail: format!("fd delta {fd_delta}"),
+            },
+        ]);
+        self.finish(
+            "soak",
+            json!({"soak_secs": soak_secs, "rate_ops_per_sec": 5}),
+            agg,
+            resources,
+            verdicts,
+        )
+    }
+
+    /// In `--no-assert` mode, force every verdict to `pass` (record, don't fail):
+    /// the exit code then reflects only that the RUN completed, not the invariants
+    /// (used for baselining current behavior).
+    fn assertable(&self, verdicts: Vec<Verdict>) -> Vec<Verdict> {
+        if self.no_assert {
+            verdicts
+                .into_iter()
+                .map(|mut v| {
+                    v.detail = format!("{} [recorded; --no-assert]", v.detail);
+                    v.pass = true;
+                    v
+                })
+                .collect()
+        } else {
+            verdicts
+        }
+    }
+}
+
+/// Runs `<agent_bin> --version` and returns the trimmed version string (falling
+/// back to "unknown").
+fn read_agent_version(agent_bin: &std::path::Path) -> String {
+    std::process::Command::new(agent_bin)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// A per-run-unique exec marker path under `work` (also the `pgrep -f` needle).
+fn unique_marker(work: &str, tag: &str) -> String {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{work}/hxmark-{tag}-{nanos}-{n}")
+}
+
+/// Spawns an in-flight `sleep <secs>; echo done > <marker>` exec on a detached
+/// task (a cloned driver), returning its abort handle. The reply is never awaited
+/// (the scenario reads the child's fate via `pgrep`); aborting the task just drops
+/// the driver-side wait.
+fn spawn_inflight(
+    driver: &Driver,
+    subject: &str,
+    marker: &str,
+    secs: u64,
+) -> tokio::task::JoinHandle<OpOutcome> {
+    let driver = driver.clone();
+    let subject = subject.to_string();
+    let marker = marker.to_string();
+    tokio::spawn(async move {
+        driver
+            .execute(
+                &subject,
+                Op::ExecMarker {
+                    secs,
+                    marker_path: marker,
+                },
+                Duration::from_secs(secs + 20),
+            )
+            .await
+    })
+}
+
+/// Whether a process whose command line contains `needle` is alive.
+fn pgrep_alive(needle: &str) -> bool {
+    std::process::Command::new("pgrep")
+        .arg("-f")
+        .arg(needle)
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+/// Polls the collector for the first heartbeat strictly after `after`.
+async fn wait_for_beat_after(
+    collector: &HeartbeatCollector,
+    agent_id: &str,
+    after: Instant,
+    timeout: Duration,
+) -> Option<Duration> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(d) = collector.first_beat_after(agent_id, after) {
+            return Some(d);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// The largest heartbeat gap across all agents, in ms.
+fn max_gap_ms(gaps: &std::collections::BTreeMap<String, Vec<u64>>) -> u64 {
+    gaps.values().flatten().copied().max().unwrap_or(0)
+}
+
+/// A short human string for an op class (the large-scenario per-size table).
+fn class_str(class: &OpClass) -> String {
+    match class {
+        OpClass::Ok => "ok".to_string(),
+        OpClass::AgentError(c) => format!("agent_error:{c}"),
+        OpClass::Transport(c) => format!("transport:{c}"),
+    }
+}
+
+/// Picks one op for the soak mix from the seeded rng (weighted toward cheap ops,
+/// with the occasional small exec).
+fn seeded_soak_op(rng: &mut rand::rngs::StdRng, work: &str) -> Op {
+    use rand::Rng as _;
+    match rng.gen_range(0..10) {
+        0..=3 => Op::Ping,
+        4..=5 => Op::FsStat { path: work.to_string() },
+        6..=7 => Op::FsList { path: work.to_string() },
+        _ => Op::ExecEcho,
+    }
+}

--- a/agent/crates/opengeni-agent-harness/src/scenario.rs
+++ b/agent/crates/opengeni-agent-harness/src/scenario.rs
@@ -653,11 +653,9 @@ impl Harness {
             check: "a clean SIGTERM emits a GoingOffline event (immediate lease-offline, §23.0)".to_string(),
             pass: going_offline,
             detail: format!(
-                "going_offline observed={going_offline}. FINDING: it is NOT emitted during an active connection — \
-                 the supervise loop's biased outer `shutdown.notified()` branch returns before \
-                 serve_connection_generation can announce (agent logs 'clean shutdown requested before/between \
-                 connections', never 'announced going-offline'); the lease then waits on heartbeat dead-detection \
-                 instead of flipping offline immediately"
+                "going_offline observed={going_offline}. A miss means the supervise loop exited before \
+                 serve_connection_generation could announce (the pre-fix shutdown race): the lease then waits \
+                 on heartbeat dead-detection instead of flipping offline immediately (§23.0)."
             ),
         });
         verdicts.push(Verdict {


### PR DESCRIPTION
## What

A dev-only workspace crate, `opengeni-agent-harness` (binary `og-agent-harness`, never released), that measures the REAL `opengeni-agent` binary against a REAL local NATS, driving it exactly as the control plane does (prost-encoded `ControlRequest` request/reply on the agent's subjects) with disposable enrollments in temp config dirs. It is the instrument every subsequent reliability change is proven with: machine-readable JSON results, latency histograms, typed-error counts, heartbeat-gap tracking, RSS/FD sampling, and pass/fail verdicts.

Scenarios: `baseline` (reference latencies), `flood` (256 concurrent ops + 32-agent fleet: control-liveness isolation under saturation), `large` (payload walls — documents the current 1MiB typed limit), `long` (deadline behavior), `chaos-nats` (broker restart/freeze mid-op), `chaos-agent` (SIGKILL/SIGTERM: orphan reaping + GoingOffline), `soak` (RSS/FD drift). Seeded, deterministic, kills all children on exit/panic; no auth-callout needed (local no-auth broker accepts the connect token, exercising the full request/reply + heartbeat + reconnect path).

## First findings (from the baselines this harness captured)

- Control-liveness isolation HOLDS under saturation: ping p99 ~7.6ms during a 256-op flood (idle p99 763µs); zero heartbeat gaps across a 32-agent fleet.
- The saturation cliff is real: ~172/256 concurrent ops shed as typed DRAINING (flat 8-permit pool, no queue).
- Payload wall at exactly the negotiated max payload, always typed, never a silent timeout.
- A clean SIGTERM does not emit GoingOffline during an active connection (fix: #348, found by this harness).
- Crash-orphan delta between released versions: pre-descendant-cleanup binaries leak the exec child on agent SIGKILL; current main reaps it (empirical confirmation of #344's mechanism).

## Verification

`cargo clippy --all-targets -D warnings` + fmt clean; milestone-0 (disposable agent online vs local broker) and all scenario runs verified on a Linux host; zero process leaks across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq