### PR TITLE
fix(agent): OOM fate isolation — per-op cgroups, oom_score_adj, hardened unit (#345)

### DIFF
--- a/agent/crates/opengeni-agent-platform/Cargo.toml
+++ b/agent/crates/opengeni-agent-platform/Cargo.toml
@@ -54,3 +54,5 @@ opengeni-agent-macos-ffi = { path = "../opengeni-agent-macos-ffi", optional = tr
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "process", "io-util", "time"] }
 tempfile = { workspace = true }
+# The wire types the cgroup-placement integration test builds an ExecRequest with.
+opengeni-agent-proto = { path = "../opengeni-agent-proto" }

--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -1,0 +1,502 @@
+//! Per-op memory cgroup isolation for host execs (issue #345).
+//!
+//! # The failure this closes
+//!
+//! The agent's control supervisor (heartbeat + `ping`) and every native `exec`
+//! descendant share ONE systemd service cgroup. On a swapless host under memory
+//! pressure, `systemd-oomd` — or the kernel OOM killer — can select that cgroup
+//! and SIGKILL the whole unit, taking the supervisor down with a runaway command.
+//! Bounded concurrency (the supervisor's work pool) is not resource-aware and does
+//! not give process/cgroup FATE isolation.
+//!
+//! # What this module does (Linux, cgroup v2 only)
+//!
+//! Given a delegated cgroup v2 service cgroup (the hardened unit renders
+//! `Delegate=yes` + `MemoryHigh=` — see [`crate::service`]), it:
+//!
+//! 1. **Startup dance** ([`establish_oom_isolation`]). cgroup v2 forbids a cgroup
+//!    from holding member processes AND enabling controllers for its children (the
+//!    "no internal processes" rule), so we move the agent process into a
+//!    `<service>/supervisor` leaf, then enable the memory controller in
+//!    `<service>/cgroup.subtree_control`. Per-op cgroups are then
+//!    `<service>/op-<n>` siblings of `supervisor`, each with its own memory
+//!    accounting.
+//! 2. **Per-exec placement** ([`OpCgroups::place_op`]). After a child is spawned,
+//!    its PID and the #344 process-group anchor's PID are written into a fresh
+//!    `op-<n>` leaf (optionally capped by [`OpCgroupConfig`]). A memory blow-up in
+//!    that leaf is contained to the leaf; the supervisor in its own leaf survives.
+//! 3. **Teardown** ([`OpCgroupHandle`]). The op leaf is `rmdir`'d after the op's
+//!    process tree is reaped, tolerating a transient `EBUSY` with a bounded retry.
+//!
+//! # Fallback ladder — never fail to serve
+//!
+//! Every step degrades gracefully: not Linux, no cgroup v2, the memory controller
+//! is not delegated, or any step returns `EPERM`/IO error → the reason is logged
+//! ONCE and the agent keeps serving with today's behavior (all work in the service
+//! cgroup, no per-op isolation). Isolation being unavailable must never stop the
+//! agent from answering control RPCs.
+//!
+//! # Cross-platform posture
+//!
+//! This is a Linux-first feature. On macOS/Windows [`establish_oom_isolation`]
+//! returns `None` (a documented no-op) and no cgroup is ever touched — the same
+//! honest-degradation posture the metrics reader uses for its `/proc` sources.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// The cgroup v2 unified mount on a standard systemd host.
+#[cfg(target_os = "linux")]
+const CGROUP2_MOUNT: &str = "/sys/fs/cgroup";
+
+/// The leaf the agent process is moved into so the service cgroup itself holds no
+/// member processes (the cgroup v2 no-internal-processes rule) and can delegate
+/// the memory controller to per-op sibling leaves.
+#[cfg(target_os = "linux")]
+const SUPERVISOR_LEAF: &str = "supervisor";
+
+/// How many times [`OpCgroupHandle::teardown`] retries an `rmdir` that returns
+/// `EBUSY` (the op's processes are reaped a moment after the group is killed).
+#[cfg(target_os = "linux")]
+const TEARDOWN_ATTEMPTS: u32 = 5;
+
+/// The delay between the bounded teardown `rmdir` retries.
+#[cfg(target_os = "linux")]
+const TEARDOWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Environment variable naming an optional per-op `memory.max` hard cap, in bytes.
+const OP_MEMORY_MAX_ENV: &str = "OPENGENI_AGENT_OP_MEMORY_MAX";
+
+/// Environment variable naming an optional per-op `memory.high` throttle, in bytes.
+const OP_MEMORY_HIGH_ENV: &str = "OPENGENI_AGENT_OP_MEMORY_HIGH";
+
+/// Optional per-op memory limits applied to each `op-<n>` leaf. Both default to
+/// unset: the leaf still ACCOUNTS memory separately (which is what fate-isolates
+/// the supervisor), and only caps the op when an operator opts in.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpCgroupConfig {
+    /// The per-op `memory.max` hard limit in bytes (a hit is an in-op OOM). Unset =
+    /// no hard cap.
+    pub memory_max: Option<u64>,
+    /// The per-op `memory.high` throttle in bytes (reclaim pressure, not a kill).
+    /// Unset = no throttle.
+    pub memory_high: Option<u64>,
+}
+
+impl OpCgroupConfig {
+    /// Reads the optional per-op limits from the environment
+    /// ([`OP_MEMORY_MAX_ENV`], [`OP_MEMORY_HIGH_ENV`]); an unset/zero/invalid value
+    /// leaves that limit unset.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            memory_max: parse_bytes_env(OP_MEMORY_MAX_ENV),
+            memory_high: parse_bytes_env(OP_MEMORY_HIGH_ENV),
+        }
+    }
+}
+
+/// Parses a positive byte count from environment variable `key`; `None` when
+/// unset, empty, non-numeric, or zero.
+fn parse_bytes_env(key: &str) -> Option<u64> {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// An established per-op cgroup manager: the resolved service cgroup, the per-op
+/// limits, and a monotonic op-id counter. Constructed ONLY by a successful
+/// [`establish_oom_isolation`] (so its presence means the startup dance ran and
+/// the memory controller is delegated to per-op leaves).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Debug)]
+pub struct OpCgroups {
+    /// The absolute path of the delegated service cgroup (`op-<n>` leaves and the
+    /// `supervisor` leaf are its children).
+    service_dir: PathBuf,
+    /// The per-op memory limits to stamp on each leaf.
+    config: OpCgroupConfig,
+    /// The next op-id; each `place_op` allocates a unique `op-<n>` sibling.
+    next_op: AtomicU64,
+    /// Guards the "log once" of the per-op placement fallback so a persistent
+    /// degradation is reported exactly once, not per exec.
+    fallback_logged: AtomicBool,
+}
+
+impl OpCgroups {
+    /// Places one exec's processes into a fresh `op-<n>` memory leaf and returns a
+    /// teardown handle. `pids` is the requested child plus the #344 group anchor —
+    /// both are moved so the whole op shares one memory fate.
+    ///
+    /// Best-effort by contract: a failure to create the leaf, stamp a cap, or move
+    /// a PID (e.g. the process already exited) is logged once and the op keeps
+    /// running in the service cgroup. Returns a handle whenever the leaf exists (so
+    /// it is torn down), or `None` when the leaf could not be created.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn place_op(&self, pids: &[u32]) -> Option<OpCgroupHandle> {
+        let op_id = self.next_op.fetch_add(1, Ordering::Relaxed);
+        let dir = self.service_dir.join(op_cgroup_name(op_id));
+        if let Err(error) = create_dir_idempotent(&dir) {
+            self.note_fallback(format_args!(
+                "cannot create op cgroup {}: {error}",
+                dir.display()
+            ));
+            return None;
+        }
+
+        // Optional per-op caps (default: unset). A failing cap is non-fatal: the
+        // leaf still accounts memory separately, which is what isolates the
+        // supervisor; the cap only bounds a single op when an operator opts in.
+        if let Some(max) = self.config.memory_max {
+            if let Err(error) = std::fs::write(dir.join("memory.max"), max.to_string()) {
+                self.note_fallback(format_args!(
+                    "cannot set memory.max on {}: {error}",
+                    dir.display()
+                ));
+            }
+        }
+        if let Some(high) = self.config.memory_high {
+            if let Err(error) = std::fs::write(dir.join("memory.high"), high.to_string()) {
+                self.note_fallback(format_args!(
+                    "cannot set memory.high on {}: {error}",
+                    dir.display()
+                ));
+            }
+        }
+
+        // Move the exec's processes into the leaf. cgroup.procs takes one PID per
+        // write; the tiny window between spawn and this move is the accepted
+        // post-spawn billing window (no async-signal-unsafe pre_exec tricks).
+        let procs = dir.join("cgroup.procs");
+        for pid in pids {
+            if let Err(error) = std::fs::write(&procs, pid.to_string()) {
+                self.note_fallback(format_args!(
+                    "cannot place pid {pid} into {}: {error}",
+                    dir.display()
+                ));
+            }
+        }
+
+        Some(OpCgroupHandle { dir })
+    }
+
+    /// Non-Linux no-op: no manager is ever constructed off Linux, so this is never
+    /// reached; it exists so the cross-platform exec path type-checks.
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn place_op(&self, _pids: &[u32]) -> Option<OpCgroupHandle> {
+        None
+    }
+
+    /// Logs the per-op placement fallback reason exactly once (a persistent
+    /// degradation must not spam a line per exec).
+    #[cfg(target_os = "linux")]
+    fn note_fallback(&self, reason: std::fmt::Arguments<'_>) {
+        if !self.fallback_logged.swap(true, Ordering::Relaxed) {
+            tracing::info!(
+                %reason,
+                "per-op OOM cgroup placement degraded; continuing to serve in the service cgroup (logged once)"
+            );
+        }
+    }
+}
+
+/// A handle to one placed `op-<n>` leaf, responsible for removing it once the op's
+/// process tree is reaped.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) struct OpCgroupHandle {
+    /// The op leaf's absolute path.
+    dir: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl OpCgroupHandle {
+    /// Removes the op leaf after the op's processes are reaped, tolerating a
+    /// transient `EBUSY` (the kernel drops reaped PIDs from `cgroup.procs` a moment
+    /// after the group is killed) with a bounded retry. A leaf that stays busy past
+    /// the retries is left in place and logged — a leaked EMPTY cgroup is cosmetic
+    /// and the whole subtree is reclaimed when systemd stops the unit. Awaited on
+    /// the normal completion path, where the caller has already reaped the tree.
+    pub(crate) async fn teardown(self) {
+        for attempt in 1..=TEARDOWN_ATTEMPTS {
+            match std::fs::remove_dir(&self.dir) {
+                Ok(()) => return,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+                Err(_) if attempt < TEARDOWN_ATTEMPTS => {
+                    tokio::time::sleep(TEARDOWN_RETRY_DELAY).await;
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        dir = %self.dir.display(),
+                        %error,
+                        "left an empty op cgroup after bounded teardown retries (cosmetic)"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A single, non-blocking teardown attempt for the drop path (a cancelled or
+    /// timed-out exec). The group was just SIGKILL'd, so the processes usually
+    /// outlive this one `rmdir`; the reaped-later leaf is a cosmetic leak the next
+    /// unit stop reclaims. Kept sync so it is safe to call from `Drop`.
+    pub(crate) fn teardown_best_effort(&self) {
+        if let Err(error) = std::fs::remove_dir(&self.dir) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::debug!(
+                    dir = %self.dir.display(),
+                    %error,
+                    "op cgroup not removed on the cancel/timeout path (reaped later; cosmetic)"
+                );
+            }
+        }
+    }
+}
+
+/// Non-Linux stubs so the cross-platform exec path type-checks; never reached off
+/// Linux (no handle is ever constructed).
+#[cfg(not(target_os = "linux"))]
+impl OpCgroupHandle {
+    #[allow(dead_code)]
+    pub(crate) async fn teardown(self) {}
+
+    #[allow(dead_code)]
+    pub(crate) fn teardown_best_effort(&self) {}
+}
+
+/// Runs the startup dance and returns an active [`OpCgroups`], or `None` (with a
+/// once-logged reason) when isolation is unavailable — the agent then serves with
+/// today's behavior. Call this ONCE at startup, before any host exec runs and
+/// before spawning agent-infra children (e.g. Xvfb), so those children inherit the
+/// `supervisor` leaf and only host work lands in per-op leaves.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn establish_oom_isolation(config: OpCgroupConfig) -> Option<Arc<OpCgroups>> {
+    // 1. cgroup v2 unified hierarchy at the standard mount?
+    let mount = Path::new(CGROUP2_MOUNT);
+    if !mount.join("cgroup.controllers").exists() {
+        tracing::info!(
+            mount = CGROUP2_MOUNT,
+            "OOM cgroup isolation unavailable: no cgroup v2 unified hierarchy; serving without per-op isolation"
+        );
+        return None;
+    }
+
+    // 2. Our own service cgroup, from the `0::` line of /proc/self/cgroup.
+    let proc_cgroup = match std::fs::read_to_string("/proc/self/cgroup") {
+        Ok(text) => text,
+        Err(error) => {
+            tracing::info!(%error, "OOM cgroup isolation unavailable: cannot read /proc/self/cgroup; serving without per-op isolation");
+            return None;
+        }
+    };
+    let Some(unified) = parse_unified_cgroup_path(&proc_cgroup) else {
+        tracing::info!("OOM cgroup isolation unavailable: not in a cgroup v2 unified hierarchy; serving without per-op isolation");
+        return None;
+    };
+    if unified == "/" {
+        tracing::info!("OOM cgroup isolation unavailable: running in the root cgroup (not a delegated service); serving without per-op isolation");
+        return None;
+    }
+    let service_dir = service_cgroup_dir(mount, &unified);
+
+    // 3. Is the memory controller delegated to our service cgroup? (Delegate=yes +
+    //    MemoryAccounting on the unit make systemd enable it in our parent's
+    //    subtree_control, so it shows up in our cgroup.controllers.)
+    let controllers = match std::fs::read_to_string(service_dir.join("cgroup.controllers")) {
+        Ok(text) => text,
+        Err(error) => {
+            tracing::info!(%error, dir = %service_dir.display(), "OOM cgroup isolation unavailable: cannot read the service cgroup controllers; serving without per-op isolation");
+            return None;
+        }
+    };
+    if !controllers_contains(&controllers, "memory") {
+        tracing::info!(
+            dir = %service_dir.display(),
+            "OOM cgroup isolation unavailable: the memory controller is not delegated to this unit (needs Delegate=yes + memory accounting); serving without per-op isolation"
+        );
+        return None;
+    }
+
+    // 4. No-internal-processes dance: move ourselves into the supervisor leaf, then
+    //    delegate the memory controller to our children. Order matters — the
+    //    service cgroup must hold no member processes before subtree_control can
+    //    enable a controller.
+    let supervisor_dir = service_dir.join(SUPERVISOR_LEAF);
+    if let Err(error) = create_dir_idempotent(&supervisor_dir) {
+        tracing::info!(%error, dir = %supervisor_dir.display(), "OOM cgroup isolation unavailable: cannot create the supervisor leaf; serving without per-op isolation");
+        return None;
+    }
+    if let Err(error) = std::fs::write(
+        supervisor_dir.join("cgroup.procs"),
+        std::process::id().to_string(),
+    ) {
+        tracing::info!(%error, "OOM cgroup isolation unavailable: cannot move the supervisor into its leaf; serving without per-op isolation");
+        return None;
+    }
+    if let Err(error) = std::fs::write(service_dir.join("cgroup.subtree_control"), "+memory") {
+        tracing::info!(
+            %error,
+            "OOM cgroup isolation unavailable: cannot delegate the memory controller to per-op leaves; serving without per-op isolation (the supervisor already runs in its own leaf)"
+        );
+        return None;
+    }
+
+    tracing::info!(
+        service_cgroup = %service_dir.display(),
+        memory_max = ?config.memory_max,
+        memory_high = ?config.memory_high,
+        "established per-op OOM cgroup isolation: host execs run in memory sub-cgroups; the control supervisor is fate-isolated in its own leaf"
+    );
+    Some(Arc::new(OpCgroups {
+        service_dir,
+        config,
+        next_op: AtomicU64::new(0),
+        fallback_logged: AtomicBool::new(false),
+    }))
+}
+
+/// Non-Linux no-op: per-op cgroup isolation is a Linux cgroup v2 feature. Returns
+/// `None` so the agent runs unchanged on macOS/Windows.
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn establish_oom_isolation(_config: OpCgroupConfig) -> Option<Arc<OpCgroups>> {
+    tracing::debug!("per-op OOM cgroup isolation is Linux-only; running without it on this OS");
+    None
+}
+
+/// Creates `dir`, treating an already-existing directory as success (a leaked leaf
+/// from a prior run is reusable).
+#[cfg(target_os = "linux")]
+fn create_dir_idempotent(dir: &Path) -> std::io::Result<()> {
+    match std::fs::create_dir(dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+// --- Pure, cross-platform helpers (unit-tested on any host) -------------------
+
+/// Extracts the cgroup v2 unified path from `/proc/self/cgroup` — the path after
+/// the `0::` prefix of the unified line. `None` when there is no unified line (a
+/// pure cgroup v1 host) or its path is empty.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_unified_cgroup_path(contents: &str) -> Option<String> {
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToString::to_string)
+}
+
+/// Joins the cgroup v2 mount and a unified path (which is absolute-from-mount, e.g.
+/// `/user.slice/.../opengeni-agent.service`) into the service cgroup's real dir.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn service_cgroup_dir(mount: &Path, unified_path: &str) -> PathBuf {
+    mount.join(unified_path.trim_start_matches('/'))
+}
+
+/// Whether a `cgroup.controllers`/`cgroup.subtree_control` body (space-separated
+/// controller names) lists `controller`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn controllers_contains(contents: &str, controller: &str) -> bool {
+    contents.split_whitespace().any(|name| name == controller)
+}
+
+/// The name of the `op-<n>` leaf for op id `op_id`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn op_cgroup_name(op_id: u64) -> String {
+    format!("op-{op_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_unified_line_from_a_hybrid_proc_cgroup() {
+        // A hybrid host lists v1 controllers then the `0::` unified line last.
+        let contents = "\
+12:pids:/user.slice
+1:name=systemd:/user.slice/session-3.scope
+0::/user.slice/user-1000.slice/user@1000.service/app.slice/opengeni-agent.service
+";
+        assert_eq!(
+            parse_unified_cgroup_path(contents).as_deref(),
+            Some("/user.slice/user-1000.slice/user@1000.service/app.slice/opengeni-agent.service")
+        );
+    }
+
+    #[test]
+    fn parses_a_pure_v2_proc_cgroup() {
+        assert_eq!(
+            parse_unified_cgroup_path("0::/system.slice/opengeni-agent.service\n").as_deref(),
+            Some("/system.slice/opengeni-agent.service")
+        );
+    }
+
+    #[test]
+    fn no_unified_line_is_none() {
+        // A pure cgroup v1 host has no `0::` line.
+        assert!(parse_unified_cgroup_path("3:memory:/foo\n1:name=systemd:/bar\n").is_none());
+        // An empty unified path (the root, but reported blank) is not a service.
+        assert!(parse_unified_cgroup_path("0::\n").is_none());
+    }
+
+    #[test]
+    fn service_dir_joins_mount_and_absolute_unified_path() {
+        let dir = service_cgroup_dir(
+            Path::new("/sys/fs/cgroup"),
+            "/system.slice/opengeni-agent.service",
+        );
+        assert_eq!(
+            dir,
+            PathBuf::from("/sys/fs/cgroup/system.slice/opengeni-agent.service")
+        );
+    }
+
+    #[test]
+    fn controllers_contains_matches_whole_names_only() {
+        assert!(controllers_contains("cpuset cpu io memory pids", "memory"));
+        assert!(!controllers_contains("cpuset cpu io pids", "memory"));
+        // A prefix/substring must not match a different controller name.
+        assert!(!controllers_contains("memoryfoo", "memory"));
+        assert!(controllers_contains("memory", "memory"));
+    }
+
+    #[test]
+    fn op_cgroup_names_are_unique_per_id() {
+        assert_eq!(op_cgroup_name(0), "op-0");
+        assert_eq!(op_cgroup_name(42), "op-42");
+        assert_ne!(op_cgroup_name(1), op_cgroup_name(2));
+    }
+
+    #[test]
+    fn config_from_env_reads_positive_byte_limits_only() {
+        // Serialize the env mutation so parallel tests don't clobber the vars.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        std::env::remove_var(OP_MEMORY_MAX_ENV);
+        std::env::remove_var(OP_MEMORY_HIGH_ENV);
+        assert_eq!(OpCgroupConfig::from_env().memory_max, None);
+        assert_eq!(OpCgroupConfig::from_env().memory_high, None);
+
+        std::env::set_var(OP_MEMORY_MAX_ENV, "1073741824");
+        std::env::set_var(OP_MEMORY_HIGH_ENV, "0"); // zero is "unset"
+        let cfg = OpCgroupConfig::from_env();
+        assert_eq!(cfg.memory_max, Some(1_073_741_824));
+        assert_eq!(cfg.memory_high, None, "zero disables the limit");
+
+        std::env::set_var(OP_MEMORY_MAX_ENV, "not-a-number");
+        assert_eq!(OpCgroupConfig::from_env().memory_max, None);
+
+        std::env::remove_var(OP_MEMORY_MAX_ENV);
+        std::env::remove_var(OP_MEMORY_HIGH_ENV);
+    }
+}

--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -377,6 +377,41 @@ fn create_dir_idempotent(dir: &Path) -> std::io::Result<()> {
     }
 }
 
+// --- oom_score_adj: bias the kernel OOM killer toward host work ----------------
+
+/// The `oom_score_adj` stamped on every exec child. A positive bias makes the
+/// kernel's GLOBAL OOM killer sacrifice a runaway child (and its descendants,
+/// which inherit the value on fork) before the supervisor, which stays at its
+/// default. Raising the value is unprivileged-legal; the mid-range 500 is a strong
+/// bias without pinning the child as the unconditional first victim.
+#[cfg(target_os = "linux")]
+const EXEC_OOM_SCORE_ADJ: i32 = 500;
+
+/// Guards the "log once" of an `oom_score_adj` write failure so a restrictive host
+/// policy is reported once, not per exec.
+#[cfg(target_os = "linux")]
+static OOM_SCORE_ADJ_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Raises `/proc/<pid>/oom_score_adj` on a freshly-spawned exec child so the kernel
+/// OOM killer prefers it over the control supervisor (issue #345). Composes with
+/// the per-op cgroup: this biases the GLOBAL kernel OOM killer, the cgroup gives
+/// systemd-oomd a bounded scope — both apply. Best-effort: a failure (the child
+/// already exited, or a locked-down policy) is logged once and ignored.
+#[cfg(target_os = "linux")]
+pub(crate) fn raise_exec_oom_score_adj(pid: u32) {
+    let path = format!("/proc/{pid}/oom_score_adj");
+    if let Err(error) = std::fs::write(&path, EXEC_OOM_SCORE_ADJ.to_string()) {
+        if !OOM_SCORE_ADJ_WARNED.swap(true, Ordering::Relaxed) {
+            tracing::info!(
+                %error,
+                pid,
+                target = EXEC_OOM_SCORE_ADJ,
+                "could not raise exec child oom_score_adj; continuing (logged once)"
+            );
+        }
+    }
+}
+
 // --- Pure, cross-platform helpers (unit-tested on any host) -------------------
 
 /// Extracts the cgroup v2 unified path from `/proc/self/cgroup` — the path after

--- a/agent/crates/opengeni-agent-platform/src/lib.rs
+++ b/agent/crates/opengeni-agent-platform/src/lib.rs
@@ -30,6 +30,7 @@
 
 #![doc(html_root_url = "https://docs.rs/opengeni-agent-platform")]
 
+mod cgroup;
 mod desktop;
 mod error;
 mod native;
@@ -53,6 +54,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use opengeni_agent_proto::v1;
 
+pub use cgroup::{establish_oom_isolation, OpCgroupConfig, OpCgroups};
 pub use desktop::{
     fit_frame_to_budget, resolve_desktop, CapturedFrame, DesktopBackend, FittedFrame, NoDesktop,
 };

--- a/agent/crates/opengeni-agent-platform/src/native.rs
+++ b/agent/crates/opengeni-agent-platform/src/native.rs
@@ -192,6 +192,15 @@ impl ExecProcessGroup {
             }
         };
 
+        // Bias the kernel's global OOM killer toward this child (and its inheriting
+        // descendants) so a runaway command is sacrificed before the supervisor.
+        // Always applied on Linux — independent of, and composing with, the per-op
+        // cgroup below (which bounds systemd-oomd's scope).
+        #[cfg(target_os = "linux")]
+        if let Some(child_pid) = child.id() {
+            crate::cgroup::raise_exec_oom_score_adj(child_pid);
+        }
+
         // Place the requested child AND the group anchor into a per-op memory leaf
         // so they share one OOM fate, isolated from the control supervisor. The tiny
         // window between spawn and this move is the accepted post-spawn billing
@@ -1270,6 +1279,49 @@ mod tests {
         let _ = exec_task.await;
 
         assert_process_exits(descendant_pid, "cancelled exec").await;
+    }
+
+    /// Every exec child is stamped `oom_score_adj=500` so the kernel OOM killer
+    /// sacrifices a runaway command before the supervisor (issue #345). This needs
+    /// no cgroup delegation (raising is always unprivileged-legal), so it runs on
+    /// any Linux host. The direct child (the fixture) reports its own PID — the one
+    /// the exec path stamps — and holds it alive long enough to read the value.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn exec_child_gets_raised_oom_score_adj() {
+        let (platform, dir) = rooted();
+        let pid_file = dir.path().join("oom-score-child.pid");
+        let req = ExecRequest {
+            command: descendant_command("native::tests::exec_descendant_fixture"),
+            shell: false,
+            env: descendant_exec_env(&pid_file),
+            timeout_ms: 5_000,
+            ..Default::default()
+        };
+        let platform = Arc::new(platform);
+        let task_platform = platform.clone();
+        let exec_task = tokio::spawn(async move { task_platform.exec(&req).await });
+
+        let child_pid = recorded_pid(&pid_file).await;
+        // The stamp is written post-spawn, so poll briefly for the raised value
+        // rather than assume it landed before the fixture published its PID.
+        let oom_path = format!("/proc/{child_pid}/oom_score_adj");
+        let mut observed = String::new();
+        for _ in 0..200 {
+            if let Ok(text) = tokio::fs::read_to_string(&oom_path).await {
+                observed = text.trim().to_string();
+                if observed == "500" {
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        exec_task.abort();
+        let _ = exec_task.await;
+        assert_eq!(
+            observed, "500",
+            "exec child {child_pid} must have oom_score_adj=500, saw {observed:?}"
+        );
     }
 
     #[tokio::test]

--- a/agent/crates/opengeni-agent-platform/src/native.rs
+++ b/agent/crates/opengeni-agent-platform/src/native.rs
@@ -17,6 +17,7 @@ use command_group::{AsyncCommandGroup, AsyncGroupChild};
 use opengeni_agent_proto::v1;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
+use crate::cgroup::OpCgroups;
 use crate::desktop::{resolve_desktop, DesktopBackend};
 use crate::error::{PlatformError, PlatformResult};
 use crate::{HostIdentity, Platform, StreamRegistry};
@@ -36,6 +37,11 @@ pub struct NativePlatform {
     /// agent supervisor once it has a relay connection. `None` until then (and in
     /// unit contexts), in which case the stream ops report a clean `Unsupported`.
     stream_registry: Option<Arc<dyn StreamRegistry>>,
+    /// The per-op OOM cgroup manager, wired by the supervisor at startup on a
+    /// delegated Linux cgroup v2 host (issue #345). `None` until then (and on every
+    /// non-Linux / non-delegated host), in which case exec runs with no per-op
+    /// memory isolation — its children still get a raised `oom_score_adj`.
+    cgroups: Option<Arc<OpCgroups>>,
 }
 
 impl std::fmt::Debug for NativePlatform {
@@ -44,6 +50,7 @@ impl std::fmt::Debug for NativePlatform {
             .field("workspace_root", &self.workspace_root)
             .field("has_display", &self.desktop.probe().is_some())
             .field("has_stream_registry", &self.stream_registry.is_some())
+            .field("has_oom_isolation", &self.cgroups.is_some())
             .finish()
     }
 }
@@ -65,6 +72,7 @@ impl NativePlatform {
             workspace_root,
             desktop: Arc::from(resolve_desktop()),
             stream_registry: None,
+            cgroups: None,
         }
     }
 
@@ -76,6 +84,7 @@ impl NativePlatform {
             workspace_root: workspace_root.into(),
             desktop: Arc::from(resolve_desktop()),
             stream_registry: None,
+            cgroups: None,
         }
     }
 
@@ -85,6 +94,16 @@ impl NativePlatform {
     #[must_use]
     pub fn with_stream_registry(mut self, registry: Arc<dyn StreamRegistry>) -> Self {
         self.stream_registry = Some(registry);
+        self
+    }
+
+    /// Returns a copy of this platform with a per-op OOM cgroup manager wired in, so
+    /// each `exec` child is placed in its own memory sub-cgroup (issue #345). Called
+    /// by the agent supervisor at startup after [`crate::establish_oom_isolation`]
+    /// succeeds on a delegated Linux cgroup v2 host; left unset everywhere else.
+    #[must_use]
+    pub fn with_oom_isolation(mut self, cgroups: Arc<OpCgroups>) -> Self {
+        self.cgroups = Some(cgroups);
         self
     }
 
@@ -138,11 +157,18 @@ struct ExecProcessGroup {
     child: tokio::process::Child,
     pgid: i32,
     running: bool,
+    /// The per-op memory leaf this exec's processes were placed in (issue #345),
+    /// or `None` when isolation is unavailable. Torn down once the process tree is
+    /// reaped. Always `None` off Linux (no manager is ever wired there).
+    op_cgroup: Option<crate::cgroup::OpCgroupHandle>,
 }
 
 #[cfg(unix)]
 impl ExecProcessGroup {
-    fn spawn(mut command: tokio::process::Command) -> std::io::Result<Self> {
+    fn spawn(
+        mut command: tokio::process::Command,
+        cgroups: Option<&OpCgroups>,
+    ) -> std::io::Result<Self> {
         let mut anchor_command = tokio::process::Command::new("/bin/sh");
         anchor_command
             .arg("-c")
@@ -166,11 +192,22 @@ impl ExecProcessGroup {
             }
         };
 
+        // Place the requested child AND the group anchor into a per-op memory leaf
+        // so they share one OOM fate, isolated from the control supervisor. The tiny
+        // window between spawn and this move is the accepted post-spawn billing
+        // window — pre_exec placement is async-signal-unsafe and deliberately not
+        // used. A no-op when `cgroups` is `None` (isolation unavailable / off Linux).
+        let op_cgroup = cgroups.and_then(|cg| {
+            let pids: Vec<u32> = [anchor.id(), child.id()].into_iter().flatten().collect();
+            cg.place_op(&pids)
+        });
+
         Ok(Self {
             anchor,
             child,
             pgid,
             running: true,
+            op_cgroup,
         })
     }
 
@@ -210,28 +247,41 @@ impl ExecProcessGroup {
         // and Drop will not signal the now-recyclable numeric PGID.
         let _ = self.anchor.wait().await?;
         self.running = false;
-        Ok(ExecOutput {
+        let output = ExecOutput {
             exit_code: status.code().unwrap_or(-1),
             stdout,
             stderr,
-        })
+        };
+        // The process tree is reaped, so the op leaf can be removed now (bounded
+        // EBUSY retry). Taking the handle here means Drop below won't touch it.
+        if let Some(handle) = self.op_cgroup.take() {
+            handle.teardown().await;
+        }
+        Ok(output)
     }
 }
 
 #[cfg(unix)]
 impl Drop for ExecProcessGroup {
     fn drop(&mut self) {
-        if !self.running || self.anchor.id().is_none() {
-            return;
-        }
-        if let Err(error) = self.terminate() {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(
-                    group_id = self.pgid,
-                    %error,
-                    "failed to terminate cancelled exec process group"
-                );
+        if self.running && self.anchor.id().is_some() {
+            if let Err(error) = self.terminate() {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        group_id = self.pgid,
+                        %error,
+                        "failed to terminate cancelled exec process group"
+                    );
+                }
             }
+        }
+        // A cancelled/timed-out exec drops here with its op leaf still present: the
+        // group was just SIGKILL'd but its processes reap asynchronously, so this
+        // best-effort rmdir usually leaves an (eventually empty) leaf that the next
+        // unit stop reclaims. On the normal path the handle was already taken and
+        // torn down in wait_with_output, so this is a no-op there.
+        if let Some(handle) = self.op_cgroup.take() {
+            handle.teardown_best_effort();
         }
     }
 }
@@ -372,7 +422,7 @@ impl Platform for NativePlatform {
 
         let started = Instant::now();
         #[cfg(unix)]
-        let mut child = ExecProcessGroup::spawn(cmd)
+        let mut child = ExecProcessGroup::spawn(cmd, self.cgroups.as_deref())
             .map_err(|e| PlatformError::from_io(&format!("spawn {}", req.command[0]), &e))?;
         #[cfg(windows)]
         let mut child = {

--- a/agent/crates/opengeni-agent-platform/src/service.rs
+++ b/agent/crates/opengeni-agent-platform/src/service.rs
@@ -137,6 +137,17 @@ pub fn render_systemd_unit(spec: &ServiceSpec) -> String {
          # A clean stop sends SIGTERM so the agent emits its going-offline message.\n\
          KillSignal=SIGTERM\n\
          TimeoutStopSec=15\n\
+         # OOM fate isolation (issue #345). Delegate a cgroup subtree so the agent can\n\
+         # place each host exec in its own memory sub-cgroup (see cgroup.rs), keeping a\n\
+         # runaway command from making the heartbeat/control supervisor the OOM victim.\n\
+         # ManagedOOMPreference=avoid biases systemd-oomd away from selecting this unit\n\
+         # for a whole-unit kill; MemoryHigh throttles the unit under sustained\n\
+         # pressure (and turns on the memory accounting the delegated sub-cgroups need)\n\
+         # instead of letting the kernel SIGKILL the supervisor. Linux-only directives;\n\
+         # they are inert on the macOS/Windows service backends.\n\
+         Delegate=yes\n\
+         ManagedOOMPreference=avoid\n\
+         MemoryHigh=75%\n\
          \n\
          [Install]\n\
          WantedBy={wanted_by}\n"
@@ -303,6 +314,32 @@ mod tests {
         s.scope = ServiceScope::System;
         let unit = render_systemd_unit(&s);
         assert!(unit.contains("WantedBy=multi-user.target"));
+    }
+
+    #[test]
+    fn systemd_unit_carries_oom_fate_isolation_directives_in_both_scopes() {
+        // Issue #345: both the user and the system unit must delegate a cgroup
+        // subtree, bias systemd-oomd away from a whole-unit kill, and set a memory
+        // high-watermark (which also enables the accounting the sub-cgroups need).
+        // These live in [Service], never [Unit] or [Install].
+        for scope in [ServiceScope::User, ServiceScope::System] {
+            let mut s = spec();
+            s.scope = scope;
+            let unit = render_systemd_unit(&s);
+            let service_start = unit.find("[Service]").expect("service section");
+            let install_start = unit.find("[Install]").expect("install section");
+            let service_section = &unit[service_start..install_start];
+            for directive in [
+                "Delegate=yes",
+                "ManagedOOMPreference=avoid",
+                "MemoryHigh=75%",
+            ] {
+                assert!(
+                    service_section.contains(directive),
+                    "{scope:?} unit [Service] must contain {directive}; got:\n{unit}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/agent/crates/opengeni-agent-platform/tests/cgroup_placement.rs
+++ b/agent/crates/opengeni-agent-platform/tests/cgroup_placement.rs
@@ -1,0 +1,198 @@
+//! Live cgroup-placement integration test for OOM fate isolation (issue #345).
+//!
+//! Exercises the REAL path — [`establish_oom_isolation`] runs the startup dance
+//! and a real `exec` places its child into an `op-<n>` memory leaf — then asserts
+//! the child lands in that leaf with `oom_score_adj=500` while the supervisor (this
+//! process) stays in the `supervisor` leaf.
+//!
+//! # Why it is environment-gated
+//!
+//! The dance MOVES this process's own cgroup and enables a controller, which only
+//! works in a delegated cgroup v2 service cgroup where this process is the SOLE
+//! member. A shared or non-delegated cgroup (a normal `cargo test`, most CI) fails
+//! the gate and the test SKIPS LOUDLY without mutating anything. To run the
+//! positive path, launch the test binary alone in a delegated scope, e.g.:
+//!
+//! ```text
+//! bin=$(cargo test -p opengeni-agent-platform --test cgroup_placement --no-run \
+//!         --message-format=json | jq -r 'select(.executable!=null).executable')
+//! systemd-run --user --scope -p Delegate=yes -p MemoryAccounting=yes -- \
+//!   "$bin" --exact child_lands_in_op_cgroup_supervisor_stays_isolated --nocapture
+//! ```
+//!
+//! Off Linux the whole test compiles to a loud skip (isolation is Linux-only).
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn cgroup_placement_is_linux_only() {
+    eprintln!(
+        "SKIP: per-op cgroup placement is a Linux cgroup v2 feature; nothing to verify on this OS"
+    );
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    use opengeni_agent_platform::{
+        establish_oom_isolation, NativePlatform, OpCgroupConfig, Platform,
+    };
+    use opengeni_agent_proto::v1::ExecRequest;
+
+    /// The cgroup v2 unified path (after the `0::` prefix) for a PID's cgroup file.
+    fn unified_cgroup_of(cgroup_file: &str) -> Option<String> {
+        cgroup_file
+            .lines()
+            .find_map(|line| line.strip_prefix("0::"))
+            .map(|p| p.trim().to_string())
+    }
+
+    /// Read-only gate: returns the service cgroup dir only when this process is the
+    /// SOLE member of a delegated cgroup v2 service cgroup with the memory
+    /// controller available — i.e. it is safe to run the (mutating) startup dance
+    /// here. Everything else (shared cgroup, no delegation, no cgroup v2) returns
+    /// `None` and the caller skips WITHOUT touching any cgroup.
+    fn delegated_and_isolated() -> Option<PathBuf> {
+        let mount = Path::new("/sys/fs/cgroup");
+        if !mount.join("cgroup.controllers").exists() {
+            return None;
+        }
+        let proc_cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+        let unified = unified_cgroup_of(&proc_cgroup)?;
+        if unified == "/" || unified.is_empty() {
+            return None;
+        }
+        let dir = mount.join(unified.trim_start_matches('/'));
+        let controllers = std::fs::read_to_string(dir.join("cgroup.controllers")).ok()?;
+        if !controllers.split_whitespace().any(|c| c == "memory") {
+            return None;
+        }
+        // Sole-member check: refuse to move a cgroup we share with other processes.
+        let procs = std::fs::read_to_string(dir.join("cgroup.procs")).ok()?;
+        let members: Vec<&str> = procs.split_whitespace().collect();
+        let me = std::process::id().to_string();
+        if members != [me.as_str()] {
+            return None;
+        }
+        Some(dir)
+    }
+
+    #[tokio::test]
+    async fn child_lands_in_op_cgroup_supervisor_stays_isolated() {
+        let Some(service_dir) = delegated_and_isolated() else {
+            eprintln!(
+                "SKIP: not the sole member of a delegated cgroup v2 service cgroup; \
+                 re-run the binary alone under `systemd-run --user --scope -p Delegate=yes` \
+                 to exercise the live placement path (see the module docs)"
+            );
+            return;
+        };
+
+        // Run the REAL startup dance: this moves us into `<service>/supervisor` and
+        // delegates the memory controller to per-op leaves.
+        let cgroups = establish_oom_isolation(OpCgroupConfig::default())
+            .expect("delegated + isolated cgroup should establish per-op isolation");
+        let platform = std::sync::Arc::new(
+            NativePlatform::with_root(std::env::temp_dir()).with_oom_isolation(cgroups),
+        );
+
+        // The supervisor (this process) must now live in the `supervisor` leaf.
+        let self_cgroup =
+            std::fs::read_to_string("/proc/self/cgroup").expect("read own cgroup after dance");
+        let self_unified = unified_cgroup_of(&self_cgroup).expect("own unified cgroup");
+        assert!(
+            self_unified.ends_with("/supervisor"),
+            "supervisor must be fate-isolated in its own leaf, got {self_unified}"
+        );
+
+        // Run a real exec whose direct child reports its PID and stays alive (a pure
+        // shell busy-loop — no coreutil dependency) so we can inspect it live.
+        let pid_file = std::env::temp_dir().join(format!("oom-itest-{}.pid", std::process::id()));
+        let _ = std::fs::remove_file(&pid_file);
+        let req = ExecRequest {
+            command: vec![format!(
+                "echo $$ > {}; while :; do :; done",
+                pid_file.display()
+            )],
+            shell: true,
+            ..Default::default()
+        };
+        let task_platform = platform.clone();
+        let exec_task = tokio::spawn(async move { task_platform.exec(&req).await });
+
+        let child_pid = read_child_pid(&pid_file).await;
+
+        // Placement is post-spawn, so poll the child's cgroup + score for the target.
+        let child_unified = poll_child_cgroup(child_pid).await;
+        let score = std::fs::read_to_string(format!("/proc/{child_pid}/oom_score_adj"))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        exec_task.abort();
+        let _ = exec_task.await;
+        let _ = std::fs::remove_file(&pid_file);
+
+        eprintln!("LIVE EVIDENCE (issue #345 OOM fate isolation):");
+        eprintln!("  supervisor (this process) cgroup: {self_unified}");
+        eprintln!("  exec child {child_pid} cgroup:      {child_unified}");
+        eprintln!("  exec child {child_pid} oom_score_adj: {score}");
+
+        assert!(
+            child_unified.contains("/op-"),
+            "exec child {child_pid} must run in an op-<n> leaf, got {child_unified}"
+        );
+        assert!(
+            child_unified.starts_with(&self_unified[..self_unified.len() - "/supervisor".len()]),
+            "the op leaf must be a sibling of the supervisor leaf under the service cgroup \
+             ({child_unified} vs {self_unified})"
+        );
+        assert_eq!(
+            score, "500",
+            "exec child {child_pid} must carry oom_score_adj=500"
+        );
+
+        // The op leaf is a real child of the resolved service cgroup.
+        assert!(
+            service_dir
+                .join(child_unified.rsplit('/').next().expect("op leaf name"))
+                .exists(),
+            "the op leaf {child_unified} should exist under {}",
+            service_dir.display()
+        );
+    }
+
+    /// Waits for the child fixture to publish its PID (bounded), then parses it.
+    async fn read_child_pid(pid_file: &Path) -> u32 {
+        for _ in 0..200 {
+            if let Ok(raw) = tokio::fs::read_to_string(pid_file).await {
+                if let Ok(pid) = raw.trim().parse::<u32>() {
+                    return pid;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "child fixture never published its PID to {}",
+            pid_file.display()
+        );
+    }
+
+    /// Polls the child's unified cgroup path until it is placed in an op leaf (the
+    /// move is post-spawn), returning the last observed value.
+    async fn poll_child_cgroup(child_pid: u32) -> String {
+        let mut last = String::new();
+        for _ in 0..200 {
+            if let Ok(text) = tokio::fs::read_to_string(format!("/proc/{child_pid}/cgroup")).await {
+                if let Some(unified) = unified_cgroup_of(&text) {
+                    last = unified;
+                    if last.contains("/op-") {
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        last
+    }
+}

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -217,6 +217,16 @@ async fn run(args: RunArgs, api_url: &str) -> anyhow_lite::Result {
         enroll_command(enroll_args, api_url).await?
     };
 
+    // Establish per-op OOM cgroup isolation (issue #345) BEFORE spawning any
+    // agent-infra child (e.g. Xvfb below): the startup dance moves the agent into a
+    // `supervisor` cgroup leaf, so children spawned afterward inherit that leaf and
+    // only host execs land in their own per-op memory leaves. Returns None (a
+    // logged, graceful no-op) off a delegated Linux cgroup v2 host — the agent then
+    // serves exactly as before, with no per-op isolation.
+    let op_cgroups = opengeni_agent_platform::establish_oom_isolation(
+        opengeni_agent_platform::OpCgroupConfig::from_env(),
+    );
+
     // Opt-in Xvfb for a headless Linux box (`--virtual-desktop`). Held for the run
     // lifetime; dropping it (on stop) tears the virtual display down. Linux-only.
     let _virtual_desktop = maybe_spawn_virtual_desktop(&args);
@@ -232,7 +242,12 @@ async fn run(args: RunArgs, api_url: &str) -> anyhow_lite::Result {
     });
     // Build the platform with the relay registrar wired; its desktop backend is
     // (re)resolved against the now-present $DISPLAY (a real screen or the Xvfb one).
-    let platform = Arc::new(NativePlatform::new().with_stream_registry(Arc::new(hub)));
+    // Wire the per-op cgroup manager in when the startup dance established one.
+    let mut platform = NativePlatform::new().with_stream_registry(Arc::new(hub));
+    if let Some(cgroups) = op_cgroups {
+        platform = platform.with_oom_isolation(cgroups);
+    }
+    let platform = Arc::new(platform);
 
     let supervisor = Supervisor::new(platform.clone(), creds, env!("CARGO_PKG_VERSION"));
     let shutdown = supervisor.shutdown_handle();


### PR DESCRIPTION
# Fate-isolate the Connected Machine supervisor from host-work OOM (per-op cgroups)

Closes part of #345.

## Problem

The control supervisor (heartbeat + `ping`) and every native `exec` descendant
share ONE systemd service cgroup. On a swapless host under memory pressure,
`systemd-oomd` — or the kernel OOM killer — selects that cgroup and SIGKILLs the
whole unit, taking the supervisor down with a runaway command. Bounded concurrency
is not resource-aware and gives no process/cgroup **fate** isolation.

## What this PR does (Linux cgroup v2 only)

The least-privileged mechanism the issue asks us to choose: **per-op memory
sub-cgroups under a user-or-system-delegated service cgroup**, plus an
unprivileged `oom_score_adj` bias. No root, no `CAP_SYS_RESOURCE`, no new
privileged helper.

1. **Unit template hardening** (`service.rs`). Both the user and system systemd
   units now render `Delegate=yes`, `ManagedOOMPreference=avoid`, and
   `MemoryHigh=75%`. Delegation gives us a writable subtree; `ManagedOOMPreference`
   biases `systemd-oomd` away from a whole-unit kill; `MemoryHigh` throttles under
   sustained pressure and turns on the memory accounting the sub-cgroups need.
2. **Per-op sub-cgroup module** (`cgroup.rs`). At startup the agent runs the
   cgroup v2 no-internal-processes dance — move itself into a `<service>/supervisor`
   leaf, then enable the memory controller in `<service>/cgroup.subtree_control`.
   Each `exec` then places its child **and** the #344 process-group anchor into a
   fresh `<service>/op-<n>` memory leaf (optional `memory.max`/`memory.high` from
   `OPENGENI_AGENT_OP_MEMORY_MAX`/`_HIGH`, default unset). The leaf is `rmdir`'d
   once the process tree is reaped, tolerating a transient `EBUSY` with a bounded
   retry; a leaked empty leaf is cosmetic and reclaimed on the next unit stop.
3. **`oom_score_adj`** (`cgroup.rs` + `native.rs`). Every exec child is stamped
   `oom_score_adj=500` post-spawn (inherited by descendants on fork), so even the
   kernel's GLOBAL OOM killer sacrifices a runaway child before the supervisor,
   which stays at its default. This composes with (2) and works even when cgroup
   delegation is unavailable.

**Fallback ladder — never fail to serve.** Not Linux, no cgroup v2, the memory
controller not delegated, or any `EPERM`/IO error: the reason is logged **once**
and the agent keeps serving exactly as before (all work in the service cgroup, no
per-op isolation). Isolation being unavailable must never stop the agent answering
control RPCs.

## Which #345 invariants this PR satisfies

- **"Accepted native work cannot make the supervisor an OOM victim merely because
  it shares the service cgroup."** — Satisfied: per-op memory leaves + a dedicated
  supervisor leaf + the `oom_score_adj` bias.
- **"Each request has enforceable memory limits or an equivalently isolated work
  scope; one request cannot consume the supervisor budget."** — Satisfied: each
  exec runs in its own memory leaf (optional hard cap), and the supervisor's own
  leaf is never in that scope.
- **"Deadline/cancellation cleanup (#343) remains complete across the new scope
  boundary."** — Satisfied: the op leaf holds the child + the #344 anchor (one PGID
  tree, one memory fate); teardown runs on normal completion, timeout, and cancel,
  and the #344 group-kill is unchanged.
- **"Restart/reconnect semantics and enrollment identity remain unchanged."** —
  Satisfied: establish is a startup-only, pre-serve step; connect/hello/epoch and
  enrollment are untouched; the fallback keeps the agent serving.
- **"Cross-platform behavior is explicit."** — Satisfied: **Linux-only** guarantee.
  macOS/Windows are a documented no-op (`establish_oom_isolation` returns `None`,
  no cgroup is touched, `oom_score_adj` is skipped).
- **"Structured diagnostics without logging command contents."** — The isolation
  lifecycle (establish result, once-logged fallback reasons, teardown) is
  structured `tracing`; no command contents are ever logged.

## Explicitly complementary (NOT in this PR)

`#345` also asks for resource-aware **admission** (typed retryable backpressure
before starting work when a supervisor reserve / machine budget would be violated)
and heartbeat **metric fields** (admission rejections, cgroup peaks). Those are a
separate lever: admission is enforced in the supervisor's work pool, and new metric
fields would touch the shared wire proto. This PR builds the isolation substrate
they sit on; it does not add or change admission or the metrics proto.

## Rollout note (from the unit change)

Existing installs keep their **old** unit file until it is re-rendered — the new
`Delegate=yes` / `MemoryHigh=` directives only take effect after
`opengeni-agent service install` re-renders the unit (and `systemctl daemon-reload`
+ restart). The rollout runbook must refresh the unit on already-enrolled service
installs. Follow-up: teach `self-update` to refresh the unit automatically.

Until the unit is re-rendered, the agent still runs safely: on a unit without
`Delegate=yes` the memory controller is not delegated, `establish_oom_isolation`
logs the reason once and returns `None`, and the agent serves with today's behavior
plus the always-on `oom_score_adj` bias (which needs no delegation).

## Linux-only guarantee

Per the issue's cross-platform requirement: the cgroup dance and `oom_score_adj`
are Linux cgroup v2 features. On macOS/Windows this PR is a compile-time no-op and
promises nothing; the systemd directives are inert on the launchd/SCM backends.

## Tests + verification

- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt
  --check`: clean. Full workspace `cargo test`: green.
- Unit tests: renderer snapshots assert the OOM directives are in `[Service]` for
  both scopes; cgroup path-derivation / `/proc/self/cgroup` parsing / controller
  parsing / config-from-env / fallback helpers.
- `oom_score_adj`: a Linux test runs a real exec and reads the child's live
  `/proc/<pid>/oom_score_adj == 500` (no cgroup delegation required).
- Env-gated integration test (`tests/cgroup_placement.rs`): runs the real startup
  dance + a real exec and asserts the child lands in an `op-<n>` leaf with
  `oom_score_adj=500` while the supervisor stays in `supervisor/`. It self-skips
  loudly unless the process is the sole member of a delegated cgroup v2 service
  cgroup (normal `cargo test` / CI skip without mutating anything).

### Live evidence (delegated `systemd-run --user --scope`)

Integration test, run alone in a delegated scope:

```
supervisor (this process) cgroup: .../run-<scope>.scope/supervisor
exec child <pid> cgroup:          .../run-<scope>.scope/op-0
exec child <pid> oom_score_adj:   500
```

Real `opengeni-agent run` binary, run in a delegated scope, at startup:

```
INFO established per-op OOM cgroup isolation: host execs run in memory sub-cgroups;
     the control supervisor is fate-isolated in its own leaf
     service_cgroup=.../oom-verify-agent-<pid>.scope memory_max=None memory_high=None
# and the agent process's own cgroup:
0::/.../oom-verify-agent-<pid>.scope/supervisor
```
