### PR TITLE
feat(chart): enable worker autoscaling + right-size worker memory on managed profile

### DIFF
--- a/deploy/helm/opengeni/templates/worker-hpa.yaml
+++ b/deploy/helm/opengeni/templates/worker-hpa.yaml
@@ -20,4 +20,28 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ ((.Values.worker).autoscaling).targetCPUUtilizationPercentage }}
+    {{- if ((.Values.worker).autoscaling).targetMemoryUtilizationPercentage }}
+    # The worker is MEMORY bound, not CPU bound: each pod holds the full
+    # in-turn conversation history for every session it runs, so pods approach
+    # the memory limit (and OOM) long before CPU saturates. Memory is the
+    # signal that actually tracks the pressure; keep the target high (headroom)
+    # and pair it with the scaleDown stabilization in `behavior` so a transient
+    # dip never evicts a pod mid-turn.
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ ((.Values.worker).autoscaling).targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with ((.Values.worker).autoscaling).customMetrics }}
+    # Optional custom/external metrics (needs a Prometheus adapter). A
+    # session-count or Temporal task-queue-backlog metric tracks worker load
+    # better than CPU; wire it here once the adapter is available.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with ((.Values.worker).autoscaling).behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -15,18 +15,21 @@ worker:
   # session holding its full in-turn history (observed up to ~345k input
   # tokens). Pods were OOMKilled (exit 137) against the 4Gi chart default
   # repeatedly under fleet load; peak is spiky because serializing a large run
-  # state transiently copies it. Raise the limit for real headroom and raise
-  # the request toward the steady-state footprint so (a) the scheduler reserves
-  # realistically and (b) the memory-utilization HPA below is meaningful — HPA
-  # memory utilization is measured against the REQUEST, so a 1Gi request would
-  # read >100% and peg the HPA at max on the first sample.
+  # state transiently copies it. Raise the limit to 6Gi (50% over the observed
+  # kill point) and raise the request toward the steady-state footprint so
+  # (a) the scheduler reserves realistically and (b) the memory-utilization HPA
+  # below is meaningful — HPA memory utilization is measured against the
+  # REQUEST, so a 1Gi request would read >100% and peg the HPA at max on the
+  # first sample. 6Gi (not 8Gi) keeps headroom on the ~16Gi nodes for api/relay/
+  # system pods; once proactive context compaction is fixed the histories — and
+  # thus this footprint — shrink further.
   resources:
     requests:
       cpu: 500m
       memory: 3Gi
     limits:
       cpu: "2"
-      memory: 8Gi
+      memory: 6Gi
   # Worker autoscaling was never enabled on this managed profile (the chart
   # default is enabled:false and only relay opted in), so production ran a
   # fixed 2 replicas while the fleet grew — the ~27-session load could not
@@ -38,10 +41,13 @@ worker:
   # and earlier context compaction are what prevent a single-pod OOM. The
   # scaleDown stabilization keeps a transient dip from evicting a pod mid-turn
   # (the 120s termination grace + PDB minAvailable:1 requeue survivors, but the
-  # graceful path loses less).
+  # graceful path loses less). minReplicas is 3, not 2: two pods at ~13 fat
+  # sessions each is exactly the density that OOMed, so the floor is cheap
+  # insurance that de-densifies deterministically without waiting on HPA
+  # scale-up (which only lands new sessions on new pods).
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 20
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80

--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -10,6 +10,55 @@ worker:
   image:
     tag: "RELEASE_TAG"
     digest: "sha256:WORKER_IMAGE_DIGEST"
+  # Memory sizing grounded in production measurement (2026-07-10): a single
+  # worker pod runs ~13 concurrent sessions plus ~17 sandbox clients, each
+  # session holding its full in-turn history (observed up to ~345k input
+  # tokens). Pods were OOMKilled (exit 137) against the 4Gi chart default
+  # repeatedly under fleet load; peak is spiky because serializing a large run
+  # state transiently copies it. Raise the limit for real headroom and raise
+  # the request toward the steady-state footprint so (a) the scheduler reserves
+  # realistically and (b) the memory-utilization HPA below is meaningful — HPA
+  # memory utilization is measured against the REQUEST, so a 1Gi request would
+  # read >100% and peg the HPA at max on the first sample.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 3Gi
+    limits:
+      cpu: "2"
+      memory: 8Gi
+  # Worker autoscaling was never enabled on this managed profile (the chart
+  # default is enabled:false and only relay opted in), so production ran a
+  # fixed 2 replicas while the fleet grew — the ~27-session load could not
+  # spread. Enable it here. The worker is MEMORY bound, not CPU bound (CPU
+  # stayed well under target while pods OOMed), so memory is the primary signal
+  # with CPU as a secondary load valve. Caveats this does NOT solve on its own,
+  # documented for operators: HPA scale-up is laggy and new pods only take NEW
+  # sessions, so it cannot rescue an already-hot pod — the limit headroom above
+  # and earlier context compaction are what prevent a single-pod OOM. The
+  # scaleDown stabilization keeps a transient dip from evicting a pod mid-turn
+  # (the 120s termination grace + PDB minAvailable:1 requeue survivors, but the
+  # graceful path loses less).
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+    customMetrics: []
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 60
+        policies:
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 600
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 300
 
 web:
   image:

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -261,6 +261,16 @@ worker:
     minReplicas: 2
     maxReplicas: 20
     targetCPUUtilizationPercentage: 70
+    # The worker is memory bound (each pod holds the full in-turn history for
+    # every session it runs), so CPU alone is a poor scaling signal — pods OOM
+    # long before CPU saturates. Set a memory target to scale on the pressure
+    # that actually matters; keep it high (headroom) and pair with a scaleDown
+    # stabilization window in `behavior` so a transient dip never evicts a pod
+    # mid-turn. Left null here so the default (disabled) install is unchanged;
+    # managed profiles opt in.
+    targetMemoryUtilizationPercentage: null
+    customMetrics: []
+    behavior: {}
 
 web:
   enabled: true


### PR DESCRIPTION
## Enable worker autoscaling + right-size worker memory on the managed profile

Production worker pods were **OOMKilled (exit 137) repeatedly** under fleet load on 2026-07-10, hard-stalling every session on the killed pod (Temporal reschedules + replays the in-flight turns onto the surviving worker). This is the top reliability finding from the prod perf audit.

### Why the worker HPA wasn't running (investigated first)

**A plain gap, not a deliberate disable.** The chart default is `worker.autoscaling.enabled: false` (unchanged since the first production-foundation commit `8802d703`). When the relay tier was added, the managed profile (`values.azure-managed.example.yaml`) opted **relay** into autoscaling but never added a `worker.autoscaling` block, so the worker inherited the disabled default. There is no flapping note, disable PR, or comment anywhere — the `relay:` block enables autoscaling three lines below a `worker:` block that only carries an image tag. Production therefore ran a fixed **2 worker replicas** while the fleet grew to ~27 concurrent sessions, and the load could not spread.

(Verified: production is a real helm release created at bootstrap, but day-to-day deploys are imperative `kubectl set image` — see the deploy note below.)

### What this changes (all additive, managed profile only)

1. **`templates/worker-hpa.yaml`** — extend the worker HPA to support an optional **memory** metric + optional `customMetrics` + `behavior`, mirroring the existing relay HPA. Backward-compatible: installs that enable worker autoscaling without a memory target get the exact CPU-only HPA as before (verified with `helm template`).
2. **`values.yaml`** — add the new optional keys to `worker.autoscaling` with defaults that keep the disabled default install byte-identical (`targetMemoryUtilizationPercentage: null`, `customMetrics: []`, `behavior: {}`).
3. **`values.azure-managed.example.yaml`** — enable worker autoscaling and right-size worker memory (details below).

`helm lint` clean; `helm template` verified for: managed profile (CPU+memory+behavior render), default install (no worker HPA, no error), and enabled-without-memory-target (CPU-only, no error).

### Metric choice (the justification you asked for)

The worker is **memory bound, not CPU bound**: each pod holds the full in-turn conversation history for every session it runs (observed up to ~345k input tokens/session), so pods approach the memory limit long before CPU saturates — during the incident worker CPU sat at ~0.5–1.1 cores of a 2-core limit while memory hit the 4Gi ceiling. So **a CPU-only HPA would not have scaled during the OOM window.** Memory is the primary signal here; CPU stays as a secondary load valve for the CPU-bound 10x case.

Two honest caveats, documented inline for operators:
- **HPA memory utilization is measured against the pod REQUEST, not the limit.** The old 1Gi request against ~2.4–4Gi real usage would read >100% and peg the HPA at max on the first sample. So enabling a memory HPA *requires* raising the request toward the real footprint — done below.
- **HPA scale-up is laggy and new pods only take NEW sessions** (Temporal pull model), so it cannot rescue an already-hot pod. The single-pod OOM is prevented by the **limit headroom** (below) and by **earlier context compaction** (proposal below), not by the HPA. The HPA's job is to keep steady-state sessions/pod low enough that pods don't approach the limit in the first place.
- **Anti-flap / mid-turn protection:** `behavior.scaleDown` uses a 600s stabilization window + max 1 pod / 5 min; scaleUp is faster (2 pods / 60s). Combined with the existing 120s termination grace and PDB `minAvailable: 1`, a scale-down never yanks a pod mid-turn (survivors requeue, graceful checkpoint loses less).

### Memory limit/request review (grounded in measured numbers)

Measured 2026-07-10: one pod ran ~13 concurrent sessions + ~17 sandbox clients; sat at 2425Mi mid-life and climbing; OOMKilled at the 4Gi limit; both worker pods hit 4 OOM restarts across the window. Peak is spiky because serializing a large run state transiently copies it.

- **limit: 4Gi → 8Gi** (real headroom over the spiky serialize peaks).
- **request: 1Gi → 3Gi** (near steady-state; also makes the memory HPA meaningful, per the caveat above).

**Node-capacity check before deploy:** prod nodes are ~16Gi (observed 7676Mi ≈ 50%). At a 3Gi request the scheduler packs ~1–2 workers/node; the 6Gi limit is a ceiling reached only under spike. `topologySpreadConstraints` (already set) spreads workers and the cluster autoscaler added a node during the incident, so headroom exists — confirm the node pool can hold `maxReplicas` growth.

### Decisions (settled with reviewer)

- **`minReplicas`: 3.** Two pods at ~13 fat sessions each is exactly the density that OOMed; the floor de-densifies deterministically without waiting on HPA scale-up (which only lands new sessions on new pods).
- **limit: 6Gi** (not 8Gi), request 3Gi. 6Gi is 50% over the observed kill point and keeps headroom on ~16Gi nodes for api/relay/system pods; once compaction is fixed the histories shrink anyway.
- **memory target 80%:** with a 3Gi request this triggers scale-up at ~2.4Gi/pod avg — intentionally de-densifying toward more, smaller pods.

### (C) → shipped as a separate PR (B2): context-window per model

Root cause of the giant histories that drive the OOM: the compaction budget is calibrated for a ~1M-token model but the fleet runs `codex/gpt-5.6-*`. Defaults: `contextWindowTokens` 1,050,000, `contextReservedOutputTokens` 128,000 (→ input budget B ≈ 922k), soft-fraction 0.70 → **proactive compaction only fires at ~645k input tokens**, but the model hard-rejects at ~334–348k (`context_length_exceeded`) — so proactive compaction never fires on the codex path; only the reactive post-overflow backstop does. Fixed by declaring gpt-5.6's real window per model so the proactive trigger lands well below the cliff. Tracked in its own PR (no deploy; reviewer sequences).

### Deploy note (does NOT self-apply on the normal deploy)

The daily `deploy-production.yml` is imperative (`kubectl set image` / `set env` / `patch`) and will **not** create the HPA or change resources. This change lands only through the **helm/bootstrap path** (`helm upgrade --install opengeni ... -f values.azure-managed.example.yaml`), in a coordinated window (worker rolling restart → brief turn-redispatch churn), announced on the coordination ticket first. Reviewer runs it after merge.

### Verification plan (post-deploy)

- `kubectl -n opengeni get hpa opengeni-worker` exists; `REPLICAS` responds to load; `TARGETS` shows cpu + memory.
- Worker `RESTARTS` stop climbing; `kubectl describe` shows no new `OOMKilled`.
- `kubectl top pods` worker memory stays under the 8Gi limit with headroom; per-pod session count drops as replicas rise.
- No session-stall reports during the next heavy-fleet window.

### Rollback

Revert this commit and re-run the helm upgrade (or `kubectl delete hpa opengeni-worker` + `kubectl set resources`/patch back to 4Gi/1Gi). The HPA is additive; deleting it returns to the fixed 2-replica behavior immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq