### PR TITLE
fix(selfhosted): surface the exec-deadline hint on the stdout-only SDK path

### DIFF
--- a/.changeset/exec-deadline-hint-reaches-model.md
+++ b/.changeset/exec-deadline-hint-reaches-model.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Surface the Connected Machine (selfhosted) exec-deadline hint on the stdout-only SDK path: when a command is killed at its exec deadline, `execCommand` now returns the "terminated at the N-second limit — run long jobs in the background and poll" hint as its output (alone when stdout is empty, appended after the partial output otherwise), instead of returning an empty string the model reads as "no output". The structured `exec()` result is unchanged (the hint stays on stderr for the Channel-A parsers); it now also carries a `timedOut` flag.

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -267,6 +267,10 @@ export interface SelfhostedExecResult {
   stdout: string;
   stderr: string;
   exitCode: number | null;
+  /** True when the agent killed the child at the exec deadline. Additive to the
+   *  Channel-A superset (consumers that don't read it are unaffected); `execCommand`
+   *  reads it to surface the deadline hint on the stdout-only SDK path. */
+  timedOut?: boolean;
 }
 
 /** The `exec` args the structural surface accepts (mirrors ChannelAExecArgs). */
@@ -448,19 +452,25 @@ export class SelfhostedSession {
     }
   }
 
+  /** The clamped exec process deadline (ms): the exec-specific budget when threaded,
+   *  else the control timeout. Shared by `exec()` (the wire deadline) and
+   *  `execCommand()` (the timed-out hint's "N-second limit"), so the two never drift. */
+  private execDeadlineMs(): number {
+    // exec gets its OWN (much larger) deadline distinct from the short control
+    // timeout — a real command routinely outlives 30s. Falls back to `timeoutMs`
+    // when no exec deadline is threaded (unchanged for those callers).
+    return Math.max(
+      1,
+      Math.min(Math.trunc(this.execTimeoutMs ?? this.timeoutMs), SELFHOSTED_MAX_EXEC_TIMEOUT_MS),
+    );
+  }
+
   /** Channel-A `exec`: run a command on the machine and return its output. */
   async exec(args: SelfhostedExecArgs): Promise<SelfhostedExecResult> {
     // Keep the process deadline inside the request/reply deadline. Previously the
     // wire carried timeoutMs=0 (unbounded) while the caller stopped waiting after
     // ~30s, leaving accepted work invisible and able to starve control liveness.
-    // exec gets its OWN (much larger) deadline distinct from the short control
-    // timeout — a real command routinely outlives 30s. Falls back to `timeoutMs`
-    // when no exec deadline is threaded (unchanged for those callers).
-    const execDeadlineMs = this.execTimeoutMs ?? this.timeoutMs;
-    const executionTimeoutMs = Math.max(
-      1,
-      Math.min(Math.trunc(execDeadlineMs), SELFHOSTED_MAX_EXEC_TIMEOUT_MS),
-    );
+    const executionTimeoutMs = this.execDeadlineMs();
     const execReq: ExecRequest = {
       // The agent does NOT shell-interpret unless `shell` — Channel-A passes a
       // single shell command string, so run it through the platform shell.
@@ -496,9 +506,22 @@ export class SelfhostedSession {
 
   /** SDK shell capability `execCommand`: run a command and return its stdout (the
    *  `exec_command` tool). Selfhosted exec is non-interactive (no PTY) — `tty` is
-   *  ignored; `supportsPty()` is false so the SDK never offers a stdin session. */
+   *  ignored; `supportsPty()` is false so the SDK never offers a stdin session.
+   *
+   *  On a DEADLINE timeout the SDK path is stdout-only (the model sees `result.output`
+   *  and nothing else), so the deadline hint that `exec()` puts on stderr would be
+   *  invisible — a >deadline command would return `{"output":""}` and the model would
+   *  conclude "no output" with no idea it was killed. So when the result timed out we
+   *  surface the hint HERE, on stdout: the hint alone when stdout is empty, or appended
+   *  after a newline when there is partial output (a timed-out result is already not
+   *  cleanly parseable — silence is worse than an explanatory suffix). The structured
+   *  `exec()` result is left untouched for the Channel-A parsers. */
   async execCommand(args: { cmd: string; workdir?: string; runAs?: string }): Promise<string> {
     const result = await this.exec({ cmd: args.cmd, workdir: args.workdir, runAs: args.runAs });
+    if (result.timedOut) {
+      const hint = execDeadlineHint(Math.round(this.execDeadlineMs() / 1000));
+      return result.output ? `${result.output}\n${hint}` : hint;
+    }
     return result.output;
   }
 
@@ -1058,6 +1081,7 @@ function execResultToChannelA(res: ExecResponse, execDeadlineMs: number): Selfho
     stdout,
     stderr,
     exitCode: res.exitCode,
+    timedOut: res.timedOut,
   };
 }
 

--- a/packages/runtime/test/selfhosted-resilience.test.ts
+++ b/packages/runtime/test/selfhosted-resilience.test.ts
@@ -428,6 +428,53 @@ describe("exec / control deadline split", () => {
     expect(res.stdout).toBe("partial output\n");
     expect(res.stderr).toContain("300-second execution limit");
     expect(res.stderr).toContain("nohup");
+    // The result carries the timedOut flag for the stdout-only execCommand path.
+    expect(res.timedOut).toBe(true);
+  });
+});
+
+describe("execCommand — the deadline hint reaches the stdout-only SDK path", () => {
+  const timedOutExecStep =
+    (stdout: string) =>
+    (req: ControlRequest): ControlResponse => ({
+      requestId: req.requestId,
+      error: undefined,
+      result: {
+        $case: "exec",
+        exec: {
+          exitCode: null,
+          stdout: encoder.encode(stdout),
+          stderr: new Uint8Array(0),
+          timedOut: true,
+          durationMs: "120000",
+        },
+      },
+    });
+
+  test("empty-stdout timeout: execCommand returns the hint (never a silent empty string)", async () => {
+    const rpc = new ScriptedRpc([timedOutExecStep("")]);
+    const out = await sessionWith(rpc, { execTimeoutMs: 120_000 }).execCommand({
+      cmd: "sleep 999",
+    });
+    expect(out).not.toBe("");
+    expect(out).toContain("120-second execution limit");
+    expect(out).toContain("nohup");
+  });
+
+  test("partial-stdout timeout: execCommand appends the hint after the output", async () => {
+    const rpc = new ScriptedRpc([timedOutExecStep("partial output\n")]);
+    const out = await sessionWith(rpc, { execTimeoutMs: 120_000 }).execCommand({
+      cmd: "sleep 999",
+    });
+    // The original output, then the hint after a newline separator.
+    expect(out).toBe(`partial output\n\n${execDeadlineHint(120)}`);
+  });
+
+  test("non-timeout: execCommand returns stdout unchanged", async () => {
+    const rpc = new ScriptedRpc([execOkStep]);
+    const out = await sessionWith(rpc, { execTimeoutMs: 120_000 }).execCommand({ cmd: "echo ok" });
+    expect(out).toBe("ok\n");
+    expect(out).not.toContain("execution limit");
   });
 });
 


### PR DESCRIPTION
A >deadline exec on a Connected Machine returned \`{"output":""}\` to the model — totally silent. #347's deadline hint was placed on the timed-out result's **stderr** (deliberately, to protect Channel-A stdout parsers), but the SDK shell capability \`execCommand\` returns only \`result.output\` (stdout) — so the hint was invisible on exactly the path models use. Staging drill reproduced it: a 130s command against the 120s deadline returned an empty string with no explanation.

## Fix (selfhosted session layer only)

- \`SelfhostedExecResult\` gains additive \`timedOut?: boolean\` (from the ExecResponse; Channel-A consumers unaffected).
- \`execCommand()\`: when the result timed out, the hint IS the output — alone when stdout is empty, or appended after a newline when there is partial output (a timed-out result is already not cleanly parseable; silence is worse than an explanatory suffix).
- Structured \`exec()\` untouched — the stderr hint stays for parsers.
- One shared \`execDeadlineMs()\` helper feeds both the wire deadline and the hint's "N-second limit" so they can never drift.

## Verification

- New tests: empty-stdout timeout → hint returned (never \`""\`); partial-stdout timeout → output + hint; non-timeout → stdout unchanged; \`timedOut\` asserted on the existing exec-timeout test.
- Full resilience suite + selfhosted-session + routing-proxy + turn-integration green; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq