### PR TITLE
perf(codex): honest per-model context window + compact at 90% of it

### DIFF
--- a/.changeset/codex-context-window-honest.md
+++ b/.changeset/codex-context-window-honest.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/codex": patch
+"@opengeni/config": patch
+"@opengeni/runtime": patch
+---
+
+Proactive context compaction now actually fires on the codex-subscription path: codex models declare their real (empirically measured) context window instead of inheriting the 1.05M global default, and the default compaction trigger moves from 60% to 90% of the declared window — compact as late as possible now that the window base is honest, with the reactive compact-on-reject ladder absorbing any overshoot.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2383,6 +2383,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 promptCacheKey,
               })
           : undefined;
+      // Client-path compaction must budget against the RESOLVED model's real
+      // context window (the codex subscription window is far smaller than the
+      // 1.05M global default), mirroring the SDK path above. Without this the
+      // threshold (window * ratio) uses 1.05M and proactive compaction never
+      // fires for codex turns — histories grow to the ~340k model cliff.
+      const compactionContextWindowTokens =
+        resolvedModel?.configured.contextWindowTokens ?? runSettings.contextWindowTokens;
       // Pre-turn client-side context compaction (Azure path). When the
       // resolved mode is "client" and the single Codex-parity threshold is
       // crossed, this summarizes the current active history and rebuilds active
@@ -2404,7 +2411,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           );
           const outcome = await maybeCompactContext(
             db,
-            runSettings,
+            { ...runSettings, contextWindowTokens: compactionContextWindowTokens },
             {
               accountId: input.accountId,
               workspaceId: input.workspaceId,
@@ -2558,6 +2565,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         const clientCompactionSettings: Settings = {
           ...runSettings,
           contextCompactionMode: "client",
+          contextWindowTokens: compactionContextWindowTokens,
         };
         const outcome = await maybeCompactContext(
           db,

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -11,6 +11,7 @@ import {
   CODEX_APPS_MCP_URL,
   CODEX_APPS_STARTUP_TIMEOUT_MS,
   CODEX_FALLBACK_MODEL_SLUGS,
+  CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
   CODEX_MODEL_ID_PREFIX,
   CODEX_PROVIDER_BASE_URL,
   CODEX_PROVIDER_ID,
@@ -166,6 +167,10 @@ export function withCodexProvider(settings: Settings): Settings {
       id: `${CODEX_MODEL_ID_PREFIX}${slug}`,
       label: slug,
       reasoningEffort: true,
+      // The subscription window is far smaller than the raw API's; declare it so
+      // proactive compaction fires before the ~340k reject cliff instead of
+      // never firing against the 1.05M global default.
+      contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
     })),
   };
   return { ...settings, modelProvidersJson: JSON.stringify([...providers, codexProvider]) };

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { parseModelProvidersJson } from "@opengeni/config";
+import { configuredModels, parseModelProvidersJson } from "@opengeni/config";
+import { CODEX_MODEL_CONTEXT_WINDOW_TOKENS } from "@opengeni/codex";
 import * as opengeniDb from "@opengeni/db";
+import { clientCompactionThresholdTokens } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
 import {
@@ -23,6 +25,36 @@ describe("withCodexProvider", () => {
     expect(codex?.baseUrl).toBe("https://chatgpt.com/backend-api");
     expect(codex?.models.every((m) => m.id.startsWith("codex/"))).toBe(true);
     expect(codex?.models.some((m) => m.id === "codex/gpt-5.6-sol")).toBe(true);
+  });
+
+  test("declares the codex subscription context window so proactive compaction fires before the reject cliff", () => {
+    const settings = withCodexProvider(testSettings({ modelProvidersJson: "[]" }));
+    const providers = parseModelProvidersJson(settings.modelProvidersJson);
+    const codex = providers.find((p) => p.id === "codex-subscription");
+    // Every codex model carries the (smaller-than-API) subscription window.
+    expect(
+      codex?.models.every((m) => m.contextWindowTokens === CODEX_MODEL_CONTEXT_WINDOW_TOKENS),
+    ).toBe(true);
+    // It flows through to the resolved model catalog.
+    const sol = configuredModels(settings).find((m) => m.id === "codex/gpt-5.6-sol");
+    expect(sol?.contextWindowTokens).toBe(CODEX_MODEL_CONTEXT_WINDOW_TOKENS);
+    // The proactive client-compaction trigger (window * ratio, default 0.60)
+    // lands well below the empirical ~340k reject cliff — and under the 230k bar.
+    const trigger = clientCompactionThresholdTokens({
+      contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
+      contextReservedOutputTokens: settings.contextReservedOutputTokens,
+      contextCompactionThresholdRatio: settings.contextCompactionThresholdRatio,
+    });
+    expect(trigger).toBe(192_000);
+    expect(trigger).toBeLessThan(230_000);
+    expect(trigger).toBeLessThan(340_000);
+    // Contrast: the old 1.05M global default never fired before the cliff.
+    const globalTrigger = clientCompactionThresholdTokens({
+      contextWindowTokens: 1_050_000,
+      contextReservedOutputTokens: settings.contextReservedOutputTokens,
+      contextCompactionThresholdRatio: settings.contextCompactionThresholdRatio,
+    });
+    expect(globalTrigger).toBeGreaterThan(340_000);
   });
 
   test("preserves existing registry providers", () => {

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -38,16 +38,16 @@ describe("withCodexProvider", () => {
     // It flows through to the resolved model catalog.
     const sol = configuredModels(settings).find((m) => m.id === "codex/gpt-5.6-sol");
     expect(sol?.contextWindowTokens).toBe(CODEX_MODEL_CONTEXT_WINDOW_TOKENS);
-    // The proactive client-compaction trigger (window * ratio, default 0.60)
-    // lands well below the empirical ~340k reject cliff — and under the 230k bar.
+    // The proactive client-compaction trigger (window * ratio, default 0.90 —
+    // compact as late as possible against the honest window) lands below the
+    // empirical ~334-348k reject cliff with margin for estimator skew.
     const trigger = clientCompactionThresholdTokens({
       contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
       contextReservedOutputTokens: settings.contextReservedOutputTokens,
       contextCompactionThresholdRatio: settings.contextCompactionThresholdRatio,
     });
-    expect(trigger).toBe(192_000);
-    expect(trigger).toBeLessThan(230_000);
-    expect(trigger).toBeLessThan(340_000);
+    expect(trigger).toBe(288_000);
+    expect(trigger).toBeLessThan(334_000);
     // Contrast: the old 1.05M global default never fired before the cliff.
     const globalTrigger = clientCompactionThresholdTokens({
       contextWindowTokens: 1_050_000,

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -30,6 +30,16 @@ export const CODEX_MODEL_ID_PREFIX = "codex/";
 // this product allowlist.
 export const CODEX_FALLBACK_MODEL_SLUGS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
 
+// The ChatGPT/Codex subscription serves a SMALLER effective context window than
+// the raw gpt-5.6 API: production turns hard-rejected with
+// `context_length_exceeded` at ~334-348k input tokens on 2026-07-10. We declare
+// a real per-model window so proactive compaction (threshold = window * ratio,
+// default 0.60) fires WELL before that cliff instead of never firing against
+// the 1.05M global default. 320k (below the empirical ~340k reject) yields a
+// ~192k proactive trigger with a ~148k safety margin. Applies to every codex
+// subscription slug (all gpt-5.6 family on the same subscription window).
+export const CODEX_MODEL_CONTEXT_WINDOW_TOKENS = 320_000;
+
 // Sent as the `version` header and inside the User-Agent. Staging-proven on
 // 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models, while the
 // official Codex 0.144.0 release returned all three exact slugs above.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -211,15 +211,18 @@ const SettingsSchema = z.object({
   // budget the client path.
   contextWindowTokens: z.coerce.number().int().positive().default(1_050_000),
   // Proactive compaction threshold as a ratio of the model context window.
-  // Defaults to 60% and is clamped to [0.3, 0.9] so deployments can tune the
-  // trigger without accidentally disabling compaction or waiting until the
-  // provider is already at the cliff.
+  // Defaults to 90%: compact as late as possible — retained context beats early
+  // headroom now that per-model windows are declared honestly (input-effective,
+  // empirically measured), and the fail-closed reactive compact-on-reject path
+  // absorbs any overshoot as one retried call rather than a dead session.
+  // Clamped to [0.3, 0.9] so deployments can tune the trigger without
+  // accidentally disabling compaction.
   contextCompactionThresholdRatio: z.coerce
     .number()
-    .default(0.6)
+    .default(0.9)
     .transform((value) => {
       if (!Number.isFinite(value)) {
-        return 0.6;
+        return 0.9;
       }
       return Math.min(0.9, Math.max(0.3, value));
     }),

--- a/packages/config/test/context-compaction.test.ts
+++ b/packages/config/test/context-compaction.test.ts
@@ -27,7 +27,7 @@ describe("context compaction config defaults", () => {
     const settings = withEnv({}, () => getSettings());
     expect(settings.contextCompactionMode).toBe("auto");
     expect(settings.contextWindowTokens).toBe(1_050_000);
-    expect(settings.contextCompactionThresholdRatio).toBeCloseTo(0.6);
+    expect(settings.contextCompactionThresholdRatio).toBeCloseTo(0.9);
     expect(settings.contextReservedOutputTokens).toBe(128_000);
     expect(settings.contextServerCompactThresholdTokens).toBeUndefined();
     expect(settings.contextCompactSoftFraction).toBeCloseTo(0.7);

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -20,7 +20,14 @@ export const COMPACTION_SUMMARY_MARKER = "opengeni_context_summary";
 
 export const SUMMARY_BUFFER_TOKENS = 20_000;
 export const COMPACT_USER_MESSAGE_MAX_TOKENS = 20_000;
-export const DEFAULT_COMPACTION_THRESHOLD_RATIO = 0.6;
+// 0.9: compact as LATE as possible — retained context is worth more than early
+// headroom now that declared per-model windows are honest (input-effective,
+// empirically measured). Overshoot from estimator skew is absorbed by the
+// fail-closed reactive compact-on-reject ladder, so a late trigger costs at
+// worst one retried call, never a dead session. Was 0.6 when windows lied
+// (1.05M default vs the codex ~340k cliff meant the ratio compensated for the
+// wrong base — fix the base, not the ratio).
+export const DEFAULT_COMPACTION_THRESHOLD_RATIO = 0.9;
 export const MIN_COMPACTION_THRESHOLD_RATIO = 0.3;
 export const MAX_COMPACTION_THRESHOLD_RATIO = 0.9;
 export const COMPACTION_FALLBACK_TARGET_RATIO = 0.5;

--- a/packages/runtime/test/capabilities.test.ts
+++ b/packages/runtime/test/capabilities.test.ts
@@ -68,8 +68,8 @@ describe("provider-aware capability selection", () => {
       compact_threshold: number;
     }>;
     expect(contextManagement[0]!.type).toBe("compaction");
-    // floor(1_050_000 * 0.60) = 630_000, NOT the SDK's 240_000 fallback.
-    expect(contextManagement[0]!.compact_threshold).toBe(Math.floor(1_050_000 * 0.6));
+    // floor(window * defaultRatio 0.90) = 945_000, NOT the SDK's 240_000 fallback.
+    expect(contextManagement[0]!.compact_threshold).toBe(Math.floor(1_050_000 * 0.9));
     expect(contextManagement[0]!.compact_threshold).not.toBe(240_000);
   });
 });

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -92,7 +92,7 @@ describe("codex-parity constants and summary marker", () => {
 });
 
 describe("single client compaction threshold", () => {
-  test("computes 60 percent of the model context window by default", () => {
+  test("computes 90 percent of the model context window by default", () => {
     expect(
       clientCompactionThresholdTokens({
         contextWindowTokens: WINDOW,

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -47,7 +47,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     sessionHistorySource: "run_state",
     contextCompactionMode: "auto",
     contextWindowTokens: 1_050_000,
-    contextCompactionThresholdRatio: 0.6,
+    contextCompactionThresholdRatio: 0.9,
     contextReservedOutputTokens: 128_000,
     contextServerCompactThresholdTokens: undefined,
     contextCompactSoftFraction: 0.7,


### PR DESCRIPTION
## The most consequential wrong number in the system

Proactive context compaction has **never fired** for codex-subscription turns. The trigger is `ratio × contextWindowTokens`, and the codex models inherited the 1.05M global default window → trigger ≈ 645K. But the subscription's gpt-5.6 models hard-reject with `context_length_exceeded` at **~334–348K observed input tokens** (prod, 2026-07-10). Result: histories grew straight to the reject cliff — slow prefills on every call, worker memory pressure, and reject/retry loops on long autonomous sessions. This is a direct contributor to the token-streaming sluggishness under fleet load.

## Fix — two honest numbers

1. **Honest window**: codex provider models declare `CODEX_MODEL_CONTEXT_WINDOW_TOKENS = 320_000` (just under the measured cliff), and the worker budgets client-path compaction against the **resolved model's** window instead of the global default (mirroring what the SDK path already did).
2. **Late trigger**: default compaction threshold ratio moves **0.6 → 0.9** in both places it's defined (config zod default + runtime fallback). Retained context beats early headroom now that the window base is honest; the fail-closed reactive compact-on-reject ladder absorbs any overshoot as one retried call, never a dead session.

Net for gpt-5.6: trigger moves from 645K (unreachable) to **288K**, with ~46K margin below the cliff for tokenizer-estimate skew.

## Verification

- `codex-overlay` worker tests updated + passing (11/11): overlay models carry the declared window; compaction settings resolve per-model.
- Full `packages/config` + `packages/runtime` suites: 730 pass.
- Typecheck clean on worker/config/runtime.
- No deployment pins `OPENGENI_COMPACTION_THRESHOLD_RATIO`, so the new default takes effect on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq