### PR TITLE
test: pin the compaction ratio the recovery-loop scenario was calibrated to

### DIFF
--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1235,6 +1235,12 @@ describe("worker activities integration", () => {
         contextCompactionMode: "client",
         contextWindowTokens: 100_000,
         contextReservedOutputTokens: 0,
+        // This scenario is calibrated so the resumed turn's 80k-token model
+        // report sits ABOVE the proactive trigger (it tests the shrink-invariant
+        // loop guard, not the trigger default). Pin the ratio the calibration
+        // assumed instead of inheriting the production default (now 0.9, which
+        // would put the trigger at 90k and never re-compact here).
+        contextCompactionThresholdRatio: 0.6,
         mcpServers: [
           {
             id: "opengeni",


### PR DESCRIPTION
Fixes the one red check on main after #357.

The \`strictly shrinks\` recovery-loop integration test was calibrated against the old 0.6 default: its resumed turn's 80k-token model report needs to sit above the proactive trigger for the second compaction to fire. #357 moved the default to 0.9 (trigger 90k on the test's 100k window) so the re-compaction stopped firing and the turn completed instead of preempting. The test verifies the **shrink-invariant loop guard**, not the trigger default — so it now pins \`contextCompactionThresholdRatio: 0.6\` explicitly, with a comment explaining the calibration.

Verified with the exact CI invocation against the real Postgres+NATS harness: 1 pass (48.8s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq