### PR TITLE
fix(selfhosted): four-field machine-fault rendering, typed PAYLOAD_TOO_LARGE, provably-safe blip heal

### DIFF
--- a/.changeset/selfhosted-fault-legibility.md
+++ b/.changeset/selfhosted-fault-legibility.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Make Connected Machine (selfhosted) faults legible to the agent in-band. The `exec_command` tool now returns a four-field rendering (what happened / which layer / what was preserved / what to try) with a correct retry verdict — machine-offline and consent faults no longer reach the model mislabelled "Please try again". PAYLOAD_TOO_LARGE is typed with a distinguishing flag and rendered with the size wall plus recovery moves (redirect to a file, read in chunks). A transient offline blip the transport KNOWS occurred pre-send (no connection / no responder — the op provably never reached the machine) now heals with a short bounded retry for any op kind, while an ambiguous post-send fault is never blindly re-issued.

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -198,9 +198,18 @@ export {
   payloadTooLargeMessage,
   drainingMessage,
   execDeadlineHint,
+  NEVER_SENT_DETAIL_KEY,
   type NatsRequestConnection,
   type SelfhostedUnavailableReason,
 } from "./selfhosted/control-rpc";
+// The four-field in-band fault renderer (the failure-visibility doctrine).
+export {
+  renderSelfhostedFault,
+  FAULT_FIELD_WHAT_HAPPENED,
+  FAULT_FIELD_WHICH_LAYER,
+  FAULT_FIELD_WHAT_PRESERVED,
+  FAULT_FIELD_WHAT_TO_TRY,
+} from "./selfhosted/fault-rendering";
 // The selfhosted control-op retry policy (the pure decision + the injected clock).
 export {
   decideSelfhostedRetry,
@@ -210,6 +219,7 @@ export {
   SELFHOSTED_DRAINING_MAX_RETRIES,
   SELFHOSTED_EXEC_DRAINING_MAX_RETRIES,
   SELFHOSTED_TIMEOUT_MAX_RETRIES,
+  SELFHOSTED_NEVER_SENT_MAX_RETRIES,
   SELFHOSTED_RETRY_BACKOFF_BASE_MS,
   SELFHOSTED_RETRY_BACKOFF_FACTOR,
   SELFHOSTED_RETRY_BACKOFF_CAP_MS,

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -28,6 +28,8 @@
 // `@opengeni/db`.
 
 import type { ExposedPortEndpoint } from "../stream-port";
+import { SelfhostedControlError } from "../selfhosted/control-rpc";
+import { renderSelfhostedFault } from "../selfhosted/fault-rendering";
 
 /** The per-session active-sandbox pointer the proxy re-reads on every op. Mirror
  *  of `@opengeni/db`'s `ActiveSandboxPointer` (structural, so the leaf does not
@@ -357,6 +359,31 @@ export class RoutingSandboxSession implements RoutableBackendSession {
     throw lastError ?? new Error(`routing op "${op}" exhausted fence retries`);
   }
 
+  /**
+   * The failure-visibility boundary for the `exec_command` SDK capability tool — the
+   * dominant fault surface, and the one whose thrown `SelfhostedControlError` reaches
+   * the model wrapped by the SDK's generic tool-error function as
+   * "…Please try again. Error: …" — actively wrong for a machine that is offline, a
+   * consent that is not granted, or an oversized reply. Since the SDK closure-captures
+   * its `errorFunction` (there is no seam to attach one to its internally-built tools),
+   * we render the fault into the doctrine's four fields HERE and return it as the
+   * tool's string result — legible, in-band, and free of the misleading wrapper.
+   * (`apply_patch` already surfaces `error.message` via the SDK's own catch; the
+   * skills / `view_image` tools consume their session methods internally, so they are
+   * rendered elsewhere or left to their own SDK renderers — not this string boundary.)
+   *
+   * A FENCE error is re-thrown, NEVER rendered: `dispatch` already retries it against
+   * a re-resolved backend, and a fence that escapes retries is a routing condition the
+   * turn handles, not a model-facing fault. Any non-selfhosted error (a Modal fault, a
+   * `RoutingUnsupportedError`) is re-thrown unchanged.
+   */
+  private renderSelfhostedFaultOrThrow(error: unknown): string {
+    if (error instanceof SelfhostedControlError && !error.fenced) {
+      return renderSelfhostedFault(error);
+    }
+    throw error;
+  }
+
   // ── The forwarded structural surface ──────────────────────────────────────
   // Every method is PRESENT on the proxy (the SDK binds presence once) and
   // dispatches to the active backend at call-time. A missing backend method
@@ -376,16 +403,22 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   }
 
   async execCommand(args: unknown): Promise<string> {
-    return this.dispatch("execCommand", async (s) => {
-      if (s.execCommand) {
-        return s.execCommand(args);
-      }
-      if (s.exec) {
-        const r = (await s.exec(args)) as { stdout?: string; output?: string };
-        return r.stdout ?? r.output ?? "";
-      }
-      throw new RoutingUnsupportedError("execCommand", this.cached?.kind ?? "unknown");
-    });
+    try {
+      return await this.dispatch("execCommand", async (s) => {
+        if (s.execCommand) {
+          return s.execCommand(args);
+        }
+        if (s.exec) {
+          const r = (await s.exec(args)) as { stdout?: string; output?: string };
+          return r.stdout ?? r.output ?? "";
+        }
+        throw new RoutingUnsupportedError("execCommand", this.cached?.kind ?? "unknown");
+      });
+    } catch (error) {
+      // Render a terminal selfhosted fault as the tool's result (four fields, correct
+      // verdict) instead of letting the SDK mislabel it "Please try again".
+      return this.renderSelfhostedFaultOrThrow(error);
+    }
   }
 
   async writeStdin(args: unknown): Promise<string> {

--- a/packages/runtime/src/sandbox/selfhosted/control-rpc.ts
+++ b/packages/runtime/src/sandbox/selfhosted/control-rpc.ts
@@ -88,6 +88,15 @@ export class SelfhostedControlError extends Error {
   readonly draining: boolean;
   readonly agentOffline: boolean;
   readonly osNotFound: boolean;
+  /** The reply exceeded the transport's max payload (a distinguishing flag so the
+   *  fault renderer can name the size wall + recovery instead of a generic OS error). */
+  readonly payloadTooLarge: boolean;
+  /** The transport synthesized this fault PRE-SEND — it KNOWS the request never
+   *  reached the machine (no connection, or no responder on the subject), so the op
+   *  provably did not execute. Only such a fault is safe to re-issue for ANY op kind
+   *  (a post-send timeout is ambiguous — at-least-once — and must not be re-sent
+   *  unless the op is read-only). Never set for an agent-returned error. */
+  readonly neverSent: boolean;
   readonly detail: Record<string, string>;
 
   constructor(input: {
@@ -99,6 +108,8 @@ export class SelfhostedControlError extends Error {
     draining?: boolean;
     agentOffline?: boolean;
     osNotFound?: boolean;
+    payloadTooLarge?: boolean;
+    neverSent?: boolean;
     detail?: Record<string, string>;
   }) {
     super(input.message);
@@ -109,6 +120,8 @@ export class SelfhostedControlError extends Error {
     this.draining = input.draining ?? false;
     this.agentOffline = input.agentOffline ?? false;
     this.osNotFound = input.osNotFound ?? false;
+    this.payloadTooLarge = input.payloadTooLarge ?? false;
+    this.neverSent = input.neverSent ?? false;
     this.detail = input.detail ?? {};
   }
 }
@@ -139,12 +152,17 @@ export function agentErrorToControlError(err: AgentError): SelfhostedControlErro
   const detail = err.detail ?? {};
   switch (err.code) {
     case ErrorCode.ERROR_CODE_AGENT_OFFLINE:
+      // AGENT_OFFLINE is ONLY ever synthesized by our transport (the agent never
+      // sends it). The synthesis marks `neverSent` on the pre-send paths (no NATS
+      // connection, or no responder on the subject) — the op provably never reached
+      // the machine — via the reserved detail key `NEVER_SENT_DETAIL_KEY`.
       return new SelfhostedControlError({
         message: message || "the enrolled agent is offline",
         code: err.code,
         reason: "agent_offline",
         retryable: false,
         agentOffline: true,
+        neverSent: detail[NEVER_SENT_DETAIL_KEY] === "1",
         detail,
       });
     case ErrorCode.ERROR_CODE_TIMEOUT:
@@ -190,6 +208,7 @@ export function agentErrorToControlError(err: AgentError): SelfhostedControlErro
         code: err.code,
         reason: null,
         retryable: false,
+        payloadTooLarge: true,
         detail,
       });
     case ErrorCode.ERROR_CODE_FENCED:
@@ -279,7 +298,8 @@ export function drainingExhaustedError(
     reason: base.reason,
     retryable: base.retryable,
     draining: base.draining,
-    detail: base.detail,
+    // Carry the retry count in `detail` so the fault renderer can state it.
+    detail: { ...base.detail, retries: String(retries) },
   });
 }
 
@@ -297,14 +317,26 @@ export function execDeadlineHint(seconds: number): string {
   );
 }
 
+/** The reserved `detail` key the transport sets to "1" when it KNOWS a synthesized
+ *  AGENT_OFFLINE fault occurred pre-send (no connection / no responder) — so the op
+ *  provably never reached the machine. `agentErrorToControlError` reads it into
+ *  `SelfhostedControlError.neverSent`. Reserved (never sent by the agent). */
+export const NEVER_SENT_DETAIL_KEY = "_never_sent";
+
 /** Build a synthesized AGENT_OFFLINE `AgentError` — the control plane uses this
- *  when no agent responds on the subject at all. */
-export function offlineAgentError(message = "no agent responded (offline)"): AgentError {
+ *  when no agent responds on the subject at all. `neverSent` marks that the request
+ *  provably never reached the machine (no connection / no responder), which makes it
+ *  safe to re-issue for ANY op kind; leave it false for an AMBIGUOUS transport error
+ *  (a connection torn mid-request may have delivered the op). */
+export function offlineAgentError(
+  message = "no agent responded (offline)",
+  neverSent = false,
+): AgentError {
   return {
     code: ErrorCode.ERROR_CODE_AGENT_OFFLINE,
     message,
     retryable: false,
-    detail: {},
+    detail: neverSent ? { [NEVER_SENT_DETAIL_KEY]: "1" } : {},
   };
 }
 
@@ -411,7 +443,8 @@ export class NatsControlRpc implements ControlRpc {
     const conn = await this.resolveConnection();
     if (!conn) {
       // No NATS configured / not reachable → the agent is unaddressable → offline.
-      return offlineControlResponse(req.requestId);
+      // The request was never published (no connection) → NEVER SENT: safe to re-issue.
+      return offlineControlResponse(req.requestId, true);
     }
     const payload = ControlRequest.encode(req).finish();
     try {
@@ -420,11 +453,13 @@ export class NatsControlRpc implements ControlRpc {
     } catch (err) {
       // Re-allow a future request to re-dial if the cached conn was torn down.
       if (isNoRespondersError(err)) {
-        // No subscriber on the subject at all → the machine is offline.
-        return offlineControlResponse(req.requestId);
+        // No subscriber on the subject at all → the request reached no responder and
+        // was NOT delivered → NEVER SENT (provably not executed): safe to re-issue.
+        return offlineControlResponse(req.requestId, true);
       }
       if (isRequestTimeoutError(err)) {
-        // A responder may exist but the request timed out → a transient blip.
+        // A responder may exist but the request timed out → a transient blip. AMBIGUOUS
+        // (the op may have run and only the reply was lost) — never marked never-sent.
         return timeoutControlResponse(req.requestId);
       }
       // Any other transport error → treat as offline (never a NotFound). The op
@@ -435,9 +470,11 @@ export class NatsControlRpc implements ControlRpc {
   }
 }
 
-/** A `ControlResponse` carrying a synthesized AGENT_OFFLINE error. */
-export function offlineControlResponse(requestId: string): ControlResponse {
-  return { requestId, error: offlineAgentError(), result: undefined };
+/** A `ControlResponse` carrying a synthesized AGENT_OFFLINE error. `neverSent` marks
+ *  a pre-send synthesis (no connection / no responder) — the op provably never
+ *  reached the machine, so it is safe to re-issue for any op kind. */
+export function offlineControlResponse(requestId: string, neverSent = false): ControlResponse {
+  return { requestId, error: offlineAgentError(undefined, neverSent), result: undefined };
 }
 
 /** A `ControlResponse` carrying a synthesized TIMEOUT error (→ reconnecting). */

--- a/packages/runtime/src/sandbox/selfhosted/fault-rendering.ts
+++ b/packages/runtime/src/sandbox/selfhosted/fault-rendering.ts
@@ -1,0 +1,163 @@
+// The in-band fault renderer for Connected Machine (selfhosted) control faults.
+//
+// The failure-visibility doctrine: every fault the model sees at the point of
+// impact must carry FOUR fields — what happened, which layer, what was preserved,
+// what to try — with a retry verdict that is actually correct for the fault class.
+//
+// Why this exists: a thrown `SelfhostedControlError` reaches the model already
+// wrapped by the SDK's generic tool-error function as
+// "An error occurred while running the tool. Please try again. Error: …". That
+// "Please try again" is actively wrong for a machine that is offline, a consent
+// that has not been granted, or a reply that was too large — the model retries a
+// fault that a retry cannot fix, and must parse prose to recover which layer
+// failed. The typed `SelfhostedControlError` flags carry the truth; this renders
+// them into the four structural fields so the capability tools can surface a
+// legible fault as their result instead of the misleading wrapper.
+
+import { errorCodeToJSON, ErrorCode } from "@opengeni/agent-proto";
+import { SelfhostedControlError } from "./control-rpc";
+
+/** The four mandatory field labels (exported so tests can assert their presence). */
+export const FAULT_FIELD_WHAT_HAPPENED = "What happened:";
+export const FAULT_FIELD_WHICH_LAYER = "Which layer:";
+export const FAULT_FIELD_WHAT_PRESERVED = "What was preserved:";
+export const FAULT_FIELD_WHAT_TO_TRY = "What to try:";
+
+interface FaultFields {
+  headline: string;
+  happened: string;
+  layer: string;
+  preserved: string;
+  tryNext: string;
+}
+
+/** Assemble the four-field block. The typed wire code is folded into "what
+ *  happened" so the model has both the plain language and the precise code. */
+function assemble(error: SelfhostedControlError, f: FaultFields): string {
+  const code = errorCodeToJSON(error.code);
+  return [
+    `[connected machine] ${f.headline}`,
+    `${FAULT_FIELD_WHAT_HAPPENED} ${f.happened} (control code ${code}).`,
+    `${FAULT_FIELD_WHICH_LAYER} ${f.layer}`,
+    `${FAULT_FIELD_WHAT_PRESERVED} ${f.preserved}`,
+    `${FAULT_FIELD_WHAT_TO_TRY} ${f.tryNext}`,
+  ].join("\n");
+}
+
+/**
+ * Render a `SelfhostedControlError` into the doctrine's four in-band fields with a
+ * correct retry verdict. The fault CLASS is read from the typed flags (never the
+ * message prose), so each class gets the right "which layer" and "what to try":
+ *
+ *  - PAYLOAD_TOO_LARGE → the command ran but its reply was too big to return; the
+ *    fix is to bound the output, not to retry.
+ *  - DRAINING → pre-admission backpressure; nothing ran; safe to retry shortly.
+ *  - CONSENT_REQUIRED → a machine-side consent gate; retrying cannot help.
+ *  - AGENT_OFFLINE → the machine link is down. If the transport KNOWS the request
+ *    never left (`neverSent`), nothing ran; otherwise the effect is ambiguous and
+ *    the model must check before re-running. Either way "try again" is wrong until
+ *    the machine reconnects.
+ *  - agent_reconnecting (TIMEOUT) → a transient link blip AFTER send: ambiguous, so
+ *    a state-changing command must be checked before re-running (at-least-once).
+ *  - NOT_FOUND → a command/filesystem miss, not a link fault.
+ *  - FENCED → the active machine session changed (a swap); re-run.
+ *  - default (OS/UNSUPPORTED/STREAM/PROTOCOL) → the command/op failed on the machine.
+ */
+export function renderSelfhostedFault(error: SelfhostedControlError): string {
+  const detail = error.detail;
+
+  if (error.payloadTooLarge || error.code === ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE) {
+    const sizes =
+      detail.encoded_bytes && detail.max_payload
+        ? `its ${detail.encoded_bytes}-byte reply exceeded the machine link's ${detail.max_payload}-byte per-message limit`
+        : "its reply was larger than the machine link can deliver in one message";
+    return assemble(error, {
+      headline: "the command's output was too large to return",
+      happened: `the command ran on the machine, but ${sizes}`,
+      layer: "the machine link's per-message size limit — the command itself executed",
+      preserved: "nothing was returned; the oversized reply was dropped whole.",
+      tryNext:
+        "re-run with the output bounded: redirect to a file (`> /tmp/out.log 2>&1`) then read it " +
+        "back in ranges/chunks, or slice it with `head -c` / `tail -c` / `head` / `tail`.",
+    });
+  }
+
+  if (error.draining) {
+    const retried = detail.retries ? ` after ${detail.retries} retries` : "";
+    return assemble(error, {
+      headline: "the machine is at its concurrent-work capacity",
+      happened: `the machine rejected this command at its admission gate${retried} because its work pool is full`,
+      layer: "the machine's host-work admission — the machine is online, just saturated",
+      preserved: "nothing ran; the command was rejected before it started.",
+      tryNext: "try again shortly, or reduce the number of commands you run in parallel.",
+    });
+  }
+
+  if (error.reason === "consent_required") {
+    return assemble(error, {
+      headline: "the operation needs consent that has not been granted",
+      happened: "the machine rejected the operation because the required consent is not granted",
+      layer: "the machine's consent gate — not your command",
+      preserved: "nothing ran; the operation was rejected.",
+      tryNext:
+        "the consent must be granted on the machine itself; retrying will keep failing until it is.",
+    });
+  }
+
+  if (error.agentOffline || error.code === ErrorCode.ERROR_CODE_AGENT_OFFLINE) {
+    const preserved = error.neverSent
+      ? "nothing ran; the command never reached the machine."
+      : "unknown — the link dropped and the command may or may not have run.";
+    const tryNext = error.neverSent
+      ? "the machine appears offline; check that it is powered on and connected. Retrying will not help until it reconnects."
+      : "check the machine, and check whether the command already took effect before re-running it.";
+    return assemble(error, {
+      headline: "the machine is unreachable",
+      happened: "the enrolled machine did not respond; it appears offline",
+      layer: "the machine link — the machine itself, not your command",
+      preserved,
+      tryNext,
+    });
+  }
+
+  if (error.reason === "agent_reconnecting") {
+    return assemble(error, {
+      headline: "the machine link blipped",
+      happened: "the machine did not respond in time; the link may be reconnecting",
+      layer: "the machine link (transport) — not your command",
+      preserved: "unknown — the command may or may not have run (its reply was lost).",
+      tryNext:
+        "wait a moment and try again; if this was a state-changing command, check whether it " +
+        "already took effect before re-running it.",
+    });
+  }
+
+  if (error.osNotFound || error.code === ErrorCode.ERROR_CODE_NOT_FOUND) {
+    return assemble(error, {
+      headline: "the path or reference was not found on the machine",
+      happened: `the machine reported: ${error.message}`,
+      layer: "the command / filesystem on the machine — not the machine link",
+      preserved: "not applicable; the operation did not apply.",
+      tryNext: "check the path or reference exists on the machine, then re-run.",
+    });
+  }
+
+  if (error.fenced || error.code === ErrorCode.ERROR_CODE_FENCED) {
+    return assemble(error, {
+      headline: "the active machine session changed",
+      happened: "the machine session was swapped underneath the command",
+      layer: "the session-routing layer — not your command",
+      preserved: "nothing ran on this session.",
+      tryNext: "re-run the command; it will target the machine's current session.",
+    });
+  }
+
+  // OS / UNSUPPORTED / STREAM / PROTOCOL / UNSPECIFIED — a command/op-level failure.
+  return assemble(error, {
+    headline: "the command failed on the machine",
+    happened: `the machine reported: ${error.message}`,
+    layer: "the command / operating system on the machine",
+    preserved: "not applicable; the command did not complete successfully.",
+    tryNext: "read the message above and adjust the command; a blind retry is unlikely to help.",
+  });
+}

--- a/packages/runtime/src/sandbox/selfhosted/retry-policy.ts
+++ b/packages/runtime/src/sandbox/selfhosted/retry-policy.ts
@@ -57,6 +57,11 @@ export const SELFHOSTED_EXEC_DRAINING_MAX_RETRIES = 10;
 /** A read-only op that timed out is retried at most once (see the at-least-once
  *  note above — even a read gets a single re-issue, not an unbounded loop). */
 export const SELFHOSTED_TIMEOUT_MAX_RETRIES = 1;
+/** A fault the transport synthesized PRE-SEND (no connection / no responder) — the
+ *  op provably never reached the machine, so it is safe to re-issue for ANY op kind.
+ *  Short bounded budget (≈3.5s summed): enough to ride out a NATS reconnect blip
+ *  quietly, not so long it stalls the model on a machine that is genuinely down. */
+export const SELFHOSTED_NEVER_SENT_MAX_RETRIES = 3;
 
 /** Full-jitter backoff base (ms). Delay N is sampled in `[0, base * factor^N)`. */
 export const SELFHOSTED_RETRY_BACKOFF_BASE_MS = 500;
@@ -89,8 +94,13 @@ export function selfhostedRetryBackoffMs(attempt: number, jitter: number): numbe
  *    nothing executed. exec gets the long `SELFHOSTED_EXEC_DRAINING_MAX_RETRIES`
  *    budget (≈60s of patient queueing under the flat 8-permit pool); every other op
  *    keeps the short `SELFHOSTED_DRAINING_MAX_RETRIES` budget (≤5s).
- *  - `error.reason === "agent_reconnecting"` (a TIMEOUT / transient blip) → retry
- *    at most `SELFHOSTED_TIMEOUT_MAX_RETRIES`, and ONLY for a read-only
+ *  - `error.neverSent` (a pre-send AGENT_OFFLINE synthesis — no connection / no
+ *    responder; the op provably never reached the machine) → retry for ANY op kind
+ *    up to `SELFHOSTED_NEVER_SENT_MAX_RETRIES`. At-least-once does NOT apply (nothing
+ *    executed), so even a mutation is safe to re-issue; this heals a NATS reconnect
+ *    blip quietly. A truly-offline machine surfaces honestly after the short budget.
+ *  - `error.reason === "agent_reconnecting"` (a TIMEOUT / transient blip AFTER send)
+ *    → retry at most `SELFHOSTED_TIMEOUT_MAX_RETRIES`, and ONLY for a read-only
  *    idempotent-safe op (`SELFHOSTED_IDEMPOTENT_READONLY_OPS`). A timed-out
  *    MUTATION is never retried here — it may already have run (at-least-once).
  *  - Everything else → no retry at this layer:
@@ -108,9 +118,22 @@ export function decideSelfhostedRetry(input: {
   error: SelfhostedControlError;
   drainingRetries: number;
   timeoutRetries: number;
+  /** Prior never-sent retries. Optional (default 0) — only the pre-send AGENT_OFFLINE
+   *  branch reads it, so callers that cannot hit that class may omit it. */
+  neverSentRetries?: number;
   jitter: number;
 }): SelfhostedRetryDecision {
-  const { opKind, error, drainingRetries, timeoutRetries, jitter } = input;
+  const { opKind, error, drainingRetries, timeoutRetries, neverSentRetries = 0, jitter } = input;
+
+  if (error.neverSent) {
+    // Provably not executed (the request never reached the machine) → safe to
+    // re-issue for ANY op kind. Bounded so a genuinely-offline machine surfaces
+    // honestly rather than hanging the turn.
+    if (neverSentRetries >= SELFHOSTED_NEVER_SENT_MAX_RETRIES) {
+      return { action: "fail" };
+    }
+    return { action: "retry", delayMs: selfhostedRetryBackoffMs(neverSentRetries, jitter) };
+  }
 
   if (error.draining) {
     // exec is patient (the flat 8-permit pool needs longer than 5s to free a slot);

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -410,6 +410,7 @@ export class SelfhostedSession {
     const opKind = op.$case;
     let drainingRetries = 0;
     let timeoutRetries = 0;
+    let neverSentRetries = 0;
     for (;;) {
       const req: ControlRequest = {
         requestId: crypto.randomUUID(),
@@ -433,6 +434,7 @@ export class SelfhostedSession {
         error,
         drainingRetries,
         timeoutRetries,
+        neverSentRetries,
         jitter: this.retryClock.jitter(),
       });
       if (decision.action === "fail") {
@@ -444,7 +446,10 @@ export class SelfhostedSession {
         throw error;
       }
       await this.retryClock.sleep(decision.delayMs);
-      if (error.draining) {
+      // Advance the counter for the class that was retried (separate budgets).
+      if (error.neverSent) {
+        neverSentRetries += 1;
+      } else if (error.draining) {
         drainingRetries += 1;
       } else {
         timeoutRetries += 1;

--- a/packages/runtime/test/selfhosted-fault-legibility.test.ts
+++ b/packages/runtime/test/selfhosted-fault-legibility.test.ts
@@ -1,0 +1,389 @@
+// In-band fault legibility (the failure-visibility doctrine's in-band plane):
+//   - G2: `renderSelfhostedFault` renders every fault class into the four mandatory
+//     fields with a CORRECT retry verdict, and the routing proxy surfaces it as the
+//     `exec_command` result instead of the SDK's misleading "Please try again".
+//   - G5: PAYLOAD_TOO_LARGE is typed (a distinguishing flag) and rendered with the
+//     size wall + recovery moves.
+//   - G3-remnant: a PRE-SEND (never-sent) offline synthesis is retried for ANY op
+//     (provably not executed), while an ambiguous post-send fault is not.
+
+import { describe, expect, test } from "bun:test";
+import { type ControlRequest, type ControlResponse, ErrorCode } from "@opengeni/agent-proto";
+import {
+  type ControlRpc,
+  type RoutableBackendSession,
+  type SelfhostedRetryClock,
+  NatsControlRpc,
+  RoutingSandboxSession,
+  RoutingUnsupportedError,
+  SelfhostedControlError,
+  SelfhostedSession,
+  SELFHOSTED_NEVER_SENT_MAX_RETRIES,
+  agentErrorToControlError,
+  decideSelfhostedRetry,
+  offlineAgentError,
+  offlineControlResponse,
+  renderSelfhostedFault,
+  timeoutAgentError,
+  FAULT_FIELD_WHAT_HAPPENED,
+  FAULT_FIELD_WHICH_LAYER,
+  FAULT_FIELD_WHAT_PRESERVED,
+  FAULT_FIELD_WHAT_TO_TRY,
+} from "../src/sandbox";
+
+const WS = "11111111-1111-1111-1111-111111111111";
+const AGENT = "agent-abc";
+const RELAY = { host: "relay.test", port: 443, tls: true } as const;
+const encoder = new TextEncoder();
+
+const ALL_FIELDS = [
+  FAULT_FIELD_WHAT_HAPPENED,
+  FAULT_FIELD_WHICH_LAYER,
+  FAULT_FIELD_WHAT_PRESERVED,
+  FAULT_FIELD_WHAT_TO_TRY,
+];
+
+function mapped(code: ErrorCode, message = "", detail: Record<string, string> = {}) {
+  return agentErrorToControlError({ code, message, retryable: false, detail });
+}
+function offlineErr(neverSent: boolean): SelfhostedControlError {
+  return agentErrorToControlError(offlineAgentError(undefined, neverSent));
+}
+
+describe("renderSelfhostedFault — every fault class carries all four fields", () => {
+  const cases: Record<string, SelfhostedControlError> = {
+    "offline (never-sent)": offlineErr(true),
+    "offline (ambiguous)": offlineErr(false),
+    draining: mapped(ErrorCode.ERROR_CODE_DRAINING),
+    consent: mapped(ErrorCode.ERROR_CODE_CONSENT_REQUIRED),
+    payload: mapped(ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE, "", {
+      op: "exec",
+      encoded_bytes: "1500000",
+      max_payload: "1048576",
+    }),
+    reconnecting: agentErrorToControlError(timeoutAgentError()),
+    notFound: mapped(ErrorCode.ERROR_CODE_NOT_FOUND, "no such file: /x"),
+    fenced: mapped(ErrorCode.ERROR_CODE_FENCED),
+    os: mapped(ErrorCode.ERROR_CODE_OS, "disk write failed"),
+  };
+
+  for (const [name, error] of Object.entries(cases)) {
+    test(`${name}: all four fields present, never an empty rendering`, () => {
+      const out = renderSelfhostedFault(error);
+      expect(out.length).toBeGreaterThan(0);
+      for (const field of ALL_FIELDS) {
+        expect(out).toContain(field);
+      }
+      // The typed wire code is always folded in (typed code + plain language).
+      expect(out).toContain("control code ERROR_CODE_");
+    });
+  }
+});
+
+describe("renderSelfhostedFault — the retry verdict is correct per class", () => {
+  test("offline (never-sent): nothing ran; do NOT suggest a blind retry", () => {
+    const out = renderSelfhostedFault(offlineErr(true));
+    expect(out).toContain("nothing ran");
+    expect(out.toLowerCase()).toContain("offline");
+    expect(out.toLowerCase()).toContain("will not help");
+  });
+
+  test("offline (ambiguous): the effect is unknown; check before re-running", () => {
+    const out = renderSelfhostedFault(offlineErr(false)).toLowerCase();
+    expect(out).toContain("may or may not have run");
+    expect(out).toContain("re-running");
+  });
+
+  test("draining: nothing ran; retryable shortly", () => {
+    const out = renderSelfhostedFault(mapped(ErrorCode.ERROR_CODE_DRAINING)).toLowerCase();
+    expect(out).toContain("nothing ran");
+    expect(out).toContain("try again shortly");
+  });
+
+  test("consent: not retryable — must be granted on the machine", () => {
+    const out = renderSelfhostedFault(mapped(ErrorCode.ERROR_CODE_CONSENT_REQUIRED)).toLowerCase();
+    expect(out).toContain("consent");
+    expect(out).toContain("keep failing");
+  });
+
+  test("payload: cites the sizes, says dropped whole, gives the recovery moves", () => {
+    const out = renderSelfhostedFault(
+      mapped(ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE, "", {
+        encoded_bytes: "1500000",
+        max_payload: "1048576",
+      }),
+    );
+    expect(out).toContain("1500000");
+    expect(out).toContain("1048576");
+    expect(out).toContain("dropped whole");
+    expect(out.toLowerCase()).toContain("/tmp/out.log");
+    expect(out).toContain("head -c");
+  });
+
+  test("reconnecting: ambiguous — check effects before re-running", () => {
+    const out = renderSelfhostedFault(agentErrorToControlError(timeoutAgentError())).toLowerCase();
+    expect(out).toContain("may or may not have run");
+  });
+
+  test("never renders the SDK's misleading wrapper phrasing", () => {
+    for (const error of [
+      offlineErr(true),
+      mapped(ErrorCode.ERROR_CODE_CONSENT_REQUIRED),
+      mapped(ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE),
+    ]) {
+      expect(renderSelfhostedFault(error)).not.toContain("Please try again");
+    }
+  });
+});
+
+describe("G5 — PAYLOAD_TOO_LARGE is a typed, distinguishable fault", () => {
+  test("agentErrorToControlError sets the payloadTooLarge flag", () => {
+    const err = mapped(ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE);
+    expect(err.payloadTooLarge).toBe(true);
+    expect(err.code).toBe(ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE);
+    expect(err.retryable).toBe(false);
+  });
+});
+
+describe("G3-remnant — never-sent retry safety in the pure policy", () => {
+  const NON_READONLY = ["exec", "git", "fsWrite", "fsMove", "desktopInput"];
+
+  test("a never-sent offline fault is retried for ANY op kind (provably not executed)", () => {
+    const error = offlineErr(true);
+    for (const opKind of NON_READONLY) {
+      expect(
+        decideSelfhostedRetry({
+          opKind,
+          error,
+          drainingRetries: 0,
+          timeoutRetries: 0,
+          neverSentRetries: 0,
+          jitter: 0,
+        }).action,
+      ).toBe("retry");
+      // Exhausted after the bounded budget.
+      expect(
+        decideSelfhostedRetry({
+          opKind,
+          error,
+          drainingRetries: 0,
+          timeoutRetries: 0,
+          neverSentRetries: SELFHOSTED_NEVER_SENT_MAX_RETRIES,
+          jitter: 0,
+        }).action,
+      ).toBe("fail");
+    }
+  });
+
+  test("an AMBIGUOUS offline fault (not never-sent) is never retried", () => {
+    const error = offlineErr(false);
+    for (const opKind of [...NON_READONLY, "fsRead"]) {
+      expect(
+        decideSelfhostedRetry({
+          opKind,
+          error,
+          drainingRetries: 0,
+          timeoutRetries: 0,
+          neverSentRetries: 0,
+          jitter: 0,
+        }).action,
+      ).toBe("fail");
+    }
+  });
+});
+
+describe("G3-remnant — the transport marks never-sent only pre-send", () => {
+  const req: ControlRequest = {
+    requestId: "req-1",
+    epoch: 0,
+    op: { $case: "ping", ping: { nonce: "1" } },
+  };
+
+  test("offlineControlResponse threads never-sent through the mapping", () => {
+    expect(agentErrorToControlError(offlineControlResponse("r", true).error!).neverSent).toBe(true);
+    expect(agentErrorToControlError(offlineControlResponse("r", false).error!).neverSent).toBe(
+      false,
+    );
+  });
+
+  test("no NATS connection → offline + never-sent (the request never left)", async () => {
+    const rpc = new NatsControlRpc(async () => null);
+    const res = await rpc.request("subj", req, { timeoutMs: 10 });
+    const err = agentErrorToControlError(res.error!);
+    expect(err.agentOffline).toBe(true);
+    expect(err.neverSent).toBe(true);
+  });
+
+  test("no responders (503) → offline + never-sent (reached no responder)", async () => {
+    const conn = {
+      request: async () => {
+        throw { code: "503" };
+      },
+    };
+    const rpc = new NatsControlRpc(async () => conn);
+    const err = agentErrorToControlError(
+      (await rpc.request("subj", req, { timeoutMs: 10 })).error!,
+    );
+    expect(err.agentOffline).toBe(true);
+    expect(err.neverSent).toBe(true);
+  });
+
+  test("a request timeout → reconnecting, NOT never-sent (ambiguous, post-send)", async () => {
+    const conn = {
+      request: async () => {
+        throw { code: "TIMEOUT" };
+      },
+    };
+    const rpc = new NatsControlRpc(async () => conn);
+    const err = agentErrorToControlError(
+      (await rpc.request("subj", req, { timeoutMs: 10 })).error!,
+    );
+    expect(err.reason).toBe("agent_reconnecting");
+    expect(err.neverSent).toBe(false);
+  });
+
+  test("any other transport error → offline but NOT never-sent (ambiguous mid-send)", async () => {
+    const conn = {
+      request: async () => {
+        throw new Error("connection reset by peer");
+      },
+    };
+    const rpc = new NatsControlRpc(async () => conn);
+    const err = agentErrorToControlError(
+      (await rpc.request("subj", req, { timeoutMs: 10 })).error!,
+    );
+    expect(err.agentOffline).toBe(true);
+    expect(err.neverSent).toBe(false);
+  });
+});
+
+// ── call()-level never-sent heal (a reconnect blip that provably never sent) ────
+
+type Step = (req: ControlRequest) => ControlResponse;
+class ScriptedRpc implements ControlRpc {
+  readonly requests: ControlRequest[] = [];
+  constructor(private readonly steps: Step[]) {}
+  async request(_s: string, req: ControlRequest): Promise<ControlResponse> {
+    this.requests.push(req);
+    return this.steps[Math.min(this.requests.length - 1, this.steps.length - 1)]!(req);
+  }
+}
+function fakeClock(jitter = 0): SelfhostedRetryClock {
+  return { sleep: async () => {}, jitter: () => jitter };
+}
+function neverSentStep(req: ControlRequest): ControlResponse {
+  return offlineControlResponse(req.requestId, true);
+}
+function execOkStep(req: ControlRequest): ControlResponse {
+  return {
+    requestId: req.requestId,
+    error: undefined,
+    result: {
+      $case: "exec",
+      exec: {
+        exitCode: 0,
+        stdout: encoder.encode("ok\n"),
+        stderr: new Uint8Array(0),
+        timedOut: false,
+        durationMs: "1",
+      },
+    },
+  };
+}
+function sessionWith(rpc: ControlRpc): SelfhostedSession {
+  return new SelfhostedSession({
+    workspaceId: WS,
+    agentId: AGENT,
+    controlRpc: rpc,
+    relay: RELAY,
+    retryClock: fakeClock(),
+  });
+}
+
+describe("G3-remnant — call() heals a never-sent blip and surfaces a real outage", () => {
+  test("never-sent then success: a state-changing exec is safely re-issued", async () => {
+    const rpc = new ScriptedRpc([neverSentStep, neverSentStep, execOkStep]);
+    const res = await sessionWith(rpc).exec({ cmd: "true" });
+    expect(res.exitCode).toBe(0);
+    expect(rpc.requests).toHaveLength(3);
+  });
+
+  test("persistent never-sent surfaces offline after the bounded budget", async () => {
+    const rpc = new ScriptedRpc([neverSentStep]);
+    let err: unknown;
+    try {
+      await sessionWith(rpc).exec({ cmd: "true" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(SelfhostedControlError);
+    expect((err as SelfhostedControlError).agentOffline).toBe(true);
+    expect(rpc.requests).toHaveLength(SELFHOSTED_NEVER_SENT_MAX_RETRIES + 1);
+  });
+});
+
+// ── G2 — the routing proxy surfaces the rendering as the exec_command result ────
+
+function proxyOverBackend(backend: RoutableBackendSession): RoutingSandboxSession {
+  const resolved = { session: backend, sandboxId: null, kind: "selfhosted" };
+  return new RoutingSandboxSession({
+    defaultResolved: resolved,
+    readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+    resolveActiveBackend: async () => resolved,
+  });
+}
+
+describe("G2 — RoutingSandboxSession.execCommand renders a terminal fault as its result", () => {
+  test("an offline fault becomes a four-field string (never a thrown wrapper)", async () => {
+    const backend: RoutableBackendSession = {
+      execCommand: async () => {
+        throw offlineErr(true);
+      },
+    };
+    const out = await proxyOverBackend(backend).execCommand({ cmd: "ls" });
+    for (const field of ALL_FIELDS) {
+      expect(out).toContain(field);
+    }
+    expect(out).not.toContain("Please try again");
+  });
+
+  test("a fence error is re-thrown (routing retries it), NOT rendered", async () => {
+    const backend: RoutableBackendSession = {
+      execCommand: async () => {
+        throw mapped(ErrorCode.ERROR_CODE_FENCED);
+      },
+    };
+    let threw = false;
+    try {
+      await proxyOverBackend(backend).execCommand({ cmd: "ls" });
+    } catch (e) {
+      threw = true;
+      expect(e).toBeInstanceOf(SelfhostedControlError);
+      expect((e as SelfhostedControlError).fenced).toBe(true);
+    }
+    expect(threw).toBe(true);
+  });
+
+  test("a non-selfhosted error is re-thrown unchanged", async () => {
+    const backend: RoutableBackendSession = {
+      execCommand: async () => {
+        throw new RoutingUnsupportedError("execCommand", "modal");
+      },
+    };
+    let threw = false;
+    try {
+      await proxyOverBackend(backend).execCommand({ cmd: "ls" });
+    } catch (e) {
+      threw = true;
+      expect(e).toBeInstanceOf(RoutingUnsupportedError);
+    }
+    expect(threw).toBe(true);
+  });
+
+  test("a healthy command is unaffected (returns real stdout)", async () => {
+    const backend: RoutableBackendSession = {
+      execCommand: async () => "hello\n",
+    };
+    expect(await proxyOverBackend(backend).execCommand({ cmd: "echo hello" })).toBe("hello\n");
+  });
+});


### PR DESCRIPTION
# fix(selfhosted): in-band fault legibility (G2 + G5 + G3-remnant)

The in-band-legibility slice of the failure-visibility doctrine for the Connected
Machine (selfhosted) control path. Server-side TS only; no proto/Rust changes, no
`machine.*` events (that is the next slice). Branch off current main (includes #356).

## G2 — kill the misleading "Please try again" for machine faults

A thrown `SelfhostedControlError` reached the model wrapped by the SDK's generic
tool-error function as *"An error occurred while running the tool. Please try again.
Error: …"* — actively wrong for a machine that is offline, a consent that is not
granted, or an oversized reply, and none of the four doctrine fields were structurally
present.

**Mechanism (why not `errorFunction`).** The intended seam — `tool({errorFunction})`
— is unreachable: the SDK's capability tools build their `errorFunction` into a
closure at `tool()` construction, and the only post-build hook (`configureTools`)
receives already-baked tools whose `invoke` has *already* swallowed the throw into the
default string. So the fault is rendered at the SDK-bound boundary instead: new
`renderSelfhostedFault(error)` (packages/runtime/src/sandbox/selfhosted/fault-rendering.ts)
reads the fault CLASS from the typed flags — never the prose — and emits the four
fields with a correct verdict:

- **PAYLOAD_TOO_LARGE** — the command ran but its reply was too big; recover by bounding
  the output, not retrying.
- **DRAINING** — pre-admission backpressure; nothing ran; safe to retry shortly.
- **CONSENT_REQUIRED** — a machine-side gate; retrying cannot help.
- **AGENT_OFFLINE** — the machine link is down; `neverSent` ⇒ nothing ran, else the
  effect is ambiguous. Either way "try again" is wrong until it reconnects.
- **agent_reconnecting (TIMEOUT)** — a post-send blip; ambiguous, so a state-changing
  command must be checked before re-running.
- **NOT_FOUND / FENCED / OS-default** — command/filesystem, session-swap, and op-level.

`RoutingSandboxSession.execCommand` returns the rendering as the `exec_command` tool's
string result (in-band, legible, no wrapper). A FENCE error is re-thrown (dispatch
retries it); a non-selfhosted error (Modal, `RoutingUnsupportedError`) is re-thrown
unchanged; a healthy command is untouched.

**Scope note.** `exec_command` is the dominant "Please try again" victim and the clean
string boundary. `apply_patch` already surfaces `error.message` via the SDK's own catch
(not the generic wrapper); the skills / `view_image` tools consume their session
methods *internally* (rendering the low-level `readFile`/`pathExists` would corrupt
skill loading), so those are deliberately left to a follow-up rather than rendered here.

## G5 — PAYLOAD_TOO_LARGE typed + actionable

Added a distinguishing `payloadTooLarge` flag to `SelfhostedControlError` (the mapping
case already existed from #347; this makes it structurally distinguishable from a
generic OS error). The renderer names the size wall from `detail.encoded_bytes` /
`detail.max_payload`, states honestly that **nothing was returned — the reply was
dropped whole**, and gives the recovery moves (redirect to a file `> /tmp/out.log
2>&1`, slice with `head -c` / `tail -c`, read the file back in chunks).

## G3-remnant — bounded quiet heal, only where provably safe

Constraint (at-least-once until durable op ids ship): re-issue a reconnecting/offline
fault ONLY when the transport KNOWS the request never left. The synthesis paths in
`NatsControlRpc.request` now mark a `neverSent` flag (via a reserved `detail` key) on
exactly the pre-send cases — **no connection** and **no responder (503)**, where the op
provably never reached the machine — and NOT on a request timeout or a connection torn
mid-request (both ambiguous). `decideSelfhostedRetry` gained a `neverSent` branch:
retry for ANY op kind up to `SELFHOSTED_NEVER_SENT_MAX_RETRIES` (3, ~3.5s summed on the
existing backoff curve), so a NATS reconnect blip heals quietly and a genuinely-offline
machine surfaces honestly after the short budget. A mid-flight ambiguous non-idempotent
op is never re-sent — it is rendered (G2) stating the ambiguity. Extends the existing
policy site rather than adding a second one; `call()` tracks a separate never-sent
counter.

## Test coverage

`packages/runtime/test/selfhosted-fault-legibility.test.ts` (30 tests):
- every fault class renders all four fields (never empty) with the typed code folded in;
- per-class verdict correctness (offline never-sent = nothing ran + "will not help";
  ambiguous = check before re-running; draining = try again shortly; consent = keep
  failing; payload = sizes + dropped-whole + recovery; reconnecting = ambiguous); and
  none render "Please try again";
- G5 flag set on the mapped payload fault;
- never-sent retries any op and exhausts to an honest offline surface; ambiguous offline
  never retries;
- the transport marks never-sent only pre-send (no-connection / no-responder), not on a
  timeout or a mid-send tear (four `NatsControlRpc` cases);
- `call()` heals a never-sent blip on a state-changing exec, and surfaces offline after
  the bounded budget;
- the routing proxy returns the rendering as the `exec_command` result, re-throws fence
  + non-selfhosted errors, and leaves healthy output untouched.

Verification: monorepo `bun run typecheck` green (tsgo — incl. `packages/testing`,
which consumes Settings; this PR touches no Settings); affected runtime + worker suites
green (selfhosted-fault-legibility, -resilience, -session, -capabilities, routing-proxy,
selfhosted-turn/nats integration, worker sandbox-routing + machine-primary); oxlint +
oxfmt clean; changeset added (`@opengeni/runtime` patch).

## Not in scope (next slice)

`machine.*` session events, contracts/golden-grammar, metrics hooks, GoingOffline
ingestion; four-field rendering for `apply_patch` / `load_skill` / `view_image`.
