### PR TITLE
feat(machines): immediate-offline on clean goodbye + machine.link.* session events

### DIFF
--- a/.changeset/machine-immediate-offline.md
+++ b/.changeset/machine-immediate-offline.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+---
+
+Connected Machines read OFFLINE immediately on a clean going-offline. When a machine announces a typed GoingOffline (user-stop / self-update / host-shutdown) it now records a nullable `went_offline_at` + `went_offline_reason` marker on its enrollment, and the liveness derivation gives an un-cleared marker precedence over last_seen aging AND over a lingering liveness probe — so the dashboard and any work-routing decision see the machine as offline right away instead of waiting out the dead-detect window. A lifecycle `revoked` status still trumps the marker, and any newer liveness signal (a reconnect Hello or a fresher heartbeat) clears it back to null. Adds the `setEnrollmentWentOffline` and `clearEnrollmentWentOffline` DB helpers, threads the marker onto `EnrollmentRecord` and the `selfhostedLiveness` input, and clears it inside `touchEnrollmentLastSeen`.

--- a/.changeset/machine-link-events.md
+++ b/.changeset/machine-link-events.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/sdk": patch
+"@opengeni/db": patch
+---
+
+Add the `machine.link.lost`, `machine.link.restored`, and `machine.runner.restarted` session-event types for Connected Machine control-link observability (the failure-visibility doctrine's link plane). These are session-scoped, announce-only diagnostics fanned out only to the sessions that had an active op running on the machine when its control link changed — never to idle or historical sessions. A clean going-offline emits `machine.link.lost` (plus `machine.runner.restarted` when the reason is a self-update restart), and a reconnect Hello that actually cleared a going-offline marker emits `machine.link.restored`. All three project to the timeline's quiet tier (no rendered item) and are mirrored in the SDK event-type list. Adds the `sessionsWithActiveOpOnEnrollment` DB helper (one indexed lookup, no per-op tracking table) that resolves the fan-out target set.

--- a/apps/api/src/sandbox/machines.ts
+++ b/apps/api/src/sandbox/machines.ts
@@ -119,6 +119,8 @@ async function probeEnrollment(
       allowScreenControl: enrollment.allowScreenControl,
       hasDisplay: enrollment.hasDisplay,
       lastSeenAt: enrollment.lastSeenAt,
+      wentOfflineAt: enrollment.wentOfflineAt,
+      wentOfflineReason: enrollment.wentOfflineReason,
     },
     probeResponded,
   });

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -159,23 +159,38 @@ export async function ingestHeartbeat(
  * plane. Each session's events are stamped on its OWN active turn. No matching
  * session ⇒ nothing is emitted (an idle-machine blip must never spam idle /
  * historical sessions). Called best-effort inside the handlers' fail-soft blocks.
+ *
+ * Each session's emission is ISOLATED: one session's append failing (a
+ * session-specific constraint like a sequence collision from a racing writer, a
+ * transient write error) is logged with that sessionId and skipped, never
+ * aborting the fan-out — one session's failure must never cost the OTHER matching
+ * sessions their events. A partial fan-out stays visible per-session in the logs.
  */
 async function fanOutMachineLinkEvents(
   db: Database,
   bus: EventBus,
+  observability: Observability | undefined,
   workspaceId: string,
   enrollmentId: string,
   build: (activeTurnId: string) => AppendEventInput[],
 ): Promise<void> {
   const sessions = await sessionsWithActiveOpOnEnrollment(db, { workspaceId, enrollmentId });
   for (const session of sessions) {
-    await appendAndPublishEvents(
-      db,
-      bus,
-      workspaceId,
-      session.sessionId,
-      build(session.activeTurnId),
-    );
+    try {
+      await appendAndPublishEvents(
+        db,
+        bus,
+        workspaceId,
+        session.sessionId,
+        build(session.activeTurnId),
+      );
+    } catch (error) {
+      observability?.warn?.("Failed to fan out a machine-link event to a session", {
+        workspaceId,
+        sessionId: session.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }
 
@@ -242,15 +257,26 @@ export async function handleAgentEventPayload(
         if (bus) {
           const isSelfUpdate =
             event.event.goingOffline.reason === GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE;
-          await fanOutMachineLinkEvents(db, bus, ids.workspaceId, ids.agentId, (activeTurnId) => {
-            const events: AppendEventInput[] = [
-              { type: "machine.link.lost", turnId: activeTurnId, payload: { reason } },
-            ];
-            if (isSelfUpdate) {
-              events.push({ type: "machine.runner.restarted", turnId: activeTurnId, payload: {} });
-            }
-            return events;
-          });
+          await fanOutMachineLinkEvents(
+            db,
+            bus,
+            observability,
+            ids.workspaceId,
+            ids.agentId,
+            (activeTurnId) => {
+              const events: AppendEventInput[] = [
+                { type: "machine.link.lost", turnId: activeTurnId, payload: { reason } },
+              ];
+              if (isSelfUpdate) {
+                events.push({
+                  type: "machine.runner.restarted",
+                  turnId: activeTurnId,
+                  payload: {},
+                });
+              }
+              return events;
+            },
+          );
         }
       }
     } catch (error) {
@@ -435,9 +461,14 @@ export async function handleHelloPayload(
         enrollmentId: ids.agentId,
       });
       if (cleared && bus) {
-        await fanOutMachineLinkEvents(db, bus, ids.workspaceId, ids.agentId, (activeTurnId) => [
-          { type: "machine.link.restored", turnId: activeTurnId, payload: {} },
-        ]);
+        await fanOutMachineLinkEvents(
+          db,
+          bus,
+          observability,
+          ids.workspaceId,
+          ids.agentId,
+          (activeTurnId) => [{ type: "machine.link.restored", turnId: activeTurnId, payload: {} }],
+        );
       }
     }
   } catch (error) {

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -37,7 +37,12 @@ import {
 } from "@opengeni/db";
 import type { EventBus } from "@opengeni/events";
 import type { Observability } from "@opengeni/observability";
-import { AgentEvent, Hello, type MetricsSample } from "@opengeni/agent-proto";
+import {
+  AgentEvent,
+  Hello,
+  goingOfflineReasonToJSON,
+  type MetricsSample,
+} from "@opengeni/agent-proto";
 
 /** The wildcard subject the agent event plane publishes heartbeats on. */
 export const AGENT_EVENTS_SUBJECT = "agent.*.*.events";
@@ -167,8 +172,23 @@ export async function handleAgentEventPayload(
     });
     return;
   }
+  // A clean GoingOffline is the machine-plane's typed shutdown signal — previously
+  // dropped here. Record it ALWAYS on the machine plane (a Prometheus counter keyed
+  // by the typed reason) so a fleet operator can see clean stops / self-updates /
+  // host shutdowns. It does NOT touch last-seen (a shutdown must not look "more
+  // recently alive" — the derived liveness ages to offline naturally). The
+  // session-plane fan-out (machine.link.lost to sessions with active ops) is a
+  // separate slice.
+  if (event.event?.$case === "goingOffline") {
+    observability?.incrementCounter({
+      name: "opengeni_machine_going_offline_total",
+      help: "Total Connected Machine clean GoingOffline signals by typed reason.",
+      labels: { reason: goingOfflineReasonToJSON(event.event.goingOffline.reason) },
+    });
+    return;
+  }
   if (event.event?.$case !== "heartbeat") {
-    return; // going-offline / unknown → not a metrics point.
+    return; // an unknown event kind → not a metrics point.
   }
   const metrics = event.event.heartbeat.metrics;
   if (!metrics) {

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -31,16 +31,19 @@ import {
   clearEnrollmentWentOffline,
   getEnrollment,
   ingestMachineMetricsSample,
+  sessionsWithActiveOpOnEnrollment,
   setEnrollmentDisplayState,
   setEnrollmentWentOffline,
   touchEnrollmentLastSeen,
+  type AppendEventInput,
   type Database,
   type MachineMetricsSample,
 } from "@opengeni/db";
-import type { EventBus } from "@opengeni/events";
+import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import type { Observability } from "@opengeni/observability";
 import {
   AgentEvent,
+  GoingOfflineReason,
   Hello,
   goingOfflineReasonToJSON,
   type MetricsSample,
@@ -150,15 +153,45 @@ export async function ingestHeartbeat(
 }
 
 /**
+ * Fan out one or more machine-LINK session events to the sessions that had an
+ * active op running on the machine when its control link changed (per
+ * `sessionsWithActiveOpOnEnrollment`) — the announce-only failure-visibility
+ * plane. Each session's events are stamped on its OWN active turn. No matching
+ * session ⇒ nothing is emitted (an idle-machine blip must never spam idle /
+ * historical sessions). Called best-effort inside the handlers' fail-soft blocks.
+ */
+async function fanOutMachineLinkEvents(
+  db: Database,
+  bus: EventBus,
+  workspaceId: string,
+  enrollmentId: string,
+  build: (activeTurnId: string) => AppendEventInput[],
+): Promise<void> {
+  const sessions = await sessionsWithActiveOpOnEnrollment(db, { workspaceId, enrollmentId });
+  for (const session of sessions) {
+    await appendAndPublishEvents(
+      db,
+      bus,
+      workspaceId,
+      session.sessionId,
+      build(session.activeTurnId),
+    );
+  }
+}
+
+/**
  * Decode a raw `AgentEvent` payload + ingest it (the per-message handler). A
- * heartbeat carrying a metrics sample is ingested; a going-offline (or a
- * heartbeat without metrics) is a no-op. Decode failures are reported + swallowed.
+ * heartbeat carrying a metrics sample is ingested; a going-offline records the
+ * machine-plane marker + fans out the link-plane session events. Decode failures
+ * are reported + swallowed. `bus` (when present) enables the session-event
+ * fan-out; the live consumer always supplies it, pure unit tests may omit it.
  */
 export async function handleAgentEventPayload(
   db: Database,
   observability: Observability | undefined,
   payload: Uint8Array,
   subject: string,
+  bus?: EventBus,
 ): Promise<void> {
   const ids = parseAgentEventSubject(subject);
   if (!ids) {
@@ -201,6 +234,24 @@ export async function handleAgentEventPayload(
           enrollmentId: ids.agentId,
           reason,
         });
+        // Fan out the link-plane events to the sessions with an active op on this
+        // machine: machine.link.lost (its control link is going away) for every
+        // clean going-offline, PLUS machine.runner.restarted when the reason is a
+        // self-update restart specifically (link.lost fires for it too; this
+        // distinguishes a restart from a plain stop / host shutdown).
+        if (bus) {
+          const isSelfUpdate =
+            event.event.goingOffline.reason === GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE;
+          await fanOutMachineLinkEvents(db, bus, ids.workspaceId, ids.agentId, (activeTurnId) => {
+            const events: AppendEventInput[] = [
+              { type: "machine.link.lost", turnId: activeTurnId, payload: { reason } },
+            ];
+            if (isSelfUpdate) {
+              events.push({ type: "machine.runner.restarted", turnId: activeTurnId, payload: {} });
+            }
+            return events;
+          });
+        }
       }
     } catch (error) {
       observability?.warn?.("Failed to record a machine clean going-offline", {
@@ -242,7 +293,7 @@ export function startMetricsIngestion(deps: {
   observability?: Observability;
 }): () => void {
   return deps.bus.subscribeAgentEvents(AGENT_EVENTS_SUBJECT, (payload, subject) =>
-    handleAgentEventPayload(deps.db, deps.observability, payload, subject),
+    handleAgentEventPayload(deps.db, deps.observability, payload, subject, deps.bus),
   );
 }
 
@@ -326,15 +377,19 @@ export async function refreshEnrollmentDisplay(
 }
 
 /**
- * Decode a raw `Hello` payload + refresh the enrollment's display cursor (the
- * per-message handler for the hello plane). Decode failures + write failures are
- * reported + swallowed — a display refresh must NEVER break the agent's connect.
+ * Decode a raw `Hello` payload + refresh the enrollment's display cursor + clear
+ * any pending clean going-offline marker and, when the reconnect actually cleared
+ * one, fan out machine.link.restored to the sessions with an active op on the
+ * machine (the per-message handler for the hello plane). Decode failures + write
+ * failures are reported + swallowed — a Hello must NEVER break the agent's connect.
+ * `bus` (when present) enables the link.restored fan-out.
  */
 export async function handleHelloPayload(
   db: Database,
   observability: Observability | undefined,
   payload: Uint8Array,
   subject: string,
+  bus?: EventBus,
 ): Promise<void> {
   const ids = parseAgentHelloSubject(subject);
   if (!ids) {
@@ -367,15 +422,23 @@ export async function handleHelloPayload(
   // marker no longer holds — clear it so the liveness derivation stops reading the
   // machine offline. Best-effort + fail-soft, and change-guarded in the DB (a
   // steady-state Hello with no marker writes nothing), so this never breaks the
-  // agent's connect and never churns.
+  // agent's connect and never churns. When a marker was ACTUALLY cleared (the
+  // machine had been reported link.lost), fan out machine.link.restored to the
+  // sessions with an active op on it — a restored only ever pairs a prior lost, so
+  // a routine connect Hello (no marker) emits nothing.
   try {
     const enrollment = await getEnrollment(db, ids.workspaceId, ids.agentId);
     if (enrollment) {
-      await clearEnrollmentWentOffline(db, {
+      const { cleared } = await clearEnrollmentWentOffline(db, {
         accountId: enrollment.accountId,
         workspaceId: ids.workspaceId,
         enrollmentId: ids.agentId,
       });
+      if (cleared && bus) {
+        await fanOutMachineLinkEvents(db, bus, ids.workspaceId, ids.agentId, (activeTurnId) => [
+          { type: "machine.link.restored", turnId: activeTurnId, payload: {} },
+        ]);
+      }
     }
   } catch (error) {
     observability?.warn?.("Failed to clear a machine going-offline marker on a Hello", {
@@ -397,6 +460,6 @@ export function startHelloIngestion(deps: {
   observability?: Observability;
 }): () => void {
   return deps.bus.subscribeAgentEvents(AGENT_HELLO_SUBJECT, (payload, subject) =>
-    handleHelloPayload(deps.db, deps.observability, payload, subject),
+    handleHelloPayload(deps.db, deps.observability, payload, subject, deps.bus),
   );
 }

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -28,9 +28,11 @@
 // back-pressures the agent, or breaks its connect.
 
 import {
+  clearEnrollmentWentOffline,
   getEnrollment,
   ingestMachineMetricsSample,
   setEnrollmentDisplayState,
+  setEnrollmentWentOffline,
   touchEnrollmentLastSeen,
   type Database,
   type MachineMetricsSample,
@@ -172,19 +174,40 @@ export async function handleAgentEventPayload(
     });
     return;
   }
-  // A clean GoingOffline is the machine-plane's typed shutdown signal — previously
-  // dropped here. Record it ALWAYS on the machine plane (a Prometheus counter keyed
-  // by the typed reason) so a fleet operator can see clean stops / self-updates /
-  // host shutdowns. It does NOT touch last-seen (a shutdown must not look "more
-  // recently alive" — the derived liveness ages to offline naturally). The
-  // session-plane fan-out (machine.link.lost to sessions with active ops) is a
-  // separate slice.
+  // A clean GoingOffline is the machine-plane's typed shutdown signal. Two things
+  // happen, in this order:
+  //   1. Record it ALWAYS on the machine plane (a Prometheus counter keyed by the
+  //      typed reason) so a fleet operator can see clean stops / self-updates /
+  //      host shutdowns. This fires unconditionally, independent of the DB.
+  //   2. Stamp the enrollment's clean going-offline marker so the liveness
+  //      derivation reads the machine OFFLINE immediately instead of waiting out
+  //      the last_seen dead-detect window. Best-effort + fail-soft (like the rest
+  //      of this module): an unknown enrollment is a no-op and a DB error is
+  //      swallowed so a bad write never tears down the consumer. Deliberately does
+  //      NOT touch last-seen (a shutdown must not look "more recently alive").
   if (event.event?.$case === "goingOffline") {
+    const reason = goingOfflineReasonToJSON(event.event.goingOffline.reason);
     observability?.incrementCounter({
       name: "opengeni_machine_going_offline_total",
       help: "Total Connected Machine clean GoingOffline signals by typed reason.",
-      labels: { reason: goingOfflineReasonToJSON(event.event.goingOffline.reason) },
+      labels: { reason },
     });
+    try {
+      const enrollment = await getEnrollment(db, ids.workspaceId, ids.agentId);
+      if (enrollment) {
+        await setEnrollmentWentOffline(db, {
+          accountId: enrollment.accountId,
+          workspaceId: ids.workspaceId,
+          enrollmentId: ids.agentId,
+          reason,
+        });
+      }
+    } catch (error) {
+      observability?.warn?.("Failed to record a machine clean going-offline", {
+        subject,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return;
   }
   if (event.event?.$case !== "heartbeat") {
@@ -336,6 +359,26 @@ export async function handleHelloPayload(
     });
   } catch (error) {
     observability?.warn?.("Failed to refresh an enrollment's display from a Hello", {
+      subject,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  // A reconnect Hello re-announces the machine, so any pending clean going-offline
+  // marker no longer holds — clear it so the liveness derivation stops reading the
+  // machine offline. Best-effort + fail-soft, and change-guarded in the DB (a
+  // steady-state Hello with no marker writes nothing), so this never breaks the
+  // agent's connect and never churns.
+  try {
+    const enrollment = await getEnrollment(db, ids.workspaceId, ids.agentId);
+    if (enrollment) {
+      await clearEnrollmentWentOffline(db, {
+        accountId: enrollment.accountId,
+        workspaceId: ids.workspaceId,
+        enrollmentId: ids.agentId,
+      });
+    }
+  } catch (error) {
+    observability?.warn?.("Failed to clear a machine going-offline marker on a Hello", {
       subject,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -28,7 +28,11 @@ import {
 import { subjectFor } from "@opengeni/runtime";
 import { createApp } from "../src/app";
 import type { AppDependencies, SessionWorkflowClient } from "@opengeni/core";
-import { handleHelloPayload, startMetricsIngestion } from "../src/sandbox/metrics-ingestion";
+import {
+  handleAgentEventPayload,
+  handleHelloPayload,
+  startMetricsIngestion,
+} from "../src/sandbox/metrics-ingestion";
 
 // Track started ingestion consumers so afterEach can unsubscribe them (each test
 // uses its own bus, but cleaning up keeps subscriptions from leaking).
@@ -707,5 +711,80 @@ describe("machine.link.* fan-out — link-plane session events on going-offline 
       where workspace_id = ${workspaceId}
         and (type like 'machine.link.%' or type = 'machine.runner.restarted')`;
     expect(count).toBe(0);
+  }, 90_000);
+
+  test("a per-session emission failure is ISOLATED: the first session's append rejecting still delivers to the rest + logs the failure", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, enrollment, sandbox, bus } = await seed();
+
+    // Two sessions with an active op on the machine. sessionA is created first, so
+    // the fan-out's stable order (oldest first) processes it FIRST.
+    const mk = async (msg: string) =>
+      await createSession(db, {
+        accountId,
+        workspaceId,
+        initialMessage: msg,
+        resources: [],
+        metadata: {},
+        model: "gpt-test",
+        sandboxBackend: "modal",
+      });
+    const sessionA = await mk("a");
+    const sessionB = await mk("b");
+    await makeActiveOp(
+      accountId,
+      workspaceId,
+      sessionA.id,
+      sandbox.id,
+      "eeeeeeee-0000-4000-8000-000000000001",
+    );
+    await makeActiveOp(
+      accountId,
+      workspaceId,
+      sessionB.id,
+      sandbox.id,
+      "eeeeeeee-0000-4000-8000-000000000002",
+    );
+
+    // Rig sessionA's NEXT append to REJECT: pre-occupy its next sequence slot so the
+    // unique (workspace, session, sequence) index throws on sessionA's fan-out
+    // append — a faithful stand-in for the session-specific / racing-writer failure
+    // the isolation must survive. sessionB is untouched.
+    const [{ last_sequence: lastSeqA }] = await admin<{ last_sequence: number }[]>`
+      select last_sequence from sessions where id = ${sessionA.id}`;
+    await admin`
+      insert into session_events (account_id, workspace_id, session_id, sequence, type)
+      values (${accountId}, ${workspaceId}, ${sessionA.id}, ${lastSeqA + 1}, 'user.message')`;
+
+    // Capture warns; call the handler directly so the per-session log is observable.
+    const warns: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    const observability = {
+      incrementCounter: () => {},
+      warn: (message: string, meta?: Record<string, unknown>) => warns.push({ message, meta }),
+    } as unknown as Parameters<typeof handleAgentEventPayload>[1];
+    const payload = AgentEvent.encode({
+      agentId: enrollment.id,
+      event: {
+        $case: "goingOffline",
+        goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE },
+      },
+    }).finish();
+    await handleAgentEventPayload(
+      db,
+      observability,
+      payload,
+      `agent.${workspaceId}.${enrollment.id}.events`,
+      bus,
+    );
+
+    // sessionA's append rejected → it got NO machine-link events...
+    expect(await machineLinkEvents(sessionA.id)).toEqual([]);
+    // ...but sessionB, processed AFTER the failure, still received its full set.
+    expect((await machineLinkEvents(sessionB.id)).map((e) => e.type)).toEqual([
+      "machine.link.lost",
+      "machine.runner.restarted",
+    ]);
+    // ...and the failure is visible in the logs, naming the failed sessionId.
+    expect(warns.some((w) => w.meta?.sessionId === sessionA.id)).toBe(true);
   }, 90_000);
 });

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -11,6 +11,7 @@ import {
   ControlRequest,
   ControlResponse,
   GoingOfflineReason,
+  Hello,
 } from "@opengeni/agent-proto";
 import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
 import {
@@ -20,13 +21,14 @@ import {
   createSession,
   listSandboxes,
   revokeEnrollment,
+  setActiveSandbox,
   type Database,
   type DbClient,
 } from "@opengeni/db";
 import { subjectFor } from "@opengeni/runtime";
 import { createApp } from "../src/app";
 import type { AppDependencies, SessionWorkflowClient } from "@opengeni/core";
-import { startMetricsIngestion } from "../src/sandbox/metrics-ingestion";
+import { handleHelloPayload, startMetricsIngestion } from "../src/sandbox/metrics-ingestion";
 
 // Track started ingestion consumers so afterEach can unsubscribe them (each test
 // uses its own bus, but cleaning up keeps subscriptions from leaking).
@@ -565,5 +567,145 @@ describe("M10 flag gate + authz", () => {
 
     // No bearer at all → 401.
     expect((await onApp.request(`/v1/workspaces/${workspaceId}/machines`)).status).toBe(401);
+  }, 90_000);
+});
+
+describe("machine.link.* fan-out — link-plane session events on going-offline / reconnect", () => {
+  // Read the machine-link events a session accumulated (ordered), each with the
+  // turn they were stamped on.
+  async function machineLinkEvents(
+    sessionId: string,
+  ): Promise<Array<{ type: string; turn_id: string | null }>> {
+    return await admin<{ type: string; turn_id: string | null }[]>`
+      select type, turn_id from session_events
+      where session_id = ${sessionId}
+        and (type like 'machine.link.%' or type = 'machine.runner.restarted')
+      order by sequence`;
+  }
+
+  // Point a seeded session at its machine's sandbox with a running turn, so the
+  // fan-out query counts it as "a session with an active op on the machine".
+  async function makeActiveOp(
+    accountId: string,
+    workspaceId: string,
+    sessionId: string,
+    sandboxId: string,
+    turnId: string,
+  ): Promise<void> {
+    await setActiveSandbox(db, {
+      accountId,
+      workspaceId,
+      sessionId,
+      targetSandboxId: sandboxId,
+      expectedEpoch: 0,
+    });
+    await admin`update sessions set active_turn_id = ${turnId} where id = ${sessionId}`;
+  }
+
+  function helloBytes(agentId: string, workspaceId: string): Uint8Array {
+    return Hello.encode(
+      Hello.fromPartial({ agentId, workspaceId, capabilities: { desktop: true } }),
+    ).finish();
+  }
+
+  test("a self-update GoingOffline fans out link.lost + runner.restarted to the active-op session, on its running turn", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, session, enrollment, sandbox, bus } = await seed();
+    const turnId = "dddddddd-0000-4000-8000-000000000001";
+    await makeActiveOp(accountId, workspaceId, session.id, sandbox.id, turnId);
+    appFor(bus); // starts the metrics-ingestion consumer
+
+    await emitGoingOffline(
+      bus,
+      workspaceId,
+      enrollment.id,
+      GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE,
+    );
+
+    const events = await machineLinkEvents(session.id);
+    expect(events.map((e) => e.type)).toEqual(["machine.link.lost", "machine.runner.restarted"]);
+    // Both are stamped on the session's OWN running turn.
+    expect(events.every((e) => e.turn_id === turnId)).toBe(true);
+  }, 90_000);
+
+  test("a plain (non-update) GoingOffline fans out link.lost ONLY (no runner.restarted)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, session, enrollment, sandbox, bus } = await seed();
+    const turnId = "dddddddd-0000-4000-8000-000000000002";
+    await makeActiveOp(accountId, workspaceId, session.id, sandbox.id, turnId);
+    appFor(bus);
+
+    await emitGoingOffline(
+      bus,
+      workspaceId,
+      enrollment.id,
+      GoingOfflineReason.GOING_OFFLINE_REASON_HOST_SHUTDOWN,
+    );
+
+    expect((await machineLinkEvents(session.id)).map((e) => e.type)).toEqual(["machine.link.lost"]);
+  }, 90_000);
+
+  test("a reconnect Hello after a lost fans out link.restored; a second Hello (marker already cleared) emits nothing more", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, session, enrollment, sandbox, bus } = await seed();
+    const turnId = "dddddddd-0000-4000-8000-000000000003";
+    await makeActiveOp(accountId, workspaceId, session.id, sandbox.id, turnId);
+    appFor(bus);
+
+    // Lose the link first (sets the marker + emits link.lost).
+    await emitGoingOffline(
+      bus,
+      workspaceId,
+      enrollment.id,
+      GoingOfflineReason.GOING_OFFLINE_REASON_USER_STOP,
+    );
+
+    // Reconnect: the Hello clears the marker → emits link.restored on the turn.
+    await handleHelloPayload(
+      db,
+      undefined,
+      helloBytes(enrollment.id, workspaceId),
+      `agent.${workspaceId}.${enrollment.id}.hello`,
+      bus,
+    );
+    const afterFirst = await machineLinkEvents(session.id);
+    const restored = afterFirst.filter((e) => e.type === "machine.link.restored");
+    expect(restored).toHaveLength(1);
+    expect(restored[0]!.turn_id).toBe(turnId);
+
+    // A second Hello finds no marker to clear → no further restored (a restored only
+    // ever pairs a prior lost).
+    await handleHelloPayload(
+      db,
+      undefined,
+      helloBytes(enrollment.id, workspaceId),
+      `agent.${workspaceId}.${enrollment.id}.hello`,
+      bus,
+    );
+    const afterSecond = await machineLinkEvents(session.id);
+    expect(afterSecond.filter((e) => e.type === "machine.link.restored")).toHaveLength(1);
+  }, 90_000);
+
+  test("no session with an active op on the machine ⇒ a GoingOffline emits NO session events (idle blip stays silent)", async () => {
+    if (!available) return;
+    // seed() creates a session but does NOT point it at the machine / give it a
+    // running turn, so the fan-out query matches nothing.
+    const { workspaceId, session, enrollment, bus } = await seed();
+    appFor(bus);
+
+    await emitGoingOffline(
+      bus,
+      workspaceId,
+      enrollment.id,
+      GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE,
+    );
+
+    expect(await machineLinkEvents(session.id)).toEqual([]);
+    // And nothing leaked onto any other session in the workspace either.
+    const [{ count }] = await admin<{ count: number }[]>`
+      select count(*)::int as count from session_events
+      where workspace_id = ${workspaceId}
+        and (type like 'machine.link.%' or type = 'machine.runner.restarted')`;
+    expect(count).toBe(0);
   }, 90_000);
 });

--- a/apps/api/test/machines-routes.test.ts
+++ b/apps/api/test/machines-routes.test.ts
@@ -6,7 +6,12 @@ import {
   acquireSharedTestDatabase,
   type SharedTestDatabase,
 } from "@opengeni/testing";
-import { AgentEvent, ControlRequest, ControlResponse } from "@opengeni/agent-proto";
+import {
+  AgentEvent,
+  ControlRequest,
+  ControlResponse,
+  GoingOfflineReason,
+} from "@opengeni/agent-proto";
 import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
 import {
   createDb,
@@ -156,6 +161,21 @@ async function emitHeartbeat(
         },
       },
     },
+  }).finish();
+  await bus.emitAgentEvent(`agent.${workspaceId}.${agentId}.events`, event);
+}
+
+/** Emit a clean GoingOffline AgentEvent, driving the ingestion consumer to stamp
+ *  the enrollment's clean going-offline marker. */
+async function emitGoingOffline(
+  bus: MemoryEventBus,
+  workspaceId: string,
+  agentId: string,
+  reason: GoingOfflineReason,
+): Promise<void> {
+  const event = AgentEvent.encode({
+    agentId,
+    event: { $case: "goingOffline", goingOffline: { reason } },
   }).finish();
   await bus.emitAgentEvent(`agent.${workspaceId}.${agentId}.events`, event);
 }
@@ -338,6 +358,43 @@ describe("M10 GET /machines — dashboard list + states + metrics", () => {
     expect(group!.sandboxId).toBe(session.sandboxGroupId);
     // Both the group box + the enrolled machine are present.
     expect(sessBody.machines.length).toBe(2);
+  }, 90_000);
+
+  test("clean going-offline round-trip: online → GoingOffline reads OFFLINE immediately (probe still responds) → heartbeat reads ONLINE again", async () => {
+    if (!available) return;
+    // seed() registers a ping responder (online) + a fresh last_seen, so WITHOUT a
+    // marker the machine reads online. This proves the marker takes precedence over
+    // BOTH a still-responding probe and a still-fresh last_seen — the #348 fix —
+    // end-to-end through the real ingestion consumer + derivation + endpoint.
+    const { accountId, workspaceId, enrollment, bus } = await seed();
+    const app = appFor(bus);
+    const auth = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
+    const stateNow = async (): Promise<string> => {
+      const body = (await (
+        await app.request(`/v1/workspaces/${workspaceId}/machines`, {
+          headers: { authorization: auth },
+        })
+      ).json()) as { machines: Array<{ state: string }> };
+      return body.machines[0]!.state;
+    };
+
+    // 1. Online: probe responds + last_seen fresh.
+    await emitHeartbeat(bus, workspaceId, enrollment.id, 10);
+    expect(await stateNow()).toBe("online");
+
+    // 2. Clean GoingOffline → OFFLINE immediately, though the probe STILL responds
+    //    and last_seen is still fresh (the marker wins).
+    await emitGoingOffline(
+      bus,
+      workspaceId,
+      enrollment.id,
+      GoingOfflineReason.GOING_OFFLINE_REASON_HOST_SHUTDOWN,
+    );
+    expect(await stateNow()).toBe("offline");
+
+    // 3. A fresh heartbeat clears the marker → ONLINE again (round-trip complete).
+    await emitHeartbeat(bus, workspaceId, enrollment.id, 12);
+    expect(await stateNow()).toBe("online");
   }, 90_000);
 
   test("state matrix: displayed-but-unconsented is ONLINE (view/control decoupled); offline when no responder", async () => {

--- a/apps/api/test/metrics-ingestion.test.ts
+++ b/apps/api/test/metrics-ingestion.test.ts
@@ -36,7 +36,7 @@ describe("handleAgentEventPayload — GoingOffline machine-plane recording", () 
     return { counters, observability: { incrementCounter: (c: never) => counters.push(c) } };
   }
 
-  test("a clean GoingOffline increments the counter by typed reason (no DB write)", async () => {
+  test("a clean GoingOffline increments the counter by typed reason (counter fires independent of the DB)", async () => {
     const { counters, observability } = counterCapture();
     const payload = AgentEvent.encode({
       event: {
@@ -44,8 +44,10 @@ describe("handleAgentEventPayload — GoingOffline machine-plane recording", () 
         goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE },
       },
     }).finish();
-    // `db` is never touched on the GoingOffline path (the branch returns before any
-    // enrollment lookup), so a bare stub proves the "no DB write" contract.
+    // The machine-plane counter fires FIRST + unconditionally; the enrollment-marker
+    // write that follows is best-effort + fail-soft. A bare stub `db` makes that
+    // write throw, which the branch swallows — so the counter still lands. (The real
+    // DB round-trip through setEnrollmentWentOffline is covered in machines-routes.)
     await handleAgentEventPayload(
       {} as never,
       observability as never,

--- a/apps/api/test/metrics-ingestion.test.ts
+++ b/apps/api/test/metrics-ingestion.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   AGENT_EVENTS_SUBJECT,
+  handleAgentEventPayload,
   parseAgentEventSubject,
   wireSampleToDbSample,
 } from "../src/sandbox/metrics-ingestion";
-import type { MetricsSample } from "@opengeni/agent-proto";
+import { AgentEvent, GoingOfflineReason, type MetricsSample } from "@opengeni/agent-proto";
 
 // M10 — the PURE metrics-ingestion helpers (subject parse + wire→DB sample
 // projection). No DB / broker — the round-trip ingestion through createApp + a
@@ -26,6 +27,51 @@ describe("parseAgentEventSubject", () => {
     expect(parseAgentEventSubject("agent.ws.ag.rpc")).toBeNull();
     expect(parseAgentEventSubject("agent.ws.events")).toBeNull();
     expect(parseAgentEventSubject("not.an.agent.subject")).toBeNull();
+  });
+});
+
+describe("handleAgentEventPayload — GoingOffline machine-plane recording", () => {
+  function counterCapture() {
+    const counters: Array<{ name: string; labels?: Record<string, string> }> = [];
+    return { counters, observability: { incrementCounter: (c: never) => counters.push(c) } };
+  }
+
+  test("a clean GoingOffline increments the counter by typed reason (no DB write)", async () => {
+    const { counters, observability } = counterCapture();
+    const payload = AgentEvent.encode({
+      event: {
+        $case: "goingOffline",
+        goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_UPDATE },
+      },
+    }).finish();
+    // `db` is never touched on the GoingOffline path (the branch returns before any
+    // enrollment lookup), so a bare stub proves the "no DB write" contract.
+    await handleAgentEventPayload(
+      {} as never,
+      observability as never,
+      payload,
+      "agent.11111111-1111-1111-1111-111111111111.agent-abc.events",
+    );
+    expect(counters).toHaveLength(1);
+    expect(counters[0]!.name).toBe("opengeni_machine_going_offline_total");
+    expect(counters[0]!.labels?.reason).toBe("GOING_OFFLINE_REASON_UPDATE");
+  });
+
+  test("a malformed subject is ignored (no counter, no throw)", async () => {
+    const { counters, observability } = counterCapture();
+    const payload = AgentEvent.encode({
+      event: {
+        $case: "goingOffline",
+        goingOffline: { reason: GoingOfflineReason.GOING_OFFLINE_REASON_USER_STOP },
+      },
+    }).finish();
+    await handleAgentEventPayload(
+      {} as never,
+      observability as never,
+      payload,
+      "not.an.events.subject",
+    );
+    expect(counters).toHaveLength(0);
   });
 });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3137,6 +3137,23 @@ export const SessionEventType = z.enum([
   // requires regenerating the golden snapshots (the golden-grammar gate).
   "machine.op.failed",
   "machine.op.recovered",
+  // Connected Machine (selfhosted) LINK-plane observability (failure-visibility
+  // doctrine). SESSION-scoped, ANNOUNCE-ONLY facts fanned out to the sessions that
+  // had an active op running on the machine when its control link changed — never
+  // to idle/historical sessions. Payloads carry ids / a typed reason / key-names
+  // only, NEVER command content.
+  //
+  // `machine.link.lost` — the machine announced a clean GoingOffline (its control
+  // link is going away) while a session had a running turn on it. `machine.link.
+  // restored` — a reconnect Hello re-established the link that was previously lost.
+  // `machine.runner.restarted` — the additional signal that the going-offline was
+  // a self-update restart specifically (link.lost also fires for it; this
+  // distinguishes a restart from a plain stop / host shutdown). All three hit the
+  // timeline projection's quiet default tier (no rendered item); adding a rendered
+  // item requires regenerating the golden snapshots (the golden-grammar gate).
+  "machine.link.lost",
+  "machine.link.restored",
+  "machine.runner.restarted",
 ]);
 export type SessionEventType = z.infer<typeof SessionEventType>;
 

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -174,6 +174,8 @@ async function probeEnrollment(
       allowScreenControl: enrollment.allowScreenControl,
       hasDisplay: enrollment.hasDisplay,
       lastSeenAt: enrollment.lastSeenAt,
+      wentOfflineAt: enrollment.wentOfflineAt,
+      wentOfflineReason: enrollment.wentOfflineReason,
     },
     probeResponded,
   });

--- a/packages/db/drizzle/0049_enrollment_went_offline.sql
+++ b/packages/db/drizzle/0049_enrollment_went_offline.sql
@@ -1,0 +1,28 @@
+-- Immediate-offline on a CLEAN going-offline signal.
+--
+-- A machine that explicitly announced "I'm stopping" (a typed GoingOffline:
+-- user-stop / self-update / host-shutdown) must read OFFLINE immediately — for the
+-- Machines dashboard AND for anything deciding whether to route work at it —
+-- instead of waiting out the last_seen dead-detect window. Persist that goodbye as
+-- a nullable marker on the enrollment: went_offline_at (WHEN it said goodbye) +
+-- went_offline_reason (the typed reason string). The liveness derivation gives an
+-- un-cleared marker precedence over last_seen aging; ANY newer liveness signal (a
+-- reconnect Hello or a fresher heartbeat) clears it back to NULL. Both NULL (the
+-- default) ⇒ today's behavior exactly — every existing + new row is a
+-- behavior-preserving no-op, no backfill.
+ALTER TABLE "enrollments"
+  ADD COLUMN IF NOT EXISTS "went_offline_at" timestamptz,
+  ADD COLUMN IF NOT EXISTS "went_offline_reason" text;
+
+-- Re-grant on the new columns (idempotent; schema-agnostic per the Migration
+-- Authoring rules — grants target current_schema() via dynamic SQL so an embedded
+-- host running under a dedicated data schema is covered, not just `public`).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO opengeni_app',
+      current_schema()
+    );
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -86,6 +86,7 @@ import {
   gt,
   gte,
   inArray,
+  isNotNull,
   isNull,
   lt,
   ne,
@@ -11385,6 +11386,12 @@ export type EnrollmentRecord = {
   os: EnrollmentOs;
   arch: string;
   lastSeenAt: string | null;
+  /** When the machine announced a clean GoingOffline; the liveness derivation reads
+   *  an un-cleared marker as offline immediately. NULL ⇒ no goodbye pending. */
+  wentOfflineAt: string | null;
+  /** The typed reason string of the pending clean going-offline (e.g.
+   *  GOING_OFFLINE_REASON_UPDATE); NULL when there is no un-cleared marker. */
+  wentOfflineReason: string | null;
   createdAt: string;
   revokedAt: string | null;
   updatedAt: string;
@@ -11404,6 +11411,8 @@ function mapEnrollment(row: typeof schema.enrollments.$inferSelect): EnrollmentR
     os: row.os as EnrollmentOs,
     arch: row.arch,
     lastSeenAt: row.lastSeenAt ? row.lastSeenAt.toISOString() : null,
+    wentOfflineAt: row.wentOfflineAt ? row.wentOfflineAt.toISOString() : null,
+    wentOfflineReason: row.wentOfflineReason ?? null,
     createdAt: row.createdAt.toISOString(),
     revokedAt: row.revokedAt ? row.revokedAt.toISOString() : null,
     updatedAt: row.updatedAt.toISOString(),
@@ -11569,6 +11578,13 @@ export async function revokeEnrollment(
 
 // Heartbeat liveness cursor: the agent reports it is alive. last_seen_at is read
 // by the online/reconnecting/offline derivation in the Machines surface.
+//
+// A fresh heartbeat is also the definitive "the machine is alive NOW" signal, so
+// it CLEARS any pending clean going-offline marker in the SAME update: a machine
+// that said goodbye but is heartbeating again is not offline. went_offline_at /
+// went_offline_reason go back to NULL alongside the last_seen bump (unconditional —
+// this update always fires on a heartbeat, so a set marker never outlives the next
+// heartbeat).
 export async function touchEnrollmentLastSeen(
   db: Database,
   input: {
@@ -11583,13 +11599,89 @@ export async function touchEnrollmentLastSeen(
     async (scopedDb) => {
       await scopedDb
         .update(schema.enrollments)
-        .set({ lastSeenAt: new Date(), updatedAt: new Date() })
+        .set({
+          lastSeenAt: new Date(),
+          wentOfflineAt: null,
+          wentOfflineReason: null,
+          updatedAt: new Date(),
+        })
         .where(
           and(
             eq(schema.enrollments.workspaceId, input.workspaceId),
             eq(schema.enrollments.id, input.enrollmentId),
           ),
         );
+    },
+  );
+}
+
+// Record a CLEAN going-offline: the machine announced a typed GoingOffline
+// (user-stop / self-update / host-shutdown). Stamps went_offline_at = now() +
+// the typed reason so the liveness derivation reads the machine OFFLINE
+// immediately (an un-cleared marker beats last_seen aging), for the dashboard AND
+// for anything deciding whether to route work at it. Deliberately does NOT touch
+// last_seen — a shutdown must not look "more recently alive". An unknown enrollment
+// is a no-op (no row → no write).
+export async function setEnrollmentWentOffline(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    enrollmentId: string;
+    reason: string;
+  },
+): Promise<void> {
+  await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      await scopedDb
+        .update(schema.enrollments)
+        .set({
+          wentOfflineAt: new Date(),
+          wentOfflineReason: input.reason,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.enrollments.workspaceId, input.workspaceId),
+            eq(schema.enrollments.id, input.enrollmentId),
+          ),
+        );
+    },
+  );
+}
+
+// Clear a pending clean going-offline marker: a reconnect Hello re-announced the
+// machine, so the goodbye no longer holds. CHANGE-GUARDED (`went_offline_at IS NOT
+// NULL`) so a steady-state Hello — the overwhelmingly common case — issues NO
+// write and never churns; `cleared` reports whether a marker was actually present,
+// which the ingestion path uses to decide whether a link.restored is warranted (a
+// restored only pairs a prior lost).
+export async function clearEnrollmentWentOffline(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    enrollmentId: string;
+  },
+): Promise<{ cleared: boolean }> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const rows = await scopedDb
+        .update(schema.enrollments)
+        .set({ wentOfflineAt: null, wentOfflineReason: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.enrollments.workspaceId, input.workspaceId),
+            eq(schema.enrollments.id, input.enrollmentId),
+            isNotNull(schema.enrollments.wentOfflineAt),
+          ),
+        )
+        .returning({ id: schema.enrollments.id });
+      return { cleared: rows.length > 0 };
     },
   );
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12328,6 +12328,42 @@ export type ActiveSandboxPointer = {
   workingDir: string | null;
 };
 
+// The INVERSE of readActiveSandbox: every session in a workspace whose ACTIVE
+// SANDBOX resolves to enrollment X AND that has a RUNNING TURN — i.e. "sessions
+// with an active op on machine X". This is the fan-out target set for the
+// machine-link session events (a machine's control link changing only concerns the
+// sessions actively using it; an idle-machine blip must never spam historical
+// sessions). ONE indexed lookup: the query drives from `sandboxes` via the partial
+// `sandboxes_enrollment_idx` (enrollment_id WHERE NOT NULL), joins `sessions` on
+// the active-sandbox pointer, and keeps only rows with a non-null active_turn_id (a
+// running turn). Deliberately a v1 OVER-APPROXIMATION — no per-op tracking table.
+export async function sessionsWithActiveOpOnEnrollment(
+  db: Database,
+  input: { workspaceId: string; enrollmentId: string },
+): Promise<Array<{ sessionId: string; activeTurnId: string }>> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {
+    const rows = await scopedDb
+      .select({
+        sessionId: schema.sessions.id,
+        activeTurnId: schema.sessions.activeTurnId,
+      })
+      .from(schema.sandboxes)
+      .innerJoin(schema.sessions, eq(schema.sessions.activeSandboxId, schema.sandboxes.id))
+      .where(
+        and(
+          eq(schema.sandboxes.workspaceId, input.workspaceId),
+          eq(schema.sandboxes.kind, "selfhosted"),
+          eq(schema.sandboxes.enrollmentId, input.enrollmentId),
+          isNotNull(schema.sessions.activeTurnId),
+        ),
+      );
+    // active_turn_id is non-null by the WHERE guard; the map narrows the type.
+    return rows.flatMap((row) =>
+      row.activeTurnId ? [{ sessionId: row.sessionId, activeTurnId: row.activeTurnId }] : [],
+    );
+  });
+}
+
 // Read the session's current pointer (the routing proxy re-reads this PER TOOL
 // CALL). NULL active_sandbox_id == "use the session's own group sandbox".
 export async function readActiveSandbox(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12356,7 +12356,11 @@ export async function sessionsWithActiveOpOnEnrollment(
           eq(schema.sandboxes.enrollmentId, input.enrollmentId),
           isNotNull(schema.sessions.activeTurnId),
         ),
-      );
+      )
+      // Stable fan-out order (oldest session first): makes the emission
+      // deterministic + replayable, so a per-session emission failure is isolated
+      // predictably rather than depending on the planner's row order.
+      .orderBy(asc(schema.sessions.createdAt), asc(schema.sessions.id));
     // active_turn_id is non-null by the WHERE guard; the map narrows the type.
     return rows.flatMap((row) =>
       row.activeTurnId ? [{ sessionId: row.sessionId, activeTurnId: row.activeTurnId }] : [],

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1356,6 +1356,14 @@ export const enrollments = pgTable(
     arch: text("arch").notNull().default("x86_64"),
     // Heartbeat liveness cursor. Null until the first connect.
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+    // Clean going-offline marker (migration 0049). Set when the machine announces a
+    // typed GoingOffline (user-stop / self-update / host-shutdown); the liveness
+    // derivation reads an un-cleared marker as OFFLINE immediately, regardless of a
+    // still-fresh last_seen. Any newer liveness signal (a reconnect Hello or a
+    // fresher heartbeat via touchEnrollmentLastSeen) clears BOTH back to NULL. NULL
+    // (the default) ⇒ no goodbye pending — today's last_seen-aging behavior.
+    wentOfflineAt: timestamp("went_offline_at", { withTimezone: true }),
+    wentOfflineReason: text("went_offline_reason"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/test/sandboxes-enrollments.test.ts
+++ b/packages/db/test/sandboxes-enrollments.test.ts
@@ -19,6 +19,7 @@ import {
   readMachineMetricsLatestForWorkspace,
   readMachineMetricsSeries,
   revokeEnrollment,
+  sessionsWithActiveOpOnEnrollment,
   setActiveSandbox,
   setEnrollmentWentOffline,
   touchEnrollmentLastSeen,
@@ -225,6 +226,90 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
       enrollmentId: created.id,
     });
     expect(secondClear.cleared).toBe(false); // nothing to clear → no churn
+  }, 60_000);
+
+  test("sessionsWithActiveOpOnEnrollment: only active-sandbox + running-turn sessions for enrollment X", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const enrollX = await createEnrollment(db, {
+      accountId,
+      workspaceId,
+      pubkey: "ed25519:FANX",
+      hasDisplay: true,
+    });
+    const enrollY = await createEnrollment(db, {
+      accountId,
+      workspaceId,
+      pubkey: "ed25519:FANY",
+      hasDisplay: true,
+    });
+    const sandX = await createSandbox(db, {
+      accountId,
+      workspaceId,
+      kind: "selfhosted",
+      name: "machine-x",
+      enrollmentId: enrollX.id,
+    });
+    const sandY = await createSandbox(db, {
+      accountId,
+      workspaceId,
+      kind: "selfhosted",
+      name: "machine-y",
+      enrollmentId: enrollY.id,
+    });
+    const sandModal = await createSandbox(db, {
+      accountId,
+      workspaceId,
+      kind: "modal",
+      name: "group-box",
+    });
+
+    const mkSession = async () =>
+      await createSession(db, {
+        accountId,
+        workspaceId,
+        initialMessage: "hi",
+        resources: [],
+        metadata: {},
+        model: "gpt",
+        sandboxBackend: "modal",
+      });
+    const point = async (sessionId: string, sandboxId: string) =>
+      await setActiveSandbox(db, {
+        accountId,
+        workspaceId,
+        sessionId,
+        targetSandboxId: sandboxId,
+        expectedEpoch: 0,
+      });
+    const setTurn = async (sessionId: string, turnId: string) =>
+      await admin`update sessions set active_turn_id = ${turnId} where id = ${sessionId}`;
+
+    // INCLUDED: pointer → machine X's sandbox + a running turn.
+    const included = await mkSession();
+    await point(included.id, sandX.id);
+    const includedTurn = "cccccccc-0000-4000-8000-000000000001";
+    await setTurn(included.id, includedTurn);
+
+    // EXCLUDED: pointer → machine X but NO running turn (active_turn_id null).
+    const noTurn = await mkSession();
+    await point(noTurn.id, sandX.id);
+
+    // EXCLUDED: pointer → machine Y's sandbox (a different enrollment) + a turn.
+    const otherEnrollment = await mkSession();
+    await point(otherEnrollment.id, sandY.id);
+    await setTurn(otherEnrollment.id, "cccccccc-0000-4000-8000-000000000002");
+
+    // EXCLUDED: pointer → the Modal group box (kind != selfhosted) + a turn.
+    const modal = await mkSession();
+    await point(modal.id, sandModal.id);
+    await setTurn(modal.id, "cccccccc-0000-4000-8000-000000000003");
+
+    const rows = await sessionsWithActiveOpOnEnrollment(db, {
+      workspaceId,
+      enrollmentId: enrollX.id,
+    });
+    expect(rows).toEqual([{ sessionId: included.id, activeTurnId: includedTurn }]);
   }, 60_000);
 
   test("sandbox create: selfhosted requires enrollment, modal forbids it; get + list", async () => {

--- a/packages/db/test/sandboxes-enrollments.test.ts
+++ b/packages/db/test/sandboxes-enrollments.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
 import {
+  clearEnrollmentWentOffline,
   createDb,
   createEnrollment,
   createSandbox,
@@ -19,6 +20,7 @@ import {
   readMachineMetricsSeries,
   revokeEnrollment,
   setActiveSandbox,
+  setEnrollmentWentOffline,
   touchEnrollmentLastSeen,
   upsertMachineMetricsLatest,
   type Database,
@@ -166,6 +168,63 @@ describe("0024 sandboxes / enrollments / metrics DAOs + active-sandbox pointer",
     expect(reactivated.id).toBe(created.id);
     expect(reactivated.status).toBe("active");
     expect(reactivated.revokedAt).toBeNull();
+  }, 60_000);
+
+  test("clean going-offline marker: set → clear-on-heartbeat and clear-on-Hello (change-guarded)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const created = await createEnrollment(db, {
+      accountId,
+      workspaceId,
+      pubkey: "ed25519:GOODBYE",
+      hasDisplay: true,
+    });
+    // A machine reporting a heartbeat first (fresh last_seen, no marker).
+    await touchEnrollmentLastSeen(db, { accountId, workspaceId, enrollmentId: created.id });
+    const online = await getEnrollment(db, workspaceId, created.id);
+    expect(online?.wentOfflineAt).toBeNull();
+    expect(online?.lastSeenAt).not.toBeNull();
+
+    // GoingOffline stamps the marker (WHEN + typed reason) WITHOUT touching last_seen.
+    await setEnrollmentWentOffline(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: created.id,
+      reason: "GOING_OFFLINE_REASON_HOST_SHUTDOWN",
+    });
+    const goodbye = await getEnrollment(db, workspaceId, created.id);
+    expect(goodbye?.wentOfflineAt).not.toBeNull();
+    expect(goodbye?.wentOfflineReason).toBe("GOING_OFFLINE_REASON_HOST_SHUTDOWN");
+    // last_seen is NOT bumped by the goodbye (a shutdown must not look more alive).
+    expect(goodbye?.lastSeenAt).toBe(online?.lastSeenAt);
+
+    // A fresh heartbeat clears the marker in the SAME update that bumps last_seen.
+    await touchEnrollmentLastSeen(db, { accountId, workspaceId, enrollmentId: created.id });
+    const revived = await getEnrollment(db, workspaceId, created.id);
+    expect(revived?.wentOfflineAt).toBeNull();
+    expect(revived?.wentOfflineReason).toBeNull();
+
+    // clearEnrollmentWentOffline (the Hello path): reports cleared only when a
+    // marker was present, and is a no-op (cleared:false) on a steady-state clear.
+    await setEnrollmentWentOffline(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: created.id,
+      reason: "GOING_OFFLINE_REASON_USER_STOP",
+    });
+    const firstClear = await clearEnrollmentWentOffline(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: created.id,
+    });
+    expect(firstClear.cleared).toBe(true);
+    expect((await getEnrollment(db, workspaceId, created.id))?.wentOfflineAt).toBeNull();
+    const secondClear = await clearEnrollmentWentOffline(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: created.id,
+    });
+    expect(secondClear.cleared).toBe(false); // nothing to clear → no churn
   }, 60_000);
 
   test("sandbox create: selfhosted requires enrollment, modal forbids it; get + list", async () => {

--- a/packages/react/test/golden/fixtures/10-machine-link-events.json
+++ b/packages/react/test/golden/fixtures/10-machine-link-events.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "00000000-0000-4000-8000-000000001001",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 1,
+    "type": "user.message",
+    "payload": {
+      "text": "Keep building on the connected machine."
+    },
+    "occurredAt": "2026-01-02T11:00:01.000Z",
+    "turnId": null
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001002",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 2,
+    "type": "turn.started",
+    "payload": {
+      "triggerEventId": "00000000-0000-4000-8000-000000001001"
+    },
+    "occurredAt": "2026-01-02T11:00:02.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001003",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 3,
+    "type": "machine.link.lost",
+    "payload": {
+      "reason": "GOING_OFFLINE_REASON_UPDATE"
+    },
+    "occurredAt": "2026-01-02T11:00:03.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001004",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 4,
+    "type": "machine.runner.restarted",
+    "payload": {},
+    "occurredAt": "2026-01-02T11:00:04.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001005",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 5,
+    "type": "machine.link.restored",
+    "payload": {},
+    "occurredAt": "2026-01-02T11:00:05.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001006",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 6,
+    "type": "agent.message.completed",
+    "payload": {
+      "text": "The machine restarted for a self-update and reconnected; the build continued."
+    },
+    "occurredAt": "2026-01-02T11:00:06.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000001007",
+    "workspaceId": "11111111-2222-4333-9444-555555555555",
+    "sessionId": "22222222-3333-4444-9555-666666666666",
+    "sequence": 7,
+    "type": "turn.completed",
+    "payload": {},
+    "occurredAt": "2026-01-02T11:00:07.000Z",
+    "turnId": "aaaaaaaa-0000-4000-8000-000000000010"
+  }
+]

--- a/packages/react/test/golden/snapshots/10-machine-link-events.json
+++ b/packages/react/test/golden/snapshots/10-machine-link-events.json
@@ -1,0 +1,66 @@
+{
+  "items": [
+    {
+      "kind": "user-message",
+      "id": "00000000-0000-4000-8000-000000001001",
+      "occurredAt": "2026-01-02T11:00:01.000Z",
+      "text": "Keep building on the connected machine.",
+      "pending": false,
+      "resources": [],
+      "tools": []
+    },
+    {
+      "kind": "agent-message",
+      "id": "00000000-0000-4000-8000-000000001006",
+      "turnId": "aaaaaaaa-0000-4000-8000-000000000010",
+      "occurredAt": "2026-01-02T11:00:06.000Z",
+      "text": "The machine restarted for a self-update and reconnected; the build continued.",
+      "streaming": false
+    },
+    {
+      "kind": "turn-end",
+      "id": "00000000-0000-4000-8000-000000001007-turn-end",
+      "turnId": "aaaaaaaa-0000-4000-8000-000000000010",
+      "occurredAt": "2026-01-02T11:00:07.000Z",
+      "outcome": "complete",
+      "failureText": null
+    }
+  ],
+  "groups": [
+    {
+      "kind": "item",
+      "item": {
+        "kind": "user-message",
+        "id": "00000000-0000-4000-8000-000000001001",
+        "occurredAt": "2026-01-02T11:00:01.000Z",
+        "text": "Keep building on the connected machine.",
+        "pending": false,
+        "resources": [],
+        "tools": []
+      }
+    },
+    {
+      "kind": "item",
+      "item": {
+        "kind": "agent-message",
+        "id": "00000000-0000-4000-8000-000000001006",
+        "turnId": "aaaaaaaa-0000-4000-8000-000000000010",
+        "occurredAt": "2026-01-02T11:00:06.000Z",
+        "text": "The machine restarted for a self-update and reconnected; the build continued.",
+        "streaming": false
+      }
+    }
+  ],
+  "facets": {
+    "itemKinds": {
+      "agent-message": 1,
+      "turn-end": 1,
+      "user-message": 1
+    },
+    "groupKinds": {
+      "item": 2
+    },
+    "activityItemKinds": {},
+    "turnOutcomes": {}
+  }
+}

--- a/packages/runtime/src/sandbox/selfhosted/capabilities.ts
+++ b/packages/runtime/src/sandbox/selfhosted/capabilities.ts
@@ -44,6 +44,13 @@ export interface SelfhostedEnrollment {
   allowScreenControl: boolean;
   hasDisplay: boolean;
   lastSeenAt: string | null;
+  /** An un-cleared clean going-offline marker (the machine announced a typed
+   *  GoingOffline). When set, the derivation reads the machine OFFLINE immediately,
+   *  regardless of a still-fresh `lastSeenAt`. NULL ⇒ no pending goodbye. */
+  wentOfflineAt: string | null;
+  /** The typed reason string of the pending goodbye (rides alongside
+   *  `wentOfflineAt`; NULL when there is no un-cleared marker). */
+  wentOfflineReason: string | null;
 }
 
 /** The derived liveness state of a selfhosted machine (the online/offline/
@@ -72,6 +79,8 @@ export const SELFHOSTED_RECONNECT_WINDOW_MS = 30_000;
  * (stale / never seen).
  *
  *   - no enrollment / revoked         → offline (the machine isn't enrolled).
+ *   - un-cleared clean goodbye        → offline (an announced GoingOffline beats
+ *                                       last_seen aging AND a lingering probe).
  *   - probe responded                 → online.
  *   - probe missed, lastSeenAt recent → reconnecting (a transient blip).
  *   - probe missed, lastSeenAt stale  → offline.
@@ -89,6 +98,15 @@ export function selfhostedLiveness(input: {
   }
   const consented = enrollment.exposure === "whole-machine" && enrollment.allowScreenControl;
   const hasDisplay = enrollment.hasDisplay;
+  // A CLEAN going-offline the machine announced takes precedence over BOTH
+  // last_seen aging and a lingering probe: a machine that said "I'm stopping" must
+  // read offline immediately (so no new work is routed at it) until a NEWER
+  // liveness signal — a reconnect Hello or a fresher heartbeat — clears the marker
+  // in the row. `status: "revoked"` above still trumps this (a revoked machine is
+  // offline regardless). This is the #348 lease-waits-on-dead-detect fix.
+  if (enrollment.wentOfflineAt) {
+    return { state: "offline", consented, hasDisplay };
+  }
   if (input.probeResponded) {
     return { state: "online", consented, hasDisplay };
   }

--- a/packages/runtime/test/selfhosted-capabilities.test.ts
+++ b/packages/runtime/test/selfhosted-capabilities.test.ts
@@ -18,6 +18,8 @@ function enrollment(overrides: Partial<SelfhostedEnrollment> = {}): SelfhostedEn
     allowScreenControl: true,
     hasDisplay: true,
     lastSeenAt: NOW.toISOString(),
+    wentOfflineAt: null,
+    wentOfflineReason: null,
     ...overrides,
   };
 }
@@ -75,6 +77,47 @@ describe("selfhostedLiveness — the online/reconnecting/offline derivation", ()
       now: NOW,
     });
     expect(live.state).toBe("offline");
+  });
+
+  test("an un-cleared clean goodbye reads OFFLINE even with a fresh lastSeenAt AND a responding probe", () => {
+    // The #348 fix: an announced GoingOffline must read offline immediately, taking
+    // precedence over both last_seen aging (fresh) and a lingering probe (responds).
+    const live = selfhostedLiveness({
+      enrollment: enrollment({
+        lastSeenAt: NOW.toISOString(),
+        wentOfflineAt: NOW.toISOString(),
+        wentOfflineReason: "GOING_OFFLINE_REASON_HOST_SHUTDOWN",
+      }),
+      probeResponded: true,
+      now: NOW,
+    });
+    expect(live.state).toBe("offline");
+    // consent/display flags are still derived from the row (the machine's config
+    // didn't change — only its reachability).
+    expect(live.consented).toBe(true);
+    expect(live.hasDisplay).toBe(true);
+  });
+
+  test("revoked STILL trumps a goodbye marker (revoked + wentOfflineAt → offline, flags cleared)", () => {
+    const live = selfhostedLiveness({
+      enrollment: enrollment({ status: "revoked", wentOfflineAt: NOW.toISOString() }),
+      probeResponded: true,
+    });
+    expect(live.state).toBe("offline");
+    // The revoked branch returns before deriving consent/display from the row.
+    expect(live.consented).toBe(false);
+    expect(live.hasDisplay).toBe(false);
+  });
+
+  test("a CLEARED marker (wentOfflineAt back to null) reads ONLINE again on a probe response", () => {
+    // Completes the round-trip at the derivation level: once a newer liveness signal
+    // clears the marker in the row, the machine reads online again exactly as before.
+    const live = selfhostedLiveness({
+      enrollment: enrollment({ wentOfflineAt: null, wentOfflineReason: null }),
+      probeResponded: true,
+      now: NOW,
+    });
+    expect(live.state).toBe("online");
   });
 });
 

--- a/packages/runtime/test/selfhosted-nats.integration.test.ts
+++ b/packages/runtime/test/selfhosted-nats.integration.test.ts
@@ -107,6 +107,8 @@ describe("selfhosted mocked-NATS integration — exec + fs round-trip through a 
         allowScreenControl: true,
         hasDisplay: true,
         lastSeenAt: new Date().toISOString(),
+        wentOfflineAt: null,
+        wentOfflineReason: null,
       },
       session,
     });
@@ -126,6 +128,8 @@ describe("selfhosted mocked-NATS integration — exec + fs round-trip through a 
         allowScreenControl: true,
         hasDisplay: true,
         lastSeenAt: new Date(Date.now() - 600_000).toISOString(),
+        wentOfflineAt: null,
+        wentOfflineReason: null,
       },
       session,
     });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -527,6 +527,11 @@ export const SESSION_EVENT_TYPES = [
   // contracts SessionEventType — the contract-parity test asserts sorted equality).
   "machine.op.failed",
   "machine.op.recovered",
+  // Connected Machine link-plane observability (announce-only, quiet; mirror of
+  // contracts SessionEventType — the contract-parity test asserts sorted equality).
+  "machine.link.lost",
+  "machine.link.restored",
+  "machine.runner.restarted",
 ] as const;
 
 export type KnownSessionEventType = (typeof SESSION_EVENT_TYPES)[number];


### PR DESCRIPTION
## What & why — the machine-link plane (B3 of the failure-visibility program)

The Connected Machine failure-visibility lane has two planes. The **op plane** (`machine.op.failed`/`machine.op.recovered`, landed in #361) reports per-op infrastructure faults for the session that ran the op. This PR adds the missing **link-lifecycle plane** plus the immediate-offline consumption of the runner's typed GoingOffline signal — which part 1 (already on this branch) started recording as a metrics counter but which was otherwise still being discarded for liveness/routing.

Two behaviors ship here:

1. **Immediate-offline on a clean goodbye.** A machine that announces a typed GoingOffline (user-stop / self-update / host-shutdown) now reads OFFLINE immediately — for the Machines dashboard and for anything deciding whether to route work at it — instead of waiting out the `last_seen` dead-detect window (the #348 lease-waits-on-dead-detect failure mode).
2. **Link-lifecycle session events.** The sessions actively using a machine learn when its control link changes, via announce-only `machine.link.lost` / `machine.link.restored` / `machine.runner.restarted` events fanned out only to those sessions.

Built in three reviewed commits: part 1 (`record clean GoingOffline`, pre-existing on the branch), part 2 (`immediate-offline`), part 3 (`machine.link.* + fan-out`).

## Part 2 — immediate-offline (migration + derivation)

- **Migration `0049`**: two nullable `enrollments` columns, `went_offline_at timestamptz` + `went_offline_reason text` (schema-agnostic re-grant via `EXECUTE format(... current_schema() ...)`). Both NULL = today's behavior exactly; no backfill.
- **Liveness precedence** (`selfhostedLiveness`), in order:
  1. `!enrollment || status !== "active"` → offline (a `revoked` lifecycle trumps everything)
  2. `went_offline_at` set → **offline** (an un-cleared goodbye beats `last_seen` aging **and** a still-responding probe)
  3. `probeResponded` → online
  4. probe missed, `last_seen` ≤ 30s → reconnecting
  5. else → offline
- **Marker clear** (any newer liveness signal wins): `touchEnrollmentLastSeen` nulls both columns in the *same* UPDATE that bumps `last_seen` (a heartbeat means alive), and the connect-Hello path calls a change-guarded `clearEnrollmentWentOffline`. `setEnrollmentWentOffline` deliberately does not touch `last_seen` (a shutdown must not look "more recently alive").

## Part 3 — link-lifecycle events + fan-out

- **Grammar**: three additive `SessionEventType` members + SDK `SESSION_EVENT_TYPES` mirror (contract-parity sorted-equality holds), plus golden fixture `10-machine-link-events.json` proving they project to **no** timeline item (the quiet tier). Mirrors the `machine.op.*` pattern from #361.
- **Fan-out query** `sessionsWithActiveOpOnEnrollment` — one indexed lookup, no per-op tracking table. Drives from `sandboxes sb` (partial index `sandboxes_enrollment_idx` on `enrollment_id WHERE NOT NULL`) `INNER JOIN sessions s ON s.active_sandbox_id = sb.id WHERE sb.workspace_id = <ws> AND sb.kind = 'selfhosted' AND sb.enrollment_id = <X> AND s.active_turn_id IS NOT NULL` → `{ sessionId, activeTurnId }[]`.
- **Emit** (apps/api ingestion, via `appendAndPublishEvents`, each event on the session's own active turn):
  - `machine.link.lost{reason}` from every clean going-offline, **plus** `machine.runner.restarted{}` when the reason is a self-update restart specifically.
  - `machine.link.restored{}` from a reconnect Hello — but **only when it actually cleared a going-offline marker**. This keeps lost/restored a **matched pair**: a crash/network-drop offline has no goodbye to emit from (that's the `last_seen` plane's job), and a routine connect Hello stays silent. Idle-machine blips never reach idle/historical sessions.

## Verification (all green on the rebased tree)

- **Migration up-test**: PASS — the db suite runs against a real throwaway Postgres and reads/writes the new columns.
- **Liveness round-trip**: PASS — `online → GoingOffline reads OFFLINE immediately (probe still responds, last_seen still fresh) → heartbeat reads ONLINE again`, end-to-end through the ingestion consumer + derivation + `/machines` endpoint.
- **golden-grammar + contract-parity**: PASS (both `machine.op.*` and `machine.link.*` present after the rebase).
- **Emission suite**: self-update → lost + runner.restarted on the running turn; plain stop → lost only; reconnect → restored once (a 2nd Hello emits nothing); no active-op session → zero events leak anywhere.
- **Full-monorepo `bun run typecheck`**: all projects clean. **oxlint**: 0 errors. **`bun run format:check`**: clean. **`bun run check:docs-refs`**: clean.

## Deviations from the original brief

| # | Deviation | Reasoning |
|---|-----------|-----------|
| 1 | `machine.link.*` enum members appended after `machine.op.*` in contracts + SDK | The rebase onto main (which now carries #361) resolved keep-both-blocks; contract-parity is order-independent. |
| 2 | Golden fixture numbered `10-`, not `09-` | `09-machine-op-events.json` is #361's; `10-` sits cleanly after it post-rebase. |
| 3 | `machine.link.restored` gated on an actual marker-clear | Matched-pair semantics: a restored only ever pairs a prior lost; crash-offline (no goodbye) is the `last_seen` plane's domain. |
| 4 | `SelfhostedEnrollment` carries both new fields though the decision reads only `wentOfflineAt` | Brief said "thread the two new fields into the input struct"; `wentOfflineReason` rides alongside intentionally. |
| 5 | Part-1 "no DB write" unit test updated | Part 2 adds a best-effort, fail-soft DB write to the goingOffline branch; the counter still fires first + unconditionally. |

Changesets: `machine-immediate-offline.md` (`@opengeni/db` + `@opengeni/runtime`), `machine-link-events.md` (`@opengeni/contracts` + `@opengeni/sdk` + `@opengeni/db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YmyyQ8HaSHarkfteTwcQq
