### PR TITLE
release(runner): v0.1.8

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1599,7 +1599,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "command-group",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "prost",
  "prost-build",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "blake3",
  "hex",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
## Runner v0.1.8 — version bump for the signed release

Bumps the agent workspace `[workspace.package]` version `0.1.7 → 0.1.8`. All seven released crates inherit it in lockstep (`opengeni-agent`, `-proto`, `-platform`, `-macos-ffi`, `-stream`, `-update`, `opengeni-relay`). `Cargo.lock` updated to match — only those seven member entries move; unrelated dependencies at 0.1.7 are untouched.

The internal `opengeni-agent-engine` (`0.1.0`, capability-gated/inert) and `opengeni-agent-harness` (`0.0.0`, unpublished test tool) keep their independent versions by design.

### What v0.1.8 ships (already merged to main)
All runtime content is already on `main`; this PR only lands the version so the release tag can be cut:

- **#348** — always emit `GoingOffline` on a clean SIGTERM during an active connection (lease flips offline immediately instead of waiting on heartbeat dead-detection).
- **#351** — per-op OOM cgroup isolation (`op-<n>` memory leaves, `oom_score_adj=500`, hardened unit) — supervisor fate-isolated from child work (addresses #345).
- **#344** — terminate exec descendant process trees (v0.1.7 content; the descendant-leak fix).
- **op-stream engine (#364)** — sequenced/acked/credit-flowed host ops; **inert** — the runner does not advertise `Capabilities.op_stream`, so behavior is unchanged until a future server flag.

### Release mechanics
The `Agent Release` Guard job matches the pushed `agent-v0.1.8` tag against `agent/Cargo.toml`'s `version`; this bump lands that match. The signed release (minisign trust root) is cut from the tag after merge.