### PR TITLE
feat(observability): streaming SLIs, failure-mode alerts, and dashboards as code

### DIFF
--- a/.changeset/streaming-slis.md
+++ b/.changeset/streaming-slis.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/worker-bundle": patch
+"@opengeni/events": patch
+---
+
+Instrument the token-streaming pipeline with SLIs so "streaming is sluggish" resolves to a number and its layer is attributable. New worker Prometheus series: `opengeni_stream_ttft_seconds{provider}` (time from a model (re)start to its first streamed content delta, re-armed after every non-content event so a post-tool response measures the model's restart, not our tool time), `opengeni_stream_inter_delta_gap_seconds{provider,class}` (gap between consecutive same-class deltas, reset across boundaries), `opengeni_stream_batch_flush_events` + `opengeni_stream_batch_flush_duration_seconds` (the runtime batcher's coalescing shape), `opengeni_session_event_append_seconds` (durable DB write path) and `opengeni_session_event_publish_seconds` (best-effort NATS delivery path) split so a p99 climb points at Postgres vs. NATS, plus `opengeni_model_input_tokens{provider}` and `opengeni_context_compactions_total{trigger}` (the context-pressure pair that makes "compaction never firing while contexts run hot" queryable). All labels are bounded — never a session id or raw user-supplied model string. `appendAndPublishEvents` gains an optional timing observer (no new dependency on the observability package) and `createRuntimeBatcher` an optional `onFlush` hook; both fire on success and failure.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -153,8 +153,14 @@ import {
 } from "../sandbox-routing";
 import {
   makeMachineOpObserver,
+  recordBatchFlush,
+  recordContextCompaction,
   recordCreditMicros,
+  recordModelInputTokens,
+  recordSessionEventAppendLatency,
+  recordSessionEventPublishLatency,
   runtimeMetricsHooksForObservability,
+  StreamTimingMetrics,
   turnLifecycleMetricsFor,
   type TurnOutcome,
 } from "../observability-metrics";
@@ -1443,7 +1449,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           producerId,
           producerSeq: ++producerSeq,
         }));
-        await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, inputs);
+        await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, inputs, {
+          onAppend: ({ durationSeconds }) =>
+            recordSessionEventAppendLatency(observability, { durationSeconds }),
+          onPublish: ({ durationSeconds }) =>
+            recordSessionEventPublishLatency(observability, { durationSeconds }),
+        });
         activityContext?.heartbeat({
           phase: "events_published",
           sessionId: input.sessionId,
@@ -2452,6 +2463,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           );
           if (outcome.compacted) {
             const trigger = forced ? "operator" : undefined;
+            recordContextCompaction(observability, trigger ?? "auto");
             await publish([
               {
                 type: "session.context.compacted",
@@ -2604,6 +2616,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           { force: true, requireShrink: true },
         );
         if (outcome.compacted) {
+          recordContextCompaction(observability, triggerLabel);
           await publish!([
             {
               type: "session.context.compacted",
@@ -2660,9 +2673,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             contextCompactionSignalTokens: () => lastInputTokensObserved,
           });
         stream = await withCodex(runStreamOnce);
-        batcher = createRuntimeBatcher(async (events) => {
-          await publish!(events);
-        });
+        // Bounded provider label for the streaming SLIs — the resolved registry
+        // provider id (or the built-in OpenAI/Azure provider), never a raw
+        // user-supplied model string.
+        const streamProvider = resolvedModel?.provider.id ?? settings.openaiProvider ?? "openai";
+        const streamTiming = new StreamTimingMetrics(observability, { provider: streamProvider });
+        batcher = createRuntimeBatcher(
+          async (events) => {
+            await publish!(events);
+          },
+          {
+            onFlush: ({ events, durationSeconds }) =>
+              recordBatchFlush(observability, { events, durationSeconds }),
+          },
+        );
 
         const iterator = stream.toStream()[Symbol.asyncIterator]();
         let streamDone = false;
@@ -2707,6 +2731,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               };
               const observed = responseUsage.usage?.inputTokens;
               if (typeof observed === "number" && observed > 0) {
+                recordModelInputTokens(observability, streamProvider, observed);
                 lastInputTokensObserved = observed;
                 await setSessionLastInputTokens(
                   db,
@@ -2772,6 +2797,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               ) {
                 event.payload = { ...modelUsageEventContext, ...event.payload };
               }
+              streamTiming.onEvent(event.type);
               await batcher.push(event);
             }
           }

--- a/apps/worker/src/activities/streaming.ts
+++ b/apps/worker/src/activities/streaming.ts
@@ -9,7 +9,20 @@ import { Context } from "@temporalio/activity";
 // cheaper than the per-delta DB round-trip it replaces).
 const TRAILING_FLUSH_MS = 33;
 
-export function createRuntimeBatcher(flushEvents: (events: AppendEventInput[]) => Promise<void>) {
+/** Optional metrics seam for the batcher. `onFlush` fires once per flush (on both
+ *  success and failure) with the coalesced event count and the flush duration, so
+ *  the worker can meter batch shape without the batcher knowing about Observability.
+ *  `now` is injectable for deterministic tests. Both are optional; absent ⇒ no-op. */
+export type RuntimeBatcherOptions = {
+  onFlush?: (info: { events: number; durationSeconds: number }) => void;
+  now?: () => number;
+};
+
+export function createRuntimeBatcher(
+  flushEvents: (events: AppendEventInput[]) => Promise<void>,
+  options: RuntimeBatcherOptions = {},
+) {
+  const now = options.now ?? (() => performance.now());
   let pending: AppendEventInput[] = [];
   let lastFlush = Date.now();
   let trailingTimer: ReturnType<typeof setTimeout> | null = null;
@@ -92,8 +105,19 @@ export function createRuntimeBatcher(flushEvents: (events: AppendEventInput[]) =
     const events = pending;
     pending = [];
     lastFlush = Date.now();
+    const startedAt = now();
     inFlight = flushEvents(events).finally(() => {
       inFlight = null;
+      if (options.onFlush) {
+        try {
+          options.onFlush({
+            events: events.length,
+            durationSeconds: Math.max(0, (now() - startedAt) / 1000),
+          });
+        } catch {
+          // Metrics emission must never affect a flush.
+        }
+      }
     });
     return inFlight;
   }

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -1,4 +1,5 @@
 import { errorCodeToJSON } from "@opengeni/agent-proto";
+import type { SessionEventType } from "@opengeni/contracts";
 import type { EventLogger } from "@opengeni/events";
 import type { Attributes, AttributeValue, Observability } from "@opengeni/observability";
 import {
@@ -386,5 +387,190 @@ export function recordCreditMicros(
     help: "Total credit micros recorded by kind.",
     labels: { kind },
     amount: amountMicros,
+  });
+}
+
+// ── Streaming SLIs ────────────────────────────────────────────────────────────
+// Instruments the token-streaming pipeline so "streaming is sluggish" is a number,
+// not a vibe. Split across the three attributable stages so an operator can tell
+// WHERE the latency lives: the model (TTFT + inter-delta gaps), our durable write
+// path (append latency), or delivery (publish latency + batcher flush shape). All
+// labels are bounded (provider from the model registry, a two-value delta class) —
+// never a session id or a raw user-supplied model string.
+
+export type StreamDeltaClass = "message" | "reasoning";
+
+/** Content-delta classes only. A `null` return means "not a content delta" — the
+ *  event that re-arms the TTFT anchor and closes an inter-delta run. */
+function contentDeltaClass(type: SessionEventType): StreamDeltaClass | null {
+  if (type === "agent.message.delta") {
+    return "message";
+  }
+  if (type === "agent.reasoning.delta") {
+    return "reasoning";
+  }
+  return null;
+}
+
+// TTFT and inter-delta live on a human-perceptible scale (tens of ms to a few
+// seconds), so they get their own SHORT buckets — the default duration buckets
+// (which run to 3600s) would collapse every real streaming value into one bucket.
+const STREAM_TTFT_BUCKETS = [0.02, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1, 1.5, 2, 3, 5, 10];
+const STREAM_INTER_DELTA_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5];
+
+/**
+ * Per-turn stream-timing tracker fed every normalized runtime event in push order.
+ * It emits two model-responsiveness SLIs from the worker's seat on the stream:
+ *
+ *   - `opengeni_stream_ttft_seconds{provider}` — time from a model (re)start to its
+ *     first streamed content delta. The anchor starts at construction (≈ runStream
+ *     start, so the first observation is "how long until text appears") and re-arms
+ *     on every non-content event (a tool call, a completed message, a usage frame),
+ *     so a post-tool response measures the model's restart latency, NOT our own
+ *     tool-execution time.
+ *   - `opengeni_stream_inter_delta_gap_seconds{provider,class}` — gap between
+ *     consecutive content deltas of the SAME class. The run resets on any
+ *     non-content event so a gap never spans a tool call or a model boundary — it
+ *     measures only the choppiness of a live token stream.
+ *
+ * Purely observational and clock-injectable; it never touches the events it sees.
+ */
+export class StreamTimingMetrics {
+  private readonly now: () => number;
+  private ttftAnchor: number;
+  private ttftArmed = true;
+  private readonly lastDeltaAt = new Map<StreamDeltaClass, number>();
+
+  constructor(
+    private readonly observability: Observability,
+    private readonly options: { provider: string; now?: () => number },
+  ) {
+    this.now = options.now ?? (() => performance.now());
+    this.ttftAnchor = this.now();
+  }
+
+  onEvent(type: SessionEventType): void {
+    const deltaClass = contentDeltaClass(type);
+    if (deltaClass === null) {
+      // A non-content event: the model paused emitting. Re-arm TTFT so the next
+      // content delta measures (re)start latency, and close every inter-delta run
+      // so no gap spans a tool call / model boundary.
+      this.ttftAnchor = this.now();
+      this.ttftArmed = true;
+      this.lastDeltaAt.clear();
+      return;
+    }
+    const at = this.now();
+    if (this.ttftArmed) {
+      this.observability.observeHistogram({
+        name: "opengeni_stream_ttft_seconds",
+        help: "Seconds from a model (re)start to its first streamed content delta.",
+        buckets: STREAM_TTFT_BUCKETS,
+        labels: { provider: this.options.provider },
+        value: Math.max(0, (at - this.ttftAnchor) / 1000),
+      });
+      this.ttftArmed = false;
+    }
+    const last = this.lastDeltaAt.get(deltaClass);
+    if (last !== undefined) {
+      this.observability.observeHistogram({
+        name: "opengeni_stream_inter_delta_gap_seconds",
+        help: "Seconds between consecutive streamed content deltas of the same class.",
+        buckets: STREAM_INTER_DELTA_BUCKETS,
+        labels: { provider: this.options.provider, class: deltaClass },
+        value: Math.max(0, (at - last) / 1000),
+      });
+    }
+    this.lastDeltaAt.set(deltaClass, at);
+  }
+}
+
+// Batch shapes: sizes are small integers; durations are the append+publish round
+// trip the flush performs (sub-ms to a couple seconds under contention).
+const STREAM_BATCH_SIZE_BUCKETS = [1, 2, 5, 10, 20, 50, 100, 200, 500];
+const STREAM_IO_BUCKETS = [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
+
+/** Flush shape of the streaming batcher: how many events coalesced into one flush
+ *  (the coalescing win) and how long that flush took (append + publish). */
+export function recordBatchFlush(
+  observability: Observability,
+  input: { events: number; durationSeconds: number },
+): void {
+  observability.observeHistogram({
+    name: "opengeni_stream_batch_flush_events",
+    help: "Session events coalesced into one streaming batcher flush.",
+    buckets: STREAM_BATCH_SIZE_BUCKETS,
+    value: input.events,
+  });
+  observability.observeHistogram({
+    name: "opengeni_stream_batch_flush_duration_seconds",
+    help: "Duration in seconds of one streaming batcher flush (append + publish).",
+    buckets: STREAM_IO_BUCKETS,
+    value: input.durationSeconds,
+  });
+}
+
+/** Latency of the durable `appendSessionEvents` DB write — the write path. A p99
+ *  climb here is our Postgres, not the model or NATS. */
+export function recordSessionEventAppendLatency(
+  observability: Observability,
+  input: { durationSeconds: number },
+): void {
+  observability.observeHistogram({
+    name: "opengeni_session_event_append_seconds",
+    help: "Duration in seconds of an appendSessionEvents DB write (the durable write path).",
+    buckets: STREAM_IO_BUCKETS,
+    value: input.durationSeconds,
+  });
+}
+
+/** Latency of the best-effort NATS live fan-out — the delivery path. A p99 climb
+ *  here (with append healthy) is delivery, not the write path. */
+export function recordSessionEventPublishLatency(
+  observability: Observability,
+  input: { durationSeconds: number },
+): void {
+  observability.observeHistogram({
+    name: "opengeni_session_event_publish_seconds",
+    help: "Duration in seconds of the best-effort NATS live fan-out publish (the delivery path).",
+    buckets: STREAM_IO_BUCKETS,
+    value: input.durationSeconds,
+  });
+}
+
+// Context tokens per response span a wide range; buckets track the pressure toward
+// a model's window so "sessions are running hot but never compacting" is queryable.
+const MODEL_INPUT_TOKENS_BUCKETS = [
+  1_000, 5_000, 10_000, 25_000, 50_000, 100_000, 150_000, 200_000, 300_000, 500_000, 1_000_000,
+];
+
+/** Observed input (context) tokens per model response — the context-pressure
+ *  signal. Paired with `opengeni_context_compactions_total`, it makes the
+ *  "compaction never firing while contexts run hot" failure mode expressible. */
+export function recordModelInputTokens(
+  observability: Observability,
+  provider: string,
+  inputTokens: number,
+): void {
+  if (!(inputTokens > 0)) {
+    return;
+  }
+  observability.observeHistogram({
+    name: "opengeni_model_input_tokens",
+    help: "Observed input (context) tokens per model response, by provider.",
+    buckets: MODEL_INPUT_TOKENS_BUCKETS,
+    labels: { provider },
+    value: inputTokens,
+  });
+}
+
+/** A context compaction actually fired, by trigger (operator | overflow | proactive
+ *  | auto). The rate of this — against the input-tokens histogram above — is how an
+ *  operator sees compaction working (or silently not). */
+export function recordContextCompaction(observability: Observability, trigger: string): void {
+  observability.incrementCounter({
+    name: "opengeni_context_compactions_total",
+    help: "Total context compactions performed, by trigger.",
+    labels: { trigger },
   });
 }

--- a/apps/worker/test/streaming-batcher.test.ts
+++ b/apps/worker/test/streaming-batcher.test.ts
@@ -137,4 +137,38 @@ describe("createRuntimeBatcher", () => {
     await batcher.flush();
     expect(flushes.length).toBe(0);
   });
+
+  test("onFlush reports coalesced size and duration for each flush (success and failure)", async () => {
+    const seen: Array<{ events: number; durationSeconds: number }> = [];
+    let clock = 0;
+    let fail = false;
+    const batcher = createRuntimeBatcher(
+      async () => {
+        clock += 5; // simulate 5ms of flush work
+        if (fail) {
+          throw new Error("append failed");
+        }
+      },
+      { onFlush: (info) => seen.push(info), now: () => clock },
+    );
+
+    // A structural event flushes one event immediately.
+    await batcher.push(delta(0, TOOLCALL));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({ events: 1, durationSeconds: 0.005 });
+
+    // Three coalesced deltas ride out on the next structural flush → size 4.
+    await batcher.push(delta(1));
+    await batcher.push(delta(2));
+    await batcher.push(delta(3));
+    await batcher.push(delta(4, TOOLCALL));
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.events).toBe(4);
+
+    // A FAILED flush still reports its shape (onFlush runs in the finally).
+    fail = true;
+    await expect(batcher.push(delta(5, TOOLCALL))).rejects.toThrow("append failed");
+    expect(seen).toHaveLength(3);
+    expect(seen[2]!.events).toBe(1); // the single structural delta(5) that failed to flush
+  });
 });

--- a/apps/worker/test/streaming-slis.test.ts
+++ b/apps/worker/test/streaming-slis.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { createObservability } from "@opengeni/observability";
+import { testSettings } from "@opengeni/testing";
+import {
+  recordBatchFlush,
+  recordContextCompaction,
+  recordModelInputTokens,
+  recordSessionEventAppendLatency,
+  recordSessionEventPublishLatency,
+  StreamTimingMetrics,
+} from "../src/observability-metrics";
+
+// Streaming SLIs: pin that each new metric hook fires with the right series, the
+// right bounded labels, and the right value — so "streaming is sluggish" resolves
+// to a number and the layer (model / write / delivery) is attributable.
+
+function worker() {
+  return createObservability(testSettings(), { component: "worker" });
+}
+
+describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
+  test("first content delta records TTFT from the response (re)start anchor", async () => {
+    const observability = worker();
+    let now = 1_000;
+    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+
+    now = 2_000; // 1.0s after construction (≈ runStream start)
+    timing.onEvent("agent.message.delta");
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(/opengeni_stream_ttft_seconds_sum\{[^}]*provider="openai"[^}]*\} 1\b/);
+    expect(metrics).toMatch(
+      /opengeni_stream_ttft_seconds_count\{[^}]*provider="openai"[^}]*\} 1\b/,
+    );
+  });
+
+  test("re-arms TTFT after a non-content event (a post-tool response measures model restart)", async () => {
+    const observability = worker();
+    let now = 1_000;
+    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+
+    now = 2_000;
+    timing.onEvent("agent.message.delta"); // TTFT #1 = 1.0
+    now = 3_000;
+    timing.onEvent("agent.toolCall.output"); // non-content → re-arm anchor to 3_000
+    now = 4_000;
+    timing.onEvent("agent.reasoning.delta"); // TTFT #2 = 1.0 (measured from the tool boundary)
+
+    const metrics = await observability.prometheusMetrics();
+    // Two observations, summing to 2.0 — the second did NOT include the 1.0s tool gap.
+    expect(metrics).toMatch(/opengeni_stream_ttft_seconds_sum\{[^}]*provider="openai"[^}]*\} 2\b/);
+    expect(metrics).toMatch(
+      /opengeni_stream_ttft_seconds_count\{[^}]*provider="openai"[^}]*\} 2\b/,
+    );
+  });
+
+  test("inter-delta gaps are measured per class and reset across a boundary", async () => {
+    const observability = worker();
+    let now = 1_000;
+    const timing = new StreamTimingMetrics(observability, { provider: "azure", now: () => now });
+
+    timing.onEvent("agent.message.delta"); // first — no gap
+    now = 1_500;
+    timing.onEvent("agent.message.delta"); // gap 0.5
+    now = 2_000;
+    timing.onEvent("agent.message.delta"); // gap 0.5
+    now = 2_500;
+    timing.onEvent("agent.toolCall.output"); // boundary → clears the run
+    now = 5_000;
+    timing.onEvent("agent.message.delta"); // first after boundary — NO gap spanning the tool
+
+    const metrics = await observability.prometheusMetrics();
+    // Two gaps of 0.5s each: sum 1.0, count 2 — the 2.5s tool gap is excluded.
+    expect(metrics).toMatch(
+      /opengeni_stream_inter_delta_gap_seconds_sum\{[^}]*class="message"[^}]*provider="azure"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_stream_inter_delta_gap_seconds_count\{[^}]*class="message"[^}]*provider="azure"[^}]*\} 2\b/,
+    );
+  });
+
+  test("reasoning and message deltas carry distinct class labels", async () => {
+    const observability = worker();
+    let now = 0;
+    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+
+    timing.onEvent("agent.reasoning.delta");
+    now = 100;
+    timing.onEvent("agent.reasoning.delta"); // reasoning gap 0.1
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_stream_inter_delta_gap_seconds_count\{[^}]*class="reasoning"[^}]*\} 1\b/,
+    );
+  });
+});
+
+describe("batcher flush shape", () => {
+  test("records flush event count and duration histograms", async () => {
+    const observability = worker();
+    recordBatchFlush(observability, { events: 50, durationSeconds: 0.01 });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(/opengeni_stream_batch_flush_events_sum\{[^}]*\} 50\b/);
+    expect(metrics).toMatch(/opengeni_stream_batch_flush_duration_seconds_count\{[^}]*\} 1\b/);
+  });
+});
+
+describe("event I/O latency split (write path vs delivery)", () => {
+  test("append and publish latency are distinct series", async () => {
+    const observability = worker();
+    recordSessionEventAppendLatency(observability, { durationSeconds: 0.02 });
+    recordSessionEventPublishLatency(observability, { durationSeconds: 0.03 });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(/opengeni_session_event_append_seconds_sum\{[^}]*\} 0\.02\b/);
+    expect(metrics).toMatch(/opengeni_session_event_publish_seconds_sum\{[^}]*\} 0\.03\b/);
+  });
+});
+
+describe("context-pressure signals", () => {
+  test("model input tokens histogram labels by provider and skips non-positive", async () => {
+    const observability = worker();
+    recordModelInputTokens(observability, "openai", 50_000);
+    recordModelInputTokens(observability, "openai", 0); // skipped
+    recordModelInputTokens(observability, "openai", -5); // skipped
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_model_input_tokens_sum\{[^}]*provider="openai"[^}]*\} 50000\b/,
+    );
+    expect(metrics).toMatch(/opengeni_model_input_tokens_count\{[^}]*provider="openai"[^}]*\} 1\b/);
+  });
+
+  test("compaction counter increments by trigger", async () => {
+    const observability = worker();
+    recordContextCompaction(observability, "overflow");
+    recordContextCompaction(observability, "overflow");
+    recordContextCompaction(observability, "operator");
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_context_compactions_total\{[^}]*trigger="overflow"[^}]*\} 2\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_context_compactions_total\{[^}]*trigger="operator"[^}]*\} 1\b/,
+    );
+  });
+});

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -79,10 +79,14 @@ spec:
           # Contexts running hot (p90 observed input tokens high) while NO
           # compaction has fired in 30m — sessions are drifting toward overflow.
           # The 150k token threshold assumes a ~200k-window model; tune to yours.
+          # `or vector(0)` is load-bearing: on a fresh cluster the compaction
+          # counter has NEVER been created, so a bare `sum(increase(...)) == 0`
+          # is an EMPTY vector, not 0 — the conjunction would silently never fire
+          # exactly when compaction has never fired. The fallback forces a real 0.
           expr: |
             histogram_quantile(0.9, sum by (le) (rate(opengeni_model_input_tokens_bucket[30m]))) > 150000
             and on()
-            sum(increase(opengeni_context_compactions_total[30m])) == 0
+            (sum(increase(opengeni_context_compactions_total[30m])) or vector(0)) == 0
           for: 15m
           labels:
             severity: warning

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -46,5 +46,95 @@ spec:
             severity: critical
           annotations:
             summary: An OpenGeni service target is down
+        # ── Streaming health ─────────────────────────────────────────────────
+        # SLIs from the token-streaming pipeline, split so an alert names the
+        # layer: the model (TTFT), the durable write path (append), or delivery
+        # (publish). Thresholds are starters — tune per deployment.
+        - alert: OpenGeniStreamingFirstTokenSlow
+          expr: histogram_quantile(0.99, sum by (le, provider) (rate(opengeni_stream_ttft_seconds_bucket[10m]))) > 8
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni p99 time-to-first-token exceeds 8s
+            description: The model is slow to START streaming (p99 TTFT by provider above 8s for 15m). Suspect the model provider before the write/delivery path.
+        - alert: OpenGeniEventAppendLatencyHigh
+          expr: histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_append_seconds_bucket[10m]))) > 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni session-event append p99 exceeds 1s (durable write path)
+            description: appendSessionEvents p99 is above 1s for 10m — Postgres is the streaming bottleneck, not the model or NATS.
+        - alert: OpenGeniEventPublishLatencyHigh
+          expr: histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[10m]))) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni live-publish p99 exceeds 500ms (delivery path)
+            description: The best-effort NATS live fan-out p99 is above 500ms for 10m — live delivery is degraded (events stay durable and reconcile on stream replay).
+        # ── Context / compaction ─────────────────────────────────────────────
+        - alert: OpenGeniCompactionNotFiring
+          # Contexts running hot (p90 observed input tokens high) while NO
+          # compaction has fired in 30m — sessions are drifting toward overflow.
+          # The 150k token threshold assumes a ~200k-window model; tune to yours.
+          expr: |
+            histogram_quantile(0.9, sum by (le) (rate(opengeni_model_input_tokens_bucket[30m]))) > 150000
+            and on()
+            sum(increase(opengeni_context_compactions_total[30m])) == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni contexts are running hot but compaction has not fired in 30m
+        # ── Connected Machines (op-outcome plane) ────────────────────────────
+        - alert: OpenGeniMachineOpInfraFailuresHigh
+          expr: sum(rate(opengeni_machine_op_total{outcome="failed"}[10m])) / clamp_min(sum(rate(opengeni_machine_op_total[10m])), 1) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni Connected Machine op infra-failure ratio exceeds 10%
+        - alert: OpenGeniMachineOpHealedFaultsSpiking
+          # Healed faults are the LEADING indicator of the next unhealed one — a
+          # blip/backpressure the transport absorbed. A rising rate precedes real
+          # op failures, so this fires EARLY (info severity) as a heads-up.
+          expr: sum(rate(opengeni_machine_op_healed_total[10m])) > 0.2
+          for: 15m
+          labels:
+            severity: info
+          annotations:
+            summary: OpenGeni Connected Machine healed-fault rate is elevated (leading indicator)
+        # ── Worker fleet ─────────────────────────────────────────────────────
+        # These two read cluster-infra series (cAdvisor + kube-state-metrics); if
+        # those exporters are absent the alerts simply never fire (no data). Pod/
+        # HPA matchers assume the default "opengeni" release name — override
+        # observability.prometheusRule.rules for a custom name.
+        - alert: OpenGeniWorkerMemoryNearLimit
+          expr: |
+            max by (namespace, pod, container) (
+              container_memory_working_set_bytes{container=~"worker|api|relay", pod=~".*opengeni.*"}
+            )
+            /
+            max by (namespace, pod, container) (
+              kube_pod_container_resource_limits{resource="memory", container=~"worker|api|relay", pod=~".*opengeni.*"}
+            ) > 0.9
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: An OpenGeni container is above 90% of its memory limit (pre-OOM)
+            description: The worker holds the full in-turn history in memory; sustained >90% of the limit precedes an OOM kill mid-turn.
+        - alert: OpenGeniHpaAtMaxReplicas
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler=~".*opengeni.*"}
+            >= kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler=~".*opengeni.*"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: An OpenGeni HPA has been pinned at maxReplicas (capacity saturation)
+            description: The autoscaler cannot add more pods; sustained saturation means turns queue. Raise maxReplicas or investigate the load source.
         {{- end }}
 {{- end }}

--- a/deploy/observability/dashboards/README.md
+++ b/deploy/observability/dashboards/README.md
@@ -1,0 +1,76 @@
+# OpenGeni Grafana dashboards
+
+Dashboards-as-code for the OpenGeni control plane. Three boards, each answering a
+different "manage and fix problems as soon as they arise" question:
+
+| File | Board | Answers |
+| --- | --- | --- |
+| `streaming-health.json` | **OpenGeni · Streaming Health** | Is streaming sluggish, and *where* — the model (TTFT + inter-delta gaps), the durable write path (append latency), or delivery (publish latency + batcher shape)? |
+| `connected-machines.json` | **OpenGeni · Connected Machines** | Are Connected Machine control ops healthy — op outcomes, healed faults (the leading indicator), op latency, the fault taxonomy, and the payload wall? |
+| `worker-fleet.json` | **OpenGeni · Worker Fleet** | Is the fleet keeping up — turns inflight/queued, worker memory vs. limit, HPA replicas, sandbox leases, and whether compaction is firing against context pressure? |
+
+All three are theme-agnostic, tagged `opengeni` + `observability`, and carry a
+`$datasource` template variable — pick your Prometheus datasource on import; no UID
+is hardcoded.
+
+## Importing
+
+**Grafana UI** — Dashboards → New → Import → Upload JSON file (or paste), then select
+your Prometheus datasource for the `$datasource` prompt.
+
+**Provisioned (file provider)** — mount this directory and point a provider at it:
+
+```yaml
+# /etc/grafana/provisioning/dashboards/opengeni.yaml
+apiVersion: 1
+providers:
+  - name: opengeni
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/opengeni
+      foldersFromFilesStructure: true
+```
+
+**Kubernetes sidecar (kube-prometheus-stack / Grafana Helm)** — wrap each file in a
+ConfigMap carrying the sidecar's discovery label (default `grafana_dashboard: "1"`);
+the sidecar imports it automatically. Example:
+
+```bash
+kubectl create configmap opengeni-streaming-health \
+  --from-file=streaming-health.json \
+  --dry-run=client -o yaml \
+  | kubectl label --local -f - grafana_dashboard=1 -o yaml \
+  | kubectl apply -f -
+```
+
+## Metric sources
+
+Most panels read **app-emitted** series scraped from OpenGeni's `/metrics` endpoints.
+Enable scraping via the chart:
+
+```yaml
+observability:
+  metrics: { enabled: true }
+  serviceMonitor: { enabled: true }   # api + worker + relay ServiceMonitors
+  prometheusRule: { enabled: true }   # the starter alerts (see ../../helm/opengeni/templates/prometheusrule.yaml)
+```
+
+App series used here (non-exhaustive): `opengeni_stream_ttft_seconds`,
+`opengeni_stream_inter_delta_gap_seconds`, `opengeni_stream_batch_flush_*`,
+`opengeni_session_event_append_seconds`, `opengeni_session_event_publish_seconds`,
+`opengeni_model_input_tokens`, `opengeni_context_compactions_total`,
+`opengeni_machine_op_*`, `opengeni_turns_*`, `opengeni_sandbox_leases`,
+`opengeni_model_call_duration_seconds`, and the prom-client defaults
+(`opengeni_process_resident_memory_bytes`).
+
+A few Worker Fleet panels read **cluster-infra** series from other exporters —
+`container_memory_working_set_bytes` (cAdvisor / kubelet) and
+`kube_pod_container_resource_limits` + `kube_horizontalpodautoscaler_*`
+(kube-state-metrics). If those exporters aren't present, only those panels are
+empty; every app-series panel still works, and the memory board falls back to the
+app-emitted RSS panel.
+
+> `machine.link.*` and `machine.op.*` are session-scoped **timeline events**, not
+> Prometheus series — a machine's link history lives in the session timeline (which
+> carries the workspace/session context Prometheus omits). The Connected Machines
+> board is the aggregate op-outcome view.

--- a/deploy/observability/dashboards/connected-machines.json
+++ b/deploy/observability/dashboards/connected-machines.json
@@ -1,0 +1,457 @@
+{
+  "uid": "opengeni-connected-machines",
+  "title": "OpenGeni \u00b7 Connected Machines",
+  "description": "Connected Machine control-op outcomes, healed faults (leading indicator), op latency, fault taxonomy, and the payload wall.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "timezone": "",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "tags": ["opengeni", "observability"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Op outcomes \u2014 the Connected Machine control plane",
+      "collapsed": false,
+      "panels": [],
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Op rate by outcome (ops/s)",
+      "description": "Every completed control op, ok vs failed.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (rate(opengeni_machine_op_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Infra-failure ratio (10m)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_machine_op_total{outcome=\"failed\"}[10m])) / clamp_min(sum(rate(opengeni_machine_op_total[10m])), 1)",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Healed faults /s (10m) \u2014 leading indicator",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_machine_op_healed_total[10m]))",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 4,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      }
+    },
+    {
+      "type": "row",
+      "title": "Healed faults & latency \u2014 the leading indicators",
+      "collapsed": false,
+      "panels": [],
+      "id": 5,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Healed-fault rate by op (recovered after \u22651 retry)",
+      "description": "A blip/backpressure the transport absorbed. Rising here precedes real op failures.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (op) (rate(opengeni_machine_op_healed_total[5m]))",
+          "legendFormat": "{{op}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 6,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Op duration p95 by op",
+      "description": "Control-op round-trip by op kind.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(opengeni_machine_op_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{op}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 7,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      }
+    },
+    {
+      "type": "row",
+      "title": "Fault taxonomy & payload wall",
+      "collapsed": false,
+      "panels": [],
+      "id": 8,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      }
+    },
+    {
+      "type": "table",
+      "title": "Failures by typed code (5m rate)",
+      "description": "Which typed fault classes are firing (offline, payload-too-large, reconnecting-timeout, \u2026).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (code, op) (rate(opengeni_machine_op_total{outcome=\"failed\"}[5m]))",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": false,
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "id": 9,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Op reply size p95 by op (payload-wall indicator)",
+      "description": "Reply bytes on payload-wall faults \u2014 approaching the wall predicts PAYLOAD_TOO_LARGE.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(opengeni_machine_op_reply_bytes_bucket[5m])))",
+          "legendFormat": "{{op}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      }
+    },
+    {
+      "type": "text",
+      "title": "About machine link events",
+      "options": {
+        "mode": "markdown",
+        "content": "**`machine.link.*` and `machine.op.*` are session-scoped timeline events, not Prometheus series** \u2014 a machine going online/offline or a per-op fault renders in the session timeline (quiet tier), where it carries the workspace/session context Prometheus deliberately omits. This dashboard is the *aggregate* op-outcome view; use the session timeline for a specific machine's link history."
+      },
+      "id": 11,
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      }
+    }
+  ]
+}

--- a/deploy/observability/dashboards/streaming-health.json
+++ b/deploy/observability/dashboards/streaming-health.json
@@ -1,0 +1,789 @@
+{
+  "uid": "opengeni-streaming-health",
+  "title": "OpenGeni \u00b7 Streaming Health",
+  "description": "TTFT, inter-delta gaps, batcher shape, and the append-vs-publish latency split \u2014 so 'streaming is sluggish' names its layer.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "timezone": "",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "tags": ["opengeni", "observability"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Model responsiveness \u2014 is the model slow to start? (TTFT)",
+      "collapsed": false,
+      "panels": [],
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Time-to-first-token p99 / p95 / p50 by provider",
+      "description": "Seconds from a model (re)start to its first streamed content delta. High here = the model, not our pipeline.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le, provider) (rate(opengeni_stream_ttft_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{provider}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(opengeni_stream_ttft_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{provider}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.5, sum by (le, provider) (rate(opengeni_stream_ttft_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{provider}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Inter-delta gap p95 by class (stream choppiness)",
+      "description": "Gap between consecutive same-class deltas. Rising gaps = a stuttering token stream.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, class) (rate(opengeni_stream_inter_delta_gap_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{class}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.5, sum by (le, class) (rate(opengeni_stream_inter_delta_gap_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{class}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Delta throughput (deltas/s)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_stream_inter_delta_gap_seconds_count[5m])) by (class)",
+          "legendFormat": "{{class}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 4,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      }
+    },
+    {
+      "type": "row",
+      "title": "Write path \u2014 the durable append (Postgres)",
+      "collapsed": false,
+      "panels": [],
+      "id": 5,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Session-event append latency p99 / p95 / p50",
+      "description": "appendSessionEvents DB write. High here (with publish healthy) = Postgres is the bottleneck.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_append_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(opengeni_session_event_append_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(opengeni_session_event_append_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 6,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Append p99 (now)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_append_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 7,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Append throughput (appends/s)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_session_event_append_seconds_count[5m]))",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 8,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      }
+    },
+    {
+      "type": "row",
+      "title": "Delivery path \u2014 the best-effort NATS fan-out",
+      "collapsed": false,
+      "panels": [],
+      "id": 9,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Live-publish latency p99 / p95 / p50",
+      "description": "NATS live publish. High here (with append healthy) = delivery, not the write path. Events stay durable and reconcile on replay.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Publish p99 (now)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(opengeni_session_event_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 11,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 27
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Publish throughput (publishes/s)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(opengeni_session_event_publish_seconds_count[5m]))",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 12,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 27
+      }
+    },
+    {
+      "type": "row",
+      "title": "Batcher \u2014 token coalescing shape",
+      "collapsed": false,
+      "panels": [],
+      "id": 13,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Batch flush size p95 / p50 (events per flush)",
+      "description": "Events coalesced per flush. Larger = the batcher is absorbing bursts (fewer DB round-trips).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(opengeni_stream_batch_flush_events_bucket[5m])))",
+          "legendFormat": "p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(opengeni_stream_batch_flush_events_bucket[5m])))",
+          "legendFormat": "p50",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "sum(rate(opengeni_stream_batch_flush_events_sum[5m])) / clamp_min(sum(rate(opengeni_stream_batch_flush_events_count[5m])), 1)",
+          "legendFormat": "avg",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 14,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Batch flush duration p95 / p50",
+      "description": "Time to append+publish one flush.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(opengeni_stream_batch_flush_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(opengeni_stream_batch_flush_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 15,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      }
+    }
+  ]
+}

--- a/deploy/observability/dashboards/worker-fleet.json
+++ b/deploy/observability/dashboards/worker-fleet.json
@@ -1,0 +1,646 @@
+{
+  "uid": "opengeni-worker-fleet",
+  "title": "OpenGeni \u00b7 Worker Fleet",
+  "description": "Turn flow, worker memory vs limit, HPA replicas, sandbox leases, and compaction firing vs context pressure.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "timezone": "",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "tags": ["opengeni", "observability"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Turn flow \u2014 inflight, queued, throughput",
+      "collapsed": false,
+      "panels": [],
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Turns inflight vs queued (fleet total)",
+      "description": "Backlog pressure. Queued climbing while inflight is flat = capacity-bound.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(opengeni_turns_inflight)",
+          "legendFormat": "inflight",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "sum(opengeni_turns_queued)",
+          "legendFormat": "queued",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Oldest inflight turn age (max)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(opengeni_turn_oldest_inflight_age_seconds)",
+          "legendFormat": "",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Turn rate by outcome (turns/s)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (rate(opengeni_turns_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 4,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      }
+    },
+    {
+      "type": "row",
+      "title": "Memory \u2014 working set vs the container limit (pre-OOM)",
+      "collapsed": false,
+      "panels": [],
+      "id": 5,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Worker memory: fraction of limit",
+      "description": "cAdvisor working set \u00f7 kube-state-metrics limit. >0.9 sustained precedes an OOM kill mid-turn.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod) (container_memory_working_set_bytes{container=\"worker\", pod=~\".*opengeni.*\"}) / max by (pod) (kube_pod_container_resource_limits{resource=\"memory\", container=\"worker\", pod=~\".*opengeni.*\"})",
+          "legendFormat": "{{pod}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 6,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "App RSS by process (fallback when cluster infra is absent)",
+      "description": "App-emitted resident memory (prom-client default metrics) \u2014 works without cAdvisor.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opengeni_process_resident_memory_bytes{component=\"worker\"}",
+          "legendFormat": "{{instance}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 7,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      }
+    },
+    {
+      "type": "row",
+      "title": "Autoscaling \u2014 HPA replicas vs max",
+      "collapsed": false,
+      "panels": [],
+      "id": 8,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Worker HPA: current vs max replicas",
+      "description": "When current pins at max and stays there, turns queue \u2014 raise max or shed load.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler=~\".*opengeni.*worker.*\"}",
+          "legendFormat": "current {{horizontalpodautoscaler}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler=~\".*opengeni.*worker.*\"}",
+          "legendFormat": "max {{horizontalpodautoscaler}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 9,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Sandbox leases by liveness",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (liveness) (opengeni_sandbox_leases)",
+          "legendFormat": "{{liveness}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      }
+    },
+    {
+      "type": "row",
+      "title": "Context pressure \u2014 is compaction keeping up?",
+      "collapsed": false,
+      "panels": [],
+      "id": 11,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction firing rate by trigger (per 15m)",
+      "description": "Flat zero while input tokens climb = compaction not firing (see the alert).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (trigger) (increase(opengeni_context_compactions_total[15m]))",
+          "legendFormat": "{{trigger}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 12,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Observed model input tokens p95 / p50 (context size)",
+      "description": "Context tokens per model response \u2014 the pressure toward the model window.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(opengeni_model_input_tokens_bucket[10m])))",
+          "legendFormat": "p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(opengeni_model_input_tokens_bucket[10m])))",
+          "legendFormat": "p50",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 13,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Model call duration p95 by provider",
+      "description": "Full model HTTP call (request \u2192 response headers).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": ["last", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(opengeni_model_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{provider}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ],
+      "id": 14,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      }
+    }
+  ]
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -396,14 +396,44 @@ export async function createResponderConnection(
   };
 }
 
+/**
+ * Optional timing seam for {@link appendAndPublishEvents}: `onAppend` fires after
+ * the durable DB write, `onPublish` after the best-effort live fan-out (on both
+ * success AND failure of the publish, so a broker blip still records its latency).
+ * Kept as a plain callback so the events package takes no dependency on the
+ * observability package; the worker wires it to Prometheus histograms.
+ */
+export type AppendPublishObserver = {
+  onAppend?: (info: { durationSeconds: number; count: number }) => void;
+  onPublish?: (info: { durationSeconds: number; count: number }) => void;
+};
+
+function observeSince(
+  fn: ((info: { durationSeconds: number; count: number }) => void) | undefined,
+  startedAt: number,
+  count: number,
+): void {
+  if (!fn) {
+    return;
+  }
+  try {
+    fn({ durationSeconds: Math.max(0, (performance.now() - startedAt) / 1000), count });
+  } catch {
+    // Metrics emission must never affect the append/publish path.
+  }
+}
+
 export async function appendAndPublishEvents(
   db: Database,
   bus: EventBus,
   workspaceId: string,
   sessionId: string,
   events: AppendEventInput[],
+  observe?: AppendPublishObserver,
 ): Promise<SessionEvent[]> {
+  const appendStartedAt = performance.now();
   const appended = await appendSessionEvents(db, workspaceId, sessionId, events);
+  observeSince(observe?.onAppend, appendStartedAt, appended.length);
   // The DB append above is the durable system of record; the publish is only a
   // best-effort LIVE fan-out. Guard it so NO EventBus implementation can throw an
   // in-flight agent turn to death on a transient NATS disconnect — consumers
@@ -411,6 +441,7 @@ export async function appendAndPublishEvents(
   // endpoint (DB replay + gap-backfill). The managed `createNatsEventBus` bus
   // already swallows internally, so this catch is the belt-and-suspenders guard
   // for any other bus impl (and a fully CLOSED connection during shutdown).
+  const publishStartedAt = performance.now();
   try {
     await bus.publish(workspaceId, sessionId, appended);
   } catch (error) {
@@ -419,6 +450,7 @@ export async function appendAndPublishEvents(
       error,
     );
   }
+  observeSince(observe?.onPublish, publishStartedAt, appended.length);
   return appended;
 }
 

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -408,7 +408,15 @@ export type AppendPublishObserver = {
   onPublish?: (info: { durationSeconds: number; count: number }) => void;
 };
 
-function observeSince(
+/**
+ * Invoke a phase-timing callback with the elapsed seconds since `startedAt` and the
+ * event count, swallowing any throw so a metrics sink can never break the
+ * append/publish path. Exported for direct unit testing: the wider test suite
+ * installs a process-global `mock.module("@opengeni/events")` that stubs
+ * `appendAndPublishEvents` (spreading the real module for everything else), so the
+ * observer wiring can only be exercised through a helper that survives that mock.
+ */
+export function observeSince(
   fn: ((info: { durationSeconds: number; count: number }) => void) | undefined,
   startedAt: number,
   count: number,

--- a/packages/events/test/observe-timing.test.ts
+++ b/packages/events/test/observe-timing.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { observeSince } from "../src/index";
+
+// The append/publish timing seam behind `appendAndPublishEvents`'s optional
+// observer (opengeni_session_event_append_seconds vs _publish_seconds). Tested at
+// the `observeSince` helper directly: the wider suite installs a process-global
+// `mock.module("@opengeni/events")` stub for `appendAndPublishEvents`, but it
+// spreads the real module for every OTHER export, so `observeSince` stays real and
+// this file passes regardless of test-file ordering.
+
+describe("observeSince", () => {
+  test("fires the callback with elapsed seconds and the event count", () => {
+    const calls: Array<{ durationSeconds: number; count: number }> = [];
+    const startedAt = performance.now();
+    observeSince((info) => calls.push(info), startedAt, 7);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.count).toBe(7);
+    expect(typeof calls[0]!.durationSeconds).toBe("number");
+    expect(calls[0]!.durationSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  test("clamps a would-be-negative elapsed to 0 (never a negative duration)", () => {
+    let observed: number | null = null;
+    // A startedAt in the FUTURE would make (now - startedAt) negative.
+    observeSince((info) => (observed = info.durationSeconds), performance.now() + 10_000, 1);
+    expect(observed).toBe(0);
+  });
+
+  test("is a no-op when no callback is supplied", () => {
+    expect(() => observeSince(undefined, performance.now(), 3)).not.toThrow();
+  });
+
+  test("swallows a throwing callback so a metrics sink never breaks append/publish", () => {
+    expect(() =>
+      observeSince(
+        () => {
+          throw new Error("sink exploded");
+        },
+        performance.now(),
+        1,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/events/test/resilience.test.ts
+++ b/packages/events/test/resilience.test.ts
@@ -148,4 +148,58 @@ describe("appendAndPublishEvents is best-effort on the live fan-out", () => {
     expect(appended).toHaveLength(1);
     expect(appended[0]!.sequence).toBe(1);
   });
+
+  test("times the append and publish phases separately via the observer", async () => {
+    const okBus = { publish: async () => {} } as never;
+    const seen: {
+      append?: { durationSeconds: number; count: number };
+      publish?: { durationSeconds: number; count: number };
+    } = {};
+
+    const appended = await appendAndPublishEvents(
+      {} as never,
+      okBus,
+      SENTINEL_WS,
+      "00000000-0000-4000-8000-000000000001",
+      [{ type: "agent.message.delta", payload: { text: "hi" } }] as never,
+      {
+        onAppend: (info) => {
+          seen.append = info;
+        },
+        onPublish: (info) => {
+          seen.publish = info;
+        },
+      },
+    );
+
+    expect(appended).toHaveLength(1);
+    expect(seen.append?.count).toBe(1);
+    expect(typeof seen.append?.durationSeconds).toBe("number");
+    expect(seen.publish?.count).toBe(1);
+    expect(typeof seen.publish?.durationSeconds).toBe("number");
+  });
+
+  test("onPublish still fires when the live publish rejects (best-effort)", async () => {
+    const rejectingBus = {
+      publish: async () => {
+        throw new Error("CONNECTION_CLOSED");
+      },
+    } as never;
+    let publishObserved = false;
+
+    await appendAndPublishEvents(
+      {} as never,
+      rejectingBus,
+      SENTINEL_WS,
+      "00000000-0000-4000-8000-000000000001",
+      [{ type: "agent.message.delta", payload: {} }] as never,
+      {
+        onPublish: () => {
+          publishObserved = true;
+        },
+      },
+    );
+
+    expect(publishObserved).toBe(true);
+  });
 });

--- a/packages/events/test/resilience.test.ts
+++ b/packages/events/test/resilience.test.ts
@@ -148,58 +148,11 @@ describe("appendAndPublishEvents is best-effort on the live fan-out", () => {
     expect(appended).toHaveLength(1);
     expect(appended[0]!.sequence).toBe(1);
   });
-
-  test("times the append and publish phases separately via the observer", async () => {
-    const okBus = { publish: async () => {} } as never;
-    const seen: {
-      append?: { durationSeconds: number; count: number };
-      publish?: { durationSeconds: number; count: number };
-    } = {};
-
-    const appended = await appendAndPublishEvents(
-      {} as never,
-      okBus,
-      SENTINEL_WS,
-      "00000000-0000-4000-8000-000000000001",
-      [{ type: "agent.message.delta", payload: { text: "hi" } }] as never,
-      {
-        onAppend: (info) => {
-          seen.append = info;
-        },
-        onPublish: (info) => {
-          seen.publish = info;
-        },
-      },
-    );
-
-    expect(appended).toHaveLength(1);
-    expect(seen.append?.count).toBe(1);
-    expect(typeof seen.append?.durationSeconds).toBe("number");
-    expect(seen.publish?.count).toBe(1);
-    expect(typeof seen.publish?.durationSeconds).toBe("number");
-  });
-
-  test("onPublish still fires when the live publish rejects (best-effort)", async () => {
-    const rejectingBus = {
-      publish: async () => {
-        throw new Error("CONNECTION_CLOSED");
-      },
-    } as never;
-    let publishObserved = false;
-
-    await appendAndPublishEvents(
-      {} as never,
-      rejectingBus,
-      SENTINEL_WS,
-      "00000000-0000-4000-8000-000000000001",
-      [{ type: "agent.message.delta", payload: {} }] as never,
-      {
-        onPublish: () => {
-          publishObserved = true;
-        },
-      },
-    );
-
-    expect(publishObserved).toBe(true);
-  });
 });
+
+// NOTE: the append/publish TIMING observer wired into `appendAndPublishEvents` is
+// exercised via `observeSince` in observe-timing.test.ts, NOT here — in the full
+// suite another test file installs a process-global `mock.module("@opengeni/events")`
+// that stubs `appendAndPublishEvents` (ignoring the observer arg), so an
+// observer assertion made THROUGH `appendAndPublishEvents` is defeated. `observeSince`
+// survives that mock because the stub spreads the real module for every other export.


### PR DESCRIPTION
Closes the gap between "metrics exist" and world-class observability for the operator bar: *manage and fix problems as soon as they arise.* Three commits, each its own deliverable.

## What a prod operator can now SEE

All worker-scraped, **bounded labels only** — `provider` + a two-value delta `class`, never a session id.

**Streaming, split so "sluggish" names its layer:**
- `opengeni_stream_ttft_seconds{provider}` — time to first content delta, **re-armed after every non-content event** so a post-tool response measures the model's *restart* latency, not our tool-execution time.
- `opengeni_stream_inter_delta_gap_seconds{provider,class}` — stream choppiness once flowing.
- `opengeni_stream_batch_flush_events` + `_duration_seconds` — the runtime batcher's coalescing shape.
- `opengeni_session_event_append_seconds` (Postgres write path) **vs** `opengeni_session_event_publish_seconds` (NATS delivery) — the triage split that answers *whose* slowness it is; a p99 climb points at the right dependency.

**Context pressure** (both series are new — "compaction never firing" wasn't expressible from existing series):
- `opengeni_model_input_tokens{provider}` and `opengeni_context_compactions_total{trigger}`.

**Three Grafana boards as code** in `deploy/observability/dashboards/` (Streaming Health, Connected Machines on the existing `opengeni_machine_op_*`, Worker Fleet) + a README with UI / file-provider / sidecar import paths.

## What will FIRE

8 alerts appended to the existing `prometheusrule.yaml` default set (promtool-validated, 12 rules total):

| Alert | Fires when |
| --- | --- |
| `OpenGeniStreamingFirstTokenSlow` | p99 TTFT > 8s for 15m |
| `OpenGeniEventAppendLatencyHigh` | append p99 > 1s (write path) |
| `OpenGeniEventPublishLatencyHigh` | publish p99 > 500ms (delivery path) |
| `OpenGeniCompactionNotFiring` | contexts hot (p90 input tokens > 150k) with zero compactions in 30m |
| `OpenGeniMachineOpInfraFailuresHigh` | machine-op infra-failure ratio > 10% |
| `OpenGeniMachineOpHealedFaultsSpiking` | healed-fault rate elevated (info — the leading indicator) |
| `OpenGeniWorkerMemoryNearLimit` | worker/api/relay container > 90% of memory limit (pre-OOM) |
| `OpenGeniHpaAtMaxReplicas` | an HPA pinned at maxReplicas (capacity saturation) |

The two fleet alerts read cluster-infra series (cAdvisor + kube-state-metrics) and simply don't fire when those exporters are absent. Matchers follow the existing `.*opengeni.*` convention.

## Decisions

- **Provider, not raw model, label** on the streaming histograms: bounded cardinality beats granularity, and raw model ids are user-typed (unbounded). Provider comes from the registry.
- **TTFT is measured worker-side** (response start → first content delta) and **complements — does not duplicate** — the existing HTTP-level `opengeni_model_call_duration_seconds` (request → response headers). Different question, different number.
- **Thresholds are documented starter values**, overridable via `observability.prometheusRule.rules`.

## Verification

Full monorepo typecheck clean (20 projects) · `oxfmt --check` clean · `oxlint` clean (only pre-existing warnings) · unit tests pass 0 fail — a hook-fires-with-right-labels test for **every** new metric, incl. TTFT re-arm, inter-delta boundary reset, and best-effort `onFlush`/`onPublish` on failure · `promtool check rules`: 12 alert rules + 41 dashboard exprs all valid · helm renders the PrometheusRule cleanly. Changeset added for the two code packages (`@opengeni/worker-bundle`, `@opengeni/events`); helm + dashboards are deploy artifacts (no changeset, matching #352).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
