### PR TITLE
fix(sessions): make stop mean stop and stop the child-completion flood

### DIFF
--- a/.changeset/stop-means-stop.md
+++ b/.changeset/stop-means-stop.md
@@ -1,0 +1,15 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/sdk": patch
+"@opengeni/react": patch
+"@opengeni/worker-bundle": patch
+"@opengeni/api-router": patch
+---
+
+Make "stop" mean stop, and stop the child-completion flood from outrunning it.
+
+- **Stop drains the queue.** A non-steer interrupt now cancels the active turn AND all queued turns, emitting one `turn.queue_drained` summary event. Steer still promotes exactly one steered message.
+- **A user-paused goal is sacred.** A machine child-completion turn can no longer re-activate a goal the user paused (`goal_set` is refused during such turns), and the wake text drops the "resume it now" nudge when the manager's own goal is user-paused.
+- **Child-completion notifications coalesce.** N spawned workers reaching terminal states now fold into ONE queued digest turn (one model run) instead of N turns, so the flood can no longer outrun a human's stop button. Each worker still gets its own result card.
+- **Honest steering copy.** The composer no longer claims steer "injects this message now"; it cancels the current step and runs the message next while the goal continues, and the stop button says it clears queued messages and pauses the goal.

--- a/.changeset/stop-means-stop.md
+++ b/.changeset/stop-means-stop.md
@@ -2,6 +2,7 @@
 "@opengeni/contracts": patch
 "@opengeni/core": patch
 "@opengeni/db": patch
+"@opengeni/runtime": patch
 "@opengeni/sdk": patch
 "@opengeni/react": patch
 "@opengeni/worker-bundle": patch
@@ -11,7 +12,7 @@
 Make "stop" mean stop, and stop the child-completion flood from outrunning it.
 
 - **Stop drains the queue.** A non-steer interrupt now cancels the active turn AND all queued turns, emitting one `turn.queue_drained` summary event. Steer still promotes exactly one steered message.
-- **A user-paused goal is sacred.** A machine child-completion turn can no longer re-activate a goal the user paused (`goal_set` is refused during such turns), and the wake text drops the "resume it now" nudge when the manager's own goal is user-paused.
+- **A user-paused goal is sacred.** A machine child-completion turn can no longer re-activate a goal the user paused (`goal_set` is refused for such callers), and the wake text drops the "resume it now" nudge when the manager's own goal is user-paused. The caller is classified by its own signed turn identity (a new `turnId` claim on the first-party MCP token), not the session's live active pointer — so the guard cannot be raced into refusing a legitimate human `goal_set`.
 - **Child-completion notifications coalesce.** N spawned workers reaching terminal states now fold into ONE queued digest turn (one model run) instead of N turns, so the flood can no longer outrun a human's stop button. Each worker still gets its own result card.
 - **Human messages preempt machine notifications.** A person's message jumps ahead of any queued child-completion notification turns (behind the running turn and earlier human turns) — it never waits behind a flood of "worker FAILED" notices.
 - **Child-completion suppression opt-in.** A new first-party `set_child_notifications_mode` tool lets a manager switch spawned-worker completions to `passive`: they appear as timeline cards only and never queue a turn or a model run. `digest` remains the default.

--- a/.changeset/stop-means-stop.md
+++ b/.changeset/stop-means-stop.md
@@ -1,5 +1,6 @@
 ---
 "@opengeni/contracts": patch
+"@opengeni/core": patch
 "@opengeni/db": patch
 "@opengeni/sdk": patch
 "@opengeni/react": patch
@@ -12,4 +13,6 @@ Make "stop" mean stop, and stop the child-completion flood from outrunning it.
 - **Stop drains the queue.** A non-steer interrupt now cancels the active turn AND all queued turns, emitting one `turn.queue_drained` summary event. Steer still promotes exactly one steered message.
 - **A user-paused goal is sacred.** A machine child-completion turn can no longer re-activate a goal the user paused (`goal_set` is refused during such turns), and the wake text drops the "resume it now" nudge when the manager's own goal is user-paused.
 - **Child-completion notifications coalesce.** N spawned workers reaching terminal states now fold into ONE queued digest turn (one model run) instead of N turns, so the flood can no longer outrun a human's stop button. Each worker still gets its own result card.
+- **Human messages preempt machine notifications.** A person's message jumps ahead of any queued child-completion notification turns (behind the running turn and earlier human turns) — it never waits behind a flood of "worker FAILED" notices.
+- **Child-completion suppression opt-in.** A new first-party `set_child_notifications_mode` tool lets a manager switch spawned-worker completions to `passive`: they appear as timeline cards only and never queue a turn or a model run. `digest` remains the default.
 - **Honest steering copy.** The composer no longer claims steer "injects this message now"; it cancels the current step and runs the message next while the goal continues, and the stop button says it clears queued messages and pauses the goal.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -17,6 +17,7 @@ import {
   encryptVariableSetValue,
   getSession,
   getSessionGoal,
+  getSessionTurn,
   getVariableSet,
   getVariableSetByName,
   listGitHubInstallationIdsForWorkspace,
@@ -614,6 +615,53 @@ function registerToolspaceProxyTools(server: McpServer, surface: ToolspaceMcpSur
   }
 }
 
+/**
+ * A turn injected by the machine to notify a manager that a spawned worker
+ * reached a terminal state — either a coalesced child-notification digest turn
+ * (source 'child_notification') or a legacy per-child wake (source 'user' with
+ * a `childCompletion` marker). NOT a genuine human message.
+ */
+export function isMachineChildNotificationTurn(turn: {
+  source: string;
+  metadata: Record<string, unknown> | null;
+}): boolean {
+  if (turn.source === "child_notification") {
+    return true;
+  }
+  return Boolean(turn.metadata && "childCompletion" in turn.metadata);
+}
+
+/**
+ * Sacred user pause: a goal a human stopped (pausedReason 'user_interrupt') must
+ * never be resurrected by a MACHINE turn. Child-completion notification turns
+ * carry a "resume it now" nudge; without this guard the agent processing one of
+ * them would call goal_set and re-arm the exact autonomous loop the user just
+ * stopped (the runaway that made "stop" feel broken). A genuine user message
+ * still redirects freely (it is not a child-notification turn), and the
+ * human-driven API resume path (PATCH /goal) is unaffected.
+ */
+export async function assertGoalReactivationAllowed(
+  deps: ApiRouteDeps,
+  workspaceId: string,
+  sessionId: string,
+): Promise<void> {
+  const goal = await getSessionGoal(deps.db, workspaceId, sessionId);
+  if (!goal || goal.status !== "paused" || goal.pausedReason !== "user_interrupt") {
+    return;
+  }
+  const session = await getSession(deps.db, workspaceId, sessionId);
+  const activeTurnId = session?.activeTurnId ?? null;
+  if (!activeTurnId) {
+    return;
+  }
+  const turn = await getSessionTurn(deps.db, workspaceId, activeTurnId);
+  if (turn && isMachineChildNotificationTurn(turn)) {
+    throw new Error(
+      "This session was paused by the user (stop). A worker-completion turn cannot resume or replace the goal — only the user can. Report your findings for the user and stop; do not call goal_set.",
+    );
+  }
+}
+
 function registerGoalTools(
   server: McpServer,
   deps: ApiRouteDeps,
@@ -634,6 +682,7 @@ function registerGoalTools(
     },
     async ({ text, successCriteria, maxAutoContinuations }) => {
       await requireSession(deps.db, grant.workspaceId, sessionId);
+      await assertGoalReactivationAllowed(deps, grant.workspaceId, sessionId);
       const { goal, replaced } = await upsertSessionGoal(deps.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -652,22 +652,31 @@ export function isMachineChildNotificationTurn(turn: {
  * stopped (the runaway that made "stop" feel broken). A genuine user message
  * still redirects freely (it is not a child-notification turn), and the
  * human-driven API resume path (PATCH /goal) is unaffected.
+ *
+ * Classification is by CALLER IDENTITY — `callerTurnId` is the turn that minted
+ * this MCP token (signed into it by the worker at turn setup). We deliberately
+ * do NOT read the session's live `active_turn_id`: that pointer can flip to a
+ * different turn between reads (a machine turn ends and a human turn becomes
+ * active mid-check), which would misclassify the caller and, worst case, refuse
+ * a legitimate human `goal_set` — inverting the guard against the very human
+ * power it must preserve. A caller turn's source/metadata are immutable, so this
+ * read is race-free. No caller identity ⇒ fail OPEN (only a positively
+ * identified machine child-notification caller is refused).
  */
 export async function assertGoalReactivationAllowed(
   deps: ApiRouteDeps,
   workspaceId: string,
   sessionId: string,
+  callerTurnId: string | null,
 ): Promise<void> {
+  if (!callerTurnId) {
+    return;
+  }
   const goal = await getSessionGoal(deps.db, workspaceId, sessionId);
   if (!goal || goal.status !== "paused" || goal.pausedReason !== "user_interrupt") {
     return;
   }
-  const session = await getSession(deps.db, workspaceId, sessionId);
-  const activeTurnId = session?.activeTurnId ?? null;
-  if (!activeTurnId) {
-    return;
-  }
-  const turn = await getSessionTurn(deps.db, workspaceId, activeTurnId);
+  const turn = await getSessionTurn(deps.db, workspaceId, callerTurnId);
   if (turn && isMachineChildNotificationTurn(turn)) {
     throw new Error(
       "This session was paused by the user (stop). A worker-completion turn cannot resume or replace the goal — only the user can. Report your findings for the user and stop; do not call goal_set.",
@@ -695,7 +704,11 @@ function registerGoalTools(
     },
     async ({ text, successCriteria, maxAutoContinuations }) => {
       await requireSession(deps.db, grant.workspaceId, sessionId);
-      await assertGoalReactivationAllowed(deps, grant.workspaceId, sessionId);
+      const callerTurnId =
+        typeof grant.metadata?.["turnId"] === "string"
+          ? (grant.metadata["turnId"] as string)
+          : null;
+      await assertGoalReactivationAllowed(deps, grant.workspaceId, sessionId, callerTurnId);
       const { goal, replaced } = await upsertSessionGoal(deps.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -37,6 +37,7 @@ import {
   requireSession,
   saveWorkspaceMemory,
   searchWorkspaceMemories,
+  setSessionChildNotificationsMode,
   setSessionGoalStatus,
   setVariableSetVariable,
   updateScheduledTask,
@@ -145,6 +146,18 @@ export function buildOpenGeniMcpServer(
       async ({ title }) => {
         const result = await updateSessionTitle(deps, grant.workspaceId, sessionId, title, "agent");
         return json({ ok: true, updated: result.updated, title: result.title ?? title });
+      },
+    );
+    server.registerTool(
+      "set_child_notifications_mode",
+      {
+        description:
+          "Control how workers you spawn report back when they finish. 'digest' (default): their completions arrive as a coalesced turn you process. 'passive': their completions appear only as quiet cards in your timeline and never queue a turn or a model run — use this when spawned-session completions are flooding your chat and you want them out of the way.",
+        inputSchema: { mode: z4.enum(["digest", "passive"]) },
+      },
+      async ({ mode }) => {
+        await setSessionChildNotificationsMode(deps.db, grant.workspaceId, sessionId, mode);
+        return json({ ok: true, mode });
       },
     );
   }

--- a/apps/api/test/goal-sacred-pause.test.ts
+++ b/apps/api/test/goal-sacred-pause.test.ts
@@ -12,7 +12,10 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 const fakeDb = {};
 let goal: any = null;
 let session: any = null;
-let turn: any = null;
+// getSessionTurn resolves BY turn id, so a test can give the caller turn and the
+// session's active turn different classifications and prove the guard reads the
+// CALLER, not the active pointer.
+let turnsById: Record<string, any> = {};
 
 const realDb = await import("@opengeni/db");
 // Capture the real function references BEFORE mock.module replaces them —
@@ -33,7 +36,9 @@ mock.module("@opengeni/db", () => ({
     db === fakeDb ? session : (realDbFns.getSession as any)(db, ...args),
   ),
   getSessionTurn: mock(async (db: unknown, ...args: unknown[]) =>
-    db === fakeDb ? turn : (realDbFns.getSessionTurn as any)(db, ...args),
+    db === fakeDb
+      ? (turnsById[args[1] as string] ?? null)
+      : (realDbFns.getSessionTurn as any)(db, ...args),
   ),
 }));
 
@@ -49,7 +54,7 @@ afterAll(() => {
 beforeEach(() => {
   goal = null;
   session = { id: "session-1", activeTurnId: "turn-1" };
-  turn = null;
+  turnsById = {};
 });
 
 describe("isMachineChildNotificationTurn", () => {
@@ -71,38 +76,83 @@ describe("isMachineChildNotificationTurn", () => {
   });
 });
 
-describe("assertGoalReactivationAllowed (sacred user pause)", () => {
-  test("REFUSES reactivation from a child-notification turn on a user-paused goal", async () => {
+describe("assertGoalReactivationAllowed (sacred user pause, by caller identity)", () => {
+  test("REFUSES reactivation when the CALLER is a child-notification turn on a user-paused goal", async () => {
     goal = { status: "paused", pausedReason: "user_interrupt" };
-    turn = { source: "child_notification", metadata: { childCompletion: {} } };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).rejects.toThrow(
+    turnsById["caller"] = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1", "caller")).rejects.toThrow(
       /paused by the user/,
     );
   });
 
-  test("ALLOWS reactivation from a genuine user turn (user re-directs)", async () => {
+  test("ALLOWS when the CALLER is a genuine user turn (user re-directs)", async () => {
     goal = { status: "paused", pausedReason: "user_interrupt" };
-    turn = { source: "user", metadata: {} };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    turnsById["caller"] = { source: "user", metadata: {} };
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "caller"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("RACE (inverse — the real, worse hole): a dying MACHINE caller is REFUSED even after the user's turn became active", async () => {
+    // The scenario that actually reproduces: a cancelled machine
+    // child-notification turn's agent keeps running (~50s cooperative-cancel
+    // lag) and calls goal_set AFTER a human turn has already become active.
+    // Reading active_turn_id would read the HUMAN turn, classify the caller as
+    // human, and wrongly ALLOW the dying machine to resurrect the user-paused
+    // goal — the exact hole lever 2 closes. Caller-identity refuses it.
+    goal = { status: "paused", pausedReason: "user_interrupt" };
+    turnsById["dying-machine"] = {
+      source: "child_notification",
+      metadata: { childCompletion: {} },
+    };
+    turnsById["user-active"] = { source: "user", metadata: {} };
+    session = { id: "session-1", activeTurnId: "user-active" };
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "dying-machine"),
+    ).rejects.toThrow(/paused by the user/);
+  });
+
+  test("RACE (forward — Bugbot's, thinner): a human caller is ALLOWED even while a machine turn is momentarily active", async () => {
+    // The guard must classify the CALLER (a human turn), not the session's
+    // active pointer — which here still shows a machine child-notification turn.
+    // Reading active_turn_id would misclassify and wrongly refuse the human.
+    goal = { status: "paused", pausedReason: "user_interrupt" };
+    turnsById["human-caller"] = { source: "user", metadata: {} };
+    turnsById["machine-active"] = {
+      source: "child_notification",
+      metadata: { childCompletion: {} },
+    };
+    session = { id: "session-1", activeTurnId: "machine-active" };
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "human-caller"),
+    ).resolves.toBeUndefined();
   });
 
   test("ALLOWS when the pause was the agent's own (not user_interrupt)", async () => {
     goal = { status: "paused", pausedReason: "agent" };
-    turn = { source: "child_notification", metadata: { childCompletion: {} } };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    turnsById["caller"] = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "caller"),
+    ).resolves.toBeUndefined();
   });
 
   test("ALLOWS when there is no goal or the goal is active", async () => {
+    turnsById["caller"] = { source: "child_notification", metadata: { childCompletion: {} } };
     goal = null;
-    turn = { source: "child_notification", metadata: { childCompletion: {} } };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "caller"),
+    ).resolves.toBeUndefined();
     goal = { status: "active", pausedReason: null };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", "caller"),
+    ).resolves.toBeUndefined();
   });
 
-  test("ALLOWS when the session has no active turn", async () => {
+  test("fail-open: no caller identity on the token ⇒ never blocks", async () => {
     goal = { status: "paused", pausedReason: "user_interrupt" };
-    session = { id: "session-1", activeTurnId: null };
-    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    turnsById["caller"] = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(
+      assertGoalReactivationAllowed(deps, "ws", "session-1", null),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/api/test/goal-sacred-pause.test.ts
+++ b/apps/api/test/goal-sacred-pause.test.ts
@@ -2,22 +2,45 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // A user-paused goal is sacred: a MACHINE child-notification turn must not
 // resurrect it via goal_set, while a genuine user turn still redirects freely.
+//
+// The db-read mocks are keyed on a `fakeDb` sentinel and delegate to the REAL
+// implementation for every other db handle. `mock.module` is process-global and
+// does not fully unwind across test files, so a mock that returned fixtures
+// unconditionally would corrupt real-db reads in later suites (it did — it fed
+// "session-1" into a real createSessionForRequest insert). Delegating keeps the
+// override invisible to everyone but this suite.
+const fakeDb = {};
 let goal: any = null;
 let session: any = null;
 let turn: any = null;
 
 const realDb = await import("@opengeni/db");
+// Capture the real function references BEFORE mock.module replaces them —
+// bun's mock.module mutates the module namespace in place, so reading
+// `realDb.getSessionGoal` at call time would resolve to the mock itself
+// (unbounded recursion). The frozen refs let delegation reach the real impl.
+const realDbFns = {
+  getSessionGoal: realDb.getSessionGoal,
+  getSession: realDb.getSession,
+  getSessionTurn: realDb.getSessionTurn,
+};
 mock.module("@opengeni/db", () => ({
   ...realDb,
-  getSessionGoal: mock(async () => goal),
-  getSession: mock(async () => session),
-  getSessionTurn: mock(async () => turn),
+  getSessionGoal: mock(async (db: unknown, ...args: unknown[]) =>
+    db === fakeDb ? goal : (realDbFns.getSessionGoal as any)(db, ...args),
+  ),
+  getSession: mock(async (db: unknown, ...args: unknown[]) =>
+    db === fakeDb ? session : (realDbFns.getSession as any)(db, ...args),
+  ),
+  getSessionTurn: mock(async (db: unknown, ...args: unknown[]) =>
+    db === fakeDb ? turn : (realDbFns.getSessionTurn as any)(db, ...args),
+  ),
 }));
 
 const { assertGoalReactivationAllowed, isMachineChildNotificationTurn } =
   await import("../src/mcp/server");
 
-const deps = { db: {} } as any;
+const deps = { db: fakeDb } as any;
 
 afterAll(() => {
   mock.restore();

--- a/apps/api/test/goal-sacred-pause.test.ts
+++ b/apps/api/test/goal-sacred-pause.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// A user-paused goal is sacred: a MACHINE child-notification turn must not
+// resurrect it via goal_set, while a genuine user turn still redirects freely.
+let goal: any = null;
+let session: any = null;
+let turn: any = null;
+
+const realDb = await import("@opengeni/db");
+mock.module("@opengeni/db", () => ({
+  ...realDb,
+  getSessionGoal: mock(async () => goal),
+  getSession: mock(async () => session),
+  getSessionTurn: mock(async () => turn),
+}));
+
+const { assertGoalReactivationAllowed, isMachineChildNotificationTurn } =
+  await import("../src/mcp/server");
+
+const deps = { db: {} } as any;
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  goal = null;
+  session = { id: "session-1", activeTurnId: "turn-1" };
+  turn = null;
+});
+
+describe("isMachineChildNotificationTurn", () => {
+  test("true for the coalesced digest source", () => {
+    expect(isMachineChildNotificationTurn({ source: "child_notification", metadata: {} })).toBe(
+      true,
+    );
+  });
+  test("true for a legacy per-child wake (childCompletion marker)", () => {
+    expect(
+      isMachineChildNotificationTurn({ source: "user", metadata: { childCompletion: {} } }),
+    ).toBe(true);
+  });
+  test("false for a genuine user message and a goal continuation", () => {
+    expect(isMachineChildNotificationTurn({ source: "user", metadata: {} })).toBe(false);
+    expect(isMachineChildNotificationTurn({ source: "goal", metadata: { goalId: "g" } })).toBe(
+      false,
+    );
+  });
+});
+
+describe("assertGoalReactivationAllowed (sacred user pause)", () => {
+  test("REFUSES reactivation from a child-notification turn on a user-paused goal", async () => {
+    goal = { status: "paused", pausedReason: "user_interrupt" };
+    turn = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).rejects.toThrow(
+      /paused by the user/,
+    );
+  });
+
+  test("ALLOWS reactivation from a genuine user turn (user re-directs)", async () => {
+    goal = { status: "paused", pausedReason: "user_interrupt" };
+    turn = { source: "user", metadata: {} };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+  });
+
+  test("ALLOWS when the pause was the agent's own (not user_interrupt)", async () => {
+    goal = { status: "paused", pausedReason: "agent" };
+    turn = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+  });
+
+  test("ALLOWS when there is no goal or the goal is active", async () => {
+    goal = null;
+    turn = { source: "child_notification", metadata: { childCompletion: {} } };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+    goal = { status: "active", pausedReason: null };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+  });
+
+  test("ALLOWS when the session has no active turn", async () => {
+    goal = { status: "paused", pausedReason: "user_interrupt" };
+    session = { id: "session-1", activeTurnId: null };
+    await expect(assertGoalReactivationAllowed(deps, "ws", "session-1")).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -38,7 +38,8 @@ export function ConsoleComposer(props: {
   controls?: ReactNode;
   /**
    * Show the queue-vs-steer delivery choice. Queue (default) stacks the
-   * message behind the running turn; steer interrupts and injects it now.
+   * message behind the running turn; steer cancels the current step and runs
+   * this message next (the goal keeps going).
    */
   showDeliveryMode?: boolean;
   /**
@@ -125,7 +126,7 @@ function DeliveryModeToggle({
         aria-checked={composer.mode === "steer"}
         disabled={disabled}
         onClick={() => composer.setMode("steer")}
-        title="Steer: interrupt the running turn and inject this message now"
+        title="Steer: cancel the current step and run this message next (the goal keeps going)"
         className={cn(
           "inline-flex h-7 items-center gap-1 rounded-full px-2.5 text-xs font-medium transition-colors",
           composer.mode === "steer"

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -252,6 +252,7 @@ export function eventLabel(type: string): string {
     "user.interrupt": "User interrupt",
     "user.approvalDecision": "Approval decision",
     "turn.queued": "Turn queued",
+    "turn.queue_drained": "Queue cleared by stop",
     "turn.updated": "Turn updated",
     "turn.started": "Turn started",
     "turn.completed": "Turn completed",

--- a/apps/web/src/lib/queue.test.ts
+++ b/apps/web/src/lib/queue.test.ts
@@ -112,17 +112,23 @@ describe("deliveryModeExplanation", () => {
     expect(deliveryModeExplanation("queue", "idle")).toContain("starts immediately");
   });
 
-  test("steer mode admits there is nothing to interrupt on idle sessions", () => {
-    expect(deliveryModeExplanation("steer", "running")).toContain("interrupts the running turn");
+  test("steer mode tells the truth: cancel the step, run next, goal continues", () => {
+    const running = deliveryModeExplanation("steer", "running");
+    expect(running).toContain("cancels the current step and runs your message next");
+    expect(running).toContain("the goal continues");
+    // No overpromise: steering does not inject mid-turn.
+    expect(running).not.toContain("injects this message now");
     expect(deliveryModeExplanation("steer", "idle")).toContain("Nothing is running");
     expect(deliveryModeExplanation("steer", "failed")).toContain("Nothing is running");
   });
 
-  // The hint must match steerMessage's actual behavior per status: interrupt
-  // only on running/requires_action, promote-without-interrupt on queued.
-  test("requires_action steers as an interrupt of the approval-blocked turn, not a plain send", () => {
+  // The hint must match steerMessage's actual behavior per status: cancel the
+  // current step and run next on running/requires_action (goal continues),
+  // promote-without-interrupt on queued.
+  test("requires_action steers by cancelling the approval-blocked step, not a plain send", () => {
     const steer = deliveryModeExplanation("steer", "requires_action");
-    expect(steer).toContain("interrupts the turn waiting on approval");
+    expect(steer).toContain("cancels the step waiting on approval");
+    expect(steer).toContain("the goal continues");
     expect(steer).not.toContain("Nothing is running");
   });
 

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -118,9 +118,9 @@ export function deliveryModeExplanation(
   if (mode === "steer") {
     switch (status) {
       case "running":
-        return "Steer interrupts the running turn and injects this message now.";
+        return "Steer cancels the current step and runs your message next — the goal continues.";
       case "requires_action":
-        return "Steer interrupts the turn waiting on approval — the pending approval is abandoned and this message runs instead.";
+        return "Steer cancels the step waiting on approval (the pending approval is abandoned) and runs your message next — the goal continues.";
       case "queued":
         return "Nothing is running yet — sends now and jumps to the front of the queue.";
       default:

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2105,6 +2105,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           accountId: input.accountId,
           workspaceId: input.workspaceId,
           sessionId: input.sessionId,
+          // Sign the calling turn into the first-party token so tools classify
+          // the caller by its own identity (sacred-pause guard), not the racy
+          // live active pointer.
+          ...(turnId ? { turnId } : {}),
           subjectId: "worker:first-party-mcp",
           subjectLabel: "OpenGeni worker",
           resolveCredential,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -78,7 +78,10 @@ export async function notifyParentOfChildTerminal(
       return;
     }
     await svc.bus.publish(workspaceId, child.parentSessionId, result.events);
-    if (svc.wakeSessionWorkflow) {
+    // Passive (suppressed) completions are a timeline card only — there is no
+    // queued turn to run, so do NOT wake the workflow (waking would spin it up
+    // just to find nothing and idle again).
+    if (!result.passive && svc.wakeSessionWorkflow) {
       await svc.wakeSessionWorkflow({
         accountId: child.accountId,
         workspaceId,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -56,12 +56,21 @@ export async function notifyParentOfChildTerminal(
       return;
     }
     const goal = await getSessionGoal(svc.db, workspaceId, childSessionId);
+    // Sacred user pause: if the MANAGER's own goal was stopped by the user, the
+    // wake must not tell it to "resume it now" — that instruction is exactly
+    // what re-arms the loop the user just stopped. Suppress the resume nudge and
+    // tell the agent to stay stopped. Paired with the goal_set reactivation
+    // guard so a nudge that slips through still cannot revive the goal.
+    const parentGoal = await getSessionGoal(svc.db, workspaceId, child.parentSessionId);
+    const parentGoalUserPaused =
+      parentGoal?.status === "paused" && parentGoal.pausedReason === "user_interrupt";
     const clientEventId = `child-completion:${childSessionId}:${episodeKey ?? child.lastSequence}`;
     const result = await wakeParentSessionForChildCompletion(svc.db, {
       workspaceId,
       parentSessionId: child.parentSessionId,
       clientEventId,
-      text: childCompletionWakeText(child, goal, terminalStatus),
+      childSummary: childCompletionSummary(child, goal, terminalStatus),
+      trailing: childCompletionTrailing(parentGoalUserPaused),
       childCompletion: childCompletionPayload(child, goal, terminalStatus),
       reasoningEffortFallback: svc.settings.openaiReasoningEffort,
     });
@@ -113,7 +122,15 @@ function childCompletionPayload(
   };
 }
 
-function childCompletionWakeText(
+/**
+ * The worker-specific lines for one child (what happened + its goal), WITHOUT
+ * the trailing "what to do next" instruction. Kept separate so N child
+ * completions can be coalesced into ONE digest turn: the DB layer stores each
+ * child's summary and rebuilds a single numbered digest with ONE shared
+ * trailing instruction, instead of enqueuing N turns (N model runs) that a
+ * human's stop button can never outrun.
+ */
+export function childCompletionSummary(
   child: Session,
   goal: SessionGoal | null,
   terminalStatus: "idle" | "failed",
@@ -143,8 +160,17 @@ function childCompletionWakeText(
       lines.push(`Pause rationale: ${goal.rationale}`);
     }
   }
-  lines.push(
-    "Read the worker's session events/notebook output for its result, then continue. If your own goal was paused awaiting this worker, resume it now.",
-  );
   return lines.join("\n");
+}
+
+/**
+ * The single trailing instruction appended to a child-completion (or digest)
+ * wake. Suppresses the "resume it now" nudge when the manager's own goal was
+ * stopped by the user — that nudge is exactly what re-arms the loop the user
+ * just stopped (paired with the goal_set reactivation guard).
+ */
+export function childCompletionTrailing(parentGoalUserPaused: boolean): string {
+  return parentGoalUserPaused
+    ? "Read each worker's session events/notebook output for its result. This session was paused by the user — do NOT resume or replace your goal; summarize the result for the user and stop."
+    : "Read each worker's session events/notebook output for its result, then continue. If your own goal was paused awaiting these workers, resume it now.";
 }

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -1,4 +1,5 @@
 import {
+  cancelQueuedSessionTurns,
   claimNextQueuedTurn as claimNextQueuedTurnDb,
   countQueuedTurns,
   countTurnSessionHistoryItems,
@@ -85,6 +86,29 @@ export function createSessionStateActivities(services: () => Promise<ActivitySer
     // so the goal loop stays active.
     if (!isSteerInterrupt(trigger)) {
       await pauseActiveGoalOnInterrupt(db, bus, input.workspaceId, input.sessionId);
+      // STOP MEANS STOP: a stop drains the ENTIRE queue, not just the active
+      // turn. Otherwise a flood of machine-injected turns (child-completion
+      // notifications arriving faster than the human can interrupt) survives the
+      // stop and keeps the session churning — the exact "interrupt never
+      // depletes the queue" failure. Steer must NOT drain (it promotes exactly
+      // one steered message), so this is gated inside the non-steer branch.
+      // Emit ONE summary event carrying the drained ids so the timeline shows
+      // the drain honestly instead of N separate cancellations. Idempotent: a
+      // retry drains nothing (no queued rows left) and emits no event.
+      const drainedTurnIds = await cancelQueuedSessionTurns(db, input.workspaceId, input.sessionId);
+      if (drainedTurnIds.length > 0) {
+        await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, [
+          {
+            type: "turn.queue_drained",
+            payload: {
+              triggerEventId: input.triggerEventId,
+              drainedCount: drainedTurnIds.length,
+              drainedTurnIds,
+            },
+          },
+        ]);
+        await refreshQueuedTurnsGauge(db, observability);
+      }
     }
     if (!session.activeTurnId) {
       return;

--- a/apps/worker/test/parent-wake-text.test.ts
+++ b/apps/worker/test/parent-wake-text.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { childCompletionSummary, childCompletionTrailing } from "../src/activities/parent-wake";
+
+const child = { id: "child-1" } as any;
+
+describe("childCompletionSummary", () => {
+  test("names the terminal state and worker id, without a trailing instruction", () => {
+    const summary = childCompletionSummary(child, null, "failed");
+    expect(summary).toContain("FAILED");
+    expect(summary).toContain("child-1");
+    // The trailing "what to do next" line is NOT part of the summary (it is
+    // appended once per digest, not once per child).
+    expect(summary).not.toContain("resume it now");
+    expect(summary).not.toContain("continue");
+  });
+});
+
+describe("childCompletionTrailing (sacred user pause)", () => {
+  test("normally nudges the manager to continue / resume", () => {
+    const trailing = childCompletionTrailing(false);
+    expect(trailing).toContain("resume it now");
+  });
+
+  test("when the manager's goal is user-paused, it suppresses the resume nudge", () => {
+    const trailing = childCompletionTrailing(true);
+    expect(trailing).toContain("paused by the user");
+    expect(trailing).toContain("do NOT resume");
+    expect(trailing).not.toContain("resume it now");
+  });
+});

--- a/apps/worker/test/session-state-cancel.test.ts
+++ b/apps/worker/test/session-state-cancel.test.ts
@@ -5,6 +5,11 @@ const finishedTurns: Array<{ turnId: string; status: string }> = [];
 const statuses: Array<{ sessionId: string; status: string; activeTurnId: string | null }> = [];
 const fakeDb = {};
 const fakeBus = {};
+// Controllable per-test: the trigger event interruptActiveTurn reads (stop vs
+// steer) and the ids cancelQueuedSessionTurns reports draining.
+let triggerEvent: any = { id: "event-1", type: "user.message", payload: { text: "stop" } };
+let drainResult: string[] = [];
+let drainCalls = 0;
 const resilienceSentinelWorkspaceId = "00000000-0000-4000-8000-0000000000ff";
 
 const realDb = await import("@opengeni/db");
@@ -14,6 +19,7 @@ const realParentWake = await import("../src/activities/parent-wake");
 const realObservabilityMetrics = await import("../src/observability-metrics");
 const realDbFns = {
   appendSessionEvents: realDb.appendSessionEvents,
+  cancelQueuedSessionTurns: realDb.cancelQueuedSessionTurns,
   claimNextQueuedTurn: realDb.claimNextQueuedTurn,
   countQueuedTurns: realDb.countQueuedTurns,
   countTurnSessionHistoryItems: realDb.countTurnSessionHistoryItems,
@@ -58,7 +64,14 @@ mock.module("@opengeni/db", () => ({
     if (db !== fakeDb) {
       return realDbFns.getSessionEvent(db as never, workspaceId, eventId);
     }
-    return { id: "event-1", type: "user.message", payload: { text: "stop" } };
+    return triggerEvent;
+  }),
+  cancelQueuedSessionTurns: mock(async (db: unknown, workspaceId: string, sessionId: string) => {
+    if (db !== fakeDb) {
+      return realDbFns.cancelQueuedSessionTurns(db as never, workspaceId, sessionId);
+    }
+    drainCalls += 1;
+    return drainResult;
   }),
   getSessionTurn: mock(async (db: unknown, workspaceId: string, turnId: string) => {
     if (db !== fakeDb) {
@@ -178,7 +191,24 @@ describe("session-state cancellation", () => {
     appendedEvents.length = 0;
     finishedTurns.length = 0;
     statuses.length = 0;
+    triggerEvent = { id: "event-1", type: "user.message", payload: { text: "stop" } };
+    drainResult = [];
+    drainCalls = 0;
   });
+
+  async function makeActivities() {
+    const { createSessionStateActivities } = await import("../src/activities/session-state");
+    return createSessionStateActivities(
+      async () =>
+        ({
+          db: fakeDb,
+          bus: fakeBus,
+          settings: {},
+          observability: {},
+          wakeSessionWorkflow: mock(async () => undefined),
+        }) as any,
+    );
+  }
 
   test("emits turn.cancelled when cancelling an active turn", async () => {
     const { createSessionStateActivities } = await import("../src/activities/session-state");
@@ -213,5 +243,76 @@ describe("session-state cancellation", () => {
     });
     expect(finishedTurns).toEqual([{ turnId: "turn-1", status: "cancelled" }]);
     expect(statuses).toEqual([{ sessionId: "session-1", status: "queued", activeTurnId: null }]);
+  });
+
+  test("stop drains the whole queue and emits one summary event", async () => {
+    triggerEvent = { id: "event-1", type: "user.interrupt", payload: {} };
+    drainResult = ["queued-a", "queued-b", "queued-c"];
+    const activities = await makeActivities();
+
+    await activities.interruptActiveTurn({
+      accountId: "account-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      triggerEventId: "event-1",
+      workflowId: "workflow-1",
+      turnId: "turn-1",
+    });
+
+    // The drain ran, and the summary event precedes the active-turn cancel.
+    expect(drainCalls).toBe(1);
+    expect(appendedEvents.map((event) => event.type)).toEqual([
+      "turn.queue_drained",
+      "turn.cancelled",
+      "session.status.changed",
+    ]);
+    expect(appendedEvents[0]).toMatchObject({
+      type: "turn.queue_drained",
+      payload: { drainedCount: 3, drainedTurnIds: ["queued-a", "queued-b", "queued-c"] },
+    });
+  });
+
+  test("stop with an empty queue drains nothing and emits no summary event", async () => {
+    triggerEvent = { id: "event-1", type: "user.interrupt", payload: {} };
+    drainResult = [];
+    const activities = await makeActivities();
+
+    await activities.interruptActiveTurn({
+      accountId: "account-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      triggerEventId: "event-1",
+      workflowId: "workflow-1",
+      turnId: "turn-1",
+    });
+
+    expect(drainCalls).toBe(1);
+    expect(appendedEvents.map((event) => event.type)).toEqual([
+      "turn.cancelled",
+      "session.status.changed",
+    ]);
+  });
+
+  test("steer cancels only the active turn — it never drains the queue", async () => {
+    triggerEvent = { id: "event-1", type: "user.interrupt", payload: { reason: "steer" } };
+    drainResult = ["queued-a", "queued-b"];
+    const activities = await makeActivities();
+
+    await activities.interruptActiveTurn({
+      accountId: "account-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      triggerEventId: "event-1",
+      workflowId: "workflow-1",
+      turnId: "turn-1",
+    });
+
+    // Steer must promote exactly one message: the queue is untouched (no drain
+    // call, no summary event), only the active turn is cancelled.
+    expect(drainCalls).toBe(0);
+    expect(appendedEvents.map((event) => event.type)).toEqual([
+      "turn.cancelled",
+      "session.status.changed",
+    ]);
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3035,6 +3035,7 @@ export const SessionEventType = z.enum([
   "turn.completed",
   "turn.failed",
   "turn.cancelled",
+  "turn.queue_drained",
   "turn.preempted",
   "agent.message.delta",
   "agent.message.completed",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -628,6 +628,12 @@ export const DelegatedAccessTokenPayload = z.object({
   // Worker-asserted session scope for first-party MCP calls (HMAC-signed, not
   // agent-controlled); enables session-scoped tools such as goal management.
   sessionId: z.string().uuid().optional(),
+  // The turn making the call (the caller's identity), HMAC-signed by the worker
+  // at turn setup. Lets a tool classify WHO is calling from the token itself,
+  // instead of racily re-reading the session's live active_turn_id — e.g. the
+  // sacred-pause guard must know if the CALLER is a machine child-notification
+  // turn, and the active pointer can flip to another turn mid-check.
+  turnId: z.string().uuid().optional(),
   exp: z.number().int().positive(),
 });
 export type DelegatedAccessTokenPayload = z.infer<typeof DelegatedAccessTokenPayload>;

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -232,6 +232,9 @@ async function delegatedAccessContext(
         metadata: {
           delegated: true,
           ...(payload.sessionId ? { sessionId: payload.sessionId } : {}),
+          // Caller identity: the turn that minted this token. Tools classify the
+          // CALLER from this instead of re-reading the live active pointer.
+          ...(payload.turnId ? { turnId: payload.turnId } : {}),
         },
       },
     ],

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -725,6 +725,11 @@ export async function postUserMessageTurn(input: {
       reasoningEffortForSession(session.metadata, settings.openaiReasoningEffort),
     sandboxBackend: session.sandboxBackend,
     metadata: {},
+    // A human's message jumps ahead of any queued machine child-completion
+    // notification turns — it must never wait behind a flood of "worker FAILED"
+    // notices (the burial that spent the user's stop-spree and killed his own
+    // message). Stays behind the running turn and earlier human turns.
+    preemptChildNotifications: true,
   });
   await appendAndPublishEvents(db, bus, workspaceId, sessionId, [
     {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14054,8 +14054,12 @@ export type WakeParentForChildCompletionInput = {
   // Stable per terminal episode, unique across episodes: the idempotency key
   // for exactly-once delivery (a unique session_events.client_event_id).
   clientEventId: string;
-  // System-authored wake text rendered to the manager as its next turn input.
-  text: string;
+  // This child's worker-specific summary lines (what happened + its goal), with
+  // NO trailing instruction. Stored per child so a coalesced digest turn can
+  // rebuild one numbered digest across all pending children.
+  childSummary: string;
+  // The single trailing "what to do next" instruction shared by the digest.
+  trailing: string;
   // Structured payload describing the completed child (id, status, goal).
   childCompletion: Record<string, unknown>;
   reasoningEffortFallback: ReasoningEffort;
@@ -14065,11 +14069,29 @@ export type WakeParentForChildCompletionResult =
   | { delivered: false; reason: "already_delivered" | "parent_cancelled" }
   | {
       delivered: true;
+      // True when this child folded into an already-queued child-notification
+      // digest turn (no new turn created); false when it opened a new one.
+      folded: boolean;
       turn: SessionTurn;
       triggerEvent: SessionEvent;
       events: SessionEvent[];
       temporalWorkflowId: string;
     };
+
+/**
+ * Render N pending child-completion summaries as ONE model-facing digest with a
+ * single shared trailing instruction. A single child reads exactly like the old
+ * per-child wake (no header/numbering); two or more are numbered under a count
+ * header. This is what lets one digest turn stand in for N enqueued turns.
+ */
+export function buildChildCompletionDigest(summaries: string[], trailing: string): string {
+  if (summaries.length <= 1) {
+    return [summaries[0] ?? "", "", trailing].join("\n");
+  }
+  const header = `${summaries.length} worker sessions you spawned reached a terminal state:`;
+  const numbered = summaries.map((summary, index) => `${index + 1}. ${summary}`).join("\n\n");
+  return [header, "", numbered, "", trailing].join("\n");
+}
 
 /**
  * Deliver a one-shot completion wake from a spawned worker into its parent
@@ -14150,10 +14172,16 @@ export async function wakeParentSessionForChildCompletion(
         const workflowId = parent.temporalWorkflowId ?? `session-${parent.id}`;
         let sequence = parent.lastSequence;
         const now = new Date();
-        const eventRows = [
+
+        // 1. Always record THIS child's own card event: a `user.message` carrying
+        // the childCompletion payload renders as one quiet worker-result card and
+        // holds the idempotency key. Its text is the single-child digest, so it
+        // doubles as the trigger text when it opens a fresh digest turn.
+        const cardText = buildChildCompletionDigest([input.childSummary], input.trailing);
+        const cardEventRows = [
           {
             type: "user.message",
-            payload: { text: input.text, childCompletion: input.childCompletion },
+            payload: { text: cardText, childCompletion: input.childCompletion },
             clientEventId: input.clientEventId,
           },
           ...(shouldQueue
@@ -14178,63 +14206,164 @@ export async function wakeParentSessionForChildCompletion(
           producerSeq: null,
           occurredAt: now,
         }));
-        const inserted = (await tx.insert(schema.sessionEvents).values(eventRows).returning()).map(
-          mapEvent,
-        );
-        const triggerEvent = inserted[0]!;
+        const inserted = (
+          await tx.insert(schema.sessionEvents).values(cardEventRows).returning()
+        ).map(mapEvent);
+        const cardEvent = inserted[0]!;
 
-        const position = await nextTurnPosition(
-          tx as unknown as Database,
-          input.workspaceId,
-          parent.id,
-        );
-        const [turnRow] = await tx
-          .insert(schema.sessionTurns)
-          .values({
-            accountId: parent.accountId,
-            workspaceId: parent.workspaceId,
-            sessionId: parent.id,
-            triggerEventId: triggerEvent.id,
-            temporalWorkflowId: workflowId,
-            status: "queued",
-            source: "user",
-            position,
-            prompt: input.text,
-            resources: [],
-            tools: parent.tools as ToolRef[],
-            model: continuationModel,
-            reasoningEffort: continuationReasoningEffort,
-            sandboxBackend: parent.sandboxBackend as SandboxBackend,
-            metadata: { childCompletion: input.childCompletion },
-          })
-          .returning();
-        if (!turnRow) {
-          throw new Error("Failed to enqueue parent wake turn");
-        }
-        const turn = mapSessionTurn(turnRow);
+        // 2. COALESCE: fold into an already-queued, not-yet-started child-
+        // notification turn instead of enqueuing a second one. `metadata ?
+        // 'childCompletion'` matches only machine child-wake turns (user/goal
+        // turns never carry it). FOR UPDATE locks the candidate so a concurrent
+        // claimNextQueuedTurn (FOR UPDATE SKIP LOCKED) cannot start it mid-fold:
+        // either we fold while it stays queued, or the claim already won and our
+        // `status = 'queued'` filter finds nothing and we open a fresh digest
+        // turn. This is what stops N terminating workers from injecting N model
+        // runs the user's stop button can never outrun.
+        const [digestTurnRow] = await tx
+          .select()
+          .from(schema.sessionTurns)
+          .where(
+            and(
+              eq(schema.sessionTurns.workspaceId, input.workspaceId),
+              eq(schema.sessionTurns.sessionId, parent.id),
+              eq(schema.sessionTurns.status, "queued"),
+              sql`jsonb_exists(${schema.sessionTurns.metadata}, 'childCompletion')`,
+            ),
+          )
+          .orderBy(desc(schema.sessionTurns.position))
+          .limit(1)
+          .for("update");
 
-        sequence += 1;
-        const [queuedEventRow] = await tx
-          .insert(schema.sessionEvents)
-          .values({
-            accountId: parent.accountId,
-            workspaceId: parent.workspaceId,
-            sessionId: parent.id,
-            sequence,
-            type: "turn.queued",
-            payload: sanitizeEventPayload({
+        let turn: SessionTurn;
+        let triggerEvent: SessionEvent;
+        let folded: boolean;
+        const events: SessionEvent[] = [...inserted];
+
+        if (digestTurnRow) {
+          // FOLD: append this child to the digest turn's trigger text. Only the
+          // new card event is published (its own result card); the trigger text
+          // update is silent — the model reads it fresh from the DB when the
+          // digest turn finally runs.
+          folded = true;
+          const priorSummaries = Array.isArray(
+            (digestTurnRow.metadata as { childSummaries?: unknown } | null)?.childSummaries,
+          )
+            ? (digestTurnRow.metadata as { childSummaries: string[] }).childSummaries
+            : [];
+          const summaries = [...priorSummaries, input.childSummary];
+          const digestText = buildChildCompletionDigest(summaries, input.trailing);
+          const [existingTrigger] = await tx
+            .select()
+            .from(schema.sessionEvents)
+            .where(
+              and(
+                eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                eq(schema.sessionEvents.id, digestTurnRow.triggerEventId),
+              ),
+            )
+            .limit(1);
+          const mergedTriggerPayload = {
+            ...(existingTrigger?.payload && typeof existingTrigger.payload === "object"
+              ? (existingTrigger.payload as Record<string, unknown>)
+              : {}),
+            text: digestText,
+          };
+          const [updatedTriggerRow] = await tx
+            .update(schema.sessionEvents)
+            .set({ payload: sanitizeEventPayload(mergedTriggerPayload) })
+            .where(
+              and(
+                eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                eq(schema.sessionEvents.id, digestTurnRow.triggerEventId),
+              ),
+            )
+            .returning();
+          triggerEvent = updatedTriggerRow ? mapEvent(updatedTriggerRow) : cardEvent;
+          const [updatedTurnRow] = await tx
+            .update(schema.sessionTurns)
+            .set({
+              prompt: digestText,
+              metadata: {
+                ...(digestTurnRow.metadata as Record<string, unknown> | null),
+                childSummaries: summaries,
+              },
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(schema.sessionTurns.workspaceId, input.workspaceId),
+                eq(schema.sessionTurns.id, digestTurnRow.id),
+              ),
+            )
+            .returning();
+          if (!updatedTurnRow) {
+            throw new Error("Failed to fold child completion into digest turn");
+          }
+          turn = mapSessionTurn(updatedTurnRow);
+        } else {
+          // CREATE: the card event IS the digest turn's trigger (its text is
+          // already the single-child digest). childSummaries seeds the fold.
+          folded = false;
+          triggerEvent = cardEvent;
+          const position = await nextTurnPosition(
+            tx as unknown as Database,
+            input.workspaceId,
+            parent.id,
+          );
+          const [turnRow] = await tx
+            .insert(schema.sessionTurns)
+            .values({
+              accountId: parent.accountId,
+              workspaceId: parent.workspaceId,
+              sessionId: parent.id,
+              triggerEventId: cardEvent.id,
+              temporalWorkflowId: workflowId,
+              status: "queued",
+              source: "user",
+              position,
+              prompt: cardText,
+              resources: [],
+              tools: parent.tools as ToolRef[],
+              model: continuationModel,
+              reasoningEffort: continuationReasoningEffort,
+              sandboxBackend: parent.sandboxBackend as SandboxBackend,
+              metadata: {
+                childCompletion: input.childCompletion,
+                childSummaries: [input.childSummary],
+              },
+            })
+            .returning();
+          if (!turnRow) {
+            throw new Error("Failed to enqueue parent wake turn");
+          }
+          turn = mapSessionTurn(turnRow);
+
+          sequence += 1;
+          const [queuedEventRow] = await tx
+            .insert(schema.sessionEvents)
+            .values({
+              accountId: parent.accountId,
+              workspaceId: parent.workspaceId,
+              sessionId: parent.id,
+              sequence,
+              type: "turn.queued",
+              payload: sanitizeEventPayload({
+                turnId: turn.id,
+                triggerEventId: cardEvent.id,
+                source: turn.source,
+              }),
+              clientEventId: null,
               turnId: turn.id,
-              triggerEventId: triggerEvent.id,
-              source: turn.source,
-            }),
-            clientEventId: null,
-            turnId: turn.id,
-            producerId: null,
-            producerSeq: null,
-            occurredAt: now,
-          })
-          .returning();
-        const events = [...inserted, ...(queuedEventRow ? [mapEvent(queuedEventRow)] : [])];
+              producerId: null,
+              producerSeq: null,
+              occurredAt: now,
+            })
+            .returning();
+          if (queuedEventRow) {
+            events.push(mapEvent(queuedEventRow));
+          }
+        }
 
         await tx
           .update(schema.sessions)
@@ -14252,6 +14381,7 @@ export async function wakeParentSessionForChildCompletion(
 
         return {
           delivered: true as const,
+          folded,
           turn,
           triggerEvent,
           events,
@@ -14550,6 +14680,41 @@ export async function cancelQueuedSessionTurn(
       throw new Error(`Queued session turn not found: ${turnId}`);
     }
     return mapSessionTurn(row);
+  });
+}
+
+/**
+ * Cancel every not-yet-started queued turn for a session in one UPDATE and
+ * return the cancelled ids (newest position first). This is the "stop means
+ * stop" drain: a user stop must clear the whole backlog, not just the active
+ * turn, so a flood of machine-injected turns (child-completion notifications)
+ * cannot outrun the human's stop button. Only `queued` rows are touched — the
+ * active `running`/`requires_action` turn is settled by `interruptActiveTurn`,
+ * and terminal turns are left as-is (idempotent: a retry drains nothing and
+ * returns []). No event is emitted here; the caller emits ONE summary event.
+ */
+export async function cancelQueuedSessionTurns(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<string[]> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb
+      .update(schema.sessionTurns)
+      .set({
+        status: "cancelled",
+        finishedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, workspaceId),
+          eq(schema.sessionTurns.sessionId, sessionId),
+          eq(schema.sessionTurns.status, "queued"),
+        ),
+      )
+      .returning({ id: schema.sessionTurns.id, position: schema.sessionTurns.position });
+    return rows.sort((a, b) => b.position - a.position).map((row) => row.id);
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1834,6 +1834,11 @@ export type EnqueueSessionTurnInput = {
   reasoningEffort: ReasoningEffort;
   sandboxBackend: SandboxBackend;
   metadata: Record<string, unknown>;
+  // When true, this turn is placed AHEAD of any queued machine child-completion
+  // notification turns instead of at the back of the queue: a genuine human
+  // message must never wait behind a flood of "worker FAILED" notices. Only the
+  // human-message enqueue path sets it; machine wakes never do.
+  preemptChildNotifications?: boolean;
 };
 
 export type UpdateQueuedSessionTurnInput = Partial<{
@@ -13520,6 +13525,32 @@ export async function updateSessionTitle(
   });
 }
 
+export type ChildNotificationsMode = "digest" | "passive";
+
+/**
+ * Set how a manager session receives spawned-worker completion notifications:
+ * `digest` (default) enqueues a coalesced turn the manager processes; `passive`
+ * lands each completion as a timeline card only, never a queued turn / model run
+ * (the "don't bring spawned sessions back into my chat" opt-in). Merges the one
+ * key into `metadata` (jsonb `||`) so nothing else on the row is clobbered.
+ */
+export async function setSessionChildNotificationsMode(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+  mode: ChildNotificationsMode,
+): Promise<void> {
+  await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    await scopedDb
+      .update(schema.sessions)
+      .set({
+        metadata: sql`${schema.sessions.metadata} || jsonb_build_object('childNotificationsMode', ${mode}::text)`,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)));
+  });
+}
+
 /**
  * Status transition helper. Idempotent: requesting the current status returns
  * `changed: false` so callers can skip emitting a duplicate event. `completed`
@@ -13944,11 +13975,7 @@ export async function enqueueSessionTurn(
     { accountId: input.accountId, workspaceId: input.workspaceId },
     async (scopedDb) =>
       await scopedDb.transaction(async (tx) => {
-        const position = await nextTurnPosition(
-          tx as unknown as Database,
-          input.workspaceId,
-          input.sessionId,
-        );
+        const position = await positionForEnqueue(tx as unknown as Database, input);
         const [row] = await tx
           .insert(schema.sessionTurns)
           .values({
@@ -14069,11 +14096,21 @@ export type WakeParentForChildCompletionResult =
   | { delivered: false; reason: "already_delivered" | "parent_cancelled" }
   | {
       delivered: true;
+      passive: false;
       // True when this child folded into an already-queued child-notification
       // digest turn (no new turn created); false when it opened a new one.
       folded: boolean;
       turn: SessionTurn;
       triggerEvent: SessionEvent;
+      events: SessionEvent[];
+      temporalWorkflowId: string;
+    }
+  | {
+      // Suppression mode: the completion landed as a passive card event only (no
+      // turn, no model run). The caller publishes `events` but must NOT wake the
+      // workflow — there is nothing to claim.
+      delivered: true;
+      passive: true;
       events: SessionEvent[];
       temporalWorkflowId: string;
     };
@@ -14150,6 +14187,54 @@ export async function wakeParentSessionForChildCompletion(
           .limit(1);
         if (existing) {
           return { delivered: false, reason: "already_delivered" as const };
+        }
+
+        const passiveMode =
+          (parent.metadata as { childNotificationsMode?: unknown } | null)
+            ?.childNotificationsMode === "passive";
+        if (passiveMode) {
+          // SUPPRESSION OPT-IN: the parent asked not to have spawned-session
+          // completions come back as queued messages. Land exactly one passive
+          // card event — the worker-result card still renders in the timeline —
+          // but create NO turn and change NO status, so it never forces a model
+          // run. The caller publishes this event and does NOT wake the workflow.
+          const passiveText = buildChildCompletionDigest([input.childSummary], input.trailing);
+          const now = new Date();
+          const sequence = parent.lastSequence + 1;
+          const [passiveRow] = await tx
+            .insert(schema.sessionEvents)
+            .values({
+              accountId: parent.accountId,
+              workspaceId: parent.workspaceId,
+              sessionId: parent.id,
+              sequence,
+              type: "user.message",
+              payload: sanitizeEventPayload({
+                text: passiveText,
+                childCompletion: input.childCompletion,
+              }),
+              clientEventId: input.clientEventId,
+              turnId: null,
+              producerId: null,
+              producerSeq: null,
+              occurredAt: now,
+            })
+            .returning();
+          await tx
+            .update(schema.sessions)
+            .set({ lastSequence: sequence, updatedAt: now })
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, parent.id),
+              ),
+            );
+          return {
+            delivered: true as const,
+            passive: true as const,
+            events: passiveRow ? [mapEvent(passiveRow)] : [],
+            temporalWorkflowId: parent.temporalWorkflowId ?? `session-${parent.id}`,
+          };
         }
 
         // Child completion is follow-up work for the manager turn that spawned
@@ -14381,6 +14466,7 @@ export async function wakeParentSessionForChildCompletion(
 
         return {
           delivered: true as const,
+          passive: false as const,
           folded,
           turn,
           triggerEvent,
@@ -15176,6 +15262,48 @@ async function latestStartedSessionTurnRow(
     .orderBy(desc(schema.sessionEvents.sequence))
     .limit(1);
   return row?.turn ?? null;
+}
+
+/**
+ * The queue position for a newly enqueued turn. Default: the back of the queue
+ * (nextTurnPosition). With `preemptChildNotifications`, a genuine human message
+ * jumps AHEAD of any queued machine child-completion notification turns — it
+ * takes the earliest such turn's slot and shifts that whole machine band back
+ * by one, so it claims strictly before them while staying behind the running
+ * turn and any earlier human turns. This is what stops a person's message from
+ * being buried behind a flood of "worker FAILED" notices (and cancelled by its
+ * own author's stop-spree before it ever runs).
+ */
+async function positionForEnqueue(db: Database, input: EnqueueSessionTurnInput): Promise<number> {
+  if (!input.preemptChildNotifications) {
+    return await nextTurnPosition(db, input.workspaceId, input.sessionId);
+  }
+  const [{ minPos } = { minPos: null }] = await db
+    .select({ minPos: sql<number | null>`min(${schema.sessionTurns.position})` })
+    .from(schema.sessionTurns)
+    .where(
+      and(
+        eq(schema.sessionTurns.workspaceId, input.workspaceId),
+        eq(schema.sessionTurns.sessionId, input.sessionId),
+        eq(schema.sessionTurns.status, "queued"),
+        sql`jsonb_exists(${schema.sessionTurns.metadata}, 'childCompletion')`,
+      ),
+    );
+  if (minPos === null || minPos === undefined) {
+    return await nextTurnPosition(db, input.workspaceId, input.sessionId);
+  }
+  await db
+    .update(schema.sessionTurns)
+    .set({ position: sql`${schema.sessionTurns.position} + 1`, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.sessionTurns.workspaceId, input.workspaceId),
+        eq(schema.sessionTurns.sessionId, input.sessionId),
+        eq(schema.sessionTurns.status, "queued"),
+        gte(schema.sessionTurns.position, minPos),
+      ),
+    );
+  return Number(minPos);
 }
 
 async function nextTurnPosition(

--- a/packages/db/test/child-completion-digest.test.ts
+++ b/packages/db/test/child-completion-digest.test.ts
@@ -7,9 +7,7 @@ import {
   createSession,
   enqueueSessionTurn,
   finishTurn,
-  getSessionEvent,
   listPendingSessionTurns,
-  listSessionEvents,
   setSessionChildNotificationsMode,
   wakeParentSessionForChildCompletion,
   createDb,
@@ -41,6 +39,17 @@ async function makeParent(accountId: string, workspaceId: string) {
     model: "gpt",
     sandboxBackend: "none",
   });
+}
+
+// Read an event's payload straight off the raw admin connection. Verification
+// reads MUST bypass the @opengeni/db package API: in the full-monorepo test run
+// another suite's unconditional `mock.module("@opengeni/db")` can leak a fixture
+// for getSessionEvent/listSessionEvents (opengeni#373), which would make these
+// assertions read empty payloads even though the fold wrote real rows.
+async function eventPayloadById(eventId: string): Promise<{ text?: string } | null> {
+  const [row] = await admin<{ payload: { text?: string } }[]>`
+    select payload from session_events where id = ${eventId}`;
+  return row?.payload ?? null;
 }
 
 function wakeInput(workspaceId: string, parentSessionId: string, childId: string) {
@@ -131,8 +140,7 @@ describe("wakeParentSessionForChildCompletion coalescing", () => {
     const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
     expect(pending.length).toBe(1);
     const digestTurn = pending[0]!;
-    const trigger = await getSessionEvent(db, workspaceId, digestTurn.triggerEventId);
-    const text = (trigger?.payload as { text?: string }).text ?? "";
+    const text = (await eventPayloadById(digestTurn.triggerEventId))?.text ?? "";
     expect(text).toContain("3 worker sessions you spawned reached a terminal state:");
     expect(text).toContain("child-1");
     expect(text).toContain("child-2");
@@ -155,11 +163,9 @@ describe("wakeParentSessionForChildCompletion coalescing", () => {
     }
     const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
     expect(pending.length).toBe(1);
-    const trigger = await getSessionEvent(db, workspaceId, pending[0]!.triggerEventId);
+    const text = (await eventPayloadById(pending[0]!.triggerEventId))?.text ?? "";
     // Single child => plain wake, no "N worker sessions" digest header.
-    expect((trigger?.payload as { text?: string }).text ?? "").not.toContain(
-      "worker sessions you spawned reached",
-    );
+    expect(text).not.toContain("worker sessions you spawned reached");
   });
 
   test("once the digest turn is claimed, the next child opens a fresh turn", async () => {
@@ -313,12 +319,14 @@ describe("child-completion suppression opt-in (lever 6)", () => {
     // No queued turn = no model run.
     const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
     expect(pending.length).toBe(0);
-    // The completion is still visible as a card event in the timeline.
-    const events = await listSessionEvents(db, workspaceId, parent.id, {});
-    const card = events.find(
-      (e) => e.type === "user.message" && (e.payload as any)?.childCompletion,
-    );
-    expect(card).toBeDefined();
+    // The completion is still visible as a card event in the timeline (read via
+    // the raw admin connection so a leaked db mock cannot mask it).
+    const cards = await admin<{ id: string }[]>`
+      select id from session_events
+      where session_id = ${parent.id}
+        and type = 'user.message'
+        and payload ? 'childCompletion'`;
+    expect(cards.length).toBe(1);
   });
 
   test("passive mode stays idempotent per child episode", async () => {

--- a/packages/db/test/child-completion-digest.test.ts
+++ b/packages/db/test/child-completion-digest.test.ts
@@ -9,6 +9,8 @@ import {
   finishTurn,
   getSessionEvent,
   listPendingSessionTurns,
+  listSessionEvents,
+  setSessionChildNotificationsMode,
   wakeParentSessionForChildCompletion,
   createDb,
   type Database,
@@ -115,7 +117,7 @@ describe("wakeParentSessionForChildCompletion coalescing", () => {
     expect(r1.delivered).toBe(true);
     expect(r2.delivered).toBe(true);
     expect(r3.delivered).toBe(true);
-    if (r1.delivered && r2.delivered && r3.delivered) {
+    if (r1.delivered && !r1.passive && r2.delivered && !r2.passive && r3.delivered && !r3.passive) {
       expect(r1.folded).toBe(false); // opened the digest
       expect(r2.folded).toBe(true); // folded in
       expect(r3.folded).toBe(true);
@@ -170,7 +172,7 @@ describe("wakeParentSessionForChildCompletion coalescing", () => {
       wakeInput(workspaceId, parent.id, "child-1"),
     );
     expect(first.delivered).toBe(true);
-    if (!first.delivered) return;
+    if (!first.delivered || first.passive) return;
     // Simulate the workflow claiming the digest turn (queued -> running).
     await admin`update session_turns set status = 'running' where id = ${first.turn.id}`;
 
@@ -179,7 +181,7 @@ describe("wakeParentSessionForChildCompletion coalescing", () => {
       wakeInput(workspaceId, parent.id, "child-2"),
     );
     expect(next.delivered).toBe(true);
-    if (next.delivered) {
+    if (next.delivered && !next.passive) {
       expect(next.folded).toBe(false); // could not fold into a running turn
       expect(next.turn.id).not.toBe(first.turn.id);
     }
@@ -240,5 +242,111 @@ describe("cancelQueuedSessionTurns (stop-drains-the-queue)", () => {
     await finishTurn(db, workspaceId, running.id, "cancelled");
     const afterFinish = await listPendingSessionTurns(db, workspaceId, session.id);
     expect(afterFinish.length).toBe(0);
+  });
+});
+
+describe("human messages preempt machine notifications (lever 5)", () => {
+  function humanTurn(accountId: string, workspaceId: string, sessionId: string, preempt: boolean) {
+    return enqueueSessionTurn(db, {
+      accountId,
+      workspaceId,
+      sessionId,
+      triggerEventId: crypto.randomUUID(),
+      temporalWorkflowId: `session-${sessionId}`,
+      source: "user" as const,
+      prompt: "human message",
+      resources: [],
+      tools: [],
+      model: "gpt",
+      reasoningEffort: "medium" as const,
+      sandboxBackend: "none" as const,
+      metadata: {},
+      preemptChildNotifications: preempt,
+    });
+  }
+
+  test("a human turn jumps AHEAD of queued child-completion turns", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+    // Two machine notifications sit in the queue (folded into one digest turn).
+    await wakeParentSessionForChildCompletion(db, wakeInput(workspaceId, parent.id, "child-1"));
+    await wakeParentSessionForChildCompletion(db, wakeInput(workspaceId, parent.id, "child-2"));
+
+    const human = await humanTurn(accountId, workspaceId, parent.id, true);
+
+    // Ordered by claim position: the human turn is first, the machine digest after.
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    expect(pending[0]!.id).toBe(human.id);
+    expect(pending[0]!.metadata).not.toHaveProperty("childCompletion");
+    expect(pending[pending.length - 1]!.metadata).toHaveProperty("childCompletion");
+  });
+
+  test("without the flag, a human turn appends to the back (unchanged default)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+    await wakeParentSessionForChildCompletion(db, wakeInput(workspaceId, parent.id, "child-1"));
+
+    const human = await humanTurn(accountId, workspaceId, parent.id, false);
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    // Machine turn was queued first, so it stays ahead of a non-preempting turn.
+    expect(pending[pending.length - 1]!.id).toBe(human.id);
+  });
+});
+
+describe("child-completion suppression opt-in (lever 6)", () => {
+  test("passive mode lands a card event with NO queued turn and no wake", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+    await setSessionChildNotificationsMode(db, workspaceId, parent.id, "passive");
+
+    const result = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    expect(result.delivered).toBe(true);
+    if (result.delivered) {
+      expect(result.passive).toBe(true);
+    }
+    // No queued turn = no model run.
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    expect(pending.length).toBe(0);
+    // The completion is still visible as a card event in the timeline.
+    const events = await listSessionEvents(db, workspaceId, parent.id, {});
+    const card = events.find(
+      (e) => e.type === "user.message" && (e.payload as any)?.childCompletion,
+    );
+    expect(card).toBeDefined();
+  });
+
+  test("passive mode stays idempotent per child episode", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+    await setSessionChildNotificationsMode(db, workspaceId, parent.id, "passive");
+    await wakeParentSessionForChildCompletion(db, wakeInput(workspaceId, parent.id, "child-1"));
+    const dup = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    expect(dup.delivered).toBe(false);
+  });
+
+  test("digest remains the default when no mode is set", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+    const result = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    expect(result.delivered).toBe(true);
+    if (result.delivered) {
+      expect(result.passive).toBe(false);
+    }
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    expect(pending.length).toBe(1);
   });
 });

--- a/packages/db/test/child-completion-digest.test.ts
+++ b/packages/db/test/child-completion-digest.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import {
+  buildChildCompletionDigest,
+  cancelQueuedSessionTurns,
+  createSession,
+  enqueueSessionTurn,
+  finishTurn,
+  getSessionEvent,
+  listPendingSessionTurns,
+  wakeParentSessionForChildCompletion,
+  createDb,
+  type Database,
+  type DbClient,
+} from "../src/index";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+  const [a] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('acct') returning id`;
+  const [w] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name) values (${a!.id}, 'ws') returning id`;
+  return { accountId: a!.id, workspaceId: w!.id };
+}
+
+async function makeParent(accountId: string, workspaceId: string) {
+  return await createSession(db, {
+    accountId,
+    workspaceId,
+    initialMessage: "manager",
+    resources: [],
+    metadata: {},
+    model: "gpt",
+    sandboxBackend: "none",
+  });
+}
+
+function wakeInput(workspaceId: string, parentSessionId: string, childId: string) {
+  return {
+    workspaceId,
+    parentSessionId,
+    clientEventId: `child-completion:${childId}:1`,
+    childSummary: `A worker session you spawned has FAILED. Worker session id: ${childId}.`,
+    trailing: "Read each worker's output, then continue.",
+    childCompletion: { childSessionId: childId, status: "failed" as const },
+    reasoningEffortFallback: "medium" as const,
+  };
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("child-completion-digest");
+  if (!shared) {
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[child-completion-digest] docker unavailable, skipping");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+}, 180_000);
+
+afterAll(async () => {
+  try {
+    await client?.close();
+  } catch {
+    /* noop */
+  }
+  await shared?.release();
+});
+
+describe("buildChildCompletionDigest (pure)", () => {
+  test("one child reads as a plain wake with no numbering", () => {
+    expect(buildChildCompletionDigest(["worker A summary"], "do X")).toBe(
+      "worker A summary\n\ndo X",
+    );
+  });
+  test("N children collapse into ONE numbered digest with one trailing", () => {
+    const digest = buildChildCompletionDigest(["A", "B", "C"], "do X");
+    expect(digest).toContain("3 worker sessions you spawned reached a terminal state:");
+    expect(digest).toContain("1. A");
+    expect(digest).toContain("2. B");
+    expect(digest).toContain("3. C");
+    // Exactly one trailing instruction, at the end.
+    expect(digest.endsWith("do X")).toBe(true);
+    expect(digest.split("do X").length - 1).toBe(1);
+  });
+});
+
+describe("wakeParentSessionForChildCompletion coalescing", () => {
+  test("three terminating workers fold into ONE queued turn (N model runs -> 1)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+
+    const r1 = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    const r2 = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-2"),
+    );
+    const r3 = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-3"),
+    );
+
+    expect(r1.delivered).toBe(true);
+    expect(r2.delivered).toBe(true);
+    expect(r3.delivered).toBe(true);
+    if (r1.delivered && r2.delivered && r3.delivered) {
+      expect(r1.folded).toBe(false); // opened the digest
+      expect(r2.folded).toBe(true); // folded in
+      expect(r3.folded).toBe(true);
+      // All three point at the SAME turn.
+      expect(r2.turn.id).toBe(r1.turn.id);
+      expect(r3.turn.id).toBe(r1.turn.id);
+    }
+
+    // Exactly ONE queued turn exists for the parent, and its trigger text is the
+    // full 3-child digest.
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    expect(pending.length).toBe(1);
+    const digestTurn = pending[0]!;
+    const trigger = await getSessionEvent(db, workspaceId, digestTurn.triggerEventId);
+    const text = (trigger?.payload as { text?: string }).text ?? "";
+    expect(text).toContain("3 worker sessions you spawned reached a terminal state:");
+    expect(text).toContain("child-1");
+    expect(text).toContain("child-2");
+    expect(text).toContain("child-3");
+  });
+
+  test("idempotent per child: a re-delivered terminal episode does not double-fold", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+
+    await wakeParentSessionForChildCompletion(db, wakeInput(workspaceId, parent.id, "child-1"));
+    const dup = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    expect(dup.delivered).toBe(false);
+    if (!dup.delivered) {
+      expect(dup.reason).toBe("already_delivered");
+    }
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    expect(pending.length).toBe(1);
+    const trigger = await getSessionEvent(db, workspaceId, pending[0]!.triggerEventId);
+    // Single child => plain wake, no "N worker sessions" digest header.
+    expect((trigger?.payload as { text?: string }).text ?? "").not.toContain(
+      "worker sessions you spawned reached",
+    );
+  });
+
+  test("once the digest turn is claimed, the next child opens a fresh turn", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const parent = await makeParent(accountId, workspaceId);
+
+    const first = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-1"),
+    );
+    expect(first.delivered).toBe(true);
+    if (!first.delivered) return;
+    // Simulate the workflow claiming the digest turn (queued -> running).
+    await admin`update session_turns set status = 'running' where id = ${first.turn.id}`;
+
+    const next = await wakeParentSessionForChildCompletion(
+      db,
+      wakeInput(workspaceId, parent.id, "child-2"),
+    );
+    expect(next.delivered).toBe(true);
+    if (next.delivered) {
+      expect(next.folded).toBe(false); // could not fold into a running turn
+      expect(next.turn.id).not.toBe(first.turn.id);
+    }
+    // One running (claimed) + one fresh queued.
+    const pending = await listPendingSessionTurns(db, workspaceId, parent.id);
+    const queued = pending.filter((t) => t.status === "queued");
+    expect(queued.length).toBe(1);
+  });
+});
+
+describe("cancelQueuedSessionTurns (stop-drains-the-queue)", () => {
+  test("cancels every queued turn and returns their ids; leaves the running turn", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const session = await makeParent(accountId, workspaceId);
+    const base = {
+      accountId,
+      workspaceId,
+      sessionId: session.id,
+      temporalWorkflowId: `session-${session.id}`,
+      source: "user" as const,
+      resources: [],
+      tools: [],
+      model: "gpt",
+      reasoningEffort: "medium" as const,
+      sandboxBackend: "none" as const,
+      metadata: {},
+    };
+    const running = await enqueueSessionTurn(db, {
+      ...base,
+      triggerEventId: crypto.randomUUID(),
+      prompt: "running",
+    });
+    await admin`update session_turns set status = 'running' where id = ${running.id}`;
+    const q1 = await enqueueSessionTurn(db, {
+      ...base,
+      triggerEventId: crypto.randomUUID(),
+      prompt: "q1",
+    });
+    const q2 = await enqueueSessionTurn(db, {
+      ...base,
+      triggerEventId: crypto.randomUUID(),
+      prompt: "q2",
+    });
+
+    const drained = await cancelQueuedSessionTurns(db, workspaceId, session.id);
+    expect(drained.sort()).toEqual([q1.id, q2.id].sort());
+
+    const pending = await listPendingSessionTurns(db, workspaceId, session.id);
+    // Only the running turn remains non-terminal; both queued turns are gone.
+    expect(pending.map((t) => t.id)).toEqual([running.id]);
+
+    // Idempotent: a second drain finds nothing.
+    const again = await cancelQueuedSessionTurns(db, workspaceId, session.id);
+    expect(again).toEqual([]);
+
+    // Finishing the running turn as cancelled is unaffected by the drain.
+    await finishTurn(db, workspaceId, running.id, "cancelled");
+    const afterFinish = await listPendingSessionTurns(db, workspaceId, session.id);
+    expect(afterFinish.length).toBe(0);
+  });
+});

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -505,8 +505,8 @@ export function ChatComposer({
                       transition={{ duration: 0.15, ease: "easeOut" }}
                       onClick={() => void composer.interrupt()}
                       disabled={composer.interrupting}
-                      aria-label="Stop the current turn"
-                      title="Stop the current turn"
+                      aria-label="Stop the session"
+                      title="Stop: cancels the current turn, clears any queued messages, and pauses the goal"
                       className={cn(
                         "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11",
                         "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -650,6 +650,17 @@ function prescanTurnAnchors(events: SessionEvent[]): TurnAnchorPrescan {
       }
     } else if (event.type === "turn.cancelled" && turnId) {
       cancelledTurnIds.add(turnId);
+    } else if (event.type === "turn.queue_drained") {
+      // A stop drained the whole queue in one shot (one summary event carrying
+      // the cancelled ids). Treat every drained turn exactly like an
+      // individually-cancelled never-started turn so its queued anchor folds
+      // away as a calm retraction instead of lingering as still-queued.
+      const drainedTurnIds = Array.isArray(payload.drainedTurnIds) ? payload.drainedTurnIds : [];
+      for (const drainedId of drainedTurnIds) {
+        if (typeof drainedId === "string") {
+          cancelledTurnIds.add(drainedId);
+        }
+      }
     }
 
     if (turnId && event.type !== "turn.queued" && event.type !== "turn.cancelled") {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1783,3 +1783,54 @@ describe("buildTimeline — memory writes", () => {
     expect(activities[0]!.items.map((item) => item.kind)).toEqual(["tool-call", "memory"]);
   });
 });
+
+describe("turn.queue_drained (stop-drains-the-queue)", () => {
+  const userItems = (items: ReturnType<typeof buildTimeline>) =>
+    items.filter((item) => item.kind === "user-message");
+
+  test("a drained queued turn is retracted exactly like an individually-cancelled one", () => {
+    reset();
+    const msgCancel = event("user.message", { text: "hi" }, { turnId: null });
+    const cancelled = buildTimeline([
+      msgCancel,
+      event(
+        "turn.queued",
+        { turnId: "turn-9", triggerEventId: msgCancel.id },
+        { turnId: "turn-9" },
+      ),
+      event("turn.cancelled", {}, { turnId: "turn-9" }),
+    ]);
+
+    reset();
+    const msgDrain = event("user.message", { text: "hi" }, { turnId: null });
+    const drained = buildTimeline([
+      msgDrain,
+      event("turn.queued", { turnId: "turn-9", triggerEventId: msgDrain.id }, { turnId: "turn-9" }),
+      event(
+        "turn.queue_drained",
+        { drainedCount: 1, drainedTurnIds: ["turn-9"] },
+        { turnId: null },
+      ),
+    ]);
+
+    // Same disposition: the drained queued message folds away just like a
+    // cancelled one, so the timeline reflects the stop honestly.
+    expect(userItems(drained).length).toBe(userItems(cancelled).length);
+  });
+
+  test("a queue_drained that does not name a turn leaves it queued", () => {
+    reset();
+    const msg = event("user.message", { text: "hi" }, { turnId: null });
+    const items = buildTimeline([
+      msg,
+      event("turn.queued", { turnId: "turn-9", triggerEventId: msg.id }, { turnId: "turn-9" }),
+      event(
+        "turn.queue_drained",
+        { drainedCount: 1, drainedTurnIds: ["turn-OTHER"] },
+        { turnId: null },
+      ),
+    ]);
+    // turn-9 was not drained, so its queued message survives.
+    expect(userItems(items).length).toBe(1);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1718,6 +1718,9 @@ export type PrepareToolsOptions = {
   // Worker-asserted session scope for first-party MCP calls; enables
   // session-scoped tools such as goal management on the API side.
   sessionId?: string;
+  // The calling turn's id, signed into the token so tools can classify the
+  // caller from its own identity instead of the session's live active pointer.
+  turnId?: string;
   subjectId?: string;
   subjectLabel?: string;
   // Overrides the fixed first-party MCP permission set for this session's
@@ -2197,6 +2200,7 @@ async function firstPartyMcpRequestInit(
       ...(options.subjectLabel ? { subjectLabel: options.subjectLabel } : {}),
       permissions: options.firstPartyPermissions ?? firstPartyMcpPermissions,
       ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      ...(options.turnId ? { turnId: options.turnId } : {}),
       exp: Math.floor(Date.now() / 1000) + 60 * 60,
     })}`;
   }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -463,6 +463,7 @@ export const SESSION_EVENT_TYPES = [
   "turn.completed",
   "turn.failed",
   "turn.cancelled",
+  "turn.queue_drained",
   "turn.preempted",
   "agent.message.delta",
   "agent.message.completed",


### PR DESCRIPTION
## Why
Prod manager session `aed24825` felt like steering/stop were broken. Read-only tracing showed the real cause: the manager spawned ~29 workers that kept reaching terminal states, and each terminal worker injected a `source=user` "worker FAILED/PAUSED" turn into the manager's queue. A specific human message (`turn pos 70`) was traced end-to-end — it was durably queued, then **cancelled as collateral of the user's own anti-flood stop-spree** because interrupt cancelled one flood turn at a time and the human message sat behind them. Continue-as-new / lost-signal was ruled out (the queue lives in Postgres; the covering workflow run recorded 13 signals, 0 ContinueAsNew, 0 resets).

## What (six levers)
1. **Stop drains the queue.** A non-steer interrupt cancels the active turn AND all queued turns, emitting one honest `turn.queue_drained` summary event. Steer still promotes exactly one steered message. — `apps/worker/src/activities/session-state.ts`, `cancelQueuedSessionTurns` in `packages/db/src/index.ts`, projection in `packages/react/src/timeline/projection.ts`.
2. **A user-paused goal is sacred.** A machine child-completion turn can no longer re-activate a `user_interrupt`-paused goal (`goal_set` refused via `assertGoalReactivationAllowed`), and the wake text drops "resume it now" when the manager's own goal is user-paused. — `apps/api/src/mcp/server.ts`, `apps/worker/src/activities/parent-wake.ts`.
3. **Child-completion notifications coalesce.** N terminating workers fold into ONE queued digest turn (one model run) instead of N, under the parent-row lock + `FOR UPDATE` on the candidate turn. Each worker keeps its own result card; idempotency stays on the per-child `clientEventId`. — `wakeParentSessionForChildCompletion` in `packages/db/src/index.ts`.
4. **Honest steering copy.** Composer/queue no longer claim steer "injects this message now" (it cancels the current step and runs the message next, goal continues); the stop button says it clears queued messages and pauses the goal. — `apps/web/src/components/Composer.tsx`, `apps/web/src/lib/queue.ts`, `packages/react/src/components/chat-composer.tsx`.
5. **Human messages preempt machine notifications.** A genuine human message enqueues ahead of any queued child-completion notification turns (behind the running turn and earlier human turns) via `preemptChildNotifications`. A person's message never waits behind a flood of "worker FAILED" notices. — `postUserMessageTurn` in `packages/core`, `positionForEnqueue` in `packages/db`.
6. **Child-completion suppression opt-in.** New first-party `set_child_notifications_mode({digest|passive})` tool: `passive` lands completions as timeline cards only, never a queued turn or model run (the user's own in-session ask). `digest` stays default. — `apps/api/src/mcp/server.ts`, `setSessionChildNotificationsMode` in `packages/db`.

## Testing
- **Stop drains / steer never drains / empty-queue no-op** — `apps/worker/test/session-state-cancel.test.ts`
- **Sacred-pause guard** (refuse machine / allow user / allow agent-pause / allow no-goal / allow no-active-turn) — `apps/api/test/goal-sacred-pause.test.ts`
- **Digest N→1 + idempotency + fresh-turn-after-claim; drain; human-preempts-machine + default-append; passive card-only + idempotent + digest-default** — `packages/db/test/child-completion-digest.test.ts` (live Postgres)
- **queue_drained projection parity** — `packages/react/test/timeline.test.ts`
- **Honest copy** — `apps/web/src/lib/queue.test.ts`; **suppression trailing** — `apps/worker/test/parent-wake-text.test.ts`
- Gates: `bun run typecheck` clean (20/20), `bun run format:check` clean, `bun run lint` exit 0 (no new errors). Broad sweep of the affected suites: 0 fail.

The api integration suite (`test/integration/api.integration.ts`) needs full services and is left to CI.

## Related
Independent zombie-turn bug surfaced during the trace, filed separately: #369 (a `session_turns` row stuck `running` 8 days on an idle session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)