### PR TITLE
fix(worker): auto-recover sessions from transient provider errors

### DIFF
--- a/.changeset/transient-provider-errors-retryable.md
+++ b/.changeset/transient-provider-errors-retryable.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Treat transient upstream model-provider failures as retryable so a goal-bearing session recovers automatically instead of going terminal. A provider 5xx (500/502/503/529), a generic "server had a bad minute" body, or a dropped/again-able network connection (ECONNRESET/ETIMEDOUT/EAI_AGAIN/…) now classifies `retryable` and routes into the existing idle + goal-continuation path (auto-continue after the backpressure delay for goal-bearing sessions; wait for the next user message otherwise). Previously only 429/rate-limit and MCP-timeout were retryable, so a generic provider 5xx fell through to a hard `session.failed` that required a manual nudge — during an upstream provider degradation window this needlessly hard-failed a fleet of live sessions. HTTP status is authoritative (every 5xx retryable, 4xx still hard-fails); the ChatGPT/Codex usage-cap 429 stays non-retryable since a retry would just re-hit the cap.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -3924,8 +3924,13 @@ export function isTransientProviderError(error: unknown): boolean {
     typeof error === "object" && error !== null && "status" in error
       ? Number((error as { status?: unknown }).status)
       : undefined;
-  if (status !== undefined && Number.isFinite(status) && status >= 500 && status < 600) {
-    return true;
+  // A real HTTP status is AUTHORITATIVE: a 5xx is transient, and ANY other status
+  // (4xx validation/auth/404, plus the 429 the earlier branches already handled) is
+  // a request fault that must NOT auto-retry — even if its body happens to read like
+  // "connection error" or "overloaded". The code/message heuristics below apply ONLY
+  // when no status survived: a network fault or an SDK-rethrown bare Error.
+  if (status !== undefined && Number.isFinite(status)) {
+    return status >= 500 && status < 600;
   }
   const code =
     typeof error === "object" && error !== null && "code" in error

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -188,6 +188,25 @@ import { randomUUID } from "node:crypto";
 export const PROVIDER_BACKPRESSURE_DELAY_MS = 60_000;
 
 /**
+ * Recovery routing for a turn failed by a RETRYABLE provider error, once the
+ * activity knows whether the session still has an active goal: a goal-bearing
+ * session idles and auto-continues after the backpressure delay, a goal-less one
+ * idles and waits for the next user message. A NON-retryable failure never reaches
+ * here — it takes the terminal session.failed path — so the contrast this encodes
+ * is "retryable provider blip ⇒ idle-with-recovery, not a dead session." Single
+ * source of truth for the recovery mode and continuation delay the retryable
+ * turn-failure branch publishes.
+ */
+export function providerRetryRecovery(goalActive: boolean): {
+  recovery: "goal_continuation" | "user_message";
+  continueDelayMs?: number;
+} {
+  return goalActive
+    ? { recovery: "goal_continuation", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS }
+    : { recovery: "user_message" };
+}
+
+/**
  * Resolve which Codex account a turn runs on (multi-account P1): session-pin >
  * workspace-active. No rotation in P1. The selected id must still be in the
  * connected set — a disconnected pin was FK-nulled, so a stale id can't appear,
@@ -3585,6 +3604,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       if (failure.retryable && publish && turnId && turnStartedPublished) {
         const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
         const goalActive = Boolean(goal && goal.status === "active");
+        const recoveryRouting = providerRetryRecovery(goalActive);
         await flushRuntimeBatcher();
         // Provider/MCP errors rarely carry SDK run state; a null falls back to
         // the previous snapshot, same degraded-context contract as the
@@ -3610,7 +3630,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               type: "turn.failed",
               payload: {
                 ...failure,
-                recovery: goalActive ? "goal_continuation" : "user_message",
+                recovery: recoveryRouting.recovery,
                 runStateSaved,
               },
             },
@@ -3623,9 +3643,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         await setSessionStatus(db, input.workspaceId, input.sessionId, "idle", null);
         activityStatus = "idle";
         activityError = error;
-        return goalActive
-          ? { status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS }
-          : { status: "idle" };
+        return {
+          status: "idle",
+          ...(recoveryRouting.continueDelayMs !== undefined
+            ? { continueDelayMs: recoveryRouting.continueDelayMs }
+            : {}),
+        };
       }
       activityStatus = "failed";
       activityError = error;
@@ -3875,6 +3898,48 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
   };
 }
 
+/**
+ * True when the error is transient upstream backpressure — a model-provider 5xx,
+ * a "server had a bad minute" body, or a dropped/again-able network connection —
+ * rather than a request the session got wrong. These are safe to retry: the turn
+ * routes into the SAME idle + goal-continuation recovery the rate-limit branch
+ * uses (a goal-bearing session auto-continues after PROVIDER_BACKPRESSURE_DELAY_MS;
+ * a goal-less one waits for the next user message), and the resume notice tells the
+ * model to re-check side effects before repeating them.
+ *
+ * This is the classification gap that hard-failed a fleet of prod sessions during a
+ * provider degradation window: their errors ("Our servers are currently overloaded",
+ * the generic 500 "An error occurred while processing your request", "Connection
+ * error") carried no retryable marker and fell through to a terminal session.failed.
+ *
+ * HTTP status is authoritative when present — EVERY 5xx is a server-side failure that
+ * is safe to retry, while 4xx (validation, auth, 404) is a request fault that must
+ * still hard-fail. The code/message matches are the fallback for network faults and
+ * SDK-rethrown bare Errors that carry no status. A ChatGPT/Codex usage cap (a 429
+ * that will NOT clear on retry) is classified and returned BEFORE this in
+ * agentRunFailurePayload, so it never reaches here.
+ */
+export function isTransientProviderError(error: unknown): boolean {
+  const status =
+    typeof error === "object" && error !== null && "status" in error
+      ? Number((error as { status?: unknown }).status)
+      : undefined;
+  if (status !== undefined && Number.isFinite(status) && status >= 500 && status < 600) {
+    return true;
+  }
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : undefined;
+  if (code && /^(?:ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE)$/i.test(code)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /overloaded|an error occurred while processing your request|connection error|service unavailable|bad gateway|gateway timeout/i.test(
+    message,
+  );
+}
+
 export function agentRunFailurePayload(error: unknown): {
   error: string;
   code?: string;
@@ -3922,6 +3987,13 @@ export function agentRunFailurePayload(error: unknown): {
       retryable: true,
       ...(message && message !== "Too Many Requests" ? { detail: message } : {}),
     };
+  }
+  // Transient upstream backpressure (5xx / overloaded / dropped connection): keep
+  // the provider's own message (it is already user-meaningful) but mark it
+  // retryable so a goal-bearing session idles and auto-continues instead of going
+  // terminal on a provider's bad minute. See isTransientProviderError.
+  if (isTransientProviderError(error)) {
+    return { error: message, code: "provider_unavailable", retryable: true };
   }
   return { error: message };
 }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -16,9 +16,12 @@ import {
   filterUnmaterializedSandboxFileDownloads,
   historyRowsToAppend,
   isLazySandboxProvisionRetryable,
+  isTransientProviderError,
   isWorkerShutdownCancellation,
   modelUsageSourceKey,
   pointerReconcileReason,
+  PROVIDER_BACKPRESSURE_DELAY_MS,
+  providerRetryRecovery,
   resolveActiveSandboxBackend,
   shouldStartOnTurnRecording,
   WORKER_SHUTDOWN_RESUME_TEXT,
@@ -829,6 +832,125 @@ describe("escaped MCP transport timeout classifier", () => {
     ).toBeNull();
     expect(classifyMcpTransportTimeoutError(new Error("sandbox creation timed out"))).toBeNull();
     expect(classifyMcpTransportTimeoutError(new Error("Too Many Requests"))).toBeNull();
+  });
+});
+
+// A model-provider 5xx / overload / dropped connection is transient backpressure,
+// not a session fault. It must classify retryable so the turn routes into the idle +
+// goal-continuation recovery instead of a terminal session.failed — the gap that
+// hard-failed a fleet of prod sessions during a provider degradation window.
+describe("transient provider error classifier", () => {
+  test("classifies 5xx status codes as transient (status is authoritative)", () => {
+    for (const status of [500, 502, 503, 504, 529]) {
+      const err = Object.assign(new Error("Service failure"), { status });
+      expect(isTransientProviderError(err)).toBe(true);
+    }
+  });
+
+  test("classifies the observed provider transient messages when no status survives", () => {
+    // The exact bodies that hard-failed prod sessions, thrown as bare Errors.
+    expect(
+      isTransientProviderError(
+        new Error(
+          "An error occurred while processing your request. You can retry your request, " +
+            "or contact us through our help center. Please include the request ID abc123.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientProviderError(
+        new Error("Our servers are currently overloaded. Please try again later."),
+      ),
+    ).toBe(true);
+    expect(isTransientProviderError(new Error("Connection error."))).toBe(true);
+  });
+
+  test("classifies node/undici network fault codes as transient", () => {
+    for (const code of ["ECONNRESET", "ETIMEDOUT", "EAI_AGAIN", "ECONNREFUSED", "EPIPE"]) {
+      expect(isTransientProviderError(Object.assign(new Error("socket"), { code }))).toBe(true);
+    }
+  });
+
+  test("does NOT treat 4xx request faults or usage caps as transient", () => {
+    expect(isTransientProviderError(Object.assign(new Error("Bad Request"), { status: 400 }))).toBe(
+      false,
+    );
+    expect(
+      isTransientProviderError(Object.assign(new Error("Unprocessable Entity"), { status: 422 })),
+    ).toBe(false);
+    expect(isTransientProviderError(Object.assign(new Error("Not Found"), { status: 404 }))).toBe(
+      false,
+    );
+    // A 429 is handled by the dedicated rate-limit / usage-cap branches, never here.
+    expect(
+      isTransientProviderError(Object.assign(new Error("Too Many Requests"), { status: 429 })),
+    ).toBe(false);
+  });
+
+  test("agentRunFailurePayload marks transient provider errors retryable, keeping the body", () => {
+    const overloaded = Object.assign(
+      new Error("Our servers are currently overloaded. Please try again later."),
+      { status: 503 },
+    );
+    expect(agentRunFailurePayload(overloaded)).toEqual({
+      error: "Our servers are currently overloaded. Please try again later.",
+      code: "provider_unavailable",
+      retryable: true,
+    });
+
+    const generic500 = Object.assign(
+      new Error(
+        "An error occurred while processing your request. You can retry your request. " +
+          "Please include the request ID 8afe928d.",
+      ),
+      { status: 500 },
+    );
+    const payload = agentRunFailurePayload(generic500);
+    expect(payload.retryable).toBe(true);
+    expect(payload.code).toBe("provider_unavailable");
+    expect(payload.error).toContain("request ID 8afe928d");
+  });
+
+  test("agentRunFailurePayload still hard-fails a non-transient 4xx (no retryable marker)", () => {
+    const validation = Object.assign(new Error("Invalid 'input': expected a string"), {
+      status: 400,
+    });
+    const payload = agentRunFailurePayload(validation);
+    expect(payload.retryable).toBeUndefined();
+    expect(payload.code).toBeUndefined();
+    expect(payload.error).toBe("Invalid 'input': expected a string");
+  });
+
+  test("a 503 with an active goal idles and auto-continues instead of failing (end-to-end routing)", () => {
+    // Classifier → retryable, then the retryable turn-failure branch's recovery
+    // routing → idle + goal_continuation + backpressure delay. This is the exact
+    // path that was missing when ~29 prod sessions hard-failed on provider 5xx.
+    const failure = agentRunFailurePayload(
+      Object.assign(new Error("Our servers are currently overloaded. Please try again later."), {
+        status: 503,
+      }),
+    );
+    expect(failure.retryable).toBe(true); // enters the retryable branch (not the terminal one)
+    expect(providerRetryRecovery(true)).toEqual({
+      recovery: "goal_continuation",
+      continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
+    });
+    // A goal-less session idles too, but waits for the next user message (no auto-continue).
+    expect(providerRetryRecovery(false)).toEqual({ recovery: "user_message" });
+  });
+
+  test("agentRunFailurePayload keeps a ChatGPT/Codex usage cap non-retryable (429 that won't clear)", () => {
+    // A usage cap is also a 429; the cap classifier runs BEFORE this transient
+    // branch and must win, staying retryable:false. Shape mirrors the real
+    // upstream payload (see codex-usage-limit.test.ts).
+    const cap = Object.assign(new Error("429 You have hit your usage limit"), {
+      status: 429,
+      type: "usage_limit_reached",
+      error: { type: "usage_limit_reached", resets_in_seconds: 7200 },
+    });
+    const payload = agentRunFailurePayload(cap);
+    expect(payload.retryable).toBe(false);
+    expect(payload.code).toBe("codex_usage_limit_reached");
   });
 });
 

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -887,6 +887,26 @@ describe("transient provider error classifier", () => {
     ).toBe(false);
   });
 
+  test("HTTP status is authoritative: a non-5xx status short-circuits, transient body or not", () => {
+    // The Bugbot catch: a KNOWN 4xx whose body happens to read like a transient
+    // fault must NOT fall through to the message heuristics and auto-retry forever.
+    expect(
+      isTransientProviderError(
+        Object.assign(new Error("Connection error. (from a validation-rejected request)"), {
+          status: 400,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTransientProviderError(
+        Object.assign(new Error("Our servers are currently overloaded."), { status: 404 }),
+      ),
+    ).toBe(false);
+    // The mirror case: the SAME "connection error" body with NO status survives is
+    // a genuine network fault and IS transient — the heuristics apply only here.
+    expect(isTransientProviderError(new Error("Connection error."))).toBe(true);
+  });
+
   test("agentRunFailurePayload marks transient provider errors retryable, keeping the body", () => {
     const overloaded = Object.assign(
       new Error("Our servers are currently overloaded. Please try again later."),


### PR DESCRIPTION
A transient upstream model-provider failure (a 5xx, a "server had a bad minute" body, or a dropped connection) was hard-failing sessions instead of being retried — turning a provider blip into a dead session that needed a manual nudge to revive.

## The bug, from a real prod session
Prod session `1b5c0ea8` broke mid-turn. The turn's `turn.failed` payload:

> "**An error occurred while processing your request. You can retry your request**, or contact us... Please include the request ID 8afe928d..."

That is an upstream OpenAI/Codex **HTTP 500**. The error text literally says *"You can retry your request"* — but the engine classified it non-retryable, flipped the session to `status: failed`, and the user had to type "." to bring it back. **Error text says retry, classifier says die.**

## Root cause
`agentRunFailurePayload()` marked only **429/rate-limit** and **MCP-timeout** as `retryable`. Everything else — a generic 5xx, "Our servers are currently overloaded" (503), "Connection error" — fell through to `return { error: message }` with `retryable` undefined, so the turn took the hard-fail branch (`session.status = failed`) instead of the retryable branch that idles the session and auto-continues a goal-bearing session after the 60s backpressure delay.

The retryable machinery already exists and is correct; the classifier's retryable set was just too narrow.

## Blast radius
This was not an anecdote. During an upstream Codex/OpenAI degradation window (2026-07-10 18:00–19:16 UTC), the transient-provider class this bug hard-fails — 503 "overloaded" + generic 500 + "Connection error" — accounted for **40 hard-failed turns across 29 distinct sessions**, every one with a null `recovery` field (confirming the terminal branch). Each needed a manual nudge or died. The 429 usage-cap class (correctly handled by the separate idle-until-reset path) is unaffected.

Not caused by any deploy — the exemplar session was created ~22 min after the day's worker rollout settled and only ever saw normal `context_compacted` preempts, never `worker_shutdown`/`worker_death`. The graceful-preempt durability path worked correctly during the actual rollout on other sessions.

## The fix
- New `isTransientProviderError(error)` — **HTTP status is authoritative**: `500 ≤ status < 600` → transient (500/502/503/504/529). Fallbacks only when no status survives: network `code` (ECONNRESET/ETIMEDOUT/EAI_AGAIN/ECONNREFUSED/EPIPE), then provider message patterns (overloaded / "an error occurred while processing your request" / "connection error" / service unavailable / bad gateway / gateway timeout).
- One new branch in `agentRunFailurePayload`, **after** the 429/rate-limit branch and **before** the terminal return: transient → `{ error: message, code: "provider_unavailable", retryable: true }`. Keeps the provider's own (already user-meaningful) message.
- **No new recovery semantics** — this routes into the existing retryable branch (idle + goal-continuation after `PROVIDER_BACKPRESSURE_DELAY_MS`), the same path 429/MCP-timeout already take. The retryable branch's recovery routing (`goalActive ? goal_continuation+delay : user_message`) is factored into a pure `providerRetryRecovery(goalActive)` helper — semantics-preserving, single source of truth, directly testable.
- **429 usage-cap stays non-retryable** — it is classified and returned before this branch (a retry would just re-hit the cap). **4xx still hard-fails** (request faults are not transient).

## Tests (`apps/worker/test/agent-turn.test.ts`, +8)
- 5xx status codes (500/502/503/504/529) classify transient
- the observed provider bodies classify transient when no status survives
- node/undici network fault codes classify transient
- 4xx (400/422/404) and a bare 429 do NOT classify transient
- `agentRunFailurePayload` marks transient retryable (keeping the body) and still hard-fails a non-transient 4xx with no retryable marker
- integration-shaped: a 503 with an active goal → retryable → `providerRetryRecovery(true)` = `{ goal_continuation, continueDelayMs }`; goal-less → `{ user_message }`
- 429 usage-cap stays non-retryable (`codex_usage_limit_reached`)

(There is no `runAgentTurn` harness in the repo — all worker tests are pure-function — so the composition is proven across the two real units rather than by mocking the whole activity. CI's integration suite exercises the full path.)

## Gate
- typecheck: all 20 projects clean
- `oxfmt --check`: clean
- `oxlint`: only a pre-existing `no-shadow` warning (present on origin/main, outside this diff)
- `bun test apps/worker/test/`: 314 pass / 0 fail (8 new)
- changeset: `@opengeni/worker-bundle` patch

## Related
Secondary finding filed separately as #370 (context compaction falling back to hard-trim on ~368K-token manager contexts) — diagnosis only, not addressed here.