### PR TITLE
feat(server): op-stream exec client — streaming exec to Connected Machines (server half)

### DIFF
--- a/.changeset/op-stream-server-client.md
+++ b/.changeset/op-stream-server-client.md
@@ -1,0 +1,17 @@
+---
+"@opengeni/runtime": minor
+"@opengeni/events": minor
+"@opengeni/db": minor
+"@opengeni/config": minor
+---
+
+Streaming exec to Connected Machines over the op-stream protocol (server half).
+When a runner advertises the `op_stream` capability (persisted from its connect
+Hello onto the enrollment) and `OPENGENI_AGENT_OP_STREAM_ENABLED` is on
+(default off), selfhosted exec streams as sequenced, acked, credit-flowed
+frames: no reply-size wall (retention-bounded, typed on overflow), blip-proof
+collection (re-attach + replay, blake3-verified byte-exact), and idempotent
+starts keyed by a durable per-tool-call op id so a re-dispatched turn attaches
+to the already-running command instead of re-running it. The legacy monolithic
+exec remains the permanent fallback wire form. The events bus gains an
+op-stream subscribe/publish accessor on the same managed NATS connection.

--- a/apps/api/src/sandbox/metrics-ingestion.ts
+++ b/apps/api/src/sandbox/metrics-ingestion.ts
@@ -21,6 +21,9 @@
 //     re-surfaced. Consuming the Hello's `capabilities.desktop` / `display` makes
 //     `has_display` track reality (both directions), which the desktop-capability
 //     gate (packages/runtime capabilities.ts) keys off.
+//     refreshEnrollmentOpStream — reconcile `enrollments.op_stream` to the LIVE
+//     runner capability the Hello reports, leaving legacy request/reply exec as the
+//     fallback unless the runner advertises the streaming engine.
 //
 // Both consumers are BEST-EFFORT and fail-soft: a decode/DB error for one message
 // is logged + swallowed (the bus subscription already swallows handler throws) so
@@ -33,6 +36,7 @@ import {
   ingestMachineMetricsSample,
   sessionsWithActiveOpOnEnrollment,
   setEnrollmentDisplayState,
+  setEnrollmentOpStreamState,
   setEnrollmentWentOffline,
   touchEnrollmentLastSeen,
   type AppendEventInput,
@@ -363,6 +367,11 @@ export function helloDesktopUnavailableReason(hello: Hello): string | null {
   return reason ? reason : null;
 }
 
+/** Whether the runner's current Hello advertises the op-stream engine. */
+export function helloReportsOpStream(hello: Hello): boolean {
+  return hello.capabilities?.opStream === true;
+}
+
 /**
  * Reconcile `enrollments.has_display` (+ the capture-blocked reason) to what a Hello
  * reports. Resolves the enrollment (the accountId is the RLS principal + the
@@ -403,6 +412,37 @@ export async function refreshEnrollmentDisplay(
 }
 
 /**
+ * Reconcile `enrollments.op_stream` to what a Hello reports. Resolves the
+ * enrollment first so the accountId remains the RLS principal and so a no-change
+ * Hello short-circuits BEFORE issuing any write (the DB writer is itself
+ * change-guarded as a backstop). An unknown/cross-workspace agentId is a no-op.
+ */
+export async function refreshEnrollmentOpStream(
+  db: Database,
+  input: {
+    workspaceId: string;
+    agentId: string;
+    opStream: boolean;
+  },
+): Promise<{ updated: boolean }> {
+  const enrollment = await getEnrollment(db, input.workspaceId, input.agentId);
+  if (!enrollment) {
+    return { updated: false };
+  }
+  if (enrollment.opStream === input.opStream) {
+    // The capability is unchanged — do not even issue the UPDATE (no churn on a
+    // steady-state Hello).
+    return { updated: false };
+  }
+  return await setEnrollmentOpStreamState(db, {
+    accountId: enrollment.accountId,
+    workspaceId: input.workspaceId,
+    enrollmentId: input.agentId,
+    opStream: input.opStream,
+  });
+}
+
+/**
  * Decode a raw `Hello` payload + refresh the enrollment's display cursor + clear
  * any pending clean going-offline marker and, when the reconnect actually cleared
  * one, fan out machine.link.restored to the sessions with an active op on the
@@ -438,8 +478,13 @@ export async function handleHelloPayload(
       hasDisplay: helloReportsDisplay(hello),
       desktopUnavailableReason: helloDesktopUnavailableReason(hello),
     });
+    await refreshEnrollmentOpStream(db, {
+      workspaceId: ids.workspaceId,
+      agentId: ids.agentId,
+      opStream: helloReportsOpStream(hello),
+    });
   } catch (error) {
-    observability?.warn?.("Failed to refresh an enrollment's display from a Hello", {
+    observability?.warn?.("Failed to refresh an enrollment's capabilities from a Hello", {
       subject,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/apps/api/test/hello-ingestion.test.ts
+++ b/apps/api/test/hello-ingestion.test.ts
@@ -17,9 +17,11 @@ import {
   AGENT_HELLO_SUBJECT,
   handleHelloPayload,
   helloDesktopUnavailableReason,
+  helloReportsOpStream,
   helloReportsDisplay,
   parseAgentHelloSubject,
   refreshEnrollmentDisplay,
+  refreshEnrollmentOpStream,
   startHelloIngestion,
 } from "../src/sandbox/metrics-ingestion";
 
@@ -122,6 +124,20 @@ describe("helloDesktopUnavailableReason", () => {
   });
 });
 
+describe("helloReportsOpStream", () => {
+  test("opStream=true → streaming exec advertised", () => {
+    expect(helloReportsOpStream(Hello.fromPartial({ capabilities: { opStream: true } }))).toBe(
+      true,
+    );
+  });
+  test("opStream=false or absent Capabilities → legacy exec fallback", () => {
+    expect(helloReportsOpStream(Hello.fromPartial({ capabilities: { opStream: false } }))).toBe(
+      false,
+    );
+    expect(helloReportsOpStream(Hello.fromPartial({}))).toBe(false);
+  });
+});
+
 // ── DB round-trip: the Hello refreshes has_display (both directions, no churn) ──
 
 let available = true;
@@ -159,22 +175,29 @@ function helloPayload(
   agentId: string,
   workspaceId: string,
   opts: {
-    desktop: boolean;
+    desktop?: boolean;
+    opStream?: boolean;
     desktopUnavailableReason?: string;
     display?: { id: string; width: number; height: number; virtual: boolean };
+    capabilitiesAbsent?: boolean;
   },
 ): Uint8Array {
   return Hello.encode(
     Hello.fromPartial({
       agentId,
       workspaceId,
-      capabilities: {
-        desktop: opts.desktop,
-        ...(opts.desktopUnavailableReason
-          ? { desktopUnavailableReason: opts.desktopUnavailableReason }
-          : {}),
-        ...(opts.display ? { display: opts.display } : {}),
-      },
+      ...(opts.capabilitiesAbsent
+        ? {}
+        : {
+            capabilities: {
+              desktop: opts.desktop ?? false,
+              opStream: opts.opStream ?? false,
+              ...(opts.desktopUnavailableReason
+                ? { desktopUnavailableReason: opts.desktopUnavailableReason }
+                : {}),
+              ...(opts.display ? { display: opts.display } : {}),
+            },
+          }),
     }),
   ).finish();
 }
@@ -259,6 +282,60 @@ describe("refreshEnrollmentDisplay — the Hello reconciles has_display", () => 
       hasDisplay: true,
     });
     expect(result.updated).toBe(false);
+  });
+
+  test("opStream=true flips the enrollment's op_stream false → true", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(false);
+
+    await handleHelloPayload(
+      db,
+      undefined,
+      helloPayload(enrollment.id, workspaceId, { desktop: false, opStream: true }),
+      `agent.${workspaceId}.${enrollment.id}.hello`,
+    );
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.opStream).toBe(true);
+  });
+
+  test("an UNCHANGED op-stream Hello writes nothing (no churn — updatedAt untouched)", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(false);
+    await refreshEnrollmentOpStream(db, {
+      workspaceId,
+      agentId: enrollment.id,
+      opStream: true,
+    });
+    const before = await getEnrollment(db, workspaceId, enrollment.id);
+
+    const result = await refreshEnrollmentOpStream(db, {
+      workspaceId,
+      agentId: enrollment.id,
+      opStream: true,
+    });
+    expect(result.updated).toBe(false);
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.opStream).toBe(true);
+    expect(after?.updatedAt).toBe(before!.updatedAt); // no write ⇒ updatedAt unchanged
+  });
+
+  test("a Hello with absent Capabilities leaves op_stream false", async () => {
+    if (!available) return;
+    const { workspaceId, enrollment } = await seedEnrollment(false);
+    const before = await getEnrollment(db, workspaceId, enrollment.id);
+
+    await handleHelloPayload(
+      db,
+      undefined,
+      helloPayload(enrollment.id, workspaceId, { capabilitiesAbsent: true }),
+      `agent.${workspaceId}.${enrollment.id}.hello`,
+    );
+
+    const after = await getEnrollment(db, workspaceId, enrollment.id);
+    expect(after?.opStream).toBe(false);
+    expect(after?.updatedAt).toBe(before!.updatedAt); // both capability refreshes no-op
   });
 
   test("a CAPTURE-BLOCKED Hello persists the reason (server-visible) with has_display=false", async () => {

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -47,6 +47,7 @@ import {
   SandboxLeaseSupersededError,
   SandboxImageConflictError,
   buildConnectionTokenResolver,
+  getEnrollment,
   type AppendEventInput,
   type ActiveSandboxPointer,
   type SandboxRecord,
@@ -151,6 +152,7 @@ import {
   routingEnabled,
   lazyProvisionEnabled,
 } from "../sandbox-routing";
+import { makeTurnOpJournal, type TurnHeartbeatDetails } from "../op-journal";
 import {
   makeMachineOpObserver,
   recordCreditMicros,
@@ -1018,6 +1020,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // run. null when the flag is off (byte-for-byte the legacy build-and-discard
     // path) OR when the backend is "none". Released + dropped in `finally`.
     let resolvedSandbox: ResumedTurnSandbox | null = null;
+    // The machine-primary SelfhostedSession (the UNWRAPPED backend, not the
+    // routing proxy): held so the turn's completion can final-ack this turn's
+    // settled op-stream ops AFTER the results are durably persisted.
+    let machinePrimarySession: import("@opengeni/runtime").SelfhostedSession | null = null;
     let lazyOwnedSandbox: EstablishedSandboxSession | null = null;
     let turnSandboxProvisioner: TurnSandboxProvisioner<ResumedTurnSandbox> | null = null;
     // The UN-PROXIED established box session, captured BEFORE wrapTurnBoxWithRouting.
@@ -1414,11 +1420,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           throw reason;
         }
       };
-      heartbeatTimer = startActivityHeartbeat(activityContext, {
+      // ONE shared details object for every heartbeat this activity sends (each
+      // site spreads it + its own phase), so cross-site fields — the op-stream
+      // settled roster in particular — survive last-write-wins instead of being
+      // clobbered by whichever site heartbeated most recently.
+      const heartbeatDetails: TurnHeartbeatDetails = {
         phase: "running",
         sessionId: input.sessionId,
         turnId,
-      });
+        opAcks: {},
+      };
+      const opJournal = makeTurnOpJournal(activityContext, heartbeatDetails);
+      heartbeatTimer = startActivityHeartbeat(activityContext, heartbeatDetails);
       let producerSeq = 0;
       // One producer per activity execution, not per turn: a turn can run
       // again on the same workflow (preemption resume, approval rerun), and
@@ -1445,16 +1458,15 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         }));
         await appendAndPublishEvents(db, bus, input.workspaceId, input.sessionId, inputs);
         activityContext?.heartbeat({
+          ...heartbeatDetails,
           phase: "events_published",
-          sessionId: input.sessionId,
-          turnId,
           producerSeq,
         });
         if (immediate) {
           await Bun.sleep(0);
         }
       };
-      activityContext?.heartbeat({ phase: "turn_started", sessionId: input.sessionId, turnId });
+      activityContext?.heartbeat({ ...heartbeatDetails, phase: "turn_started" });
 
       // A shutdown that landed during claim/billing setup preempts before the
       // turn visibly starts: nothing ran yet, so the requeued turn replays the
@@ -1942,21 +1954,35 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // stop, and bills ZERO warm-seconds). The session is a harmless in-memory
           // bind (no NATS round-trip), so build it FIRST; if the lease then fences,
           // there is nothing to clean up.
+          // Whether the machine's latest Hello advertised the op-stream engine
+          // (refreshed on every connect). Read only when the server flag is on —
+          // one indexed lookup, and the flag off keeps this path byte-identical.
+          const machineOpStream =
+            settings.agentOpStreamEnabled === true
+              ? (await getEnrollment(db, input.workspaceId, activeSandboxRecord!.enrollmentId!))
+                  ?.opStream === true
+              : false;
           const established = await establishSelfhostedTurnSession(
             {
               db,
               settings,
               bus,
               onOp: machineOpObserver.observer,
+              opJournal,
             },
             {
               workspaceId: input.workspaceId,
               agentId: activeSandboxRecord!.enrollmentId!,
+              opStream: machineOpStream,
               epoch: activeSandboxPointer!.activeEpoch,
               environment: sandboxEnvironment,
               workingDir: activeSandboxPointer!.workingDir,
             },
           );
+          // The machine-primary establish narrows `session` to SelfhostedSession
+          // (buildSelfhostedBackendSession); EstablishedSandboxSession widens it.
+          machinePrimarySession =
+            established.session as import("@opengeni/runtime").SelfhostedSession;
           const lease = await acquireSelfhostedLeaseForTurn(
             { db, settings },
             {
@@ -2862,6 +2888,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
 
         const finalOutput = String(stream.finalOutput ?? "");
         await reconcileConversationTruth();
+        // Op-stream durability fence: the tool outputs are now durably in the
+        // history store (a redispatch would NOT re-execute them), so this
+        // turn's settled ops may advance their acked frontier — journal persist
+        // then wire final ack (licensing the runner to GC its retained
+        // frames). Best-effort: a miss leaves the runner's retention TTL to
+        // reap, never fails a completed turn.
+        if (machinePrimarySession) {
+          try {
+            await machinePrimarySession.finalizeOpStreamOps();
+          } catch {
+            // The runner's retention TTL owns the fallback.
+          }
+        }
         if (settings.sessionHistorySource !== "items") {
           // Legacy conversation memory; in items mode the blob is only written
           // for requires_action pauses (the one RunState-only resume path).

--- a/apps/worker/src/op-journal.ts
+++ b/apps/worker/src/op-journal.ts
@@ -1,0 +1,46 @@
+// The Temporal adaptation of the op-stream durable-resume journal
+// (`OpStreamJournal`, @opengeni/runtime): the runtime leaf stays
+// Temporal-free; this is where its two seams bind to the activity.
+//
+// * `attachGeneration` — the consumer generation the runner fences zombie
+//   consumers by. `Info.attempt` CANNOT serve here: `runAgentTurn` runs with
+//   `maximumAttempts: 1`, so worker death is healed by the WORKFLOW
+//   redispatching a NEW activity whose attempt is 1 again. The activity's
+//   `currentAttemptScheduledTimestampMs` is Temporal-server-assigned and
+//   strictly larger for a later dispatch (death detection is bounded below by
+//   the 2-minute heartbeat timeout, far above ms resolution), so it is a
+//   monotonic generation with zero workflow plumbing. Intra-activity
+//   re-attaches (blip/gap heals) reuse it — the runner's equal-generation
+//   replay path.
+//
+// * `persistSettled` — the durable-before-wire-ack ordering hook: fold the
+//   settled op's frontier into the activity's shared heartbeat details and
+//   flush a heartbeat BEFORE the client publishes the final ack. The shared
+//   `details` object is the SAME one every other heartbeat site spreads, so a
+//   later phase heartbeat re-carries the roster instead of clobbering it.
+
+import type { Context } from "@temporalio/activity";
+import type { OpStreamJournal } from "@opengeni/runtime";
+
+/** The activity's shared heartbeat-details object: every heartbeat call site
+ *  spreads THIS one object (plus its own phase), so fields like the op-ack
+ *  roster survive across sites instead of being lost to last-write-wins. */
+export interface TurnHeartbeatDetails extends Record<string, unknown> {
+  /** Settled-op roster: durable op id → its exit seq (the final-ack frontier). */
+  opAcks: Record<string, string>;
+}
+
+export function makeTurnOpJournal(
+  context: Context | null,
+  details: TurnHeartbeatDetails,
+): OpStreamJournal {
+  return {
+    attachGeneration: () => String(context?.info.currentAttemptScheduledTimestampMs ?? 1),
+    persistSettled: (opId, exitSeq) => {
+      details.opAcks[opId] = exitSeq;
+      // Flush immediately (heartbeats are also sent on the 10s timer; this one
+      // exists so the persist precedes the wire final ack, not just eventually).
+      context?.heartbeat({ ...details, phase: "op_settled", at: new Date().toISOString() });
+    },
+  };
+}

--- a/apps/worker/src/sandbox-routing.ts
+++ b/apps/worker/src/sandbox-routing.ts
@@ -298,6 +298,25 @@ export function wrapLazyTurnBoxWithRouting(
   };
 }
 
+export type SelfhostedTurnSessionArgs = {
+  workspaceId: string;
+  /** The target machine's enrollment id == the agent subject id. */
+  agentId: string;
+  /** Whether the target machine advertised Capabilities.op_stream in its latest
+   *  Hello. The runtime-side transport gate must still require the server flag. */
+  opStream: boolean;
+  /** The active pointer's epoch — the control-op fence echoed to the agent. */
+  epoch: number;
+  /** The run's declared sandbox environment (the SAME object fed to buildAgent +
+   *  the manifest), threaded so the SDK's per-turn provided-session env delta is
+   *  empty. */
+  environment: Record<string, string>;
+  /** The session working directory (per-session pointer). Null ⇒ workspace_root. */
+  workingDir: string | null;
+};
+
+type LegacySelfhostedTurnSessionArgs = Omit<SelfhostedTurnSessionArgs, "opStream">;
+
 /**
  * Stage D machine-primary establish: bind the live SelfhostedSession for a turn
  * whose ACTIVE sandbox is a connected machine — WITHOUT establishing or leasing a
@@ -315,19 +334,7 @@ export function wrapLazyTurnBoxWithRouting(
  */
 export async function establishSelfhostedTurnSession(
   services: RoutingWiringServices,
-  args: {
-    workspaceId: string;
-    /** The target machine's enrollment id == the agent subject id. */
-    agentId: string;
-    /** The active pointer's epoch — the control-op fence echoed to the agent. */
-    epoch: number;
-    /** The run's declared sandbox environment (the SAME object fed to buildAgent +
-     *  the manifest), threaded so the SDK's per-turn provided-session env delta is
-     *  empty. */
-    environment: Record<string, string>;
-    /** The session working directory (per-session pointer). Null ⇒ workspace_root. */
-    workingDir: string | null;
-  },
+  args: SelfhostedTurnSessionArgs | LegacySelfhostedTurnSessionArgs,
 ): Promise<EstablishedSandboxSession> {
   const { settings, bus, onOp } = services;
   const { timeoutMs, execTimeoutMs } = selfhostedTimeoutsFromSettings(settings);

--- a/apps/worker/src/sandbox-routing.ts
+++ b/apps/worker/src/sandbox-routing.ts
@@ -21,6 +21,7 @@ import {
   buildSelfhostedBackendSession,
   makeActiveBackendResolver,
   NatsControlRpc,
+  NatsOpStreamTransport,
   RoutingSandboxSession,
   type ControlRpc,
   type EstablishedSandboxSession,
@@ -29,6 +30,8 @@ import {
   type RoutableSandbox,
   type SelfhostedOpObserver,
   type SelfhostedRelayConfig,
+  type OpStreamJournal,
+  type SelfhostedOpStreamDeps,
 } from "@opengeni/runtime";
 
 export type RoutingWiringServices = {
@@ -41,6 +44,11 @@ export type RoutingWiringServices = {
   /** The per-op observer wired into every selfhosted session this turn builds
    *  (out-of-band telemetry — op metrics + machine.* events). Absent ⇒ no-op. */
   onOp?: SelfhostedOpObserver;
+  /** The op-stream durable-resume journal (the Temporal adaptation from
+   *  op-journal.ts): attach generation + settled-frontier persistence. Absent ⇒
+   *  the runtime defaults (generation "1", no persistence) — tests / non-turn
+   *  callers. Only consulted when op-stream is actually enabled for the turn. */
+  opJournal?: OpStreamJournal;
 };
 
 export type RoutingWiringIds = {
@@ -332,12 +340,37 @@ type LegacySelfhostedTurnSessionArgs = Omit<SelfhostedTurnSessionArgs, "opStream
  * No NATS round-trip happens here — `resume()` just re-addresses the subject — so a
  * headless/offline machine binds fine; its ops surface agent_offline lazily.
  */
+/**
+ * The op-stream injection for a machine-primary turn: present iff the machine
+ * advertised `Capabilities.op_stream` in its latest Hello AND the server flag
+ * is on AND a bus exists to carry frames. The transport rides the SAME managed
+ * NATS connection as the control rpc (the bus's op-stream accessor); a bus
+ * without the accessor (a test double) simply yields no connection and the
+ * session falls back to the legacy exec on first use. Swap TARGETS resolved
+ * mid-turn stay legacy for now — their capability row is not at hand in the
+ * resolver, and legacy is always correct.
+ */
+function opStreamDepsFor(
+  services: RoutingWiringServices,
+  machineAdvertisesOpStream: boolean,
+): SelfhostedOpStreamDeps | undefined {
+  const { settings, bus, opJournal } = services;
+  if (!machineAdvertisesOpStream || settings.agentOpStreamEnabled !== true || !bus) {
+    return undefined;
+  }
+  return {
+    transport: new NatsOpStreamTransport(async () => bus.getOpStreamConnection?.() ?? null),
+    ...(opJournal !== undefined ? { journal: opJournal } : {}),
+  };
+}
+
 export async function establishSelfhostedTurnSession(
   services: RoutingWiringServices,
   args: SelfhostedTurnSessionArgs | LegacySelfhostedTurnSessionArgs,
 ): Promise<EstablishedSandboxSession> {
   const { settings, bus, onOp } = services;
   const { timeoutMs, execTimeoutMs } = selfhostedTimeoutsFromSettings(settings);
+  const opStream = opStreamDepsFor(services, "opStream" in args && args.opStream === true);
   const { client, session } = await buildSelfhostedBackendSession({
     workspaceId: args.workspaceId,
     agentId: args.agentId,
@@ -352,6 +385,10 @@ export async function establishSelfhostedTurnSession(
     execTimeoutMs,
     // Meter every control op (out-of-band telemetry) — no-op when unwired.
     ...(onOp !== undefined ? { onOp } : {}),
+    // The streaming exec transport — present iff the machine advertised the
+    // capability AND the server flag is on (latched per-op at OpStart; the
+    // legacy exec stays the permanent fallback wire form).
+    ...(opStream !== undefined ? { opStream } : {}),
   });
   return {
     client,

--- a/bun.lock
+++ b/bun.lock
@@ -376,6 +376,7 @@
       "name": "@opengeni/runtime",
       "version": "0.6.1",
       "dependencies": {
+        "@noble/hashes": "^1.8.0",
         "@openai/agents": "^0.11.6",
         "@openai/agents-extensions": "^0.11.6",
         "@opengeni/agent-proto": "workspace:*",
@@ -923,7 +924,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
-    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
@@ -2973,6 +2974,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@better-auth/utils/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -3020,6 +3023,8 @@
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
 
     "@typespec/ts-http-runtime/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "better-auth/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -143,6 +143,23 @@ cannot exit and leave invisible same-group work behind.
 An oversized reply is likewise returned as typed `PAYLOAD_TOO_LARGE`; neither
 backpressure nor a reply-size failure changes the machine's heartbeat state.
 
+### Streaming exec (op-stream)
+
+Runners that advertise the `op_stream` capability can serve exec over the
+op-stream protocol instead of the monolithic request/reply, when the server
+also sets `OPENGENI_AGENT_OP_STREAM_ENABLED=true` (default off; the legacy
+exec remains the permanent fallback wire form and the only form for older
+runners). Output streams as sequenced, credit-flowed frames the runner retains
+for replay: a connection blip mid-command detaches instead of killing the
+child, and the server re-attaches and collects the complete output byte-exact
+(blake3-verified). Each exec carries a durable op id derived from the model's
+tool call, and starting an op is idempotent by that id — a worker-death
+re-dispatch that re-executes the same tool call attaches to the
+already-running or completed op instead of re-running the command. The
+oversized-reply wall does not apply on this path; output is instead bounded by
+the runner's retention quotas, and exceeding them fails typed with exact
+counters, never silently truncated.
+
 ## Swap the active sandbox
 
 A session points at one active sandbox at a time. `swapActiveSandbox` re-points

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -501,6 +501,11 @@ const SettingsSchema = z.object({
   // z.coerce.boolean(), which coerces "false" -> true). Flipped per-environment via
   // the deploy-staging IaC secret/configmap pattern (dossier §17/§25.1).
   sandboxSelfhostedEnabled: EnvBoolean.default(false),
+  // Gates the op-stream (streaming exec) transport to Connected Machines. The
+  // runner must ALSO advertise Capabilities.op_stream; default off, and legacy
+  // request/reply exec is the permanent fallback. EnvBoolean (NOT
+  // z.coerce.boolean(), which coerces "false" -> true).
+  agentOpStreamEnabled: EnvBoolean.default(false),
   // The HMAC secret the control plane signs the enrollment bearer credential with
   // (the `oge_` envelope the agent presents back to the control plane). Optional:
   // when ABSENT and sandboxSelfhostedEnabled is on, the poll route reports the
@@ -1130,6 +1135,7 @@ export function getSettings(): Settings {
     sandboxOwnershipEnabled: optional("OPENGENI_SANDBOX_OWNERSHIP_ENABLED"),
     sandboxLazyProvisionEnabled: optional("OPENGENI_SANDBOX_LAZY_PROVISION"),
     sandboxSelfhostedEnabled: optional("OPENGENI_SANDBOX_SELFHOSTED_ENABLED"),
+    agentOpStreamEnabled: optional("OPENGENI_AGENT_OP_STREAM_ENABLED"),
     enrollmentSigningSecret: optional("OPENGENI_ENROLLMENT_SIGNING_SECRET"),
     selfhostedNatsUrl: optional("OPENGENI_SELFHOSTED_NATS_URL"),
     selfhostedRelayUrl: optional("OPENGENI_SELFHOSTED_RELAY_URL"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -332,6 +332,14 @@ describe("sandbox preparation profiles", () => {
     ).toBe(true);
   });
 
+  test("agent op-stream transport is gated off unless explicitly enabled", () => {
+    expect(withEnv({}, () => getSettings()).agentOpStreamEnabled).toBe(false);
+    expect(
+      withEnv({ OPENGENI_AGENT_OP_STREAM_ENABLED: "true" }, () => getSettings())
+        .agentOpStreamEnabled,
+    ).toBe(true);
+  });
+
   test("retries startup dependency operations with bounded backoff", async () => {
     const retries: string[] = [];
     let calls = 0;

--- a/packages/db/drizzle/0050_enrollment_op_stream.sql
+++ b/packages/db/drizzle/0050_enrollment_op_stream.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "enrollments" ADD COLUMN "op_stream" boolean DEFAULT false NOT NULL;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -11378,6 +11378,7 @@ export type EnrollmentRecord = {
   pubkey: string;
   exposure: EnrollmentExposure;
   hasDisplay: boolean;
+  opStream: boolean;
   /** Set when a display exists but capture is not permitted (macOS Screen Recording
    *  not granted); null when capture is permitted or the machine is headless. */
   desktopUnavailableReason: string | null;
@@ -11405,6 +11406,7 @@ function mapEnrollment(row: typeof schema.enrollments.$inferSelect): EnrollmentR
     pubkey: row.pubkey,
     exposure: row.exposure as EnrollmentExposure,
     hasDisplay: row.hasDisplay,
+    opStream: row.opStream,
     desktopUnavailableReason: row.desktopUnavailableReason ?? null,
     allowScreenControl: row.allowScreenControl,
     status: row.status as EnrollmentStatus,
@@ -11736,6 +11738,48 @@ export async function setEnrollmentDisplayState(
               ne(schema.enrollments.hasDisplay, input.hasDisplay),
               sql`${schema.enrollments.desktopUnavailableReason} IS DISTINCT FROM ${input.desktopUnavailableReason}`,
             ),
+          ),
+        )
+        .returning({ id: schema.enrollments.id });
+      return { updated: rows.length > 0 };
+    },
+  );
+}
+
+// Live op-stream cursor: the agent's connect Hello advertises whether it supports
+// the streaming exec transport. This is deliberately persisted separately from the
+// server rollout flag so routing can require BOTH server enablement and the live
+// runner capability; agents predating the op-stream engine remain false and keep
+// using legacy request/reply exec.
+//
+// CHANGE-GUARDED at the SQL layer: the write fires only when `op_stream` differs
+// from what the row already holds, so a steady-state Hello updates zero rows and
+// never churns. Returns whether a row was actually changed. Best-effort — the
+// caller swallows failures so capability refresh never breaks the agent's connect.
+export async function setEnrollmentOpStreamState(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    enrollmentId: string;
+    opStream: boolean;
+  },
+): Promise<{ updated: boolean }> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const rows = await scopedDb
+        .update(schema.enrollments)
+        .set({
+          opStream: input.opStream,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.enrollments.workspaceId, input.workspaceId),
+            eq(schema.enrollments.id, input.enrollmentId),
+            ne(schema.enrollments.opStream, input.opStream),
           ),
         )
         .returning({ id: schema.enrollments.id });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1342,6 +1342,9 @@ export const enrollments = pgTable(
       .notNull()
       .default("whole-machine"),
     hasDisplay: boolean("has_display").notNull().default(false),
+    // Refreshed from every connect Hello (Capabilities.op_stream); false for
+    // agents predating the op-stream engine.
+    opStream: boolean("op_stream").notNull().default(false),
     // When the machine has a display it CANNOT capture (macOS Screen Recording / TCC
     // not granted), the agent reports has_display=false AND a human, actionable reason
     // here (e.g. "grant Screen Recording in System Settings"). NULL means capture is

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -176,6 +176,19 @@ export interface RequestConnection {
 }
 
 /**
+ * The raw subscribe/publish surface the selfhosted OP-STREAM transport consumes
+ * (structurally identical to `@opengeni/runtime`'s `NatsOpStreamConnection`):
+ * a plain subscription for the runner's fire-and-forget op frames
+ * (`agent.<ws>.<id>.op.<op_id>`) and a plain publish for the server's acks
+ * (`agent.<ws>.<id>.ack`). Same managed connection as everything else — a NATS
+ * connection natively supports all of it; there is NEVER a second connection.
+ */
+export interface OpStreamConnection {
+  subscribe(subject: string): AsyncIterable<{ data: Uint8Array }> & { unsubscribe(): void };
+  publish(subject: string, payload: Uint8Array): void;
+}
+
+/**
  * A handler answering a request/reply on a subscribed subject: given the request
  * bytes (+ the concrete subject the message landed on, for `agent.<ws>.<id>.rpc`
  * style wildcard routing), return the response bytes to reply with. A thrown error
@@ -232,6 +245,12 @@ export type EventBus = {
    * plane injects this so the transport never opens a second connection.
    */
   getRequestConnection: () => RequestConnection;
+  /**
+   * The `OpStreamConnection` accessor the selfhosted op-stream transport
+   * consumes (`NatsOpStreamTransport`) — the same managed connection again.
+   * Optional so bus test doubles that never exercise op-stream stay valid.
+   */
+  getOpStreamConnection?: () => OpStreamConnection;
   isConnected?: () => boolean;
   close: () => Promise<void>;
 };
@@ -270,6 +289,12 @@ export async function createNatsEventBus(
   });
   const requestConnection: RequestConnection = {
     request: async (subject, payload, opts) => requestReply(nc, subject, payload, opts.timeout),
+  };
+  const opStreamConnection: OpStreamConnection = {
+    subscribe: (subject) => nc.subscribe(subject),
+    publish: (subject, payload) => {
+      nc.publish(subject, payload);
+    },
   };
   return {
     publish: async (workspaceId, sessionId, events) => {
@@ -310,6 +335,7 @@ export async function createNatsEventBus(
     subscribeRequests: (subject, handler) => subscribeRequests(nc, subject, handler),
     subscribeAgentEvents: (subject, handler) => subscribeAgentEvents(nc, subject, handler),
     getRequestConnection: () => requestConnection,
+    getOpStreamConnection: () => opStreamConnection,
     isConnected: () => connected && !nc.isClosed() && !nc.isDraining(),
     close: async () => {
       await nc.drain();

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -35,6 +35,7 @@
     "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "@openai/agents": "^0.11.6",
     "@openai/agents-extensions": "^0.11.6",
     "@opengeni/agent-proto": "workspace:*",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -140,6 +140,7 @@ import {
   restoredSandboxSessionStateFromEntry,
   setSelfhostedApplyDiff,
 } from "./sandbox";
+import { runWithToolCallCorrelation } from "./sandbox/op-correlation";
 import { computerUse, type ComputerToolMode } from "./sandbox-computer";
 import type { RuntimeMetricsHooks } from "./metrics";
 
@@ -1603,6 +1604,38 @@ function neutralizeStructuredToolTransport(
  * behaviour; the effective window only changes the server-path threshold when a
  * resolved model declares its own contextWindowTokens.
  */
+/**
+ * Wrap the shell capability's `exec_command` so its execution runs inside a
+ * tool-call correlation context (op-correlation.ts): the SDK's tool machinery
+ * passes `details.toolCall` (the model's function_call, with its durable
+ * `callId`) into every function-tool `invoke`, and binding an
+ * AsyncLocalStorage around the invocation makes that id visible to the sandbox
+ * transport underneath — which mints the DURABLE op id `{callId}:{ordinal}`
+ * (op-stream ruling B1). A re-dispatched turn re-executes the same
+ * function_call with the same callId, so the transport's idempotent OpStart
+ * ATTACHES to the already-running/completed op instead of re-running it.
+ * Without a callId (no details on the invocation) the tool runs unwrapped and
+ * the transport falls back to a random unique id — today's semantics.
+ */
+function withExecOpCorrelation(tools: Tool<unknown>[]): Tool<unknown>[] {
+  return tools.map((capabilityTool) => {
+    if (capabilityTool.type !== "function" || capabilityTool.name !== "exec_command") {
+      return capabilityTool;
+    }
+    const invoke = capabilityTool.invoke;
+    return {
+      ...capabilityTool,
+      invoke: (runContext, input, details) => {
+        const callId = details?.toolCall?.callId;
+        if (!callId) {
+          return invoke(runContext, input, details);
+        }
+        return runWithToolCallCorrelation(callId, () => invoke(runContext, input, details));
+      },
+    };
+  });
+}
+
 export function buildAgentCapabilities(
   settings: Settings,
   packSkills: PackSkill[],
@@ -1632,7 +1665,10 @@ export function buildAgentCapabilities(
   if (options.structuredToolTransport === false) {
     neutralizeStructuredToolTransport(filesystemCapability);
   }
-  const caps: ReturnType<typeof Capabilities.default> = [filesystemCapability, shell()];
+  const caps: ReturnType<typeof Capabilities.default> = [
+    filesystemCapability,
+    shell({ configureTools: withExecOpCorrelation }),
+  ];
   if (mode === "server") {
     caps.push(
       compaction({

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -248,7 +248,32 @@ export {
   type SelfhostedApplyDiff,
   type SelfhostedEditor,
   type SelfhostedImageOutput,
+  type SelfhostedOpStreamDeps,
 } from "./selfhosted/session";
+// The op-stream exec transport (op-stream protocol v1.1 — streaming exec to a
+// Connected Machine runner). The worker injects `NatsOpStreamTransport` (over
+// the same bus connection as the control rpc) plus an `OpStreamJournal`
+// adapted onto Temporal; sessions without the injection keep the legacy exec.
+export {
+  NatsOpStreamTransport,
+  OpStreamUnavailableError,
+  opAckSubject,
+  opFrameSubject,
+  type NatsOpStreamConnection,
+  type OpStreamSubscription,
+  type OpStreamTransport,
+} from "./selfhosted/op-transport";
+export {
+  OP_STREAM_ACK_INTERVAL_MS,
+  OP_STREAM_DEFAULT_WINDOW_BYTES,
+  OP_STREAM_RECONNECT_HOLD_MS,
+  OP_STREAM_SILENCE_TIMEOUT_MS,
+  type OpStreamExecOutcome,
+  type OpStreamJournal,
+} from "./selfhosted/op-stream";
+// The durable op-id correlation seam (B1): the runtime barrel BINDS it around
+// the SDK shell tool; the sandbox leaf READS it when minting op ids.
+export { nextDurableOpId, runWithToolCallCorrelation, sanitizeOpIdToken } from "./op-correlation";
 export {
   negotiateSelfhostedCapabilities,
   selfhostedLiveness,

--- a/packages/runtime/src/sandbox/op-correlation.ts
+++ b/packages/runtime/src/sandbox/op-correlation.ts
@@ -1,0 +1,70 @@
+// Durable op-identity correlation (op-stream ruling B1): the DURABLE op id a
+// sandbox transport op carries is `{sdk_tool_call_id}:{ordinal}` — minted ABOVE
+// the transport, at the semantic layer. The tool call id lives in the model's
+// function_call (persisted run history), so a re-dispatched turn re-executes the
+// SAME function_call with the SAME call id, and the transport's idempotent
+// OpStart turns an at-least-once re-execution into an ATTACH instead of a
+// re-run. The ordinal is the deterministic position of the physical sub-op
+// inside one tool invocation (a tool that performs read→write→rm mints :0, :1,
+// :2), so a re-executed invocation re-mints identical ids.
+//
+// The correlation rides an AsyncLocalStorage bound around the SDK tool's
+// `execute` (see `withExecOpCorrelation` in the runtime barrel): the SDK's tool
+// machinery passes `details.toolCall` (with `callId`) into every function-tool
+// invocation, and the shell capability's `configureTools` hook lets us wrap
+// exec_command without touching the SDK. Per-async-chain storage keeps PARALLEL
+// tool calls correctly separated.
+//
+// This module is deliberately dependency-free (node:async_hooks only) so the
+// agent-loop-free sandbox leaf may import it: the leaf READS the context; only
+// the runtime barrel (which owns the SDK imports) BINDS it.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface ToolCallCorrelation {
+  /** The sanitized sdk tool call id (a legal NATS subject-token fragment). */
+  callId: string;
+  /** The next sub-op ordinal within this tool invocation (mutable). */
+  ordinal: number;
+}
+
+const storage = new AsyncLocalStorage<ToolCallCorrelation>();
+
+/**
+ * Sanitize a tool call id into a legal NATS subject TOKEN fragment. The op id
+ * is interpolated into the per-op frame subject, whose tokens must not contain
+ * whitespace/control characters or the subject-structure characters (`.`,
+ * `*`, `>`); the runner refuses illegal ids loudly. The mapping is INJECTIVE
+ * (each disallowed char becomes `_<hex>_`), so two distinct call ids can never
+ * collide into one op id — a collision would merge two different execs through
+ * the idempotent-OpStart dedup and return the wrong result.
+ */
+export function sanitizeOpIdToken(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9_-]/g, (c) => `_${c.charCodeAt(0).toString(16)}_`);
+}
+
+/**
+ * Bind a tool-call correlation context around `fn` (the tool's execute). Every
+ * durable op id minted inside — however deep in the transport — is
+ * `{callId}:{ordinal}` with ordinals starting at 0 per invocation.
+ */
+export function runWithToolCallCorrelation<T>(callId: string, fn: () => T): T {
+  return storage.run({ callId: sanitizeOpIdToken(callId), ordinal: 0 }, fn);
+}
+
+/**
+ * Mint the next durable op id for the current tool invocation, or null when no
+ * correlation context is bound (a non-tool caller, e.g. Channel-A structural
+ * exec). Callers fall back to a random unique id — safe (never collides, never
+ * wrongly dedups), merely not stable across a turn re-dispatch, which degrades
+ * that one op to today's at-least-once semantics.
+ */
+export function nextDurableOpId(): string | null {
+  const context = storage.getStore();
+  if (!context) {
+    return null;
+  }
+  const ordinal = context.ordinal;
+  context.ordinal += 1;
+  return `${context.callId}:${ordinal}`;
+}

--- a/packages/runtime/src/sandbox/selfhosted/fault-rendering.ts
+++ b/packages/runtime/src/sandbox/selfhosted/fault-rendering.ts
@@ -110,6 +110,26 @@ export function renderSelfhostedFault(error: SelfhostedControlError): string {
   const detail = error.detail;
 
   if (error.payloadTooLarge || error.code === ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE) {
+    // The STREAMING retention-ceiling overflow (op-stream OP_OVERFLOW) is a
+    // different truth than the legacy reply-size wall: the machine STOPPED the
+    // command at the ceiling (it did not run to completion), and none of its
+    // output was returned. Same correct next action, honest distinct fields.
+    if (detail.failure_code === "OP_OVERFLOW") {
+      const retained = detail.retained_bytes
+        ? `after retaining ${detail.retained_bytes} bytes of output`
+        : "when its output exceeded what the machine can retain for delivery";
+      return assemble(error, {
+        headline: "the command produced more output than the machine link can deliver",
+        happened: `the machine stopped the command ${retained} — its output-retention ceiling was reached`,
+        layer:
+          "the machine link's output-retention ceiling — the command was terminated at the ceiling, not by its own logic",
+        preserved:
+          "no output was returned, and the command did NOT run to completion — any side effects up to the stop point may have applied.",
+        tryNext:
+          "re-run with the output bounded: redirect to a file (`> /tmp/out.log 2>&1`) then read it " +
+          "back in ranges/chunks, or slice it with `head -c` / `tail -c` / `head` / `tail`.",
+      });
+    }
     const sizes =
       detail.encoded_bytes && detail.max_payload
         ? `its ${detail.encoded_bytes}-byte reply exceeded the machine link's ${detail.max_payload}-byte per-message limit`

--- a/packages/runtime/src/sandbox/selfhosted/op-stream.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-stream.ts
@@ -299,6 +299,14 @@ class OpConsumer {
     outcome: OpStreamExecOutcome;
     exitSeq: string;
   }> {
+    // Arm the settle promise FIRST: frames can start applying the moment the
+    // attach below returns (replay is asynchronous), and a completion that
+    // fires before the resolver exists would strand the op on its wall.
+    const settled = new Promise<void>((resolve, reject) => {
+      this.settleResolve = resolve;
+      this.settleReject = reject;
+    });
+
     // Subscription BEFORE OpStart (protocol invariant): no frame can be
     // published before the consumer exists on a healthy path.
     this.subscription = await this.deps.transport.subscribe(
@@ -317,11 +325,6 @@ class OpConsumer {
     this.ackTimer = setInterval(() => {
       void this.sendAck();
     }, this.ackIntervalMs);
-
-    const settled = new Promise<void>((resolve, reject) => {
-      this.settleResolve = resolve;
-      this.settleReject = reject;
-    });
     const liveness = this.watchLiveness(wallMs);
     try {
       await Promise.race([settled, liveness.wall]);

--- a/packages/runtime/src/sandbox/selfhosted/op-stream.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-stream.ts
@@ -783,7 +783,10 @@ function runnerFailureToControlError(exit: OpExit): SelfhostedControlError {
       reason: null,
       retryable: false,
       payloadTooLarge: true,
-      detail: exit.failureDetail,
+      // failure_code lets the fault renderer distinguish the retention-ceiling
+      // overflow (command TERMINATED at the ceiling) from the legacy reply-size
+      // wall (command ran to completion) — the four fields must tell the truth.
+      detail: { ...exit.failureDetail, failure_code: exit.failureCode },
     });
   }
   return new SelfhostedControlError({

--- a/packages/runtime/src/sandbox/selfhosted/op-stream.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-stream.ts
@@ -1,0 +1,795 @@
+// The op-stream EXEC client (op-stream protocol v1.1, server half; PROTOCOL.md
+// + ENGINE-INTEGRATION.md step 6 in .agent/).
+//
+// Replaces the legacy monolithic exec request/reply with sequenced, acked,
+// credit-flowed frames when the runner advertises `Capabilities.op_stream` AND
+// the server flag is on. What it buys, in order of importance:
+//
+//   * ATTACH-NOT-RERUN (B1/B2): the op id is durable (`{tool_call_id}:{ordinal}`)
+//     and OpStart is idempotent by it — a re-dispatched turn that re-executes the
+//     same function_call COLLECTS the already-running/completed op instead of
+//     re-running the command. The at-least-once re-run hazard dies here.
+//   * No reply-size wall: output streams in ≤128 KiB frames; the runner retains
+//     ring→spool for replay, and a too-big stream fails TYPED (OP_OVERFLOW with
+//     exact counters), never silently truncated.
+//   * Blip tolerance: a connection loss detaches, never kills; frames resume via
+//     OpAttach replay (gap-triggered attach is a ROUTINE heal, incl. seq-0 loss).
+//
+// ACK POLICY (design delta Δ2, DESIGN-OPSTREAM-CLIENT.md): mid-op acks are
+// CREDIT-ONLY — `OpAck{acked_seq: 0, credit_bytes: received_total + window}`.
+// The runner FREES retained frames at acked_seq, and a re-dispatched consumer
+// must reassemble from seq 0 (its predecessor's buffered bytes died with it),
+// so no mid-op acked_seq > 0 is ever durably backed. Credit is an ABSOLUTE
+// window replacement on the wire, so growing it keeps the child flowing while
+// the runner retains everything (bounded by its ring+spool quotas — the honest
+// output ceiling, typed when hit). The acked frontier advances exactly once,
+// at the FINAL ack, after the consumed result is durable (the hard gate's
+// ordering: result durable → journal persist → wire final ack — see
+// `finalizeSettledOps`).
+//
+// Everything above the transport is unchanged: the caller builds the same
+// `ExecRequest`, receives the same `ExecResponse` shape, and every failure is a
+// `SelfhostedControlError` in the existing taxonomy so the fault renderer and
+// the op observer behave identically across the transport swap.
+
+import { blake3 } from "@noble/hashes/blake3";
+import { bytesToHex } from "@noble/hashes/utils";
+import {
+  ControlRequest,
+  ErrorCode,
+  OpAck,
+  OpChannel,
+  OpFrame,
+  OpLostReason,
+  OpState,
+  type ExecRequest,
+  type ExecResponse,
+  type OpExit,
+  type OpStatus,
+} from "@opengeni/agent-proto";
+import {
+  agentErrorToControlError,
+  SelfhostedControlError,
+  timeoutAgentError,
+  type ControlRpc,
+} from "./control-rpc";
+import { selfhostedRetryBackoffMs, type SelfhostedRetryClock } from "./retry-policy";
+import {
+  opAckSubject,
+  opFrameSubject,
+  OpStreamUnavailableError,
+  type OpStreamSubscription,
+  type OpStreamTransport,
+} from "./op-transport";
+
+/** Initial send-credit window (bytes) when the caller does not size it. Matches
+ *  the wire default OpStart advertises (~4 MiB). */
+export const OP_STREAM_DEFAULT_WINDOW_BYTES = 4 * 1024 * 1024;
+/** Cumulative-ack repetition cadence while an op is live (ruling M1: acks are
+ *  best-effort and healed by repetition). */
+export const OP_STREAM_ACK_INTERVAL_MS = 5_000;
+/** Frame-silence threshold before the client starts probing with OpQuery. The
+ *  runner emits Progress every 5s while an op is alive and quiet, so 30s of
+ *  TOTAL silence means frames are not reaching us (or the op is gone). */
+export const OP_STREAM_SILENCE_TIMEOUT_MS = 30_000;
+/** How long a silent op is held open across a machine reconnect window before
+ *  the client fails it typed (PROTOCOL liveness rule: hold ≤120s, then only a
+ *  definitive answer fails the op). */
+export const OP_STREAM_RECONNECT_HOLD_MS = 120_000;
+/** Bound on stashed out-of-order frames per op (each ≤128 KiB payload). A gap
+ *  that outgrows this is healed by attach-replay, not by buffering forever. */
+const OP_STREAM_MAX_STASHED_FRAMES = 4_096;
+/** OpStart DRAINING retry budget — mirrors the legacy exec's patient budget
+ *  (retry-policy.ts): op start is not latency-critical and a saturated machine
+ *  should queue, not fail. OpStart is idempotent by op id, so timeout blips are
+ *  also safe to re-issue (unlike legacy exec) — same small bounded budget. */
+const OP_START_DRAINING_MAX_RETRIES = 10;
+const OP_START_BLIP_MAX_RETRIES = 3;
+
+/**
+ * The durable-resume journal the worker adapts onto Temporal (design delta Δ1:
+ * the attach generation is `Info.currentAttemptScheduledTimestampMs` — strictly
+ * monotonic across worker-death redispatches, which `Info.attempt` is NOT under
+ * `maximumAttempts: 1`). `persistSettled` folds the op's settled frontier into
+ * the activity heartbeat details and MUST complete before the wire final ack
+ * (the durable-before-wire-ack gate); the default no-journal client (tests,
+ * non-activity callers) uses generation "1" and skips persistence.
+ */
+export interface OpStreamJournal {
+  /** The consumer's attach generation (u64 decimal string). */
+  attachGeneration(): string;
+  /** Durably record `opId` as settled at `exitSeq` BEFORE its final ack. */
+  persistSettled(opId: string, exitSeq: string): void | Promise<void>;
+}
+
+export interface OpStreamExecClientDeps {
+  workspaceId: string;
+  agentId: string;
+  /** The lease/active epoch every ControlRequest is fenced under. */
+  epoch: number;
+  /** The rpc request/reply seam (OpStart/OpQuery/OpAttach ride here). */
+  controlRpc: ControlRpc;
+  /** The rpc subject (`agent.<ws>.<id>.rpc`). */
+  rpcSubject: string;
+  /** The frame/ack seam (subscribe + publish). */
+  transport: OpStreamTransport;
+  journal?: OpStreamJournal;
+  windowBytes?: number;
+  /** Control-op round-trip timeout for OpStart/OpQuery/OpAttach (the SHORT
+   *  control budget, not the exec deadline). */
+  controlTimeoutMs: number;
+  /** The retry clock (sleep + jitter), injected for deterministic tests. */
+  retryClock: SelfhostedRetryClock;
+  ackIntervalMs?: number;
+  silenceTimeoutMs?: number;
+  reconnectHoldMs?: number;
+}
+
+/** A completed op-stream exec: the legacy-shaped response plus the healing
+ *  telemetry the session folds into its op observation. */
+export interface OpStreamExecOutcome {
+  response: ExecResponse;
+  /** Attach/query heals that occurred after streaming began (gap replays,
+   *  silence probes that re-attached). >0 marks the op `healed`. */
+  heals: number;
+  /** OpStart-level retries (draining/blip) before the op was accepted. */
+  startRetries: number;
+  /** Total reassembled Data payload bytes (the observer's replyBytes). */
+  replyBytes: number;
+}
+
+/** One op settled but not yet final-acked (awaiting the turn's durable point). */
+interface SettledOp {
+  opId: string;
+  exitSeq: string;
+  generation: string;
+}
+
+const OP_CHANNEL_NAMES: Partial<Record<OpChannel, "stdout" | "stderr">> = {
+  [OpChannel.OP_CHANNEL_STDOUT]: "stdout",
+  [OpChannel.OP_CHANNEL_STDERR]: "stderr",
+};
+
+/**
+ * The per-session op-stream exec client. One instance per `SelfhostedSession`;
+ * `exec()` runs one op end-to-end; `finalizeSettledOps()` is the turn-end hook
+ * that advances the acked frontier durably (journal) and then on the wire.
+ */
+export class OpStreamExecClient {
+  private readonly deps: OpStreamExecClientDeps;
+  private readonly settled: SettledOp[] = [];
+  private readonly inFlight = new Set<string>();
+
+  constructor(deps: OpStreamExecClientDeps) {
+    this.deps = deps;
+  }
+
+  private generation(): string {
+    return this.deps.journal?.attachGeneration() ?? "1";
+  }
+
+  /**
+   * Run one exec over the op stream. `opId` is the durable id (B1) — a re-issue
+   * with the same id attaches instead of re-running. `deadlineMs` is the exec
+   * process budget (relative); the runner's enforcement is authoritative.
+   * `wallMs` is the client-side give-up wall (deadline + reply grace).
+   */
+  async exec(
+    opId: string,
+    exec: ExecRequest,
+    deadlineMs: number,
+    wallMs: number,
+  ): Promise<OpStreamExecOutcome> {
+    if (this.inFlight.has(opId)) {
+      throw new SelfhostedControlError({
+        message: `op-stream exec: duplicate concurrent op id ${opId}`,
+        code: ErrorCode.ERROR_CODE_PROTOCOL,
+        reason: null,
+        retryable: false,
+      });
+    }
+    this.inFlight.add(opId);
+    try {
+      const consumer = new OpConsumer(this.deps, opId, this.generation());
+      try {
+        const outcome = await consumer.run(exec, deadlineMs, wallMs);
+        this.settled.push({ opId, exitSeq: outcome.exitSeq, generation: consumer.generation });
+        return outcome.outcome;
+      } finally {
+        consumer.teardown();
+      }
+    } finally {
+      this.inFlight.delete(opId);
+    }
+  }
+
+  /**
+   * The turn-end durability hook (the hard gate's ordering): for every op whose
+   * result the turn has durably consumed — (1) already true when this runs —
+   * (2) persist the settled frontier to the journal, then (3) publish the wire
+   * final ack (`acked_seq = exit_seq, final = true`), which licenses the runner
+   * to GC the op. A kill between (2) and (3) is safe: the re-dispatched turn
+   * does not re-execute a durably-recorded call, and the runner's retention TTL
+   * reaps the never-final-acked op — no loss, bounded residue. Publish failures
+   * are swallowed for the same reason.
+   */
+  async finalizeSettledOps(): Promise<void> {
+    const ackSubject = opAckSubject(this.deps.workspaceId, this.deps.agentId);
+    while (this.settled.length > 0) {
+      // Non-null: length checked above (single-threaded event loop).
+      const op = this.settled.shift() as SettledOp;
+      await this.deps.journal?.persistSettled(op.opId, op.exitSeq);
+      const ack = OpAck.encode({
+        opId: op.opId,
+        ackedSeq: op.exitSeq,
+        creditBytes: "0",
+        final: true,
+        attachGeneration: op.generation,
+      }).finish();
+      try {
+        await this.deps.transport.publish(ackSubject, ack);
+      } catch {
+        // Best-effort: the runner's retention TTL owns the fallback.
+      }
+    }
+  }
+}
+
+/** Internal per-op consumer: subscription, reassembly, flow, liveness. */
+class OpConsumer {
+  private readonly deps: OpStreamExecClientDeps;
+  private readonly opId: string;
+  readonly generation: string;
+  private readonly windowBytes: number;
+
+  /** Highest contiguously APPLIED seq (frames start at 1; 0 = none yet). */
+  private lastApplied = 0n;
+  private readonly stash = new Map<bigint, OpFrame>();
+  private readonly chunks: { stdout: Uint8Array[]; stderr: Uint8Array[] } = {
+    stdout: [],
+    stderr: [],
+  };
+  private receivedPayloadBytes = 0n;
+  private creditAtLastAck = 0n;
+  private exit: OpExit | undefined;
+  private exitSeq: bigint | undefined;
+  private heals = 0;
+  private lastFrameAt: number;
+  private silenceSince: number | undefined;
+  private attachInFlight = false;
+  private subscription: OpStreamSubscription | undefined;
+  private ackTimer: ReturnType<typeof setInterval> | undefined;
+  private settleResolve: (() => void) | undefined;
+  private settleReject: ((error: unknown) => void) | undefined;
+  private torn = false;
+
+  constructor(deps: OpStreamExecClientDeps, opId: string, generation: string) {
+    this.deps = deps;
+    this.opId = opId;
+    this.generation = generation;
+    this.windowBytes = deps.windowBytes ?? OP_STREAM_DEFAULT_WINDOW_BYTES;
+    this.lastFrameAt = Date.now();
+  }
+
+  private get ackIntervalMs(): number {
+    return this.deps.ackIntervalMs ?? OP_STREAM_ACK_INTERVAL_MS;
+  }
+  private get silenceTimeoutMs(): number {
+    return this.deps.silenceTimeoutMs ?? OP_STREAM_SILENCE_TIMEOUT_MS;
+  }
+  private get reconnectHoldMs(): number {
+    return this.deps.reconnectHoldMs ?? OP_STREAM_RECONNECT_HOLD_MS;
+  }
+
+  teardown(): void {
+    this.torn = true;
+    if (this.ackTimer) {
+      clearInterval(this.ackTimer);
+      this.ackTimer = undefined;
+    }
+    this.subscription?.unsubscribe();
+    this.subscription = undefined;
+  }
+
+  async run(
+    exec: ExecRequest,
+    deadlineMs: number,
+    wallMs: number,
+  ): Promise<{
+    outcome: OpStreamExecOutcome;
+    exitSeq: string;
+  }> {
+    // Subscription BEFORE OpStart (protocol invariant): no frame can be
+    // published before the consumer exists on a healthy path.
+    this.subscription = await this.deps.transport.subscribe(
+      opFrameSubject(this.deps.workspaceId, this.deps.agentId, this.opId),
+      (payload) => this.onFramePayload(payload),
+    );
+
+    const startRetries = await this.startOp(exec, deadlineMs);
+
+    // The universal begin (B2): attach from our contiguous frontier under the
+    // initial window — for a FRESH op that is seq 0 (replay nothing, start live
+    // flow); for a KNOWN op (re-dispatch) it replays everything we do not hold.
+    await this.attach(this.windowBytes);
+
+    // Cumulative-ack repetition (M1) — the periodic leg.
+    this.ackTimer = setInterval(() => {
+      void this.sendAck();
+    }, this.ackIntervalMs);
+
+    const settled = new Promise<void>((resolve, reject) => {
+      this.settleResolve = resolve;
+      this.settleReject = reject;
+    });
+    const liveness = this.watchLiveness(wallMs);
+    try {
+      await Promise.race([settled, liveness.wall]);
+    } finally {
+      liveness.stop();
+    }
+
+    // Settled: the exit frame and every frame before it are applied.
+    const exit = this.exit as OpExit;
+    const exitSeq = this.exitSeq as bigint;
+    this.verifyByteExact(exit);
+    if (exit.failureCode) {
+      throw runnerFailureToControlError(exit);
+    }
+    const stdout = concatChunks(this.chunks.stdout);
+    const stderr = concatChunks(this.chunks.stderr);
+    return {
+      outcome: {
+        response: {
+          exitCode: exit.exitCode,
+          stdout,
+          stderr,
+          timedOut: exit.timedOut,
+          durationMs: exit.durationMs,
+        },
+        heals: this.heals,
+        startRetries,
+        replyBytes: stdout.byteLength + stderr.byteLength,
+      },
+      exitSeq: exitSeq.toString(),
+    };
+  }
+
+  /** OpStart with the patient DRAINING budget and a small blip budget. OpStart
+   *  is IDEMPOTENT BY OP ID (the request id), so a timed-out/never-sent start
+   *  is safe to re-issue even though exec mutates — the runner either never saw
+   *  it or answers the SAME op. The stable request id is what makes that true. */
+  private async startOp(exec: ExecRequest, deadlineMs: number): Promise<number> {
+    let drainingRetries = 0;
+    let blipRetries = 0;
+    for (;;) {
+      try {
+        const result = await this.controlOp(
+          {
+            $case: "opStart",
+            opStart: {
+              op: { $case: "exec", exec },
+              windowBytes: String(this.windowBytes),
+              // Absolute epoch deadline (the runner's clock decides the actual
+              // budget; host clock skew shifts it — a known wire caveat).
+              deadlineMs: deadlineMs > 0 ? String(Date.now() + deadlineMs) : "0",
+              originId: this.deps.rpcSubject,
+            },
+          },
+          this.opId,
+        );
+        if (result.$case !== "opStart") {
+          throw protocolError(`op-stream start: unexpected result ${result.$case}`);
+        }
+        const status = result.opStart.status;
+        if (!result.opStart.accepted) {
+          throw this.refusedStart(status);
+        }
+        if (status?.state === OpState.OP_STATE_LOST) {
+          throw lostToControlError(status);
+        }
+        return drainingRetries + blipRetries;
+      } catch (error) {
+        if (!(error instanceof SelfhostedControlError)) {
+          throw error;
+        }
+        // A PROTOCOL/UNSUPPORTED refusal of the START ITSELF means the runner
+        // does not speak op-stream (a capability/downgrade race — M8 latches
+        // the transport per-op, and the legacy exec is the permanent fallback
+        // wire form). The op provably never started, so falling back is safe.
+        if (
+          error.code === ErrorCode.ERROR_CODE_PROTOCOL ||
+          error.code === ErrorCode.ERROR_CODE_UNSUPPORTED
+        ) {
+          throw new OpStreamUnavailableError(
+            `the runner refused OpStart (${error.message}); falling back to the legacy exec`,
+          );
+        }
+        const blip = error.reason === "agent_reconnecting" || error.neverSent;
+        if (error.draining && drainingRetries < OP_START_DRAINING_MAX_RETRIES) {
+          await this.deps.retryClock.sleep(
+            selfhostedRetryBackoffMs(drainingRetries, this.deps.retryClock.jitter()),
+          );
+          drainingRetries += 1;
+          continue;
+        }
+        if (blip && blipRetries < OP_START_BLIP_MAX_RETRIES) {
+          await this.deps.retryClock.sleep(
+            selfhostedRetryBackoffMs(blipRetries, this.deps.retryClock.jitter()),
+          );
+          blipRetries += 1;
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private refusedStart(status: OpStatus | undefined): SelfhostedControlError {
+    if (status?.state === OpState.OP_STATE_LOST) {
+      return lostToControlError(status);
+    }
+    return protocolError("op-stream start: the runner refused the op without a typed reason");
+  }
+
+  /** One control op on the rpc subject; throws the mapped
+   *  `SelfhostedControlError` on any AgentError. `requestId` is overridable
+   *  because OpStart's REQUEST ID IS THE OP ID (its idempotency key) and must
+   *  be STABLE across retries — every other op uses a fresh UUID per attempt. */
+  private async controlOp(
+    op: NonNullable<ControlRequest["op"]>,
+    requestId: string = crypto.randomUUID(),
+  ) {
+    const res = await this.deps.controlRpc.request(
+      this.deps.rpcSubject,
+      { requestId, epoch: this.deps.epoch, op },
+      { timeoutMs: this.deps.controlTimeoutMs },
+    );
+    if (res.error || !res.result) {
+      throw agentErrorToControlError(
+        res.error ?? {
+          code: ErrorCode.ERROR_CODE_PROTOCOL,
+          message: "agent returned an empty control response",
+          retryable: false,
+          detail: {},
+        },
+      );
+    }
+    return res.result;
+  }
+
+  /** OpAttach from the contiguous frontier. `windowBytes` sizes the fresh
+   *  replay window; 0 = reuse the OpStart grant (the gap-heal path). */
+  private async attach(windowBytes: number): Promise<OpStatus> {
+    const result = await this.controlOp({
+      $case: "opAttach",
+      opAttach: {
+        opId: this.opId,
+        fromSeq: this.lastApplied.toString(),
+        attachGeneration: this.generation,
+        windowBytes: String(windowBytes),
+      },
+    });
+    if (result.$case !== "opStatus") {
+      throw protocolError(`op-stream attach: unexpected result ${result.$case}`);
+    }
+    if (result.opStatus.state === OpState.OP_STATE_LOST) {
+      throw lostToControlError(result.opStatus);
+    }
+    return result.opStatus;
+  }
+
+  /** Gap/silence heal: one re-attach in flight at a time; each success counts
+   *  as a heal (the observer's `healed` breadcrumb). Failures are left to the
+   *  liveness watcher — a dead link fails typed there, not here. */
+  private requestAttachHeal(): void {
+    if (this.attachInFlight || this.torn) {
+      return;
+    }
+    this.attachInFlight = true;
+    void this.attach(0)
+      .then(() => {
+        this.heals += 1;
+      })
+      .catch((error) => {
+        if (error instanceof SelfhostedControlError && !error.retryable && !error.agentOffline) {
+          this.settleReject?.(error);
+        }
+      })
+      .finally(() => {
+        this.attachInFlight = false;
+      });
+  }
+
+  private onFramePayload(payload: Uint8Array): void {
+    let frame: OpFrame;
+    try {
+      frame = OpFrame.decode(payload);
+    } catch {
+      // A torn frame never kills the subscription; the seq gap it leaves is
+      // healed by attach-replay.
+      return;
+    }
+    if (frame.opId !== this.opId) {
+      return;
+    }
+    this.lastFrameAt = Date.now();
+    this.silenceSince = undefined;
+    const seq = BigInt(frame.seq);
+    if (seq <= this.lastApplied) {
+      return; // Duplicate (re-delivery / replay overlap) — reassembly is seq-idempotent.
+    }
+    if (seq !== this.lastApplied + 1n) {
+      // Out of order: stash and ask for the gap. Replay heals from the frontier,
+      // so an overgrown stash is dropped, not grown without bound.
+      if (this.stash.size < OP_STREAM_MAX_STASHED_FRAMES) {
+        this.stash.set(seq, frame);
+      }
+      this.requestAttachHeal();
+      return;
+    }
+    this.applyFrame(frame);
+    // Drain any stashed continuation.
+    for (;;) {
+      const next = this.stash.get(this.lastApplied + 1n);
+      if (!next) {
+        break;
+      }
+      this.stash.delete(this.lastApplied + 1n);
+      this.applyFrame(next);
+    }
+    this.maybeSettle();
+    this.maybeGrantCredit();
+  }
+
+  private applyFrame(frame: OpFrame): void {
+    this.lastApplied = BigInt(frame.seq);
+    const body = frame.body;
+    if (!body) {
+      return;
+    }
+    switch (body.$case) {
+      case "data": {
+        const channel = OP_CHANNEL_NAMES[body.data.channel];
+        if (channel) {
+          this.chunks[channel].push(body.data.bytes);
+        }
+        this.receivedPayloadBytes += BigInt(body.data.bytes.byteLength);
+        break;
+      }
+      case "progress":
+        // A liveness tick; echo our cumulative ack (M1's on-progress leg).
+        void this.sendAck();
+        break;
+      case "exit":
+        this.exit = body.exit;
+        this.exitSeq = BigInt(frame.seq);
+        break;
+    }
+  }
+
+  private maybeSettle(): void {
+    if (this.exitSeq !== undefined && this.lastApplied >= this.exitSeq) {
+      this.settleResolve?.();
+    }
+  }
+
+  /** Prompt credit replenishment: the periodic ack alone would stall a fast
+   *  child for up to the ack interval each window; grant as soon as half the
+   *  window has been consumed since the last grant. */
+  private maybeGrantCredit(): void {
+    if (this.receivedPayloadBytes - this.creditAtLastAck >= BigInt(this.windowBytes) / 2n) {
+      void this.sendAck();
+    }
+  }
+
+  /** The mid-op cumulative ack: CREDIT-ONLY (Δ2 — acked_seq stays 0 so the
+   *  runner retains every frame for a possible successor consumer; the credit
+   *  is an absolute replacement sized to keep ~one window of live headroom). */
+  private async sendAck(): Promise<void> {
+    if (this.torn) {
+      return;
+    }
+    this.creditAtLastAck = this.receivedPayloadBytes;
+    const ack = OpAck.encode({
+      opId: this.opId,
+      ackedSeq: "0",
+      creditBytes: (this.receivedPayloadBytes + BigInt(this.windowBytes)).toString(),
+      final: false,
+      attachGeneration: this.generation,
+    }).finish();
+    try {
+      await this.deps.transport.publish(
+        opAckSubject(this.deps.workspaceId, this.deps.agentId),
+        ack,
+      );
+    } catch {
+      // Acks are best-effort and healed by repetition (M1).
+    }
+  }
+
+  /**
+   * The liveness watcher: probes a silent op with OpQuery, re-attaches when the
+   * runner is ahead of us (frames lost in flight), holds a quiet-but-alive op
+   * open through the reconnect window, and enforces the client-side wall.
+   * Resolves only by rejection (typed failure) or by `stop()` at settle.
+   */
+  private watchLiveness(wallMs: number): { wall: Promise<never>; stop: () => void } {
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const wall = new Promise<never>((_, reject) => {
+      const startedAt = Date.now();
+      const tick = async () => {
+        if (stopped) {
+          return;
+        }
+        try {
+          if (Date.now() - startedAt >= wallMs) {
+            // The runner enforces the exec deadline and emits Exit{timed_out};
+            // reaching OUR wall means even that terminal frame never arrived —
+            // the same ambiguity as a legacy reply timeout, surfaced the same.
+            reject(agentErrorToControlError(timeoutAgentError()));
+            return;
+          }
+          if (Date.now() - this.lastFrameAt >= this.silenceTimeoutMs) {
+            await this.probeSilence(reject);
+          }
+        } catch (error) {
+          reject(error);
+          return;
+        }
+        timer = setTimeout(tick, Math.min(this.silenceTimeoutMs / 3, 2_500));
+      };
+      timer = setTimeout(tick, Math.min(this.silenceTimeoutMs / 3, 2_500));
+    });
+    return {
+      wall,
+      stop: () => {
+        stopped = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+      },
+    };
+  }
+
+  /** One silence probe: OpQuery the op; a definitive answer acts, an offline /
+   *  blip answer holds through the reconnect window, then fails typed. */
+  private async probeSilence(reject: (error: unknown) => void): Promise<void> {
+    this.silenceSince ??= Date.now();
+    try {
+      const result = await this.controlOp({ $case: "opQuery", opQuery: { opId: this.opId } });
+      if (result.$case !== "opStatus") {
+        throw protocolError(`op-stream query: unexpected result ${result.$case}`);
+      }
+      const status = result.opStatus;
+      if (status.state === OpState.OP_STATE_LOST) {
+        reject(lostToControlError(status));
+        return;
+      }
+      // Alive on the runner. If it is ahead of our frontier, frames were lost
+      // in flight — re-attach to replay them (this also restores live flow
+      // after a reconnect). A quiet-but-current op just keeps holding.
+      if (BigInt(status.nextSeq) > this.lastApplied + 1n) {
+        this.requestAttachHeal();
+      }
+    } catch (error) {
+      if (!(error instanceof SelfhostedControlError)) {
+        throw error;
+      }
+      const transient =
+        error.agentOffline || error.reason === "agent_reconnecting" || error.draining;
+      if (!transient) {
+        throw error;
+      }
+      const heldFor = Date.now() - (this.silenceSince ?? Date.now());
+      if (heldFor >= this.reconnectHoldMs) {
+        // The hold window expired without the machine coming back — surface
+        // the LAST probe's typed error (offline/reconnecting), same taxonomy
+        // as the legacy path.
+        reject(error);
+      }
+      // Otherwise: keep holding — op ⊥ connection (the runner keeps the child
+      // running and retains its output through the blip).
+    }
+  }
+
+  /** Byte-exactness proof: totals AND blake3 digests of the reassembled
+   *  channels must match the runner's Exit record exactly. */
+  private verifyByteExact(exit: OpExit): void {
+    for (const channel of ["stdout", "stderr"] as const) {
+      const bytes = concatChunks(this.chunks[channel]);
+      const declaredTotal = exit.totals[channel];
+      if (declaredTotal !== undefined && BigInt(declaredTotal) !== BigInt(bytes.byteLength)) {
+        throw protocolError(
+          `op-stream reassembly: ${channel} total mismatch (got ${bytes.byteLength}, ` +
+            `runner declared ${declaredTotal})`,
+        );
+      }
+      const declaredDigest = exit.digests[channel];
+      if (declaredDigest) {
+        const digest = bytesToHex(blake3(bytes));
+        if (digest !== declaredDigest) {
+          throw protocolError(
+            `op-stream reassembly: ${channel} digest mismatch (got ${digest}, ` +
+              `runner declared ${declaredDigest})`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function protocolError(message: string): SelfhostedControlError {
+  return new SelfhostedControlError({
+    message,
+    code: ErrorCode.ERROR_CODE_PROTOCOL,
+    reason: null,
+    retryable: false,
+  });
+}
+
+/** A definitive `lost` status → a typed op-level failure. The result was
+ *  bounded-retention collateral (LRU eviction / a runner restart predating the
+ *  persistence milestone) — honest, never silent. */
+function lostToControlError(status: OpStatus): SelfhostedControlError {
+  const reason =
+    status.lostReason === OpLostReason.OP_LOST_REASON_EVICTED
+      ? "its retained result was evicted before collection"
+      : status.lostReason === OpLostReason.OP_LOST_REASON_AGENT_RESTARTED
+        ? "the machine agent restarted and the op did not survive"
+        : "the runner reported it lost";
+  return new SelfhostedControlError({
+    message:
+      `The command's result is no longer available on the machine (${reason}). ` +
+      "Check whether its effects already took place before re-running it.",
+    code: ErrorCode.ERROR_CODE_STREAM,
+    reason: null,
+    retryable: false,
+    detail: { lost_reason: String(status.lostReason) },
+  });
+}
+
+/**
+ * A runner-typed terminal failure (OpExit.failure_code — OP_OVERFLOW /
+ * OP_SPOOL_IO / OP_PIPE_IO; never an exit-code sentinel). OP_OVERFLOW maps to
+ * the PAYLOAD_TOO_LARGE taxonomy: the semantics differ (retention quota vs
+ * reply size) but the model's correct next action is identical — bound the
+ * output, redirect to a file, read it back in ranges — so it gets the same
+ * actionable rendering, with the runner's exact counters in the detail.
+ */
+function runnerFailureToControlError(exit: OpExit): SelfhostedControlError {
+  if (exit.failureCode === "OP_OVERFLOW") {
+    return new SelfhostedControlError({
+      message:
+        "The command produced more output than the machine link can retain for delivery. " +
+        "Redirect the command's output to a file (for example `<command> > /tmp/out.log 2>&1`) " +
+        "and then read that file back in ranges or chunks instead of returning it all at once.",
+      code: ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE,
+      reason: null,
+      retryable: false,
+      payloadTooLarge: true,
+      detail: exit.failureDetail,
+    });
+  }
+  return new SelfhostedControlError({
+    message:
+      `The command failed on the machine's streaming transport (${exit.failureCode}). ` +
+      "The machine kept running it, but its output could not be captured intact.",
+    code: ErrorCode.ERROR_CODE_STREAM,
+    reason: null,
+    retryable: false,
+    detail: { ...exit.failureDetail, failure_code: exit.failureCode },
+  });
+}

--- a/packages/runtime/src/sandbox/selfhosted/op-testing.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-testing.ts
@@ -1,0 +1,468 @@
+// Test doubles for the op-stream exec client (op-stream.ts): an in-memory
+// transport and a scripted FAKE RUNNER that emulates the Rust runner's
+// protocol behavior faithfully enough to exercise every client path —
+// idempotent OpStart (dedup by op id, never re-runs), attach replay from
+// retention, live-emission fault injection (drops / duplicates / reordering),
+// OpQuery status, typed lost states, and DRAINING admission. The runner's own
+// half is proven by its Rust harness (the E-scenarios); this double exists so
+// the CLIENT's reassembly/heal/ack logic is unit-testable with no broker and
+// no binary, deterministically.
+//
+// Emission model (mirrors the real runner): frames live in RETENTION the
+// moment they exist. With `live: false` (the default) the op is already
+// COMPLETE at start — the client's initial attach replays everything (the
+// completed-op collection path, incl. re-dispatch attach-not-rerun). With
+// `live: true` the first attach replays nothing and triggers the LIVE
+// emission with the fault filters applied (drops/dups/reordering); any LATER
+// attach is a heal and replays from retention unfiltered — exactly how the
+// runner's ring/spool heals what the wire mangled.
+
+import { blake3 } from "@noble/hashes/blake3";
+import { bytesToHex } from "@noble/hashes/utils";
+import {
+  ControlRequest,
+  ControlResponse,
+  ErrorCode,
+  OpAck,
+  OpChannel,
+  OpFrame,
+  OpLostReason,
+  OpState,
+  type AgentError,
+  type OpExit,
+  type OpStatus,
+} from "@opengeni/agent-proto";
+import type { ControlRpc } from "./control-rpc";
+import {
+  opFrameSubject,
+  OpStreamUnavailableError,
+  type OpStreamSubscription,
+  type OpStreamTransport,
+} from "./op-transport";
+
+/**
+ * An in-memory `OpStreamTransport`: subscriptions are a subject→handler map,
+ * and everything the CLIENT publishes (its acks) is recorded for assertions
+ * and mirrored to `onPublish` (the fake runner's ack intake). `available =
+ * false` makes both primitives throw `OpStreamUnavailableError` — the
+ * legacy-fallback path.
+ */
+export class InMemoryOpStreamTransport implements OpStreamTransport {
+  available = true;
+  readonly published: Array<{ subject: string; payload: Uint8Array }> = [];
+  onPublish: ((subject: string, payload: Uint8Array) => void) | undefined;
+  private readonly handlers = new Map<string, Set<(payload: Uint8Array) => void>>();
+
+  async subscribe(
+    subject: string,
+    onMessage: (payload: Uint8Array) => void,
+  ): Promise<OpStreamSubscription> {
+    if (!this.available) {
+      throw new OpStreamUnavailableError("in-memory transport marked unavailable");
+    }
+    let set = this.handlers.get(subject);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(subject, set);
+    }
+    set.add(onMessage);
+    return {
+      unsubscribe: () => {
+        set.delete(onMessage);
+      },
+    };
+  }
+
+  async publish(subject: string, payload: Uint8Array): Promise<void> {
+    if (!this.available) {
+      throw new OpStreamUnavailableError("in-memory transport marked unavailable");
+    }
+    this.published.push({ subject, payload });
+    this.onPublish?.(subject, payload);
+  }
+
+  /** Deliver a payload to the subject's subscribers (the runner→client leg). */
+  deliver(subject: string, payload: Uint8Array): void {
+    for (const handler of this.handlers.get(subject) ?? []) {
+      handler(payload);
+    }
+  }
+
+  /** Every OpAck the client published, decoded, in publish order. */
+  decodedAcks(): OpAck[] {
+    return this.published.map(({ payload }) => OpAck.decode(payload));
+  }
+}
+
+/** One scripted data frame (the exit frame is synthesized from `exit`). */
+export interface FakeOpDataFrame {
+  channel: "stdout" | "stderr";
+  bytes: Uint8Array | string;
+}
+
+export interface FakeOpScript {
+  /** Data/progress frames in emission order (seq 1..N; the exit takes N+1). */
+  frames: Array<FakeOpDataFrame | "progress">;
+  /** Exit overrides (exitCode/timedOut/failureCode/…). Digests and totals are
+   *  computed from the scripted data frames unless overridden. */
+  exit?: Partial<OpExit>;
+  /** LIVE mode: the first attach replays nothing and triggers the (faulty)
+   *  live emission; later attaches replay from retention unfiltered. Default
+   *  false = the op is COMPLETE at start (pure collection). */
+  live?: boolean;
+  /** Seqs whose LIVE emission is dropped (retention keeps them). */
+  dropLiveSeqs?: ReadonlySet<number>;
+  /** Seqs whose LIVE emission is duplicated (delivered twice back-to-back). */
+  duplicateLiveSeqs?: ReadonlySet<number>;
+  /** Swap each adjacent live pair (1,2 → 2,1) to exercise the stash path. */
+  reorderLivePairs?: boolean;
+  /** The first N OpStarts answer a DRAINING AgentError (admission pressure). */
+  drainingStarts?: number;
+  /** Refuse every OpStart with this error (e.g. a PROTOCOL refusal from a
+   *  runner that does not speak op-stream — the legacy-fallback race). */
+  startError?: AgentError;
+}
+
+interface FakeOpRun {
+  script: FakeOpScript;
+  frames: OpFrame[];
+  exitSeq: bigint;
+  exit: OpExit;
+  startCount: number;
+  attachCount: number;
+  drainingRemaining: number;
+  liveEmitted: boolean;
+  finalAcked: boolean;
+  acks: OpAck[];
+  highestGeneration: bigint;
+}
+
+const encoder = new TextEncoder();
+
+/**
+ * The scripted fake runner: a `ControlRpc` that answers the op-stream control
+ * ops and emits frames through an `InMemoryOpStreamTransport`. Non-op-stream
+ * requests are delegated to `fallback` (a `MockAgentResponder`) so the
+ * legacy-fallback path is testable through the same instance.
+ */
+export class FakeOpRunner implements ControlRpc {
+  private readonly transport: InMemoryOpStreamTransport;
+  private readonly fallback: ControlRpc | undefined;
+  private readonly workspaceId: string;
+  private readonly agentId: string;
+  private readonly scripts = new Map<string, FakeOpScript>();
+  readonly runs = new Map<string, FakeOpRun>();
+  /** Op ids that answer LOST (evicted) on query/attach — bounded-retention
+   *  collateral. */
+  readonly lostOps = new Set<string>();
+
+  constructor(opts: {
+    transport: InMemoryOpStreamTransport;
+    workspaceId: string;
+    agentId: string;
+    /** Handles every non-op-stream ControlRequest (the legacy ops). */
+    fallback?: ControlRpc;
+  }) {
+    this.transport = opts.transport;
+    this.workspaceId = opts.workspaceId;
+    this.agentId = opts.agentId;
+    this.fallback = opts.fallback;
+    this.transport.onPublish = (_subject, payload) => this.onAck(payload);
+  }
+
+  /** Script the op the NEXT OpStart with this id will run. */
+  script(opId: string, script: FakeOpScript): void {
+    this.scripts.set(opId, script);
+  }
+
+  private onAck(payload: Uint8Array): void {
+    let ack: OpAck;
+    try {
+      ack = OpAck.decode(payload);
+    } catch {
+      return;
+    }
+    const run = this.runs.get(ack.opId);
+    if (!run) {
+      return;
+    }
+    // Generation fencing exactly like the runner: only the highest generation
+    // seen has any effect; `final` is honored only when it covers the exit.
+    const generation = BigInt(ack.attachGeneration);
+    if (generation < run.highestGeneration) {
+      return;
+    }
+    run.acks.push(ack);
+    if (ack.final && BigInt(ack.ackedSeq) >= run.exitSeq) {
+      run.finalAcked = true;
+    }
+  }
+
+  async request(
+    subject: string,
+    req: ControlRequest,
+    opts: { timeoutMs: number },
+  ): Promise<ControlResponse> {
+    const op = req.op;
+    if (!op) {
+      return errorResponse(req.requestId, ErrorCode.ERROR_CODE_PROTOCOL, "no op");
+    }
+    switch (op.$case) {
+      case "opStart":
+        return this.handleStart(req.requestId);
+      case "opAttach":
+        return this.handleAttach(
+          req.requestId,
+          op.opAttach.opId,
+          BigInt(op.opAttach.fromSeq),
+          op.opAttach.attachGeneration,
+        );
+      case "opQuery":
+        return this.handleQuery(req.requestId, op.opQuery.opId);
+      default: {
+        if (this.fallback) {
+          return this.fallback.request(subject, req, opts);
+        }
+        return errorResponse(
+          req.requestId,
+          ErrorCode.ERROR_CODE_UNSUPPORTED,
+          `fake runner: unscripted op ${op.$case}`,
+        );
+      }
+    }
+  }
+
+  private handleStart(opId: string): ControlResponse {
+    const existing = this.runs.get(opId);
+    if (existing) {
+      // IDEMPOTENT BY OP ID: a known op answers its current status and NEVER
+      // re-runs (the whole point of B1).
+      existing.startCount += 1;
+      return startResponse(opId, this.statusOf(opId, existing));
+    }
+    const script = this.scripts.get(opId);
+    if (!script) {
+      return errorResponse(
+        opId,
+        ErrorCode.ERROR_CODE_PROTOCOL,
+        `fake runner: no script for op ${opId}`,
+      );
+    }
+    if (script.startError) {
+      return { requestId: opId, error: script.startError, result: undefined };
+    }
+    const pending = this.scripts.get(opId) as FakeOpScript;
+    if ((pending.drainingStarts ?? 0) > 0) {
+      // Admission pressure: count down across retries of the un-admitted op.
+      this.scripts.set(opId, { ...pending, drainingStarts: (pending.drainingStarts ?? 0) - 1 });
+      return {
+        requestId: opId,
+        error: {
+          code: ErrorCode.ERROR_CODE_DRAINING,
+          message: "fake runner: admission pool full",
+          retryable: true,
+          detail: {},
+        },
+        result: undefined,
+      };
+    }
+    const run = this.buildRun(opId, this.scripts.get(opId) as FakeOpScript);
+    run.startCount = 1;
+    this.runs.set(opId, run);
+    return startResponse(opId, this.statusOf(opId, run));
+  }
+
+  private handleAttach(
+    requestId: string,
+    opId: string,
+    fromSeq: bigint,
+    generation: string,
+  ): ControlResponse {
+    if (this.lostOps.has(opId)) {
+      return statusOnly(requestId, lostStatus(opId));
+    }
+    const run = this.runs.get(opId);
+    if (!run) {
+      return statusOnly(requestId, lostStatus(opId));
+    }
+    run.attachCount += 1;
+    const attachGeneration = BigInt(generation);
+    if (attachGeneration > run.highestGeneration) {
+      run.highestGeneration = attachGeneration;
+    }
+    const subject = opFrameSubject(this.workspaceId, this.agentId, opId);
+    if (run.script.live && !run.liveEmitted) {
+      // First attach on a live op: nothing retained yet worth replaying — the
+      // child "runs now" and the (faulty) live flow begins.
+      this.emitLive(opId, run, subject);
+      return statusOnly(requestId, this.statusOf(opId, run));
+    }
+    // A heal (or completed-op collection): replay from RETENTION — every frame
+    // > fromSeq, in order, NO fault injection (the runner's ring/spool holds
+    // them all under the credit-only ack policy).
+    const replay = run.frames.filter((frame) => BigInt(frame.seq) > fromSeq);
+    queueMicrotask(() => {
+      for (const frame of replay) {
+        this.transport.deliver(subject, OpFrame.encode(frame).finish());
+      }
+    });
+    return statusOnly(requestId, this.statusOf(opId, run));
+  }
+
+  private handleQuery(requestId: string, opId: string): ControlResponse {
+    if (this.lostOps.has(opId)) {
+      return statusOnly(requestId, lostStatus(opId));
+    }
+    const run = this.runs.get(opId);
+    if (!run) {
+      return statusOnly(requestId, lostStatus(opId));
+    }
+    return statusOnly(requestId, this.statusOf(opId, run));
+  }
+
+  /** The LIVE flow: fault filters applied (drops, duplicates, adjacent
+   *  reordering); retention still holds every frame for the heal replay. */
+  private emitLive(opId: string, run: FakeOpRun, subject: string): void {
+    run.liveEmitted = true;
+    const { dropLiveSeqs, duplicateLiveSeqs, reorderLivePairs } = run.script;
+    let sequence = [...run.frames];
+    if (reorderLivePairs) {
+      for (let i = 0; i + 1 < sequence.length; i += 2) {
+        const a = sequence[i] as OpFrame;
+        sequence[i] = sequence[i + 1] as OpFrame;
+        sequence[i + 1] = a;
+      }
+    }
+    sequence = sequence.filter((frame) => !dropLiveSeqs?.has(Number(frame.seq)));
+    queueMicrotask(() => {
+      for (const frame of sequence) {
+        const payload = OpFrame.encode(frame).finish();
+        this.transport.deliver(subject, payload);
+        if (duplicateLiveSeqs?.has(Number(frame.seq))) {
+          this.transport.deliver(subject, payload);
+        }
+      }
+    });
+  }
+
+  private statusOf(opId: string, run: FakeOpRun): OpStatus {
+    // The fake's ops are instant: COMPLETE the moment their frames exist. A
+    // live op that has not yet emitted reads RUNNING with nothing produced;
+    // once emission ran (even if the wire dropped frames), the runner-side
+    // truth is COMPLETE with the full high watermark — exactly what a silence
+    // probe needs to see to detect "the runner is ahead of us".
+    const complete = !run.script.live || run.liveEmitted;
+    return {
+      opId,
+      state: complete ? OpState.OP_STATE_COMPLETE : OpState.OP_STATE_RUNNING,
+      nextSeq: complete ? (run.exitSeq + 1n).toString() : "1",
+      exit: complete ? run.exit : undefined,
+      lostReason: OpLostReason.OP_LOST_REASON_UNSPECIFIED,
+    };
+  }
+
+  private buildRun(opId: string, script: FakeOpScript): FakeOpRun {
+    const frames: OpFrame[] = [];
+    const channelBytes: Record<"stdout" | "stderr", Uint8Array[]> = { stdout: [], stderr: [] };
+    let seq = 0n;
+    for (const spec of script.frames) {
+      seq += 1n;
+      if (spec === "progress") {
+        frames.push({ opId, seq: seq.toString(), body: { $case: "progress", progress: {} } });
+        continue;
+      }
+      const bytes = typeof spec.bytes === "string" ? encoder.encode(spec.bytes) : spec.bytes;
+      channelBytes[spec.channel].push(bytes);
+      frames.push({
+        opId,
+        seq: seq.toString(),
+        body: {
+          $case: "data",
+          data: {
+            channel:
+              spec.channel === "stdout" ? OpChannel.OP_CHANNEL_STDOUT : OpChannel.OP_CHANNEL_STDERR,
+            bytes,
+          },
+        },
+      });
+    }
+    seq += 1n;
+    const digests: Record<string, string> = {};
+    const totals: Record<string, string> = {};
+    for (const channel of ["stdout", "stderr"] as const) {
+      const joined = concat(channelBytes[channel]);
+      digests[channel] = bytesToHex(blake3(joined));
+      totals[channel] = String(joined.byteLength);
+    }
+    const exit: OpExit = {
+      exitCode: 0,
+      timedOut: false,
+      cancelled: false,
+      durationMs: "5",
+      digests,
+      totals,
+      failureCode: "",
+      failureDetail: {},
+      ...script.exit,
+    };
+    frames.push({ opId, seq: seq.toString(), body: { $case: "exit", exit } });
+    return {
+      script,
+      frames,
+      exitSeq: seq,
+      exit,
+      startCount: 0,
+      attachCount: 0,
+      drainingRemaining: script.drainingStarts ?? 0,
+      liveEmitted: false,
+      finalAcked: false,
+      acks: [],
+      highestGeneration: 0n,
+    };
+  }
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function errorResponse(requestId: string, code: ErrorCode, message: string): ControlResponse {
+  return {
+    requestId,
+    error: { code, message, retryable: false, detail: {} },
+    result: undefined,
+  };
+}
+
+function startResponse(requestId: string, status: OpStatus): ControlResponse {
+  return {
+    requestId,
+    error: undefined,
+    result: { $case: "opStart", opStart: { accepted: true, status } },
+  };
+}
+
+function statusOnly(requestId: string, status: OpStatus): ControlResponse {
+  return {
+    requestId,
+    error: undefined,
+    result: { $case: "opStatus", opStatus: status },
+  };
+}
+
+function lostStatus(opId: string): OpStatus {
+  return {
+    opId,
+    state: OpState.OP_STATE_LOST,
+    nextSeq: "0",
+    exit: undefined,
+    lostReason: OpLostReason.OP_LOST_REASON_EVICTED,
+  };
+}

--- a/packages/runtime/src/sandbox/selfhosted/op-transport.ts
+++ b/packages/runtime/src/sandbox/selfhosted/op-transport.ts
@@ -1,0 +1,151 @@
+// The op-stream TRANSPORT seam (op-stream protocol v1.1, server half).
+//
+// The op-stream client needs two primitives the request/reply `ControlRpc`
+// cannot express: a plain SUBSCRIPTION (runner→server op frames on
+// `agent.<ws>.<id>.op.<op_id>`, fire-and-forget publishes) and a plain PUBLISH
+// (server→runner acks on `agent.<ws>.<id>.ack`). This module defines that seam
+// exactly like control-rpc.ts defines `ControlRpc`: the session leaf speaks
+// ONLY `OpStreamTransport`; the worker/api inject a live NATS-backed
+// implementation (the same lazy-factory discipline — boot never requires a
+// live NATS), and tests inject an in-memory one.
+//
+// The control ops that START/steer an op (OpStart/OpCancel/OpQuery/OpAttach)
+// deliberately do NOT ride this seam — they are ordinary `ControlRequest`s on
+// the existing rpc subject through the existing `ControlRpc`, with its typed
+// offline/timeout synthesis and retry taxonomy.
+
+/** The per-op frame subject (runner→server, fire-and-forget). Mirrors the
+ *  runner's wire constant: `agent.<ws>.<id>.op.<op_id>`. */
+export function opFrameSubject(workspaceId: string, agentId: string, opId: string): string {
+  return `agent.${workspaceId}.${agentId}.op.${opId}`;
+}
+
+/** The per-agent ack subject (server→runner, fire-and-forget). Mirrors the
+ *  runner's wire constant: `agent.<ws>.<id>.ack`. */
+export function opAckSubject(workspaceId: string, agentId: string): string {
+  return `agent.${workspaceId}.${agentId}.ack`;
+}
+
+/** A live subscription handle. `unsubscribe` is idempotent and never throws. */
+export interface OpStreamSubscription {
+  unsubscribe(): void;
+}
+
+/**
+ * The op-stream transport seam. `subscribe` MUST be established before the
+ * OpStart that makes frames flow (subscription-before-start is a protocol
+ * invariant: no frame is published before the consumer exists on a healthy
+ * path; a missed frame is healed via OpAttach replay regardless). `onMessage`
+ * is invoked in arrival order; a decode failure inside the handler must be
+ * contained by the caller (a torn frame must never kill the subscription).
+ */
+export interface OpStreamTransport {
+  subscribe(
+    subject: string,
+    onMessage: (payload: Uint8Array) => void,
+  ): Promise<OpStreamSubscription>;
+  publish(subject: string, payload: Uint8Array): Promise<void>;
+}
+
+/** Thrown when the transport has no live connection: the op-stream path is
+ *  UNAVAILABLE (never silently degraded). The session catches this pre-start
+ *  and falls back to the legacy exec — the op provably never started. */
+export class OpStreamUnavailableError extends Error {
+  readonly name = "OpStreamUnavailableError";
+}
+
+/**
+ * The minimal NATS surface the transport needs — mirrors the `nats`
+ * `NatsConnection` subscribe/publish WITHOUT importing `nats` into the
+ * agent-loop-free runtime leaf (the worker injects the live `@opengeni/events`
+ * bus connection, exactly like `NatsRequestConnection` in control-rpc.ts).
+ * `subscribe` returns the nats.js Subscription shape: an async iterable of
+ * messages plus `unsubscribe()`.
+ */
+export interface NatsOpStreamConnection {
+  subscribe(subject: string): AsyncIterable<{ data: Uint8Array }> & { unsubscribe(): void };
+  publish(subject: string, payload: Uint8Array): void;
+}
+
+/**
+ * The NATS-backed transport. Lazy memoized factory (identical discipline to
+ * `NatsControlRpc`): the connection resolves on first use; a null factory
+ * result or a dial failure surfaces `OpStreamUnavailableError` — the caller
+ * (the session) falls back to the LEGACY exec path rather than failing the op,
+ * so a NATS-less boot or a torn bus never strands a turn on a dead transport.
+ */
+export class NatsOpStreamTransport implements OpStreamTransport {
+  private readonly connect: () => Promise<NatsOpStreamConnection | null>;
+  private connection: NatsOpStreamConnection | undefined;
+  private connecting: Promise<NatsOpStreamConnection | null> | undefined;
+
+  constructor(connect: () => Promise<NatsOpStreamConnection | null>) {
+    this.connect = connect;
+  }
+
+  private async resolveConnection(): Promise<NatsOpStreamConnection | null> {
+    if (this.connection) {
+      return this.connection;
+    }
+    // Share one in-flight dial; cache only a real connection (a transient
+    // null/throw must be retried by the next call — see NatsControlRpc).
+    this.connecting ??= this.connect()
+      .then((connection) => {
+        if (connection) {
+          this.connection = connection;
+        }
+        return connection;
+      })
+      .catch(() => null)
+      .finally(() => {
+        this.connecting = undefined;
+      });
+    return this.connecting;
+  }
+
+  async subscribe(
+    subject: string,
+    onMessage: (payload: Uint8Array) => void,
+  ): Promise<OpStreamSubscription> {
+    const conn = await this.resolveConnection();
+    if (!conn) {
+      throw new OpStreamUnavailableError("op-stream transport has no live connection");
+    }
+    const subscription = conn.subscribe(subject);
+    // Pump the async iterator into the callback. The iterator ends when
+    // `unsubscribe()` is called (nats.js closes the iterator); a pump error
+    // (torn connection) simply ends delivery — the op-stream client's silence
+    // handling (OpQuery + re-attach) owns recovery, not the transport.
+    void (async () => {
+      try {
+        for await (const message of subscription) {
+          onMessage(message.data);
+        }
+      } catch {
+        // Delivery ended with the connection; recovery is the client's job.
+      }
+    })();
+    let unsubscribed = false;
+    return {
+      unsubscribe: () => {
+        if (unsubscribed) {
+          return;
+        }
+        unsubscribed = true;
+        try {
+          subscription.unsubscribe();
+        } catch {
+          // Idempotent teardown: a torn connection already unsubscribed us.
+        }
+      },
+    };
+  }
+
+  async publish(subject: string, payload: Uint8Array): Promise<void> {
+    const conn = await this.resolveConnection();
+    if (!conn) {
+      throw new OpStreamUnavailableError("op-stream transport has no live connection");
+    }
+    conn.publish(subject, payload);
+  }
+}

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -18,6 +18,7 @@
 import {
   ControlRequest,
   ControlResponse,
+  ErrorCode,
   FsEntryKind,
   StreamKind,
   type DesktopInputRequest,
@@ -38,6 +39,7 @@ import {
   agentErrorToControlError,
   drainingExhaustedError,
   execDeadlineHint,
+  SelfhostedControlError,
   subjectFor,
   type ControlRpc,
 } from "./control-rpc";
@@ -48,6 +50,9 @@ import {
 } from "./retry-policy";
 import type { SelfhostedOpObservation, SelfhostedOpObserver } from "./op-observer";
 import { selfhostedFaultClass } from "./fault-rendering";
+import { nextDurableOpId } from "../op-correlation";
+import { OpStreamExecClient, type OpStreamJournal } from "./op-stream";
+import { OpStreamUnavailableError, type OpStreamTransport } from "./op-transport";
 
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
@@ -213,11 +218,31 @@ export interface SelfhostedRelayConfig {
 /** The relay's default wss dial path (the `opengeni-relay` server route). */
 export const SELFHOSTED_RELAY_STREAM_PATH = "/stream";
 
+/**
+ * The op-stream injection (op-stream protocol v1.1 — see op-stream.ts). PRESENT
+ * = the streaming exec transport is enabled for this session (the worker
+ * injects it only when the runner advertised `Capabilities.op_stream` AND the
+ * server flag is on — the leaf carries no flag logic). ABSENT = the legacy
+ * monolithic exec, byte-identical to before. The timing knobs exist for tests.
+ */
+export interface SelfhostedOpStreamDeps {
+  transport: OpStreamTransport;
+  /** The durable-resume journal (attach generation + settled-frontier persist).
+   *  Absent (tests, non-activity callers) ⇒ generation "1", no persistence. */
+  journal?: OpStreamJournal;
+  windowBytes?: number;
+  ackIntervalMs?: number;
+  silenceTimeoutMs?: number;
+  reconnectHoldMs?: number;
+}
+
 export interface SelfhostedSessionDeps {
   workspaceId: string;
   agentId: string;
   controlRpc: ControlRpc;
   relay: SelfhostedRelayConfig;
+  /** Op-stream exec transport (present = enabled; see SelfhostedOpStreamDeps). */
+  opStream?: SelfhostedOpStreamDeps;
   /** The lease/active epoch this session is fenced under (echoed on every
    *  ControlRequest so the agent can reject a stale op with ERROR_CODE_FENCED).
    *  Defaults to 0 (no fence) for the negotiation-only / test path. */
@@ -316,6 +341,9 @@ export class SelfhostedSession {
   private readonly retryClock: SelfhostedRetryClock;
   private readonly onOp: SelfhostedOpObserver | undefined;
   private readonly subject: string;
+  /** The op-stream exec client — constructed iff `deps.opStream` was injected
+   *  (= the streaming transport is enabled for this session). */
+  private readonly opStreamClient: OpStreamExecClient | undefined;
   /** The session working directory — the path/cwd base every op is rooted under
    *  (see `toMachinePath`). "" by default ⇒ today's workspace_root behavior. */
   private readonly workingDir: string;
@@ -366,6 +394,31 @@ export class SelfhostedSession {
     this.onOp = deps.onOp;
     this.subject = subjectFor(deps.workspaceId, deps.agentId);
     this.workingDir = deps.workingDir ?? "";
+    this.opStreamClient = deps.opStream
+      ? new OpStreamExecClient({
+          workspaceId: deps.workspaceId,
+          agentId: deps.agentId,
+          epoch: this.epoch,
+          controlRpc: deps.controlRpc,
+          rpcSubject: this.subject,
+          transport: deps.opStream.transport,
+          controlTimeoutMs: this.timeoutMs,
+          retryClock: this.retryClock,
+          ...(deps.opStream.journal !== undefined ? { journal: deps.opStream.journal } : {}),
+          ...(deps.opStream.windowBytes !== undefined
+            ? { windowBytes: deps.opStream.windowBytes }
+            : {}),
+          ...(deps.opStream.ackIntervalMs !== undefined
+            ? { ackIntervalMs: deps.opStream.ackIntervalMs }
+            : {}),
+          ...(deps.opStream.silenceTimeoutMs !== undefined
+            ? { silenceTimeoutMs: deps.opStream.silenceTimeoutMs }
+            : {}),
+          ...(deps.opStream.reconnectHoldMs !== undefined
+            ? { reconnectHoldMs: deps.opStream.reconnectHoldMs }
+            : {}),
+        })
+      : undefined;
     // A valid Manifest mirroring the Modal create-manifest shape (sandbox/index.ts
     // `createManifest`: `new Manifest({ root: "/workspace", environment })`). `root`
     // is "/workspace" to match `buildManifest`'s declared root (the root-delta guard
@@ -552,6 +605,27 @@ export class SelfhostedSession {
       stdin: new Uint8Array(0),
       timeoutMs: executionTimeoutMs,
     };
+    if (this.opStreamClient) {
+      try {
+        return await this.execViaOpStream(this.opStreamClient, execReq, executionTimeoutMs);
+      } catch (error) {
+        // The transport had no live connection, or the runner refused the START
+        // itself (capability/downgrade race) — the op provably never ran, so
+        // the legacy monolithic exec (the permanent fallback wire form) is safe.
+        if (!(error instanceof OpStreamUnavailableError)) {
+          throw error;
+        }
+      }
+    }
+    return this.execLegacy(execReq, executionTimeoutMs);
+  }
+
+  /** The legacy monolithic exec request/reply — the permanent fallback wire
+   *  form (and the only form for runners without `op_stream`). */
+  private async execLegacy(
+    execReq: ExecRequest,
+    executionTimeoutMs: number,
+  ): Promise<SelfhostedExecResult> {
     const result = await this.call(
       { $case: "exec", exec: execReq },
       executionTimeoutMs + SELFHOSTED_EXEC_REPLY_GRACE_MS,
@@ -560,6 +634,85 @@ export class SelfhostedSession {
       throw new Error(`selfhosted exec: unexpected result ${result.$case}`);
     }
     return execResultToChannelA(result.exec, executionTimeoutMs);
+  }
+
+  /**
+   * The op-stream exec path: the SAME `ExecRequest`, streamed (see
+   * op-stream.ts). The durable op id comes from the tool-call correlation
+   * context (`{callId}:{ordinal}` — B1) when this exec runs inside an SDK tool
+   * invocation; a non-tool caller falls back to a random unique id (never
+   * collides, merely not stable across a turn re-dispatch). Emits the SAME
+   * per-op observation the legacy path does, with `replyBytes` filled from the
+   * reassembled stream (the field the framed transport was designed to own).
+   */
+  private async execViaOpStream(
+    client: OpStreamExecClient,
+    execReq: ExecRequest,
+    executionTimeoutMs: number,
+  ): Promise<SelfhostedExecResult> {
+    const startedAt = Date.now();
+    const opId = nextDurableOpId() ?? `anon_${crypto.randomUUID()}`;
+    try {
+      const outcome = await client.exec(
+        opId,
+        execReq,
+        executionTimeoutMs,
+        executionTimeoutMs + SELFHOSTED_EXEC_REPLY_GRACE_MS,
+      );
+      const retries = outcome.heals + outcome.startRetries;
+      this.emitOp({
+        op: "exec",
+        outcome: "ok",
+        healed: retries > 0,
+        retries,
+        durationMs: Date.now() - startedAt,
+        machineId: this.agentId,
+        replyBytes: outcome.replyBytes,
+        // A healed op's class: attach heals are link blips (reconnecting);
+        // start retries without heals were admission backpressure (draining).
+        ...(retries > 0 ? { faultClass: outcome.heals > 0 ? "reconnecting" : "draining" } : {}),
+      });
+      return execResultToChannelA(outcome.response, executionTimeoutMs);
+    } catch (error) {
+      if (error instanceof OpStreamUnavailableError) {
+        // Not a fault: the caller falls back to the legacy exec, which emits
+        // its own observation.
+        throw error;
+      }
+      const controlError =
+        error instanceof SelfhostedControlError
+          ? error
+          : new SelfhostedControlError({
+              message: error instanceof Error ? error.message : String(error),
+              code: ErrorCode.ERROR_CODE_PROTOCOL,
+              reason: null,
+              retryable: false,
+            });
+      this.emitOp({
+        op: "exec",
+        outcome: "failed",
+        healed: false,
+        retries: 0,
+        durationMs: Date.now() - startedAt,
+        code: controlError.code,
+        reason: controlError.reason,
+        neverSent: controlError.neverSent,
+        machineId: this.agentId,
+        faultClass: selfhostedFaultClass(controlError),
+      });
+      throw controlError;
+    }
+  }
+
+  /**
+   * The turn-end op-stream durability hook: persists each settled op's frontier
+   * to the journal, then final-acks it on the wire (licensing the runner to GC
+   * its retained frames). The WORKER calls this after the turn's results are
+   * durably recorded — never mid-turn (the durable-before-wire-ack ordering).
+   * A no-op for sessions without the op-stream transport.
+   */
+  async finalizeOpStreamOps(): Promise<void> {
+    await this.opStreamClient?.finalizeSettledOps();
   }
 
   // ── The agent-turn provided-session contract (over the SAME NATS primitives) ──
@@ -950,6 +1103,7 @@ export class SelfhostedSandboxClient {
   private readonly environment: Record<string, string> | undefined;
   private readonly workingDir: string | undefined;
   private readonly onOp: SelfhostedOpObserver | undefined;
+  private readonly opStream: SelfhostedOpStreamDeps | undefined;
   private controlRpcMemo: ControlRpc | undefined;
 
   constructor(opts: {
@@ -977,6 +1131,9 @@ export class SelfhostedSandboxClient {
     workingDir?: string;
     /** The per-op observer threaded into every bound session (out-of-band telemetry). */
     onOp?: SelfhostedOpObserver;
+    /** The op-stream exec transport threaded into every bound session (present
+     *  = enabled; see SelfhostedOpStreamDeps). */
+    opStream?: SelfhostedOpStreamDeps;
   }) {
     this.workspaceId = opts.workspaceId;
     this.relay = opts.relay;
@@ -988,6 +1145,7 @@ export class SelfhostedSandboxClient {
     this.environment = opts.environment;
     this.workingDir = opts.workingDir;
     this.onOp = opts.onOp;
+    this.opStream = opts.opStream;
   }
 
   private controlRpc(): ControlRpc {
@@ -1009,6 +1167,7 @@ export class SelfhostedSandboxClient {
       ...(this.environment !== undefined ? { environment: this.environment } : {}),
       ...(this.workingDir !== undefined ? { workingDir: this.workingDir } : {}),
       ...(this.onOp !== undefined ? { onOp: this.onOp } : {}),
+      ...(this.opStream !== undefined ? { opStream: this.opStream } : {}),
     });
   }
 
@@ -1088,6 +1247,10 @@ export interface SelfhostedSessionBuild {
   execTimeoutMs?: number;
   /** The per-op observer (out-of-band telemetry). Absent ⇒ no-op. */
   onOp?: SelfhostedOpObserver;
+  /** The op-stream exec transport (present = enabled for the session; the
+   *  worker injects it only when the runner advertised the capability AND the
+   *  server flag is on). Absent ⇒ the legacy exec, byte-identical to before. */
+  opStream?: SelfhostedOpStreamDeps;
 }
 
 /**
@@ -1119,6 +1282,7 @@ export async function buildSelfhostedBackendSession(
     ...(deps.onOp !== undefined ? { onOp: deps.onOp } : {}),
     ...(deps.environment !== undefined ? { environment: deps.environment } : {}),
     ...(deps.workingDir ? { workingDir: deps.workingDir } : {}),
+    ...(deps.opStream !== undefined ? { opStream: deps.opStream } : {}),
   });
   const session = await client.resume({ agentId: deps.agentId });
   return { client, session };

--- a/packages/runtime/test/op-stream-exec.test.ts
+++ b/packages/runtime/test/op-stream-exec.test.ts
@@ -180,6 +180,55 @@ describe("op-stream exec (fake runner)", () => {
     expect(failed?.faultClass).toBe("payload_too_large");
   });
 
+  test("OP_OVERFLOW renders the four FAILURE-VISIBILITY fields with the termination truth", async () => {
+    const { runner, session } = buildRig();
+    runner.script("call_render:0", {
+      frames: [],
+      exit: {
+        failureCode: "OP_OVERFLOW",
+        failureDetail: { retained_bytes: "268435456" },
+      },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const error = await runWithToolCallCorrelation("call_render", () =>
+      session.exec({ cmd: "yes" }).then(
+        () => null,
+        (e: unknown) => e,
+      ),
+    );
+    const { renderSelfhostedFault } = await import("../src/sandbox/selfhosted/fault-rendering");
+    const { SelfhostedControlError } = await import("../src/sandbox/selfhosted/control-rpc");
+    const rendered = renderSelfhostedFault(error as InstanceType<typeof SelfhostedControlError>);
+    // The doctrine's four mandatory fields, with the OVERFLOW truth: the
+    // command was STOPPED at the retention ceiling (it did not complete), and
+    // the recovery is to bound the output — never a silent truncation.
+    expect(rendered).toContain("What happened:");
+    expect(rendered).toContain("Which layer:");
+    expect(rendered).toContain("What was preserved:");
+    expect(rendered).toContain("What to try:");
+    expect(rendered).toContain("268435456");
+    expect(rendered).toContain("did NOT run to completion");
+    expect(rendered).toContain("/tmp/out.log");
+  });
+
+  test("parallel tool calls keep their correlation contexts separated (ALS)", async () => {
+    const { runWithToolCallCorrelation, nextDurableOpId } =
+      await import("../src/sandbox/op-correlation");
+    // Two overlapping tool invocations mint interleaved ids concurrently; each
+    // async chain must see ONLY its own call id and its own ordinal sequence.
+    const minted: Record<string, string[]> = { a: [], b: [] };
+    const run = (key: "a" | "b", callId: string) =>
+      runWithToolCallCorrelation(callId, async () => {
+        for (let i = 0; i < 3; i += 1) {
+          await Bun.sleep(Math.random() * 5);
+          minted[key].push(nextDurableOpId() as string);
+        }
+      });
+    await Promise.all([run("a", "call_par_a"), run("b", "call_par_b")]);
+    expect(minted.a).toEqual(["call_par_a:0", "call_par_a:1", "call_par_a:2"]);
+    expect(minted.b).toEqual(["call_par_b:0", "call_par_b:1", "call_par_b:2"]);
+  });
+
   test("a lost (evicted) op fails typed, mentioning the eviction", async () => {
     const { runner, session } = buildRig();
     runner.script("call_lost:0", { frames: [] });

--- a/packages/runtime/test/op-stream-exec.test.ts
+++ b/packages/runtime/test/op-stream-exec.test.ts
@@ -1,0 +1,298 @@
+// Unit tests for the op-stream exec client through the REAL SelfhostedSession
+// surface (exec() with deps.opStream injected), against the scripted fake
+// runner (op-testing.ts). The Rust harness proves the runner half; these prove
+// the CLIENT half: reassembly, heals, ack policy, fault taxonomy, rendering
+// parity, and the durable-before-wire-ack ordering.
+
+import { describe, expect, test } from "bun:test";
+import type { SelfhostedOpObservation } from "../src/sandbox/selfhosted/op-observer";
+import { FakeOpRunner, InMemoryOpStreamTransport } from "../src/sandbox/selfhosted/op-testing";
+import { SelfhostedSession } from "../src/sandbox/selfhosted/session";
+import type { OpStreamJournal } from "../src/sandbox/selfhosted/op-stream";
+
+const WORKSPACE = "ws-1";
+const AGENT = "agent-1";
+
+function buildRig(opts: { journal?: OpStreamJournal } = {}) {
+  const transport = new InMemoryOpStreamTransport();
+  const runner = new FakeOpRunner({ transport, workspaceId: WORKSPACE, agentId: AGENT });
+  const observations: SelfhostedOpObservation[] = [];
+  const session = new SelfhostedSession({
+    workspaceId: WORKSPACE,
+    agentId: AGENT,
+    controlRpc: runner,
+    relay: { host: "relay.test" },
+    timeoutMs: 2_000,
+    execTimeoutMs: 5_000,
+    retryClock: { sleep: async () => {}, jitter: () => 0.5 },
+    onOp: (observation) => observations.push(observation),
+    opStream: {
+      transport,
+      ...(opts.journal ? { journal: opts.journal } : {}),
+      ackIntervalMs: 20,
+      silenceTimeoutMs: 120,
+      reconnectHoldMs: 600,
+    },
+  });
+  return { transport, runner, session, observations };
+}
+
+describe("op-stream exec (fake runner)", () => {
+  test("baseline: streams stdout+stderr, byte-exact result, ok observation with replyBytes", async () => {
+    const { runner, session, observations } = buildRig();
+    runner.script("call_base:0", {
+      frames: [
+        { channel: "stdout", bytes: "hello " },
+        { channel: "stderr", bytes: "warn\n" },
+        { channel: "stdout", bytes: "world" },
+      ],
+      exit: { exitCode: 0 },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_base", () =>
+      session.exec({ cmd: "echo hello world" }),
+    );
+    expect(result.stdout).toBe("hello world");
+    expect(result.stderr).toBe("warn\n");
+    expect(result.exitCode).toBe(0);
+    const run = runner.runs.get("call_base:0");
+    expect(run?.startCount).toBe(1);
+    const ok = observations.find((o) => o.outcome === "ok");
+    expect(ok?.op).toBe("exec");
+    expect(ok?.replyBytes).toBe("hello world".length + "warn\n".length);
+  });
+
+  test("mid-op acks are credit-only; the final ack lands only via finalizeOpStreamOps, journal-first", async () => {
+    const events: string[] = [];
+    const journal: OpStreamJournal = {
+      attachGeneration: () => "7",
+      persistSettled: (opId, exitSeq) => {
+        events.push(`persist:${opId}@${exitSeq}`);
+      },
+    };
+    const { transport, runner, session } = buildRig({ journal });
+    runner.script("call_ack:0", {
+      frames: [{ channel: "stdout", bytes: "x".repeat(1024) }, "progress"],
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    await runWithToolCallCorrelation("call_ack", () => session.exec({ cmd: "true" }));
+
+    const preFinal = transport.decodedAcks();
+    // Every ack so far is CREDIT-ONLY: acked_seq 0, never final, and the
+    // credit grows past the initial window as payload arrives.
+    expect(preFinal.length).toBeGreaterThan(0);
+    for (const ack of preFinal) {
+      expect(ack.ackedSeq).toBe("0");
+      expect(ack.final).toBe(false);
+      expect(ack.attachGeneration).toBe("7");
+    }
+    const run = runner.runs.get("call_ack:0");
+    expect(run?.finalAcked).toBe(false);
+
+    // The turn-end hook: journal persist strictly BEFORE the wire final ack.
+    transport.onPublish = ((original) => (subject: string, payload: Uint8Array) => {
+      events.push("wire-ack");
+      original?.(subject, payload);
+    })(transport.onPublish);
+    await session.finalizeOpStreamOps();
+    expect(events[0]).toBe(`persist:call_ack:0@${run?.exitSeq.toString()}`);
+    expect(events[1]).toBe("wire-ack");
+    expect(runner.runs.get("call_ack:0")?.finalAcked).toBe(true);
+  });
+
+  test("re-issued op id ATTACHES and collects — never re-runs (B1)", async () => {
+    const { runner, session } = buildRig();
+    runner.script("call_dup:0", {
+      frames: [{ channel: "stdout", bytes: "once" }],
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const first = await runWithToolCallCorrelation("call_dup", () =>
+      session.exec({ cmd: "marker" }),
+    );
+    // The re-dispatch: same call id → same op id → OpStart dedups → attach
+    // replays from retention → byte-identical result.
+    const second = await runWithToolCallCorrelation("call_dup", () =>
+      session.exec({ cmd: "marker" }),
+    );
+    expect(second.stdout).toBe(first.stdout);
+    const run = runner.runs.get("call_dup:0");
+    expect(run?.startCount).toBe(2); // two OpStarts…
+    expect(runner.runs.size).toBe(1); // …ONE execution.
+  });
+
+  test("live drops + duplicates + reordering heal via attach replay (byte-exact)", async () => {
+    const { runner, session, observations } = buildRig();
+    runner.script("call_chaos:0", {
+      frames: [
+        { channel: "stdout", bytes: "a" },
+        { channel: "stdout", bytes: "b" },
+        { channel: "stdout", bytes: "c" },
+        { channel: "stdout", bytes: "d" },
+      ],
+      live: true,
+      dropLiveSeqs: new Set([2]),
+      duplicateLiveSeqs: new Set([3]),
+      reorderLivePairs: true,
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_chaos", () =>
+      session.exec({ cmd: "chaotic" }),
+    );
+    expect(result.stdout).toBe("abcd");
+    const healed = observations.find((o) => o.outcome === "ok");
+    expect(healed?.healed).toBe(true);
+  });
+
+  test("total live loss heals through the silence probe (OpQuery → re-attach)", async () => {
+    const { runner, session } = buildRig();
+    runner.script("call_silent:0", {
+      frames: [{ channel: "stdout", bytes: "recovered" }],
+      live: true,
+      dropLiveSeqs: new Set([1, 2]),
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_silent", () =>
+      session.exec({ cmd: "silent" }),
+    );
+    expect(result.stdout).toBe("recovered");
+    expect(runner.runs.get("call_silent:0")!.attachCount).toBeGreaterThan(1);
+  });
+
+  test("runner-typed OP_OVERFLOW maps to the payload-too-large taxonomy", async () => {
+    const { runner, session, observations } = buildRig();
+    runner.script("call_over:0", {
+      frames: [],
+      exit: {
+        exitCode: 0,
+        failureCode: "OP_OVERFLOW",
+        failureDetail: { retained_bytes: "268435456" },
+      },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const error = await runWithToolCallCorrelation("call_over", () =>
+      session.exec({ cmd: "yes" }).then(
+        () => null,
+        (e: unknown) => e,
+      ),
+    );
+    expect(error).toMatchObject({ name: "SelfhostedControlError", payloadTooLarge: true });
+    const failed = observations.find((o) => o.outcome === "failed");
+    expect(failed?.faultClass).toBe("payload_too_large");
+  });
+
+  test("a lost (evicted) op fails typed, mentioning the eviction", async () => {
+    const { runner, session } = buildRig();
+    runner.script("call_lost:0", { frames: [] });
+    runner.lostOps.add("call_lost:0");
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const error = await runWithToolCallCorrelation("call_lost", () =>
+      session.exec({ cmd: "gone" }).then(
+        () => null,
+        (e: unknown) => e,
+      ),
+    );
+    expect(String((error as Error).message)).toContain("no longer available");
+  });
+
+  test("timed-out exec surfaces the deadline hint on stderr (rendering parity)", async () => {
+    const { runner, session } = buildRig();
+    runner.script("call_timeout:0", {
+      frames: [{ channel: "stdout", bytes: "partial" }],
+      exit: { exitCode: -1, timedOut: true },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_timeout", () =>
+      session.exec({ cmd: "sleep 999" }),
+    );
+    expect(result.timedOut).toBe(true);
+    expect(result.stdout).toBe("partial");
+    expect(result.stderr).toContain("terminated at the 5-second execution limit");
+  });
+
+  test("DRAINING OpStarts retry patiently, then succeed (healed via draining)", async () => {
+    const { runner, session, observations } = buildRig();
+    runner.script("call_drain:0", {
+      frames: [{ channel: "stdout", bytes: "admitted" }],
+      drainingStarts: 3,
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_drain", () =>
+      session.exec({ cmd: "queued" }),
+    );
+    expect(result.stdout).toBe("admitted");
+    const ok = observations.find((o) => o.outcome === "ok");
+    expect(ok?.healed).toBe(true);
+    expect(ok?.retries).toBe(3);
+  });
+
+  test("unavailable transport falls back to the legacy exec path", async () => {
+    const transport = new InMemoryOpStreamTransport();
+    transport.available = false;
+    const { MockAgentResponder } = await import("../src/sandbox/selfhosted/testing");
+    const responder = new MockAgentResponder();
+    const session = new SelfhostedSession({
+      workspaceId: WORKSPACE,
+      agentId: AGENT,
+      controlRpc: responder,
+      relay: { host: "relay.test" },
+      timeoutMs: 2_000,
+      retryClock: { sleep: async () => {}, jitter: () => 0.5 },
+      opStream: { transport, ackIntervalMs: 20, silenceTimeoutMs: 120, reconnectHoldMs: 600 },
+    });
+    const result = await session.exec({ cmd: "echo legacy" });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("a runner that refuses OpStart (protocol) falls back to the legacy exec", async () => {
+    const transport = new InMemoryOpStreamTransport();
+    const { MockAgentResponder } = await import("../src/sandbox/selfhosted/testing");
+    const responder = new MockAgentResponder();
+    const runner = new FakeOpRunner({
+      transport,
+      workspaceId: WORKSPACE,
+      agentId: AGENT,
+      fallback: responder,
+    });
+    runner.script("call_old:0", {
+      frames: [],
+      startError: {
+        code: 7, // ERROR_CODE_PROTOCOL — an old runner: "ControlRequest carried no op"
+        message: "ControlRequest carried no op",
+        retryable: false,
+        detail: {},
+      },
+    });
+    const session = new SelfhostedSession({
+      workspaceId: WORKSPACE,
+      agentId: AGENT,
+      controlRpc: runner,
+      relay: { host: "relay.test" },
+      timeoutMs: 2_000,
+      retryClock: { sleep: async () => {}, jitter: () => 0.5 },
+      opStream: { transport, ackIntervalMs: 20, silenceTimeoutMs: 120, reconnectHoldMs: 600 },
+    });
+    const { runWithToolCallCorrelation } = await import("../src/sandbox/op-correlation");
+    const result = await runWithToolCallCorrelation("call_old", () =>
+      session.exec({ cmd: "echo legacy" }),
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("non-tool exec (no correlation context) still streams under an anonymous id", async () => {
+    const { runner, session } = buildRig();
+    // No script is registered for an anon id we cannot predict — so instead
+    // assert the OTHER direction: the exec reaches the fake runner as an
+    // opStart whose id is NOT correlation-shaped, and the typed no-script
+    // refusal (PROTOCOL) falls back to legacy, which MockAgentResponder is not
+    // wired for here — so expect the typed legacy offline surface instead.
+    // Simpler and load-bearing: unique anon ids never collide with dedup.
+    runner.script("unused", { frames: [] });
+    const error = await session.exec({ cmd: "anon" }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    // The fake refuses unknown ids with PROTOCOL → the session falls back to
+    // legacy → FakeOpRunner has no fallback here → UNSUPPORTED error surfaces.
+    expect(error).not.toBeNull();
+  });
+});

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -181,6 +181,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     sandboxOwnershipEnabled: false,
     sandboxLazyProvisionEnabled: false,
     sandboxSelfhostedEnabled: false,
+    agentOpStreamEnabled: false,
     // Mirror the production defaults for the split selfhosted op deadlines
     // (config/src/index.ts): short control window, longer exec budget.
     sandboxSelfhostedExecTimeoutMs: 120_000,

--- a/packages/testing/src/shared-pg.ts
+++ b/packages/testing/src/shared-pg.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import postgres from "postgres";
 import { migrate } from "@opengeni/db/migrate";
@@ -55,7 +56,39 @@ const ADMIN_BASE_URL = `postgres://postgres:${PASSWORD}@127.0.0.1:${PORT}`;
 // connected to the source during the copy, so keeping the template quiescent
 // is what lets concurrent clones proceed (they serialize on the source but do
 // not error) and guarantees every clone is byte-identical to the migrated schema.
-const TEMPLATE_DB = "og_test_template";
+//
+// The name carries a FINGERPRINT of the migration chain (sorted file names +
+// contents). The container OUTLIVES checkouts — it persists across sessions and
+// is shared by every worktree on the machine — so a bare name would freeze the
+// schema at whichever migration chain first built it: a branch that ADDS a
+// migration would then run all its tests against clones missing the new
+// column, failing on every touched table. Baking the fingerprint into the name
+// gives each distinct chain its own template (built on first use, coexisting
+// with older ones), with no rebuild races between checkouts.
+const TEMPLATE_DB_PREFIX = "og_test_template_";
+
+/** The migrations dir this checkout's `migrate()` applies (@opengeni/db). */
+const MIGRATIONS_DIR = fileURLToPath(new URL("../../db/drizzle", import.meta.url));
+
+let templateDbNameMemo: string | undefined;
+
+/** `og_test_template_<12-hex>` — the fingerprint of THIS checkout's migration
+ *  chain. Memoized (the chain cannot change within a process lifetime). */
+async function templateDbName(): Promise<string> {
+  if (templateDbNameMemo) {
+    return templateDbNameMemo;
+  }
+  const files = (await readdir(MIGRATIONS_DIR)).filter((file) => file.endsWith(".sql")).sort();
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const file of files) {
+    hasher.update(file);
+    hasher.update("\0");
+    hasher.update(await readFile(join(MIGRATIONS_DIR, file)));
+    hasher.update("\0");
+  }
+  templateDbNameMemo = `${TEMPLATE_DB_PREFIX}${hasher.digest("hex").slice(0, 12)}`;
+  return templateDbNameMemo;
+}
 
 const STATE_DIR = join(tmpdir(), "opengeni-shared-pg");
 const LOCK_DIR = join(STATE_DIR, "lock");
@@ -177,7 +210,7 @@ async function templateReady(): Promise<boolean> {
   const root = postgres(`${ADMIN_BASE_URL}/postgres`, { max: 1 });
   try {
     const rows = await root`
-      SELECT 1 FROM pg_database WHERE datname = ${TEMPLATE_DB} AND datistemplate`;
+      SELECT 1 FROM pg_database WHERE datname = ${await templateDbName()} AND datistemplate`;
     return rows.length > 0;
   } catch {
     return false;
@@ -200,6 +233,7 @@ async function ensureTemplateBuilt(): Promise<void> {
     return;
   }
   // Drop a partial/crashed leftover (not yet marked as a template) and rebuild.
+  const TEMPLATE_DB = await templateDbName();
   const root = postgres(`${ADMIN_BASE_URL}/postgres`, { max: 1 });
   try {
     await root.unsafe(`DROP DATABASE IF EXISTS "${TEMPLATE_DB}" WITH (FORCE)`);
@@ -350,7 +384,7 @@ async function cloneFromTemplate(dbName: string): Promise<void> {
     const deadline = Date.now() + 30_000;
     for (;;) {
       try {
-        await root.unsafe(`CREATE DATABASE "${dbName}" TEMPLATE "${TEMPLATE_DB}"`);
+        await root.unsafe(`CREATE DATABASE "${dbName}" TEMPLATE "${await templateDbName()}"`);
         return;
       } catch (err) {
         const message = String((err as { message?: string })?.message ?? err);

--- a/test/e2e/opstream-runner.e2e.ts
+++ b/test/e2e/opstream-runner.e2e.ts
@@ -1,0 +1,265 @@
+// The op-stream exec client against the REAL Rust runner binary over a REAL
+// local nats-server — the end-to-end proof for the streaming transport
+// (op-stream protocol v1.1, server half):
+//
+//   1. LONG STREAM — an exec whose output far exceeds the legacy 1 MiB reply
+//      wall streams live and reassembles byte-exact (blake3-verified by the
+//      client on every path).
+//   2. BLIP MID-EXEC — the NATS server is SIGKILLed and restarted mid-command;
+//      the child keeps running (op ⊥ connection), the runner retains its
+//      output, and the client's silence probe re-attaches and collects the
+//      complete result byte-exact.
+//   3. WORKER-DEATH / ATTACH-NOT-RERUN — a completed op is NEVER final-acked
+//      (the kill-between-persist-and-ack window); a "re-dispatched" consumer
+//      (fresh generation, SAME durable op id) re-issues OpStart, ATTACHES, and
+//      collects the identical result — the marker file proves the command ran
+//      exactly once. Then the successor final-acks (journal persist first).
+//
+// Opt-in: it needs the runner binary (cargo build -p opengeni-agent) and a
+// nats-server binary, so it SKIPS unless both resolve. Run it directly:
+//
+//   OPENGENI_OPSTREAM_E2E=1 bun test ./test/e2e/opstream-runner.e2e.ts
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createNatsEventBus, type EventBus } from "@opengeni/events";
+import {
+  NatsControlRpc,
+  NatsOpStreamTransport,
+  runWithToolCallCorrelation,
+  SelfhostedSession,
+  type OpStreamJournal,
+} from "@opengeni/runtime/sandbox";
+
+const ENABLED = process.env.OPENGENI_OPSTREAM_E2E === "1";
+const WORKSPACE_ID = "hx-ws";
+const AGENT_ID = "e2e-opstream-agent";
+
+function resolveNatsServer(): string | null {
+  if (process.env.OPENGENI_NATS_SERVER_BIN) {
+    return process.env.OPENGENI_NATS_SERVER_BIN;
+  }
+  const onPath = Bun.which("nats-server");
+  if (onPath) {
+    return onPath;
+  }
+  return null;
+}
+
+function resolveRunnerBin(): string | null {
+  if (process.env.OPENGENI_RUNNER_BIN) {
+    return process.env.OPENGENI_RUNNER_BIN;
+  }
+  const candidate = join(import.meta.dir, "../../agent/target/debug/opengeni-agent");
+  return Bun.file(candidate).size > 0 ? candidate : null;
+}
+
+async function freePort(): Promise<number> {
+  const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+  const port = server.port;
+  server.stop(true);
+  return port;
+}
+
+const natsServerBin = ENABLED ? resolveNatsServer() : null;
+const runnerBin = ENABLED ? resolveRunnerBin() : null;
+const runnable = ENABLED && natsServerBin !== null && runnerBin !== null;
+
+describe.skipIf(!runnable)("op-stream exec against the REAL runner (e2e)", () => {
+  let natsPort: number;
+  let natsProc: ReturnType<typeof Bun.spawn> | undefined;
+  let runnerProc: ReturnType<typeof Bun.spawn> | undefined;
+  let configDir: string;
+  let workDir: string;
+  let bus: EventBus;
+
+  function startNats(): void {
+    natsProc = Bun.spawn([natsServerBin as string, "-a", "127.0.0.1", "-p", String(natsPort)], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+  }
+
+  function startRunner(): void {
+    runnerProc = Bun.spawn([runnerBin as string, "run"], {
+      cwd: workDir,
+      env: {
+        ...process.env,
+        OPENGENI_CONFIG_DIR: configDir,
+        RUST_LOG: "info",
+        SHELL: "/bin/sh",
+      },
+      stdout: Bun.file(join(configDir, "runner.log")),
+      stderr: Bun.file(join(configDir, "runner.log")),
+    });
+  }
+
+  /** A session bound to the live runner with the op-stream transport injected.
+   *  `generation` emulates one Temporal dispatch (Δ1: scheduled-timestamp). */
+  function buildSession(journal: OpStreamJournal): SelfhostedSession {
+    return new SelfhostedSession({
+      workspaceId: WORKSPACE_ID,
+      agentId: AGENT_ID,
+      controlRpc: new NatsControlRpc(async () => bus.getRequestConnection()),
+      relay: { host: "relay.test" },
+      timeoutMs: 5_000,
+      execTimeoutMs: 60_000,
+      opStream: {
+        transport: new NatsOpStreamTransport(async () => bus.getOpStreamConnection?.() ?? null),
+        journal,
+        // Fast heals so the blip scenario resolves in test time (the prod
+        // defaults are 30s silence / 120s hold).
+        silenceTimeoutMs: 3_000,
+        reconnectHoldMs: 60_000,
+      },
+    });
+  }
+
+  function journalFor(generation: string, log: string[]): OpStreamJournal {
+    return {
+      attachGeneration: () => generation,
+      persistSettled: (opId, exitSeq) => {
+        log.push(`persist:${opId}@${exitSeq}`);
+      },
+    };
+  }
+
+  beforeAll(async () => {
+    natsPort = await freePort();
+    configDir = await mkdtemp(join(tmpdir(), "opstream-e2e-"));
+    workDir = join(configDir, "work");
+    await mkdir(workDir, { recursive: true });
+    // The runner's StoredCredentials shape (mirrors the Rust harness's
+    // disposable-agent recipe): a throwaway bearer a no-auth server accepts, a
+    // dead relay that is never dialed.
+    await writeFile(
+      join(configDir, "credentials.json"),
+      JSON.stringify(
+        {
+          agent_id: AGENT_ID,
+          workspace_id: WORKSPACE_ID,
+          nats_bearer: "hx-token",
+          nats_urls: [`nats://127.0.0.1:${natsPort}`],
+          relay_url: "http://127.0.0.1:9",
+          relay_token: "",
+          update_pubkey: "",
+          consented_whole_machine: true,
+          consented_screen_control: false,
+          update_channel: "stable",
+          resume_token: "",
+          last_known_epoch: 0,
+        },
+        null,
+        2,
+      ),
+    );
+    startNats();
+    startRunner();
+    bus = await createNatsEventBus(`nats://127.0.0.1:${natsPort}`);
+    // Readiness = the runner answers a real liveness probe on its subject.
+    const probe = buildSession(journalFor("1", []));
+    const deadline = Date.now() + 30_000;
+    for (;;) {
+      if (await probe.ping()) {
+        break;
+      }
+      if (Date.now() > deadline) {
+        throw new Error("runner did not become pingable within 30s");
+      }
+      await Bun.sleep(250);
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    // Close the bus while NATS is still up (a close against a dead server can
+    // hang on the drain), then kill the processes.
+    await Promise.race([bus?.close(), Bun.sleep(2_000)]).catch(() => {});
+    runnerProc?.kill(9);
+    natsProc?.kill(9);
+    await rm(configDir, { recursive: true, force: true }).catch(() => {});
+  }, 15_000);
+
+  test("long stream: >1MiB of output — past the legacy reply wall — byte-exact", async () => {
+    const session = buildSession(journalFor("1000", []));
+    const result = await runWithToolCallCorrelation("e2e_long", () =>
+      session.exec({ cmd: "seq 1 300000" }),
+    );
+    expect(result.exitCode).toBe(0);
+    const bytes = Buffer.byteLength(result.stdout);
+    expect(bytes).toBeGreaterThan(1_048_576); // the old 1MiB ceiling is dead
+    expect(result.stdout.endsWith("299999\n300000\n")).toBe(true);
+    await session.finalizeOpStreamOps();
+  }, 120_000);
+
+  test("blip mid-exec: NATS dies and restarts; the child survives; collection is byte-exact", async () => {
+    const session = buildSession(journalFor("1001", []));
+    const execPromise = runWithToolCallCorrelation("e2e_blip", () =>
+      session.exec({
+        // ~8s of output, one line per 400ms — long enough to straddle the blip.
+        cmd: 'for i in $(seq 1 20); do printf "line %s\\n" "$i"; sleep 0.4; done',
+      }),
+    );
+    await Bun.sleep(2_000);
+    natsProc?.kill(9);
+    await Bun.sleep(1_500);
+    startNats();
+    const result = await execPromise;
+    expect(result.exitCode).toBe(0);
+    const expected = Array.from({ length: 20 }, (_, i) => `line ${i + 1}\n`).join("");
+    expect(result.stdout).toBe(expected);
+    await session.finalizeOpStreamOps();
+  }, 120_000);
+
+  test("worker death: a successor generation attaches and collects — the command ran ONCE", async () => {
+    const marker = join(configDir, "marker.txt");
+    const cmd = `echo run >> ${marker}; cat ${marker}; echo done`;
+
+    // Dispatch 1: completes but DIES before its final ack (the
+    // kill-between-persist-and-ack window) — no finalize.
+    const first = buildSession(journalFor("2000", []));
+    const firstResult = await runWithToolCallCorrelation("e2e_once", () => first.exec({ cmd }));
+    expect(firstResult.stdout).toBe("run\ndone\n");
+
+    // Dispatch 2 (the workflow redispatch): a NEW consumer, HIGHER
+    // generation, the SAME durable op id — OpStart dedups, attach replays,
+    // the result is identical, and the marker proves single execution.
+    const persistLog: string[] = [];
+    const second = buildSession(journalFor("3000", persistLog));
+    const secondResult = await runWithToolCallCorrelation("e2e_once", () => second.exec({ cmd }));
+    expect(secondResult.stdout).toBe(firstResult.stdout);
+    expect(secondResult.exitCode).toBe(firstResult.exitCode);
+
+    const markerContent = await readFile(marker, "utf8");
+    expect(markerContent).toBe("run\n"); // exactly ONE execution
+
+    // The successor's turn end: journal persist precedes the wire final ack
+    // (asserted in unit tests; here we prove the runner ACCEPTS the final
+    // ack from the successor generation — no error, and the persist ran).
+    await second.finalizeOpStreamOps();
+    expect(persistLog.length).toBe(1);
+    expect(persistLog[0]).toStartWith("persist:e2e_once:0@");
+  }, 120_000);
+
+  test("legacy parity: the same runner serves the same command over the legacy wire", async () => {
+    const legacy = new SelfhostedSession({
+      workspaceId: WORKSPACE_ID,
+      agentId: AGENT_ID,
+      controlRpc: new NatsControlRpc(async () => bus.getRequestConnection()),
+      relay: { host: "relay.test" },
+      timeoutMs: 5_000,
+      execTimeoutMs: 60_000,
+      // no opStream: the permanent fallback wire form
+    });
+    const streaming = buildSession(journalFor("4000", []));
+    const viaLegacy = await legacy.exec({ cmd: "printf 'out'; printf 'err' 1>&2; exit 3" });
+    const viaStream = await runWithToolCallCorrelation("e2e_parity", () =>
+      streaming.exec({ cmd: "printf 'out'; printf 'err' 1>&2; exit 3" }),
+    );
+    expect(viaStream.stdout).toBe(viaLegacy.stdout);
+    expect(viaStream.stderr).toBe(viaLegacy.stderr);
+    expect(viaStream.exitCode).toBe(viaLegacy.exitCode);
+    await streaming.finalizeOpStreamOps();
+  }, 60_000);
+});

--- a/test/integration/selfhosted-control-transport.integration.ts
+++ b/test/integration/selfhosted-control-transport.integration.ts
@@ -204,7 +204,12 @@ describe("selfhosted control transport over a REAL local NATS", () => {
   // (e) TRANSIENT CONTROL-PLANE CONNECTION ACQUISITION: a process may ask for
   //     the managed NATS connection before it is ready. A null first result must
   //     not be memoized forever; the same ControlRpc retries and recovers.
-  test("(e) transient null connection acquisition recovers on the next request", async () => {
+  test("(e) transient null connection acquisition heals WITHIN the request (never-sent retry)", async () => {
+    // A null factory result is a PRE-SEND fault: the op provably never reached
+    // the machine, so the session's bounded never-sent retry re-issues it — for
+    // ANY op kind — and the next resolution gets the real connection. Before
+    // the never-sent retry class existed this surfaced as a hard agent_offline
+    // on the first op; the healed-in-place behavior is the current contract.
     const mock = new MockAgentResponder({ hostname: "late-nats-vm" });
     const subject = subjectFor(WS_A, AGENT);
     const unsub = bus.subscribeRequests(subject, responderFor(mock));
@@ -221,14 +226,8 @@ describe("selfhosted control transport over a REAL local NATS", () => {
     });
     const session = await client.resume({ agentId: AGENT });
     try {
-      let firstError: { agentOffline?: boolean } | undefined;
-      try {
-        await session.exec({ cmd: "true" });
-      } catch (error) {
-        firstError = error as typeof firstError;
-      }
-      expect(firstError?.agentOffline).toBe(true);
-
+      // The transient null is retried inside the SAME exec (a fresh request id
+      // per attempt), so the caller sees a clean success — no surfaced blip.
       expect((await session.exec({ cmd: "echo $HOSTNAME" })).stdout.trim()).toBe("late-nats-vm");
       expect(attempts).toBe(2);
     } finally {


### PR DESCRIPTION
The server half of the op-stream protocol (v1.1): exec to a Connected Machine streams as sequenced, acked, credit-flowed frames instead of one monolithic request/reply. The runner half shipped in #364; this PR makes the server consume it.

## Proven end-to-end against the real runner

`test/e2e/opstream-runner.e2e.ts` (opt-in) drives a **real runner binary built from main over a real nats-server**, three consecutive clean runs:

1. **The reply-size wall is dead on the wire**: a 2MB exec output (former ceiling: 1MiB per reply) streams and reassembles **byte-exact** — every path blake3-verified against the runner's exit digests.
2. **Blip ≠ kill**: the NATS server is SIGKILLed and restarted mid-command; the child keeps running (op ⊥ connection), the runner retains its output, and the client's silence probe re-attaches and collects the complete result byte-exact.
3. **Worker death ≠ re-run**: a completed op is never final-acked (the kill-between-persist-and-ack window); a successor consumer (higher attach generation, same durable op id) re-issues OpStart, **attaches instead of re-running**, and collects the identical result — a marker file proves the command executed exactly once. The successor's final ack (journal persist first) is accepted.
4. **Legacy parity**: the same runner serves the same command over the legacy wire with identical stdout/stderr/exit code.

Plus a 14-case unit matrix against a scripted fake runner (`op-testing.ts`): baseline reassembly, out-of-order/duplicate/dropped frames healed via attach replay, total-loss heal via the silence probe, DRAINING start patience, typed lost/evicted, OP_OVERFLOW rendering, timeout rendering parity, credit-only ack assertions, the journal-persist-strictly-before-final-ack ordering, attach-not-rerun, legacy fallback (unavailable transport AND protocol start-refusal), and parallel-tool-call correlation isolation.

## Flag gating — merging this changes nothing

The streaming path activates only when **both** hold, latched per-op at OpStart (no flag day):

- the machine's latest connect Hello advertised `Capabilities.op_stream` (persisted onto the enrollment by the Hello ingestion in this PR), **and**
- `OPENGENI_AGENT_OP_STREAM_ENABLED=true` (new setting, **default OFF**).

The legacy monolithic exec remains the permanent fallback wire form: older runners, an unavailable transport, or a capability/downgrade race all fall back safely (the op provably never started). Rollback = flag off. Activation in the field needs **no runner release and no runner action**: v0.1.8 already serves op-stream and advertises the capability unconditionally (verified at the wire level — the live Hello's capabilities submessage carries field 10 = true; note that pre-#364 proto bindings silently drop the unknown field, which can make the advertisement look absent). Sequencing: deploy this PR → the machine's next Hello flips `enrollment.op_stream` → flip the env flag after a live staging drill.

## Design deltas (flagged before build, ratified)

**Δ1 — attach generation = `Info.currentAttemptScheduledTimestampMs`, not "Temporal attempt number".** `runAgentTurn` runs with `maximumAttempts: 1`; worker death is healed by a *workflow redispatch* — a new activity whose attempt is always 1 — so the attempt number cannot fence zombie consumers. The schedule timestamp is Temporal-server-assigned and strictly monotonic across dispatches (death detection is bounded below by the 2-minute heartbeat timeout), needs zero workflow plumbing, and intra-dispatch re-attaches reuse it (the runner's equal-generation replay path).

**Δ2 — mid-op acks are credit-only; the acked frontier advances once, at a durable final fence.** The runner frees retained frames at `acked_seq`, and a redispatched consumer must reassemble from seq 0 (its predecessor's buffered bytes died with it; the 2MB heartbeat-details cap forecloses persisting them there) — so any mid-op `acked_seq > 0` would make frames unrecoverable for the successor by construction. While streaming, the client sends `OpAck{acked_seq: 0, credit_bytes: received + window}` (credit is an absolute replacement — the child keeps flowing) and the runner retains ring→spool. The final ack fires at turn completion, after the tool outputs are durably in the history store, under the hard gate's ordering: **result durable → journal persist → wire final ack**.

**Deliberate v1 ceiling, stated honestly**: output per exec is bounded by the runner's retention quotas (≈256× the old 1MiB wall). Exceeding it is a typed `OP_OVERFLOW` terminal with exact counters — never silent truncation — and its in-band rendering carries the four failure-visibility fields with the termination truth (the command was *stopped at the ceiling*, it did not run to completion). **V2 (designed, not built)**: progressive durable consumption — append reassembled chunks to a durable store, then advance `acked_seq` — lifts the ceiling entirely; the ack policy is an isolated module built for that swap, with no wire or runner change needed.

## What's where

- `packages/runtime/src/sandbox/selfhosted/op-stream.ts` — the client: subscription-before-OpStart, idempotent OpStart (the ControlRequest id **is** the durable op id, stable across retries — start blips become safely re-issuable, unlike legacy exec), attach-from-frontier, seq-idempotent reassembly with gap-triggered re-attach as a routine heal, cumulative-ack repetition (5s timer + on-Progress + prompt credit at half-window), frame-silence OpQuery probing with a reconnect-window hold, byte-exactness verification, typed runner failures.
- `op-transport.ts` — the subscribe/publish seam (`NatsOpStreamTransport`, same lazy-boot discipline as `NatsControlRpc`, same managed bus connection); control ops keep riding `ControlRpc`.
- `op-correlation.ts` + `shell({ configureTools })` — the durable op id `{tool_call_id}:{ordinal}` (ruling B1) via an AsyncLocalStorage bound around the SDK shell tool's execute; parallel-tool-call safe; injectively sanitized to a legal NATS subject token. No SDK fork.
- `session.ts` — `exec()` routes through the client iff `deps.opStream` was injected; identical `ExecRequest` construction, result conversion, fault taxonomy, and observer shape (the op observer now fills `replyBytes` from the reassembled stream).
- Worker: `op-journal.ts` (the Temporal adaptation), one shared heartbeat-details object across all heartbeat sites (the settled-op roster survives last-write-wins), enrollment capability read + injection in `sandbox-routing.ts`, turn-end finalize immediately after `reconcileConversationTruth()` — the point where a redispatch stops re-executing tools.
- DB/API: `enrollments.op_stream` (migration 0050) refreshed from every connect Hello with the existing change-guard discipline.
- NATS auth needs no deployment change: the runner JWT scope `agent.<ws>.>` covers the new frame/ack subjects; the control-plane user has account-default permissions.

Scope bounds (in the worktree review record): mid-turn swap *targets* stay legacy (capability row not at hand in the resolver; legacy is always correct); a paused/killed turn leaves never-final-acked ops to the runner's retention TTL (bounded, honest); `OpStart.deadline_ms` is absolute epoch so host clock skew shifts the effective budget — a runner-side wire nit for M7, along with cleaning up the stale (dead-code) `op_stream_unsupported` comment in `dispatch.rs`.

## Pre-existing issues found and fixed (not scope creep — own commits)

- **`fix(testing)`: the shared test-postgres template was frozen at whatever migration chain first built it.** The container outlives checkouts, and the template's only readiness sentinel was `datistemplate=true` — so any branch adding a migration ran its whole local suite against clones missing the new column (51 enrollment-touching tests red). The template name now carries a fingerprint of the migration chain; distinct chains coexist, no rebuild races. Every future migration PR benefits.
- **`test(integration)`: a stale integration test fails on pristine main.** `selfhosted-control-transport (e)` still asserted the pre-never-sent-retry semantics (hard `agent_offline` on a transient null connection); the retry class deliberately changed that to heal-in-place, and the full integration suite is not in per-PR CI, so it slipped through. Updated to the current contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
