### PR TITLE
feat(worker): prompt-cache hit instrumentation per model call

### DIFF
--- a/.changeset/prompt-cache-hit-instrumentation.md
+++ b/.changeset/prompt-cache-hit-instrumentation.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Make prompt-cache efficiency measurable per model call. The worker now reads `cached_tokens` from the same usage frame that feeds input-token accounting and emits two provider-labelled Prometheus series: `opengeni_model_cached_tokens_total{provider}` (cumulative prompt tokens served from the provider's cache) and `opengeni_model_cache_hit_ratio{provider}` (per-call cached/prompt ratio, bucketed around the alerting threshold). A provider that does not report cached tokens records a real 0 ratio rather than nothing — "the cache did nothing" is the signal — and never a phantom counter increment. Labels stay bounded (provider only; never a session id or account).
+
+Each per-call `model call usage` log line gains two log-only research dimensions: `servingAccountHash` (an opaque, non-reversible tag for the serving codex credential — the credential row id hashed, never a token) and `accountChangedFromPrevCall` (whether the serving account changed versus the session's previous call — the account-rotation-cold-starts-the-cache hypothesis). These are log-only and never leak into the durable `agent.model.usage` event, which already carries `cachedTokens`. The non-codex credit-debit ledger record additionally carries `cachedTokens` (additive).
+
+A new starter alert `OpenGeniCodexPromptCacheHitRatioLow` fires when the codex-subscription cache-hit ratio p50 falls below 40% over 30m while codex calls are flowing (traffic-gated with the `or vector(0)` empty-vector guard, promtool-validated).

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -153,9 +153,11 @@ import {
 } from "../sandbox-routing";
 import {
   makeMachineOpObserver,
+  modelCallAccountContext,
   recordBatchFlush,
   recordContextCompaction,
   recordCreditMicros,
+  recordModelCacheTokens,
   recordModelInputTokens,
   recordSessionEventAppendLatency,
   recordSessionEventPublishLatency,
@@ -418,6 +420,11 @@ export async function emitModelCallUsage(input: {
   model: string;
   sourceKey: string;
   usage: ModelResponseUsage | { usage?: unknown | null } | null;
+  // Prompt-cache research dimensions (log-only; NEVER on a metric label or a
+  // durable event). The opaque serving-account tag and whether it changed since
+  // the session's previous call — the account-switch hypothesis for cache misses.
+  servingAccountHash?: string;
+  accountChangedFromPrevCall?: boolean;
 }): Promise<void> {
   const usage =
     input.usage && typeof input.usage === "object" && "usage" in input.usage
@@ -441,6 +448,12 @@ export async function emitModelCallUsage(input: {
       outputTokens: telemetry.outputTokens,
       cachedTokens: telemetry.cachedTokens,
       reasoningTokens: telemetry.reasoningTokens,
+      ...(input.servingAccountHash !== undefined
+        ? { servingAccountHash: input.servingAccountHash }
+        : {}),
+      ...(input.accountChangedFromPrevCall !== undefined
+        ? { accountChangedFromPrevCall: input.accountChangedFromPrevCall }
+        : {}),
     });
   } catch {
     // Usage observability is best-effort.
@@ -1323,6 +1336,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // The Codex account this turn runs on (pin > workspace active), resolved once
     // a codex-billed turn is confirmed and threaded into the token resolver below.
     let effectiveCodexCredentialId: string | null = null;
+    // The session's Codex credential BEFORE this turn resolved its own — captured
+    // before recordSessionActiveCodexCredential overwrites the durable pointer, so
+    // a per-call usage log can report whether the serving account CHANGED since the
+    // session's previous call (the prompt-cache account-switch hypothesis).
+    let priorSessionCodexCredentialId: string | null = null;
     // Multi-account P4 (Part A): the latest usage-header snapshot scraped FOR FREE
     // off this turn's `/codex/responses` responses (a turn issues many model calls;
     // latest wins). Flushed ONCE into the P2 usage cache for the serving account in
@@ -1494,6 +1512,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         ]);
         const connectedIds = new Set(accounts.map((account) => account.id));
         const sessionPin = sessionCodex?.pinnedCredentialId ?? null;
+        // Snapshot the session's prior serving credential BEFORE the resolve/overwrite
+        // below, for the per-call account-switch usage log (prompt-cache hypothesis).
+        priorSessionCodexCredentialId = sessionCodex?.lastCredentialId ?? null;
         // The off-path / P1 default: today's workspace active pointer. Untouched
         // when rotation is off or the session is pinned (byte-identical to P1).
         let chosenActive = rotation?.activeCredentialId ?? null;
@@ -2706,6 +2727,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 dispatchId,
                 positionalKey: `response-${responseUsageCount}`,
               });
+              // Within a turn the serving credential is fixed, so a switch can only
+              // surface on the turn's FIRST model call (vs the session's prior).
+              const responseAccountCtx = modelCallAccountContext({
+                servingCredentialId: effectiveCodexCredentialId,
+                priorSessionCredentialId: priorSessionCodexCredentialId,
+                isFirstCallOfTurn: responseUsageCount === 1,
+              });
               await emitModelCallUsage({
                 observability,
                 publish: null,
@@ -2718,6 +2746,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 model: turn.model,
                 sourceKey: responseSourceKey,
                 usage: responseUsage,
+                servingAccountHash: responseAccountCtx.servingAccountHash,
+                accountChangedFromPrevCall: responseAccountCtx.accountChangedFromPrevCall,
               });
               modelUsageEventContext = {
                 accountId: input.accountId,
@@ -2742,6 +2772,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   console.error("persist last_input_tokens failed (non-fatal)", error),
                 );
               }
+              // Prompt-cache efficiency for this response — same usage frame as the
+              // input-token accounting above, so the two are always consistent.
+              recordModelCacheTokens(observability, streamProvider, {
+                cachedTokens: modelCallUsageTelemetry(responseUsage.usage).cachedTokens,
+                promptTokens: responseUsage.usage?.inputTokens,
+              });
               await recordModelUsageAndDebitCredits(settings, db, {
                 accountId: input.accountId,
                 workspaceId: input.workspaceId,
@@ -2830,6 +2866,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             sourceKey: aggregateSourceKey,
             observability,
           });
+          // The single aggregate frame is this turn's only model-usage record, so
+          // it is the first (account-switch surfaces here just like a first response).
+          const aggregateAccountCtx = modelCallAccountContext({
+            servingCredentialId: effectiveCodexCredentialId,
+            priorSessionCredentialId: priorSessionCodexCredentialId,
+            isFirstCallOfTurn: true,
+          });
+          recordModelCacheTokens(observability, streamProvider, {
+            cachedTokens: modelCallUsageTelemetry(
+              stream.state.usage as Parameters<typeof modelCallUsageTelemetry>[0],
+            ).cachedTokens,
+            promptTokens: (stream.state.usage as { inputTokens?: unknown } | undefined)
+              ?.inputTokens as number | undefined,
+          });
           await emitModelCallUsage({
             observability,
             publish,
@@ -2842,6 +2892,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             model: turn.model,
             sourceKey: aggregateSourceKey,
             usage: { usage: stream.state.usage },
+            servingAccountHash: aggregateAccountCtx.servingAccountHash,
+            accountChangedFromPrevCall: aggregateAccountCtx.accountChangedFromPrevCall,
           });
         }
         if (lastInputTokensObserved !== null) {
@@ -4185,6 +4237,13 @@ export async function recordModelUsageAndDebitCredits(
         inputTokens,
         outputTokens,
         totalTokens,
+        // Additive: the prompt-cache slice of this call's input tokens, so the
+        // per-call debit record carries cache efficiency alongside the token
+        // counts. 0 when the provider did not report cached tokens.
+        cachedTokens: positiveInt(
+          modelCallUsageTelemetry(input.usage as Parameters<typeof modelCallUsageTelemetry>[0])
+            .cachedTokens,
+        ),
       },
     });
     recordCreditMicros(input.observability, "usage", result.debitedMicros);

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { errorCodeToJSON } from "@opengeni/agent-proto";
 import type { SessionEventType } from "@opengeni/contracts";
 import type { EventLogger } from "@opengeni/events";
@@ -573,4 +574,105 @@ export function recordContextCompaction(observability: Observability, trigger: s
     help: "Total context compactions performed, by trigger.",
     labels: { trigger },
   });
+}
+
+// ── Prompt-cache efficiency ─────────────────────────────────────────────────
+// Per model-call prompt-cache signal, provider-labelled only (bounded
+// cardinality — never a session id or account). `cached_tokens` is the slice of
+// the prompt the provider served from its prompt cache; the ratio cached/prompt
+// is the efficiency of that call. The account-switch hypothesis (a codex account
+// rotation cold-starts the provider's per-account prompt cache) is tested from
+// the per-call STRUCTURED LOG below — the account id is unbounded, so it is
+// hashed into a log field and NEVER a Prometheus label.
+
+// The hit ratio lives in [0, 1]; bucket tighter around the alerting threshold so
+// a p50 near 40% resolves. The default duration buckets (to 3600) would collapse
+// every ratio into the first bucket.
+const MODEL_CACHE_HIT_RATIO_BUCKETS = [
+  0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1,
+];
+
+/**
+ * Prompt-cache efficiency of one model response, by provider. Reads from the SAME
+ * usage frame that feeds input-token accounting, so the two are always consistent:
+ *   - `opengeni_model_cached_tokens_total{provider}` — cumulative prompt tokens the
+ *     provider served from cache. Advanced only when >0, so a provider that never
+ *     reports cached tokens contributes nothing rather than phantom zero-increments.
+ *   - `opengeni_model_cache_hit_ratio{provider}` — cached/prompt for the call,
+ *     observed whenever prompt tokens are known (>0). A call whose provider does NOT
+ *     report cached_tokens records a real 0 here — "we saw a call and the cache did
+ *     nothing" is exactly the signal the alert watches, so it must not be swallowed.
+ * Absent/zero/non-finite `cachedTokens` (providers that don't report it) is safe: no
+ * counter increment, ratio 0. A call with no prompt tokens has no ratio (skipped).
+ */
+export function recordModelCacheTokens(
+  observability: Observability,
+  provider: string,
+  input: { cachedTokens: number | null | undefined; promptTokens: number | null | undefined },
+): void {
+  const cached = nonNegativeTokenCount(input.cachedTokens);
+  const prompt = nonNegativeTokenCount(input.promptTokens);
+  if (cached > 0) {
+    observability.incrementCounter({
+      name: "opengeni_model_cached_tokens_total",
+      help: "Total prompt tokens served from the provider's prompt cache, by provider.",
+      labels: { provider },
+      amount: cached,
+    });
+  }
+  if (prompt > 0) {
+    observability.observeHistogram({
+      name: "opengeni_model_cache_hit_ratio",
+      help: "Per-call prompt-cache hit ratio (cached/prompt tokens) by provider.",
+      buckets: MODEL_CACHE_HIT_RATIO_BUCKETS,
+      labels: { provider },
+      // Clamp to [0, 1]: a provider that (rarely) reports cached >= prompt must
+      // not skew the histogram past 1.0.
+      value: Math.min(1, cached / prompt),
+    });
+  }
+}
+
+function nonNegativeTokenCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * An opaque, stable, non-reversible tag for a codex credential (account) — the
+ * per-call log dimension the account-switch hypothesis correlates against. It is
+ * a hash of the NON-SECRET credential ROW id (never a token/bearer), truncated so
+ * it is short in logs while still distinguishing a handful of accounts without
+ * collision. A null/absent credential (non-codex turn, no active account) tags as
+ * "none" so the field is always present and never leaks an id verbatim.
+ */
+export function stableAccountHash(credentialId: string | null | undefined): string {
+  if (!credentialId) {
+    return "none";
+  }
+  return createHash("sha256").update(credentialId).digest("hex").slice(0, 12);
+}
+
+/**
+ * The per-call account dimensions for the usage log: the opaque serving-account
+ * tag and whether that account CHANGED versus the session's previous call. Within
+ * one turn the serving credential is fixed, so a switch can only surface on the
+ * turn's FIRST call (compared against the session's durably-recorded prior
+ * credential); later calls in the same turn report `false`. A switch is reported
+ * only when there was a KNOWN prior account that differs — a session's very first
+ * call (no prior) is a cold start, not a switch.
+ */
+export function modelCallAccountContext(input: {
+  servingCredentialId: string | null;
+  priorSessionCredentialId: string | null;
+  isFirstCallOfTurn: boolean;
+}): { servingAccountHash: string; accountChangedFromPrevCall: boolean } {
+  const accountChangedFromPrevCall =
+    input.isFirstCallOfTurn &&
+    input.servingCredentialId !== null &&
+    input.priorSessionCredentialId !== null &&
+    input.priorSessionCredentialId !== input.servingCredentialId;
+  return {
+    servingAccountHash: stableAccountHash(input.servingCredentialId),
+    accountChangedFromPrevCall,
+  };
 }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -412,6 +412,46 @@ describe("model call usage observability", () => {
         }),
       },
     ]);
+    // The account-switch dimensions are LOG-ONLY (the research hypothesis) and
+    // must NEVER leak into the durable event payload.
+    expect(infos[0]).not.toHaveProperty("servingAccountHash");
+    expect(events[0]?.payload).not.toHaveProperty("servingAccountHash");
+    expect(events[0]?.payload).not.toHaveProperty("accountChangedFromPrevCall");
+  });
+
+  test("logs the opaque serving-account tag and account-switch flag when provided", async () => {
+    const infos: Array<Record<string, unknown>> = [];
+    const observability = {
+      info: (_message: string, attributes: Record<string, unknown>) => infos.push(attributes),
+      warn: mock(),
+    };
+
+    await emitModelCallUsage({
+      observability: observability as any,
+      publish: null,
+      accountId: "acct-1",
+      workspaceId: "ws-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      provider: "codex-subscription",
+      providerApi: "responses",
+      model: "codex/gpt-5.6",
+      sourceKey: "resp-1",
+      usage: {
+        responseId: "resp-1",
+        usage: { inputTokens: 1200, inputTokensDetails: { cached_tokens: 200 } },
+      },
+      servingAccountHash: "abc123def456",
+      accountChangedFromPrevCall: true,
+    });
+
+    expect(infos[0]).toMatchObject({
+      sessionId: "sess-1",
+      inputTokens: 1200,
+      cachedTokens: 200,
+      servingAccountHash: "abc123def456",
+      accountChangedFromPrevCall: true,
+    });
   });
 });
 

--- a/apps/worker/test/cache-metrics.test.ts
+++ b/apps/worker/test/cache-metrics.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { createObservability } from "@opengeni/observability";
+import { testSettings } from "@opengeni/testing";
+import {
+  modelCallAccountContext,
+  recordModelCacheTokens,
+  stableAccountHash,
+} from "../src/observability-metrics";
+
+// Prompt-cache efficiency: pin that each per-call cache signal fires with the
+// right series and bounded labels, degrades safely on providers that do not
+// report cached tokens, and that the account-switch log dimension is computed
+// correctly — so the "is the codex prompt cache working" question is a number,
+// and the account-rotation hypothesis is testable from the logs.
+
+function worker() {
+  return createObservability(testSettings(), { component: "worker" });
+}
+
+describe("recordModelCacheTokens — prompt-cache efficiency", () => {
+  test("counts cached tokens and observes the cached/prompt ratio by provider", async () => {
+    const observability = worker();
+    recordModelCacheTokens(observability, "codex-subscription", {
+      cachedTokens: 512,
+      promptTokens: 1024,
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_model_cached_tokens_total\{[^}]*provider="codex-subscription"[^}]*\} 512\b/,
+    );
+    // ratio 0.5 → histogram sum 0.5, one observation
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_sum\{[^}]*provider="codex-subscription"[^}]*\} 0\.5\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_count\{[^}]*provider="codex-subscription"[^}]*\} 1\b/,
+    );
+  });
+
+  test("a call with prompt tokens but NO cached tokens records a real 0 ratio (cache did nothing)", async () => {
+    const observability = worker();
+    recordModelCacheTokens(observability, "codex-subscription", {
+      cachedTokens: 0,
+      promptTokens: 2000,
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    // The 0 must land in the histogram (it is the low-cache signal the alert watches).
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_sum\{[^}]*provider="codex-subscription"[^}]*\} 0\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_count\{[^}]*provider="codex-subscription"[^}]*\} 1\b/,
+    );
+    // No cached tokens → the counter is never created (no phantom zero-increment).
+    expect(metrics).not.toMatch(/opengeni_model_cached_tokens_total/);
+  });
+
+  test("absent/null cached tokens (providers that don't report it) does not throw and counts nothing", async () => {
+    const observability = worker();
+    expect(() =>
+      recordModelCacheTokens(observability, "openai", {
+        cachedTokens: null,
+        promptTokens: 1000,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      recordModelCacheTokens(observability, "openai", {
+        cachedTokens: undefined,
+        promptTokens: undefined,
+      }),
+    ).not.toThrow();
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).not.toMatch(/opengeni_model_cached_tokens_total/);
+    // The null-cached/prompt=1000 call still recorded a 0 ratio; the all-absent call did not.
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_count\{[^}]*provider="openai"[^}]*\} 1\b/,
+    );
+  });
+
+  test("no prompt tokens → no ratio observation (a call with no prompt has no ratio)", async () => {
+    const observability = worker();
+    recordModelCacheTokens(observability, "openai", { cachedTokens: 10, promptTokens: 0 });
+
+    const metrics = await observability.prometheusMetrics();
+    // cached still counts; ratio series is never created (no prompt to divide by).
+    expect(metrics).toMatch(
+      /opengeni_model_cached_tokens_total\{[^}]*provider="openai"[^}]*\} 10\b/,
+    );
+    expect(metrics).not.toMatch(/opengeni_model_cache_hit_ratio/);
+  });
+
+  test("ratio is clamped to 1 when cached exceeds prompt", async () => {
+    const observability = worker();
+    recordModelCacheTokens(observability, "openai", { cachedTokens: 1500, promptTokens: 1000 });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_model_cache_hit_ratio_sum\{[^}]*provider="openai"[^}]*\} 1\b/,
+    );
+  });
+
+  test("non-finite / negative inputs are ignored, not thrown or counted", async () => {
+    const observability = worker();
+    expect(() =>
+      recordModelCacheTokens(observability, "openai", {
+        cachedTokens: Number.NaN,
+        promptTokens: -5,
+      }),
+    ).not.toThrow();
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).not.toMatch(/opengeni_model_cached_tokens_total/);
+    expect(metrics).not.toMatch(/opengeni_model_cache_hit_ratio/);
+  });
+});
+
+describe("stableAccountHash — opaque, stable account tag", () => {
+  test("is stable, opaque (never the raw id), and short", () => {
+    const id = "cred_01H8XABCDEF1234567890";
+    const hash = stableAccountHash(id);
+    expect(hash).toBe(stableAccountHash(id)); // stable
+    expect(hash).not.toBe(id); // opaque — never the id verbatim
+    expect(hash).not.toContain(id);
+    expect(hash).toMatch(/^[0-9a-f]{12}$/); // short hex tag
+  });
+
+  test("distinct accounts get distinct tags", () => {
+    expect(stableAccountHash("cred-a")).not.toBe(stableAccountHash("cred-b"));
+  });
+
+  test("a null/absent/empty account tags as 'none'", () => {
+    expect(stableAccountHash(null)).toBe("none");
+    expect(stableAccountHash(undefined)).toBe("none");
+    expect(stableAccountHash("")).toBe("none");
+  });
+});
+
+describe("modelCallAccountContext — account-switch dimension", () => {
+  test("first call of a turn on a NEW account reports a switch", () => {
+    const ctx = modelCallAccountContext({
+      servingCredentialId: "cred-new",
+      priorSessionCredentialId: "cred-old",
+      isFirstCallOfTurn: true,
+    });
+    expect(ctx.accountChangedFromPrevCall).toBe(true);
+    expect(ctx.servingAccountHash).toBe(stableAccountHash("cred-new"));
+  });
+
+  test("first call on the SAME account is not a switch", () => {
+    const ctx = modelCallAccountContext({
+      servingCredentialId: "cred-x",
+      priorSessionCredentialId: "cred-x",
+      isFirstCallOfTurn: true,
+    });
+    expect(ctx.accountChangedFromPrevCall).toBe(false);
+  });
+
+  test("a session's very first call (no prior account) is a cold start, not a switch", () => {
+    const ctx = modelCallAccountContext({
+      servingCredentialId: "cred-x",
+      priorSessionCredentialId: null,
+      isFirstCallOfTurn: true,
+    });
+    expect(ctx.accountChangedFromPrevCall).toBe(false);
+    expect(ctx.servingAccountHash).toBe(stableAccountHash("cred-x"));
+  });
+
+  test("later calls within the same turn never report a switch (account is fixed per turn)", () => {
+    const ctx = modelCallAccountContext({
+      servingCredentialId: "cred-new",
+      priorSessionCredentialId: "cred-old",
+      isFirstCallOfTurn: false,
+    });
+    expect(ctx.accountChangedFromPrevCall).toBe(false);
+  });
+
+  test("a non-codex turn (no serving credential) tags 'none' and never a switch", () => {
+    const ctx = modelCallAccountContext({
+      servingCredentialId: null,
+      priorSessionCredentialId: null,
+      isFirstCallOfTurn: true,
+    });
+    expect(ctx.servingAccountHash).toBe("none");
+    expect(ctx.accountChangedFromPrevCall).toBe(false);
+  });
+});

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -92,6 +92,25 @@ spec:
             severity: warning
           annotations:
             summary: OpenGeni contexts are running hot but compaction has not fired in 30m
+        - alert: OpenGeniCodexPromptCacheHitRatioLow
+          # The codex-subscription prompt cache is doing little work: median per-call
+          # cache-hit ratio below 40% over 30m while codex calls are actually flowing.
+          # A sustained drop is the signature of prompt-cache thrash (e.g. an account
+          # rotation cold-starting the provider's per-account cache).
+          # `or vector(0)` on the traffic gate is load-bearing (the #367 lesson): with
+          # no codex calls yet the ratio series has never been created, so a bare
+          # `_count` rate is an EMPTY vector — the fallback forces a real 0 so the
+          # conjunction is well-formed and the alert simply stays quiet on no traffic.
+          expr: |
+            histogram_quantile(0.5, sum by (le) (rate(opengeni_model_cache_hit_ratio_bucket{provider="codex-subscription"}[30m]))) < 0.4
+            and on()
+            (sum(rate(opengeni_model_cache_hit_ratio_count{provider="codex-subscription"}[30m])) or vector(0)) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenGeni codex prompt-cache hit ratio p50 below 40% over 30m
+            description: The codex-subscription prompt cache is serving under 40% of prompt tokens from cache (median call) for 30m. Suspect prompt-cache thrash — an account rotation cold-starts the provider's per-account cache. Cross-check the per-call usage logs' accountChangedFromPrevCall against cachedTokens.
         # ── Connected Machines (op-outcome plane) ────────────────────────────
         - alert: OpenGeniMachineOpInfraFailuresHigh
           expr: sum(rate(opengeni_machine_op_total{outcome="failed"}[10m])) / clamp_min(sum(rate(opengeni_machine_op_total[10m])), 1) > 0.1


### PR DESCRIPTION
Makes OpenGeni's prompt-cache efficiency **measurable per model call** in the worker's model-call path. Reads `cached_tokens` from the same usage frame that already feeds input-token accounting, so cache metrics and token metrics are always consistent. Measurement only — no change to credential selection or routing.

## Why now

Codex-subscription turns are landing a per-call prompt-cache hit ratio around **48%** when a stable session should sit near **96%** — roughly half the prompt is being re-billed and re-processed instead of served from cache. This change makes that gap a first-class number per call and pins the leading suspect (a codex account switch cold-starting the provider's per-account cache) to a concrete, queryable signal, so the fix can be chosen from evidence rather than a hunch.

## What an operator sees

- **Cache-hit ratio per call** — two new Prometheus series (provider label only, bounded cardinality): `opengeni_model_cached_tokens_total{provider}` (cumulative prompt tokens served from cache) and `opengeni_model_cache_hit_ratio{provider}` (per-call cached/prompt, bucketed around the 40% threshold). A provider that doesn't report cached tokens records a real `0` ratio — "the cache did nothing" — rather than a silent gap, and never a phantom counter increment.
- **Account-switch dimension** — each per-call `model call usage` log line now carries `servingAccountHash` (an opaque, non-reversible tag for the serving codex credential — the credential row id hashed, never a token) and `accountChangedFromPrevCall` (did the serving account change vs the session's previous call). Cross-referencing `accountChangedFromPrevCall` against `cachedTokens` in the logs is how the account-rotation hypothesis gets confirmed or ruled out. These are log-only and never leak into the durable event.
- **Low-cache alert** — `OpenGeniCodexPromptCacheHitRatioLow` fires when the codex-subscription cache-hit ratio p50 falls below 40% over 30m while codex calls are flowing, traffic-gated with the `or vector(0)` empty-vector guard.

The durable `agent.model.usage` session event already persisted `cachedTokens` (added in #367), so staging gains historical cached-token data as soon as it deploys; the non-codex credit-debit ledger metadata now additionally carries `cachedTokens` (additive).

## How verified

- Typecheck: all 20 projects clean. Format (oxfmt) + lint (oxlint): clean, zero findings in changed files.
- Unit tests: 321/321 worker tests pass, plus a new `cache-metrics.test.ts` (zero/absent/non-finite cached tokens, no-prompt, ratio clamp, hash opacity/stability, switch vs cold-start vs same-account vs non-codex) and an extended `agent-turn.test.ts` (account-log wiring + a guard that the account dimensions never leak into the durable event).
- Alert rules: `promtool check rules` passes all 13 rules; `promtool test rules` passes 3 behavior scenarios — fires on cold-cache-with-traffic, stays quiet on no-traffic (proving the empty-vector guard) and on a healthy cache.

Diff is 220 insertions, 0 deletions — purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
