### PR TITLE
docs(caching): prompt-cache ADR, verified baseline, and subscription capacity north-star

### DIFF
--- a/docs/design/prompt-cache-affinity.md
+++ b/docs/design/prompt-cache-affinity.md
@@ -1,0 +1,230 @@
+<!-- docs-refs: record -->
+
+> **Point-in-time design record.** Written against the tree at authoring time; paths and names may move. Code wins. Measured production figures are snapshots from the audit window, not a live SLO.
+
+# ADR: Prompt-cache-aware codex request construction and account affinity
+
+Status: accepted (records existing invariants + one confirmed regression class)
+Scope: the codex-subscription model path (gpt-5.x driven through ChatGPT/Codex accounts).
+
+## Context
+
+OpenGeni drives gpt-5.x through ChatGPT/Codex subscription accounts over a **stateless
+resend** path: every model call re-sends the full request (`store: false` on the OpenAI
+platform, reasoning continuity via replayed `reasoning.encrypted_content`, no
+`previous_response_id`). There is no server-side conversation state to lean on, so the
+**only** thing that makes a 180k–240k-token request cheap instead of expensive is
+**OpenAI automatic prompt caching**: an exact-prefix-hash match from the start of the
+request. A cache hit is charged at the cached input rate and returns faster (lower TTFT);
+a miss is charged at full input rate *and* burns that much harder against the account's
+5-hour / weekly subscription rate-limit windows.
+
+Because the mechanism is prefix-hash-only and invisible unless you measure it, it is
+easy to silently destroy — one wrong byte in the wrong layer cold-starts an entire
+history prefix on every call, and nothing errors. This ADR records the invariants every
+future agent must preserve, the one regression class we have already hit, and the
+verified baseline that says the mechanism is worth this discipline.
+
+## Decision — the invariants
+
+### 1. The cacheable prefix is `[instructions, tools, history-prefix]` and it is BYTE-sensitive
+
+OpenAI hashes the request as an ordered prefix starting at byte 0: the `instructions`
+block, then the `tools` block, then the `input` history items. Matching is exact-prefix:
+the cache is used up to the **first byte that differs** from a previously-seen request,
+and everything after that point is a miss. The minimum cacheable prefix is ~1024 tokens.
+
+Consequences that are non-negotiable:
+
+- The `tools` block precedes the history. **Any** change to a tool definition (a
+  description, a schema, even key ordering) invalidates the entire history that follows
+  it — not just the tool.
+- The `instructions` block precedes everything. A change there invalidates the whole
+  request.
+- Serialization must be stable. `buildAgent(...)` runs **once per turn**; the request
+  body key order is fixed (`model, instructions, input, include, tools, stream, store`).
+  Do not introduce a code path that re-derives instructions or tools per model call.
+
+### 2. Nothing dynamic may render into instructions or tool definitions — per-turn snapshots only
+
+Everything in the `instructions` and `tools` layers must be a **snapshot taken once at
+turn start** and held byte-identical for every model call in that turn. Specifically,
+none of the following may appear in those two layers:
+
+- Live/mutable state that fills or changes during the turn (a `Set`/`Map`/array populated
+  by in-flight work, a counter, a "currently active X" pointer).
+- Timestamps, dates, elapsed time, or "now".
+- Unordered collections serialized without a stable sort (iteration/key order drift is
+  byte drift).
+- Per-call randomness (nonce, uuid, sampled value).
+
+If a value legitimately must change within a turn, it belongs in the **append-only tail**
+after the history (where earlier bytes stay stable), never in the instructions/tools
+prefix. This is the same discipline Codex CLI uses: static compiled-in base instructions,
+environment context appended via an append-only diff where unchanged turns emit nothing.
+
+### 3. Caches are per-subscription-account; a switch is a cold prefix
+
+Prompt caches are **not shared between organizations**, and each ChatGPT/Codex account is
+a distinct org. Therefore:
+
+- A different account = a **cold** prefix. Switching a session's account mid-life throws
+  away its warm cache. On the codex fleet this was measured at ~26 percentage points of
+  cache loss on the first call of a switched turn.
+- `prompt_cache_key` is a **routing/affinity hint only** — it nudges requests with the
+  same key toward the same backend to improve hit rates. It does **not** create
+  cross-account sharing and cannot rescue a switch. We set it to the session id
+  (`promptCacheKey = sessionId`), which is stable per session; keep it that way.
+- Cache warmth is therefore an **account-affinity** property. Keeping a session on one
+  account preserves its warm prefix; the full capacity/assignment design that exploits
+  this lives in `docs/design/subscription-capacity-and-caching.md`.
+
+### 4. Retention is short and some invalidation is legitimate — be schedule-aware
+
+The Codex path cache expires after roughly **15 minutes idle** (OpenAI docs quote
+5–10 min up to 1h; OpenAI staff quote ~15 min specifically for the Codex path). Two
+kinds of invalidation are **expected, not bugs**, and must not be "fixed":
+
+- **Long idle gaps.** An autonomous turn that idles > ~15 min between model calls
+  legitimately cold-starts the next call. This is an OpenAI TTL, not a client defect.
+- **Compaction.** Compaction deliberately rewrites the stable history prefix to shrink
+  context. The next call after a compaction is *supposed* to re-warm from a new prefix.
+
+Distinguish these scheduled invalidations from a *bug* (a warm, recent, same-account
+request that still misses). Only the latter is a client problem.
+
+### 5. Measurement is empirical — read `cached_tokens`, never assume
+
+Cache behavior is not inferable from the code; it must be observed per call.
+`usage-telemetry.ts` reads the cached count from the Responses API usage under the field
+aliases `cached_tokens` / `cachedInputTokens` / `cached_input_tokens` and emits it on the
+persisted `agent.model.usage` event (input tokens, cached tokens, provider, model,
+sourceKey). The cached ratio for a call is `cached_tokens / input_tokens`, where
+`input_tokens` is the total input (cached is a subset of it). Any claim about caching —
+"this change helped", "the prefix is stable", "the account is warm" — must be backed by
+that number, not by reading the request construction.
+
+## The canonical regression: "mutable state rendered into the stable prefix"
+
+**Pattern name: mutable state rendered into the stable prefix.** Correct data, placed in
+the wrong layer (the byte-stable, cache-hashed prefix), at the wrong cadence (per model
+call instead of per turn), silently cold-starts every request.
+
+### The incident (tool_search)
+
+`installCodexToolSearch` wraps `getAllTools`, so the `tool_search` tool **description is
+re-rendered on every model call** from a **live by-reference `Set`** of connector
+namespaces that fills *during the turn* as the `codex_apps` `tools/list` results resolve.
+The description flips mid-turn from:
+
+> "…Connected sources: none currently available."
+
+to:
+
+> "…You have access to tools from the following sources: - github - gmail - linear"
+
+Because the `tools` block precedes the history in the prefix (invariant 1), the model
+call *after* that flip misses the **entire history prefix**, not just the tool. Nothing
+errors; the only symptom is a collapsed `cached_tokens`.
+
+This was confirmed on the wire: a two-model-call capture showed the core client prefix
+byte-stable (`instructions equal: true`, `tools equal: true`, shared input items
+identical) **except** the `tool_search` description, which was `equal across calls:
+false` once the connector `Set` filled between calls. So the core request construction is
+clean; this one rewrap is the confirmed client-side breaker. Its blast radius is scoped
+to connector-enabled turns at the discovery transition — real and fixable, but not the
+whole story (steady-state within-turn non-warming has a separate, backend-leaning cause;
+see the plan doc).
+
+### The fix shape (and its trap)
+
+Snapshot the `tool_search` description **once per turn** instead of reading the live
+`Set` per call. But the snapshot has a capability trap: the connector `Set` fills lazily,
+and the description is the model's *only* signal of which connectors exist (schemas are
+deferred). Freezing an empty/partial snapshot at "first model call" would tell the model
+"no connectors" for the whole turn even though the user connected some — a **functional
+capability loss, worse than a cache miss**. The only safe form is: populate the connector
+`Set` *before* the first model call (block on discovery), then freeze; on discovery
+timeout/partial-failure, **fall back to today's per-call live render** and accept the
+cache miss. Never freeze an empty or partial snapshot.
+
+## Reviewer checklist — before anything renders into `instructions` or `tools`
+
+Ask, for every value composed into those two layers:
+
+1. **Live state?** Does it read a `Set`/`Map`/array/counter/"active pointer" that is
+   populated or mutated *during* the turn? (The tool_search bug.)
+2. **Time?** Does it include a timestamp, date, elapsed time, or "now"?
+3. **Unordered serialization?** Does it serialize a `Set`/`Map`/object whose
+   iteration/key order is not explicitly, stably sorted?
+4. **Per-call randomness?** A nonce, uuid, or sampled value?
+5. **Cadence?** Is it computed **once per turn** (like `buildAgent`), or re-derived per
+   model call by some wrapper?
+6. **If it must change within the turn**, is it in the append-only tail *after* the
+   history, rather than in the instructions/tools prefix?
+
+Any "yes" to 1–4, or "per model call" on 5, is a prefix breaker. Move it to a per-turn
+snapshot or to the append-only tail, and verify with `cached_tokens` on a two-call turn.
+
+## The verified baseline (reference table)
+
+The mechanism is worth the discipline because a single account, using this exact
+construction, caches almost perfectly. The bar below is recomputed from local Codex CLI
+rollouts and is reproducible with the committed script.
+
+### Codex CLI baseline — the bar (verified, reproducible)
+
+| Metric | Value |
+| --- | --- |
+| Rollout files scanned | 2,130 (2,017 with measured calls) |
+| Model calls measured | 1,586,180 |
+| Σ input tokens | 228,313,685,685 |
+| Σ cached input tokens | 219,153,436,672 |
+| **Token-weighted cached ratio** | **96.0%** |
+| Per-call cached ratio, median (p50) | 98.8% |
+| Per-call distribution p10 / p50 / p90 | 88.2% / 98.8% / 99.7% |
+| Long agentic sessions (≥10 calls, ≥200k input), per-session median | 93.2% |
+| Calls below 50% cached (cold starts) | 2.53% |
+| Sanity: calls with cached > input | 0 |
+
+Method: per model call, Codex logs an `event_msg` with `payload.type == "token_count"`
+whose `payload.info.last_token_usage` carries `{ input_tokens, cached_input_tokens }` for
+that single call. Token-weighted ratio = `Σ cached_input_tokens / Σ input_tokens`. The
+per-call median (98.8%) is *higher* than the token-weighted figure (96.0%) because the
+minority of large cold-start calls (the 2.53% below 50%) carry disproportionate token
+weight — the correct relationship, and the reason the token-weighted number is the
+headline for cost.
+
+Reproduce: `node scripts/recompute-codex-cache-baseline.mjs` (reads
+`~/.codex/sessions/**/rollout-*.jsonl`).
+
+### OpenGeni codex-subscription fleet — the gap (measured at audit time)
+
+Measured from the persisted `agent.model.usage` events over a 4-day window on the codex
+fleet (point-in-time; requires production data access to reproduce, so it is *not* in the
+committed script):
+
+| Metric | Value | Note |
+| --- | --- | --- |
+| Token-weighted cached ratio | ~48% | vs the 96% bar on the same construction |
+| Within-turn call 1 → call 2 warming (same account) | ~31% → ~31% | call 2 re-sends call 1's prefix seconds later and does not warm |
+| Model variance (same client code) | ~46%–76% across models | strong signal of a backend/model component |
+| Account-switch penalty (first call of a switched turn) | ~26pp lower | invariant 3, quantified |
+
+The gap between 96% and ~48% is the subject of the north-star plan. The core client
+construction is byte-stable (proven on the wire), so the loss splits between the narrow,
+confirmed `tool_search` breaker above and a steady-state floor most consistent with an
+OpenAI backend / per-account concurrency effect (a controlled low-load probe to nail the
+latter was blocked at audit time). Treat the cache-regime win from load-spreading as a
+**hypothesis to be proven by measurement**, not a certainty — see the plan.
+
+## Canonical code
+
+- `packages/runtime/src/index.ts` — request construction, `store: false`, `prompt_cache_key`, `agent.model.usage` emission
+- `packages/runtime/src/codex-tool-search.ts` — the `tool_search` rewrap (the regression site)
+- `packages/runtime/src/usage-telemetry.ts` — `cached_tokens` capture
+- `packages/runtime/src/history-sanitizer.ts` — stable history serialization for the resend
+- `apps/worker/src/activities/agent-turn.ts` — per-turn `promptCacheKey = sessionId`, credential selection
+- `apps/worker/src/activities/codex-rotation.ts` — account rotation / affinity
+- `apps/worker/src/observability-metrics.ts` — model token metrics
+- `scripts/recompute-codex-cache-baseline.mjs` — reproduces the baseline table above

--- a/docs/design/subscription-capacity-and-caching.md
+++ b/docs/design/subscription-capacity-and-caching.md
@@ -1,0 +1,171 @@
+<!-- docs-refs: record -->
+
+> **Point-in-time design record.** Written against the tree at authoring time; paths and names may move. Code wins. Phase status (exists / building / future) reflects the authoring window.
+
+# Subscription capacity + caching — end-state plan
+
+Companion to `docs/design/prompt-cache-affinity.md` (which owns the request-construction
+and account-affinity *invariants*). This doc owns the **capacity architecture**: how we
+assign, protect, observe, and optimize a pool of subscription accounts.
+
+## Target
+
+Run **thousands of concurrent sessions across N subscription accounts and multiple
+providers, optimally** — where "optimally" means, in priority order:
+
+1. **Never stall** a session that has any available capacity anywhere in the pool.
+2. **Balance the burn** so no single account's short-window (5h / weekly) cap is hit
+   while sibling accounts sit idle.
+3. **Preserve cache warmth** — keep a session on one account so its prefix stays warm,
+   and (hypothesis) spread load so no account is thrashed into cache eviction.
+4. **Protect priority work** — orchestrator/manager sessions must not be starved of
+   capacity by a swarm of workers.
+
+These can conflict (warmth wants stickiness; balance wants spreading; protection wants
+partitioning). The design resolves them as layers, cheapest and most-certain first.
+
+## The layers
+
+### L1 — Atomic credential leasing
+A unit of work acquires an account through a single race-free write, never a
+read-count-then-write. Today assignment is a durable single-write **session pin**
+(`sessions.codex_pinned_credential_id`), which is atomic per session but has no notion of
+a per-account *slot* or hard capacity. Deterministic assignment (L3) removes the need for
+coordinated leasing at genesis; true atomic leasing (compare-and-set on an account slot)
+becomes necessary only when pools carry hard per-account concurrency limits (L2/P1).
+
+### L2 — Named, protected pools with inheritance
+Accounts are grouped into named pools. A session belongs to a **self pool** and hands a
+**child-default pool** to sessions it spawns. Example end-state: orchestrator/manager
+sessions run on a small **protected** pool; workers inherit a **worker** pool covering
+the rest. Protection means a worker swarm draining its pool cannot touch the protected
+accounts, so a manager always has warm, uncapped capacity. **Promotion** moves an account
+between pools. None of this exists yet; it is the P1 layer.
+
+### L3 — Deterministic sharded assignment
+Assign a session to a home account by **`stableAccountList[hash(sessionId) % N]`** within
+its pool. This is coordination-free (no read-then-write race, no shared cursor), balanced
+in expectation, and stable (the same session recomputes the same home). It replaces the
+naive "least-loaded by live session count" idea, which is both a race (burst creation →
+all pick the same account) and a weak load proxy (session count ≠ token burn). Real
+imbalance is corrected reactively (L1 rebalance on cap), not by a fragile count metric.
+
+### L4 — Observe-first cache affinity
+Only **after** measurement proves that spreading load raises cache hit rate do we let
+cache warmth rank assignment (e.g. prefer the home account, but bias new sessions toward
+less-thrashed accounts). This is deliberately last: the cache-regime win is a
+**hypothesis** (see "Honesty" below), and ranking by an unproven signal would be
+premature optimization. Ships only when the data earns it.
+
+### L5 — Live observability + a queryable capacity surface
+Per-account, live: cache hit ratio, quota/window headroom, eviction pressure, active
+session count, token burn rate. Rendered as dashboards **and** exposed as a surface a
+manager agent can query ("which pool is under pressure? should I trim or add
+subscriptions?"). When sustained eviction pressure co-occurs with high concurrency on an
+account, the guidance is **add subscriptions or reduce per-account concurrency**; when
+accounts sit persistently idle, **trim**. This is the control loop that keeps the pool
+right-sized.
+
+## Phases
+
+### P0 — Landing now: instrument, fix the confirmed breaker, shard deterministically
+- **Instrumentation.** Add a cached-input-token counter next to the existing
+  `opengeni_model_calls_total` / `opengeni_model_input_tokens`, and add a
+  **per-credential/account label** (cardinality ~N, safe) plus a per-account active-session
+  gauge. Without a per-account label you cannot see load-spread, and an aggregate hit-rate
+  read is confounded by hour-of-day and model mix. Commit to a **same-hour-of-day,
+  model-sliced** before/after read for any policy verdict.
+- **tool_search prefix fix** (the confirmed regression from the ADR): per-turn snapshot of
+  the tool_search description, populated *before* the first model call, with a live-render
+  fallback on discovery timeout — never freeze an empty/partial connector list.
+- **Deterministic sharded strategy** (the assignment change; see required amendments).
+
+### P1 — Named / protected pools + inheritance
+Introduce pool membership, the self/child-default inheritance rule, and promotion. Land
+protected-pool semantics so orchestrators are insulated from worker swarms. This is where
+**atomic slot leasing** (L1, hard-capacity form) is built, because pools introduce
+per-pool capacity that assignment must respect atomically.
+
+### P2 — Cache-affinity ranking (gated on measurement)
+Only after P0 instrumentation shows that spreading load measurably improves per-account
+cache hit rate: let warmth/eviction-pressure bias assignment within a pool. Ships or is
+dropped based on the P0 data.
+
+### P3 — Multi-provider generalization
+Generalize pools and assignment across providers (not just ChatGPT/Codex accounts):
+per-provider affinity fields (`prompt_cache_key` for OpenAI, provider-specific hints
+elsewhere), per-provider retention/quota models, and cross-provider routing that still
+honors the per-account warmth and protection rules.
+
+## What exists / building / future
+
+| Piece | Status | Where |
+| --- | --- | --- |
+| Stateless resend + `store:false` + `prompt_cache_key = sessionId` | **exists** | `packages/runtime/src/index.ts`, `apps/worker/src/activities/agent-turn.ts` |
+| Per-call `cached_tokens` capture + `agent.model.usage` event | **exists** | `packages/runtime/src/usage-telemetry.ts` |
+| `opengeni_model_calls_total`, `_call_duration_seconds`, `_input_tokens` (provider-labeled) | **exists** | `apps/worker/src/observability-metrics.ts` |
+| Session pin + last-credential columns; `selectCodexCredentialForTurn` (pin > active) | **exists** | DB + `apps/worker/src/activities/agent-turn.ts` |
+| Rotation strategies (`drain_then_next`, `most_remaining`) + reactive-429 path | **exists** | `apps/worker/src/activities/codex-rotation.ts` |
+| Cached-token counter + per-credential/account label + per-account load gauge | **building (P0)** | `apps/worker/src/observability-metrics.ts` |
+| tool_search per-turn description snapshot (+ safe fallback) | **building (P0)** | `packages/runtime/src/codex-tool-search.ts` |
+| Deterministic sharded assignment (+ amendments below) | **building (P0)** | agent-turn credential block + rotation |
+| Named / protected pools + inheritance + promotion | **future (P1)** | new |
+| Atomic account-slot leasing (hard-capacity) | **future (P1)** | new |
+| Cache-affinity ranking | **future (P2, gated)** | new |
+| Multi-provider generalization | **future (P3)** | new |
+| Manager-agent-queryable capacity surface + trim/add guidance | **future (P1–P2)** | new |
+
+## Required amendments for deterministic sharding (P0)
+
+Sharding is **not** "an assignment policy on top of existing plumbing with no new
+architecture" — that framing is wrong. The pin column and reactive path exist, but
+correct sharding needs real additions:
+
+- **Pin-source discriminator (schema).** A pin today cannot distinguish a *manual* "run on
+  this account" override from a *policy* home assignment. Add `codex_pin_source`
+  (`manual` | `policy`). Both rotation guards read `pin == null` to mean "may rotate"; to
+  override a policy home on a capped account while never overriding a manual pin, they must
+  tell the two apart.
+- **Both rotation guards honor policy pins.** Teach the proactive and reactive guards to
+  allow rebalance when a *policy*-pinned account is capped/near-cap; never override a
+  manual pin.
+- **Reactive rebalance rewrites the pin durably.** `selectCodexCredentialForTurn` returns a
+  cooling pinned account with no exhaustion check, so a pointer-only move leaves the
+  session stuck on the capped pin. The rebalance must durably **rewrite the session pin** to
+  a healthy account.
+- **Proactive re-shard.** The proactive block must health-check a policy-pinned session's
+  account and re-shard *before* the model call, to keep pre-cap avoidance and avoid a
+  wasted 429 per cap boundary.
+- **Re-shard on failover, not first-eligible.** When an account caps, every session on it
+  rebalances independently; if they all pick the same failover account the cold-cliff
+  reappears as a warm-cliff. The failover pick must **re-shard** (hash over the healthy
+  set, or least-loaded excluding the capped account).
+- **Assign lazily at first codex turn, not genesis-only.** In-flight sessions created
+  before a workspace switches to sharded otherwise never converge; first-turn assignment
+  is also fresher than a stale genesis snapshot.
+- **Deterministic hash, not least-loaded-count.** Removes the burst read-then-write skew
+  and cursor contention; real imbalance is handled by the reactive rebalance above.
+
+## Honesty about the wins
+
+Two wins are **robust** and hold regardless of the open cache question:
+
+- **Limit-burn balance.** Spreading sessions across all N accounts avoids synchronized
+  single-account saturation and the cold-cliff at each drain boundary. (Note: the current
+  `drain_then_next` does cycle accounts over a window; the real difference is
+  *instantaneous* concentration, not total quota.)
+- **Switch-cost elimination.** Pinned sessions stop following the shared workspace pointer,
+  removing the cross-session-drag "manual" switches measured at ~26pp of cache loss each.
+
+One win is a **hypothesis**, not a certainty:
+
+- **Cache-regime lift** (busy-account ~35–49% → quiet-account ~65–73%) depends on the
+  claim that OpenAI under-caches an account under high concurrent load. That claim is
+  **field-correlational only** (per-account hit rate tracks inversely with call volume);
+  a controlled low-load probe to confirm it was blocked at audit time. Sell it as a
+  well-supported bet, verified by P0 instrumentation — never as a settled result. If the
+  probe later refutes it, the two robust wins above still justify P0.
+
+## See also
+
+- `docs/design/prompt-cache-affinity.md` — the request-construction + affinity invariants and the verified baseline.

--- a/scripts/recompute-codex-cache-baseline.mjs
+++ b/scripts/recompute-codex-cache-baseline.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Recompute the Codex CLI prompt-cache baseline from local rollout files.
+//
+// This is a one-shot analysis artifact, not part of the build. It exists so the
+// "96% token-weighted cached ratio" figure in
+// docs/design/prompt-cache-affinity.md stays reproducible rather than asserted.
+//
+// Source: ~/.codex/sessions/**/rollout-*.jsonl (one file per Codex CLI session).
+// Per model call, Codex emits an `event_msg` whose `payload.type == "token_count"`
+// and whose `payload.info.last_token_usage` is THAT single call's usage:
+//     input_tokens         -- total input tokens for the call (INCLUSIVE of cached)
+//     cached_input_tokens  -- the cached subset of input_tokens
+// Verified: total_token_usage.input_tokens accumulates and each step equals the
+// next last_token_usage.input_tokens, so last_token_usage is genuinely per-call;
+// and cached_input_tokens never exceeds input_tokens (it is a subset).
+//
+// Cached ratio for a call        = cached_input_tokens / input_tokens
+// Token-weighted global ratio    = sum(cached_input_tokens) / sum(input_tokens)
+//
+// Usage: node scripts/recompute-codex-cache-baseline.mjs [sessionsDir]
+// Default sessionsDir = ~/.codex/sessions
+import { createReadStream } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const root = process.argv[2] ?? join(homedir(), ".codex", "sessions");
+
+async function listRollouts(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await listRollouts(full)));
+    } else if (entry.isFile() && /^rollout-.*\.jsonl$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function percentile(sorted, q) {
+  if (sorted.length === 0) return NaN;
+  if (sorted.length === 1) return sorted[0];
+  const pos = q * (sorted.length - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.min(lo + 1, sorted.length - 1);
+  return sorted[lo] * (1 - (pos - lo)) + sorted[hi] * (pos - lo);
+}
+
+const files = (await listRollouts(root)).sort();
+
+let filesWithCalls = 0;
+let totalCalls = 0;
+let nullInfoEvents = 0;
+let zeroInputCalls = 0;
+let cachedGtInput = 0;
+let sumInput = 0;
+let sumCached = 0;
+const perCall = []; // unweighted per-call cached ratio (input>0)
+const sessions = []; // { calls, input, cached } per file
+
+for (const path of files) {
+  let calls = 0;
+  let input = 0;
+  let cached = 0;
+  const rl = createInterface({ input: createReadStream(path), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.includes('"token_count"')) continue;
+    let rec;
+    try {
+      rec = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const payload = rec?.payload;
+    if (payload?.type !== "token_count") continue;
+    const info = payload.info;
+    if (!info) {
+      nullInfoEvents += 1;
+      continue;
+    }
+    const last = info.last_token_usage ?? {};
+    const inp = last.input_tokens;
+    if (inp === undefined || inp === null) continue;
+    const c = last.cached_input_tokens ?? 0;
+    if (c > inp) cachedGtInput += 1;
+    calls += 1;
+    input += inp;
+    cached += c;
+    if (inp > 0) perCall.push(c / inp);
+    else zeroInputCalls += 1;
+  }
+  if (calls > 0) {
+    filesWithCalls += 1;
+    totalCalls += calls;
+    sumInput += input;
+    sumCached += cached;
+    sessions.push({ calls, input, cached });
+  }
+}
+
+const tw = sumInput > 0 ? sumCached / sumInput : NaN;
+perCall.sort((a, b) => a - b);
+const p = (q) => (percentile(perCall, q) * 100).toFixed(2);
+const below50 = perCall.filter((r) => r < 0.5).length;
+
+const long = sessions.filter((s) => s.calls >= 10 && s.input >= 200_000);
+const longRatios = long
+  .filter((s) => s.input > 0)
+  .map((s) => s.cached / s.input)
+  .sort((a, b) => a - b);
+const longPooledIn = long.reduce((a, s) => a + s.input, 0);
+const longPooledCached = long.reduce((a, s) => a + s.cached, 0);
+
+const fmt = (n) => n.toLocaleString("en-US");
+console.log("====================================================================");
+console.log("CODEX CLI PROMPT-CACHE BASELINE — recomputed from local rollouts");
+console.log("====================================================================");
+console.log(`sessions dir                 : ${root}`);
+console.log(`rollout files scanned        : ${files.length}`);
+console.log(`files with >=1 measured call : ${filesWithCalls}`);
+console.log(`model calls measured         : ${fmt(totalCalls)}`);
+console.log(`  token_count w/o usage skipped: ${fmt(nullInfoEvents)}`);
+console.log(`  zero-input calls (excl ratio): ${fmt(zeroInputCalls)}`);
+console.log(`  SANITY cached>input (must be 0): ${cachedGtInput}`);
+console.log("");
+console.log(`sum(input_tokens)            : ${fmt(sumInput)}`);
+console.log(`sum(cached_input_tokens)     : ${fmt(sumCached)}`);
+console.log(`TOKEN-WEIGHTED cached ratio  : ${(tw * 100).toFixed(2)}%   <-- headline`);
+console.log("");
+console.log("Per-call cached ratio (unweighted, input>0):");
+console.log(`  calls counted              : ${fmt(perCall.length)}`);
+console.log(
+  `  p10 / p25 / p50 / p75 / p90 : ${p(0.1)}% / ${p(0.25)}% / ${p(0.5)}% / ${p(0.75)}% / ${p(0.9)}%`,
+);
+console.log(
+  `  calls <50% cached (cold)   : ${fmt(below50)} (${((below50 / perCall.length) * 100).toFixed(2)}%)`,
+);
+console.log("");
+console.log("Long agentic sessions (>=10 calls AND >=200k total input):");
+console.log(`  qualifying sessions        : ${long.length}`);
+console.log(`  per-session ratio median   : ${(percentile(longRatios, 0.5) * 100).toFixed(2)}%`);
+console.log(
+  `  pooled token-weighted      : ${((longPooledCached / longPooledIn) * 100).toFixed(2)}%`,
+);


### PR DESCRIPTION
Records the design + verified baseline for the codex-subscription caching/capacity program. Docs-only plus a reproduction script; touches no published package.

## Verified baseline — 96.0% confirmed (independently recomputed: 95.99%)

Recomputed from local Codex CLI rollouts (`~/.codex/sessions/**/rollout-*.jsonl`). Each model call logs a `token_count` event whose `payload.info.last_token_usage` carries `{ input_tokens, cached_input_tokens }` for that call; verified per-call (its `input_tokens` equals each step of the accumulating `total_token_usage.input_tokens`) with `cached_input_tokens` a subset of `input_tokens` — **0 anomalies** where cached > input across all 1.56M calls.

Formula: token-weighted = `Σ cached_input_tokens / Σ input_tokens` = 219,153,436,672 / 228,313,685,685 = **95.99%**.

| Metric | Value |
| --- | --- |
| Rollout files (with usage) | 2,130 (2,017) |
| Model calls measured | 1,586,180 |
| **Token-weighted cached ratio** | **95.99%** |
| Per-call median (p50) | 98.77% |
| Per-call p10 / p50 / p90 | 88.22% / 98.77% / 99.67% |
| Long sessions (≥10 calls, ≥200k input), per-session median | 93.18% |
| Cold calls (<50% cached) | 2.53% |

Reproduce: `node scripts/recompute-codex-cache-baseline.mjs`. (The cold-start minority carries the token weight that pulls the weighted figure below the per-call median — which is why token-weighted is the cost headline.)

## ADR — `docs/design/prompt-cache-affinity.md`

Records the invariants every future agent must preserve: the cacheable prefix `[instructions, tools, history-prefix]` is byte-sensitive and must be a per-turn snapshot (nothing dynamic — no live state, timestamps, unordered serialization, or per-call randomness — may render into instructions/tools), caches are per-subscription-account so a switch is a cold prefix (`prompt_cache_key` is a routing hint, not cross-account sharing), and cache behavior must be measured via `cached_tokens`, never assumed. The canonical bug pattern **"mutable state rendered into the stable prefix"** is the `tool_search` regression — a live by-reference `Set` rendered into a tool description per call silently cold-started every request's entire history prefix — documented with the fix's capability trap and a reviewer checklist.

## North-star — `docs/design/subscription-capacity-and-caching.md`

Target: thousands of concurrent sessions across N accounts and providers, optimally. Layers: atomic leasing, protected pools + inheritance, deterministic hash-sharding, observe-first affinity, live observability. Robust wins (limit-burn balance, switch-cost elimination) are stated as certain; the cache-regime lift is framed as a measurement-gated hypothesis.

| Phase | Scope |
| --- | --- |
| P0 (landing now) | instrumentation (cached-token counter + per-credential/switched labels) · tool_search prefix fix · deterministic sharded strategy |
| P1 | named/protected pools + child-default inheritance + promotion · atomic slot leasing |
| P2 | cache-affinity ranking (gated on P0 measurement proving load-spread helps) |
| P3 | multi-provider generalization |

## Gates
- `check:docs-refs` passes (design docs are record-tier with markers/banners)
- oxlint clean (0/0), oxfmt clean on the script
- No changeset (release/package-versioning only; no published-package change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)