### PR TITLE
fix(runtime): isolate best-effort MCP server failures — an optional server never fails an unrelated turn

### DIFF
--- a/.changeset/optional-mcp-auth-isolation.md
+++ b/.changeset/optional-mcp-auth-isolation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Isolate optional/best-effort MCP servers so an expired credential can never fail an unrelated turn. A best-effort server (an optional ToolRef, a connection-broker-backed capability MCP, or codex_apps) whose `tools/list` throws at run time — most often an expired/failed connection credential surfacing as a StreamableHTTP "authentication required" 401 — now degrades to zero tools for the turn instead of propagating out of the SDK's run-time `getAllMcpTools` and hard-failing the whole turn. Previously the best-effort isolation only wrapped the connect handshake, so a server that connected fine but had its credential expire by tool-listing time took down turns that never even used its tools. Required (explicitly-requested, non-best-effort) servers keep the fail-loud default: a `tools/list` failure still fails the turn. The actionable `tool.auth_needed` signal is preserved — the connection-broker fetch publishes it before returning the 401 that provokes the throw, so the drop is fully observable and the user still gets prompted to re-authenticate.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1798,6 +1798,28 @@ export async function prepareAgentTools(
       const fetchImpl = config.connectionRef
         ? connectionBrokerFetch(baseFetch, config, options)
         : baseFetch;
+      // A server is connected BEST-EFFORT (a connect OR tools-list failure drops
+      // it — its tools go unavailable for the turn — instead of failing the turn)
+      // in two cases:
+      //  - codex_apps: connector availability is RUNTIME-DISCOVERED — the
+      //    device-code login may lack the connector scopes, and the backend can
+      //    reject the bearer at the initialize/tools-list handshake, so a 401/403
+      //    (or a missing/failed token) drops the server.
+      //  - an optional ToolRef: either an auto-attached workspace-default
+      //    capability MCP or a client/pack-selected portable ref. A
+      //    broken/expired credential or unavailable endpoint skips the server
+      //    with a warning, never killing the turn before the model runs. Bare
+      //    refs stay strict (below), preserving the fail-loud default.
+      // The connect-time drop is handled by connectMcpServers({ strict: false });
+      // the tools-list-time drop is enforced inside PrefixedMcpServer.listTools —
+      // a best-effort server whose tools/list throws (e.g. an expired connection
+      // credential surfacing as a StreamableHTTP "authentication required" 401)
+      // degrades to zero tools rather than throwing out of the SDK's run-time
+      // getAllMcpTools and failing an unrelated turn. The actionable
+      // tool.auth_needed signal is preserved: the connection-broker fetch
+      // publishes it before returning the 401 that provokes the throw.
+      const optional = tool.optional === true;
+      const bestEffort = isCodexAppsMcpServer(config) || optional || !!config.connectionRef;
       const server = new PrefixedMcpServer(
         new MCPServerStreamableHttp({
           url,
@@ -1818,22 +1840,11 @@ export async function prepareAgentTools(
         }),
         config.id,
         config.allowedTools,
+        bestEffort,
       );
-      // A server is connected BEST-EFFORT (a connect / tools-list failure drops
-      // it instead of failing the turn) in two cases:
-      //  - codex_apps: connector availability is RUNTIME-DISCOVERED — the
-      //    device-code login may lack the connector scopes, and the backend can
-      //    reject the bearer at the initialize/tools-list handshake, so a 401/403
-      //    (or a missing/failed token) drops the server.
-      //  - an optional ToolRef: either an auto-attached workspace-default
-      //    capability MCP or a client/pack-selected portable ref. A
-      //    broken/expired credential or unavailable endpoint skips the server
-      //    with a warning, never killing the turn before the model runs. Bare
-      //    refs stay strict (below), preserving the fail-loud default.
-      const optional = tool.optional === true;
       return {
         server,
-        bestEffort: isCodexAppsMcpServer(config) || optional || !!config.connectionRef,
+        bestEffort,
         optional,
       };
     }),
@@ -2412,16 +2423,24 @@ class PrefixedMcpServer implements MCPServer {
   readonly name: string;
   readonly prefix: string;
   private readonly allowedTools: Set<string> | undefined;
+  // Best-effort servers (optional refs, connectionRef-backed capability MCPs,
+  // codex_apps) must never fail a turn: a tools/list throw degrades to zero
+  // tools instead of propagating. Deduplicate the warn so one degraded server
+  // doesn't spam the log when the SDK re-lists across model turns.
+  private readonly bestEffort: boolean;
+  private loggedListToolsFailure = false;
 
   constructor(
     private readonly inner: MCPServer,
     registryId: string,
     allowedTools?: string[],
+    bestEffort = false,
   ) {
     this.name = registryId;
     this.prefix = prefixedMcpToolName(registryId, "");
     this.cacheToolsList = inner.cacheToolsList;
     this.allowedTools = allowedTools ? new Set(allowedTools) : undefined;
+    this.bestEffort = bestEffort;
   }
 
   connect(): Promise<void> {
@@ -2433,7 +2452,32 @@ class PrefixedMcpServer implements MCPServer {
   }
 
   async listTools(): Promise<RuntimeMcpTool[]> {
-    const tools = await this.inner.listTools();
+    let tools: RuntimeMcpTool[];
+    try {
+      tools = await this.inner.listTools();
+    } catch (error) {
+      // A REQUIRED server's tools/list failure is fatal (fail-loud default): the
+      // caller explicitly requested it, so its absence must fail the turn.
+      if (!this.bestEffort) {
+        throw error;
+      }
+      // Best-effort isolation. The SDK's run-time getAllMcpTools calls listTools
+      // OUTSIDE the connect-time connectMcpServers({ strict: false }) guard, so a
+      // best-effort server whose tools/list throws here (most often an
+      // expired/failed connection credential surfacing as a StreamableHTTP
+      // "authentication required" 401) would otherwise take down an unrelated
+      // turn. Drop this server's tools for the turn instead; the actionable
+      // tool.auth_needed signal was already published by the connection-broker
+      // fetch before the throw, so degrading here does not silence it.
+      if (!this.loggedListToolsFailure) {
+        this.loggedListToolsFailure = true;
+        console.warn(
+          `[mcp] best-effort server "${this.name}" failed to list tools; dropping its tools for this turn`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+      return [];
+    }
     return tools
       .filter((tool) => this.isAllowed(tool.name))
       .map((tool) => ({ ...tool, name: prefixedMcpToolName(this.name, tool.name) }));

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2463,17 +2463,26 @@ class PrefixedMcpServer implements MCPServer {
       }
       // Best-effort isolation. The SDK's run-time getAllMcpTools calls listTools
       // OUTSIDE the connect-time connectMcpServers({ strict: false }) guard, so a
-      // best-effort server whose tools/list throws here (most often an
+      // best-effort server whose tools/list throws here — for ANY reason (an
       // expired/failed connection credential surfacing as a StreamableHTTP
-      // "authentication required" 401) would otherwise take down an unrelated
-      // turn. Drop this server's tools for the turn instead; the actionable
-      // tool.auth_needed signal was already published by the connection-broker
-      // fetch before the throw, so degrading here does not silence it.
+      // "authentication required" 401, a provider 5xx, a network blip) — would
+      // otherwise take down an unrelated turn. Drop this server's tools for the
+      // turn instead. An auth failure additionally published tool.auth_needed via
+      // the connection-broker fetch before the throw (so that actionable signal
+      // is preserved), but a non-auth failure has NO such signal — the structured
+      // warn below is its only visibility, so a chronically-dead optional
+      // integration surfaces in logs/metrics rather than being silently swallowed.
+      // Warn once per degraded server per turn (instances are per-turn), so a
+      // re-list across model turns does not spam the log.
       if (!this.loggedListToolsFailure) {
         this.loggedListToolsFailure = true;
         console.warn(
-          `[mcp] best-effort server "${this.name}" failed to list tools; dropping its tools for this turn`,
-          error instanceof Error ? error.message : error,
+          "[mcp] best-effort server tools/list failed; its tools are unavailable this turn",
+          {
+            serverId: this.name,
+            errorClass: error instanceof Error ? error.constructor.name : typeof error,
+            message: error instanceof Error ? error.message : String(error),
+          },
         );
       }
       return [];

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -2924,6 +2924,142 @@ describe("runtime event normalization", () => {
     }
   });
 
+  test("best-effort server whose tools/list throws at RUN time does not fail an unrelated turn", async () => {
+    // Regression for the prod incident where a session turn hard-failed with
+    // "Streamable HTTP error: Error POSTing to endpoint: authentication required"
+    // because an OPTIONAL connection-broker-backed MCP server had an expired
+    // credential. The server connects fine (its `initialize` handshake resolves a
+    // still-valid credential), so the connect-time best-effort isolation lets it
+    // through — but the credential is gone by the time the SDK's run-time
+    // getAllMcpTools calls tools/list, which throws OUTSIDE the connect guard. The
+    // invariant: that best-effort server drops to zero tools (with its
+    // tool.auth_needed preserved) while a healthy sibling's tools survive and the
+    // turn proceeds. Pre-fix, getAllMcpTools rethrows and the whole turn dies.
+    const connectionId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    // The broker resolves a valid credential during connect (initialize), then the
+    // credential expires: any resolve AFTER connect returns auth_needed(expired),
+    // exactly reproducing "valid at connect, gone at tools/list".
+    let connected = false;
+    const expired = startTestMcpServer();
+    const healthy = startTestMcpServer();
+    const authNeeded: unknown[] = [];
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    try {
+      const prepared = await prepareAgentTools(
+        testSettings({
+          mcpServers: [
+            {
+              id: "cap-expired",
+              name: "Expired-credential capability MCP",
+              url: expired.url,
+              connectionRef: {
+                connectionId,
+                providerDomain: "api.integrations-example.com",
+                kind: "oauth2",
+                subjectScope: "workspace",
+              },
+              cacheToolsList: false,
+            },
+            { id: "docs", name: "Document Search", url: healthy.url, cacheToolsList: false },
+          ],
+        }),
+        [
+          { kind: "mcp", id: "cap-expired" },
+          { kind: "mcp", id: "docs" },
+        ],
+        {
+          workspaceId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          resolveCredential: async (): Promise<ResolveConnectionCredentialResult> =>
+            connected
+              ? {
+                  status: "auth_needed",
+                  reason: "expired",
+                  providerDomain: "api.integrations-example.com",
+                  connectionId,
+                }
+              : {
+                  status: "ok",
+                  connectionId,
+                  headers: { authorization: "Bearer valid-at-connect" },
+                },
+          onAuthNeeded: (payload) => {
+            authNeeded.push(payload);
+          },
+        },
+      );
+      // Connect succeeded for both servers; the credential expires only now.
+      connected = true;
+      try {
+        // Both connected, so both are handed to the runner.
+        expect(prepared.mcpServers.map((server) => server.name).sort()).toEqual([
+          "cap-expired",
+          "docs",
+        ]);
+        // Drive the exact code path the agent runner uses. Pre-fix this REJECTS
+        // (the expired server's tools/list 401 throws out of getAllMcpTools).
+        const tools = await getAllMcpTools({ mcpServers: prepared.mcpServers });
+        const toolNames = tools.map((tool) => tool.name);
+        // The healthy sibling's tools survive; the expired server contributes none.
+        expect(toolNames).toContain("docs__search_documents");
+        expect(toolNames.some((name) => name.startsWith("cap-expired__"))).toBe(false);
+        // The actionable signal is NOT silenced by the degrade.
+        expect(authNeeded).toContainEqual(
+          expect.objectContaining({
+            serverId: "cap-expired",
+            reason: "expired",
+            providerDomain: "api.integrations-example.com",
+            connectionId,
+          }),
+        );
+      } finally {
+        await prepared.close();
+      }
+      // The drop is observable in the log.
+      const warned = warnings.some((args) =>
+        args.some((arg) => typeof arg === "string" && arg.includes("cap-expired")),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      expired.close();
+      healthy.close();
+    }
+  });
+
+  test("REQUIRED server whose tools/list throws at RUN time still fails the turn", async () => {
+    // The fail-loud default is unchanged for explicitly-requested servers (no
+    // `optional` flag, no connectionRef => not best-effort): a run-time tools/list
+    // failure must propagate. The server connects (its `initialize` handshake is
+    // accepted) but rejects `tools/list` with a 401, so the throw surfaces from
+    // getAllMcpTools exactly like the best-effort case — only here it is NOT
+    // contained, because the caller depends on this server.
+    const strict = startTestMcpServer({ unauthorizedForMethods: ["tools/list"] });
+    try {
+      const prepared = await prepareAgentTools(
+        testSettings({
+          mcpServers: [
+            { id: "docs-strict", name: "Document Search", url: strict.url, cacheToolsList: false },
+          ],
+        }),
+        [{ kind: "mcp", id: "docs-strict" }],
+      );
+      try {
+        // Connect succeeded, so the server is handed to the runner.
+        expect(prepared.mcpServers).toHaveLength(1);
+        // The run-time tools/list 401 must propagate (fail-loud), not degrade.
+        await expect(getAllMcpTools({ mcpServers: prepared.mcpServers })).rejects.toThrow();
+      } finally {
+        await prepared.close();
+      }
+    } finally {
+      strict.close();
+    }
+  });
+
   test("does not bleed the permission-scoped first-party tools-list across sessions", async () => {
     // The Agents SDK caches tools/list in a process-global map keyed by MCP
     // server name. The built-in `opengeni` server has the same name for every

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -3018,14 +3018,80 @@ describe("runtime event normalization", () => {
       } finally {
         await prepared.close();
       }
-      // The drop is observable in the log.
+      // The drop is observable in the log as a structured warn carrying the
+      // server id and the error class (failure-visibility doctrine).
       const warned = warnings.some((args) =>
-        args.some((arg) => typeof arg === "string" && arg.includes("cap-expired")),
+        args.some(
+          (arg) =>
+            typeof arg === "object" &&
+            arg !== null &&
+            (arg as { serverId?: unknown }).serverId === "cap-expired" &&
+            typeof (arg as { errorClass?: unknown }).errorClass === "string",
+        ),
       );
       expect(warned).toBe(true);
     } finally {
       console.warn = originalWarn;
       expired.close();
+      healthy.close();
+    }
+  });
+
+  test("best-effort server whose tools/list throws a NON-auth error also degrades, not just auth", async () => {
+    // Rider on the auth fix: the invariant is generic — an OPTIONAL server that is
+    // unavailable for ANY reason (here a provider 500, no connectionRef, so no
+    // auth machinery is involved at all) must never fail an unrelated turn. This
+    // guards against the fix silently narrowing to auth-only. The degrade has NO
+    // tool.auth_needed to lean on, so the structured warn is the only visibility.
+    const brokenOptional = startTestMcpServer({ serverErrorForMethods: ["tools/list"] });
+    const healthy = startTestMcpServer();
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    try {
+      const prepared = await prepareAgentTools(
+        testSettings({
+          mcpServers: [
+            {
+              id: "flaky",
+              name: "Flaky optional MCP",
+              url: brokenOptional.url,
+              cacheToolsList: false,
+            },
+            { id: "docs", name: "Document Search", url: healthy.url, cacheToolsList: false },
+          ],
+        }),
+        [
+          { kind: "mcp", id: "flaky", optional: true },
+          { kind: "mcp", id: "docs" },
+        ],
+      );
+      try {
+        // The optional server connects (initialize is fine); only tools/list 500s.
+        expect(prepared.mcpServers.map((server) => server.name).sort()).toEqual(["docs", "flaky"]);
+        const tools = await getAllMcpTools({ mcpServers: prepared.mcpServers });
+        const toolNames = tools.map((tool) => tool.name);
+        expect(toolNames).toContain("docs__search_documents");
+        expect(toolNames.some((name) => name.startsWith("flaky__"))).toBe(false);
+      } finally {
+        await prepared.close();
+      }
+      // The non-auth degrade is observable: server id + a real error class.
+      const warned = warnings.some((args) =>
+        args.some(
+          (arg) =>
+            typeof arg === "object" &&
+            arg !== null &&
+            (arg as { serverId?: unknown }).serverId === "flaky" &&
+            typeof (arg as { errorClass?: unknown }).errorClass === "string",
+        ),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      brokenOptional.close();
       healthy.close();
     }
   });

--- a/packages/testing/src/mcp.ts
+++ b/packages/testing/src/mcp.ts
@@ -25,6 +25,11 @@ export function startTestMcpServer(
     forbiddenTools?: string[];
     unauthorizedAuthenticateHeader?: string;
     forbiddenAuthenticateHeader?: string;
+    // JSON-RPC methods that get a 401 even when auth headers are satisfied. Lets a
+    // test connect successfully (its `initialize` handshake passes) and then fail
+    // a later request such as `tools/list`, reproducing a credential that is valid
+    // at connect but rejected at run time.
+    unauthorizedForMethods?: string[];
   } = {},
 ): TestMcpServer {
   const calls: TestMcpToolCall[] = [];
@@ -63,6 +68,17 @@ export function startTestMcpServer(
           });
         }
       }
+      if (await matchesJsonRpcMethod(request, options.unauthorizedForMethods ?? [])) {
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: {
+            "content-type": "application/json",
+            ...(options.unauthorizedAuthenticateHeader
+              ? { "www-authenticate": options.unauthorizedAuthenticateHeader }
+              : {}),
+          },
+        });
+      }
       const forbiddenTool = await forbiddenToolName(request, options.forbiddenTools ?? []);
       if (forbiddenTool) {
         return new Response(JSON.stringify({ error: "insufficient_scope", tool: forbiddenTool }), {
@@ -91,6 +107,18 @@ export function startTestMcpServer(
     calls,
     close: () => server.stop(true),
   };
+}
+
+async function matchesJsonRpcMethod(request: Request, methods: string[]): Promise<boolean> {
+  if (methods.length === 0 || request.method !== "POST") {
+    return false;
+  }
+  try {
+    const body = (await request.clone().json()) as { method?: unknown };
+    return typeof body.method === "string" && methods.includes(body.method);
+  } catch {
+    return false;
+  }
 }
 
 async function forbiddenToolName(

--- a/packages/testing/src/mcp.ts
+++ b/packages/testing/src/mcp.ts
@@ -30,6 +30,10 @@ export function startTestMcpServer(
     // a later request such as `tools/list`, reproducing a credential that is valid
     // at connect but rejected at run time.
     unauthorizedForMethods?: string[];
+    // JSON-RPC methods that get a generic 500. Lets a test connect successfully
+    // and then fail a later request with a NON-auth error, modeling an optional
+    // integration that is simply down (provider 5xx) rather than unauthenticated.
+    serverErrorForMethods?: string[];
   } = {},
 ): TestMcpServer {
   const calls: TestMcpToolCall[] = [];
@@ -77,6 +81,12 @@ export function startTestMcpServer(
               ? { "www-authenticate": options.unauthorizedAuthenticateHeader }
               : {}),
           },
+        });
+      }
+      if (await matchesJsonRpcMethod(request, options.serverErrorForMethods ?? [])) {
+        return new Response(JSON.stringify({ error: "internal_error" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
         });
       }
       const forbiddenTool = await forbiddenToolName(request, options.forbiddenTools ?? []);


### PR DESCRIPTION
## The bug (prod, 2026-07-11)

A session turn hard-failed wholesale with `Streamable HTTP error: Error POSTing to endpoint: authentication required` because an **optional/best-effort** connection-broker-backed MCP server had an expired OAuth token — even though the turn never used that server's tools. The system correctly emitted `tool.auth_needed reason=expired`, but the turn still died.

## Root cause

The best-effort isolation only wrapped `connect()` (`connectMcpServers({ strict: false })`). But `connect()` (the StreamableHTTP `initialize` handshake) does **not** list tools — it succeeds. The auth failure surfaces later, when the SDK's Runner calls `getAllMcpTools` → `server.listTools()` at **run time, outside that guard**. `PrefixedMcpServer.listTools()` awaited the inner `listTools()` with no catch, so the tools/list 401 threw wholesale and killed the turn.

## The fix

Thread the `bestEffort` classification into `PrefixedMcpServer` and guard `listTools()`:

- A **best-effort** server (optional ToolRef, connection-broker-backed capability MCP, or codex_apps) whose `tools/list` throws — for **any** reason (expired credential 401, provider 5xx, network blip) — degrades to zero tools for the turn instead of propagating.
- A **required** (explicitly-requested) server keeps the fail-loud default: its `tools/list` failure still fails the turn.
- The actionable `tool.auth_needed` signal is preserved — the connection-broker fetch publishes it before returning the 401 that provokes the throw. Non-auth degrades (which have no such signal) surface via a structured warn (`serverId` + `errorClass`), once per degraded server per turn, so a chronically-dead optional integration is visible in logs/metrics rather than swallowed.

No cache poisoning: these best-effort servers all use `cacheToolsList: false`, so an empty degraded list is never stored in the SDK's process-global cache.

## Tests

- **Reproduction (auth)**: a best-effort connectionRef server connects, its credential expires, `tools/list` 401s → asserts the turn's toolset survives (healthy sibling's tools remain) with `tool.auth_needed` still emitted. Fails on pre-fix code with the exact prod symptom.
- **Generality (non-auth)**: an optional server (no connectionRef) that 500s `tools/list` also degrades — guards against narrowing to auth-only.
- **Strict path**: a required server whose `tools/list` throws still fails the turn.

Adds `unauthorizedForMethods` / `serverErrorForMethods` knobs to the shared test MCP server to model "valid at connect, rejected/broken at run time".

## Gates

- Full monorepo typecheck: all 20 projects clean
- `format:check` clean, `oxlint` exit 0 (no new warnings)
- `packages/runtime/test/runtime.test.ts`: 133 pass / 0 fail
- Changeset: `@opengeni/runtime: patch`

Generic OpenGeni robustness — no provider-specific hardcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)