### PR TITLE
feat: add devcontainer for GitHub Codespaces testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "opengeni",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:${containerEnv:HOME}/.bun/bin"
+  },
+  "onCreateCommand": "curl -fsSL https://bun.sh/install | bash",
+  "postCreateCommand": "bash .devcontainer/setup-env.sh",
+  "postStartCommand": "bash .devcontainer/publish-api-port.sh",
+  "forwardPorts": [3000, 8000, 8222, 9001],
+  "portsAttributes": {
+    "3000": { "label": "web" },
+    "8000": { "label": "api" },
+    "8222": { "label": "nats monitor", "onAutoForward": "silent" },
+    "9001": { "label": "minio console", "onAutoForward": "silent" }
+  }
+}

--- a/.devcontainer/publish-api-port.sh
+++ b/.devcontainer/publish-api-port.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Best-effort: make the forwarded API port public so the browser-served web
+# app can call it without GitHub's port auth (XHR cannot pass the private-port
+# auth redirect). The default Codespaces token sometimes lacks the codespace
+# scope, so fall back to instructions instead of failing the container start.
+set -uo pipefail
+
+if [ -z "${CODESPACE_NAME:-}" ]; then
+  exit 0
+fi
+
+if gh codespace ports visibility 8000:public -c "$CODESPACE_NAME" 2>/dev/null; then
+  echo "Port 8000 (api) is now public."
+else
+  echo "Could not set port 8000 to public automatically."
+  echo "In the Ports panel, right-click port 8000 -> Port Visibility -> Public,"
+  echo "otherwise the web app cannot reach the API from your browser."
+fi
+exit 0

--- a/.devcontainer/setup-env.sh
+++ b/.devcontainer/setup-env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Prepare .env for `bun run dev`. Outside Codespaces this only seeds .env from
+# .env.example. Inside Codespaces it also points the web console, Vite host
+# allowlist, and API CORS at the Codespace's forwarded hostnames, because the
+# browser reaches the dev stack through https://<codespace>-<port>.<domain>
+# instead of 127.0.0.1.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+[ -f .env ] || cp .env.example .env
+
+if [ -z "${CODESPACES:-}" ] || [ -z "${CODESPACE_NAME:-}" ]; then
+  exit 0
+fi
+
+domain="${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
+web_host="${CODESPACE_NAME}-3000.${domain}"
+api_url="https://${CODESPACE_NAME}-8000.${domain}"
+escaped_web_host="${web_host//./\\.}"
+
+set_env() {
+  local key="$1" value="$2"
+  grep -v "^${key}=" .env > .env.tmp || true
+  mv .env.tmp .env
+  printf '%s=%s\n' "$key" "$value" >> .env
+}
+
+set_env VITE_API_BASE_URL "$api_url"
+set_env OPENGENI_WEB_ALLOWED_HOSTS "$web_host"
+set_env OPENGENI_CORS_ALLOW_ORIGIN_REGEX "'^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?\$|^https://${escaped_web_host}\$'"
+
+echo "Codespaces .env configured: web https://${web_host} -> api ${api_url}"
+echo "Run 'bun run dev' to start the stack, then make port 8000 Public in the Ports panel."

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ bun run dev:worker
 bun run dev:web
 ```
 
+## GitHub Codespaces
+
+The repo ships a devcontainer (`.devcontainer/`), so the full stack also runs in a GitHub Codespace — useful for testing changes from a browser or phone:
+
+1. On the repo page: **Code → Codespaces → Create codespace** (pick a 4-core machine; the devcontainer requests one).
+2. In the Codespace terminal, run `bun run dev`.
+3. Make port `8000` (api) **Public** in the Ports panel if the container startup did not manage to do it automatically (right-click the port → Port Visibility → Public). The web app is loaded from the forwarded port `3000` URL and calls the API on the forwarded port `8000` URL, which the browser cannot reach while the port is private.
+4. Open the forwarded URL for port `3000`.
+
+On creation, `.devcontainer/setup-env.sh` rewrites `.env` so `VITE_API_BASE_URL`, `OPENGENI_WEB_ALLOWED_HOSTS`, and `OPENGENI_CORS_ALLOW_ORIGIN_REGEX` point at the Codespace's forwarded hostnames. Note that a public port `8000` exposes the dev API (unauthenticated by default) to anyone who has the unguessable Codespace URL; set `OPENGENI_AUTH_REQUIRED=true` plus `OPENGENI_ACCESS_KEY` in `.env` if that matters for your testing.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and configure at least:


### PR DESCRIPTION
Adds a .devcontainer with docker-in-docker and Bun so 'bun run dev' runs the full stack in a Codespace. A post-create script rewrites .env so the web console, Vite host allowlist, and API CORS target the Codespace's forwarded hostnames, and a post-start script best-effort publishes the API port. Documents the workflow in the README.


Claude-Session: https://claude.ai/code/session_01XtJjdWFUuorPRACPtBVqNt

## Summary

-

## Testing

- [ ] `bun run typecheck`
- [ ] `bun test`

## Notes

-
