### PR TITLE
feat: per-workspace model/provider hard-block policy (never-Azure for codex workspaces)

### DIFF
--- a/.changeset/workspace-model-policy.md
+++ b/.changeset/workspace-model-policy.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/db": patch
+"@opengeni/contracts": patch
+"@opengeni/config": patch
+"@opengeni/runtime": patch
+"@opengeni/core": patch
+---
+
+Per-workspace model/provider hard-block policy. A new `workspace_model_policies` table (NULL = unrestricted) lets a workspace strictly allowlist which providers and/or exact model ids may serve its turns. Enforced twice: a 422 at every API model choke point (user message, queued-turn update, scheduled task, and session creation — where the EFFECTIVE model, `payload.model ?? deployment default`, is vetted, since an omitted model stamps the deployment default onto the session), and authoritatively in the worker immediately after turn model resolution, where a blocked provider/model throws `WorkspaceModelPolicyBlockedError` before any model call — including the legacy null-resolution fallback to the built-in OpenAI/Azure client, which is attributed to the built-in's own provider id so blocking the built-in also closes that path. Goal continuations that inherit a blocked model recover to the session's allowed default or pause the goal visibly with a truthful rationale. New `GET/PUT /v1/workspaces/:workspaceId/model-policy` routes (read / admin) manage the policy. Workspaces without a policy row behave exactly as before. This exists so a codex-subscription workspace can be fail-closed to codex: a turn may wait or fail loud, but can never fall through to a paid provider.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -101,6 +101,7 @@ import {
 import {
   acceptSessionUserMessage,
   assertConfiguredModel,
+  assertWorkspaceModelPolicyAllows,
   createSessionForRequest,
   requireQueuedTurnForApi,
   readSessionLineage,
@@ -518,8 +519,10 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
     const existing = await requireQueuedTurnForApi(db, workspaceId, sessionId, turnId);
     const payload = UpdateSessionTurnRequest.parse(await c.req.json());
     // A turn-update may switch the queued turn's model; reject one the host
-    // does not expose (omitted leaves the existing model unchanged).
+    // does not expose (omitted leaves the existing model unchanged) or one the
+    // workspace's model policy blocks.
     assertConfiguredModel(settings, payload.model);
+    await assertWorkspaceModelPolicyAllows(db, settings, workspaceId, payload.model);
     const session = await requireSession(db, workspaceId, sessionId);
     const runtimeSettings = settingsWithSessionMcpServerMetadata(
       await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings),

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -4,6 +4,7 @@ import {
   ListWorkspaceMembersResponse,
   SetWorkspaceDefaultRigRequest,
   UpdateWorkspaceMemberRequest,
+  UpdateWorkspaceModelPolicyRequest,
   UpdateWorkspaceRequest,
   UpdateWorkspaceSettingsRequest,
   Workspace,
@@ -18,6 +19,7 @@ import {
   createWorkspace,
   deleteWorkspace,
   getManagedUserByEmail,
+  getWorkspaceModelPolicy,
   grantWorkspaceAccess,
   listScheduledTasks,
   listWorkspaceMembers,
@@ -28,6 +30,7 @@ import {
   setWorkspaceDefaultRig,
   updateWorkspace,
   updateWorkspaceSettings,
+  upsertWorkspaceModelPolicy,
 } from "@opengeni/db";
 import type { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -128,6 +131,36 @@ export function registerWorkspaceRoutes(app: Hono, deps: ApiRouteDeps): void {
     }
     const workspace = await updateWorkspaceSettings(deps.db, workspaceId, parsed.data);
     return c.json(Workspace.parse(workspace));
+  });
+
+  // Per-workspace model/provider availability policy (the HARD blocker over
+  // which providers/models may serve a turn at all). Absent row reads as
+  // unrestricted {null, null}.
+  app.get("/v1/workspaces/:workspaceId/model-policy", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    await requireAccessGrant(c, deps, workspaceId, "workspace:read");
+    const policy = await getWorkspaceModelPolicy(deps.db, workspaceId);
+    return c.json({
+      allowedProviders: policy?.allowedProviders ?? null,
+      allowedModels: policy?.allowedModels ?? null,
+    });
+  });
+
+  // Full replace (PUT, not merge): null/omitted = unrestricted for that
+  // dimension; an empty array is a valid explicit total block. Admin access —
+  // this decides whether turns can reach paid providers, so it is the same
+  // trust level as billing-affecting workspace settings.
+  app.put("/v1/workspaces/:workspaceId/model-policy", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
+    const payload = UpdateWorkspaceModelPolicyRequest.parse(await c.req.json());
+    const policy = await upsertWorkspaceModelPolicy(deps.db, {
+      accountId: grant.accountId,
+      workspaceId,
+      allowedProviders: payload.allowedProviders ?? null,
+      allowedModels: payload.allowedModels ?? null,
+    });
+    return c.json(policy);
   });
 
   app.put("/v1/workspaces/:workspaceId/default-rig", async (c) => {

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2294,7 +2294,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             modelId: turn.model,
           });
           if (!verdict.allowed) {
-            throw new WorkspaceModelPolicyBlockedError(turn.model, effectiveProviderId, verdict.reason);
+            throw new WorkspaceModelPolicyBlockedError(
+              turn.model,
+              effectiveProviderId,
+              verdict.reason,
+            );
           }
         }
       }

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -23,6 +23,7 @@ import {
   releaseCodexCredentialLease,
   CODEX_CREDENTIAL_LEASE_TTL_MS,
   getCodexRotationSettings,
+  getWorkspaceModelPolicy,
   listCodexAccountStatuses,
   fetchCodexUsageForAccount,
   getSessionCodexState,
@@ -93,6 +94,7 @@ import {
   type EstablishedSandboxSession,
 } from "@opengeni/runtime";
 import {
+  builtinProviderId,
   calculateModelUsageCostMicros,
   configuredModelPricing,
   configuredStaticUsageLimits,
@@ -204,9 +206,14 @@ import {
 import { captureWorkspaceRevision } from "./workspace-capture";
 import type { ChannelASession } from "@opengeni/runtime/sandbox";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
-import { desktopCapableBackend, sandboxRunAs } from "@opengeni/runtime";
+import {
+  desktopCapableBackend,
+  sandboxRunAs,
+  WorkspaceModelPolicyBlockedError,
+} from "@opengeni/runtime";
 import {
   CAPABILITY_DESCRIPTORS,
+  evaluateWorkspaceModelPolicy,
   type ResourceRef,
   type SessionEventType,
 } from "@opengeni/contracts";
@@ -2266,6 +2273,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // keeps gating consistent with the router. Cost accounting covers registry
       // models via configuredModelPricing.
       const resolvedModel = runtime.resolveTurnModel(capabilitySettings, turn.model);
+      // WORKSPACE MODEL POLICY — the authoritative hard gate. Runs immediately
+      // after resolution and BEFORE any model call (the compaction summarizer
+      // and the main run both come later in this scope), so a blocked
+      // provider/model can never be reached through ANY stamp path: explicit
+      // turn model, inherited session default, goal-continuation inheritance,
+      // or the legacy null-resolution fallback (null → the built-in
+      // OpenAI/Azure client, attributed here via builtinProviderId so a policy
+      // blocking the built-in also blocks that fallback — this exact path is
+      // how bare-model turns silently spent real Azure money in a
+      // codex-intended workspace). Fail-loud, never a silent remap.
+      {
+        const workspaceModelPolicy = await getWorkspaceModelPolicy(db, input.workspaceId);
+        if (workspaceModelPolicy) {
+          const effectiveProviderId = resolvedModel
+            ? resolvedModel.provider.id
+            : builtinProviderId(capabilitySettings);
+          const verdict = evaluateWorkspaceModelPolicy(workspaceModelPolicy, {
+            providerId: effectiveProviderId,
+            modelId: turn.model,
+          });
+          if (!verdict.allowed) {
+            throw new WorkspaceModelPolicyBlockedError(turn.model, effectiveProviderId, verdict.reason);
+          }
+        }
+      }
       // A codex-subscription turn resolves the bearer for THIS turn's effective
       // codex account (effectiveCodexCredentialId; pin > workspace-active) at
       // model-call time — multi-account P1 means a workspace can hold N accounts,

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -1,5 +1,10 @@
-import { configuredStaticUsageLimits, type Settings } from "@opengeni/config";
 import {
+  configuredStaticUsageLimits,
+  policyProviderIdForModel,
+  type Settings,
+} from "@opengeni/config";
+import {
+  evaluateWorkspaceModelPolicy,
   mergeToolRefs,
   reasoningEffortForMetadata,
   type SessionGoal,
@@ -10,6 +15,7 @@ import {
   evaluateGoalContinuation,
   getBillingBalance,
   getLatestStartedSessionTurn,
+  getWorkspaceModelPolicy,
   getSessionEvent,
   getSessionGoal,
   isCodexBilledTurn,
@@ -51,10 +57,34 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
       input.workspaceId,
       input.sessionId,
     );
-    const continuationModel = latestStartedTurn?.model ?? session.model;
+    let continuationModel = latestStartedTurn?.model ?? session.model;
     const continuationReasoningEffort =
       latestStartedTurn?.reasoningEffort ??
       reasoningEffortForMetadata(session.metadata, settings.openaiReasoningEffort);
+    // Workspace model policy: a continuation inherits the last STARTED turn's
+    // model, so a single policy-violating turn would otherwise re-arm itself on
+    // every continuation (exactly how one bare-model turn kept a goal loop on
+    // the paid built-in provider all night). If the inherited model is blocked
+    // but the session's own default is allowed, recover to the default; if
+    // both are blocked, pause the goal visibly (the budget-pause channel, with
+    // a truthful rationale) instead of synthesizing a turn the worker's hard
+    // gate would fail over and over.
+    let modelPolicyBlocked: string | null = null;
+    const workspaceModelPolicy = await getWorkspaceModelPolicy(db, input.workspaceId);
+    if (workspaceModelPolicy) {
+      const policyBlocks = (modelId: string): boolean =>
+        !evaluateWorkspaceModelPolicy(workspaceModelPolicy, {
+          providerId: policyProviderIdForModel(settings, modelId),
+          modelId,
+        }).allowed;
+      if (policyBlocks(continuationModel)) {
+        if (continuationModel !== session.model && !policyBlocks(session.model)) {
+          continuationModel = session.model;
+        } else {
+          modelPolicyBlocked = `workspace model policy blocks model "${continuationModel}"; pick an allowed model or change the workspace model policy`;
+        }
+      }
+    }
     // A codex-model goal continuation is paid by the user's ChatGPT/Codex plan,
     // so it must not be budget-paused for zero OpenGeni credits. This file uses
     // BASE settings (no codex overlay); the predicate does its own credential read.
@@ -79,7 +109,10 @@ export function createGoalActivities(services: () => Promise<ActivityServices>) 
       sessionId: input.sessionId,
       defaultMaxAutoContinuations: settings.goalMaxAutoContinuations ?? null,
       noProgressLimit: settings.goalNoProgressLimit,
-      budgetBlocked,
+      // A model-policy block takes precedence: it is deterministic (a budget
+      // pause can clear on its own; a policy pause needs a model/policy change)
+      // and rides the same visible-pause channel.
+      budgetBlocked: modelPolicyBlocked ?? budgetBlocked,
     });
     if (decision.decision === "none" || decision.decision === "queue") {
       return { action: decision.decision };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,7 +9,7 @@ import {
   StaticUsageLimits,
   UsageLimitsMode,
 } from "@opengeni/contracts";
-import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex/constants";
+import { CODEX_MODEL_ID_PREFIX, CODEX_PROVIDER_ID } from "@opengeni/codex/constants";
 import { z } from "zod";
 
 const envName = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -1338,6 +1338,27 @@ export function configuredProviders(settings: Settings): ResolvedModelProvider[]
     }),
   );
   return [builtin, ...registry];
+}
+
+/**
+ * The provider identity a model id resolves to, for workspace model-policy
+ * evaluation — MUST agree with the real router (resolveTurnModel /
+ * MultiProviderModelProvider) on every case:
+ *   - `codex/<slug>` → the codex-subscription provider id, ALWAYS. With no
+ *     active subscription the router fails loud (CodexSubscriptionUnavailableError),
+ *     never the built-in — so attributing by prefix is exact even against BASE
+ *     settings where the overlay provider is not injected.
+ *   - a configured model id → its configuredModels providerId (registry or built-in).
+ *   - anything else → the built-in id: an unknown id is the legacy
+ *     resolveTurnModel-null fallback, which the built-in OpenAI/Azure client
+ *     serves. A policy blocking the built-in must block this path too.
+ */
+export function policyProviderIdForModel(settings: Settings, modelId: string): string {
+  if (modelId.startsWith(CODEX_MODEL_ID_PREFIX)) {
+    return CODEX_PROVIDER_ID;
+  }
+  const configured = configuredModels(settings).find((model) => model.id === modelId);
+  return configured?.providerId ?? builtinProviderId(settings);
 }
 
 /**

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1283,8 +1283,14 @@ export function resolveProviderApiKey(
   return undefined;
 }
 
-/** The built-in provider's stable id: "openai" on the OpenAI platform, "azure" on Azure. */
-function builtinProviderId(settings: Pick<Settings, "openaiProvider">): string {
+/**
+ * The built-in provider's stable id: "openai" on the OpenAI platform, "azure"
+ * on Azure. Exported because the workspace model-policy gate must attribute
+ * the legacy resolveTurnModel-null fallback (which routes to this built-in
+ * client) to the SAME identity the router uses — otherwise a policy blocking
+ * the built-in could be bypassed through the null-resolution path.
+ */
+export function builtinProviderId(settings: Pick<Settings, "openaiProvider">): string {
   return settings.openaiProvider === "azure" ? "azure" : "openai";
 }
 

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -7,6 +7,7 @@ import {
   defaultModelPricing,
   getSettings,
   parseModelProvidersJson,
+  policyProviderIdForModel,
   resolveModelProvider,
   resolveProviderApiKey,
 } from "../src";
@@ -647,3 +648,45 @@ function withEnv<T>(env: NodeJS.ProcessEnv, fn: () => T): T {
     process.env = original;
   }
 }
+
+describe("policyProviderIdForModel", () => {
+  // The attribution the workspace model policy evaluates MUST agree with the
+  // real router on every path — especially the two that historically leaked:
+  // a codex/ id evaluated against BASE settings (no overlay injected), and an
+  // UNKNOWN id (the legacy resolveTurnModel-null fallback → built-in client).
+  test("codex/ id attributes to codex-subscription even on BASE settings", () => {
+    const settings = withEnv({ OPENGENI_OPENAI_API_KEY: "sk-test" }, () => getSettings());
+    // No codex provider is injected here — attribution is by prefix, mirroring
+    // the router's guarantee that a codex/ id NEVER routes to the built-in.
+    expect(policyProviderIdForModel(settings, "codex/gpt-5.6-sol")).toBe("codex-subscription");
+  });
+
+  test("registry model attributes to its registry provider", () => {
+    const settings = withEnv(
+      { OPENGENI_OPENAI_API_KEY: "sk-test", OPENGENI_MODEL_PROVIDERS_JSON: fireworksRegistry },
+      () => getSettings(),
+    );
+    expect(policyProviderIdForModel(settings, "accounts/fireworks/models/glm-5p2")).toBe(
+      "fireworks",
+    );
+  });
+
+  test("configured bare model attributes to the built-in id", () => {
+    const settings = withEnv({ OPENGENI_OPENAI_API_KEY: "sk-test" }, () => getSettings());
+    expect(policyProviderIdForModel(settings, settings.openaiModel)).toBe("openai");
+  });
+
+  test("UNKNOWN model id attributes to the built-in (legacy null-resolution fallback)", () => {
+    const settings = withEnv(
+      {
+        OPENGENI_OPENAI_PROVIDER: "azure",
+        OPENGENI_AZURE_OPENAI_BASE_URL: "https://example.openai.azure.com/openai/v1",
+        OPENGENI_AZURE_OPENAI_API_KEY: "azure-test",
+      },
+      () => getSettings(),
+    );
+    // An id the router cannot resolve falls back to the built-in client, so a
+    // policy blocking the built-in must see the built-in's identity here.
+    expect(policyProviderIdForModel(settings, "totally-unknown-model")).toBe("azure");
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -588,6 +588,16 @@ export const SetWorkspaceDefaultRigRequest = z.object({
 });
 export type SetWorkspaceDefaultRigRequest = z.infer<typeof SetWorkspaceDefaultRigRequest>;
 
+// PUT body for the workspace model policy (full replace, not a merge). null (or
+// omitted) = unrestricted for that dimension; an EMPTY array is a valid,
+// explicit total block. Entries are provider ids / exact model ids as the
+// router resolves them (see evaluateWorkspaceModelPolicy).
+export const UpdateWorkspaceModelPolicyRequest = z.object({
+  allowedProviders: z.array(z.string().min(1).max(128)).max(64).nullable().optional(),
+  allowedModels: z.array(z.string().min(1).max(256)).max(256).nullable().optional(),
+});
+export type UpdateWorkspaceModelPolicyRequest = z.infer<typeof UpdateWorkspaceModelPolicyRequest>;
+
 export const AccountGrant = z.object({
   accountId: z.string().uuid(),
   subjectId: z.string().min(1),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4709,3 +4709,39 @@ export type HealthResponse = {
   variableSet: string;
   ok: boolean;
 };
+
+/**
+ * Per-workspace model/provider availability policy (see @opengeni/db
+ * workspace_model_policies). NULL fields = unrestricted; a non-null
+ * allowedProviders is a strict allowlist over RESOLVED provider identities
+ * (the built-in OpenAI/Azure client's id — "openai"/"azure" — including the
+ * legacy null-resolution fallback; "codex-subscription" for the ChatGPT/Codex
+ * overlay; registry providers by their declared ids); a non-null allowedModels
+ * is an additional exact-model-id allowlist. Pure and shared so the API edge
+ * (422) and the worker's authoritative post-resolution gate (fail-loud
+ * turn.failed, never a silent remap) can never disagree on semantics.
+ */
+export type WorkspaceModelPolicyContract = {
+  allowedProviders: string[] | null;
+  allowedModels: string[] | null;
+};
+
+export type WorkspaceModelPolicyVerdict =
+  | { allowed: true }
+  | { allowed: false; reason: "provider" | "model" };
+
+export function evaluateWorkspaceModelPolicy(
+  policy: WorkspaceModelPolicyContract | null | undefined,
+  candidate: { providerId: string; modelId: string },
+): WorkspaceModelPolicyVerdict {
+  if (!policy) {
+    return { allowed: true };
+  }
+  if (policy.allowedProviders !== null && !policy.allowedProviders.includes(candidate.providerId)) {
+    return { allowed: false, reason: "provider" };
+  }
+  if (policy.allowedModels !== null && !policy.allowedModels.includes(candidate.modelId)) {
+    return { allowed: false, reason: "model" };
+  }
+  return { allowed: true };
+}

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AddDocumentRequest,
   CapabilityCatalogResponse,
+  evaluateWorkspaceModelPolicy,
   CapabilityPack,
   ClientConfig,
   ClientModel,
@@ -629,5 +630,63 @@ describe("cleared run-state sentinel", () => {
       false,
     );
     expect(isClearedRunStateBlob("null")).toBe(false);
+  });
+});
+
+describe("evaluateWorkspaceModelPolicy", () => {
+  test("no policy allows everything", () => {
+    expect(
+      evaluateWorkspaceModelPolicy(null, { providerId: "azure", modelId: "gpt-5.6-sol" }),
+    ).toEqual({ allowed: true });
+  });
+
+  test("null fields are unrestricted", () => {
+    expect(
+      evaluateWorkspaceModelPolicy(
+        { allowedProviders: null, allowedModels: null },
+        { providerId: "azure", modelId: "gpt-5.6-sol" },
+      ),
+    ).toEqual({ allowed: true });
+  });
+
+  test("provider allowlist blocks a non-listed provider (the codex-only posture)", () => {
+    const policy = { allowedProviders: ["codex-subscription"], allowedModels: null };
+    expect(
+      evaluateWorkspaceModelPolicy(policy, { providerId: "azure", modelId: "gpt-5.6-sol" }),
+    ).toEqual({ allowed: false, reason: "provider" });
+    expect(
+      evaluateWorkspaceModelPolicy(policy, {
+        providerId: "codex-subscription",
+        modelId: "codex/gpt-5.6-sol",
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  test("model allowlist is an ADDITIONAL restriction on top of providers", () => {
+    const policy = {
+      allowedProviders: ["codex-subscription"],
+      allowedModels: ["codex/gpt-5.6-sol"],
+    };
+    expect(
+      evaluateWorkspaceModelPolicy(policy, {
+        providerId: "codex-subscription",
+        modelId: "codex/gpt-5.6-luna",
+      }),
+    ).toEqual({ allowed: false, reason: "model" });
+    expect(
+      evaluateWorkspaceModelPolicy(policy, {
+        providerId: "codex-subscription",
+        modelId: "codex/gpt-5.6-sol",
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  test("empty arrays are an explicit total block, not unrestricted", () => {
+    expect(
+      evaluateWorkspaceModelPolicy(
+        { allowedProviders: [], allowedModels: null },
+        { providerId: "codex-subscription", modelId: "codex/gpt-5.6-sol" },
+      ),
+    ).toEqual({ allowed: false, reason: "provider" });
   });
 });

--- a/packages/core/src/domain/scheduled-tasks.ts
+++ b/packages/core/src/domain/scheduled-tasks.ts
@@ -21,7 +21,7 @@ import type { SessionWorkflowClient } from "../dependencies";
 import type { ObjectStorageDependency } from "../dependencies";
 import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
 import { validateVariableSetAttachment } from "./environments";
-import { assertConfiguredModel } from "./sessions";
+import { assertConfiguredModel, assertWorkspaceModelPolicyAllows } from "./sessions";
 import {
   normalizeResources,
   validateFileResources,
@@ -328,6 +328,14 @@ async function validateScheduledTaskAgentConfig(input: {
   // a model the host does not expose). An omitted model inherits the host
   // default downstream, which is always configured.
   assertConfiguredModel(input.settings, input.payload.agentConfig.model);
+  // Same policy vetting as the session choke points; an omitted model flows
+  // through session creation later, where the effective default is vetted.
+  await assertWorkspaceModelPolicyAllows(
+    input.db,
+    input.settings,
+    input.workspaceId,
+    input.payload.agentConfig.model,
+  );
   const resources = normalizeResources(input.payload.agentConfig.resources ?? []);
   const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(
     input.db,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1,7 +1,12 @@
 import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex";
-import { configuredAllowedModels, type Settings } from "@opengeni/config";
+import {
+  configuredAllowedModels,
+  policyProviderIdForModel,
+  type Settings,
+} from "@opengeni/config";
 import {
   CreateSessionRequest,
+  evaluateWorkspaceModelPolicy,
   reasoningEffortForMetadata,
   type AccessGrant,
   type GoalSpec,
@@ -34,6 +39,7 @@ import {
   getSessionByCreateIdempotencyKey,
   getSessionLineage,
   getSessionTurn,
+  getWorkspaceModelPolicy,
   requireSession,
   setTemporalWorkflowId,
   updateSessionTitle as updateSessionTitleRow,
@@ -572,6 +578,42 @@ export function assertConfiguredModel(settings: Settings, model: string | null |
   throw new HTTPException(422, { message: `model is not available: ${model}` });
 }
 
+/**
+ * Reject a model the WORKSPACE's model policy blocks, at the same choke points
+ * as assertConfiguredModel — a 422 at the edge instead of a queued turn the
+ * worker's authoritative post-resolution gate would fail. `model` is the
+ * EFFECTIVE value the caller is about to persist: pass the explicit value at
+ * message/turn-update/scheduled-task edges (omitted inherits an
+ * already-validated stored default), but at session CREATION pass
+ * `payload.model ?? settings.openaiModel` — an omitted model stamps the
+ * deployment default onto the session, and under a restricted policy that
+ * default may be exactly the provider the policy exists to block.
+ */
+export async function assertWorkspaceModelPolicyAllows(
+  db: Database,
+  settings: Settings,
+  workspaceId: string,
+  model: string | null | undefined,
+): Promise<void> {
+  if (model === null || model === undefined) {
+    return;
+  }
+  const policy = await getWorkspaceModelPolicy(db, workspaceId);
+  if (!policy) {
+    return;
+  }
+  const providerId = policyProviderIdForModel(settings, model);
+  const verdict = evaluateWorkspaceModelPolicy(policy, { providerId, modelId: model });
+  if (!verdict.allowed) {
+    throw new HTTPException(422, {
+      message:
+        verdict.reason === "provider"
+          ? `model "${model}" is not allowed by this workspace's model policy: provider "${providerId}" is not in the allowed providers`
+          : `model "${model}" is not allowed by this workspace's model policy`,
+    });
+  }
+}
+
 export async function requireQueuedTurnForApi(
   db: Database,
   workspaceId: string,
@@ -630,6 +672,7 @@ export async function postUserMessageTurn(input: {
   // Reject an explicit per-message model the host does not expose; an omitted
   // model inherits the session's model downstream (always a configured id).
   assertConfiguredModel(settings, requestedModel);
+  await assertWorkspaceModelPolicyAllows(db, settings, workspaceId, requestedModel);
   const appended = await appendSessionEventsWithLockedSessionUpdate(
     db,
     workspaceId,
@@ -829,6 +872,16 @@ export async function createSessionForRequest(
     }
   }
   assertConfiguredModel(settings, payload.model);
+  // Session creation persists the EFFECTIVE model — an omitted payload.model
+  // stamps the deployment default onto the session — so the policy must vet
+  // that effective value, not just explicit ones (a restricted workspace's
+  // default-model session would otherwise be born blocked).
+  await assertWorkspaceModelPolicyAllows(
+    db,
+    settings,
+    workspaceId,
+    payload.model ?? settings.openaiModel,
+  );
   const model = payload.model ?? settings.openaiModel;
   const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
   // A session's first-party MCP token can carry a non-default permission set

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1,9 +1,5 @@
 import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex";
-import {
-  configuredAllowedModels,
-  policyProviderIdForModel,
-  type Settings,
-} from "@opengeni/config";
+import { configuredAllowedModels, policyProviderIdForModel, type Settings } from "@opengeni/config";
 import {
   CreateSessionRequest,
   evaluateWorkspaceModelPolicy,

--- a/packages/db/drizzle/0056_workspace_model_policies.sql
+++ b/packages/db/drizzle/0056_workspace_model_policies.sql
@@ -1,0 +1,48 @@
+-- Per-workspace model/provider availability policy: the HARD blocker deciding
+-- which providers/models may serve a turn in a workspace at all. NULL columns =
+-- unrestricted (exactly today's behavior; no row is ever required). A non-null
+-- allowed_providers is a strict allowlist over resolved provider identities
+-- (the built-in OpenAI/Azure client — including the legacy null-resolution
+-- fallback — maps to one well-known id); allowed_models is an additional exact
+-- model-id allowlist. Enforced at the API model choke points (422) and
+-- authoritatively in the worker after turn model resolution, so a
+-- codex-subscription workspace can be fail-closed to codex: a blocked turn
+-- waits or fails loud, it never falls through to the paid built-in provider.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+CREATE TABLE IF NOT EXISTS "workspace_model_policies" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
+  "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
+  "allowed_providers" text[],
+  "allowed_models" text[],
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_model_policies_workspace_idx"
+  ON "workspace_model_policies" ("workspace_id");
+
+-- RLS — verbatim pattern from 0028_codex_multi_account.sql (codex_rotation_settings).
+ALTER TABLE "workspace_model_policies" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "workspace_model_policies" FORCE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_policies
+    WHERE schemaname = current_schema() AND tablename = 'workspace_model_policies' AND policyname = 'workspace_isolation') THEN
+    DROP POLICY workspace_isolation ON "workspace_model_policies";
+  END IF;
+END $$;
+CREATE POLICY workspace_isolation ON "workspace_model_policies"
+  USING (opengeni_private.workspace_rls_visible(account_id, workspace_id))
+  WITH CHECK (opengeni_private.workspace_rls_visible(account_id, workspace_id));
+
+-- Re-grant (verbatim from 0028/0024): new tables are not covered by prior grants.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9402,6 +9402,81 @@ export type CodexRotationSettings = {
   rotationStrategy: string; // P1: 'most_remaining' (unused)
 };
 
+/**
+ * Per-workspace model/provider availability policy. NULL fields = unrestricted
+ * (identical to no row — the default for every workspace). Non-null
+ * allowedProviders is a strict allowlist over resolved provider identities;
+ * non-null allowedModels an additional exact model-id allowlist. Consumers:
+ * the API model choke points (fail 422) and the worker's post-resolution gate
+ * (a blocked provider never reaches a model call and never silently remaps).
+ */
+export type WorkspaceModelPolicy = {
+  allowedProviders: string[] | null;
+  allowedModels: string[] | null;
+};
+
+/** The per-workspace model policy row (null when none exists = unrestricted). */
+export async function getWorkspaceModelPolicy(
+  db: Database,
+  workspaceId: string,
+): Promise<WorkspaceModelPolicy | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
+      .select({
+        allowedProviders: schema.workspaceModelPolicies.allowedProviders,
+        allowedModels: schema.workspaceModelPolicies.allowedModels,
+      })
+      .from(schema.workspaceModelPolicies)
+      .where(eq(schema.workspaceModelPolicies.workspaceId, workspaceId))
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+/**
+ * Create or replace the workspace's model policy. Passing null for a field
+ * clears that restriction; a policy of {null, null} is kept as an explicit
+ * "unrestricted" row (delete is not needed for correctness — it reads the same
+ * as no row).
+ */
+export async function upsertWorkspaceModelPolicy(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    allowedProviders: string[] | null;
+    allowedModels: string[] | null;
+  },
+): Promise<WorkspaceModelPolicy> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const [row] = await scopedDb
+        .insert(schema.workspaceModelPolicies)
+        .values({
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          allowedProviders: input.allowedProviders,
+          allowedModels: input.allowedModels,
+        })
+        .onConflictDoUpdate({
+          target: [schema.workspaceModelPolicies.workspaceId],
+          set: {
+            allowedProviders: input.allowedProviders,
+            allowedModels: input.allowedModels,
+            updatedAt: new Date(),
+          },
+        })
+        .returning({
+          allowedProviders: schema.workspaceModelPolicies.allowedProviders,
+          allowedModels: schema.workspaceModelPolicies.allowedModels,
+        });
+      return row!;
+    },
+  );
+}
+
 /** The per-workspace rotation/active-pointer row (null when none exists yet). */
 export async function getCodexRotationSettings(
   db: Database,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -398,6 +398,38 @@ export const codexRotationSettings = pgTable(
   }),
 );
 
+// Per-workspace model/provider availability policy — the HARD blocker deciding
+// which providers/models may serve a turn in this workspace AT ALL. NULL columns
+// mean unrestricted (today's behavior for every workspace without a row). A
+// non-null allowed_providers is a strict allowlist over provider identities
+// (the same identities the model router resolves to, with the built-in
+// OpenAI/Azure client — including the legacy resolveTurnModel-null fallback —
+// mapped to one well-known id); a non-null allowed_models is an additional
+// exact-model-id allowlist. Enforced at the API model-choke points (422) and,
+// authoritatively, in the worker immediately after turn model resolution: a
+// blocked resolution NEVER reaches a model call and NEVER silently remaps.
+// This exists so a codex-subscription workspace can be fail-closed to codex —
+// a turn can wait/fail loud, but can never fall through to the paid built-in.
+export const workspaceModelPolicies = pgTable(
+  "workspace_model_policies",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => managedAccounts.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    allowedProviders: text("allowed_providers").array(),
+    allowedModels: text("allowed_models").array(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    workspace: uniqueIndex("workspace_model_policies_workspace_idx").on(table.workspaceId),
+  }),
+);
+
 // One workspace-local short-lived holder per running Codex turn. Selection and
 // insertion happen atomically while codex_rotation_settings is locked FOR
 // UPDATE, so concurrent replicas in the SAME workspace see one another's

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -690,9 +690,9 @@ export class WorkspaceModelPolicyBlockedError extends Error {
     super(
       reason === "provider"
         ? `Model "${modelName}" is not available in this workspace: its provider ("${providerId}") is not in the workspace's allowed providers. ` +
-          `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`
+            `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`
         : `Model "${modelName}" is not in this workspace's allowed models. ` +
-          `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`,
+            `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`,
     );
     this.name = "WorkspaceModelPolicyBlockedError";
   }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -677,6 +677,27 @@ export class CodexSubscriptionUnavailableError extends Error {
   }
 }
 
+/**
+ * The workspace's model policy blocks the provider/model this turn resolved
+ * to. Thrown at the worker's post-resolution gate INSTEAD of running the turn
+ * on the blocked provider — a policy-restricted workspace (e.g. fail-closed to
+ * the Codex subscription) must never silently remap to, or fall through to,
+ * the paid built-in client. Like CodexSubscriptionUnavailableError the message
+ * is user-actionable and surfaces verbatim as a non-retryable turn.failed.
+ */
+export class WorkspaceModelPolicyBlockedError extends Error {
+  constructor(modelName: string, providerId: string, reason: "provider" | "model") {
+    super(
+      reason === "provider"
+        ? `Model "${modelName}" is not available in this workspace: its provider ("${providerId}") is not in the workspace's allowed providers. ` +
+          `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`
+        : `Model "${modelName}" is not in this workspace's allowed models. ` +
+          `Pick an allowed model, or ask a workspace admin to change the workspace model policy.`,
+    );
+    this.name = "WorkspaceModelPolicyBlockedError";
+  }
+}
+
 export function configureOpenAI(settings: Settings): void {
   setOpenAIResponsesTransport(settings.openaiResponsesTransport);
   setTracingDisabled(settings.disableOpenaiTracing || !settings.observabilityOtlpEndpoint);


### PR DESCRIPTION
## Why

On 2026-07-11/12, codex-intended orchestrator workspaces silently spent ~$2,197 of real Azure money. Root cause (prod evidence, not theory): the sessions' STORED default model was the bare built-in id (`gpt-5.6-sol`); a message posted with the model omitted inherits that stored default, and goal continuations inherit the last started turn's model — so one bare turn kept whole goal loops on the paid built-in provider all night. There was no demote/promote bug; the stored default itself was the loaded gun. The affected 84 sessions were remapped to `codex/<slug>` at the data level and the account balance is $0 (the provider-aware credit gate blocks Azure at zero), but both are soft layers. This PR is the structural one: a workspace can now declare which providers/models may serve its turns AT ALL.

## What

- **`workspace_model_policies`** (migration 0056, RLS `workspace_isolation`, rotation-settings precedent): one row per workspace; `allowed_providers text[]` / `allowed_models text[]`; NULL = unrestricted (no row = today's behavior, byte-for-byte).
- **Shared pure semantics** — `evaluateWorkspaceModelPolicy` (contracts) + `policyProviderIdForModel` (config): attribution MUST agree with the real router, so `codex/` ids map to `codex-subscription` even against base settings (the router never routes them to the built-in), configured/registry ids map to their provider, and an UNKNOWN id maps to the built-in id (`builtinProviderId`, now exported) — because an unknown id is the legacy `resolveTurnModel`-null fallback that the built-in client serves. Blocking the built-in therefore also closes the null-resolution path.
- **Worker hard gate** (authoritative): in `runAgentTurn` immediately after `resolveTurnModel`, before ANY model call (incl. the compaction summarizer). Blocked → `WorkspaceModelPolicyBlockedError` (non-retryable, user-actionable, `CodexSubscriptionUnavailableError` precedent). Never a silent remap.
- **API edge 422s** beside `assertConfiguredModel` at all four choke points: user message, queued-turn update, scheduled-task agentConfig, and session CREATION — where the EFFECTIVE model (`payload.model ?? deployment default`) is vetted, since an omitted model stamps the deployment default onto the session (the exact mechanism above).
- **Goal continuations**: an inherited blocked model recovers to the session's allowed default; if both are blocked the goal pauses visibly through the existing limits channel with a truthful rationale (no infinite re-fail loop).
- **Routes**: `GET/PUT /v1/workspaces/:workspaceId/model-policy` (read / admin). PUT is a full replace; empty array = explicit total block.

## Not in this PR

- UI picker filtering: `/v1/config/client` is deployment-scoped; the web picker should filter via the GET route (follow-up).
- Flipping the policy on for the two orchestrator workspaces (in-pod op after deploy: `allowed_providers = ['codex-subscription']`).

## Tests / gates

- Pure semantics fully covered: provider/model allowlists, empty-array total block, null-unrestricted (contracts); codex-prefix-on-base-settings, registry, configured-bare→builtin, and unknown→builtin attribution (config, incl. an azure-platform case).
- Full monorepo typecheck clean; oxfmt clean; oxlint no errors; changeset (db/contracts/config/runtime/core patch).
- Full `bun test`: policy-touched files green; an unrelated set of known contention-flaky files fails only under saturated full-suite runs (they pass in isolation and on main's CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)