### PR TITLE
fix(codex): send stable session_id header — backend sticky prompt-cache routing (CLI parity)

### DIFF
--- a/.changeset/codex-session-affinity-header.md
+++ b/.changeset/codex-session-affinity-header.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/codex": patch
+---
+
+Send a stable `session_id` header on every codex-subscription request. This is the backend's sticky prompt-cache-routing key: measured with byte-identical ~99k-token gpt-5.6-sol requests on one idle account, repeat requests WITHOUT the header hit the prompt cache only ~50% of the time (a per-request routing lottery across cache shards — matching the production fleet's 48.6% token-weighted hit rate), while WITH a stable session_id 10/10 requests hit at the 99.0% ceiling. Codex CLI always sends this header (its own last-3-days token-weighted rate on the same account is 94%); `prompt_cache_key` in the body only influences routing and does not pin it. The worker supplies the OpenGeni sessionId — the same value already used for `prompt_cache_key` — so routing and cache key agree, and the compaction summarizer (same request context) rides the same warm shard. Requests without a session context are unchanged.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2288,6 +2288,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               );
               return {
                 clientVersion: CODEX_CLIENT_VERSION,
+                // Backend sticky cache-routing key — the SAME id as the body's
+                // prompt_cache_key (set from input.sessionId for codex turns),
+                // so routing and cache key agree. Without this header on the
+                // wire, byte-identical resends hit the prompt cache ~50%
+                // (per-request shard lottery = prod's measured 48.6% on sol);
+                // with it, resends pin to the warm shard (Codex CLI parity).
+                sessionId: input.sessionId,
                 getToken: resolver.getToken,
                 refresh: resolver.refresh,
                 resolveModel: buildModelResolver(

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -142,6 +142,12 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
       headers.set("version", ctx.clientVersion);
       headers.set("accept", "text/event-stream");
       headers.set("content-type", "application/json");
+      if (ctx.sessionId) {
+        // Backend sticky cache-routing key (see CodexRequestContext.sessionId):
+        // without it, byte-identical resends miss the prompt cache ~half the
+        // time; with it they pin to a warm shard and hit at the ceiling.
+        headers.set("session_id", ctx.sessionId);
+      }
       if (auth.isFedramp) {
         headers.set("X-OpenAI-Fedramp", "true");
       }

--- a/packages/codex/src/request-context.ts
+++ b/packages/codex/src/request-context.ts
@@ -32,6 +32,19 @@ export type CodexUsageHeaderSnapshot = {
 
 export type CodexRequestContext = {
   clientVersion: string;
+  /**
+   * Stable per-session affinity id, sent as the `session_id` header on every
+   * request. This is the backend's STICKY CACHE-ROUTING key — measured
+   * 2026-07-12 with byte-identical ~99k-token gpt-5.6-sol requests on one idle
+   * account: without the header, repeat requests hit the prompt cache ~50% of
+   * the time (a per-request routing lottery across cache shards; matches the
+   * prod fleet's 48.6%); with a stable session_id, 10/10 requests hit at the
+   * 99.0% ceiling — Codex CLI parity (the CLI always sends it; its own last-3d
+   * token-weighted rate here is 94%). `prompt_cache_key` in the body only
+   * influences routing and does NOT pin it. Use the SAME value as
+   * prompt_cache_key (the OpenGeni sessionId) so routing and cache key agree.
+   */
+  sessionId?: string;
   /** Worker-supplied: proactive refresh + single-flight + db persist. */
   getToken: () => Promise<CodexTokenSnapshot>;
   /** Forced refresh used for the 401 retry. */

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -83,6 +83,28 @@ describe("codexSubscriptionFetch", () => {
     expect("id" in sent.input[0]).toBe(false);
   });
 
+  test("sends the session_id affinity header when the context carries a sessionId", async () => {
+    // The backend's sticky cache-routing key: without it, byte-identical
+    // resends miss the prompt cache ~50% (measured shard lottery); with it
+    // they pin to the warm shard. Must ride EVERY request of the session.
+    const { base, captures } = baseRecorder();
+    const fetchImpl = codexSubscriptionFetch(base);
+    await codexRequestStorage.run(ctx({ sessionId: "11111111-2222-4333-8444-555555555555" }), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: "{}" }),
+    );
+    const headers = new Headers(captures[0]?.init?.headers);
+    expect(headers.get("session_id")).toBe("11111111-2222-4333-8444-555555555555");
+  });
+
+  test("omits the session_id header when the context has none (legacy behavior)", async () => {
+    const { base, captures } = baseRecorder();
+    const fetchImpl = codexSubscriptionFetch(base);
+    await codexRequestStorage.run(ctx(), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", { method: "POST", body: "{}" }),
+    );
+    expect(new Headers(captures[0]?.init?.headers).get("session_id")).toBeNull();
+  });
+
   test("does not double-rewrite when url already targets /codex/responses", async () => {
     const { base, captures } = baseRecorder();
     const fetchImpl = codexSubscriptionFetch(base);


### PR DESCRIPTION
## The finding

Production codex-subscription turns cache at 48.6% token-weighted (sol) while Codex CLI on the same account achieves 94% (last 3 days, measured from real rollouts). The gap was attributed with a controlled wire experiment (byte-identical ~99k-token requests, one idle account, same `prompt_cache_key`):

- **Without a `session_id` header**: repeat requests hit 0% or 99% at random — ~50% of calls, a per-request routing lottery across backend cache shards. Matches prod's 48.6% almost exactly. Reproduced A/B/A.
- **With a stable `session_id` header**: **10/10 requests hit at the 99.0% ceiling**, including an appended-turn prefix and a fresh-`prompt_cache_key` phase.

`prompt_cache_key` (body) only *influences* routing; the `session_id` **header** pins it. Codex CLI always sends this header; OpenGeni never did.

## The fix (one header, strictly scoped)

- `CodexRequestContext` gains optional `sessionId`; `codexSubscriptionFetch` sets `session_id: <sessionId>` on every request when present.
- The worker supplies `input.sessionId` — the SAME value already used for `prompt_cache_key`, so routing and cache key agree. The compaction summarizer shares the request context and therefore the warm shard.
- No context/sessionId (e.g. model-picker probes) → header omitted, behavior unchanged. Non-codex turns untouched.

## Why this matters

Codex-subscription inputs are ~22.7B tokens / 4 days; every uncached token burns the 5h/weekly subscription windows ~2x faster and adds TTFT. Expected effect: fleet hit rate moves from ~50-56% toward the CLI's 90%+ regime; account swaps (sharded rotation) remain the only cold points, which is exactly the intended minimum.

## Evidence trail

- Probe: byte-identical bodies (equal `bodyBytes`), zero partial hits across 44 samples — hits are always full-prefix (99.0%/95.1% = max possible given the min-1024 tail), so our prefix construction is byte-perfect and prefix mutation is ruled out.
- A/B/A: no-header (5/10 random) → header (10/10) → no-header (lottery again), same hour, same account.
- CLI baseline current-regime: 94.0% global, sol 87.3% at 32-128k (the bucket prod hits 30.9%).

## Gates

- New wire tests: header present when context carries sessionId; absent otherwise. fetch.test.ts 28 pass.
- Full monorepo typecheck clean; oxfmt clean; oxlint 0 errors; changeset (@opengeni/codex patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)