### PR TITLE
fix(runtime): usage telemetry records cached_tokens 0 as 0, not null

### DIFF
--- a/.changeset/usage-telemetry-zero-cached.md
+++ b/.changeset/usage-telemetry-zero-cached.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Record a provider-reported `cached_tokens: 0` as 0 in model-call usage telemetry instead of null. The previous >0-only filter made "the provider cached nothing" indistinguishable from "no telemetry returned" — which is exactly how 10k+ genuinely-uncached Azure gpt-5.6 calls masqueraded as a telemetry gap during the 2026-07-12 incident forensics. Absent detail objects still record null (unknown). Pricing is unaffected (null and 0 both bill the uncached rate); dashboards gain an honest zero.

--- a/packages/runtime/src/usage-telemetry.ts
+++ b/packages/runtime/src/usage-telemetry.ts
@@ -45,16 +45,27 @@ function firstPositiveDetailNumber(
   if (!details) {
     return null;
   }
+  // A reported 0 is REAL DATA ("the provider cached/reasoned nothing"), not
+  // absence — the old >0-only filter recorded wire `cached_tokens: 0` as null,
+  // making "0% cached" indistinguishable from "no telemetry" (which is exactly
+  // how 10k+ genuinely-uncached Azure calls masqueraded as a telemetry gap).
+  // Prefer the first positive value across entries (multi-entry detail arrays
+  // may carry zero placeholders next to the real number), but if every entry
+  // says 0, report 0.
   const entries = Array.isArray(details) ? details : [details];
+  let sawZero = false;
   for (const entry of entries) {
     for (const key of keys) {
       const value = finiteNumberOrNull(entry[key]);
       if (value !== null && value > 0) {
         return value;
       }
+      if (value === 0) {
+        sawZero = true;
+      }
     }
   }
-  return null;
+  return sawZero ? 0 : null;
 }
 
 function finiteNumberOrNull(value: unknown): number | null {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -238,6 +238,29 @@ describe("runtime event normalization", () => {
       cachedTokens: 30,
       reasoningTokens: null,
     });
+    // A wire `cached_tokens: 0` is REAL data (the provider cached nothing) and
+    // must record as 0, not null — 10k+ genuinely-uncached Azure calls once
+    // masqueraded as a telemetry gap because 0 was coerced to null. Absent
+    // details still record null (unknown).
+    expect(
+      modelCallUsageTelemetry({
+        inputTokens: 50,
+        outputTokens: 10,
+        inputTokensDetails: { cached_tokens: 0 },
+        outputTokensDetails: { reasoning_tokens: 0 },
+      }),
+    ).toEqual({
+      inputTokens: 50,
+      outputTokens: 10,
+      cachedTokens: 0,
+      reasoningTokens: 0,
+    });
+    expect(modelCallUsageTelemetry({ inputTokens: 50, outputTokens: 10 })).toEqual({
+      inputTokens: 50,
+      outputTokens: 10,
+      cachedTokens: null,
+      reasoningTokens: null,
+    });
   });
 
   test("ignores duplicate raw Responses text delta mirror events", () => {


### PR DESCRIPTION
## What

`modelCallUsageTelemetry`'s detail extractor only accepted values > 0, so a provider-reported `cached_tokens: 0` recorded as **null** — making "the provider cached nothing" indistinguishable from "no telemetry returned".

## Why it matters

During the 2026-07-12 Azure incident forensics, all 10,257 Azure gpt-5.6-sol/terra calls showed `cachedTokens: null` and were initially misread as a telemetry gap. Ground truth (probes against the same deployment): the API returns `input_tokens_details.cached_tokens` on every call — those production calls genuinely cached **0%** (while gpt-5.5 cached 92% the same day, and the same gpt-5.6 deployment caches 98-99% under every probed shape/size today; that anomaly is tracked separately). The telemetry must be able to say so.

Behavior: first positive value across detail entries still wins (multi-entry arrays can carry zero placeholders); all-zero records 0; absent details still record null. Pricing unaffected (null and 0 both bill the uncached rate). Applies to `reasoningTokens` extraction symmetrically.

## Gates

runtime.test.ts 140 pass (new cases: explicit-zero and absent-details); full typecheck clean; oxfmt/oxlint clean; changeset @opengeni/runtime patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)