### PR TITLE
fix(runtime): strip internal resume marker from model wire — prod outage fix

### DIFF
--- a/.changeset/internal-resume-marker-wire-leak.md
+++ b/.changeset/internal-resume-marker-wire-leak.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Never serialize the internal resume-message marker (`opengeni_internal_resume` in item providerData) to any model provider. The @openai/agents SDK spreads providerData keys verbatim into the wire item and strict Responses backends reject unknown per-item fields — in production every turn whose input contained a marked resume message failed deterministically with `400 Unknown parameter: 'input[N].opengeni_internal_resume'`, and because the marker is durable in replayed conversation history, retries could never succeed (sessions stayed dead). The sanitizer now strips the key from every history item and from the fresh trailing resume message before ANY model request; unrelated providerData keys are preserved and untouched items keep reference identity. Resume-notice detection (isInternalResumeMessage) reads stored history and keeps its text-prefix fallback, so compaction housekeeping degrades gracefully instead of ever failing a turn.

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -9,7 +9,10 @@
  * from the active model-facing history; the database audit rows remain.
  */
 
-import { TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE } from "./history-sanitizer";
+import {
+  INTERNAL_RESUME_MESSAGE_MARKER,
+  TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE,
+} from "./history-sanitizer";
 
 export type CompactionItem = Record<string, unknown>;
 
@@ -18,7 +21,9 @@ export type CompactionItem = Record<string, unknown>;
  * next rebuild can exclude old summaries from the retained user-message set.
  */
 export const COMPACTION_SUMMARY_MARKER = "opengeni_context_summary";
-export const INTERNAL_RESUME_MESSAGE_MARKER = "opengeni_internal_resume";
+// Moved to history-sanitizer (this module imports from it; the wire sanitizer
+// strips the marker before ANY model request). Re-exported for compatibility.
+export { INTERNAL_RESUME_MESSAGE_MARKER };
 
 export const SUMMARY_BUFFER_TOKENS = 20_000;
 // A single cumulative budget for all retained real user messages, matching

--- a/packages/runtime/src/history-sanitizer.ts
+++ b/packages/runtime/src/history-sanitizer.ts
@@ -315,9 +315,56 @@ export function sanitizeHistoryItemsForModel<T extends HistoryItem>(items: reado
   }
 
   if (dropped.size === 0) {
-    return items.slice();
+    return items.map(stripInternalResumeMarker);
   }
-  return items.filter((_item, index) => !dropped.has(index));
+  return items.filter((_item, index) => !dropped.has(index)).map(stripInternalResumeMarker);
+}
+
+/**
+ * Internal marker stamping machine-generated resume/continuation messages
+ * (turn-resumed notices, goal continuations) so compaction housekeeping can
+ * recognize them in STORED history. Lives here (not context-compaction, which
+ * imports from this module) so the wire sanitizer below can strip it without
+ * an import cycle; context-compaction re-exports it.
+ */
+export const INTERNAL_RESUME_MESSAGE_MARKER = "opengeni_internal_resume";
+
+/**
+ * Remove the {@link INTERNAL_RESUME_MESSAGE_MARKER} providerData key from a
+ * single item before it reaches ANY model wire. Pure + non-mutating; returns
+ * the SAME reference when there is nothing to strip (keeping the common path
+ * byte-identical, mirroring {@link stripReasoningEncryptedContent}).
+ *
+ * WHY. The @openai/agents SDK serializes providerData keys verbatim into the
+ * request item, and strict Responses backends reject unknown per-item fields —
+ * observed in production as `400 Unknown parameter:
+ * 'input[N].opengeni_internal_resume'`, which deterministically failed every
+ * turn whose replayed history contained a marked resume message (the marker is
+ * durable in conversation truth, so retries could never succeed). Detection
+ * (isInternalResumeMessage) reads STORED items and also keeps a text-prefix
+ * fallback, so stripping at the wire degrades housekeeping gracefully and
+ * never the turn.
+ */
+export function stripInternalResumeMarker<T extends HistoryItem>(item: T): T {
+  const providerData = (item as Record<string, unknown>).providerData;
+  if (
+    !providerData ||
+    typeof providerData !== "object" ||
+    !(INTERNAL_RESUME_MESSAGE_MARKER in (providerData as Record<string, unknown>))
+  ) {
+    return item;
+  }
+  const { [INTERNAL_RESUME_MESSAGE_MARKER]: _dropped, ...rest } = providerData as Record<
+    string,
+    unknown
+  >;
+  const next: Record<string, unknown> = { ...(item as Record<string, unknown>) };
+  if (Object.keys(rest).length > 0) {
+    next.providerData = rest;
+  } else {
+    delete next.providerData;
+  }
+  return next as T;
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -122,6 +122,7 @@ import {
   elideSupersededViewImagePairs,
   normalizeComputerCallActions,
   sanitizeHistoryItemsForModel,
+  stripInternalResumeMarker,
 } from "./history-sanitizer";
 import { installCodexToolSearch } from "./codex-tool-search";
 import { modelCallUsageTelemetry } from "./usage-telemetry";
@@ -2857,7 +2858,11 @@ export async function prepareRunInput(
         // input can exceed the model window (pre-turn compaction is best-effort
         // and can no-op). Trim the oldest history at a clean turn boundary so an
         // over-budget request is never sent. No-op when no budget is supplied.
-        input: guardAssembledInput(sanitizedHistory, trailingMessage, options.inputBudgetTokens),
+        input: guardAssembledInput(
+          sanitizedHistory,
+          stripInternalResumeMarker(trailingMessage as Record<string, unknown>) as AgentInputItem,
+          options.inputBudgetTokens,
+        ),
         ...(sandboxSessionState ? { sandboxSessionState } : {}),
       };
     }
@@ -2868,7 +2873,15 @@ export async function prepareRunInput(
     // after a /clear, so recognizing the sentinel here is what keeps the next
     // turn working (a fresh, empty context) instead of bricking on deserialize.
     if (!input.serializedRunState || isClearedRunStateBlob(input.serializedRunState)) {
-      return { input: input.internalResumeKind ? [trailingMessage] : input.text };
+      return {
+        input: input.internalResumeKind
+          ? [
+              stripInternalResumeMarker(
+                trailingMessage as Record<string, unknown>,
+              ) as AgentInputItem,
+            ]
+          : input.text,
+      };
     }
     const state = await RunState.fromString(agent, input.serializedRunState);
     const sandboxSessionState = await restoredSandboxSessionState(state, options.sandboxClient);
@@ -2882,7 +2895,11 @@ export async function prepareRunInput(
       // Read-path budget guard (see the items path above): keep an over-budget
       // resumed history off the wire by trimming the oldest turns when a budget
       // is supplied.
-      input: guardAssembledInput(sanitizedHistory, trailingMessage, options.inputBudgetTokens),
+      input: guardAssembledInput(
+        sanitizedHistory,
+        stripInternalResumeMarker(trailingMessage as Record<string, unknown>) as AgentInputItem,
+        options.inputBudgetTokens,
+      ),
       ...(sandboxSessionState ? { sandboxSessionState } : {}),
       serializedRunStateForSandbox: input.serializedRunState,
     };

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -798,7 +798,14 @@ describe("runtime event normalization", () => {
     expect(prepared.input).toBe("hello");
   });
 
-  test("marks platform resume notices so compaction cannot retain them as user intent", async () => {
+  test("platform resume notices reach the wire WITHOUT the internal marker", async () => {
+    // The marker must never be serialized to a provider: strict Responses
+    // backends reject unknown per-item fields — in production every turn whose
+    // input carried it died with `400 Unknown parameter:
+    // 'input[N].opengeni_internal_resume'`, and because the marker is durable
+    // in replayed history, retries could never succeed. Detection of resume
+    // notices uses STORED history plus the text-prefix fallback
+    // (isInternalResumeMessage), so the wire copy stays clean.
     const prepared = await prepareRunInput(
       buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []),
       {
@@ -812,9 +819,38 @@ describe("runtime event normalization", () => {
         type: "message",
         role: "user",
         content: "[TURN RESUMED AFTER CONTEXT COMPACTION] Continue.",
-        providerData: { opengeni_internal_resume: "context_compacted" },
       },
     ]);
+    expect(JSON.stringify(prepared.input)).not.toContain("opengeni_internal_resume");
+  });
+
+  test("replayed history items are stripped of the internal resume marker (the prod 400)", async () => {
+    // Reproduces the outage shape: a PRIOR turn's resume message persisted with
+    // the marker in providerData; replaying it must not leak the key to the
+    // wire, while unrelated providerData keys survive.
+    const prepared = await prepareRunInput(
+      buildOpenGeniAgent(testSettings({ sandboxBackend: "none" }), []),
+      {
+        kind: "message",
+        text: "continue",
+        historyItems: [
+          {
+            type: "message",
+            role: "user",
+            content: "[TURN RESUMED AFTER WORKER RESTART] Continue.",
+            providerData: { opengeni_internal_resume: "worker_restart", keep_me: "yes" },
+          } as never,
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "ok" }],
+          } as never,
+        ],
+      },
+    );
+    const serialized = JSON.stringify(prepared.input);
+    expect(serialized).not.toContain("opengeni_internal_resume");
+    expect(serialized).toContain("keep_me");
   });
 
   test("treats the cleared run-state sentinel as a fresh start (run_state mode /clear)", async () => {


### PR DESCRIPTION
## Outage

Since the 10:54Z prod deploy of `21e21cb2` (which includes #391's resume-message housekeeping), **every turn whose input contained a marked resume message failed deterministically** with `400 Unknown parameter: 'input[N].opengeni_internal_resume'`. The marker was attached via item `providerData`, which the @openai/agents SDK serializes verbatim into the wire item; strict Responses backends reject unknown per-item fields. Because resume messages persist into conversation history, the poison was durable — retries replayed it and died again. Fleet codex call volume: ~1,250/hr → 0 by 12:00Z; both orchestration sessions failed.

## Fix (wire-side, stored data untouched)

- `sanitizeHistoryItemsForModel` now strips `opengeni_internal_resume` from every item's providerData (same reference returned when nothing to strip — mirrors `stripReasoningEncryptedContent`); unrelated providerData keys preserved.
- The fresh trailing resume message is stripped at all three assembly sites in `prepareRunInput`.
- Constant moved to history-sanitizer (context-compaction imports from it; re-exported for compatibility).
- Detection (`isInternalResumeMessage`) reads STORED history and keeps #391's text-prefix fallback, so housekeeping degrades gracefully. Note for a follow-up: the sibling `COMPACTION_SUMMARY_MARKER` rides a top-level item key, which the SDK converter never serializes — moving the resume marker to the same pattern would restore precise durable detection.

## Tests

- Rewrote #391's wire assertion (it asserted the outage behavior — marker present on prepared input) to assert the corrected contract.
- New reproduce-test: replayed history item carrying the marker + an unrelated providerData key → serialized prepared input contains no marker, keeps the unrelated key. Runtime suite 724/724; full typecheck clean; oxfmt/oxlint clean; changeset patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)