### PR TITLE
fix(OPE-22): close post-cutover release gates

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -495,9 +495,10 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/queue/:turnId/cancel", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    await assertSessionExists(db, workspaceId, sessionId);
     const payload = CancelSessionQueueItemRequest.parse(await c.req.json());
     try {
-      const sessionId = c.req.param("sessionId");
       const result = await cancelQueuedSessionTurnWithVersion(
         db,
         workspaceId,

--- a/apps/api/test/session-queue-cancel.test.ts
+++ b/apps/api/test/session-queue-cancel.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+import { Hono } from "hono";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { createDb, createSession, type Database, type DbClient } from "@opengeni/db";
+import { signDelegatedAccessToken } from "@opengeni/contracts";
+import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
+import { registerSessionRoutes } from "../src/routes/sessions";
+
+const DELEGATION_SECRET = "session-queue-cancel-test-secret";
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+let app: Hono;
+let published = 0;
+let wakes = 0;
+
+const settings = testSettings({
+  productAccessMode: "managed",
+  delegationSecret: DELEGATION_SECRET,
+});
+
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('queue cancel account') returning id`;
+  const [workspace] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name) values (${account!.id}, 'queue cancel workspace') returning id`;
+  return { accountId: account!.id, workspaceId: workspace!.id };
+}
+
+function workflowClient(): SessionWorkflowClient {
+  const noop = async () => {};
+  return {
+    signalUserMessage: noop,
+    wakeSessionWorkflow: async () => {
+      wakes += 1;
+    },
+    signalApprovalDecision: noop,
+    signalSessionControl: noop,
+    syncScheduledTask: noop,
+    deleteScheduledTaskSchedule: noop,
+    triggerScheduledTask: noop,
+  } as unknown as SessionWorkflowClient;
+}
+
+function deps(): ApiRouteDeps {
+  const bus = new MemoryEventBus();
+  const publish = bus.publish.bind(bus);
+  bus.publish = async (...args) => {
+    published += 1;
+    await publish(...args);
+  };
+  return {
+    settings,
+    db,
+    bus,
+    workflowClient: workflowClient(),
+    githubStateSecret: "x",
+    objectStorage: null,
+    documentIndexer: { indexDocument: async () => {} },
+    getDocumentServices: () => ({}) as never,
+  } as unknown as ApiRouteDeps;
+}
+
+async function bearer(accountId: string, workspaceId: string): Promise<string> {
+  const token = await signDelegatedAccessToken(DELEGATION_SECRET, {
+    accountId,
+    workspaceId,
+    subjectId: "queue-controller",
+    permissions: ["sessions:control"],
+    exp: Math.floor(Date.now() / 1000) + 3_600,
+  });
+  return `Bearer ${token}`;
+}
+
+async function cancel(workspaceId: string, sessionId: string, authorization: string) {
+  return app.request(
+    `http://x/v1/workspaces/${workspaceId}/sessions/${sessionId}/queue/00000000-0000-4000-8000-000000000001/cancel`,
+    {
+      method: "POST",
+      headers: { authorization, "content-type": "application/json" },
+      body: JSON.stringify({ expectedQueueVersion: 0, expectedItemVersion: 1 }),
+    },
+  );
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("session-queue-cancel");
+  if (!shared) {
+    if (requireRealDatabase) {
+      throw new Error("PostgreSQL test database unavailable while OPENGENI_REQUIRE_REAL_DB=1");
+    }
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[session-queue-cancel] docker unavailable, skipping");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+  app = new Hono();
+  registerSessionRoutes(app, deps());
+}, 180_000);
+
+afterAll(async () => {
+  try {
+    await client?.close();
+  } catch {
+    /* noop */
+  }
+  await shared?.release();
+}, 180_000);
+
+describe("session queue cancellation lookup", () => {
+  test("returns 404 without side effects for missing and cross-workspace sessions", async () => {
+    if (!available) return;
+    const owner = await freshWorkspace();
+    const other = await freshWorkspace();
+    const otherSession = await createSession(db, {
+      accountId: other.accountId,
+      workspaceId: other.workspaceId,
+      initialMessage: "tenant-isolated queue",
+      resources: [],
+      metadata: {},
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+    const authorization = await bearer(owner.accountId, owner.workspaceId);
+
+    for (const sessionId of ["00000000-0000-4000-8000-000000000002", otherSession.id]) {
+      const response = await cancel(owner.workspaceId, sessionId, authorization);
+      expect(response.status).toBe(404);
+      expect(await response.text()).toContain("session not found");
+    }
+
+    expect(published).toBe(0);
+    expect(wakes).toBe(0);
+  });
+});

--- a/packages/db/test/session-control-cutover-audit.test.ts
+++ b/packages/db/test/session-control-cutover-audit.test.ts
@@ -1,8 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import {
-  acquireBlankTestDatabase,
-  type BlankTestDatabase,
-} from "@opengeni/testing";
+import { acquireBlankTestDatabase, type BlankTestDatabase } from "@opengeni/testing";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,10 +9,7 @@ import {
   reconcileSessionControlCutover,
 } from "../src/session-control-cutover-audit";
 
-const migrationsDir = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "../drizzle",
-);
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
 const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
 
 async function applyFile(sql: postgres.Sql, file: string): Promise<void> {
@@ -40,9 +34,7 @@ beforeAll(async () => {
       );
     }
     available = false;
-    console.warn(
-      "[session-control-cutover-audit] postgres unavailable, skipping",
-    );
+    console.warn("[session-control-cutover-audit] postgres unavailable, skipping");
   }
 }, 180_000);
 
@@ -55,9 +47,7 @@ describe("session-control production cutover audit", () => {
     if (!available || !blank) return;
     const sql = postgres(blank.databaseUrl, { max: 1 });
     try {
-      const files = (await readdir(migrationsDir))
-        .filter((file) => file.endsWith(".sql"))
-        .sort();
+      const files = (await readdir(migrationsDir)).filter((file) => file.endsWith(".sql")).sort();
       const oldFiles = files.filter((file) => file < "0057_");
       await sql.unsafe(
         `create table if not exists schema_migrations (name text primary key, applied_at timestamptz not null default now())`,
@@ -95,13 +85,7 @@ describe("session-control production cutover audit", () => {
       const scheduledTurnId = crypto.randomUUID();
       const goalTurnId = crypto.randomUUID();
       const drainedTurnId = crypto.randomUUID();
-      const turnIds = [
-        runningTurnId,
-        queuedUserTurnId,
-        scheduledTurnId,
-        goalTurnId,
-        drainedTurnId,
-      ];
+      const turnIds = [runningTurnId, queuedUserTurnId, scheduledTurnId, goalTurnId, drainedTurnId];
       const triggerIds = turnIds.map(() => crypto.randomUUID());
       await sql`
           insert into session_turns (
@@ -182,11 +166,7 @@ describe("session-control production cutover audit", () => {
       const app = postgres(appUrl.toString(), { max: 1 });
       try {
         await expect(
-          captureSessionControlCutoverSnapshot(
-            app,
-            "baseline",
-            "2026-07-14T10:00:00.000Z",
-          ),
+          captureSessionControlCutoverSnapshot(app, "baseline", "2026-07-14T10:00:00.000Z"),
         ).rejects.toThrow("requires a superuser or BYPASSRLS role");
       } finally {
         await app.end().catch(() => undefined);
@@ -218,59 +198,29 @@ describe("session-control production cutover audit", () => {
         "migrated",
         "2026-07-14T10:01:00.000Z",
       );
-      const result = reconcileSessionControlCutover(
-        baseline,
-        migrated,
-        "migration",
-      );
+      const result = reconcileSessionControlCutover(baseline, migrated, "migration");
       expect(result.errors).toEqual([]);
       expect(result.ok).toBe(true);
 
-      const main = migrated.sessions.find(
-        (session) => session.id === sessionId,
-      );
+      const main = migrated.sessions.find((session) => session.id === sessionId);
       if (!main) throw new Error("migrated session is missing");
-      expect(main.turns.find((turn) => turn.id === runningTurnId)?.status).toBe(
-        "recovering",
-      );
-      expect(
-        main.turns.find((turn) => turn.id === queuedUserTurnId)?.status,
-      ).toBe("queued");
-      expect(
-        main.turns.find((turn) => turn.id === scheduledTurnId)?.status,
-      ).toBe("superseded");
-      expect(main.turns.find((turn) => turn.id === goalTurnId)?.status).toBe(
-        "superseded",
-      );
-      expect(
-        main.systemUpdates.some(
-          (update) => update.sourceId === scheduledTurnId,
-        ),
-      ).toBe(true);
-      const recovery = migrated.sessions.find(
-        (session) => session.id === recoverySessionId,
-      );
+      expect(main.turns.find((turn) => turn.id === runningTurnId)?.status).toBe("recovering");
+      expect(main.turns.find((turn) => turn.id === queuedUserTurnId)?.status).toBe("queued");
+      expect(main.turns.find((turn) => turn.id === scheduledTurnId)?.status).toBe("superseded");
+      expect(main.turns.find((turn) => turn.id === goalTurnId)?.status).toBe("superseded");
+      expect(main.systemUpdates.some((update) => update.sourceId === scheduledTurnId)).toBe(true);
+      const recovery = migrated.sessions.find((session) => session.id === recoverySessionId);
       if (!recovery) throw new Error("migrated recovery session is missing");
-      expect(
-        recovery.turns.find((turn) => turn.id === drainedTurnId)?.status,
-      ).toBe("recovering");
+      expect(recovery.turns.find((turn) => turn.id === drainedTurnId)?.status).toBe("recovering");
 
       const damaged = structuredClone(migrated);
-      const damagedMain = damaged.sessions.find(
-        (session) => session.id === sessionId,
-      );
+      const damagedMain = damaged.sessions.find((session) => session.id === sessionId);
       const damagedHistory = damagedMain?.history[0];
       if (!damagedHistory) throw new Error("migrated history row is missing");
       damagedHistory.active = false;
-      const rejected = reconcileSessionControlCutover(
-        baseline,
-        damaged,
-        "migration",
-      );
+      const rejected = reconcileSessionControlCutover(baseline, damaged, "migration");
       expect(rejected.ok).toBe(false);
-      expect(
-        rejected.errors.some((error) => error.includes("history row")),
-      ).toBe(true);
+      expect(rejected.errors.some((error) => error.includes("history row"))).toBe(true);
     } finally {
       await sql.end().catch(() => undefined);
     }

--- a/scripts/operator/session-control-cutover.test.ts
+++ b/scripts/operator/session-control-cutover.test.ts
@@ -6,9 +6,7 @@ describe("production cutover operator retry ownership", () => {
     const note = "OpenGeni production maintenance opengeni-cutover-main";
     expect(schedulePauseOwnedByRun(false, null, note)).toBe(true);
     expect(schedulePauseOwnedByRun(true, note, note)).toBe(true);
-    expect(schedulePauseOwnedByRun(true, "manual operator pause", note)).toBe(
-      false,
-    );
+    expect(schedulePauseOwnedByRun(true, "manual operator pause", note)).toBe(false);
     expect(schedulePauseOwnedByRun(true, null, note)).toBe(false);
   });
 });

--- a/scripts/operator/session-control-cutover.ts
+++ b/scripts/operator/session-control-cutover.ts
@@ -24,8 +24,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const flags = new Set<string>();
   for (let index = 0; index < rest.length; index += 1) {
     const current = rest[index]!;
-    if (!current.startsWith("--"))
-      throw new Error(`unexpected argument: ${current}`);
+    if (!current.startsWith("--")) throw new Error(`unexpected argument: ${current}`);
     const next = rest[index + 1];
     if (!next || next.startsWith("--")) {
       flags.add(current);
@@ -109,22 +108,15 @@ async function readJson<T>(path: string): Promise<T> {
   return parseJson<T>(await readFile(path, "utf8"), path);
 }
 
-function verifySnapshot(
-  value: SessionControlCutoverSnapshot,
-  path: string,
-): void {
+function verifySnapshot(value: SessionControlCutoverSnapshot, path: string): void {
   const { sha256: recorded, ...body } = value;
   const calculated = sha256(body);
   if (calculated !== recorded) {
-    throw new Error(
-      `${path}: snapshot checksum mismatch (${recorded} != ${calculated})`,
-    );
+    throw new Error(`${path}: snapshot checksum mismatch (${recorded} != ${calculated})`);
   }
 }
 
-async function readSnapshot(
-  path: string,
-): Promise<SessionControlCutoverSnapshot> {
+async function readSnapshot(path: string): Promise<SessionControlCutoverSnapshot> {
   const value = await readJson<SessionControlCutoverSnapshot>(path);
   verifySnapshot(value, path);
   return value;
@@ -159,9 +151,7 @@ async function capture(args: ParsedArgs): Promise<void> {
   });
   try {
     const snapshot = await sql.begin(async (transaction) => {
-      await transaction.unsafe(
-        "set transaction isolation level repeatable read, read only",
-      );
+      await transaction.unsafe("set transaction isolation level repeatable read, read only");
       return await captureSessionControlCutoverSnapshot(transaction, phase);
     });
     if (
@@ -192,11 +182,8 @@ async function reconcile(args: ParsedArgs): Promise<void> {
   const result = reconcileSessionControlCutover(baseline, observed, mode);
   await writeJson(required(args, "--output"), result);
   if (!result.ok) {
-    for (const error of result.errors)
-      process.stderr.write(`[cutover-audit] ${error}\n`);
-    throw new Error(
-      `${mode} reconciliation failed with ${result.errors.length} error(s)`,
-    );
+    for (const error of result.errors) process.stderr.write(`[cutover-audit] ${error}\n`);
+    throw new Error(`${mode} reconciliation failed with ${result.errors.length} error(s)`);
   }
   process.stderr.write(
     `[cutover-audit] ${mode}: all pre-cutover identities reconciled, sha256 ${result.sha256}\n`,
@@ -231,9 +218,7 @@ async function wake(args: ParsedArgs): Promise<void> {
         "claimable-session scan reached its hard limit; refusing a partial wake repair",
       );
     }
-    const ordered = [...rows].sort((a, b) =>
-      a.session_id.localeCompare(b.session_id),
-    );
+    const ordered = [...rows].sort((a, b) => a.session_id.localeCompare(b.session_id));
     const failures: Array<{ sessionId: string; error: string }> = [];
     const woken: string[] = [];
     if (execute) {
@@ -245,36 +230,33 @@ async function wake(args: ParsedArgs): Promise<void> {
         namespace: temporalSettingsValue.namespace,
       });
       const queue = [...ordered];
-      const workers = Array.from(
-        { length: Math.min(20, Math.max(1, queue.length)) },
-        async () => {
-          for (;;) {
-            const row = queue.shift();
-            if (!row) return;
-            try {
-              await temporal.workflow.signalWithStart("sessionWorkflow", {
-                taskQueue: temporalSettingsValue.taskQueue,
-                workflowId: row.temporal_workflow_id,
-                workflowIdReusePolicy: "ALLOW_DUPLICATE",
-                args: [
-                  {
-                    accountId: row.account_id,
-                    workspaceId: row.workspace_id,
-                    sessionId: row.session_id,
-                  },
-                ],
-                signal: "queueChanged",
-              });
-              woken.push(row.session_id);
-            } catch (error) {
-              failures.push({
-                sessionId: row.session_id,
-                error: error instanceof Error ? error.message : String(error),
-              });
-            }
+      const workers = Array.from({ length: Math.min(20, Math.max(1, queue.length)) }, async () => {
+        for (;;) {
+          const row = queue.shift();
+          if (!row) return;
+          try {
+            await temporal.workflow.signalWithStart("sessionWorkflow", {
+              taskQueue: temporalSettingsValue.taskQueue,
+              workflowId: row.temporal_workflow_id,
+              workflowIdReusePolicy: "ALLOW_DUPLICATE",
+              args: [
+                {
+                  accountId: row.account_id,
+                  workspaceId: row.workspace_id,
+                  sessionId: row.session_id,
+                },
+              ],
+              signal: "queueChanged",
+            });
+            woken.push(row.session_id);
+          } catch (error) {
+            failures.push({
+              sessionId: row.session_id,
+              error: error instanceof Error ? error.message : String(error),
+            });
           }
-        },
-      );
+        }
+      });
       await Promise.all(workers);
     }
     const draft = {
@@ -347,28 +329,20 @@ async function temporalSchedules(args: ParsedArgs): Promise<void> {
     });
     let expectedResumeIds: Set<string> | null = null;
     if (action === "resume") {
-      const pauseArtifact = await readJson<SchedulePauseArtifact>(
-        required(args, "--input"),
-      );
+      const pauseArtifact = await readJson<SchedulePauseArtifact>(required(args, "--input"));
       const { sha256: recorded, ...body } = pauseArtifact;
       if (
-        pauseArtifact.contractVersion !==
-          "opengeni/session-control-cutover-schedules/v1" ||
+        pauseArtifact.contractVersion !== "opengeni/session-control-cutover-schedules/v1" ||
         pauseArtifact.action !== "pause" ||
         pauseArtifact.runId !== runId ||
         sha256(body) !== recorded ||
         !Array.isArray(pauseArtifact.changedScheduleIds) ||
         pauseArtifact.changedScheduleIds.some(
-          (id) =>
-            typeof id !== "string" ||
-            !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(id),
+          (id) => typeof id !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(id),
         ) ||
-        new Set(pauseArtifact.changedScheduleIds).size !==
-          pauseArtifact.changedScheduleIds.length
+        new Set(pauseArtifact.changedScheduleIds).size !== pauseArtifact.changedScheduleIds.length
       ) {
-        throw new Error(
-          "schedule pause artifact is stale, malformed, or belongs to another run",
-        );
+        throw new Error("schedule pause artifact is stale, malformed, or belongs to another run");
       }
       expectedResumeIds = new Set(pauseArtifact.changedScheduleIds);
     }
@@ -388,10 +362,7 @@ async function temporalSchedules(args: ParsedArgs): Promise<void> {
       const handle = temporal.schedule.getHandle(scheduleId);
       const before = await handle.describe();
       const wasPaused = before.state.paused;
-      if (
-        action === "pause" &&
-        schedulePauseOwnedByRun(wasPaused, before.state.note, note)
-      ) {
+      if (action === "pause" && schedulePauseOwnedByRun(wasPaused, before.state.note, note)) {
         if (!wasPaused) await handle.pause(note);
         // A retry after the pause succeeded but before its receipt was committed
         // still owns this schedule. Re-emit that ownership so the eventual resume
@@ -410,11 +381,7 @@ async function temporalSchedules(args: ParsedArgs): Promise<void> {
       if (action === "pause" && !after.state.paused) {
         throw new Error(`schedule ${scheduleId} did not acknowledge pause`);
       }
-      if (
-        action === "resume" &&
-        expectedResumeIds?.has(scheduleId) &&
-        after.state.paused
-      ) {
+      if (action === "resume" && expectedResumeIds?.has(scheduleId) && after.state.paused) {
         throw new Error(`schedule ${scheduleId} did not acknowledge resume`);
       }
       summaries.push({
@@ -425,13 +392,9 @@ async function temporalSchedules(args: ParsedArgs): Promise<void> {
       });
     }
     if (expectedResumeIds) {
-      const missing = [...expectedResumeIds].filter(
-        (id) => !listed.includes(id),
-      );
+      const missing = [...expectedResumeIds].filter((id) => !listed.includes(id));
       if (missing.length > 0) {
-        throw new Error(
-          `paused schedules disappeared before resume: ${missing.join(", ")}`,
-        );
+        throw new Error(`paused schedules disappeared before resume: ${missing.join(", ")}`);
       }
     }
     const draft = {
@@ -486,9 +449,7 @@ async function temporalWorkflows(args: ParsedArgs): Promise<void> {
       });
     }
     captured.sort(
-      (a, b) =>
-        a.workflowId.localeCompare(b.workflowId) ||
-        a.runId.localeCompare(b.runId),
+      (a, b) => a.workflowId.localeCompare(b.workflowId) || a.runId.localeCompare(b.runId),
     );
     const terminated: Array<{ workflowId: string; runId: string }> = [];
     if (action === "terminate") {
@@ -524,9 +485,7 @@ async function temporalWorkflows(args: ParsedArgs): Promise<void> {
       }
     }
     if (action === "terminate" && remaining.length > 0) {
-      throw new Error(
-        `${remaining.length} running session workflows remain after termination`,
-      );
+      throw new Error(`${remaining.length} running session workflows remain after termination`);
     }
     const draft = {
       contractVersion: "opengeni/session-control-cutover-workflows/v1",
@@ -536,9 +495,7 @@ async function temporalWorkflows(args: ParsedArgs): Promise<void> {
       capturedAt: new Date().toISOString(),
       captured,
       terminated,
-      remaining: remaining.sort((a, b) =>
-        a.workflowId.localeCompare(b.workflowId),
-      ),
+      remaining: remaining.sort((a, b) => a.workflowId.localeCompare(b.workflowId)),
     };
     const artifact = { ...draft, sha256: sha256(draft) };
     await writeJson(output, artifact);
@@ -555,12 +512,7 @@ async function responseJson(
   operation: string,
 ): Promise<Record<string, unknown>> {
   const body = await response.json().catch(() => null);
-  if (
-    !response.ok ||
-    !body ||
-    typeof body !== "object" ||
-    Array.isArray(body)
-  ) {
+  if (!response.ok || !body || typeof body !== "object" || Array.isArray(body)) {
     throw new Error(`${operation} returned HTTP ${response.status}`);
   }
   return body as Record<string, unknown>;
@@ -571,27 +523,16 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
   const runId = safeRunId(required(args, "--run-id"));
   const model = required(args, "--model");
   if (!model.startsWith("codex/")) {
-    throw new Error(
-      "production canary model must use an existing Codex subscription",
-    );
+    throw new Error("production canary model must use an existing Codex subscription");
   }
   const apiBaseUrl = required(args, "--api-base-url").replace(/\/+$/, "");
-  if (!/^https?:\/\//.test(apiBaseUrl))
-    throw new Error("--api-base-url must be HTTP(S)");
-  const requestedWorkspaceId =
-    args.values.get("--workspace-id")?.trim() || null;
+  if (!/^https?:\/\//.test(apiBaseUrl)) throw new Error("--api-base-url must be HTTP(S)");
+  const requestedWorkspaceId = args.values.get("--workspace-id")?.trim() || null;
   if (requestedWorkspaceId && !/^[0-9a-f-]{36}$/.test(requestedWorkspaceId)) {
     throw new Error("--workspace-id must be a UUID");
   }
-  const timeoutSeconds = Number.parseInt(
-    args.values.get("--timeout-seconds") ?? "600",
-    10,
-  );
-  if (
-    !Number.isInteger(timeoutSeconds) ||
-    timeoutSeconds < 30 ||
-    timeoutSeconds > 1_800
-  ) {
+  const timeoutSeconds = Number.parseInt(args.values.get("--timeout-seconds") ?? "600", 10);
+  if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 30 || timeoutSeconds > 1_800) {
     throw new Error("--timeout-seconds must be between 30 and 1800");
   }
   const sql = postgres(migrationDatabaseUrl(), {
@@ -603,9 +544,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
   });
   let apiKeyId: string | null = null;
   try {
-    const candidates = (await sql.unsafe<
-      Array<{ workspace_id: string; account_id: string }>
-    >(
+    const candidates = (await sql.unsafe<Array<{ workspace_id: string; account_id: string }>>(
       `select w.id as workspace_id, w.account_id
        from workspaces w
        where w.inference_state = 'active'
@@ -636,8 +575,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
         now() + interval '15 minutes'
       ) returning id`;
     apiKeyId = inserted[0]?.id ?? null;
-    if (!apiKeyId)
-      throw new Error("failed to create the temporary canary API key");
+    if (!apiKeyId) throw new Error("failed to create the temporary canary API key");
 
     const headers = {
       authorization: `Bearer ${token}`,
@@ -662,13 +600,9 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
         }),
       },
     );
-    const created = await responseJson(
-      createResponse,
-      "canary session creation",
-    );
+    const created = await responseJson(createResponse, "canary session creation");
     const sessionId = typeof created.id === "string" ? created.id : null;
-    if (!sessionId)
-      throw new Error("canary session creation returned no session id");
+    if (!sessionId) throw new Error("canary session creation returned no session id");
 
     const deadline = Date.now() + timeoutSeconds * 1_000;
     let completedEventId: string | null = null;
@@ -692,25 +626,18 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
           event.payload && typeof event.payload === "object"
             ? (event.payload as Record<string, unknown>)
             : {};
-        if (
-          event.type === "agent.message.completed" &&
-          payload.text === canaryMarker
-        ) {
+        if (event.type === "agent.message.completed" && payload.text === canaryMarker) {
           completedEventId = typeof event.id === "string" ? event.id : null;
         }
         if (event.type === "agent.model.usage" && payload.model === model) {
           usageEventId = typeof event.id === "string" ? event.id : null;
-          observedProvider =
-            typeof payload.provider === "string" ? payload.provider : null;
-          observedModel =
-            typeof payload.model === "string" ? payload.model : null;
+          observedProvider = typeof payload.provider === "string" ? payload.provider : null;
+          observedModel = typeof payload.model === "string" ? payload.model : null;
         }
-        if (event.type === "turn.failed" || event.type === "turn.cancelled")
-          terminalFailure = true;
+        if (event.type === "turn.failed" || event.type === "turn.cancelled") terminalFailure = true;
       }
       if (completedEventId && usageEventId) break;
-      if (terminalFailure)
-        throw new Error("production Codex canary turn failed or was cancelled");
+      if (terminalFailure) throw new Error("production Codex canary turn failed or was cancelled");
       await Bun.sleep(2_000);
     }
     if (!completedEventId || !usageEventId || observedModel !== model) {
@@ -750,10 +677,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
 }
 
 async function maintenanceServer(): Promise<never> {
-  const port = Number.parseInt(
-    process.env.OPENGENI_MAINTENANCE_PORT ?? "8000",
-    10,
-  );
+  const port = Number.parseInt(process.env.OPENGENI_MAINTENANCE_PORT ?? "8000", 10);
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new Error("OPENGENI_MAINTENANCE_PORT must be a valid TCP port");
   }
@@ -769,8 +693,7 @@ async function maintenanceServer(): Promise<never> {
         {
           error: {
             code: "production_maintenance",
-            message:
-              "OpenGeni is briefly paused for a production update. Retry shortly.",
+            message: "OpenGeni is briefly paused for a production update. Retry shortly.",
           },
         },
         {
@@ -804,21 +727,13 @@ async function preflight(args: ParsedArgs): Promise<void> {
 
   const migrationPath = "packages/db/drizzle/0057_durable_queue_control.sql";
   const migrationBytes = await readFile(migrationPath);
-  const migrationSha256 = createHash("sha256")
-    .update(migrationBytes)
-    .digest("hex");
+  const migrationSha256 = createHash("sha256").update(migrationBytes).digest("hex");
   const workerPackage = parseJson<{
     devDependencies?: Record<string, string>;
-  }>(
-    await readFile("apps/worker/package.json", "utf8"),
-    "apps/worker/package.json",
-  );
-  const agentsCoreVersion =
-    workerPackage.devDependencies?.["@openai/agents-core"];
+  }>(await readFile("apps/worker/package.json", "utf8"), "apps/worker/package.json");
+  const agentsCoreVersion = workerPackage.devDependencies?.["@openai/agents-core"];
   if (!agentsCoreVersion || !/^\d+\.\d+\.\d+$/.test(agentsCoreVersion)) {
-    throw new Error(
-      "apps/worker must pin an exact @openai/agents-core version",
-    );
+    throw new Error("apps/worker must pin an exact @openai/agents-core version");
   }
 
   const schemaProbe = Bun.spawnSync({
@@ -841,10 +756,7 @@ async function preflight(args: ParsedArgs): Promise<void> {
     schemaProbe.stdout.toString(),
     "RunState schema probe",
   );
-  if (
-    typeof schema.schemaVersion !== "string" ||
-    !/^\d+\.\d+$/.test(schema.schemaVersion)
-  ) {
+  if (typeof schema.schemaVersion !== "string" || !/^\d+\.\d+$/.test(schema.schemaVersion)) {
     throw new Error("RunState schema probe returned an invalid version");
   }
 
@@ -888,18 +800,14 @@ if (import.meta.main) {
     else if (args.command === "capture") await capture(args);
     else if (args.command === "reconcile") await reconcile(args);
     else if (args.command === "wake") await wake(args);
-    else if (args.command === "temporal-schedules")
-      await temporalSchedules(args);
-    else if (args.command === "temporal-workflows")
-      await temporalWorkflows(args);
+    else if (args.command === "temporal-schedules") await temporalSchedules(args);
+    else if (args.command === "temporal-workflows") await temporalWorkflows(args);
     else if (args.command === "canary") await productionCodexCanary(args);
     else if (args.command === "maintenance-server") await maintenanceServer();
     else if (args.command === "help" || args.flags.has("--help")) usage();
     else throw new Error(`unknown command: ${args.command}`);
   } catch (error) {
-    process.stderr.write(
-      `${error instanceof Error ? error.message : String(error)}\n`,
-    );
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary

- fixes PR #394's post-merge `format:check` failure by formatting exactly the three rejected cutover files
- makes `POST /queue/:turnId/cancel` resolve the workspace-scoped session before queue mutation, returning 404 for missing or cross-workspace session IDs instead of 500
- adds a deterministic real-PostgreSQL/FORCE-RLS route regression proving 404 with no event publication or workflow wake
- does not change the merged session lifecycle, settlement, lock-order, or generation semantics

## Verification

- `bun run format:check` — pass
- `bun run check:docs-refs` — pass
- `bun run typecheck` — pass, all 19 projects
- `bun run lint` — zero errors (existing warnings only)
- focused cutover/route tests — pass; PostgreSQL cases report unavailable locally because this Modal sandbox cannot start Docker
- combined `bun test` — 2,914 pass; the only real failures were two fail-closed PostgreSQL suites blocked by the unavailable daemon, while two credential-script failures caused by sandbox-injected token path overrides passed 6/6 when those path names were unset

CI must provide the exact real PostgreSQL/FORCE-RLS proof with `OPENGENI_REQUIRE_REAL_DB=1`; the new regression fails closed under that setting.

## Release gate

No release is authorized by this PR. Merge requires green exact-head CI and independent `codex/gpt-5.6-sol` xhigh approval. Production remains serialized through OPE-25, adopting the existing operation key rather than dispatching a duplicate cutover.
