### PR TITLE
refactor(session-control): durable queue, pause, recovery, and compaction

### DIFF
--- a/UPGRADE_LOG.md
+++ b/UPGRADE_LOG.md
@@ -1,0 +1,82 @@
+# Dependency Upgrade Log
+
+**Date:** 2026-07-14  
+**Project:** OpenGeni  
+**Language:** TypeScript  
+**Manifests:** `package.json`, `packages/runtime/package.json`,
+`packages/testing/package.json`, `apps/worker/package.json`
+
+## Summary
+
+This log covers every dependency changed during the session-control clean
+cutover. Direct packages were updated within their declared stable ranges, and
+the root resolution contract now pins patched transitive releases so production
+does not ship advisories hidden behind older dependency trees.
+
+## Updates
+
+### OpenAI Agents JS: 0.11.6 → 0.13.3
+
+- Bound all direct `@openai/agents`, `@openai/agents-core`, and
+  `@openai/agents-extensions` declarations to the same latest stable release.
+- The relevant upstream fix is the Modal adapter's use of
+  `sandboxes.create(..., { command: ["sleep", "infinity"] })`. Version 0.11.6
+  attempted an optional `Image.cmd()` call that Modal JS 0.7.4 did not expose,
+  so registry images whose default command exited produced unusable sandboxes.
+- Upstream source: `openai/openai-agents-js` tag `v0.13.3`, commit
+  `7833c50d6bb9ca1d63a43c84b330c46d024b1cfd`.
+
+### Modal JS: 0.7.4 → 0.7.6
+
+- Pinned to the newest release in the Agents JS 0.13.3 declared peer range
+  (`modal@^0.7.6`). Modal 0.9.0 was tested and rejected: it typechecked but did
+  not change the real-service scheduling wait and would violate the adapter's
+  supported dependency contract.
+- Debug evidence showed the apparent resume hang was a pending
+  `SandboxGetTaskId`, before command-router initialization. The account had 129
+  active sandboxes at the time, so the new diagnostic box was created but had
+  not received compute capacity.
+
+### OpenAI Node: 6.36.0 → 6.47.0
+
+- Aligned OpenGeni's direct runtime dependency with the current client required
+  by Agents JS 0.13.3. Keeping 6.36.0 installed a second `OpenAI` class whose
+  private identity was incompatible with the Agents SDK's 6.47.0 types.
+- The upstream changelog from 6.37.0 through 6.47.0 contains additive API work
+  and bug fixes; no OpenGeni call-site migration was required.
+
+### Compatible workspace updates
+
+- Temporal JS `1.17.0` → `1.20.2`.
+- Playwright `1.59.1` → `1.61.1`.
+- `@types/bun` `1.3.13` → `1.3.14`.
+- `@codemirror/view` `6.43.1` → `6.43.6` and
+  `@uiw/react-codemirror` `4.25.10` → `4.25.11`.
+- Changesets CLI `2.27.11` → `2.31.0`.
+
+### Patched transitive security floor
+
+The root override map binds the dependency graph to patched stable releases of
+`@grpc/grpc-js`, `dompurify`, `esbuild`, `form-data`, `hono`, `ip-address`,
+`js-yaml`, `mermaid`, `protobufjs`, `qs`, `uuid`, `vite`, and `ws`. This reduced
+`bun audit` from 45 advisories (12 high) to zero.
+
+## Validation
+
+- [x] Typecheck (19 projects)
+- [x] Provider unit tests
+- [x] Full real-database suite (2,953 passed, 3 explicitly gated live-service
+  tests skipped, 0 failed)
+- [x] Dependency audit (0 vulnerabilities)
+- [ ] Production Codex-subscription canary and post-cutover continuity proof
+
+## Commands
+
+```bash
+bun install
+bun run typecheck
+bun test packages/runtime/test/sandbox-provider-registry.test.ts
+bun test apps/api/test/sandbox-resume-modal-smoke.test.ts
+OPENGENI_REQUIRE_REAL_SERVICES=1 bun test --max-concurrency 6 --timeout 30000
+bun audit
+```

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -93,8 +93,15 @@ export async function createTemporalWorkflowClient(
         signalArgs: [wakeRevision],
       });
     },
-    signalApprovalDecision: async ({ eventId, workflowId }) => {
-      await temporal.workflow.getHandle(workflowId).signal("approvalDecision", eventId);
+    signalApprovalDecision: async ({ accountId, workspaceId, sessionId, eventId, workflowId }) => {
+      await temporal.workflow.signalWithStart("sessionWorkflow", {
+        taskQueue: settings.temporalTaskQueue,
+        workflowId,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        args: [{ accountId, workspaceId, sessionId }],
+        signal: "approvalDecision",
+        signalArgs: [eventId],
+      });
     },
     signalSessionControl: async ({ accountId, workspaceId, sessionId, eventId, workflowId }) => {
       // Start-or-signal: a control sent after the prior workflow returned idle

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -9,6 +9,7 @@ import {
   UpdateScheduledTaskRequest,
 } from "@opengeni/contracts";
 import {
+  addSessionSystemUpdate,
   correctWorkspaceMemory,
   countVariableSets,
   beginRigChangeVerificationAttempt,
@@ -203,7 +204,7 @@ export function buildOpenGeniMcpServer(
   // and mint GitHub install links out of the box. A user DEMOTES a specific
   // session by setting a narrower session.firstPartyMcpPermissions (capped to
   // the creator's own grant); operators still cap what any session can be given.
-  registerWorkspaceOrchestrationTools(server, deps, grant, can, json);
+  registerWorkspaceOrchestrationTools(server, deps, grant, can, sessionId, json);
   registerVariableSetTools(server, deps, grant, can, json);
   if (can("github:use")) {
     registerGitHubConnectTool(server, deps, grant, options, json);
@@ -1229,14 +1230,15 @@ function registerRigTools(
   }
 }
 
-// Workspace orchestration for manager-style agents: sessions are listed,
-// inspected, spawned, and steered with the same domain functions the REST
-// routes use, so limits, validation, and usage metering cannot drift.
+// Workspace orchestration for manager-style agents. Session-authenticated
+// workers communicate through the typed internal-update plane; only a
+// sessionless operator can append a visible prompt through this surface.
 function registerWorkspaceOrchestrationTools(
   server: McpServer,
   deps: ApiRouteDeps,
   grant: AccessGrant,
   can: (permission: Permission) => boolean,
+  callerSessionId: string | null,
   json: JsonResult,
 ): void {
   if (can("sessions:read")) {
@@ -1385,26 +1387,61 @@ function registerWorkspaceOrchestrationTools(
       "session_send_message",
       {
         description:
-          "Post a human/operator message into an existing session. delivery='queue' (default) appends normally. delivery='steer' atomically inserts and promotes this exact item, fences the active turn, and delivers it next with no intermediate queued inference.",
+          "Send information to another session. From an OpenGeni worker this becomes a coalescible internal update, never a visible prompt-queue row; pending updates are delivered together on the target's next inference. A sessionless operator call appends one visible prompt.",
         inputSchema: {
           sessionId: z4.string().uuid(),
           text: z4.string().min(1),
-          delivery: z4.enum(["queue", "steer"]).optional(),
           // Header-value rotation only. URL/name/tool settings are immutable
           // after create; core enforces mcp_servers:attach on this field.
           mcpCredentialUpdates: z4.array(z4.unknown()).optional(),
         },
       },
-      async ({ sessionId, text, delivery, mcpCredentialUpdates }) => {
+      async ({ sessionId: targetSessionId, text, mcpCredentialUpdates }) => {
+        if (callerSessionId !== null) {
+          if ((mcpCredentialUpdates?.length ?? 0) > 0) {
+            throw new Error("internal session updates cannot change MCP credentials");
+          }
+          const result = await addSessionSystemUpdate(deps.db, {
+            accountId: grant.accountId,
+            workspaceId: grant.workspaceId,
+            sessionId: targetSessionId,
+            kind: "runtime_notice",
+            classification: "info",
+            sourceId: callerSessionId,
+            dedupeKey: `session-message:${callerSessionId}:${crypto.randomUUID()}`,
+            summary: text,
+            payload: { text },
+            lineage: { sourceSessionId: callerSessionId, targetSessionId },
+          });
+          if (result.reason === "session_cancelled") {
+            return json({ delivered: false, reason: result.reason });
+          }
+          if (result.added && result.events.length > 0) {
+            await deps.bus.publish(grant.workspaceId, targetSessionId, result.events);
+          }
+          if (result.shouldWake) {
+            await deps.workflowClient.wakeSessionWorkflow({
+              accountId: grant.accountId,
+              workspaceId: grant.workspaceId,
+              sessionId: targetSessionId,
+              workflowId: result.temporalWorkflowId ?? workflowIdForSession(targetSessionId),
+            });
+          }
+          return json({
+            delivered: true,
+            updateId: result.update.id,
+            delivery: "coalesced_internal_update",
+          });
+        }
         const { accepted, turn } = await acceptSessionUserMessage(
           deps,
           grant,
           grant.workspaceId,
-          sessionId,
+          targetSessionId,
           {
             text,
             toolsProvided: false,
-            delivery: delivery ?? "queue",
+            delivery: "queue",
             origin: "operator",
             mcpCredentialUpdates: (mcpCredentialUpdates ?? []).map((update) =>
               SessionMcpCredentialUpdateInput.parse(update),

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -35,6 +35,7 @@ import {
 import { streamTokenDegraded } from "@opengeni/config";
 import {
   cancelQueuedSessionTurnWithVersion,
+  acceptSessionApprovalDecision,
   clearSessionGoal,
   clearSessionContext,
   closePtySession,
@@ -52,7 +53,6 @@ import {
   listSessionTurns,
   recordStreamAcknowledgment,
   requestSessionCompaction,
-  requireSession,
   setSessionCodexPin,
   withCodexCapacityMutation,
   setSessionPin,
@@ -71,7 +71,11 @@ import {
   workspaceCaptureAtRevision,
   type AppendEventInput,
 } from "@opengeni/db";
-import { appendAndPublishEvents, coalesceSessionEventDeltas } from "@opengeni/events";
+import {
+  appendAndPublishEvents,
+  coalesceSessionEventDeltas,
+  publishDurableSessionEvents,
+} from "@opengeni/events";
 import { z } from "zod";
 import { withChannelA } from "../sandbox/channel-a";
 import { negotiateCapabilities } from "@opengeni/runtime/sandbox";
@@ -639,27 +643,30 @@ export function registerSessionRoutes(app: Hono, deps: ApiRouteDeps): void {
       return c.json(accepted, 202);
     }
 
-    const session = await requireSession(db, workspaceId, sessionId);
-    if (event.type === "user.approvalDecision" && session.status !== "requires_action") {
-      throw new HTTPException(409, {
-        message: `session is ${session.status}; no approval is pending`,
-      });
-    }
-    const eventsToAppend: AppendEventInput[] = [
-      {
-        type: event.type,
+    if (event.type === "user.approvalDecision") {
+      const accepted = await acceptSessionApprovalDecision(db, {
+        accountId: grant.accountId,
+        workspaceId,
+        sessionId,
         payload: event.payload,
-        ...(event.clientEventId ? { clientEventId: event.clientEventId } : {}),
-      },
-    ];
-    const appended = await appendAndPublishEvents(db, bus, workspaceId, sessionId, eventsToAppend);
-    const accepted = appended[0];
-    if (!accepted) {
-      throw new HTTPException(500, { message: "failed to append client event" });
+        clientEventId: event.clientEventId ?? null,
+      });
+      if (accepted.action === "conflict") {
+        throw new HTTPException(409, {
+          message: `session is ${accepted.sessionStatus}; no unhandled approval is pending`,
+        });
+      }
+      await publishDurableSessionEvents(bus, workspaceId, sessionId, accepted.events);
+      const workflowId = workflowIdForSession(sessionId);
+      await workflowClient.signalApprovalDecision({
+        accountId: grant.accountId,
+        workspaceId,
+        sessionId,
+        eventId: accepted.event.id,
+        workflowId,
+      });
+      return c.json(accepted.event, 202);
     }
-    const workflowId = workflowIdForSession(sessionId);
-    await workflowClient.signalApprovalDecision({ sessionId, eventId: accepted.id, workflowId });
-    return c.json(accepted, 202);
   });
 
   // ── API-direct stream capabilities + viewer attach (P1.4) ─────────────────

--- a/apps/api/src/sandbox/access.ts
+++ b/apps/api/src/sandbox/access.ts
@@ -82,7 +82,10 @@ export function makeResumeBoxById(
     let session: ApiSandboxSession;
     try {
       const state = await client.deserializeSessionState(resumeState);
-      session = await client.resume(state);
+      // API-direct access borrows the live box. The lease remains its sole
+      // lifecycle owner, even when the serialized founding handle was owned.
+      // Clone instead of mutating the canonical resume envelope.
+      session = await client.resume({ ...state, ownsSandbox: false });
     } catch (error) {
       throw new SandboxResumeError(
         `Failed to resume sandbox box by id on backend "${backend}": ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/api/test/sandbox-access.test.ts
+++ b/apps/api/test/sandbox-access.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { ApiSandboxClient, ApiSandboxSession } from "@opengeni/core";
+import { makeResumeBoxById, SandboxResumeError } from "../src/sandbox/access";
+
+describe("makeResumeBoxById", () => {
+  test("borrows a resumed box without inheriting the founding handle's ownership", async () => {
+    const canonicalState = {
+      sandboxId: "sb-owned",
+      ownsSandbox: true,
+      providerField: "preserved",
+    };
+    let resumedWith: Record<string, unknown> | undefined;
+    const resumedSession: ApiSandboxSession = { state: { sandboxId: "sb-owned" } };
+    const client: ApiSandboxClient = {
+      backendId: "modal",
+      deserializeSessionState: async (state) => {
+        expect(state).toEqual(canonicalState);
+        return state;
+      },
+      resume: async (state) => {
+        resumedWith = state;
+        return resumedSession;
+      },
+    };
+
+    const result = await makeResumeBoxById(client)({
+      backend: "modal",
+      resumeState: canonicalState,
+    });
+
+    expect(result).toBe(resumedSession);
+    expect(resumedWith).toEqual({
+      sandboxId: "sb-owned",
+      ownsSandbox: false,
+      providerField: "preserved",
+    });
+    expect(canonicalState.ownsSandbox).toBe(true);
+  });
+
+  test("rejects a resume envelope for a different backend", async () => {
+    const resume = makeResumeBoxById({ backendId: "modal" });
+    expect(
+      resume({ backend: "docker", resumeState: { sandboxId: "sb-cross" } }),
+    ).rejects.toBeInstanceOf(SandboxResumeError);
+  });
+
+  test("rejects a backend without deserialize and resume support", async () => {
+    const resume = makeResumeBoxById({ backendId: "modal" });
+    expect(
+      resume({ backend: "modal", resumeState: { sandboxId: "sb-unsupported" } }),
+    ).rejects.toBeInstanceOf(SandboxResumeError);
+  });
+});

--- a/apps/api/test/sandbox-resume-modal-smoke.test.ts
+++ b/apps/api/test/sandbox-resume-modal-smoke.test.ts
@@ -19,9 +19,9 @@ import {
 // The marker must round-trip. The box is ALWAYS terminated in finally (cost).
 //
 // Modal creds: the active [opengeni] profile in ~/.modal.toml (the modal JS SDK
-// reads it NATIVELY — no token is injected into settings or printed here). When
-// no profile/token is available the smoke skips (it is not a merge blocker for
-// the non-gated scope, per the implementation plan's NEEDS-CREDS protocol).
+// reads it NATIVELY — no token is injected into settings or printed here). The
+// smoke is additionally opt-in because it allocates real Modal capacity and
+// must not turn every credentialed deterministic-suite run into external work.
 
 const IMAGE_TAG = process.env.OPENGENI_MODAL_SMOKE_IMAGE ?? "python:3.12-slim";
 const APP_NAME = process.env.OPENGENI_MODAL_SMOKE_APP ?? "opengeni-p0-4-resume-smoke";
@@ -78,10 +78,16 @@ async function execMarker(session: ApiSandboxSession, marker: string): Promise<s
   // mishandles -n. The SDK reads `cmd` (a string) and wraps it in /bin/sh -lc.
   const cmd = `printf '%s' '${marker}'`;
   if (session.execCommand) {
-    return parseExecOutput(await session.execCommand({ cmd }));
+    return parseExecOutput(
+      await session.execCommand({ cmd, yieldTimeMs: 30_000, maxOutputTokens: 1_000 }),
+    );
   }
   if (session.exec) {
-    const result = (await session.exec({ cmd })) as { output?: string; stdout?: string };
+    const result = (await session.exec({
+      cmd,
+      yieldTimeMs: 30_000,
+      maxOutputTokens: 1_000,
+    })) as { output?: string; stdout?: string };
     const text = result.output ?? result.stdout ?? "";
     return parseExecOutput(text);
   }
@@ -106,10 +112,21 @@ async function terminate(session: ApiSandboxSession | null | undefined): Promise
   }
 }
 
-const credentialed = hasModalCredentials();
+async function measuredPhase<T>(name: string, run: () => Promise<T>): Promise<T> {
+  const startedAt = Date.now();
+  console.info(`[modal resume smoke] ${name}: start`);
+  try {
+    return await run();
+  } finally {
+    console.info(`[modal resume smoke] ${name}: ${Date.now() - startedAt}ms`);
+  }
+}
 
-describe("P0.4 API-direct Modal resume smoke (NEEDS-CREDS(Modal))", () => {
-  test.skipIf(!credentialed)(
+const credentialed = hasModalCredentials();
+const liveGate = process.env.OPENGENI_P04_LIVE_MODAL === "1" && credentialed;
+
+describe("P0.4 API-direct Modal resume smoke (opt-in real service)", () => {
+  test.skipIf(!liveGate)(
     "the API resumes a real Modal box by id and execs a marker that round-trips",
     async () => {
       const settings = testSettings({
@@ -142,37 +159,41 @@ describe("P0.4 API-direct Modal resume smoke (NEEDS-CREDS(Modal))", () => {
           serializeSessionState(state: unknown): Promise<Record<string, unknown>>;
         };
         expect(typeof modalClient.create).toBe("function");
-        foundingSession = await modalClient.create();
-        expect(await foundingSession.running?.()).toBe(true);
+        foundingSession = await measuredPhase("create", () => modalClient.create());
 
         expect(typeof modalClient.serializeSessionState).toBe("function");
-        const resumeState = await modalClient.serializeSessionState(foundingSession.state);
+        const resumeState = await measuredPhase("serialize", () =>
+          modalClient.serializeSessionState(foundingSession!.state),
+        );
         expect(resumeState && typeof resumeState).toBe("object");
 
         // 2) THE API-DIRECT RESUME: deps.resumeBoxById resumes the box by id,
         //    in-process, with NO worker and NO Temporal.
-        resumedSession = await resumeBoxById({ backend: "modal", resumeState });
-        expect(await resumedSession.running?.()).toBe(true);
+        resumedSession = await measuredPhase("resume", () =>
+          resumeBoxById({ backend: "modal", resumeState }),
+        );
 
         // 3) Exec the marker on the resumed handle — proves the API can touch the
         //    real box and round-trip output.
-        const echoed = await execMarker(resumedSession, marker);
+        const echoed = await measuredPhase("resumed exec", () =>
+          execMarker(resumedSession!, marker),
+        );
         expect(echoed).toBe(marker);
       } finally {
         // ALWAYS terminate (cost). The founding handle owns the box; terminating
         // it kills the box for both handles (resume is a non-owning 2nd handle).
-        await terminate(foundingSession);
+        await measuredPhase("founding teardown", () => terminate(foundingSession));
         // Best-effort drop of the resumed handle too (no-op once box is dead).
-        await terminate(resumedSession);
+        await measuredPhase("borrowed-handle teardown", () => terminate(resumedSession));
       }
     },
-    180_000,
+    360_000,
   );
 
-  test.skipIf(credentialed)("smoke is skipped without Modal credentials (documented)", () => {
-    // A visible breadcrumb in the non-credentialed run so the gated smoke is not
-    // silently absent. The non-gated scope (config + deployment + import guard)
-    // still proves P0.4 builds and wires correctly.
-    expect(credentialed).toBe(false);
-  });
+  test.skipIf(liveGate)(
+    "live smoke is visibly skipped unless OPENGENI_P04_LIVE_MODAL=1 and credentials exist",
+    () => {
+      expect(liveGate).toBe(false);
+    },
+  );
 });

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -51,7 +51,7 @@
     "@temporalio/workflow": "^1.17.0"
   },
   "devDependencies": {
-    "@openai/agents-core": "0.11.6",
+    "@openai/agents-core": "0.13.3",
     "@opengeni/testing": "workspace:*",
     "postgres": "^3.4.9",
     "tsup": "^8.5.0",

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -31,13 +31,15 @@ export type {
   GetCodexCapacityWaitInput,
   ReconcileCodexCapacityWaitInput,
   ReconcileCodexCapacityWaitResult,
-  RecoverTurnAfterWorkerDeathInput,
-  RecoverTurnAfterWorkerDeathResult,
+  RecoverDispatchInput,
+  RecoverDispatchResult,
   RunAgentTurnInput,
   RunAgentTurnResult,
 } from "./activities/types";
 
-export function createActivities(dependencies: ActivityDependencies = {}) {
+function createActivityServices(
+  dependencies: ActivityDependencies,
+): () => Promise<ActivityServices> {
   let servicesPromise: Promise<ActivityServices> | null = null;
 
   async function services(): Promise<ActivityServices> {
@@ -111,9 +113,11 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
     return servicesPromise;
   }
 
-  const runAgentTurn = createRunAgentTurnActivity(services);
+  return services;
+}
+
+function controlActivities(services: () => Promise<ActivityServices>) {
   return {
-    runAgentTurn,
     ...createDocumentActivities(services),
     ...createSessionStateActivities(services),
     ...createScheduledTaskActivities(services),
@@ -127,20 +131,35 @@ export function createActivities(dependencies: ActivityDependencies = {}) {
   };
 }
 
-const defaultActivities = createActivities();
+export function createControlActivities(dependencies: ActivityDependencies = {}) {
+  return controlActivities(createActivityServices(dependencies));
+}
 
-export const runAgentTurn = defaultActivities.runAgentTurn;
-export const indexDocument = defaultActivities.indexDocument;
-export const failSession = defaultActivities.failSession;
-export const settleSessionControl = defaultActivities.settleSessionControl;
-export const recoverTurnAfterWorkerDeath = defaultActivities.recoverTurnAfterWorkerDeath;
-export const claimNextSessionExecution = defaultActivities.claimNextSessionExecution;
-export const markSessionIdle = defaultActivities.markSessionIdle;
-export const dispatchScheduledTaskRun = defaultActivities.dispatchScheduledTaskRun;
-export const maybeContinueGoal = defaultActivities.maybeContinueGoal;
-export const getCodexCapacityWait = defaultActivities.getCodexCapacityWait;
-export const reconcileCodexCapacityWait = defaultActivities.reconcileCodexCapacityWait;
-export const reapSandboxLeases = defaultActivities.reapSandboxLeases;
-export const reapExpiredFileUploads = defaultActivities.reapExpiredFileUploads;
-export const verifyRigChange = defaultActivities.verifyRigChange;
-export const verifyRigVersion = defaultActivities.verifyRigVersion;
+export function createTurnActivities(dependencies: ActivityDependencies = {}) {
+  return { runAgentTurn: createRunAgentTurnActivity(createActivityServices(dependencies)) };
+}
+
+/** Direct activity harness for tests; production workers always choose one role. */
+export function createActivityTestHarness(dependencies: ActivityDependencies = {}) {
+  const services = createActivityServices(dependencies);
+  return { runAgentTurn: createRunAgentTurnActivity(services), ...controlActivities(services) };
+}
+
+const defaultControlActivities = createControlActivities();
+const defaultTurnActivities = createTurnActivities();
+
+export const runAgentTurn = defaultTurnActivities.runAgentTurn;
+export const indexDocument = defaultControlActivities.indexDocument;
+export const failSessionAttempt = defaultControlActivities.failSessionAttempt;
+export const settleSessionControl = defaultControlActivities.settleSessionControl;
+export const recoverDispatch = defaultControlActivities.recoverDispatch;
+export const peekSessionWork = defaultControlActivities.peekSessionWork;
+export const markSessionIdle = defaultControlActivities.markSessionIdle;
+export const dispatchScheduledTaskRun = defaultControlActivities.dispatchScheduledTaskRun;
+export const maybeContinueGoal = defaultControlActivities.maybeContinueGoal;
+export const getCodexCapacityWait = defaultControlActivities.getCodexCapacityWait;
+export const reconcileCodexCapacityWait = defaultControlActivities.reconcileCodexCapacityWait;
+export const reapSandboxLeases = defaultControlActivities.reapSandboxLeases;
+export const reapExpiredFileUploads = defaultControlActivities.reapExpiredFileUploads;
+export const verifyRigChange = defaultControlActivities.verifyRigChange;
+export const verifyRigVersion = defaultControlActivities.verifyRigVersion;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1,7 +1,7 @@
 import {
   applySessionTurnSettlement,
   requestSessionTurnRecovery,
-  claimNextSessionExecution as claimNextSessionExecutionDb,
+  claimSessionWorkForAttempt,
   applyCreditDebitUpToBalance,
   getBillingBalance,
   getRigName,
@@ -12,7 +12,6 @@ import {
   requireFile,
   getSessionEvent,
   getSessionGoal,
-  getSessionTurn,
   getLatestRunState,
   isCodexBilledTurn,
   workspaceCodexSubscriptionActive,
@@ -38,7 +37,6 @@ import {
   countConsecutiveReactiveRotations,
   requireSession,
   recordUsageEvent,
-  registerSessionTurnDispatch,
   registerPendingSessionToolCall,
   recordPendingSessionToolCallResult,
   clearDurablePendingSessionToolCalls,
@@ -219,6 +217,7 @@ import {
   CAPABILITY_DESCRIPTORS,
   evaluateWorkspaceModelPolicy,
   type ResourceRef,
+  type SessionEvent,
   type SessionEventType,
   type SessionStatus,
 } from "@opengeni/contracts";
@@ -462,7 +461,7 @@ export async function recordCompletedModelCallBeforeOwnershipFences(input: {
 type TurnEventPublisher = (
   events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>,
   immediate?: boolean,
-) => Promise<void>;
+) => Promise<{ events: SessionEvent[]; accepted: boolean }>;
 
 export async function emitModelCallUsage(input: {
   observability: ActivityServices["observability"];
@@ -481,6 +480,7 @@ export async function emitModelCallUsage(input: {
   // the session's previous call — the account-switch hypothesis for cache misses.
   servingAccountHash?: string;
   accountChangedFromPrevCall?: boolean;
+  emittedSourceKeys?: Set<string>;
 }): Promise<void> {
   const usage =
     input.usage && typeof input.usage === "object" && "usage" in input.usage
@@ -489,7 +489,37 @@ export async function emitModelCallUsage(input: {
   if (!usage || typeof usage !== "object") {
     return;
   }
+  if (input.emittedSourceKeys?.has(input.sourceKey)) return;
   const telemetry = modelCallUsageTelemetry(usage as Parameters<typeof modelCallUsageTelemetry>[0]);
+  const appended = await input.publish?.(
+    [
+      {
+        type: "agent.model.usage",
+        payload: {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          provider: input.provider,
+          providerApi: input.providerApi,
+          model: input.model,
+          sourceKey: input.sourceKey,
+          ...telemetry,
+        },
+      },
+    ],
+    true,
+  );
+  input.emittedSourceKeys?.add(input.sourceKey);
+  const authoritative = appended?.events.some(
+    (event) =>
+      event.type === "agent.model.usage" &&
+      event.turnAssociation === "current" &&
+      event.payload !== null &&
+      typeof event.payload === "object" &&
+      (event.payload as Record<string, unknown>).sourceKey === input.sourceKey,
+  );
+  if (!authoritative) return;
   try {
     input.observability.info("model call usage", {
       accountId: input.accountId,
@@ -512,35 +542,7 @@ export async function emitModelCallUsage(input: {
         : {}),
     });
   } catch {
-    // Usage observability is best-effort.
-  }
-  try {
-    await input.publish?.(
-      [
-        {
-          type: "agent.model.usage",
-          payload: {
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            sessionId: input.sessionId,
-            turnId: input.turnId,
-            provider: input.provider,
-            providerApi: input.providerApi,
-            model: input.model,
-            sourceKey: input.sourceKey,
-            ...telemetry,
-          },
-        },
-      ],
-      true,
-    );
-  } catch (error) {
-    input.observability.warn("model call usage event publish failed", {
-      sessionId: input.sessionId,
-      turnId: input.turnId,
-      sourceKey: input.sourceKey,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    // Durable event + billing already committed; logging is best-effort only.
   }
 }
 
@@ -1101,12 +1103,22 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     const activitySpan = observability.startSpan("worker.run_agent_segment", {
       "opengeni.session_id": input.sessionId,
       "opengeni.workflow_id": input.workflowId,
-      "opengeni.trigger_event_id": input.triggerEventId,
+      "opengeni.trigger_kind": input.trigger.kind,
     });
     let activityStatus: RunAgentTurnResult["status"] | "unknown" = "unknown";
     let turnMetricOutcome: TurnOutcome | null = null;
     let activityError: unknown;
     let turnId: string | undefined;
+    let triggerEventId: string | undefined;
+    const claimedResult = (
+      result: Omit<
+        Extract<RunAgentTurnResult, { status: Exclude<RunAgentTurnResult["status"], "unclaimed"> }>,
+        "turnId" | "attemptId"
+      >,
+    ): RunAgentTurnResult => {
+      if (!turnId) throw new Error("Claimed activity result produced before turn admission");
+      return { ...result, turnId, attemptId: input.attemptId } as RunAgentTurnResult;
+    };
     // The Connected Machine op observer for this turn: meters every op AND buffers
     // the eventable ones (infra failures + healed recoveries) as machine.op.* session
     // events, drained (awaited) at turn end in the finally below. ONE instance shared
@@ -1300,12 +1312,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       await current?.flush().catch(() => undefined);
     };
     let preparedTools: Awaited<ReturnType<OpenGeniRuntime["prepareTools"]>> | null = null;
-    let publish:
-      | ((
-          events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>,
-          immediate?: boolean,
-        ) => Promise<void>)
-      | null = null;
+    let publish: TurnEventPublisher | null = null;
     let settle:
       | ((input: {
           events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>;
@@ -1619,42 +1626,26 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       );
       runtime.configure(capabilitySettings);
       const session = await requireSession(db, input.workspaceId, input.sessionId);
-      let turn = input.turnId
-        ? await getSessionTurn(db, input.workspaceId, input.turnId)
-        : await claimNextSessionExecutionDb(
-            db,
-            input.workspaceId,
-            input.sessionId,
-            input.workflowId,
-          );
-      if (!turn) {
-        activityStatus = "cancelled";
-        turnMetricOutcome = "cancelled";
-        return { status: "cancelled" };
-      }
-      // The workflow input is the execution trigger. It equals the turn's
-      // prompt trigger on a normal/recovery run and advances to a newer
-      // user.approvalDecision on an approval resume. Dispatch registration
-      // validates and durably records that advancement under the turn lock.
-      const trigger = await getSessionEvent(db, input.workspaceId, input.triggerEventId);
-      if (!trigger) {
-        throw new Error(`Trigger event not found: ${input.triggerEventId}`);
-      }
-      triggerType = trigger.type;
-      turnId = turn.id;
-      executionGeneration = turn.executionGeneration;
-      const registeredDispatch = await registerSessionTurnDispatch(db, input.workspaceId, {
+      const claim = await claimSessionWorkForAttempt(db, input.workspaceId, {
         sessionId: input.sessionId,
-        turnId,
-        triggerEventId: trigger.id,
+        workflowId: input.workflowId,
         attemptId: input.attemptId,
         dispatchId,
+        trigger: input.trigger,
       });
-      if (registeredDispatch.action === "stale") {
-        activityStatus = "cancelled";
-        turnMetricOutcome = "cancelled";
-        return { status: "cancelled" };
+      if (claim.action === "unclaimed") {
+        activityStatus = "unclaimed";
+        return { status: "unclaimed", reason: claim.reason };
       }
+      const turn = claim.turn;
+      turnId = turn.id;
+      triggerEventId = turn.triggerEventId;
+      const trigger = await getSessionEvent(db, input.workspaceId, triggerEventId);
+      if (!trigger) {
+        throw new Error(`Trigger event not found: ${triggerEventId}`);
+      }
+      triggerType = trigger.type;
+      executionGeneration = turn.executionGeneration;
       const latestTurnState = await getLatestRunState(db, input.workspaceId, input.sessionId);
       const continuationCodexCredentialId =
         latestTurnState?.turnId === turnId ? latestTurnState.frozenCodexCredentialId : null;
@@ -1727,6 +1718,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // one exactly like production.
       codexLeaseHolderId = dispatchId;
       const modelUsageDispatchId = activityContext?.info.activityId ?? dispatchId;
+      const emittedModelUsageSourceKeys = new Set<string>();
       publish = async (
         events: Array<Omit<AppendEventInput, "producerId" | "producerSeq" | "turnId">>,
         immediate = false,
@@ -1759,6 +1751,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (immediate) {
           await Bun.sleep(0);
         }
+        return appended;
       };
       settle = async (inputSettlement) => {
         const inputs = inputSettlement.events.map((event) => ({
@@ -1771,7 +1764,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         const result = await applySessionTurnSettlement(db, input.workspaceId, {
           sessionId: input.sessionId,
           turnId: turnId!,
-          triggerEventId: input.triggerEventId,
+          triggerEventId: triggerEventId!,
           attemptId: input.attemptId,
           turnStatus: inputSettlement.turnStatus,
           sessionStatus: inputSettlement.sessionStatus,
@@ -1806,7 +1799,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             { type: "session.status.changed", payload: { status: "running" } },
             {
               type: "turn.started",
-              payload: { triggerEventId: input.triggerEventId },
+              payload: { triggerEventId },
             },
           ],
           turnStatus: "running",
@@ -1814,7 +1807,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           activeTurnId: turnId,
         }))
       ) {
-        return { status: "cancelled" };
+        return claimedResult({ status: "cancelled" });
       }
       turnStartedPublished = true;
 
@@ -2096,11 +2089,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 activeTurnId: null,
               }))
             ) {
-              return { status: "cancelled" };
+              return claimedResult({ status: "cancelled" });
             }
             turnMetricOutcome = "cancelled";
             activityStatus = "idle";
-            return { status: "idle", deferredUntilWake: true };
+            return claimedResult({ status: "idle", deferredUntilWake: true });
           }
           const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(
             () => null,
@@ -2131,7 +2124,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               );
               turnMetricOutcome = "failed";
               activityStatus = "idle";
-              return {
+              return claimedResult({
                 status: "idle",
                 capacityWait: {
                   waiterId: armed.waiter.id,
@@ -2139,7 +2132,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
                   wakeRevision: armed.waiter.wakeRevision,
                 },
-              };
+              });
             }
           }
           if (
@@ -2161,11 +2154,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               activeTurnId: null,
             }))
           ) {
-            return { status: "cancelled" };
+            return claimedResult({ status: "cancelled" });
           }
           turnMetricOutcome = "failed";
           activityStatus = "idle";
-          return { status: "idle" };
+          return claimedResult({ status: "idle" });
         }
 
         if (rotationDecision.kind === "allCapped" && turnId) {
@@ -2191,11 +2184,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 activeTurnId: null,
               }))
             ) {
-              return { status: "cancelled" };
+              return claimedResult({ status: "cancelled" });
             }
             turnMetricOutcome = "cancelled";
             activityStatus = "idle";
-            return { status: "idle", deferredUntilWake: true };
+            return claimedResult({ status: "idle", deferredUntilWake: true });
           }
           // Every eligible account is capped/cooling (and a usage refresh did NOT
           // surface a reset): idle the turn AT THE BOUNDARY (no wasted model/sandbox
@@ -2246,7 +2239,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               );
               turnMetricOutcome = "failed";
               activityStatus = "idle";
-              return {
+              return claimedResult({
                 status: "idle",
                 capacityWait: {
                   waiterId: armed.waiter.id,
@@ -2254,7 +2247,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
                   wakeRevision: armed.waiter.wakeRevision,
                 },
-              };
+              });
             }
           }
           if (
@@ -2280,19 +2273,21 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               activeTurnId: null,
             }))
           ) {
-            return { status: "cancelled" };
+            return claimedResult({ status: "cancelled" });
           }
           turnMetricOutcome = "failed";
           activityStatus = "idle";
           // idleUntilReset marks this a MANDATORY hold: session.ts must wait the full
           // resumeMs even if a future change made it 0 — never a tight re-dispatch.
-          return goalActive
-            ? {
-                status: "idle",
-                continueDelayMs: resumeMs,
-                idleUntilReset: true,
-              }
-            : { status: "idle" };
+          return claimedResult(
+            goalActive
+              ? {
+                  status: "idle",
+                  continueDelayMs: resumeMs,
+                  idleUntilReset: true,
+                }
+              : { status: "idle" },
+          );
         }
         if (effectiveCodexCredentialId) {
           const priorAccountId = sessionCodex?.lastCredentialId ?? null;
@@ -2527,6 +2522,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               priorSessionCredentialId: priorSessionCodexCredentialId,
               isFirstCallOfTurn: compactionUsageCount === 1,
             });
+            await recordModelUsageAndDebitCredits(settings, db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId: turn.id,
+              model: resolvedModel?.configured.id ?? turn.model,
+              isCodexTurn,
+              usage: usage.usage,
+              sourceKey,
+              observability,
+            });
             await emitModelCallUsage({
               observability,
               publish,
@@ -2541,17 +2547,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               usage,
               servingAccountHash: responseAccountCtx.servingAccountHash,
               accountChangedFromPrevCall: responseAccountCtx.accountChangedFromPrevCall,
-            });
-            await recordModelUsageAndDebitCredits(settings, db, {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              turnId: turn.id,
-              model: resolvedModel?.configured.id ?? turn.model,
-              isCodexTurn,
-              usage: usage.usage,
-              sourceKey,
-              observability,
+              emittedSourceKeys: emittedModelUsageSourceKeys,
             });
           },
         });
@@ -2658,11 +2654,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "completed";
         activityStatus = "idle";
-        return { status: "idle" };
+        return claimedResult({ status: "idle" });
       }
 
       const turnResources = mergeResourceRefs(session.resources, turn.resources);
@@ -2759,7 +2755,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           },
           activeSandboxPointer,
           (sandboxId) => getSandbox(db, input.workspaceId, sandboxId),
-          publish ?? undefined,
+          publish
+            ? async (events) => {
+                await publish!(events);
+              }
+            : undefined,
         );
         activeSandboxPointer = reconciled.pointer;
         activeSandboxRecord = reconciled.record;
@@ -3661,7 +3661,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               streamDone = true;
               break;
             }
-            let modelUsageEventContext: Record<string, unknown> | null = null;
             const responseUsage = modelResponseUsageFromSdkEvent(next.value);
             if (responseUsage) {
               await recordCompletedModelCallBeforeOwnershipFences({
@@ -3682,9 +3681,20 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                     priorSessionCredentialId: priorSessionCodexCredentialId,
                     isFirstCallOfTurn: responseUsageCount === 1,
                   });
+                  await recordModelUsageAndDebitCredits(settings, db, {
+                    accountId: input.accountId,
+                    workspaceId: input.workspaceId,
+                    sessionId: input.sessionId,
+                    turnId: activeTurnId,
+                    model: turn.model,
+                    isCodexTurn,
+                    usage: responseUsage.usage,
+                    sourceKey: responseSourceKey,
+                    observability,
+                  });
                   await emitModelCallUsage({
                     observability,
-                    publish: null,
+                    publish,
                     accountId: input.accountId,
                     workspaceId: input.workspaceId,
                     sessionId: input.sessionId,
@@ -3696,17 +3706,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                     usage: responseUsage,
                     servingAccountHash: responseAccountCtx.servingAccountHash,
                     accountChangedFromPrevCall: responseAccountCtx.accountChangedFromPrevCall,
+                    emittedSourceKeys: emittedModelUsageSourceKeys,
                   });
-                  modelUsageEventContext = {
-                    accountId: input.accountId,
-                    workspaceId: input.workspaceId,
-                    sessionId: input.sessionId,
-                    turnId: activeTurnId,
-                    provider: resolvedModel?.provider.id ?? settings.openaiProvider,
-                    providerApi: resolvedModel?.provider.api ?? "responses",
-                    model: turn.model,
-                    sourceKey: responseSourceKey,
-                  };
                   const observed = responseUsage.usage?.inputTokens;
                   if (typeof observed === "number" && observed > 0) {
                     recordModelInputTokens(observability, streamProvider, observed);
@@ -3717,17 +3718,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   recordModelCacheTokens(observability, streamProvider, {
                     cachedTokens: modelCallUsageTelemetry(responseUsage.usage).cachedTokens,
                     promptTokens: responseUsage.usage?.inputTokens,
-                  });
-                  await recordModelUsageAndDebitCredits(settings, db, {
-                    accountId: input.accountId,
-                    workspaceId: input.workspaceId,
-                    sessionId: input.sessionId,
-                    turnId: activeTurnId,
-                    model: turn.model,
-                    isCodexTurn,
-                    usage: responseUsage.usage,
-                    sourceKey: responseSourceKey,
-                    observability,
                   });
                 },
                 recordAttemptSignals: async () => {
@@ -3833,18 +3823,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             }
             const normalized = normalizeSdkEvent(next.value);
             for (const event of normalized) {
-              // Assigned inside the awaited metering closure above. TypeScript's
-              // control-flow analysis does not propagate closure writes, so take
-              // an explicit post-await snapshot for the usage-event enrichment.
-              const usageEventContext = modelUsageEventContext as Record<string, unknown> | null;
-              if (
-                event.type === "agent.model.usage" &&
-                usageEventContext &&
-                event.payload &&
-                typeof event.payload === "object"
-              ) {
-                event.payload = { ...usageEventContext, ...event.payload };
-              }
               streamTiming.onEvent(event.type);
               await batcher.push(event);
             }
@@ -3913,6 +3891,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 usage: { usage: aggregateUsage },
                 servingAccountHash: aggregateAccountCtx.servingAccountHash,
                 accountChangedFromPrevCall: aggregateAccountCtx.accountChangedFromPrevCall,
+                emittedSourceKeys: emittedModelUsageSourceKeys,
               });
             },
             recordAttemptSignals: async () => {
@@ -3952,10 +3931,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               activeTurnId,
             }))
           ) {
-            return { status: "cancelled" };
+            return claimedResult({ status: "cancelled" });
           }
           activityStatus = "requires_action";
-          return { status: "requires_action" };
+          return claimedResult({ status: "requires_action" });
         }
 
         const finalOutput = String(stream.finalOutput ?? "");
@@ -3988,7 +3967,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "completed";
         await recordUsageEvent(db, {
@@ -4002,7 +3981,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           idempotencyKey: `usage:agent_run.completed:${activeTurnId}`,
         });
         activityStatus = "idle";
-        return { status: "idle" };
+        return claimedResult({ status: "idle" });
       };
 
       await prepareRunAttemptInput();
@@ -4095,12 +4074,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 activeTurnId: null,
               }))
             ) {
-              return { status: "cancelled" };
+              return claimedResult({ status: "cancelled" });
             }
             turnMetricOutcome = "failed";
             activityStatus = "idle";
             activityError = attemptError;
-            return { status: "idle" };
+            return claimedResult({ status: "idle" });
           }
           // Codex parity: compaction remains inside the same logical turn and
           // the same activity. Rebuild the model-visible history from the
@@ -4129,7 +4108,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // The turn id falls
       // back to the workflow-claimed turn when the local lookup had not
       // finished yet.
-      const recoveryTurnId = turnId ?? input.turnId;
+      const recoveryTurnId = turnId;
       // P1.2: a lease supersession during resume (a newer epoch re-established
       // the box concurrently) is NOT a session failure. Recover the same turn
       // so its next attempt reattaches under the current epoch.
@@ -4138,14 +4117,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
             sessionId: input.sessionId,
             turnId: recoveryTurnId,
-            triggerEventId: input.triggerEventId,
+            triggerEventId: triggerEventId!,
             attemptId: input.attemptId,
             reason: "sandbox_lease_superseded",
           });
           if (recovery.action === "stale") {
             activityStatus = "cancelled";
             turnMetricOutcome = "cancelled";
-            return { status: "cancelled" };
+            return claimedResult({ status: "cancelled" });
           }
           await publishDurableSessionEvents(
             bus,
@@ -4155,7 +4134,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           );
           activityStatus = "recovering";
           turnMetricOutcome = "recovering";
-          return { status: "recovering" };
+          return claimedResult({ status: "recovering" });
         } catch (recoveryError) {
           console.error("sandbox lease supersession recovery failed", recoveryError);
           throw recoveryError;
@@ -4175,14 +4154,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
             sessionId: input.sessionId,
             turnId: recoveryTurnId,
-            triggerEventId: input.triggerEventId,
+            triggerEventId: triggerEventId!,
             attemptId: input.attemptId,
             reason: "worker_shutdown",
           });
           if (recovery.action === "stale") {
             activityStatus = "cancelled";
             turnMetricOutcome = "cancelled";
-            return { status: "cancelled" };
+            return claimedResult({ status: "cancelled" });
           }
           await publishDurableSessionEvents(
             bus,
@@ -4192,7 +4171,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           );
           activityStatus = "recovering";
           turnMetricOutcome = "recovering";
-          return { status: "recovering" };
+          return claimedResult({ status: "recovering" });
         } catch (recoveryError) {
           // The database transition is atomic. If it could not commit, surface
           // the failure so Temporal can retry on a healthy worker; never mutate
@@ -4209,7 +4188,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // control transaction. Return locally; no Temporal cancellation and no
         // competing turn/session settlement is needed.
         turnMetricOutcome = "cancelled";
-        return { status: "cancelled" };
+        return claimedResult({ status: "cancelled" });
       }
       if (error instanceof CancelledFailure) {
         activityStatus = "cancelled";
@@ -4251,7 +4230,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "completed";
         await recordUsageEvent(db, {
@@ -4265,7 +4244,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           idempotencyKey: `usage:agent_run.completed:${turnId}`,
         });
         activityStatus = "idle";
-        return { status: "idle" };
+        return claimedResult({ status: "idle" });
       }
       const settleLostCodexAttempt = async (
         lostTurnId: string,
@@ -4299,7 +4278,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           expectedRedispatches: redispatchesAtDispatch,
           checkpointDurable,
           recoveryPayload: {
-            triggerEventId: input.triggerEventId,
+            triggerEventId: triggerEventId!,
             reason: "codex_lease_lost",
             credentialId: effectiveCodexCredentialId,
           },
@@ -4336,11 +4315,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             "failed",
             `turn:${lostTurnId}`,
           );
-          return { status: "failed" };
+          return claimedResult({ status: "failed" });
         }
         activityStatus = "recovering";
         turnMetricOutcome = "recovering";
-        return { status: "recovering" };
+        return claimedResult({ status: "recovering" });
       };
 
       // A missing/expired/superseded lease is an execution-ownership failure,
@@ -4501,7 +4480,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               expectedRedispatches: redispatchesAtDispatch,
               maxFailovers: Math.max(1, accounts.length),
               recoveryPayload: {
-                triggerEventId: input.triggerEventId,
+                triggerEventId: triggerEventId!,
                 reason: "codex_credential_failover",
                 credentialId: effectiveCodexCredentialId,
                 failureKind: codexCredentialFailure.kind,
@@ -4535,7 +4514,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               });
               activityStatus = "recovering";
               turnMetricOutcome = "recovering";
-              return { status: "recovering" };
+              return claimedResult({ status: "recovering" });
             }
             if (settlement.action === "stale") {
               // One transaction proves both exact-holder recovery (including a
@@ -4543,7 +4522,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               // rejection. A stale activity performs no second settlement.
               activityStatus = "recovering";
               turnMetricOutcome = "recovering";
-              return { status: "recovering" };
+              return claimedResult({ status: "recovering" });
             }
           }
         }
@@ -4798,7 +4777,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnMetricOutcome = "failed";
             activityStatus = "idle";
             activityError = error;
-            return {
+            return claimedResult({
               status: "idle",
               capacityWait: {
                 waiterId: armed.waiter.id,
@@ -4806,7 +4785,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
                 wakeRevision: armed.waiter.wakeRevision,
               },
-            };
+            });
           }
         }
         if (
@@ -4829,7 +4808,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "failed";
         activityStatus = "idle";
@@ -4844,11 +4823,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // slow-retry floor, and once consecutive failovers exceed the account count + margin
             // the circuit breaker returns a fixed MANDATORY idle (idleUntilReset) — never a 0-delay
             // hot loop against a capped backend + DB.
-            return {
+            return claimedResult({
               status: "idle",
               continueDelayMs: rotationResumeMs,
               ...(rotationResumeIdleUntilReset ? { idleUntilReset: true } : {}),
-            };
+            });
           }
           // All-capped: clamp to [MIN_IDLE_MS, max] — a POSITIVE, BOUNDED hold (never 0,
           // so session.ts can never tight-loop). The post-idle continuation re-dispatch
@@ -4863,13 +4842,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   CODEX_USAGE_LIMIT_MAX_RESUME_MS,
                 )
               : CODEX_USAGE_LIMIT_MAX_RESUME_MS;
-          return {
+          return claimedResult({
             status: "idle",
             continueDelayMs: resumeMs,
             ...(allCappedResetAt ? { idleUntilReset: true } : {}),
-          };
+          });
         }
-        return { status: "idle" };
+        return claimedResult({ status: "idle" });
       }
       // Budget/limit exhaustion between model calls is account state, not an
       // agent failure: idle the session for goal-bearing and goal-less runs
@@ -4897,7 +4876,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "completed";
         await recordUsageEvent(db, {
@@ -4911,7 +4890,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           idempotencyKey: `usage:agent_run.completed:${turnId}`,
         });
         activityStatus = "idle";
-        return { status: "idle" };
+        return claimedResult({ status: "idle" });
       }
       // A retryable provider/MCP failure is transient external backpressure,
       // not a session failure: the in-client retry budget is already
@@ -4949,17 +4928,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             activeTurnId: null,
           }))
         ) {
-          return { status: "cancelled" };
+          return claimedResult({ status: "cancelled" });
         }
         turnMetricOutcome = "failed";
         activityStatus = "idle";
         activityError = error;
-        return {
+        return claimedResult({
           status: "idle",
           ...(recoveryRouting.continueDelayMs !== undefined
             ? { continueDelayMs: recoveryRouting.continueDelayMs }
             : {}),
-        };
+        });
       }
       activityStatus = "failed";
       activityError = error;
@@ -4984,7 +4963,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           activeTurnId: null,
         }))
       ) {
-        return { status: "cancelled" };
+        return claimedResult({ status: "cancelled" });
       }
       turnMetricOutcome = "failed";
       // The common failure path ends here: runAgentTurn marks the session
@@ -5001,7 +4980,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         "failed",
         `turn:${turnId}`,
       );
-      return { status: "failed" };
+      return claimedResult({ status: "failed" });
     } finally {
       const durationSeconds = (performance.now() - activityStarted) / 1000;
       observability.recordWorkerActivity({
@@ -5122,7 +5101,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           db,
           objectStorage,
           settings,
-          publish,
+          publish: publish
+            ? async (events) => {
+                await publish!(events);
+              }
+            : null,
           session: setupBoxSession as ChannelASession,
           leaseEpoch: resolvedSandbox.leaseEpoch,
           sandboxGroupId,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -6,7 +6,7 @@ import {
   addSessionSystemUpdateWithSourceMutation,
   claimPendingSessionSystemUpdateOutbox,
   getOrCreateSessionSystemUpdateOutbox,
-  listClaimableSessions,
+  listEnrollableSessions,
   markSessionSystemUpdateOutboxDeliveredInTransaction,
   markSessionSystemUpdateOutboxFailed,
   type Database,
@@ -158,7 +158,7 @@ export async function reconcilePendingParentSystemUpdates(
 ): Promise<{ claimed: number; delivered: number; failed: number; wakeRepairs: number }> {
   let wakeRepairs = 0;
   if (svc.wakeSessionWorkflow) {
-    const repairs = await listClaimableSessions(svc.db, limit);
+    const repairs = await listEnrollableSessions(svc.db, limit);
     for (const repair of repairs) {
       await svc.wakeSessionWorkflow({
         accountId: repair.accountId,

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -1,11 +1,11 @@
 import {
   settlePendingSessionControl,
   applySessionTurnSettlement,
-  applySessionTurnWorkerDeath,
-  claimNextSessionExecution as claimNextSessionExecutionDb,
+  recoverSessionDispatch,
+  peekSessionWork as peekSessionWorkDb,
   countQueuedTurns,
   getSessionEvent,
-  getSessionTurn,
+  getSessionTurnForAttempt,
   requireSession,
   settleSessionIdleWithParentOutbox,
 } from "@opengeni/db";
@@ -14,22 +14,22 @@ import { notifyParentOfChildTerminal } from "./parent-wake";
 import { recordTurnsQueuedGauge } from "../observability-metrics";
 import type {
   ActivityServices,
-  ClaimNextSessionExecutionInput,
+  PeekSessionWorkInput,
+  FailSessionAttemptInput,
   SettleSessionControlInput,
   MarkSessionIdleInput,
-  RecoverTurnAfterWorkerDeathInput,
-  RecoverTurnAfterWorkerDeathResult,
-  RunAgentTurnInput,
+  RecoverDispatchInput,
+  RecoverDispatchResult,
 } from "./types";
 
 export type SessionStateActivityOverrides = Partial<{
   settlePendingSessionControl: typeof settlePendingSessionControl;
   applySessionTurnSettlement: typeof applySessionTurnSettlement;
-  applySessionTurnWorkerDeath: typeof applySessionTurnWorkerDeath;
-  claimNextSessionExecution: typeof claimNextSessionExecutionDb;
+  recoverSessionDispatch: typeof recoverSessionDispatch;
+  peekSessionWork: typeof peekSessionWorkDb;
   countQueuedTurns: typeof countQueuedTurns;
   getSessionEvent: typeof getSessionEvent;
-  getSessionTurn: typeof getSessionTurn;
+  getSessionTurnForAttempt: typeof getSessionTurnForAttempt;
   requireSession: typeof requireSession;
   settleSessionIdleWithParentOutbox: typeof settleSessionIdleWithParentOutbox;
   publishDurableSessionEvents: typeof publishDurableSessionEvents;
@@ -51,13 +51,11 @@ export function createSessionStateActivities(
     overrides.settlePendingSessionControl ?? settlePendingSessionControl;
   const applySessionTurnSettlementFn =
     overrides.applySessionTurnSettlement ?? applySessionTurnSettlement;
-  const applySessionTurnWorkerDeathFn =
-    overrides.applySessionTurnWorkerDeath ?? applySessionTurnWorkerDeath;
-  const claimNextSessionExecutionFn =
-    overrides.claimNextSessionExecution ?? claimNextSessionExecutionDb;
+  const recoverSessionDispatchFn = overrides.recoverSessionDispatch ?? recoverSessionDispatch;
+  const peekSessionWorkFn = overrides.peekSessionWork ?? peekSessionWorkDb;
   const countQueuedTurnsFn = overrides.countQueuedTurns ?? countQueuedTurns;
   const getSessionEventFn = overrides.getSessionEvent ?? getSessionEvent;
-  const getSessionTurnFn = overrides.getSessionTurn ?? getSessionTurn;
+  const getSessionTurnForAttemptFn = overrides.getSessionTurnForAttempt ?? getSessionTurnForAttempt;
   const requireSessionFn = overrides.requireSession ?? requireSession;
   const settleSessionIdleWithParentOutboxFn =
     overrides.settleSessionIdleWithParentOutbox ?? settleSessionIdleWithParentOutbox;
@@ -67,18 +65,24 @@ export function createSessionStateActivities(
     overrides.notifyParentOfChildTerminal ?? notifyParentOfChildTerminal;
   const recordTurnsQueuedGaugeFn = overrides.recordTurnsQueuedGauge ?? recordTurnsQueuedGauge;
 
-  async function failSession(input: RunAgentTurnInput & { error?: string }): Promise<void> {
+  async function failSessionAttempt(input: FailSessionAttemptInput): Promise<void> {
     const { db, bus, settings, observability, wakeSessionWorkflow } = await services();
     const session = await requireSessionFn(db, input.workspaceId, input.sessionId);
     if (session.status === "failed") {
       return;
     }
-    const turnId = input.turnId;
-    const trigger = await getSessionEventFn(db, input.workspaceId, input.triggerEventId);
+    const turn = await getSessionTurnForAttemptFn(
+      db,
+      input.workspaceId,
+      input.sessionId,
+      input.attemptId,
+    );
+    if (!turn) return;
+    const trigger = await getSessionEventFn(db, input.workspaceId, turn.triggerEventId);
     const result = await applySessionTurnSettlementFn(db, input.workspaceId, {
       sessionId: input.sessionId,
-      turnId,
-      triggerEventId: input.triggerEventId,
+      turnId: turn.id,
+      triggerEventId: turn.triggerEventId,
       attemptId: input.attemptId,
       turnStatus: "failed",
       sessionStatus: "failed",
@@ -87,7 +91,7 @@ export function createSessionStateActivities(
         {
           type: "turn.failed",
           payload: {
-            triggerEventId: input.triggerEventId,
+            triggerEventId: turn.triggerEventId,
             trigger: trigger?.payload ?? null,
             error: input.error ?? "Agent activity failed before it could report a terminal state.",
           },
@@ -107,7 +111,9 @@ export function createSessionStateActivities(
     );
   }
 
-  async function settleSessionControl(input: SettleSessionControlInput): Promise<void> {
+  async function settleSessionControl(
+    input: SettleSessionControlInput,
+  ): Promise<{ action: "paused" | "continue" | "stale" }> {
     const { db, bus, observability } = await services();
     const applied = await settlePendingSessionControlFn(
       db,
@@ -119,6 +125,7 @@ export function createSessionStateActivities(
       await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, applied.events);
     }
     await refreshQueuedTurnsGauge(db, observability, countQueuedTurnsFn, recordTurnsQueuedGaugeFn);
+    return { action: applied.action };
   }
 
   /**
@@ -128,25 +135,16 @@ export function createSessionStateActivities(
    * same turn; recovery creates a new fenced attempt, never a prompt-queue row
    * or a synthetic resume message. Repeated worker deaths are bounded per turn.
    */
-  async function recoverTurnAfterWorkerDeath(
-    input: RecoverTurnAfterWorkerDeathInput,
-  ): Promise<RecoverTurnAfterWorkerDeathResult> {
+  async function recoverDispatch(input: RecoverDispatchInput): Promise<RecoverDispatchResult> {
     const { settings, db, bus, observability, wakeSessionWorkflow } = await services();
-    const turn = await getSessionTurnFn(db, input.workspaceId, input.turnId);
-    if (!turn || (turn.status !== "running" && turn.status !== "requires_action")) {
-      return { action: "stale" };
-    }
-    const result = await applySessionTurnWorkerDeathFn(db, input.workspaceId, {
+    const result = await recoverSessionDispatchFn(db, input.workspaceId, {
       sessionId: input.sessionId,
-      turnId: input.turnId,
-      triggerEventId: input.triggerEventId,
       attemptId: input.attemptId,
-      dispatchId: input.dispatchId,
       timeoutType: input.timeoutType,
       maxRedispatches: WORKER_DEATH_MAX_REDISPATCHES,
     });
-    if (result.action === "stale") {
-      return { action: "stale" };
+    if (result.action === "stale" || result.action === "unclaimed") {
+      return { action: result.action };
     }
     await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, result.events);
     await refreshQueuedTurnsGauge(db, observability, countQueuedTurnsFn, recordTurnsQueuedGaugeFn);
@@ -156,23 +154,26 @@ export function createSessionStateActivities(
         input.workspaceId,
         input.sessionId,
         "failed",
-        `turn:${input.turnId}`,
+        `turn:${result.turnId}`,
       );
-      return { action: "exceeded", redispatches: result.redispatches };
+      return {
+        action: "exceeded",
+        turnId: result.turnId,
+        redispatches: result.redispatches,
+      };
     }
-    return { action: "recovering", redispatches: result.redispatches };
+    return {
+      action: "recovering",
+      turnId: result.turnId,
+      redispatches: result.redispatches,
+    };
   }
 
-  async function claimNextSessionExecution(input: ClaimNextSessionExecutionInput) {
+  async function peekSessionWork(input: PeekSessionWorkInput) {
     const { db, observability } = await services();
-    const turn = await claimNextSessionExecutionFn(
-      db,
-      input.workspaceId,
-      input.sessionId,
-      input.workflowId,
-    );
+    const peek = await peekSessionWorkFn(db, input.workspaceId, input.sessionId);
     await refreshQueuedTurnsGauge(db, observability, countQueuedTurnsFn, recordTurnsQueuedGaugeFn);
-    return turn;
+    return peek;
   }
 
   async function markSessionIdle(input: MarkSessionIdleInput): Promise<void> {
@@ -204,10 +205,10 @@ export function createSessionStateActivities(
   }
 
   return {
-    failSession,
+    failSessionAttempt,
     settleSessionControl,
-    recoverTurnAfterWorkerDeath,
-    claimNextSessionExecution,
+    recoverDispatch,
+    peekSessionWork,
     markSessionIdle,
   };
 }

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -109,10 +109,9 @@ export type RunAgentTurnInput = {
   accountId: string;
   workspaceId: string;
   sessionId: string;
-  triggerEventId: string;
   workflowId: string;
-  turnId: string;
   attemptId: string;
+  trigger: { kind: "next" } | { kind: "approval"; triggerEventId: string };
 };
 
 export type SettleSessionControlInput = {
@@ -123,24 +122,27 @@ export type SettleSessionControlInput = {
   workflowId: string;
 };
 
-export type RecoverTurnAfterWorkerDeathInput = {
+export type FailSessionAttemptInput = {
   accountId: string;
   workspaceId: string;
   sessionId: string;
-  // The trigger the dead attempt was actually running (for an approval rerun
-  // this is the approval-decision event, not the turn row's original trigger).
-  triggerEventId: string;
-  workflowId: string;
-  turnId: string;
   attemptId: string;
-  dispatchId: string;
+  error?: string;
+};
+
+export type RecoverDispatchInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  attemptId: string;
   timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START";
 };
 
-export type RecoverTurnAfterWorkerDeathResult =
+export type RecoverDispatchResult =
   // The same current inference is now recoverable. It never enters the prompt
   // queue; the next claim creates a new attempt for this exact turn.
-  | { action: "recovering"; redispatches: number }
+  | { action: "unclaimed" }
+  | { action: "recovering"; turnId: string; redispatches: number }
   // The turn is no longer running/requires_action: the timed-out attempt was
   // a zombie that actually settled the turn after the server gave up on its
   // heartbeats. Nothing to redo; the workflow just continues its loop.
@@ -148,12 +150,11 @@ export type RecoverTurnAfterWorkerDeathResult =
   // The per-turn crash-loop guard tripped; the workflow must fail the
   // session for real. `redispatches` is the count already consumed (== the
   // ceiling), so the failed attempt was worker death number redispatches + 1.
-  | { action: "exceeded"; redispatches: number };
+  | { action: "exceeded"; turnId: string; redispatches: number };
 
-export type ClaimNextSessionExecutionInput = {
+export type PeekSessionWorkInput = {
   workspaceId: string;
   sessionId: string;
-  workflowId: string;
 };
 
 export type MarkSessionIdleInput = {
@@ -196,10 +197,12 @@ export type IndexDocumentInput = {
   documentId: string;
 };
 
-export type RunAgentTurnResult = {
+type ClaimedRunAgentTurnResult = {
   // "recovering": this attempt ended after durably preserving the same current
   // inference for a new attempt. Recovery is not prompt queue work.
   status: "idle" | "requires_action" | "failed" | "cancelled" | "recovering";
+  turnId: string;
+  attemptId: string;
   // Provider backpressure pacing: when set on an idle result, the session
   // workflow holds the loop this long before admitting the next turn (an
   // active goal's continuation would otherwise immediately re-hit the limit).
@@ -220,3 +223,10 @@ export type RunAgentTurnResult = {
   // prompt claim ordering consumes the request in-turn.
   deferredUntilWake?: boolean;
 };
+
+export type RunAgentTurnResult =
+  | ClaimedRunAgentTurnResult
+  | {
+      status: "unclaimed";
+      reason: "gate-closed" | "no-work" | "stale-approval" | "control-pending";
+    };

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,8 +21,13 @@ import {
 } from "@temporalio/client";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { ensureModalRegistryImage } from "@opengeni/runtime";
-import { createActivities, type ActivityDependencies } from "./activities";
+import {
+  createControlActivities,
+  createTurnActivities,
+  type ActivityDependencies,
+} from "./activities";
 import type { SignalCodexCapacityWorkflow, WakeSessionWorkflowSignal } from "./activities/types";
+import { turnTaskQueue } from "./workflows/activities";
 import { dbReadyCheck, natsReadyCheck, startWorkerHttpServer } from "./http";
 import { observabilityEventLogger } from "./observability-metrics";
 
@@ -35,9 +40,12 @@ const SANDBOX_REAPER_SCHEDULE_ID = "opengeni-sandbox-lease-reaper";
 export const FILE_UPLOAD_REAPER_SCHEDULE_ID = "opengeni-file-upload-reaper";
 export const FILE_UPLOAD_REAPER_PERIOD_MS = 15 * 60 * 1_000;
 
+export type OpenGeniWorkerRole = "control" | "turn";
+
 export type WorkerOptions = {
+  role: OpenGeniWorkerRole;
   settings?: Settings;
-  activities?: ReturnType<typeof createActivities>;
+  activities?: ReturnType<typeof createControlActivities> | ReturnType<typeof createTurnActivities>;
   activityDependencies?: ActivityDependencies;
   // Embedded hosts install @opengeni/worker-bundle under node_modules, where
   // Temporal's workflow webpack refuses to transpile TS. They relocate
@@ -46,26 +54,28 @@ export type WorkerOptions = {
   workflowsPath?: string;
 };
 
-export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise<{
+export async function createOpenGeniWorker(options: WorkerOptions): Promise<{
   worker: Worker;
   connection: NativeConnection;
 }> {
   const settings = options.settings ?? getSettings();
   const observability =
     options.activityDependencies?.observability ??
-    createObservability(settings, { component: "worker" });
+    createObservability(settings, { component: `worker-${options.role}` });
   // Pre-resolve a PRIVATE-registry sandbox image before any turn creates a box.
   // No-op unless OPENGENI_MODAL_IMAGE_REGISTRY_SECRET + OPENGENI_MODAL_IMAGE_REF are
   // both set (so non-modal / public-image deployments are byte-unchanged and never
   // load the modal SDK here). Memoized in the provider, so this runs once per process.
-  await retryStartupDependency(
-    "Modal private-registry image",
-    () => ensureModalRegistryImage(settings),
-    {
-      ...startupRetryOptions(settings),
-      onRetry: (event) => logStartupDependencyRetry(observability, event),
-    },
-  );
+  if (options.role === "turn") {
+    await retryStartupDependency(
+      "Modal private-registry image",
+      () => ensureModalRegistryImage(settings),
+      {
+        ...startupRetryOptions(settings),
+        onRetry: (event) => logStartupDependencyRetry(observability, event),
+      },
+    );
+  }
   const connection = await retryStartupDependency(
     "Temporal",
     () => NativeConnection.connect({ address: settings.temporalHost }),
@@ -76,7 +86,7 @@ export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise
   );
   const activities =
     options.activities ??
-    createActivities({
+    (options.role === "control" ? createControlActivities : createTurnActivities)({
       ...options.activityDependencies,
       settings,
       observability,
@@ -84,10 +94,19 @@ export async function createOpenGeniWorker(options: WorkerOptions = {}): Promise
   const worker = await Worker.create({
     connection,
     namespace: settings.temporalNamespace,
-    taskQueue: settings.temporalTaskQueue,
-    workflowsPath:
-      options.workflowsPath ?? new URL("../src/workflows.ts", import.meta.url).pathname,
+    taskQueue:
+      options.role === "control"
+        ? settings.temporalTaskQueue
+        : turnTaskQueue(settings.temporalTaskQueue),
+    ...(options.role === "control"
+      ? {
+          workflowsPath:
+            options.workflowsPath ?? new URL("../src/workflows.ts", import.meta.url).pathname,
+          maxConcurrentWorkflowTaskExecutions: 40,
+        }
+      : {}),
     activities,
+    maxConcurrentActivityTaskExecutions: options.role === "turn" ? 8 : 32,
     // GRACEFUL DEPLOY SHUTDOWN (with the SIGTERM handler in startWorker):
     // after shutdown() stops polling, in-flight activities get this long to
     // finish naturally; the rest are then CANCELLED with WORKER_SHUTDOWN —
@@ -273,8 +292,12 @@ export async function registerFileUploadReaperSchedule(
 }
 
 export async function startWorker() {
+  const role = process.env.OPENGENI_WORKER_ROLE;
+  if (role !== "control" && role !== "turn") {
+    throw new Error("OPENGENI_WORKER_ROLE must be explicitly set to 'control' or 'turn'");
+  }
   const settings = getSettings();
-  const observability = createObservability(settings, { component: "worker" });
+  const observability = createObservability(settings, { component: `worker-${role}` });
   const retryOptions = startupRetryOptions(settings);
   const onRetry = (event: Parameters<typeof logStartupDependencyRetry>[1]) =>
     logStartupDependencyRetry(observability, event);
@@ -311,6 +334,7 @@ export async function startWorker() {
       { ...retryOptions, onRetry },
     );
     workerBundle = await createOpenGeniWorker({
+      role,
       settings,
       activityDependencies: {
         observability,
@@ -329,22 +353,26 @@ export async function startWorker() {
         temporal: signaler.check,
       },
     });
-    // Register the ONE global reaper Schedule (no-op when sandboxOwnershipEnabled
-    // is false). Idempotent across the pool: only the first worker creates it. The
-    // static global-queue Worker.create above is UNCHANGED — there is no
-    // per-session worker factory.
-    reaperSchedule = await retryStartupDependency(
-      "Temporal schedule (sandbox reaper)",
-      () => registerSandboxReaperSchedule(settings, observability),
-      { ...retryOptions, onRetry },
-    );
-    fileUploadReaperSchedule = await retryStartupDependency(
-      "Temporal schedule (file upload reaper)",
-      () => registerFileUploadReaperSchedule(settings, observability),
-      { ...retryOptions, onRetry },
-    );
+    // Control workers alone own global schedules. Turn workers poll only the
+    // bounded inference activity queue and can never duplicate schedule setup.
+    if (role === "control") {
+      reaperSchedule = await retryStartupDependency(
+        "Temporal schedule (sandbox reaper)",
+        () => registerSandboxReaperSchedule(settings, observability),
+        { ...retryOptions, onRetry },
+      );
+      fileUploadReaperSchedule = await retryStartupDependency(
+        "Temporal schedule (file upload reaper)",
+        () => registerFileUploadReaperSchedule(settings, observability),
+        { ...retryOptions, onRetry },
+      );
+    }
     observability.info("OpenGeni worker listening", {
-      temporalTaskQueue: settings.temporalTaskQueue,
+      role,
+      temporalTaskQueue:
+        role === "control" ? settings.temporalTaskQueue : turnTaskQueue(settings.temporalTaskQueue),
+      maxConcurrentActivityTaskExecutions: role === "turn" ? 8 : 32,
+      maxConcurrentWorkflowTaskExecutions: role === "control" ? 40 : 0,
       httpPort: settings.workerHttpPort,
     });
     // GRACEFUL DEPLOY SHUTDOWN — the missing link that made every deploy a

--- a/apps/worker/src/workflows/activities.ts
+++ b/apps/worker/src/workflows/activities.ts
@@ -1,21 +1,28 @@
 import { proxyActivities } from "@temporalio/workflow";
 import type * as activities from "../activities";
 
-export const activity = proxyActivities<typeof activities>({
-  // Agent segments legitimately run for days (goal-bearing infrastructure
-  // sessions). Dead workers are detected by the heartbeat, not this timeout,
-  // so it is deliberately generous rather than a pacing bound.
+type ControlActivities = Omit<typeof activities, "runAgentTurn">;
+
+export const activity = proxyActivities<ControlActivities>({
   startToCloseTimeout: "30 days",
-  // 2 min (not 30s): the heartbeat timer fires every 10s but the Temporal SDK
-  // throttles forwarded heartbeats to ~80% of this timeout, and it shares the
-  // turn's event loop — a 30s timeout left only ~6s of slack, so a GC pause or
-  // synchronous work assembling a large-context model request tripped a FALSE
-  // worker-death (then a full redispatch, capped → could fail the session).
-  // A real dead worker is still detected within 2 min, immaterial for turns
-  // that legitimately run for days.
-  heartbeatTimeout: "2 minutes",
   retry: { maximumAttempts: 1 },
 });
+
+export function turnTaskQueue(baseTaskQueue: string): string {
+  return `${baseTaskQueue}-turns`;
+}
+
+export function turnActivityForTaskQueue(baseTaskQueue: string) {
+  return proxyActivities<Pick<typeof activities, "runAgentTurn">>({
+    taskQueue: turnTaskQueue(baseTaskQueue),
+    // Agent segments legitimately run for days. A started turn heartbeats;
+    // queued activities remain queued truthfully until a capped turn worker
+    // accepts them and performs the atomic claim.
+    startToCloseTimeout: "30 days",
+    heartbeatTimeout: "2 minutes",
+    retry: { maximumAttempts: 1 },
+  });
+}
 
 export const documentActivity = proxyActivities<Pick<typeof activities, "indexDocument">>({
   startToCloseTimeout: "30 minutes",

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -11,7 +11,7 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 import type * as activities from "../activities";
-import { activity, workflowFailureMessage } from "./activities";
+import { activity, turnActivityForTaskQueue, workflowFailureMessage } from "./activities";
 
 /**
  * Deterministic backstop for continueAsNew. A session workflow is long-lived
@@ -75,19 +75,18 @@ export function continuationHoldMs(
  */
 function workerDeathFailure(
   error: unknown,
-): { dispatchId: string; timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START" } | null {
+): { timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START" } | null {
   if (!(error instanceof ActivityFailure)) {
     return null;
   }
   const cause = error.cause;
   if (
     !(cause instanceof TimeoutFailure) ||
-    (cause.timeoutType !== "HEARTBEAT" && cause.timeoutType !== "SCHEDULE_TO_START") ||
-    !error.activityId
+    (cause.timeoutType !== "HEARTBEAT" && cause.timeoutType !== "SCHEDULE_TO_START")
   ) {
     return null;
   }
-  return { dispatchId: error.activityId, timeoutType: cause.timeoutType };
+  return { timeoutType: cause.timeoutType };
 }
 
 export const userMessage = defineSignal<[string]>("userMessage");
@@ -112,7 +111,8 @@ export type SessionWorkflowInput = {
 };
 
 export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void> {
-  const approvalQueue: string[] = [];
+  const turnActivity = turnActivityForTaskQueue(workflowInfo().taskQueue);
+  let approvalWakeups = 0;
   let controlEventId: string | null = null;
   let wakeups = 0;
   let capacityWakeups = 0;
@@ -128,8 +128,8 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
   setHandler(queueChanged, () => {
     wakeups += 1;
   });
-  setHandler(approvalDecision, (eventId) => {
-    approvalQueue.push(eventId);
+  setHandler(approvalDecision, () => {
+    approvalWakeups += 1;
   });
   setHandler(sessionControl, (eventId) => {
     controlEventId = eventId;
@@ -224,31 +224,22 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
     // reconstruct — so we refuse to continueAsNew while one is set and let the
     // loop handle it first. A buffered userMessage/queueChanged signal only
     // bumps `wakeups`, and its turn was written to Postgres BEFORE the signal
-    // was sent, so the fresh run re-claims it on its first claimNextSessionExecution
+    // was sent, so the fresh run observes it on its first durable work peek
     // — losing the counter strands nothing. The queue living in Postgres is the
     // safety net: continueAsNew carries only the self-contained
     // SessionWorkflowInput (no initialEventId — the new run claims from the
     // queue, it does not replay a seed event).
     //
-    // The approval queue is NOT a boundary condition, and is cleared here. A
-    // genuinely-pending approval keeps the workflow blocked INSIDE runTurn (the
-    // `await condition(...)` in the requires_action branch), so it never
-    // reaches the top of the loop — meaning every approvalQueue entry observed
-    // here is necessarily STALE (an approvalDecision signal for a turn that
-    // already settled; the API guard only checks status==='requires_action', so
-    // two decisions submitted while requires_action both land in the queue and
-    // the surplus is left behind once the turn completes without re-blocking).
-    // Coupling continueAsNew to `approvalQueue.length === 0` would let one such
-    // stale entry wedge the guard forever, re-introducing the exact
-    // history-overflow termination this branch prevents. Dropping the surplus
-    // is safe: a real pending approval also leaves the session in
-    // requires_action with the turn re-dispatchable from Postgres.
+    // Approval signals are wakeups, never conversation truth. A genuinely
+    // accepted decision is already persisted on the turn and is rediscovered
+    // by the next durable peek, including after continue-as-new. Stale or
+    // duplicate signals therefore cannot block this boundary or manufacture a
+    // second approval dispatch.
     {
       const info = workflowInfo();
       const maxTurnsPerRun = input.maxTurnsPerRun ?? TURNS_PER_RUN_BACKSTOP;
       const shouldContinue = info.continueAsNewSuggested || turnsThisRun >= maxTurnsPerRun;
       if (shouldContinue && controlEventId === null) {
-        approvalQueue.length = 0;
         await continueAsNew<typeof sessionWorkflow>({
           accountId: input.accountId,
           workspaceId: input.workspaceId,
@@ -261,30 +252,33 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       }
     }
     const workflowId = workflowInfo().workflowId;
-    const turn = await activity.claimNextSessionExecution({
+    const peek = await activity.peekSessionWork({
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
-      workflowId,
     });
-    if (!turn) {
-      // A durable Codex capacity waiter replaces the generic goal continuation
-      // loop. This read also repairs the DB-commit -> activity-return boundary:
-      // if runAgentTurn committed the waiter and then its worker died, the fresh
-      // workflow reconstructs the timer here instead of synthesizing work.
+    if (peek.kind === "fence-settle") {
+      const settlement = await activity.settleSessionControl({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        triggerEventId: peek.controlEventId,
+        workflowId,
+      });
+      if (controlEventId === peek.controlEventId) controlEventId = null;
+      if (settlement.action === "paused") return;
+      continue;
+    }
+    if (peek.kind === "capacity-wait") {
+      await waitForCodexCapacity(peek.ref);
+      continue;
+    }
+    if (peek.kind === "approval-wait") {
+      const seenApprovalWakeups = approvalWakeups;
+      await condition(() => controlEventId !== null || approvalWakeups !== seenApprovalWakeups);
+      continue;
+    }
+    if (peek.kind === "idle") {
       if (controlEventId === null) {
-        const capacityWait = await activity.getCodexCapacityWait({
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-        });
-        if (capacityWait) {
-          await waitForCodexCapacity(capacityWait);
-          continue;
-        }
-      }
-      if (controlEventId === null) {
-        // With an active goal, idling out is replaced by a synthesized
-        // continuation turn; the queue (any non-terminal turn) always wins and
-        // the no-progress/max-continuation guards auto-pause runaway goals.
         let continuation: activities.MaybeContinueGoalResult = { action: "none" };
         try {
           continuation = await activity.maybeContinueGoal({
@@ -294,93 +288,54 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
             workflowId,
           });
         } catch (error) {
-          if (isCancellation(error)) {
-            throw error;
-          }
-          // A failing goal check must not kill the session (activity retry is
-          // 1). Fall through to the idle path: the goal stays active in the
-          // database and the next wake retries, which means the workflow CAN
-          // complete normally with an active goal on this error path.
+          if (isCancellation(error)) throw error;
         }
-        if (continuation.action === "continue" || continuation.action === "queue") {
-          // "continue": a goal continuation turn was just enqueued; "queue":
-          // queued work appeared concurrently. Claim it on the next loop pass.
-          continue;
-        }
+        if (continuation.action === "continue" || continuation.action === "queue") continue;
       }
       const seenWakeups = wakeups;
-      const woke = await condition(() => controlEventId !== null || wakeups !== seenWakeups, "5s");
-      if (controlEventId) {
-        const idleControlEventId = controlEventId;
-        controlEventId = null;
-        await activity.settleSessionControl({
-          accountId: input.accountId,
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-          triggerEventId: idleControlEventId,
-          workflowId,
-        });
-        return;
-      }
-      if (woke) {
-        continue;
-      }
-      const finalTurn = await activity.claimNextSessionExecution({
+      const seenApprovalWakeups = approvalWakeups;
+      const woke = await condition(
+        () =>
+          controlEventId !== null ||
+          wakeups !== seenWakeups ||
+          approvalWakeups !== seenApprovalWakeups,
+        "5s",
+      );
+      if (woke) continue;
+      const finalPeek = await activity.peekSessionWork({
         workspaceId: input.workspaceId,
         sessionId: input.sessionId,
-        workflowId,
       });
-      if (!finalTurn) {
-        await activity.markSessionIdle({
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-        });
-        // A queueChanged/userMessage signal can land between the final claim and
-        // completion; Temporal blocks completion while a signal is buffered, so
-        // re-checking here guarantees the queued turn is picked up instead of
-        // stranding it (the signaler skips its start-child fallback on success).
-        if (controlEventId !== null || wakeups !== seenWakeups) {
-          continue;
-        }
-        return;
-      }
-      turnsThisRun += 1;
+      if (finalPeek.kind !== "idle") continue;
+      await activity.markSessionIdle({
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+      });
       if (
-        !(await runTurn(
-          input.accountId,
-          input.workspaceId,
-          input.sessionId,
-          finalTurn.id,
-          finalTurn.triggerEventId,
-        ))
+        controlEventId !== null ||
+        wakeups !== seenWakeups ||
+        approvalWakeups !== seenApprovalWakeups
       ) {
-        return;
+        continue;
       }
-      continue;
-    }
-    turnsThisRun += 1;
-    if (
-      !(await runTurn(
-        input.accountId,
-        input.workspaceId,
-        input.sessionId,
-        turn.id,
-        turn.triggerEventId,
-      ))
-    ) {
       return;
     }
+    turnsThisRun += 1;
+    const trigger =
+      peek.kind === "approval-pending"
+        ? ({ kind: "approval", triggerEventId: peek.triggerEventId } as const)
+        : ({ kind: "next" } as const);
+    if (!(await runTurn(input.accountId, input.workspaceId, input.sessionId, trigger))) return;
   }
 
   async function runTurn(
     accountId: string,
     workspaceId: string,
     sessionId: string,
-    turnId: string,
-    triggerEventId: string,
+    trigger: activities.RunAgentTurnInput["trigger"],
   ): Promise<boolean> {
     if (controlEventId) {
-      await activity.settleSessionControl({
+      const settlement = await activity.settleSessionControl({
         accountId,
         workspaceId,
         sessionId,
@@ -388,7 +343,7 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         workflowId: workflowInfo().workflowId,
       });
       controlEventId = null;
-      return true;
+      return settlement.action !== "paused";
     }
 
     const capacityWaitEntryBaseline = { wakeups, capacityWakeups };
@@ -399,14 +354,13 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
     // The stateless resume-by-id model (lease acquire + non-owned injection +
     // release) lives entirely in the runAgentTurn activity.
     const turn: Promise<activities.RunAgentTurnResult> = scope.run(() =>
-      activity.runAgentTurn({
+      turnActivity.runAgentTurn({
         accountId,
         workspaceId,
         sessionId,
-        triggerEventId,
         workflowId,
-        turnId,
         attemptId,
+        trigger,
       }),
     );
     const outcome:
@@ -422,7 +376,7 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
 
     if (outcome.kind === "control") {
       scope.cancel();
-      await activity.settleSessionControl({
+      const settlement = await activity.settleSessionControl({
         accountId,
         workspaceId,
         sessionId,
@@ -430,7 +384,7 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         workflowId: workflowInfo().workflowId,
       });
       controlEventId = null;
-      return true;
+      return settlement.action !== "paused";
     }
 
     if (outcome.kind === "failure") {
@@ -451,15 +405,11 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       // bounded by a per-turn redispatch counter persisted on the turn row.
       const workerDeath = workerDeathFailure(outcome.error);
       if (workerDeath) {
-        const recovery = await activity.recoverTurnAfterWorkerDeath({
+        const recovery = await activity.recoverDispatch({
           accountId,
           workspaceId,
           sessionId,
-          triggerEventId,
-          workflowId,
-          turnId,
           attemptId,
-          dispatchId: workerDeath.dispatchId,
           timeoutType: workerDeath.timeoutType,
         });
         if (recovery.action !== "exceeded") {
@@ -473,17 +423,18 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         // truth when the bounded redispatch ceiling was exceeded.
         return false;
       }
-      await activity.failSession({
+      await activity.failSessionAttempt({
         accountId,
         workspaceId,
         sessionId,
-        triggerEventId,
-        workflowId,
-        turnId,
         attemptId,
         error: workflowFailureMessage(outcome.error),
       });
       return false;
+    }
+
+    if (outcome.result.status === "unclaimed") {
+      return true;
     }
 
     if (outcome.result.status === "failed" || outcome.result.status === "cancelled") {
@@ -503,24 +454,7 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       return wakeups !== capacityWaitEntryBaseline.wakeups;
     }
 
-    if (outcome.result.status === "requires_action") {
-      await condition(() => controlEventId !== null || approvalQueue.length > 0);
-      if (controlEventId) {
-        await activity.settleSessionControl({
-          accountId,
-          workspaceId,
-          sessionId,
-          triggerEventId: controlEventId,
-          workflowId,
-        });
-        controlEventId = null;
-        return true;
-      }
-      const approvalEventId = approvalQueue.shift();
-      if (approvalEventId) {
-        return await runTurn(accountId, workspaceId, sessionId, turnId, approvalEventId);
-      }
-    }
+    if (outcome.result.status === "requires_action") return true;
 
     const holdMs = continuationHoldMs(outcome.result, ROTATION_IDLE_FLOOR_MS);
     if (holdMs > 0) {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -555,6 +555,14 @@ describe("model call usage observability", () => {
             payload: event.payload,
           })),
         );
+        return {
+          accepted: true,
+          events: batch.map((event) => ({
+            ...event,
+            id: crypto.randomUUID(),
+            turnAssociation: "current" as const,
+          })) as any,
+        };
       },
       accountId: "acct-1",
       workspaceId: "ws-1",
@@ -617,7 +625,14 @@ describe("model call usage observability", () => {
 
     await emitModelCallUsage({
       observability: observability as any,
-      publish: null,
+      publish: async (batch) => ({
+        accepted: true,
+        events: batch.map((event) => ({
+          ...event,
+          id: crypto.randomUUID(),
+          turnAssociation: "current" as const,
+        })) as any,
+      }),
       accountId: "acct-1",
       workspaceId: "ws-1",
       sessionId: "sess-1",
@@ -644,6 +659,37 @@ describe("model call usage observability", () => {
       servingAccountHash: "abc123def456",
       accountChangedFromPrevCall: true,
     });
+  });
+
+  test("does not log a duplicate usage observation as authoritative", async () => {
+    const infos: Array<Record<string, unknown>> = [];
+    await emitModelCallUsage({
+      observability: {
+        info: (_message: string, attributes: Record<string, unknown>) => infos.push(attributes),
+        warn: mock(),
+      } as any,
+      publish: async (batch) => ({
+        accepted: true,
+        events: batch.map((event) => ({
+          ...event,
+          id: crypto.randomUUID(),
+          turnAssociation: "duplicate" as const,
+          duplicateOfEventId: crypto.randomUUID(),
+          duplicateReason: "duplicate_provider_response_usage",
+        })) as any,
+      }),
+      accountId: "acct-1",
+      workspaceId: "ws-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      provider: "openai",
+      providerApi: "responses",
+      model: "gpt-5.6-sol",
+      sourceKey: "resp-duplicate",
+      usage: { usage: { inputTokens: 10, outputTokens: 1 } },
+    });
+
+    expect(infos).toEqual([]);
   });
 });
 

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -1,14 +1,13 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   bootstrapWorkspace,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   createDb,
   createSession,
   getActiveSessionHistoryItems,
   getSessionTurn,
   isSessionCompactionRequested,
   listSessionEvents,
-  registerSessionTurnDispatch,
   requestSessionCompaction,
   withWorkspaceRls,
 } from "@opengeni/db";
@@ -20,8 +19,27 @@ import {
   testSettings,
   type SharedTestDatabase,
 } from "@opengeni/testing";
-import { createActivities } from "../src/activities";
+import { createActivityTestHarness } from "../src/activities";
 import { maybeCompactContext } from "../src/activities/context-compaction";
+
+async function claimCompactionForAttempt(
+  db: Parameters<typeof claimSessionWorkForAttempt>[0],
+  workspaceId: string,
+  sessionId: string,
+  attemptId: string,
+) {
+  const result = await claimSessionWorkForAttempt(db, workspaceId, {
+    sessionId,
+    workflowId: `session-${sessionId}`,
+    attemptId,
+    dispatchId: `dispatch-${crypto.randomUUID()}`,
+    trigger: { kind: "next" },
+  });
+  if (result.action !== "claimed") {
+    throw new Error(`Expected compaction claim, got ${result.reason}`);
+  }
+  return result.turn;
+}
 
 describe("standalone context compaction execution", () => {
   let shared: SharedTestDatabase;
@@ -89,13 +107,6 @@ describe("standalone context compaction execution", () => {
       ]);
     });
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const turn = await claimNextSessionExecution(
-      client.db,
-      grant.workspaceId!,
-      session.id,
-      `session-${session.id}`,
-    );
-    expect(turn?.source).toBe("compaction");
 
     let compactionCalls = 0;
     let forbiddenRuntimeCalls = 0;
@@ -152,7 +163,7 @@ describe("standalone context compaction execution", () => {
       subscribe: async function* () {},
       close: async () => undefined,
     } as unknown as EventBus;
-    const activities = createActivities({
+    const activities = createActivityTestHarness({
       settings: testSettings({
         databaseUrl: shared.appUrl,
         openaiModel: "scripted-compactor",
@@ -163,25 +174,26 @@ describe("standalone context compaction execution", () => {
       runtime,
     });
 
+    const attemptId = crypto.randomUUID();
     const result = await activities.runAgentTurn({
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,
       sessionId: session.id,
-      triggerEventId: turn!.triggerEventId,
       workflowId: `session-${session.id}`,
-      turnId: turn!.id,
-      attemptId: crypto.randomUUID(),
+      attemptId,
+      trigger: { kind: "next" },
     });
 
-    expect(result).toEqual({ status: "idle" });
+    expect(result).toMatchObject({ status: "idle", attemptId });
+    if (result.status === "unclaimed") throw new Error("Compaction was not claimed");
+    const turn = await getSessionTurn(client.db, grant.workspaceId!, result.turnId);
+    expect(turn?.source).toBe("compaction");
     expect(compactionCalls).toBe(1);
     expect(forbiddenRuntimeCalls).toBe(0);
     expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
       false,
     );
-    expect((await getSessionTurn(client.db, grant.workspaceId!, turn!.id))?.status).toBe(
-      "completed",
-    );
+    expect(turn?.status).toBe("completed");
     const activeHistory = await getActiveSessionHistoryItems(
       client.db,
       grant.workspaceId!,
@@ -255,22 +267,13 @@ describe("standalone context compaction execution", () => {
       );
     });
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const turn = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const turn = await claimCompactionForAttempt(
       client.db,
       grant.workspaceId!,
       session.id,
-      `session-${session.id}`,
+      attemptId,
     );
-    const attemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-        sessionId: session.id,
-        turnId: turn!.id,
-        triggerEventId: turn!.triggerEventId,
-        attemptId,
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
 
     const outcome = await maybeCompactContext(
       client.db,
@@ -340,22 +343,13 @@ describe("standalone context compaction execution", () => {
       });
     });
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const turn = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const turn = await claimCompactionForAttempt(
       client.db,
       grant.workspaceId!,
       session.id,
-      `session-${session.id}`,
+      attemptId,
     );
-    const attemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-        sessionId: session.id,
-        turnId: turn!.id,
-        triggerEventId: turn!.triggerEventId,
-        attemptId,
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
 
     const inputLengths: number[] = [];
     const overflow = Object.assign(new Error("maximum context length exceeded"), {

--- a/apps/worker/test/session-state-worker-death.test.ts
+++ b/apps/worker/test/session-state-worker-death.test.ts
@@ -3,11 +3,12 @@ import { createSessionStateActivities } from "../src/activities/session-state";
 
 const fakeDb = {};
 const publishedEvents: unknown[] = [];
-const workerDeathCalls: unknown[] = [];
-let currentTurn: { id: string; status: string } | null = null;
-let workerDeathResult:
-  | { action: "recovering"; redispatches: number; events: any[] }
-  | { action: "exceeded"; redispatches: number; events: any[] }
+const recoveryCalls: unknown[] = [];
+const parentWakeCalls: unknown[] = [];
+let recoveryResult:
+  | { action: "unclaimed"; events: [] }
+  | { action: "recovering"; turnId: string; redispatches: number; events: any[] }
+  | { action: "exceeded"; turnId: string; redispatches: number; events: any[] }
   | { action: "stale"; events: []; turnStatus: string | null; activeTurnId: string | null };
 
 function makeActivities() {
@@ -21,117 +22,105 @@ function makeActivities() {
         wakeSessionWorkflow: null,
       }) as any,
     {
-      getSessionTurn: mock(async () => currentTurn as any),
-      getSessionEvent: mock(async () => ({
-        id: "trigger-1",
-        type: "goal.continuation",
-        payload: {},
-      })),
-      countQueuedTurns: mock(async () => 0),
-      applySessionTurnWorkerDeath: mock(async (...args: unknown[]) => {
-        workerDeathCalls.push(args[2]);
-        return workerDeathResult;
+      recoverSessionDispatch: mock(async (...args: unknown[]) => {
+        recoveryCalls.push(args[2]);
+        return recoveryResult as any;
       }),
+      countQueuedTurns: mock(async () => 0),
       publishDurableSessionEvents: mock(
         async (_bus, _workspaceId, _sessionId, events: unknown[]) => {
           publishedEvents.push(...events);
         },
       ),
-      notifyParentOfChildTerminal: mock(async () => undefined),
+      notifyParentOfChildTerminal: mock(async (...args: unknown[]) => {
+        parentWakeCalls.push(args);
+      }),
       recordTurnsQueuedGauge: mock(() => undefined),
     },
   );
 }
 
 async function runRecovery(timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START" = "HEARTBEAT") {
-  return makeActivities().recoverTurnAfterWorkerDeath({
+  return makeActivities().recoverDispatch({
     accountId: "account-1",
     workspaceId: "workspace-1",
     sessionId: "session-1",
-    triggerEventId: "trigger-1",
-    workflowId: "workflow-1",
-    turnId: "turn-1",
     attemptId: "attempt-1",
-    dispatchId: "activity-7",
     timeoutType,
   });
 }
 
-describe("recoverTurnAfterWorkerDeath: atomic dispatch fence", () => {
-  test("passes the exact Temporal dispatch and typed timeout", async () => {
-    currentTurn = { id: "turn-1", status: "running" };
-    workerDeathCalls.length = 0;
+describe("recoverDispatch: exact attempt ownership fence", () => {
+  test("passes only the exact attempt identity and typed timeout", async () => {
+    recoveryCalls.length = 0;
     publishedEvents.length = 0;
-    workerDeathResult = {
+    parentWakeCalls.length = 0;
+    recoveryResult = {
       action: "recovering",
+      turnId: "turn-1",
       redispatches: 1,
       events: [{ id: "recovery-1", type: "turn.recovery.requested" }],
     };
 
-    expect(await runRecovery()).toEqual({ action: "recovering", redispatches: 1 });
-    expect(workerDeathCalls).toEqual([
-      expect.objectContaining({
+    expect(await runRecovery()).toEqual({
+      action: "recovering",
+      turnId: "turn-1",
+      redispatches: 1,
+    });
+    expect(recoveryCalls).toEqual([
+      {
         sessionId: "session-1",
-        turnId: "turn-1",
-        triggerEventId: "trigger-1",
         attemptId: "attempt-1",
-        dispatchId: "activity-7",
         timeoutType: "HEARTBEAT",
         maxRedispatches: 3,
-      }),
+      },
     ]);
     expect(publishedEvents).toEqual([{ id: "recovery-1", type: "turn.recovery.requested" }]);
+    expect(parentWakeCalls).toHaveLength(0);
   });
 
-  test("preserves schedule-to-start as the sole typed no-registration recovery", async () => {
-    currentTurn = { id: "turn-1", status: "running" };
-    workerDeathCalls.length = 0;
+  test("preserves schedule-to-start as the sole typed unclaimed recovery", async () => {
+    recoveryCalls.length = 0;
     publishedEvents.length = 0;
-    workerDeathResult = {
-      action: "recovering",
-      redispatches: 1,
-      events: [],
-    };
-    await runRecovery("SCHEDULE_TO_START");
-    expect(workerDeathCalls).toEqual([
-      expect.objectContaining({ timeoutType: "SCHEDULE_TO_START" }),
-    ]);
+    recoveryResult = { action: "unclaimed", events: [] };
+    expect(await runRecovery("SCHEDULE_TO_START")).toEqual({ action: "unclaimed" });
+    expect(recoveryCalls).toEqual([expect.objectContaining({ timeoutType: "SCHEDULE_TO_START" })]);
+    expect(publishedEvents).toHaveLength(0);
   });
 
-  test("does not call the atomic helper for terminal or missing turns", async () => {
-    currentTurn = { id: "turn-1", status: "completed" };
-    workerDeathCalls.length = 0;
-    expect(await runRecovery()).toEqual({ action: "stale" });
-    expect(workerDeathCalls).toHaveLength(0);
-    currentTurn = null;
-    expect(await runRecovery()).toEqual({ action: "stale" });
-    expect(workerDeathCalls).toHaveLength(0);
-  });
-
-  test("an event-free stale helper result remains stale", async () => {
-    currentTurn = { id: "turn-1", status: "running" };
-    workerDeathCalls.length = 0;
+  test("delegates terminal, missing, or successor ownership classification atomically", async () => {
+    recoveryCalls.length = 0;
     publishedEvents.length = 0;
-    workerDeathResult = {
+    recoveryResult = {
       action: "stale",
       events: [],
-      turnStatus: "running",
-      activeTurnId: "turn-1",
+      turnStatus: "completed",
+      activeTurnId: null,
     };
     expect(await runRecovery()).toEqual({ action: "stale" });
+    expect(recoveryCalls).toHaveLength(1);
     expect(publishedEvents).toHaveLength(0);
   });
 
   test("exhaustion is already terminal and wakes the parent once", async () => {
-    currentTurn = { id: "turn-1", status: "running" };
-    workerDeathCalls.length = 0;
+    recoveryCalls.length = 0;
     publishedEvents.length = 0;
-    workerDeathResult = {
+    parentWakeCalls.length = 0;
+    recoveryResult = {
       action: "exceeded",
+      turnId: "turn-1",
       redispatches: 3,
       events: [{ id: "failed-1", type: "turn.failed" }],
     };
-    expect(await runRecovery()).toEqual({ action: "exceeded", redispatches: 3 });
+    expect(await runRecovery()).toEqual({
+      action: "exceeded",
+      turnId: "turn-1",
+      redispatches: 3,
+    });
     expect(publishedEvents).toEqual([{ id: "failed-1", type: "turn.failed" }]);
+    expect(parentWakeCalls).toHaveLength(1);
+    expect(parentWakeCalls[0]).toEqual(
+      expect.arrayContaining(["workspace-1", "session-1", "failed", "turn:turn-1"]),
+    );
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,13 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/lang-python": "^6.2.1",
-        "@codemirror/view": "^6.43.1",
+        "@codemirror/view": "^6.43.6",
         "@pierre/trees": "1.0.0-beta.4",
-        "@uiw/react-codemirror": "^4.25.10",
+        "@uiw/react-codemirror": "^4.25.11",
       },
       "devDependencies": {
         "@axe-core/playwright": "4.10.2",
-        "@changesets/cli": "^2.27.11",
+        "@changesets/cli": "^2.31.0",
         "@opengeni/agent-proto": "workspace:*",
         "@opengeni/api-router": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -34,13 +34,13 @@
         "@opengeni/storage": "workspace:*",
         "@opengeni/testing": "workspace:*",
         "@opengeni/worker-bundle": "workspace:*",
-        "@temporalio/client": "^1.17.0",
-        "@temporalio/worker": "^1.17.0",
-        "@types/bun": "^1.3.4",
+        "@temporalio/client": "^1.20.2",
+        "@temporalio/worker": "^1.20.2",
+        "@types/bun": "^1.3.14",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "oxfmt": "0.58.0",
         "oxlint": "1.73.0",
-        "playwright": "^1.57.0",
+        "playwright": "^1.61.1",
         "postgres": "^3.4.9",
         "typescript": "^6.0.3",
       },
@@ -141,7 +141,7 @@
         "@temporalio/workflow": "^1.17.0",
       },
       "devDependencies": {
-        "@openai/agents-core": "^0.11.6",
+        "@openai/agents-core": "0.13.3",
         "@opengeni/testing": "workspace:*",
         "postgres": "^3.4.9",
         "tsup": "^8.5.0",
@@ -381,14 +381,14 @@
       "version": "0.6.1",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
-        "@openai/agents": "^0.11.6",
-        "@openai/agents-extensions": "^0.11.6",
+        "@openai/agents": "0.13.3",
+        "@openai/agents-extensions": "0.13.3",
         "@opengeni/agent-proto": "workspace:*",
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
-        "modal": "^0.7.4",
-        "openai": "6.36.0",
+        "modal": "0.7.6",
+        "openai": "6.47.0",
       },
       "devDependencies": {
         "tsup": "^8.5.0",
@@ -427,7 +427,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/agents": "^0.11.6",
+        "@openai/agents": "0.13.3",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -444,6 +444,21 @@
         "typescript": "^6.0.3",
       },
     },
+  },
+  "overrides": {
+    "@grpc/grpc-js": "1.14.4",
+    "dompurify": "3.4.12",
+    "esbuild": "0.25.0",
+    "form-data": "4.0.6",
+    "hono": "4.12.30",
+    "ip-address": "10.2.0",
+    "js-yaml": "3.15.0",
+    "mermaid": "11.16.0",
+    "protobufjs": "7.6.5",
+    "qs": "6.15.3",
+    "uuid": "11.1.1",
+    "vite": "8.1.4",
+    "ws": "8.21.1",
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
@@ -664,15 +679,7 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
-
-    "@chevrotain/gast": ["@chevrotain/gast@12.0.0", "", { "dependencies": { "@chevrotain/types": "12.0.0" } }, "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ=="],
-
-    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@12.0.0", "", {}, "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA=="],
-
-    "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
-
-    "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
@@ -700,71 +707,69 @@
 
     "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
 
-    "@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+    "@codemirror/view": ["@codemirror/view@6.43.6", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.0", "", { "os": "android", "cpu": "arm" }, "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.0", "", { "os": "android", "cpu": "arm64" }, "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.0", "", { "os": "android", "cpu": "x64" }, "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.0", "", { "os": "linux", "cpu": "arm" }, "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.0", "", { "os": "linux", "cpu": "x64" }, "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.0", "", { "os": "none", "cpu": "arm64" }, "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.0", "", { "os": "none", "cpu": "x64" }, "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -786,7 +791,7 @@
 
     "@google-cloud/storage": ["@google-cloud/storage@7.19.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0", "uuid": "^8.0.0" } }, "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ=="],
 
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
@@ -922,11 +927,11 @@
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
-    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -942,15 +947,15 @@
 
     "@novnc/novnc": ["@novnc/novnc@1.7.0", "", {}, "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA=="],
 
-    "@openai/agents": ["@openai/agents@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@openai/agents-openai": "0.11.6", "@openai/agents-realtime": "0.11.6", "debug": "^4.4.0", "openai": "^6.35.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-YLwycYJQ65ETEq1SzjdFO6U9VhWHOKKIVh6wZCd/FmTZoqYq9UF/5uvX+wF8cZ58J+wIyyLynPdCmzEEov2rhw=="],
+    "@openai/agents": ["@openai/agents@0.13.3", "", { "dependencies": { "@openai/agents-core": "0.13.3", "@openai/agents-openai": "0.13.3", "@openai/agents-realtime": "0.13.3", "debug": "^4.4.0", "openai": "^6.46.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-CgqDp1KNMRVj8fIXjdsX3YFsEgcyxjlj4xyVM4t63Dm8YCoRfBhY+4SZSg1kvEKm6wttMQ5N88tK5MW6X6FfJA=="],
 
-    "@openai/agents-core": ["@openai/agents-core@0.11.6", "", { "dependencies": { "debug": "^4.4.0", "openai": "^6.35.0" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.26.0" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-jWeo4mF+zjp9R80OPg+9prAnwF53dIpok2ymp9OkC3DpK2qcqBO8CfoEgocNp+E5HXXFW4uvCaY0olNCCcmTFw=="],
+    "@openai/agents-core": ["@openai/agents-core@0.13.3", "", { "dependencies": { "debug": "^4.4.0", "openai": "^6.46.0" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.26.0" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-988j7+ON1RBSIMQXy4RERnOus9aKZhFiZyOLQS3j6UiXYklaBsK1o1lq8bFbnujQQ0oF+rHwTk96bMfYU1SV8w=="],
 
-    "@openai/agents-extensions": ["@openai/agents-extensions@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@types/ws": "^8.18.1", "debug": "^4.4.0" }, "peerDependencies": { "@ai-sdk/provider": "^2.0.0 || ^3.0.0", "@blaxel/core": "^0.2.82", "@daytonaio/sdk": "^0.162.0", "@e2b/code-interpreter": "^2.3.3", "@openai/agents": ">=0.0.0", "@openai/codex-sdk": ">=0.86.0", "@runloop/api-client": "^1.16.2", "@vercel/sandbox": "^1.9.3", "ai": "^6.0.0", "e2b": "^2.14.1", "modal": "^0.7.4", "ws": "^8.18.1", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@blaxel/core", "@daytonaio/sdk", "@e2b/code-interpreter", "@openai/codex-sdk", "@runloop/api-client", "@vercel/sandbox", "ai", "e2b", "modal"] }, "sha512-lTWr0kFos15PXEqs/gbTPLjVHblFvYx/YKVYy3fK89g56vdW78Tusgvjh9enIFLdmqnzPacTBA3GB2V8V7pr7g=="],
+    "@openai/agents-extensions": ["@openai/agents-extensions@0.13.3", "", { "dependencies": { "@openai/agents-core": "0.13.3", "@types/ws": "^8.18.1", "debug": "^4.4.0" }, "peerDependencies": { "@ai-sdk/provider": "^2.0.0 || ^3.0.0", "@blaxel/core": "^0.2.82", "@daytonaio/sdk": "^0.162.0", "@e2b/code-interpreter": "^2.3.3", "@openai/agents": ">=0.0.0", "@openai/codex-sdk": ">=0.86.0", "@runloop/api-client": "^1.16.2", "@vercel/sandbox": "^1.9.3", "ai": "^6.0.0", "e2b": "^2.14.1", "modal": "^0.7.6", "ws": "^8.21.0", "zod": "^4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@blaxel/core", "@daytonaio/sdk", "@e2b/code-interpreter", "@openai/codex-sdk", "@runloop/api-client", "@vercel/sandbox", "ai", "e2b", "modal"] }, "sha512-7YCQMFfr4SFZ4Zl70q0t6Iqze06sj63zzuy9FnJphFHT/iGUziVF2jBgTx8MuvU/SkQbiYH4c3fGg6WwDGHnkw=="],
 
-    "@openai/agents-openai": ["@openai/agents-openai@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "debug": "^4.4.0", "openai": "^6.35.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A=="],
+    "@openai/agents-openai": ["@openai/agents-openai@0.13.3", "", { "dependencies": { "@openai/agents-core": "0.13.3", "debug": "^4.4.0", "openai": "^6.46.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-IOffFqBw9AFf9vcU67usjIwom0kF4UQOA1RqR1XQ2776TNwHRdNyxU0ZilpwSxxH2cmAiN4inYOsX/uNFJBRwg=="],
 
-    "@openai/agents-realtime": ["@openai/agents-realtime@0.11.6", "", { "dependencies": { "@openai/agents-core": "0.11.6", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.18.1" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-jw4lLO6B2xyCBtgLtAXZmqhjEAqSLO1EtJzfwfrZuzGpPgs4nJBQ+O7ybtdPPKt8iWdIOlrYRDqxhBHv7Qqo7w=="],
+    "@openai/agents-realtime": ["@openai/agents-realtime@0.13.3", "", { "dependencies": { "@openai/agents-core": "0.13.3", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.21.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-6lTTB/1GY86fUzm2IpizTj21OD/545xRtuxLOrqvxH6DDOXcupr28IsYq5uC/hw2qZUXSuxVXnedW0SbNf1YDg=="],
 
     "@opengeni/agent-proto": ["@opengeni/agent-proto@workspace:packages/agent-proto"],
 
@@ -992,7 +997,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.58.0", "", { "os": "android", "cpu": "arm" }, "sha512-Uz62sHduGGPftXtILGyxdSW4PX82rUg+rfdNqhsgxe881g4rIoXlIqmZQ6HVKcF4f+F8qMhdD03Bx5u7gmeTdg=="],
 
@@ -1084,13 +1089,11 @@
 
     "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
 
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
 
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
 
     "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.1", "", {}, "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="],
 
     "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
 
@@ -1218,35 +1221,35 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -1504,21 +1507,21 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
-    "@temporalio/activity": ["@temporalio/activity@1.17.0", "", { "dependencies": { "@temporalio/client": "1.17.0", "@temporalio/common": "1.17.0", "abort-controller": "^3.0.0" } }, "sha512-jjF38/VX7c9eyAb9g4oP4CAAYO3oWNIPIks5R5z0yszoDGBq+29UwsHYd6WrMviGt63NvLhWJWEOyeyGdA6L1g=="],
+    "@temporalio/activity": ["@temporalio/activity@1.20.2", "", { "dependencies": { "@temporalio/client": "1.20.2", "@temporalio/common": "1.20.2" } }, "sha512-j2WAFsBrUcalJOt/GJ5bL+oD426KKNGR1M/O2noy94jdL9P0Q8QbkrQoixInHOPmQX0WY9cSVBdH+Ho6toe5BA=="],
 
-    "@temporalio/client": ["@temporalio/client@1.17.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.17.0", "@temporalio/proto": "1.17.0", "abort-controller": "^3.0.0", "long": "^5.2.3", "uuid": "^11.1.0" } }, "sha512-mc1VHfuVjT7D/QprjEGQFpbePMvuA0/kqIWhrEN+D1VYkLdhaMkuMgVjPtsxXjvACR20+qEsDg5m0a1qjllEoA=="],
+    "@temporalio/client": ["@temporalio/client@1.20.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.20.2", "@temporalio/proto": "1.20.2", "abort-controller": "^3.0.0", "long": "^5.2.3", "nexus-rpc": "^0.0.2", "uuid": "^11.1.0" } }, "sha512-z9CLE/K6yHQeI3ArF9Y7nao8urpZCrLF9FKPLr34TZQa6+UbuOABcKBaJOHUW/Ecjwtee0uFke/FF9oGx0A4Yw=="],
 
-    "@temporalio/common": ["@temporalio/common@1.17.0", "", { "dependencies": { "@temporalio/proto": "1.17.0", "long": "^5.2.3", "ms": "3.0.0-canary.1", "nexus-rpc": "^0.0.2", "proto3-json-serializer": "^2.0.0" } }, "sha512-xOnb1vLYOO9PwTX2kmQdZROnH4fpC+wHSKQxQVZCOFrtxmcF8iN6Llzvc1tP+PQJncLnVpx+YrSCIzSY+e43cw=="],
+    "@temporalio/common": ["@temporalio/common@1.20.2", "", { "dependencies": { "@temporalio/proto": "1.20.2", "long": "^5.2.3", "ms": "3.0.0-canary.1", "nexus-rpc": "^0.0.2", "proto3-json-serializer": "^2.0.0" } }, "sha512-MXWFfnb/1Y+pynT9d8DZaNeovMJwPgwaNLzCLJtLZf5Ufn/TtMZlrXkoiUPjr8ERLOs2v9K0jkq4g1XZT3CJgw=="],
 
-    "@temporalio/core-bridge": ["@temporalio/core-bridge@1.17.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.17.0" } }, "sha512-AR6vLRIyvIaY4raq2wZ9iboKe0IljWgwXM8Hei2OvbmgLNEt0PTiwFPQmVPbsafijOZPKazF1KiPrGrDCE33yA=="],
+    "@temporalio/core-bridge": ["@temporalio/core-bridge@1.20.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.20.2" } }, "sha512-Jw1WTQeAnfLONDpDZIGfs3K4JL8W29SOOqzzIUDBiz9oxLd+qHQljqfJowP7vUDQYUG9hFA8pw8VT45SVszUUQ=="],
 
-    "@temporalio/nexus": ["@temporalio/nexus@1.17.0", "", { "dependencies": { "@temporalio/client": "1.17.0", "@temporalio/common": "1.17.0", "@temporalio/proto": "1.17.0", "long": "^5.2.3", "nexus-rpc": "^0.0.2" } }, "sha512-IdVTVS3INmXlRCgmG0Rt0wDfiXrk94A/813AahCDbgq3NdcCRCnAbO0a7KwOJh0S0P0153zX4YZlIStRwfQEGQ=="],
+    "@temporalio/nexus": ["@temporalio/nexus@1.20.2", "", { "dependencies": { "@temporalio/client": "1.20.2", "@temporalio/common": "1.20.2", "@temporalio/proto": "1.20.2", "long": "^5.2.3", "nexus-rpc": "^0.0.2" } }, "sha512-NzFZOdvzfPChXGg0JbeqGW47nkyRNSmKc1l9xN2LFMBv68fHFhFe5OqWay5LyuQyM4zFXJcY7G45oXJby6xVEg=="],
 
-    "@temporalio/proto": ["@temporalio/proto@1.17.0", "", { "dependencies": { "long": "^5.2.3", "protobufjs": "7.5.5" } }, "sha512-Ymo/ka9gO79o3LI0QOSlZuWA2MzrK1ymbwdrBiQrmQFFx/+kb7iFJG91sAaadbCXQONagBG1N+pmFei0b6bSZw=="],
+    "@temporalio/proto": ["@temporalio/proto@1.20.2", "", { "dependencies": { "long": "^5.2.3", "protobufjs": "^7.6.4" } }, "sha512-m/lfRAV4u0RQ9FszvH0c9+GEvRXZPLCQgSFaTb9BrLhuJFxUHgqc8gwbWhOyRG1pgAilRZtfkhOi/OLAUFDfNA=="],
 
-    "@temporalio/worker": ["@temporalio/worker@1.17.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@swc/core": "^1.3.102", "@temporalio/activity": "1.17.0", "@temporalio/client": "1.17.0", "@temporalio/common": "1.17.0", "@temporalio/core-bridge": "1.17.0", "@temporalio/nexus": "1.17.0", "@temporalio/proto": "1.17.0", "@temporalio/workflow": "1.17.0", "abort-controller": "^3.0.0", "heap-js": "^2.6.0", "memfs": "^4.6.0", "nexus-rpc": "^0.0.2", "proto3-json-serializer": "^2.0.0", "protobufjs": "^7.5.5", "rxjs": "^7.8.1", "source-map": "^0.7.4", "source-map-loader": "^4.0.2", "supports-color": "^8.1.1", "swc-loader": "^0.2.3", "unionfs": "^4.5.1", "webpack": "^5.104.1" } }, "sha512-oMqar4aMeFyPX30/NfrSGb9VNHzPoP0w9fYiKvyzWV7ZzpvWYufIZYBahnnvy6UwtFBOyv+RwiSxmgOu9TexWA=="],
+    "@temporalio/worker": ["@temporalio/worker@1.20.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@swc/core": "^1.3.102", "@temporalio/activity": "1.20.2", "@temporalio/client": "1.20.2", "@temporalio/common": "1.20.2", "@temporalio/core-bridge": "1.20.2", "@temporalio/nexus": "1.20.2", "@temporalio/proto": "1.20.2", "@temporalio/workflow": "1.20.2", "heap-js": "^2.6.0", "memfs": "^4.6.0", "nexus-rpc": "^0.0.2", "protobufjs": "^7.6.4", "rxjs": "^7.8.1", "source-map": "^0.7.4", "source-map-loader": "^5.0.0", "supports-color": "^8.1.1", "swc-loader": "^0.2.3", "unionfs": "^4.5.1", "webpack": "^5.106.2" } }, "sha512-p0wd8Ga7OIijL7wqV4FqcZMTn64QdhASJSf8pq+92spOlhF16gOElaEmM2ZqgMKgO73kWrh/HjooMNVoLvPtow=="],
 
-    "@temporalio/workflow": ["@temporalio/workflow@1.17.0", "", { "dependencies": { "@temporalio/common": "1.17.0", "@temporalio/proto": "1.17.0", "nexus-rpc": "^0.0.2" } }, "sha512-/iYRcjUYQmW/K6le63Y7yp+bdI+4cw8tWDVvHHUEtaT5b2L/4eMbQzmNwuKb0LZCNXi9R6SaUHNJp6EqHMpFNQ=="],
+    "@temporalio/workflow": ["@temporalio/workflow@1.20.2", "", { "dependencies": { "@temporalio/common": "1.20.2", "@temporalio/proto": "1.20.2", "nexus-rpc": "^0.0.2" } }, "sha512-n7yusxqs4xcRUsHBqSkt4qXXCZ0xrmkEY67NiVyIBAlqUB1pRFt1OMF/oayDH9G1jRYNlzyCbv4nbMJthMSVmg=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -1526,9 +1529,9 @@
 
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
@@ -1652,9 +1655,9 @@
 
     "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.5", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw=="],
 
-    "@uiw/codemirror-extensions-basic-setup": ["@uiw/codemirror-extensions-basic-setup@4.25.10", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ=="],
+    "@uiw/codemirror-extensions-basic-setup": ["@uiw/codemirror-extensions-basic-setup@4.25.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw=="],
 
-    "@uiw/react-codemirror": ["@uiw/react-codemirror@4.25.10", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@codemirror/commands": "^6.1.0", "@codemirror/state": "^6.1.1", "@codemirror/theme-one-dark": "^6.0.0", "@uiw/codemirror-extensions-basic-setup": "4.25.10", "codemirror": "^6.0.0" }, "peerDependencies": { "@codemirror/view": ">=6.0.0", "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w=="],
+    "@uiw/react-codemirror": ["@uiw/react-codemirror@4.25.11", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@codemirror/commands": "^6.1.0", "@codemirror/state": "^6.1.1", "@codemirror/theme-one-dark": "^6.0.0", "@uiw/codemirror-extensions-basic-setup": "4.25.11", "codemirror": "^6.0.0" }, "peerDependencies": { "@codemirror/view": ">=6.0.0", "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -1732,7 +1735,7 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -1782,7 +1785,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -1813,10 +1816,6 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
-
-    "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
-
-    "chevrotain-allstar": ["chevrotain-allstar@0.4.3", "", { "dependencies": { "lodash-es": "^4.18.1" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -1966,7 +1965,7 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "dprint-node": ["dprint-node@1.0.8", "", { "dependencies": { "detect-libc": "^1.0.3" } }, "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg=="],
 
@@ -2006,7 +2005,9 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
-    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+
+    "esbuild": ["esbuild@0.25.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.0", "@esbuild/android-arm": "0.25.0", "@esbuild/android-arm64": "0.25.0", "@esbuild/android-x64": "0.25.0", "@esbuild/darwin-arm64": "0.25.0", "@esbuild/darwin-x64": "0.25.0", "@esbuild/freebsd-arm64": "0.25.0", "@esbuild/freebsd-x64": "0.25.0", "@esbuild/linux-arm": "0.25.0", "@esbuild/linux-arm64": "0.25.0", "@esbuild/linux-ia32": "0.25.0", "@esbuild/linux-loong64": "0.25.0", "@esbuild/linux-mips64el": "0.25.0", "@esbuild/linux-ppc64": "0.25.0", "@esbuild/linux-riscv64": "0.25.0", "@esbuild/linux-s390x": "0.25.0", "@esbuild/linux-x64": "0.25.0", "@esbuild/netbsd-arm64": "0.25.0", "@esbuild/netbsd-x64": "0.25.0", "@esbuild/openbsd-arm64": "0.25.0", "@esbuild/openbsd-x64": "0.25.0", "@esbuild/sunos-x64": "0.25.0", "@esbuild/win32-arm64": "0.25.0", "@esbuild/win32-ia32": "0.25.0", "@esbuild/win32-x64": "0.25.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -2070,7 +2071,7 @@
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -2132,7 +2133,7 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
 
@@ -2154,7 +2155,7 @@
 
     "heap-js": ["heap-js@2.7.1", "", {}, "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
@@ -2188,7 +2189,7 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -2234,7 +2235,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -2257,8 +2258,6 @@
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
     "kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
-
-    "langium": ["langium@4.2.3", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.3", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
@@ -2360,7 +2359,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2428,7 +2427,7 @@
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
-    "modal": ["modal@0.7.4", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-md/+L67tM1RazAt2xvLO+gUqRz6zllyYoNNiM8h+Eb1wLy7JzliH7vnx9f9Sq4zE3qQHENpX0Tjy/LSkIyrANA=="],
+    "modal": ["modal@0.7.6", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-AOFRO/eGl4fcNKxHkNLx55+tL318IeAiTDJCMh/Q1ZXhoaZFnpmlirVV2J5BhO32XLA7AiH6KYGA7gRBGA09lQ=="],
 
     "motion": ["motion@12.40.0", "", { "dependencies": { "framer-motion": "^12.40.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA=="],
 
@@ -2540,7 +2539,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -2550,7 +2549,7 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
@@ -2586,13 +2585,13 @@
 
     "proto3-json-serializer": ["proto3-json-serializer@2.0.2", "", { "dependencies": { "protobufjs": "^7.2.5" } }, "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ=="],
 
-    "protobufjs": ["protobufjs@7.5.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg=="],
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
-    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -2666,7 +2665,7 @@
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "rollup": ["rollup@4.62.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.0", "@rollup/rollup-android-arm64": "4.62.0", "@rollup/rollup-darwin-arm64": "4.62.0", "@rollup/rollup-darwin-x64": "4.62.0", "@rollup/rollup-freebsd-arm64": "4.62.0", "@rollup/rollup-freebsd-x64": "4.62.0", "@rollup/rollup-linux-arm-gnueabihf": "4.62.0", "@rollup/rollup-linux-arm-musleabihf": "4.62.0", "@rollup/rollup-linux-arm64-gnu": "4.62.0", "@rollup/rollup-linux-arm64-musl": "4.62.0", "@rollup/rollup-linux-loong64-gnu": "4.62.0", "@rollup/rollup-linux-loong64-musl": "4.62.0", "@rollup/rollup-linux-ppc64-gnu": "4.62.0", "@rollup/rollup-linux-ppc64-musl": "4.62.0", "@rollup/rollup-linux-riscv64-gnu": "4.62.0", "@rollup/rollup-linux-riscv64-musl": "4.62.0", "@rollup/rollup-linux-s390x-gnu": "4.62.0", "@rollup/rollup-linux-x64-gnu": "4.62.0", "@rollup/rollup-linux-x64-musl": "4.62.0", "@rollup/rollup-openbsd-x64": "4.62.0", "@rollup/rollup-openharmony-arm64": "4.62.0", "@rollup/rollup-win32-arm64-msvc": "4.62.0", "@rollup/rollup-win32-ia32-msvc": "4.62.0", "@rollup/rollup-win32-x64-gnu": "4.62.0", "@rollup/rollup-win32-x64-msvc": "4.62.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA=="],
 
@@ -2712,7 +2711,7 @@
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
@@ -2732,7 +2731,7 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "source-map-loader": ["source-map-loader@4.0.2", "", { "dependencies": { "iconv-lite": "^0.6.3", "source-map-js": "^1.0.2" }, "peerDependencies": { "webpack": "^5.72.1" } }, "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg=="],
+    "source-map-loader": ["source-map-loader@5.0.0", "", { "dependencies": { "iconv-lite": "^0.6.3", "source-map-js": "^1.0.2" }, "peerDependencies": { "webpack": "^5.72.1" } }, "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
@@ -2906,19 +2905,7 @@
 
     "virtua": ["virtua@0.49.2", "", { "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0", "solid-js": ">=1.0", "svelte": ">=5.0", "vue": ">=3.2" }, "optionalPeers": ["react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-aEp3+6cmIRjHUlQnWdgGXYMYtrIG26QnN9jJDZEE5LRhvo1Z9HzoJwLDgyVULUPWcSdCnZAroQm7raXJyTG0AA=="],
 
-    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
-
-    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
-
-    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
-
-    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
-
-    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
-
-    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
-
-    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+    "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
@@ -2946,7 +2933,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -2984,11 +2971,27 @@
 
     "@better-auth/utils/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+    "@codemirror/autocomplete/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/commands/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/lang-html/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/lang-javascript/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/lang-markdown/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/language/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/lint/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/search/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/theme-one-dark/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@codemirror/view/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
 
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "@google-cloud/storage/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@17.67.0", "", { "dependencies": { "@jsonjoy.com/base64": "17.67.0", "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0", "@jsonjoy.com/json-pointer": "17.67.0", "@jsonjoy.com/util": "17.67.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w=="],
 
@@ -3008,6 +3011,16 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@openai/agents/openai": ["openai@6.47.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw=="],
+
+    "@openai/agents-core/openai": ["openai@6.47.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw=="],
+
+    "@openai/agents-openai/openai": ["openai@6.47.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw=="],
+
+    "@opengeni/runtime/openai": ["openai@6.47.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -3026,13 +3039,13 @@
 
     "@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
-    "@temporalio/proto/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
-
-    "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
-
     "@typespec/ts-http-runtime/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
+    "@uiw/codemirror-extensions-basic-setup/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
+
     "better-auth/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "codemirror/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -3048,15 +3061,13 @@
 
     "dprint-node/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
-    "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "es-set-tostringtag/hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
-    "happy-dom/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "get-intrinsic/hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -3072,9 +3083,9 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+    "playwright/playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
@@ -3092,63 +3103,25 @@
 
     "teeny-request/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
-    "teeny-request/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "unplugin/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite/postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
-
-    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@google-cloud/storage/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -3162,69 +3135,13 @@
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "@types/request/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
-    "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
-
-    "drizzle-kit/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
-
-    "drizzle-kit/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
-
-    "drizzle-kit/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
-
-    "drizzle-kit/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
-
-    "drizzle-kit/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
-
-    "drizzle-kit/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
-
-    "drizzle-kit/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
-
-    "drizzle-kit/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
-
-    "drizzle-kit/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
-
-    "drizzle-kit/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
-
-    "drizzle-kit/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
-
-    "drizzle-kit/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
-
-    "drizzle-kit/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
-
-    "drizzle-kit/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
-
-    "drizzle-kit/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
-
-    "drizzle-kit/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
-
-    "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -3233,7 +3150,5 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
-    "@types/request/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,7 @@
         "openai": "6.47.0",
       },
       "devDependencies": {
+        "@openai/agents-core": "0.13.3",
         "tsup": "^8.5.0",
         "typescript": "^6.0.3",
       },

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/deploy/helm/opengeni/templates/dependency-networkpolicy.yaml
+++ b/deploy/helm/opengeni/templates/dependency-networkpolicy.yaml
@@ -22,7 +22,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: worker
+            matchExpressions:
+              - key: opengeni.ai/worker-role
+                operator: Exists
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
@@ -60,7 +62,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: worker
+            matchExpressions:
+              - key: opengeni.ai/worker-role
+                operator: Exists
       ports:
         - protocol: TCP
           port: {{ .Values.temporal.service.port }}
@@ -90,7 +94,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: worker
+            matchExpressions:
+              - key: opengeni.ai/worker-role
+                operator: Exists
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}

--- a/deploy/helm/opengeni/templates/nats-networkpolicy.yaml
+++ b/deploy/helm/opengeni/templates/nats-networkpolicy.yaml
@@ -24,7 +24,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "opengeni.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: worker
+            matchExpressions:
+              - key: opengeni.ai/worker-role
+                operator: Exists
       ports:
         - protocol: TCP
           port: {{ .Values.nats.clientPort }}

--- a/deploy/helm/opengeni/templates/poddisruptionbudgets.yaml
+++ b/deploy/helm/opengeni/templates/poddisruptionbudgets.yaml
@@ -13,21 +13,37 @@ spec:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: api
 {{- end }}
-{{- if and .Values.worker.enabled ((.Values.worker).podDisruptionBudget).enabled }}
+{{- if and .Values.worker.enabled .Values.worker.control.podDisruptionBudget.enabled }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "opengeni.fullname" . }}-worker
+  name: {{ include "opengeni.fullname" . }}-worker-control
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    app.kubernetes.io/component: worker-control
 spec:
-  minAvailable: {{ ((.Values.worker).podDisruptionBudget).minAvailable }}
+  minAvailable: {{ .Values.worker.control.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: worker
+      app.kubernetes.io/component: worker-control
+{{- end }}
+{{- if and .Values.worker.enabled .Values.worker.turns.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "opengeni.fullname" . }}-worker-turns
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker-turns
+spec:
+  minAvailable: {{ .Values.worker.turns.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "opengeni.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker-turns
 {{- end }}
 {{- if and .Values.web.enabled .Values.web.podDisruptionBudget.enabled }}
 ---

--- a/deploy/helm/opengeni/templates/servicemonitor.yaml
+++ b/deploy/helm/opengeni/templates/servicemonitor.yaml
@@ -25,31 +25,33 @@ spec:
       scrapeTimeout: {{ ((.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
 {{- end }}
 {{- if and .Values.worker.enabled ((.Values.observability).serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- range $role := list "control" "turns" }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "opengeni.fullname" . }}-worker
+  name: {{ include "opengeni.fullname" $ }}-worker-{{ $role }}
   labels:
-    {{- include "opengeni.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
-    {{- with ((.Values.observability).serviceMonitor).labels }}
+    {{- include "opengeni.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker-{{ $role }}
+    {{- with (($.Values.observability).serviceMonitor).labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ((.Values.observability).serviceMonitor).annotations }}
+  {{- with (($.Values.observability).serviceMonitor).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "opengeni.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: worker
+      {{- include "opengeni.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: worker-{{ $role }}
   endpoints:
     - port: http
-      path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
-      interval: {{ ((.Values.observability).serviceMonitor).interval | default "30s" | quote }}
-      scrapeTimeout: {{ ((.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
+      path: {{ (($.Values.observability).metrics).path | default "/metrics" | quote }}
+      interval: {{ (($.Values.observability).serviceMonitor).interval | default "30s" | quote }}
+      scrapeTimeout: {{ (($.Values.observability).serviceMonitor).scrapeTimeout | default "10s" | quote }}
+{{- end }}
 {{- end }}
 {{- if and .Values.relay.enabled ((.Values.observability).serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 ---

--- a/deploy/helm/opengeni/templates/worker-hpa.yaml
+++ b/deploy/helm/opengeni/templates/worker-hpa.yaml
@@ -1,47 +1,44 @@
-{{- if and .Values.worker.enabled ((.Values.worker).autoscaling).enabled }}
+{{- range $role := list "control" "turns" }}
+{{- $config := index $.Values.worker $role }}
+{{- if and $.Values.worker.enabled $config.autoscaling.enabled }}
+{{- if ne $role "control" }}
+---
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "opengeni.fullname" . }}-worker
+  name: {{ include "opengeni.fullname" $ }}-worker-{{ $role }}
   labels:
-    {{- include "opengeni.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    {{- include "opengeni.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker-{{ $role }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "opengeni.fullname" . }}-worker
-  minReplicas: {{ ((.Values.worker).autoscaling).minReplicas }}
-  maxReplicas: {{ ((.Values.worker).autoscaling).maxReplicas }}
+    name: {{ include "opengeni.fullname" $ }}-worker-{{ $role }}
+  minReplicas: {{ $config.autoscaling.minReplicas }}
+  maxReplicas: {{ $config.autoscaling.maxReplicas }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ ((.Values.worker).autoscaling).targetCPUUtilizationPercentage }}
-    {{- if ((.Values.worker).autoscaling).targetMemoryUtilizationPercentage }}
-    # The worker is MEMORY bound, not CPU bound: each pod holds the full
-    # in-turn conversation history for every session it runs, so pods approach
-    # the memory limit (and OOM) long before CPU saturates. Memory is the
-    # signal that actually tracks the pressure; keep the target high (headroom)
-    # and pair it with the scaleDown stabilization in `behavior` so a transient
-    # dip never evicts a pod mid-turn.
+          averageUtilization: {{ $config.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if $config.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ ((.Values.worker).autoscaling).targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ $config.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-    {{- with ((.Values.worker).autoscaling).customMetrics }}
-    # Optional custom/external metrics (needs a Prometheus adapter). A
-    # session-count or Temporal task-queue-backlog metric tracks worker load
-    # better than CPU; wire it here once the adapter is available.
+    {{- with $config.autoscaling.customMetrics }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ((.Values.worker).autoscaling).behavior }}
+  {{- with $config.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/worker-networkpolicy.yaml
+++ b/deploy/helm/opengeni/templates/worker-networkpolicy.yaml
@@ -10,7 +10,9 @@ spec:
   podSelector:
     matchLabels:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: worker
+    matchExpressions:
+      - key: opengeni.ai/worker-role
+        operator: Exists
   policyTypes:
     {{- if .Values.networkPolicy.egress.enabled }}
     - Egress

--- a/deploy/helm/opengeni/templates/worker-service.yaml
+++ b/deploy/helm/opengeni/templates/worker-service.yaml
@@ -1,25 +1,30 @@
 {{- if .Values.worker.enabled }}
+{{- range $role := list "control" "turns" }}
+{{- if ne $role "control" }}
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "opengeni.fullname" . }}-worker
+  name: {{ include "opengeni.fullname" $ }}-worker-{{ $role }}
   labels:
-    {{- include "opengeni.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
-  {{- if ((.Values.observability).metrics).enabled }}
+    {{- include "opengeni.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker-{{ $role }}
+  {{- if (($.Values.observability).metrics).enabled }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/path: {{ ((.Values.observability).metrics).path | default "/metrics" | quote }}
-    prometheus.io/port: {{ (.Values.worker.service).port | default 8001 | quote }}
+    prometheus.io/path: {{ (($.Values.observability).metrics).path | default "/metrics" | quote }}
+    prometheus.io/port: {{ ($.Values.worker.service).port | default 8001 | quote }}
   {{- end }}
 spec:
-  type: {{ (.Values.worker.service).type | default "ClusterIP" }}
+  type: {{ ($.Values.worker.service).type | default "ClusterIP" }}
   ports:
-    - port: {{ (.Values.worker.service).port | default 8001 }}
+    - port: {{ ($.Values.worker.service).port | default 8001 }}
       targetPort: http
       protocol: TCP
       name: http
   selector:
-    {{- include "opengeni.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    {{- include "opengeni.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker-{{ $role }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
@@ -2,26 +2,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "opengeni.fullname" . }}-worker-control
+  name: {{ include "opengeni.fullname" . }}-worker-turns
   labels:
     {{- include "opengeni.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker-control
+    app.kubernetes.io/component: worker-turns
 spec:
-  replicas: {{ .Values.worker.control.replicaCount }}
-  {{- with .Values.worker.control.strategy }}
+  replicas: {{ .Values.worker.turns.replicaCount }}
+  {{- with .Values.worker.turns.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "opengeni.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: worker-control
+      app.kubernetes.io/component: worker-turns
   template:
     metadata:
       labels:
         {{- include "opengeni.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: worker-control
-        opengeni.ai/worker-role: control
+        app.kubernetes.io/component: worker-turns
+        opengeni.ai/worker-role: turns
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secret.create }}
@@ -65,19 +65,10 @@ spec:
             - name: OPENGENI_WORKER_HTTP_PORT
               value: {{ .Values.worker.containerPort | quote }}
             - name: OPENGENI_WORKER_ROLE
-              value: control
+              value: turn
             {{- if or .Values.postgres.enabled .Values.temporal.enabled .Values.minio.enabled }}
             {{- include "opengeni.generatedRuntimeEnv" . | nindent 12 }}
             {{- if .Values.minio.enabled }}
-            # Worker-only override: the worker performs SERVER-SIDE object-storage
-            # PUTs in-cluster (e.g. recording uploads) and mints NO browser-facing
-            # presigned URLs, so it must reach MinIO over the in-cluster Service. The
-            # shared OPENGENI_OBJECT_STORAGE_ENDPOINT emitted by generatedRuntimeEnv is
-            # the PUBLIC endpoint that api/web sign browser presigned URLs against; on
-            # managed deployments that host has no MinIO ingress route, so a server-side
-            # PUT there 401s (the recording-upload bug). A later duplicate env entry
-            # wins in a container env list, so this overrides ONLY the worker — api/web
-            # keep the public endpoint for browser uploads.
             - name: OPENGENI_OBJECT_STORAGE_ENDPOINT
               value: {{ include "opengeni.minioInternalEndpoint" . | quote }}
             {{- end }}
@@ -91,10 +82,10 @@ spec:
             {{- include "opengeni.httpProbe" (dict "probe" ((.Values.worker).probes).liveness) | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.worker.control.resources | nindent 12 }}
+            {{- toYaml .Values.worker.turns.resources | nindent 12 }}
       {{- if ((.Values.worker).topologySpreadConstraints).enabled }}
       topologySpreadConstraints:
-        {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "worker-control" "values" .Values.worker) | nindent 8 }}
+        {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "worker-turns" "values" .Values.worker) | nindent 8 }}
       {{- end }}
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -10,61 +10,43 @@ worker:
   image:
     tag: "RELEASE_TAG"
     digest: "sha256:WORKER_IMAGE_DIGEST"
-  # Memory sizing grounded in production measurement (2026-07-10): a single
-  # worker pod runs ~13 concurrent sessions plus ~17 sandbox clients, each
-  # session holding its full in-turn history (observed up to ~345k input
-  # tokens). Pods were OOMKilled (exit 137) against the 4Gi chart default
-  # repeatedly under fleet load; peak is spiky because serializing a large run
-  # state transiently copies it. Raise the limit to 6Gi (50% over the observed
-  # kill point) and raise the request toward the steady-state footprint so
-  # (a) the scheduler reserves realistically and (b) the memory-utilization HPA
-  # below is meaningful — HPA memory utilization is measured against the
-  # REQUEST, so a 1Gi request would read >100% and peg the HPA at max on the
-  # first sample. 6Gi (not 8Gi) keeps headroom on the ~16Gi nodes for api/relay/
-  # system pods; once proactive context compaction is fixed the histories — and
-  # thus this footprint — shrink further.
-  resources:
-    requests:
-      cpu: 500m
-      memory: 3Gi
-    limits:
-      cpu: "2"
-      memory: 6Gi
-  # Worker autoscaling was never enabled on this managed profile (the chart
-  # default is enabled:false and only relay opted in), so production ran a
-  # fixed 2 replicas while the fleet grew — the ~27-session load could not
-  # spread. Enable it here. The worker is MEMORY bound, not CPU bound (CPU
-  # stayed well under target while pods OOMed), so memory is the primary signal
-  # with CPU as a secondary load valve. Caveats this does NOT solve on its own,
-  # documented for operators: HPA scale-up is laggy and new pods only take NEW
-  # sessions, so it cannot rescue an already-hot pod — the limit headroom above
-  # and earlier context compaction are what prevent a single-pod OOM. The
-  # scaleDown stabilization keeps a transient dip from evicting a pod mid-turn
-  # (the 120s termination grace + PDB minAvailable:1 requeue survivors, but the
-  # graceful path loses less). minReplicas is 3, not 2: two pods at ~13 fat
-  # sessions each is exactly the density that OOMed, so the floor is cheap
-  # insurance that de-densifies deterministically without waiting on HPA
-  # scale-up (which only lands new sessions on new pods).
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 20
-    targetCPUUtilizationPercentage: 70
-    targetMemoryUtilizationPercentage: 80
-    customMetrics: []
-    behavior:
-      scaleUp:
-        stabilizationWindowSeconds: 60
-        policies:
-          - type: Pods
-            value: 2
-            periodSeconds: 60
-      scaleDown:
-        stabilizationWindowSeconds: 600
-        policies:
-          - type: Pods
-            value: 1
-            periodSeconds: 300
+  # Control workflows and short recovery activities are isolated from agent
+  # inference so a saturated turn fleet cannot starve Pause, Steer, or wakeup.
+  control:
+    replicaCount: 2
+  turns:
+    replicaCount: 4
+    # Turn pods hold the in-flight model history and sandbox clients. The
+    # per-pod activity cap is enforced by the worker process; these limits cover
+    # the measured transient serialization peak without granting control work
+    # the same oversized footprint.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 3Gi
+      limits:
+        cpu: "2"
+        memory: 6Gi
+    autoscaling:
+      enabled: true
+      minReplicas: 4
+      maxReplicas: 20
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
+      customMetrics: []
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 60
+          policies:
+            - type: Pods
+              value: 2
+              periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 600
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 300
 
 web:
   image:

--- a/deploy/helm/opengeni/values.local-kubernetes.example.yaml
+++ b/deploy/helm/opengeni/values.local-kubernetes.example.yaml
@@ -19,17 +19,25 @@ api:
       maxUnavailable: 1
 
 worker:
-  replicaCount: 1
   image:
     repository: opengeni-worker
     tag: local-k8s
     pullPolicy: IfNotPresent
   command: ["bun", "packages/testing/src/e2e-worker.ts"]
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+  control:
+    replicaCount: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
+  turns:
+    replicaCount: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
 
 web:
   replicaCount: 1

--- a/deploy/helm/opengeni/values.preview-managed.example.yaml
+++ b/deploy/helm/opengeni/values.preview-managed.example.yaml
@@ -11,12 +11,20 @@ api:
       maxUnavailable: 1
 
 worker:
-  replicaCount: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+  control:
+    replicaCount: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
+  turns:
+    replicaCount: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
 
 web:
   replicaCount: 1

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -185,12 +185,6 @@ api:
 
 worker:
   enabled: true
-  replicaCount: 2
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
   image:
     repository: opengeni-worker
     # Empty tag resolves to the chart appVersion via the opengeni.image helper.
@@ -199,13 +193,56 @@ worker:
     pullPolicy: IfNotPresent
   command: []
   containerPort: 8001
-  resources:
-    requests:
-      cpu: 500m
-      memory: 1Gi
-    limits:
-      cpu: "2"
-      memory: 4Gi
+  control:
+    replicaCount: 2
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: null
+      customMetrics: []
+      behavior: {}
+  turns:
+    replicaCount: 4
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    autoscaling:
+      enabled: false
+      minReplicas: 4
+      maxReplicas: 20
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: null
+      customMetrics: []
+      behavior: {}
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1000
@@ -250,27 +287,9 @@ worker:
       periodSeconds: 20
       timeoutSeconds: 2
       failureThreshold: 3
-  podDisruptionBudget:
-    enabled: true
-    minAvailable: 1
   service:
     type: ClusterIP
     port: 8001
-  autoscaling:
-    enabled: false
-    minReplicas: 2
-    maxReplicas: 20
-    targetCPUUtilizationPercentage: 70
-    # The worker is memory bound (each pod holds the full in-turn history for
-    # every session it runs), so CPU alone is a poor scaling signal — pods OOM
-    # long before CPU saturates. Set a memory target to scale on the pressure
-    # that actually matters; keep it high (headroom) and pair with a scaleDown
-    # stabilization window in `behavior` so a transient dip never evicts a pod
-    # mid-turn. Left null here so the default (disabled) install is unchanged;
-    # managed profiles opt in.
-    targetMemoryUtilizationPercentage: null
-    customMetrics: []
-    behavior: {}
 
 web:
   enabled: true

--- a/docs/design/session-control-plane-clean-cutover-2026-07-13.md
+++ b/docs/design/session-control-plane-clean-cutover-2026-07-13.md
@@ -10,7 +10,8 @@
 
 # OpenGeni session control-plane clean cutover
 
-Status: accepted implementation plan, pending code review and production proof
+Status: first clean-cutover implementation merged; production remediation amendment
+accepted after Fable rounds 29-31, pending implementation and production proof
 Scope: prompt queue, steer, session/workspace pause, current-inference recovery,
 internal updates, goals, compaction, timeline UI, worker deploy continuity, and
 removal of superseded runtime paths.
@@ -211,6 +212,57 @@ OpenGeni follows the official local path because cross-subscription portability 
 the premise of remote v2, not because the local algorithm is a preferred custom design.
 Model metadata remains versioned/resolved; the 272k/258.4k/244.8k values must be proven
 for the configured current Codex model rather than copied blindly to unrelated models.
+
+### 3.6 Why the first production cutover failed after the code deployed correctly
+
+The first production cutover run deployed the reviewed API, web, relay, worker, and
+0057 migration successfully. It then woke 80 durable sessions. The wake helper limited
+concurrent Temporal signals to 20, but signals are not the expensive operation. Every
+new session workflow immediately claimed database work and scheduled `runAgentTurn` on
+the same worker task queue as control/recovery activities. The worker had no explicit
+activity concurrency setting, so the Temporal TypeScript SDK admitted up to its default
+100 activities per pod. Three 2-CPU/6-GiB pods therefore admitted the entire heavyweight
+burst.
+
+This saturated the worker event loops, delayed the 10-second turn heartbeat beyond the
+two-minute heartbeat timeout, made readiness probes time out, and triggered the existing
+worker-death recovery loop. Recovery reparked and reclaimed work, amplifying the burst.
+The HPA reacted only after the damage and scaled from three toward seven pods. The wake
+receipt proved only that 80 signals were accepted; it did not prove that those sessions
+were stably enrolled or executing. At later samples the Cloudgeni workspace still held
+queued/recovering work while roughly two dozen turns ran.
+
+The production canary exposed the same contention without spending Azure model tokens.
+Its create request used the existing `codex/gpt-5.6-sol` subscription and durably returned
+HTTP 202 after 31.744 seconds, but the client aborted at its hardcoded 30-second timeout.
+The idempotently created session and turn completed correctly. Roughly 29 seconds were
+spent waiting behind workspace-row/database-pool contention before the first turn insert.
+This proves the endpoint was temporarily delayed, not permanently broken, and that the
+canary treated an ambiguous transport timeout as a definitive server failure.
+
+That one successful provider response also exposed a separate audit defect: the same
+response ID produced three authoritative `agent.model.usage` events and three usage log
+lines. Billing remained correct because its deterministic response-source idempotency key
+persisted one zero-cost Codex usage row and no credit debit. The timeline/audit stream did
+not have the same uniqueness boundary: repeated SDK completion-wrapper events each passed
+through runtime normalization and received a different producer sequence.
+
+The remediation is structural:
+
+1. isolate heavyweight turns in a separate process/deployment and Temporal task queue;
+2. cap turn activity admission explicitly;
+3. claim a turn only after a bounded turn-worker slot actually starts the activity;
+4. prove workflow enrollment and bounded progress rather than claimable-row disappearance;
+5. run the ambiguity-safe canary before waking the production backlog; and
+6. give provider-response usage one canonical producer plus a durable uniqueness
+   invariant that preserves duplicates as classified audit evidence.
+
+Fable rounds 29-31 reviewed these conclusions in the same durable Claude Code/Fable 5
+session. Round 29 caught that two Workers in one Node process would still share and starve
+one event loop. Round 30 caught false `running` state from pre-claim and the canary-before-
+wake ordering. Round 31 restored first-class attempt ownership, found the cutover strand
+for `requires_action` workflows, and specified the durable usage-classification boundary.
+All three ended `SHIP-TO-IMPLEMENT`; later rounds explicitly corrected earlier mistakes.
 
 ## 4. Locked product semantics
 
@@ -570,17 +622,90 @@ unknown)” with debug detail; it is not hidden. Repeated real recoveries remain
 
 ## 9. Claim and control ordering
 
-For an active, workspace-eligible session, one transaction chooses work in this order:
+Temporal scheduling and database ownership have separate meanings:
+
+- a running session workflow means the durable session state is enrolled for handling;
+- a scheduled `runAgentTurn` activity may still be waiting for bounded turn capacity;
+- a database turn becomes `running` only when the turn worker has received a slot and its
+  claim transaction registers the exact attempt;
+- queued and recovering state therefore remain truthful while the activity waits in
+  Temporal, and the UI never needs or shows a second machine-work queue.
+
+The workflow mints a replay-deterministic `attemptId` before scheduling a turn activity.
+The activity input does not trust a selected turn ID:
+
+```ts
+type RunAgentTurnInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  workflowId: string;
+  attemptId: string;
+  trigger: { kind: "next" } | { kind: "approval"; triggerEventId: string };
+};
+```
+
+Normal work uses `next`, so a Steer that lands before the turn slot is granted changes
+the durable head and the eventual claim selects that new head. Approval uses the durable
+decision event ID; the database derives and validates the matching current
+`requires_action` turn. No caller-selected turn ID can resurrect a superseded approval.
+
+For an active, workspace-eligible session, the turn-slot claim transaction chooses work
+in this order:
 
 1. recover the nonterminal current inference;
-2. claim the first submitted prompt;
-3. start one combined update/goal continuation if eligible;
-4. otherwise remain idle.
+2. resume a current `requires_action` inference only from its accepted durable approval;
+3. resume a capacity-waiting inference whose durable waiter has been released;
+4. claim the first submitted prompt;
+5. consume an idle manual-compaction request;
+6. start one combined update/goal continuation if eligible;
+7. otherwise return a typed unclaimed result without changing the database.
 
-Pause eligibility is checked before all four. A pending control cancellation must settle
-or be reconciled by the claim path before a new attempt owns the same current inference.
-No deadline, machine lane, role lane, or invisible promotion can reorder the visible
-prompt queue.
+Pause eligibility is checked before every choice. The transaction takes the established
+workspace-then-session-then-turn lock order, advances the execution generation, sets
+`active_attempt_id = attemptId`, stores the Temporal dispatch identity, and changes the
+turn/session to `running` atomically. This is the only supported transition into running.
+The first heartbeat repeats that receipt for liveness and observability, but the database
+attempt fence—not a heartbeat—is ownership authority.
+
+A lightweight read-only peek keeps idle or waiting workflows from consuming turn slots:
+
+```ts
+type SessionWorkPeek =
+  | { kind: "runnable" }
+  | { kind: "approval-pending"; triggerEventId: string }
+  | { kind: "approval-wait" }
+  | { kind: "capacity-wait"; ref: CodexCapacityWaitRef }
+  | { kind: "fence-settle"; controlEventId: string }
+  | { kind: "idle" };
+```
+
+Peek is advisory; the later locked claim is authoritative. A Pause before slot grant
+closes the gate and leaves the prompt queued or current inference recovering/awaiting
+approval. A Steer before slot grant supersedes the current inference and changes the head.
+An approval decision is persisted atomically before its Temporal nudge; start-or-signal
+can therefore recreate a missing workflow and let peek rediscover the decision after
+cutover, worker loss, or continue-as-new.
+
+Transport failure recovery also keys on the workflow-minted attempt, never just the
+session or current turn:
+
+```ts
+type RecoverDispatchOutcome =
+  | { kind: "unclaimed" }
+  | { kind: "reparked"; turnId: string }
+  | { kind: "exceeded"; turnId: string }
+  | { kind: "stale" };
+```
+
+`unclaimed` means the activity never registered its attempt and therefore changes no
+row and consumes no redispatch budget. `reparked` and `exceeded` require the exact current
+attempt/dispatch owner under one lock transaction. `stale` means a successor or terminal
+settlement owns the truth. There is no second catch-all settlement.
+
+A pending control cancellation must settle or be identified as stale before another
+attempt owns the inference. No deadline, machine lane, role lane, or invisible promotion
+can reorder the visible prompt queue.
 
 ## 10. Clean production cutover
 
@@ -601,9 +726,11 @@ Azure infrastructure access is allowed, but Azure model-token use is prohibited.
    using the existing durable Fable session.
 6. Merge the reviewed public implementation to `main`; pin the exact public revision in
    the private production workflow.
-7. Produce a preflight report with image digests, migration checksum, expected schema,
-   production namespace/context, and proof that no Azure model endpoint is configured for
-   the validation calls.
+7. Produce a preflight report with image digests, the exact ordered migration list
+   (`0057` and `0058`) and per-file checksums, expected schema, production
+   namespace/context, worker roles/caps, and proof that no Azure model endpoint is
+   configured for the validation calls. The former single-migration field is deleted;
+   no compatibility request shape is accepted.
 8. Assert that the `@openai/agents` SDK serialization version is identical before and
    after the cutover. Saved `requires_action` RunState is version-bound; an SDK upgrade is
    not part of this release, and a mismatch aborts before maintenance rather than adding
@@ -629,35 +756,83 @@ Store the report durably in the private release evidence location. Do not print 
 1. Enable a single production maintenance/admission gate that rejects new Send/Steer/
    Resume/manual-compact/goal-start claims with a truthful retry response while leaving
    reads available.
-2. Pause Temporal Schedules and signal workers to gracefully preempt active inferences.
-   Stop new claims. Permit each activity up to the existing 120-second termination grace
-   to checkpoint and release ownership. The migration's fail-closed unknown-row check
-   catches anything written during the drain window.
-3. Verify no activity still owns a current inference. Any non-acknowledging attempt is
-   marked recovering under its generation fence; its late writes remain diagnostic only.
-4. Terminate the drained old `session-*` Temporal workflow executions. Postgres durable
-   state is the recovery truth; no old workflow history may require removed activity or
-   `patched()` code. This is also the hard history boundary for replacing the prior
-   queue-named Temporal activity type with `claimNextSessionExecution`: activity type
-   strings are recorded in workflow history, so the new worker registers only the new
-   name after every history containing the prior name is terminated. No alias, dual
-   registration, or compatibility branch is shipped.
-5. Scale the old worker fleet to zero and prove no old public revision remains able to
-   claim work.
-6. Apply one-way schema/data migration:
-   - convert legitimate unstarted human queue rows to the single prompt queue/order;
-   - convert active/requeued execution attempts to current inference + recovering state;
-   - move pending machine queue data to typed update rows or goal state;
-   - preserve order, IDs, events, inactive history, attempts, approvals, and audit data;
-   - establish workspace pause generations/exceptions;
-   - assert no active remote-compaction rows and no unclassified legacy queue row;
-   - drop old columns, constraints, enums, and tables after the assertions pass.
-7. Deploy API/web/worker code containing only the new semantics and exact public revision.
-8. Start fresh Temporal workflows from Postgres truth and run one generalized wake-repair
-   scan covering current recoveries, queued prompts, pending updates, active goals, and
-   capacity waiters.
-9. Remove maintenance admission and resume Temporal Schedules only after health, schema,
-   version, and claim-invariant checks pass.
+2. Pause Temporal Schedules. Drain the old worker deployment to zero and allow its
+   existing 120-second termination grace to checkpoint current attempts. The drain
+   receipt must prove zero controller, ready, available, and updated worker replicas.
+3. Inspect and terminate every running `session-*` Temporal workflow. Postgres is the
+   durable recovery truth; no old history may replay changed activity routing. The
+   termination receipt must prove no matching workflow remains running.
+4. Apply the exact ordered migrations while all workers and session workflows remain
+   stopped. `0057` is already recorded in the failed first cutover and therefore no-ops;
+   `0058` adds the final event columns and workflow-enrollment contract required by the
+   current operator code.
+   `0058`:
+   - adds classified duplicate-usage association and duplicate pointers/reasons;
+   - reclassifies existing duplicate usage rows while retaining the earliest event as
+     current evidence;
+   - creates the partial uniqueness index for current turn/source usage; and
+   - installs the enrollable-session scan that includes queued, recovering,
+     waiting-capacity, requires-action, pending-update, active-goal, and stale-control-
+     fence sessions.
+5. Run the distinct evidence-writing `repark-orphaned-turns` operator action. It refuses
+   unless workflow termination is complete and both migrations are present. Under database
+   locks it changes orphaned
+   `running` turns to `recovering`, exact-matching either the registered attempt or the
+   null-owner residue created when an old worker ran after the partially applied `0057`,
+   clears any attempt owner, restores matching session status/pointers, and leaves queued
+   prompt rows and positions untouched. This is not a prompt enqueue and not a legacy
+   rollback.
+6. Capture and reconcile the migrated snapshot before starting any new worker. Migration
+   reconciliation must preserve all baseline identities, prompt order, run state,
+   approvals, updates, history, and sandbox routing.
+7. Deploy the exact API/web/relay images and split the worker image into two separate
+   process/deployment roles:
+   - **control worker**: workflow tasks and every short/control/recovery activity, never
+     `runAgentTurn`, with explicit workflow/activity/cache caps;
+   - **turn worker**: derived `<control-task-queue>-turns`, only `runAgentTurn`, explicit
+     fixed concurrency eight per pod, its own resources, HPA, PDB, service, readiness,
+     liveness, and termination grace.
+
+   Both roles use one Worker per process. No same-process dual Worker, SDK default slot
+   count, resource tuner, semaphore, activity alias, or dual-routing fallback ships.
+8. Start turn workers before control workers, then prove both deployments are fully ready
+   on the reviewed digest and expose the configured role/cap in startup evidence.
+9. Run the production Codex canary **before** waking the backlog. It calls the internal API
+   service while public ingress remains in maintenance, uses only the workspace's existing
+   Codex subscription, retries ambiguous create/network/5xx outcomes with the same
+   idempotency key inside one overall deadline, and records per-attempt/stage timing. Its
+   temporary key TTL is derived from the deadline plus cleanup buffer.
+10. The canary must prove all of the following before continuing:
+    - its session remains queued until a turn slot actually claims it;
+    - `running` implies a registered attempt on a turn worker;
+    - the exact requested Codex model/provider returned the marker;
+    - one provider response source has exactly one current authoritative usage event;
+    - the billing ledger contains its one idempotent zero-cost Codex marker and no credit
+      debit; and
+    - no Azure model deployment/token endpoint was invoked.
+11. Wake v2 replaces wake v1. Scan the enrollable set once, signal-with-start every
+    workflow (bounded signal concurrency is acceptable because signals are cheap), and
+    verify enrollment rather than waiting for all work to finish:
+    - every initially enrollable session has a running expected workflow or became
+      durably ineligible/terminal through authoritative progress;
+    - approval and capacity waiters remain truthfully waiting with live workflows;
+    - stale control fences are settled;
+    - turn starts/progress reach the configured global turn capacity when enough runnable
+      work exists, while DB `running` count never exceeds that bound; and
+    - a stability window longer than the heartbeat timeout shows ready workers and no new
+      heartbeat-timeout recovery storm.
+
+    Claimable rows need not reach zero: a prompt/recovery waiting behind bounded turn
+    capacity deliberately remains queued/recovering and truthful while its workflow is
+    enrolled. Maintenance never waits days for long agents to drain.
+12. Capture final state, reconcile every baseline fate, usage uniqueness, enrollment, and
+    the read-only storm-casualty report. Production evidence observed no post-storm
+    redispatch-ceiling casualty requiring mutation, so the explicit policy is
+    `preserve_failed`; no automatic resurrection path exists.
+13. Resume only the schedules paused by this exact cutover, restore the production API
+    ingress, delete maintenance resources, and verify the complete production workload
+    set and exact images. The immutable failed run remains audit evidence; this remediation
+    uses a new app/ops-SHA-derived idempotency key.
 
 There is no automated reverse migration. If a catastrophic infrastructure problem occurs
 before destructive migration, stop before step 6. After step 6, restore the reviewed
@@ -674,6 +849,8 @@ Verify:
 - Enter appends in server/UI order.
 - Cmd/Ctrl+Enter head-inserts and interrupts current inference.
 - repeated steer during cancellation is accepted and newest-first.
+- a queued prompt remains visibly queued while its Temporal turn activity waits for a
+  bounded turn-worker slot; it changes to running only with a registered attempt.
 - Pause interrupts and prevents every claim source. Send while paused stays inert and
   Resume continues the same inference before the appended prompt. Steer while paused
   durably supersedes that inference and stays inert; Resume runs the steered prompt first.
@@ -693,7 +870,13 @@ Verify:
   a product dependency.
 - worker restart/deploy recovery continues the same durable current inference and closes
   interrupted tool calls truthfully.
+- a requires-action session survives workflow termination, re-enrolls in approval-wait,
+  and a durable approval decision starts or signals its workflow exactly once.
+- capacity-waiting and stale-control-fence sessions re-enroll without becoming prompts.
 - stale-attempt output appears only as rejected-late diagnostics.
+- every provider response source has at most one current usage event; repeated SDK
+  wrappers or recovered observations are retained only as classified duplicate evidence,
+  never as another authoritative usage row or authoritative usage log line.
 - real sandbox lifecycle events have operation identity/origin and no compaction-induced
   duplicates.
 
@@ -725,7 +908,15 @@ new fake user message, regress its goal, or remain owned by the old revision.
 - Workspace generation exceptions, new-pause invalidation, and interruption of a live
   non-exempt session attempt.
 - Exactly one current inference and one owning attempt.
+- Claim and attempt registration are one transaction executed only after turn-slot grant;
+  failure before claim is typed unclaimed and consumes no redispatch budget.
+- Exact-attempt recovery returns unclaimed/reparked/exceeded/stale under one ownership
+  lock and never chains a catch-all settlement.
 - Atomic settlement and late-event non-authority.
+- Durable approval acceptance, start-or-signal revival, approval-vs-pause/steer, and
+  approval-wait restoration after terminate/continue-as-new.
+- Current model-usage uniqueness by turn/source, in-batch duplicate classification,
+  cross-attempt duplicate classification, and unchanged rejected-late semantics.
 - Exactly-once update delivery and at-most-one update continuation.
 - Goal/update co-claim and human-first ordering.
 - One-way legacy data classification with fail-closed unknown rows.
@@ -750,10 +941,16 @@ new fake user message, regress its goal, or remain owned by the old revision.
 
 - graceful preemption within termination grace and same-turn redispatch.
 - tool-call interrupted result and uncertain-side-effect recovery context.
-- generalized wake repair for every claim source.
+- separate control and turn deployments/processes/task queues with explicit caps; no
+  `runAgentTurn` registration in the control process and no control activity in the turn
+  process.
+- deterministic derived turn queue for production and randomized integration test queues.
+- generalized enrollment repair for runnable, approval-wait, capacity-wait, updates,
+  goals, and stale fences; enrollment/progress proof does not require backlog drain.
 - old Temporal workflows cannot execute after code deletion.
-- private workflow enforces one public revision, one migration checksum, maintenance
-  ordering, baseline/final reconciliation, and Azure-model-token prohibition.
+- private workflow enforces one public revision, exact ordered migration hashes,
+  repark/canary-before-wake ordering, worker roles/capacity, baseline/final reconciliation,
+  and Azure-model-token prohibition.
 - no `legacy`, `durable_v1`, reverse-conversion, or staging-evidence branch remains.
 
 ### UI
@@ -772,26 +969,67 @@ temporary runtime fallback.
 1. **Reconcile branch and preserve good OPE-22 foundations**: merge current `main`, audit
    dirty queue-removal work, retain atomic settlement/generation/capacity/audit fixes.
 2. **Schema and state model**: new prompt/current/update/workspace-generation concepts,
-   shared runnable predicate, one-way migration, removal of legacy schema.
+   shared runnable predicate, one-way 0057 migration, classified current/duplicate/late
+   usage evidence and enrollable-session 0058 migration, removal of legacy schema.
 3. **Send/Steer/Pause/Resume APIs**: one transaction per control, delete-only queue,
    remove aliases and alternate mutation APIs.
-4. **Worker claim loop**: rename the complete domain/activity operation to
-   `claimNextSessionExecution`; current inference recovery first, then prompt, then combined
-   update/goal continuation; no machine queue work.
-5. **Attempt ownership and recovery**: generation/attempt fences, interrupted tool result,
-   rejected-late diagnostics, graceful deploy checkpoint.
+4. **Worker claim loop and admission**: split control/turn task queues and deployments;
+   make read-only peek drive the workflow; claim and register the exact attempt only inside
+   the bounded turn-slot activity; recover current inference, approval/capacity state,
+   prompt, compaction, then combined update/goal continuation; no machine queue work or
+   false running state.
+5. **Attempt ownership and recovery**: generation/attempt/dispatch fences from claim t0,
+   typed unclaimed/reparked/exceeded/stale transport recovery, interrupted tool result,
+   rejected-late diagnostics, graceful deploy checkpoint, durable approval revival.
 6. **Codex 0.144.4 compaction**: official local semantics, allocator integration,
    transactional history replacement, removal of all alternate paths.
 7. **Workspace control**: pause generation, explicit per-session run, removal of kill and
    fan-out state rewriting.
 8. **React/SDK cleanup**: one composer queue, exact server order, compact goal/agents,
    one Pause control, precise sandbox lifecycle UI.
-9. **Private ops clean cutover**: replace the dirty legacy rollback workflow/scripts with
-   maintenance drain, baseline, one-way migration, wake repair, and final reconciliation.
+9. **Private ops clean cutover**: exact 0057+0058 migration list; maintenance drain;
+   workflow termination; evidence-writing repark; split-worker deployment; ambiguity-safe
+   canary before fleet wake; enrollment/progress wake v2; final reconciliation.
 10. **Review and production proof**: Fable implementation review, UBS, complete local
     matrix, merge, production cutover, bounded subscription canary, all-session audit.
 11. **Canonical docs and cleanup**: update current-tier lifecycle, deployment, SDK, and
     rotation docs; archive incident evidence; verify no obsolete symbol/string/path remains.
+
+### 12.1 Remediation dependency graph
+
+The second production attempt follows this dependency graph; a later node must not be
+implemented or released against a provisional predecessor contract:
+
+```text
+R1 production evidence + Fable architecture verdict
+ ├─> R2 0058 schema/event/enrollment contract
+ │    ├─> R3 attempt-owned late claim + peek/recovery DB functions
+ │    │    ├─> R4 workflow/API approval-capacity-control state machine
+ │    │    └─> R5 isolated control/turn workers + chart topology
+ │    └─> R6 canonical usage producer + durable classifier
+ ├─> R7 canary retry/truth/uniqueness contract (depends on R3,R5,R6)
+ ├─> R8 repark + wake-v2 enrollment/progress operator (depends on R2-R5)
+ └─> R9 public full verification and serialized Fable implementation review
+      └─> R10 public merge + immutable image build
+           └─> R11 private ops v2 contract/driver/workflow (depends on R7,R8,R10)
+                └─> R12 private tests + Fable release review + merge/build
+                     └─> R13 production remediation cutover
+                          └─> R14 production continuity/UI/runtime audit
+                               └─> R15 Linear/docs/learning/worktree closure
+```
+
+R2 blocks all runtime code because its event and enrollment shapes are the durable
+contract. R3 blocks the workflow and deployment split because the separate queue would
+otherwise create false running state. R5 and R6 block the canary because the canary is
+the proof of those exact mechanisms. Public main and immutable images block private ops
+request assembly; the private workflow never points at a branch or mutable tag. Production
+is the only deployed verification environment for this amendment, but every deterministic
+and real-service local suite remains a prerequisite.
+
+The repository does not contain the `br`/beads tool, so this graph remains canonical in
+this plan and the active Codex goal/plan state rather than being copied into an unavailable
+parallel task database. Linear remains issue-level coordination, not the execution source
+of truth for the live maintenance run.
 
 ## 13. Linear reconciliation
 
@@ -822,7 +1060,8 @@ The work is not finished until all of the following are true:
 - the exact reviewed revision is deployed to production with no staging deployment;
 - no Azure model tokens were used;
 - production canary verifies queue, steer, pause, workspace exception, updates/goals,
-  recovery, compaction, rotation, UI, sandbox evidence, and late diagnostics;
+  truthful late claim, recovery, approval/capacity enrollment, compaction, rotation, unique
+  usage, UI, sandbox evidence, and late diagnostics;
 - every pre-cutover live session has a reconciled post-cutover fate;
 - all production workloads are healthy and only the new revision can claim work;
 - canonical current-tier docs match the shipped system;

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
-    "@codemirror/view": "^6.43.1",
+    "@codemirror/view": "^6.43.6",
     "@pierre/trees": "1.0.0-beta.4",
-    "@uiw/react-codemirror": "^4.25.10"
+    "@uiw/react-codemirror": "^4.25.11"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.10.2",
-    "@changesets/cli": "^2.27.11",
+    "@changesets/cli": "^2.31.0",
     "@opengeni/agent-proto": "workspace:*",
     "@opengeni/api-router": "workspace:*",
     "@opengeni/config": "workspace:*",
@@ -91,14 +91,29 @@
     "@opengeni/storage": "workspace:*",
     "@opengeni/testing": "workspace:*",
     "@opengeni/worker-bundle": "workspace:*",
-    "@temporalio/client": "^1.17.0",
-    "@temporalio/worker": "^1.17.0",
-    "@types/bun": "^1.3.4",
+    "@temporalio/client": "^1.20.2",
+    "@temporalio/worker": "^1.20.2",
+    "@types/bun": "^1.3.14",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "oxfmt": "0.58.0",
     "oxlint": "1.73.0",
-    "playwright": "^1.57.0",
+    "playwright": "^1.61.1",
     "postgres": "^3.4.9",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "@grpc/grpc-js": "1.14.4",
+    "dompurify": "3.4.12",
+    "esbuild": "0.25.0",
+    "form-data": "4.0.6",
+    "hono": "4.12.30",
+    "ip-address": "10.2.0",
+    "js-yaml": "3.15.0",
+    "mermaid": "11.16.0",
+    "protobufjs": "7.6.5",
+    "qs": "6.15.3",
+    "uuid": "11.1.1",
+    "vite": "8.1.4",
+    "ws": "8.21.1"
   }
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4014,7 +4014,9 @@ export const SessionEvent = z.object({
   turnId: z.string().uuid().nullable().optional(),
   turnGeneration: z.number().int().nonnegative().nullable().optional(),
   turnAttemptId: z.string().uuid().nullable().optional(),
-  turnAssociation: z.enum(["current", "late_rejected"]).nullable().optional(),
+  turnAssociation: z.enum(["current", "late_rejected", "duplicate"]).nullable().optional(),
+  duplicateOfEventId: z.string().uuid().nullable().optional(),
+  duplicateReason: z.string().min(1).nullable().optional(),
 });
 export type SessionEvent = z.infer<typeof SessionEvent>;
 

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -31,6 +31,8 @@ export type SessionWorkflowClient = {
     wakeRevision: number;
   }) => Promise<void>;
   signalApprovalDecision: (input: {
+    accountId: string;
+    workspaceId: string;
     sessionId: string;
     eventId: string;
     workflowId: string;

--- a/packages/core/src/sandbox-types.ts
+++ b/packages/core/src/sandbox-types.ts
@@ -42,9 +42,9 @@ export type ApiSandboxSession = {
 
 export type ApiSandboxClient = {
   backendId: string;
-  deserializeSessionState?(state: Record<string, unknown>): Promise<unknown>;
-  resume?(state: unknown, options?: unknown): Promise<ApiSandboxSession>;
-  delete?(state: unknown): Promise<void>;
+  deserializeSessionState?(state: Record<string, unknown>): Promise<Record<string, unknown>>;
+  resume?(state: Record<string, unknown>, options?: unknown): Promise<ApiSandboxSession>;
+  delete?(state: Record<string, unknown>): Promise<void>;
 };
 
 export type ResumeBoxByIdInput = {

--- a/packages/db/drizzle/0058_turn_admission_usage_enrollment.sql
+++ b/packages/db/drizzle/0058_turn_admission_usage_enrollment.sql
@@ -1,0 +1,158 @@
+-- One-way production remediation after the 0057 session-control cutover.
+--
+-- 1. Provider response usage has exactly one authoritative current event. SDK
+--    wrapper duplicates stay in the audit log with an explicit association.
+-- 2. Workflow repair enrolls every durable state that needs a session workflow,
+--    including approval/capacity waits and pending control settlement.
+
+ALTER TABLE "session_events"
+  DROP CONSTRAINT "session_events_turn_association_check";
+
+ALTER TABLE "session_events"
+  ADD COLUMN "duplicate_of_event_id" uuid,
+  ADD COLUMN "duplicate_reason" text;
+
+ALTER TABLE "session_events"
+  ADD CONSTRAINT "session_events_duplicate_of_event_fk"
+  FOREIGN KEY ("duplicate_of_event_id")
+  REFERENCES "session_events"("id") ON DELETE RESTRICT;
+
+ALTER TABLE "session_events"
+  ADD CONSTRAINT "session_events_turn_association_check"
+  CHECK (
+    "turn_association" IS NULL
+    OR "turn_association" IN ('current', 'late_rejected', 'duplicate')
+  );
+
+-- Keep the earliest event as the authoritative observation. Every later event
+-- for the same turn/provider-response source remains queryable and points to
+-- that canonical row; nothing is deleted or disguised as a late attempt write.
+WITH ranked AS (
+  SELECT
+    e."id",
+    first_value(e."id") OVER (
+      PARTITION BY
+        e."workspace_id",
+        e."session_id",
+        e."turn_id",
+        e."payload" ->> 'sourceKey'
+      ORDER BY e."sequence", e."id"
+    ) AS "canonical_id",
+    row_number() OVER (
+      PARTITION BY
+        e."workspace_id",
+        e."session_id",
+        e."turn_id",
+        e."payload" ->> 'sourceKey'
+      ORDER BY e."sequence", e."id"
+    ) AS "ordinal"
+  FROM "session_events" e
+  WHERE e."type" = 'agent.model.usage'
+    AND e."turn_association" = 'current'
+    AND e."turn_id" IS NOT NULL
+    AND nullif(e."payload" ->> 'sourceKey', '') IS NOT NULL
+)
+UPDATE "session_events" e
+SET "turn_association" = 'duplicate',
+    "duplicate_of_event_id" = ranked."canonical_id",
+    "duplicate_reason" = 'duplicate_provider_response_usage'
+FROM ranked
+WHERE e."id" = ranked."id"
+  AND ranked."ordinal" > 1;
+
+ALTER TABLE "session_events"
+  ADD CONSTRAINT "session_events_duplicate_classification_check"
+  CHECK (
+    (
+      "turn_association" = 'duplicate'
+      AND "type" = 'agent.model.usage'
+      AND "duplicate_of_event_id" IS NOT NULL
+      AND "duplicate_of_event_id" <> "id"
+      AND nullif("duplicate_reason", '') IS NOT NULL
+    )
+    OR (
+      "turn_association" IS DISTINCT FROM 'duplicate'
+      AND "duplicate_of_event_id" IS NULL
+      AND "duplicate_reason" IS NULL
+    )
+  );
+
+CREATE UNIQUE INDEX "session_events_current_model_usage_source_uq"
+  ON "session_events" (
+    "workspace_id",
+    "session_id",
+    "turn_id",
+    (("payload" ->> 'sourceKey'))
+  )
+  WHERE "type" = 'agent.model.usage'
+    AND "turn_association" = 'current'
+    AND "turn_id" IS NOT NULL
+    AND nullif("payload" ->> 'sourceKey', '') IS NOT NULL;
+
+-- The old name described database claimability, not the actual operational
+-- contract. A workflow must also be enrolled while it waits for approval or
+-- capacity, and any pending Pause/Steer control needs a workflow to settle it.
+DROP FUNCTION opengeni_private.list_claimable_sessions(integer);
+
+CREATE FUNCTION opengeni_private.list_enrollable_sessions(p_limit integer)
+RETURNS TABLE (
+  account_id uuid,
+  workspace_id uuid,
+  session_id uuid,
+  temporal_workflow_id text
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT DISTINCT
+    s.account_id,
+    s.workspace_id,
+    s.id,
+    coalesce(s.temporal_workflow_id, 'session-' || s.id::text)
+  FROM sessions s
+  JOIN workspaces w ON w.id = s.workspace_id
+  WHERE
+    -- Controls are durable intent. Even a closed inference gate must enroll a
+    -- workflow long enough to settle the pending Pause/Steer fence.
+    s.pending_control_event_id IS NOT NULL
+    OR (
+      s.control_state = 'active'
+      AND (
+        w.inference_state = 'active'
+        OR s.workspace_run_exception_generation = w.inference_generation
+      )
+      AND (
+        EXISTS (
+          SELECT 1 FROM session_turns t
+          WHERE t.workspace_id = s.workspace_id
+            AND t.session_id = s.id
+            AND t.status IN ('queued', 'recovering', 'waiting_capacity', 'requires_action')
+        )
+        OR EXISTS (
+          SELECT 1 FROM session_system_updates u
+          WHERE u.workspace_id = s.workspace_id
+            AND u.session_id = s.id
+            AND u.state = 'pending'
+        )
+        OR EXISTS (
+          SELECT 1 FROM session_goals g
+          WHERE g.workspace_id = s.workspace_id
+            AND g.session_id = s.id
+            AND g.status = 'active'
+        )
+      )
+    )
+  ORDER BY s.id
+  LIMIT greatest(1, least(coalesce(p_limit, 1000), 10000));
+$$;
+
+REVOKE ALL ON FUNCTION opengeni_private.list_enrollable_sessions(integer) FROM PUBLIC;
+
+DO $$
+DECLARE target_schema text := current_schema();
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.list_enrollable_sessions(integer)
+      TO opengeni_app;
+  END IF;
+END $$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1577,7 +1577,9 @@ export type AppendEventInput = {
   turnId?: string | null;
   turnGeneration?: number | null;
   turnAttemptId?: string | null;
-  turnAssociation?: "current" | "late_rejected" | null;
+  turnAssociation?: "current" | "late_rejected" | "duplicate" | null;
+  duplicateOfEventId?: string | null;
+  duplicateReason?: string | null;
   producerId?: string;
   producerSeq?: number;
   occurredAt?: Date;
@@ -12987,7 +12989,7 @@ export async function listOpenPtySessions(
 // double-spawn guard is the UNIQUE (workspace_id, sandbox_group_id) index +
 // plain SELECT … FOR UPDATE (block, NOT skip-locked) + the cold->warming CAS
 // inside that row lock. lease_epoch is integer (returns a JS number) but every
-// read is Number()-coerced defensively. Mirrors the claimNextSessionExecution
+// read is Number()-coerced defensively. Mirrors the atomic turn-admission
 // withWorkspaceRls/withRlsContext -> scopedDb.transaction -> tx.execute(sql<T>``)
 // pattern (the row type goes on the sql tag, not on .execute).
 // ============================================================================
@@ -13267,7 +13269,7 @@ export async function acquireLease(
       `);
 
         // (2) Serialize ALL concurrent arrivals on this group's row. Plain FOR
-        // UPDATE (block, do NOT skip) — unlike claimNextSessionExecution's SKIP LOCKED,
+        // UPDATE (block, do NOT skip) — unlike concurrent enrollment scans,
         // because we WANT the loser to block then attach, not skip and lose.
         const rows = await tx.execute<LeaseRow>(sql`
         select * from sandbox_leases
@@ -17568,12 +17570,35 @@ export async function enqueueSessionTurn(
   );
 }
 
-export async function claimNextSessionExecution(
+export type SessionWorkTrigger = { kind: "next" } | { kind: "approval"; triggerEventId: string };
+
+export type ClaimSessionWorkForAttemptInput = {
+  sessionId: string;
+  workflowId: string;
+  attemptId: string;
+  dispatchId: string;
+  trigger: SessionWorkTrigger;
+};
+
+export type ClaimSessionWorkForAttemptResult =
+  | { action: "claimed"; turn: SessionTurn }
+  | {
+      action: "unclaimed";
+      reason: "gate-closed" | "no-work" | "stale-approval" | "control-pending";
+    };
+
+/**
+ * Claim and register one inference attempt after a turn worker has accepted the
+ * Temporal activity. This is the only transition into `running`: queue choice,
+ * execution generation, active attempt identity, dispatch identity, and the
+ * session's public state commit atomically under the workspace/session lock.
+ */
+export async function claimSessionWorkForAttempt(
   db: Database,
   workspaceId: string,
-  sessionId: string,
-  workflowId: string,
-): Promise<SessionTurn | null> {
+  input: ClaimSessionWorkForAttemptInput,
+): Promise<ClaimSessionWorkForAttemptResult> {
+  const { sessionId, workflowId } = input;
   return await withWorkspaceRls(
     db,
     workspaceId,
@@ -17582,6 +17607,7 @@ export async function claimNextSessionExecution(
         const deliverPendingUpdates = async (
           accountId: string,
           turnId: string,
+          turnGeneration: number,
           nextSequence: number,
           occurredAt: Date,
           triggerEventId?: string,
@@ -17666,6 +17692,9 @@ export async function claimNextSessionExecution(
             workspaceId,
             sessionId,
             turnId,
+            turnGeneration,
+            turnAttemptId: input.attemptId,
+            turnAssociation: "current",
             sequence: nextSequence,
             type: "system.update.delivered",
             payload: sanitizeEventPayload({
@@ -17704,14 +17733,12 @@ export async function claimNextSessionExecution(
           )
           .for("update")
           .limit(1);
-        if (!workspace || !session) {
-          return null;
-        }
+        if (!workspace || !session) return { action: "unclaimed", reason: "no-work" };
         const workspaceAllowsRun =
           workspace.inferenceState === "active" ||
           session.workspaceRunExceptionGeneration === workspace.inferenceGeneration;
         if (!workspaceAllowsRun || session.controlState !== "active") {
-          return null;
+          return { action: "unclaimed", reason: "gate-closed" };
         }
         if (session.activeTurnId !== null) {
           const [activeTurn] = await tx
@@ -17726,8 +17753,90 @@ export async function claimNextSessionExecution(
             )
             .for("update")
             .limit(1);
-          if (activeTurn?.status === "recovering") {
+          const parsedDispatch = readTurnDispatchMetadata(activeTurn?.metadata);
+          if (parsedDispatch.kind === "malformed") {
+            throw new Error(`Malformed turn dispatch metadata: ${parsedDispatch.reason}`);
+          }
+          if (
+            activeTurn?.status === "running" &&
+            activeTurn.activeAttemptId === input.attemptId &&
+            parsedDispatch.attempt?.id === input.dispatchId
+          ) {
+            return { action: "claimed", turn: mapSessionTurn(activeTurn) };
+          }
+          if (session.pendingControlEventId) {
+            return { action: "unclaimed", reason: "control-pending" };
+          }
+          if (activeTurn?.status === "requires_action") {
+            if (input.trigger.kind !== "approval") {
+              return { action: "unclaimed", reason: "no-work" };
+            }
+            const advancesApproval = await isNewerApprovalTrigger(
+              tx as unknown as Database,
+              workspaceId,
+              sessionId,
+              activeTurn.triggerEventId,
+              input.trigger.triggerEventId,
+            );
+            if (!advancesApproval) {
+              return { action: "unclaimed", reason: "stale-approval" };
+            }
+            if (parsedDispatch.generation >= Number.MAX_SAFE_INTEGER) {
+              throw new Error("Turn dispatch generation exhausted; refusing to wrap or reuse it");
+            }
             const now = new Date();
+            const dispatchGeneration = parsedDispatch.generation + 1;
+            await tx.execute(sql`set local opengeni.session_inference_claim = '1'`);
+            const [resumed] = await tx
+              .update(schema.sessionTurns)
+              .set({
+                status: "running",
+                triggerEventId: input.trigger.triggerEventId,
+                temporalWorkflowId: workflowId,
+                executionGeneration: sql`${schema.sessionTurns.executionGeneration} + 1`,
+                activeAttemptId: input.attemptId,
+                metadata: metadataWithTurnDispatchAttempt(activeTurn.metadata, {
+                  id: input.dispatchId,
+                  generation: dispatchGeneration,
+                  triggerEventId: input.trigger.triggerEventId,
+                }),
+                version: sql`${schema.sessionTurns.version} + 1`,
+                startedAt: now,
+                finishedAt: null,
+                updatedAt: now,
+              })
+              .where(eq(schema.sessionTurns.id, activeTurn.id))
+              .returning();
+            if (!resumed) throw new Error(`Approval turn not found: ${activeTurn.id}`);
+            await tx
+              .update(schema.sessions)
+              .set({ status: "running", updatedAt: now })
+              .where(eq(schema.sessions.id, sessionId));
+            return { action: "claimed", turn: mapSessionTurn(resumed) };
+          }
+          if (activeTurn?.status === "recovering" || activeTurn?.status === "waiting_capacity") {
+            if (input.trigger.kind !== "next") {
+              return { action: "unclaimed", reason: "stale-approval" };
+            }
+            if (activeTurn.status === "waiting_capacity") {
+              const [waiter] = await tx
+                .select({ id: schema.codexCapacityWaiters.id })
+                .from(schema.codexCapacityWaiters)
+                .where(
+                  and(
+                    eq(schema.codexCapacityWaiters.workspaceId, workspaceId),
+                    eq(schema.codexCapacityWaiters.sessionId, sessionId),
+                    eq(schema.codexCapacityWaiters.status, "waiting"),
+                  ),
+                )
+                .limit(1);
+              if (waiter) return { action: "unclaimed", reason: "no-work" };
+            }
+            if (parsedDispatch.generation >= Number.MAX_SAFE_INTEGER) {
+              throw new Error("Turn dispatch generation exhausted; refusing to wrap or reuse it");
+            }
+            const now = new Date();
+            const dispatchGeneration = parsedDispatch.generation + 1;
             await tx.execute(sql`set local opengeni.session_inference_claim = '1'`);
             const [resumed] = await tx
               .update(schema.sessionTurns)
@@ -17735,8 +17844,15 @@ export async function claimNextSessionExecution(
                 status: "running",
                 temporalWorkflowId: workflowId,
                 executionGeneration: sql`${schema.sessionTurns.executionGeneration} + 1`,
-                activeAttemptId: null,
+                activeAttemptId: input.attemptId,
+                metadata: metadataWithTurnDispatchAttempt(activeTurn.metadata, {
+                  id: input.dispatchId,
+                  generation: dispatchGeneration,
+                  triggerEventId: activeTurn.triggerEventId,
+                }),
                 version: sql`${schema.sessionTurns.version} + 1`,
+                startedAt: now,
+                finishedAt: null,
                 updatedAt: now,
               })
               .where(eq(schema.sessionTurns.id, activeTurn.id))
@@ -17749,24 +17865,14 @@ export async function claimNextSessionExecution(
                 updatedAt: now,
               })
               .where(eq(schema.sessions.id, sessionId));
-            return mapSessionTurn(resumed);
+            return { action: "claimed", turn: mapSessionTurn(resumed) };
           }
-          if (
-            activeTurn &&
-            ["running", "requires_action", "waiting_capacity"].includes(activeTurn.status)
-          ) {
-            return null;
+          if (activeTurn?.status === "running") {
+            return { action: "unclaimed", reason: "no-work" };
           }
-          await tx
-            .update(schema.sessions)
-            .set({ activeTurnId: null, updatedAt: new Date() })
-            .where(
-              and(
-                eq(schema.sessions.workspaceId, workspaceId),
-                eq(schema.sessions.id, sessionId),
-                eq(schema.sessions.activeTurnId, session.activeTurnId),
-              ),
-            );
+          throw new Error(
+            `Session ${sessionId} has non-runnable active turn ${session.activeTurnId} (${activeTurn?.status ?? "missing"})`,
+          );
         }
 
         // A Pause/Steer signal settles the exact observed attempt before another
@@ -17796,31 +17902,29 @@ export async function claimNextSessionExecution(
               expectedTurn.executionGeneration === session.pendingControlExpectedGeneration) &&
             (session.pendingControlExpectedAttemptId === null ||
               expectedTurn.activeAttemptId === session.pendingControlExpectedAttemptId);
-          if (pendingTurnStillLive) return null;
-          await tx
-            .update(schema.sessions)
-            .set({
-              pendingControlEventId: null,
-              pendingControlKind: null,
-              pendingControlExpectedTurnId: null,
-              pendingControlExpectedGeneration: null,
-              pendingControlExpectedAttemptId: null,
-              updatedAt: new Date(),
-            })
-            .where(
-              and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
-            );
+          if (pendingTurnStillLive || session.pendingControlEventId) {
+            return { action: "unclaimed", reason: "control-pending" };
+          }
         }
 
-        const rows = await rawRows<{ id: string }>(
+        if (input.trigger.kind === "approval") {
+          return { action: "unclaimed", reason: "stale-approval" };
+        }
+
+        const rows = await rawRows<{
+          id: string;
+          trigger_event_id: string;
+          metadata: Record<string, unknown>;
+        }>(
           tx as unknown as Database,
-          sql`select id from session_turns
+          sql`select id, trigger_event_id, metadata from session_turns
               where workspace_id = ${workspaceId} and session_id = ${sessionId}
                 and status = 'queued' and source in ('user', 'api')
               order by position asc, created_at asc, id asc
               for update skip locked limit 1`,
         );
-        const id = rows[0]?.id;
+        const queuedTurn = rows[0];
+        const id = queuedTurn?.id;
         if (!id) {
           // Manual compaction is a first-class maintenance execution, never
           // prompt queue work. A waiting human/API prompt stays ahead because
@@ -17832,6 +17936,7 @@ export async function claimNextSessionExecution(
             const now = new Date();
             const turnId = crypto.randomUUID();
             const triggerEventId = crypto.randomUUID();
+            const dispatchGeneration = 1;
             const [{ position } = { position: 1 }] = await tx
               .select({
                 position: sql<number>`coalesce(max(${schema.sessionTurns.position}), 0) + 1`,
@@ -17871,6 +17976,8 @@ export async function claimNextSessionExecution(
                 triggerEventId,
                 temporalWorkflowId: workflowId,
                 status: "running",
+                executionGeneration: 1,
+                activeAttemptId: input.attemptId,
                 source: "compaction",
                 position: Number(position),
                 prompt: "",
@@ -17883,7 +17990,14 @@ export async function claimNextSessionExecution(
                 ),
                 sandboxBackend: latestStarted?.sandboxBackend ?? session.sandboxBackend,
                 sandboxOs: latestStarted?.sandboxOs ?? session.sandboxOs,
-                metadata: { executionKind: "context_compaction" },
+                metadata: metadataWithTurnDispatchAttempt(
+                  { executionKind: "context_compaction" },
+                  {
+                    id: input.dispatchId,
+                    generation: dispatchGeneration,
+                    triggerEventId,
+                  },
+                ),
                 startedAt: now,
               })
               .returning();
@@ -17897,6 +18011,7 @@ export async function claimNextSessionExecution(
                 sessionId,
                 turnId,
                 turnGeneration: compactionTurn.executionGeneration,
+                turnAttemptId: input.attemptId,
                 turnAssociation: "current",
                 sequence: session.lastSequence + 1,
                 type: "session.context.compaction.requested",
@@ -17921,7 +18036,7 @@ export async function claimNextSessionExecution(
                   eq(schema.sessions.id, sessionId),
                 ),
               );
-            return mapSessionTurn(compactionTurn);
+            return { action: "claimed", turn: mapSessionTurn(compactionTurn) };
           }
 
           const pendingUpdates = await tx
@@ -17936,7 +18051,9 @@ export async function claimNextSessionExecution(
             )
             .limit(1)
             .for("update");
-          if (pendingUpdates.length === 0) return null;
+          if (pendingUpdates.length === 0) {
+            return { action: "unclaimed", reason: "no-work" };
+          }
 
           const now = new Date();
           const turnId = crypto.randomUUID();
@@ -17955,11 +18072,14 @@ export async function claimNextSessionExecution(
           const delivered = await deliverPendingUpdates(
             session.accountId,
             turnId,
+            1,
             session.lastSequence + 1,
             now,
             triggerEventId,
           );
-          if (delivered.count === 0) return null;
+          if (delivered.count === 0) {
+            return { action: "unclaimed", reason: "no-work" };
+          }
           const goalUpdate = delivered.updates.find(
             (update) => update.payload.type === "goal_continuation",
           );
@@ -18012,6 +18132,7 @@ export async function claimNextSessionExecution(
               temporalWorkflowId: workflowId,
               status: "running",
               executionGeneration: 1,
+              activeAttemptId: input.attemptId,
               source: goalUpdate ? "goal" : "system",
               position: Number(position),
               prompt: "Process the delivered internal session updates.",
@@ -18021,10 +18142,13 @@ export async function claimNextSessionExecution(
               reasoningEffort,
               sandboxBackend,
               sandboxOs: latestStarted?.sandboxOs ?? session.sandboxOs,
-              metadata: {
-                internalUpdateCount: delivered.count,
-                ...(goalUpdate ? { goalId: goalUpdate.payload.goalId } : {}),
-              },
+              metadata: metadataWithTurnDispatchAttempt(
+                {
+                  internalUpdateCount: delivered.count,
+                  ...(goalUpdate ? { goalId: goalUpdate.payload.goalId } : {}),
+                },
+                { id: input.dispatchId, generation: 1, triggerEventId },
+              ),
               startedAt: now,
             })
             .returning();
@@ -18053,12 +18177,20 @@ export async function claimNextSessionExecution(
             .where(
               and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
             );
-          return mapSessionTurn(internalTurn);
+          return { action: "claimed", turn: mapSessionTurn(internalTurn) };
         }
         // The database guard makes this function the only supported
         // queued-to-running transition. Raw or stale claimers cannot bypass the
         // generation/active-pointer transaction.
         const now = new Date();
+        const queuedDispatch = readTurnDispatchMetadata(queuedTurn?.metadata);
+        if (queuedDispatch.kind === "malformed") {
+          throw new Error(`Malformed turn dispatch metadata: ${queuedDispatch.reason}`);
+        }
+        if (queuedDispatch.generation >= Number.MAX_SAFE_INTEGER) {
+          throw new Error("Turn dispatch generation exhausted; refusing to wrap or reuse it");
+        }
+        const dispatchGeneration = queuedDispatch.generation + 1;
         await tx.execute(sql`set local opengeni.session_inference_claim = '1'`);
         const [row] = await tx
           .update(schema.sessionTurns)
@@ -18066,7 +18198,12 @@ export async function claimNextSessionExecution(
             status: "running",
             temporalWorkflowId: workflowId,
             executionGeneration: sql`${schema.sessionTurns.executionGeneration} + 1`,
-            activeAttemptId: null,
+            activeAttemptId: input.attemptId,
+            metadata: metadataWithTurnDispatchAttempt(queuedTurn?.metadata, {
+              id: input.dispatchId,
+              generation: dispatchGeneration,
+              triggerEventId: queuedTurn!.trigger_event_id,
+            }),
             version: sql`${schema.sessionTurns.version} + 1`,
             startedAt: now,
             updatedAt: now,
@@ -18101,6 +18238,7 @@ export async function claimNextSessionExecution(
         const delivered = await deliverPendingUpdates(
           session.accountId,
           row.id,
+          row.executionGeneration,
           session.lastSequence + 1,
           now,
         );
@@ -18116,9 +18254,165 @@ export async function claimNextSessionExecution(
           .where(
             and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
           );
-        return mapSessionTurn(row);
+        return { action: "claimed", turn: mapSessionTurn(row) };
       }),
   );
+}
+
+export type SessionWorkPeek =
+  | { kind: "runnable" }
+  | { kind: "approval-pending"; triggerEventId: string }
+  | { kind: "approval-wait" }
+  | {
+      kind: "capacity-wait";
+      ref: {
+        waiterId: string;
+        generation: number;
+        nextCheckAt: string;
+        wakeRevision: number;
+      };
+    }
+  | { kind: "fence-settle"; controlEventId: string }
+  | { kind: "idle" };
+
+/** Read durable session state without reserving a turn-worker slot or mutating it. */
+export async function peekSessionWork(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionWorkPeek> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [workspace] = await scopedDb
+      .select({
+        inferenceState: schema.workspaces.inferenceState,
+        inferenceGeneration: schema.workspaces.inferenceGeneration,
+      })
+      .from(schema.workspaces)
+      .where(eq(schema.workspaces.id, workspaceId))
+      .limit(1);
+    const [session] = await scopedDb
+      .select()
+      .from(schema.sessions)
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)))
+      .limit(1);
+    if (!workspace || !session) return { kind: "idle" };
+    if (session.pendingControlEventId) {
+      return { kind: "fence-settle", controlEventId: session.pendingControlEventId };
+    }
+    if (!sessionInferenceGateOpen(workspace, session)) return { kind: "idle" };
+
+    const [capacityWait] = await scopedDb
+      .select()
+      .from(schema.codexCapacityWaiters)
+      .where(
+        and(
+          eq(schema.codexCapacityWaiters.workspaceId, workspaceId),
+          eq(schema.codexCapacityWaiters.sessionId, sessionId),
+          eq(schema.codexCapacityWaiters.status, "waiting"),
+        ),
+      )
+      .limit(1);
+    if (capacityWait) {
+      return {
+        kind: "capacity-wait",
+        ref: {
+          waiterId: capacityWait.id,
+          generation: capacityWait.generation,
+          nextCheckAt:
+            capacityWait.wakeRevision > capacityWait.observedWakeRevision
+              ? new Date(0).toISOString()
+              : capacityWait.nextCheckAt.toISOString(),
+          wakeRevision: capacityWait.wakeRevision,
+        },
+      };
+    }
+
+    if (session.activeTurnId) {
+      const [turn] = await scopedDb
+        .select()
+        .from(schema.sessionTurns)
+        .where(
+          and(
+            eq(schema.sessionTurns.workspaceId, workspaceId),
+            eq(schema.sessionTurns.sessionId, sessionId),
+            eq(schema.sessionTurns.id, session.activeTurnId),
+          ),
+        )
+        .limit(1);
+      if (!turn) {
+        throw new Error(
+          `Session ${sessionId} points to missing active turn ${session.activeTurnId}`,
+        );
+      }
+      if (turn.status === "recovering" || turn.status === "waiting_capacity") {
+        return { kind: "runnable" };
+      }
+      if (turn.status === "requires_action") {
+        const [currentTrigger] = await scopedDb
+          .select({ sequence: schema.sessionEvents.sequence })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, workspaceId),
+              eq(schema.sessionEvents.sessionId, sessionId),
+              eq(schema.sessionEvents.id, turn.triggerEventId),
+            ),
+          )
+          .limit(1);
+        if (!currentTrigger) {
+          throw new Error(`Turn ${turn.id} points to missing trigger ${turn.triggerEventId}`);
+        }
+        const [approval] = await scopedDb
+          .select({ id: schema.sessionEvents.id })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, workspaceId),
+              eq(schema.sessionEvents.sessionId, sessionId),
+              eq(schema.sessionEvents.type, "user.approvalDecision"),
+              gt(schema.sessionEvents.sequence, currentTrigger.sequence),
+            ),
+          )
+          .orderBy(desc(schema.sessionEvents.sequence), desc(schema.sessionEvents.id))
+          .limit(1);
+        return approval
+          ? { kind: "approval-pending", triggerEventId: approval.id }
+          : { kind: "approval-wait" };
+      }
+      if (turn.status === "running") {
+        throw new Error(
+          `Session workflow reached admission with turn ${turn.id} still owned by attempt ${turn.activeAttemptId ?? "none"}`,
+        );
+      }
+      throw new Error(`Session ${sessionId} has terminal active turn ${turn.id} (${turn.status})`);
+    }
+
+    const [queued] = await scopedDb
+      .select({ id: schema.sessionTurns.id })
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, workspaceId),
+          eq(schema.sessionTurns.sessionId, sessionId),
+          eq(schema.sessionTurns.status, "queued"),
+          inArray(schema.sessionTurns.source, ["user", "api"]),
+        ),
+      )
+      .limit(1);
+    if (queued || session.compactRequested) return { kind: "runnable" };
+    const [pendingUpdate] = await scopedDb
+      .select({ id: schema.sessionSystemUpdates.id })
+      .from(schema.sessionSystemUpdates)
+      .where(
+        and(
+          eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
+          eq(schema.sessionSystemUpdates.sessionId, sessionId),
+          eq(schema.sessionSystemUpdates.state, "pending"),
+        ),
+      )
+      .limit(1);
+    return pendingUpdate ? { kind: "runnable" } : { kind: "idle" };
+  });
 }
 
 /**
@@ -18357,14 +18651,6 @@ function readTurnDispatchMetadata(metadata: unknown): TurnDispatchMetadata {
   };
 }
 
-function turnDispatchGeneration(metadata: unknown): number {
-  const parsed = readTurnDispatchMetadata(metadata);
-  if (parsed.kind === "malformed") {
-    throw new Error(`Malformed turn dispatch metadata: ${parsed.reason}`);
-  }
-  return parsed.generation;
-}
-
 function metadataWithTurnDispatchAttempt(
   metadata: Record<string, unknown> | null | undefined,
   attempt: TurnDispatchAttempt,
@@ -18382,22 +18668,6 @@ function metadataWithoutTurnDispatchAttempt(
   const next = { ...(metadata ?? {}) };
   delete next[TURN_DISPATCH_ATTEMPT_METADATA_KEY];
   return next;
-}
-
-function dispatchAttemptMatches(
-  attempt: TurnDispatchAttempt | null,
-  input: {
-    dispatchId: string;
-    dispatchGeneration?: number;
-    triggerEventId: string;
-  },
-): boolean {
-  if (!attempt) return false;
-  return (
-    attempt.id === input.dispatchId &&
-    attempt.triggerEventId === input.triggerEventId &&
-    (input.dispatchGeneration === undefined || attempt.generation === input.dispatchGeneration)
-  );
 }
 
 type WorkerDeathRedispatchMetadata =
@@ -18453,140 +18723,6 @@ async function isNewerApprovalTrigger(
     candidate.type === "user.approvalDecision" &&
     candidate.sequence > current.sequence,
   );
-}
-
-export type RegisterSessionTurnDispatchResult =
-  | { action: "registered"; dispatchGeneration: number }
-  | {
-      action: "stale";
-      dispatchGeneration: null;
-      turnStatus: SessionTurnStatus | null;
-      activeTurnId: string | null;
-    };
-
-/**
- * Register the Temporal activity execution that owns one dispatch attempt.
- * Activity ids are unique per scheduled execution and stable for a genuine
- * Temporal activity retry. Persisting that id plus a monotonic generation on
- * the turn gives every later settlement an exact zombie fence without a
- * schema migration. OPE-18 can project this compatibility token into its
- * first-class generation column when the broader queue schema lands.
- */
-export async function registerSessionTurnDispatch(
-  db: Database,
-  workspaceId: string,
-  input: {
-    sessionId: string;
-    turnId: string;
-    triggerEventId: string;
-    attemptId: string;
-    dispatchId: string;
-  },
-): Promise<RegisterSessionTurnDispatchResult> {
-  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
-    return await scopedDb.transaction(async (tx) => {
-      const [workspace] = await tx
-        .select()
-        .from(schema.workspaces)
-        .where(eq(schema.workspaces.id, workspaceId))
-        .for("update")
-        .limit(1);
-      const [session] = await tx
-        .select()
-        .from(schema.sessions)
-        .where(
-          and(
-            eq(schema.sessions.workspaceId, workspaceId),
-            eq(schema.sessions.id, input.sessionId),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      if (!workspace || !session) {
-        throw new Error(`Session not found: ${input.sessionId}`);
-      }
-      const [turn] = await tx
-        .select()
-        .from(schema.sessionTurns)
-        .where(
-          and(
-            eq(schema.sessionTurns.workspaceId, workspaceId),
-            eq(schema.sessionTurns.sessionId, input.sessionId),
-            eq(schema.sessionTurns.id, input.turnId),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      const turnStatus = (turn?.status as SessionTurnStatus | undefined) ?? null;
-      const advancesApproval = Boolean(
-        turn &&
-        turnStatus === "requires_action" &&
-        turn.triggerEventId !== input.triggerEventId &&
-        (await isNewerApprovalTrigger(
-          tx as unknown as Database,
-          workspaceId,
-          input.sessionId,
-          turn.triggerEventId,
-          input.triggerEventId,
-        )),
-      );
-      if (
-        !turn ||
-        !sessionInferenceGateOpen(workspace, session) ||
-        session.activeTurnId !== input.turnId ||
-        (turnStatus !== "running" && turnStatus !== "requires_action") ||
-        (turn.triggerEventId !== input.triggerEventId && !advancesApproval)
-      ) {
-        return {
-          action: "stale" as const,
-          dispatchGeneration: null,
-          turnStatus,
-          activeTurnId: session.activeTurnId,
-        };
-      }
-
-      const parsedMetadata = readTurnDispatchMetadata(turn.metadata);
-      if (parsedMetadata.kind === "malformed") {
-        throw new Error(`Malformed turn dispatch metadata: ${parsedMetadata.reason}`);
-      }
-      const current = parsedMetadata.attempt;
-      if (
-        turn.activeAttemptId === input.attemptId &&
-        current?.id === input.dispatchId &&
-        current.triggerEventId === input.triggerEventId
-      ) {
-        return { action: "registered" as const, dispatchGeneration: current.generation };
-      }
-      const previousGeneration = turnDispatchGeneration(turn.metadata);
-      if (previousGeneration >= Number.MAX_SAFE_INTEGER) {
-        throw new Error("Turn dispatch generation exhausted; refusing to wrap or reuse it");
-      }
-      const dispatchGeneration = previousGeneration + 1;
-      await tx
-        .update(schema.sessionTurns)
-        .set({
-          // An approval decision is the current execution trigger for this same
-          // turn. Persist it so worker recovery replays the decision through
-          // the frozen RunState instead of falling back to the original prompt.
-          triggerEventId: input.triggerEventId,
-          activeAttemptId: input.attemptId,
-          metadata: metadataWithTurnDispatchAttempt(turn.metadata, {
-            id: input.dispatchId,
-            generation: dispatchGeneration,
-            triggerEventId: input.triggerEventId,
-          }),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.sessionTurns.workspaceId, workspaceId),
-            eq(schema.sessionTurns.sessionId, input.sessionId),
-            eq(schema.sessionTurns.id, input.turnId),
-          ),
-        );
-      return { action: "registered" as const, dispatchGeneration };
-    });
-  });
 }
 
 export type ApplySessionTurnSettlementInput = {
@@ -19644,19 +19780,206 @@ export async function requestSessionTurnRecovery(
   });
 }
 
-export type ApplySessionTurnWorkerDeathInput = {
+export type ReparkOrphanedSessionTurnInput = {
   sessionId: string;
   turnId: string;
-  triggerEventId: string;
+  attemptId: string | null;
+  reason: string;
+};
+
+export type ReparkOrphanedSessionTurnResult =
+  | {
+      action: "recovering";
+      sessionStatus: "recovering" | "paused";
+      closedToolCalls: number;
+      events: SessionEvent[];
+    }
+  | {
+      action: "stale";
+      events: [];
+      turnStatus: SessionTurnStatus | null;
+      activeTurnId: string | null;
+      activeAttemptId: string | null;
+    };
+
+/**
+ * Repark one current inference after the production cutover has drained every
+ * worker and terminated every session workflow. This is an evidence-writing
+ * ownership transition, not queue admission: the same turn and active-turn
+ * pointer are preserved and unresolved tool calls are closed truthfully. A
+ * registered attempt is matched exactly. The null case is also matched exactly
+ * so a partially applied 0057 cutover can recover a turn that an old worker
+ * moved back to `running` without ever registering first-class attempt identity.
+ */
+export async function reparkOrphanedSessionTurn(
+  db: Database,
+  workspaceId: string,
+  input: ReparkOrphanedSessionTurnInput,
+): Promise<ReparkOrphanedSessionTurnResult> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    return await scopedDb.transaction(async (tx) => {
+      const [workspace] = await tx
+        .select()
+        .from(schema.workspaces)
+        .where(eq(schema.workspaces.id, workspaceId))
+        .for("update")
+        .limit(1);
+      const [session] = await tx
+        .select()
+        .from(schema.sessions)
+        .where(
+          and(
+            eq(schema.sessions.workspaceId, workspaceId),
+            eq(schema.sessions.id, input.sessionId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (!workspace || !session) {
+        throw new Error(`Session not found: ${input.sessionId}`);
+      }
+      const [turn] = await tx
+        .select()
+        .from(schema.sessionTurns)
+        .where(
+          and(
+            eq(schema.sessionTurns.workspaceId, workspaceId),
+            eq(schema.sessionTurns.sessionId, input.sessionId),
+            eq(schema.sessionTurns.id, input.turnId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      const turnStatus = (turn?.status as SessionTurnStatus | undefined) ?? null;
+      const attemptMatches =
+        input.attemptId === null
+          ? turn?.activeAttemptId === null
+          : turn?.activeAttemptId === input.attemptId;
+      if (
+        !turn ||
+        session.activeTurnId !== input.turnId ||
+        turnStatus !== "running" ||
+        !attemptMatches
+      ) {
+        return {
+          action: "stale" as const,
+          events: [] as [],
+          turnStatus,
+          activeTurnId: session.activeTurnId,
+          activeAttemptId: turn?.activeAttemptId ?? null,
+        };
+      }
+
+      const now = new Date();
+      let sequence = session.lastSequence;
+      const closedTools = await closePendingSessionToolCallsTx(tx as unknown as Database, {
+        accountId: session.accountId,
+        workspaceId,
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        reason: input.reason,
+        sequence,
+        now,
+      });
+      sequence = closedTools.sequence;
+      const workspaceAllowsRun =
+        workspace.inferenceState === "active" ||
+        session.workspaceRunExceptionGeneration === workspace.inferenceGeneration;
+      const sessionStatus: "recovering" | "paused" =
+        workspaceAllowsRun && session.controlState === "active" ? "recovering" : "paused";
+      const inserted = await tx
+        .insert(schema.sessionEvents)
+        .values([
+          {
+            accountId: session.accountId,
+            workspaceId,
+            sessionId: input.sessionId,
+            sequence: ++sequence,
+            type: "turn.recovery.requested",
+            turnId: input.turnId,
+            turnGeneration: turn.executionGeneration,
+            turnAttemptId: input.attemptId,
+            turnAssociation: "current",
+            payload: sanitizeEventPayload({
+              triggerEventId: turn.triggerEventId,
+              reason: input.reason,
+            }),
+            occurredAt: now,
+          },
+          {
+            accountId: session.accountId,
+            workspaceId,
+            sessionId: input.sessionId,
+            sequence: ++sequence,
+            type: "session.status.changed",
+            turnId: input.turnId,
+            turnGeneration: turn.executionGeneration,
+            turnAttemptId: input.attemptId,
+            turnAssociation: "current",
+            payload: sanitizeEventPayload({ status: sessionStatus }),
+            occurredAt: now,
+          },
+        ])
+        .returning();
+      await tx
+        .update(schema.sessionTurns)
+        .set({
+          status: "recovering",
+          activeAttemptId: null,
+          finishedAt: null,
+          cancelledBy: null,
+          cancelReason: null,
+          version: turn.version + 1,
+          metadata: metadataWithoutTurnDispatchAttempt(turn.metadata),
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(schema.sessionTurns.workspaceId, workspaceId),
+            eq(schema.sessionTurns.sessionId, input.sessionId),
+            eq(schema.sessionTurns.id, input.turnId),
+            eq(schema.sessionTurns.status, "running"),
+            input.attemptId === null
+              ? isNull(schema.sessionTurns.activeAttemptId)
+              : eq(schema.sessionTurns.activeAttemptId, input.attemptId),
+          ),
+        );
+      await tx
+        .update(schema.sessions)
+        .set({
+          status: sessionStatus,
+          activeTurnId: input.turnId,
+          lastSequence: sequence,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(schema.sessions.workspaceId, workspaceId),
+            eq(schema.sessions.id, input.sessionId),
+            eq(schema.sessions.activeTurnId, input.turnId),
+          ),
+        );
+      return {
+        action: "recovering" as const,
+        sessionStatus,
+        closedToolCalls: closedTools.closed,
+        events: [...closedTools.events, ...inserted.map(mapEvent)],
+      };
+    });
+  });
+}
+
+export type RecoverSessionDispatchInput = {
+  sessionId: string;
   attemptId: string;
-  dispatchId: string;
   timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START";
   maxRedispatches: number;
 };
 
-export type ApplySessionTurnWorkerDeathResult =
-  | { action: "recovering"; redispatches: number; events: SessionEvent[] }
-  | { action: "exceeded"; redispatches: number; events: SessionEvent[] }
+export type RecoverSessionDispatchResult =
+  | { action: "unclaimed"; events: [] }
+  | { action: "recovering"; turnId: string; redispatches: number; events: SessionEvent[] }
+  | { action: "exceeded"; turnId: string; redispatches: number; events: SessionEvent[] }
   | {
       action: "stale";
       events: [];
@@ -19665,18 +19988,15 @@ export type ApplySessionTurnWorkerDeathResult =
     };
 
 /**
- * Atomically settle a Temporal worker-death boundary. The exact activity id is
- * the dispatch fence for heartbeat timeouts. A schedule-to-start timeout may
- * have no registered attempt because the activity never ran; that explicitly
- * typed case may recover the unregistered claim, including a fresh approval
- * trigger after a prior requires_action settlement, but can never replace a
- * different registered activity that actually started.
+ * Atomically recover the exact attempt that owned a running turn. An activity
+ * that never reached the turn worker has no active attempt and returns
+ * `unclaimed` without consuming the crash-loop budget.
  */
-export async function applySessionTurnWorkerDeath(
+export async function recoverSessionDispatch(
   db: Database,
   workspaceId: string,
-  input: ApplySessionTurnWorkerDeathInput,
-): Promise<ApplySessionTurnWorkerDeathResult> {
+  input: RecoverSessionDispatchInput,
+): Promise<RecoverSessionDispatchResult> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     return await scopedDb.transaction(async (tx) => {
       const [workspace] = await tx
@@ -19706,44 +20026,31 @@ export async function applySessionTurnWorkerDeath(
           and(
             eq(schema.sessionTurns.workspaceId, workspaceId),
             eq(schema.sessionTurns.sessionId, input.sessionId),
-            eq(schema.sessionTurns.id, input.turnId),
+            eq(schema.sessionTurns.activeAttemptId, input.attemptId),
           ),
         )
         .for("update")
         .limit(1);
+      if (!turn) {
+        return input.timeoutType === "SCHEDULE_TO_START"
+          ? { action: "unclaimed", events: [] }
+          : {
+              action: "stale",
+              events: [],
+              turnStatus: null,
+              activeTurnId: session.activeTurnId,
+            };
+      }
       const turnStatus = (turn?.status as SessionTurnStatus | undefined) ?? null;
       const parsedMetadata = readTurnDispatchMetadata(turn?.metadata);
-      const attempt = parsedMetadata.kind === "valid" ? parsedMetadata.attempt : null;
-      const exactAttempt =
-        dispatchAttemptMatches(attempt, {
-          dispatchId: input.dispatchId,
-          triggerEventId: input.triggerEventId,
-        }) && turn?.activeAttemptId === input.attemptId;
-      const safeUnstartedSchedule =
-        input.timeoutType === "SCHEDULE_TO_START" &&
-        attempt === null &&
-        turn?.activeAttemptId === null &&
-        Boolean(turn && turn.triggerEventId === input.triggerEventId);
-      const safeApprovalSchedule =
-        input.timeoutType === "SCHEDULE_TO_START" &&
-        attempt === null &&
-        turn?.activeAttemptId === null &&
-        turn?.status === "requires_action" &&
-        (await isNewerApprovalTrigger(
-          tx as unknown as Database,
-          workspaceId,
-          input.sessionId,
-          turn.triggerEventId,
-          input.triggerEventId,
-        ));
       if (
         !workspace ||
-        !turn ||
         parsedMetadata.kind === "malformed" ||
+        parsedMetadata.attempt === null ||
         !sessionInferenceGateOpen(workspace, session) ||
-        session.activeTurnId !== input.turnId ||
-        (turnStatus !== "running" && turnStatus !== "requires_action") ||
-        (!exactAttempt && !safeUnstartedSchedule && !safeApprovalSchedule)
+        session.activeTurnId !== turn.id ||
+        turnStatus !== "running" ||
+        turn.activeAttemptId !== input.attemptId
       ) {
         return {
           action: "stale" as const,
@@ -19771,37 +20078,20 @@ export async function applySessionTurnWorkerDeath(
         };
       }
       const metadata = { ...(turn.metadata ?? {}) } as Record<string, unknown>;
-      if (!exactAttempt) {
-        if (parsedMetadata.generation >= Number.MAX_SAFE_INTEGER) {
-          return {
-            action: "stale" as const,
-            events: [] as [],
-            turnStatus,
-            activeTurnId: session.activeTurnId,
-          };
-        }
-        // A schedule-to-start timeout represents a real Temporal dispatch that
-        // never entered the activity and therefore could not self-register.
-        // Consume its generation here so a later registered attempt remains
-        // strictly newer and an old timeout can never alias it.
-        metadata[TURN_DISPATCH_GENERATION_METADATA_KEY] = parsedMetadata.generation + 1;
-      }
       const redispatches = redispatchMetadata.count + 1;
       metadata.workerDeathRedispatches = redispatches;
 
       const now = new Date();
       let sequence = session.lastSequence;
-      const closedTools = exactAttempt
-        ? await closePendingSessionToolCallsTx(tx as unknown as Database, {
-            accountId: session.accountId,
-            workspaceId,
-            sessionId: input.sessionId,
-            turnId: input.turnId,
-            reason: "worker_death",
-            sequence,
-            now,
-          })
-        : { sequence, events: [] as SessionEvent[], closed: 0 };
+      const closedTools = await closePendingSessionToolCallsTx(tx as unknown as Database, {
+        accountId: session.accountId,
+        workspaceId,
+        sessionId: input.sessionId,
+        turnId: turn.id,
+        reason: "worker_death",
+        sequence,
+        now,
+      });
       sequence = closedTools.sequence;
       if (redispatches > input.maxRedispatches) {
         const inserted = await tx
@@ -19813,12 +20103,12 @@ export async function applySessionTurnWorkerDeath(
               sessionId: input.sessionId,
               sequence: ++sequence,
               type: "turn.failed",
-              turnId: input.turnId,
+              turnId: turn.id,
               turnGeneration: turn.executionGeneration,
               turnAttemptId: input.attemptId,
               turnAssociation: "current",
               payload: sanitizeEventPayload({
-                triggerEventId: input.triggerEventId,
+                triggerEventId: turn.triggerEventId,
                 code: "worker_death_redispatch_exhausted",
                 error: `Worker died ${redispatches} times while running this turn (heartbeat timeout); giving up after ${input.maxRedispatches} re-dispatches.`,
                 redispatches: input.maxRedispatches,
@@ -19831,7 +20121,7 @@ export async function applySessionTurnWorkerDeath(
               sessionId: input.sessionId,
               sequence: ++sequence,
               type: "session.status.changed",
-              turnId: input.turnId,
+              turnId: turn.id,
               turnGeneration: turn.executionGeneration,
               turnAttemptId: input.attemptId,
               turnAssociation: "current",
@@ -19854,7 +20144,7 @@ export async function applySessionTurnWorkerDeath(
             and(
               eq(schema.sessionTurns.workspaceId, workspaceId),
               eq(schema.sessionTurns.sessionId, input.sessionId),
-              eq(schema.sessionTurns.id, input.turnId),
+              eq(schema.sessionTurns.id, turn.id),
             ),
           );
         await enqueueFailedChildOutboxForTurnTx(
@@ -19880,6 +20170,7 @@ export async function applySessionTurnWorkerDeath(
           );
         return {
           action: "exceeded" as const,
+          turnId: turn.id,
           redispatches: input.maxRedispatches,
           events: [...closedTools.events, ...inserted.map(mapEvent)],
         };
@@ -19894,12 +20185,12 @@ export async function applySessionTurnWorkerDeath(
             sessionId: input.sessionId,
             sequence: ++sequence,
             type: "turn.recovery.requested",
-            turnId: input.turnId,
+            turnId: turn.id,
             turnGeneration: turn.executionGeneration,
             turnAttemptId: input.attemptId,
             turnAssociation: "current",
             payload: sanitizeEventPayload({
-              triggerEventId: input.triggerEventId,
+              triggerEventId: turn.triggerEventId,
               reason: "worker_death",
               redispatches,
             }),
@@ -19911,7 +20202,7 @@ export async function applySessionTurnWorkerDeath(
             sessionId: input.sessionId,
             sequence: ++sequence,
             type: "session.status.changed",
-            turnId: input.turnId,
+            turnId: turn.id,
             turnGeneration: turn.executionGeneration,
             turnAttemptId: input.attemptId,
             turnAssociation: "current",
@@ -19938,14 +20229,14 @@ export async function applySessionTurnWorkerDeath(
           and(
             eq(schema.sessionTurns.workspaceId, workspaceId),
             eq(schema.sessionTurns.sessionId, input.sessionId),
-            eq(schema.sessionTurns.id, input.turnId),
+            eq(schema.sessionTurns.id, turn.id),
           ),
         );
       await tx
         .update(schema.sessions)
         .set({
           status: "recovering",
-          activeTurnId: input.turnId,
+          activeTurnId: turn.id,
           lastSequence: sequence,
           updatedAt: now,
         })
@@ -19957,6 +20248,7 @@ export async function applySessionTurnWorkerDeath(
         );
       return {
         action: "recovering" as const,
+        turnId: turn.id,
         redispatches,
         events: [...closedTools.events, ...inserted.map(mapEvent)],
       };
@@ -19975,6 +20267,28 @@ export async function getSessionTurn(
       .from(schema.sessionTurns)
       .where(
         and(eq(schema.sessionTurns.workspaceId, workspaceId), eq(schema.sessionTurns.id, turnId)),
+      )
+      .limit(1);
+    return row ? mapSessionTurn(row) : null;
+  });
+}
+
+export async function getSessionTurnForAttempt(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+  attemptId: string,
+): Promise<SessionTurn | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
+      .select()
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, workspaceId),
+          eq(schema.sessionTurns.sessionId, sessionId),
+          eq(schema.sessionTurns.activeAttemptId, attemptId),
+        ),
       )
       .limit(1);
     return row ? mapSessionTurn(row) : null;
@@ -20387,24 +20701,24 @@ export async function claimPendingSessionSystemUpdateOutbox(
   return rows.map(mapSystemUpdateOutboxRow);
 }
 
-export type ClaimableSession = {
+export type EnrollableSession = {
   accountId: string;
   workspaceId: string;
   sessionId: string;
   temporalWorkflowId: string;
 };
 
-/** Bounded repair scan using the same runnable predicate as normal claims. */
-export async function listClaimableSessions(
+/** Bounded repair scan for every durable state that requires a session workflow. */
+export async function listEnrollableSessions(
   db: Database,
   limit = 100,
-): Promise<ClaimableSession[]> {
+): Promise<EnrollableSession[]> {
   const rows = await rawRows<{
     account_id: string;
     workspace_id: string;
     session_id: string;
     temporal_workflow_id: string;
-  }>(db, sql`select * from opengeni_private.list_claimable_sessions(${limit})`);
+  }>(db, sql`select * from opengeni_private.list_enrollable_sessions(${limit})`);
   return rows.map((row) => ({
     accountId: row.account_id,
     workspaceId: row.workspace_id,
@@ -21180,7 +21494,11 @@ export async function settlePendingSessionControl(
   workspaceId: string,
   sessionId: string,
   controlEventId: string,
-): Promise<{ events: SessionEvent[]; recoveringTurnId: string | null }> {
+): Promise<{
+  action: "paused" | "continue" | "stale";
+  events: SessionEvent[];
+  recoveringTurnId: string | null;
+}> {
   return await withWorkspaceRls(
     db,
     workspaceId,
@@ -21205,11 +21523,11 @@ export async function settlePendingSessionControl(
           .limit(1);
         if (!workspace || !session) throw new Error(`Session not found: ${sessionId}`);
         if (session.pendingControlEventId !== controlEventId) {
-          return { events: [], recoveringTurnId: null };
+          return { action: "stale", events: [], recoveringTurnId: null };
         }
         const pendingKind = session.pendingControlKind;
         if (!pendingKind || !["pause", "workspace_pause", "steer"].includes(pendingKind)) {
-          return { events: [], recoveringTurnId: null };
+          return { action: "stale", events: [], recoveringTurnId: null };
         }
         const [turn] = session.pendingControlExpectedTurnId
           ? await tx
@@ -21294,6 +21612,7 @@ export async function settlePendingSessionControl(
           })
           .where(eq(schema.sessions.id, session.id));
         return {
+          action: nextStatus === "paused" ? "paused" : "continue",
           events: eventRows.map(mapEvent),
           recoveringTurnId: matchesPausedAttempt && turn ? turn.id : null,
         };
@@ -21624,7 +21943,7 @@ export async function setWorkspaceInferenceControl(
             ? (
                 await rawRows<{ session_id: string }>(
                   tx as unknown as Database,
-                  sql`select session_id from opengeni_private.list_claimable_sessions(10000)
+                  sql`select session_id from opengeni_private.list_enrollable_sessions(10000)
                       where workspace_id = ${input.workspaceId}`,
                 )
               ).map((row) => row.session_id)
@@ -22108,6 +22427,8 @@ export async function appendSessionEvents(
           turnGeneration: input.turnGeneration ?? null,
           turnAttemptId: input.turnAttemptId ?? null,
           turnAssociation: input.turnAssociation ?? (input.turnId ? "current" : null),
+          duplicateOfEventId: input.duplicateOfEventId ?? null,
+          duplicateReason: input.duplicateReason ?? null,
           producerId: input.producerId ?? null,
           producerSeq: input.producerSeq ?? null,
           occurredAt: input.occurredAt ?? new Date(),
@@ -22120,6 +22441,140 @@ export async function appendSessionEvents(
             and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
           );
         return inserted.map(mapEvent);
+      }),
+  );
+}
+
+export type AcceptSessionApprovalDecisionResult =
+  | { action: "accepted"; event: SessionEvent; events: SessionEvent[] }
+  | { action: "conflict"; sessionStatus: SessionStatus };
+
+/**
+ * Accept exactly one decision for the currently waiting approval boundary.
+ * The session and active turn are locked with the append so concurrent Pause,
+ * Steer, and duplicate decisions cannot manufacture a second resume trigger.
+ */
+export async function acceptSessionApprovalDecision(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sessionId: string;
+    payload: Record<string, unknown>;
+    clientEventId?: string | null;
+  },
+): Promise<AcceptSessionApprovalDecisionResult> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) =>
+      await scopedDb.transaction(async (tx) => {
+        await tx
+          .select({ id: schema.workspaces.id })
+          .from(schema.workspaces)
+          .where(eq(schema.workspaces.id, input.workspaceId))
+          .for("update")
+          .limit(1);
+        const [session] = await tx
+          .select()
+          .from(schema.sessions)
+          .where(
+            and(
+              eq(schema.sessions.workspaceId, input.workspaceId),
+              eq(schema.sessions.id, input.sessionId),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (!session) throw new Error(`Session not found: ${input.sessionId}`);
+        if (input.clientEventId) {
+          const [existing] = await tx
+            .select()
+            .from(schema.sessionEvents)
+            .where(
+              and(
+                eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                eq(schema.sessionEvents.sessionId, input.sessionId),
+                eq(schema.sessionEvents.clientEventId, input.clientEventId),
+              ),
+            )
+            .limit(1);
+          if (existing) {
+            if (existing.type !== "user.approvalDecision") {
+              throw new Error("clientEventId belongs to a different session event");
+            }
+            return { action: "accepted", event: mapEvent(existing), events: [] } as const;
+          }
+        }
+        const [turn] = session.activeTurnId
+          ? await tx
+              .select()
+              .from(schema.sessionTurns)
+              .where(
+                and(
+                  eq(schema.sessionTurns.workspaceId, input.workspaceId),
+                  eq(schema.sessionTurns.sessionId, input.sessionId),
+                  eq(schema.sessionTurns.id, session.activeTurnId),
+                ),
+              )
+              .for("update")
+              .limit(1)
+          : [];
+        if (session.status !== "requires_action" || turn?.status !== "requires_action") {
+          return {
+            action: "conflict",
+            sessionStatus: session.status as SessionStatus,
+          } as const;
+        }
+        const [trigger] = await tx
+          .select({ sequence: schema.sessionEvents.sequence })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, input.workspaceId),
+              eq(schema.sessionEvents.sessionId, input.sessionId),
+              eq(schema.sessionEvents.id, turn.triggerEventId),
+            ),
+          )
+          .limit(1);
+        if (!trigger) throw new Error(`Turn trigger not found: ${turn.triggerEventId}`);
+        const [alreadyAccepted] = await tx
+          .select({ id: schema.sessionEvents.id })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, input.workspaceId),
+              eq(schema.sessionEvents.sessionId, input.sessionId),
+              eq(schema.sessionEvents.type, "user.approvalDecision"),
+              gt(schema.sessionEvents.sequence, trigger.sequence),
+            ),
+          )
+          .limit(1);
+        if (alreadyAccepted) {
+          return { action: "conflict", sessionStatus: "requires_action" } as const;
+        }
+        const [event] = await tx
+          .insert(schema.sessionEvents)
+          .values({
+            accountId: session.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId: turn.id,
+            turnGeneration: turn.executionGeneration,
+            turnAssociation: "current",
+            sequence: session.lastSequence + 1,
+            type: "user.approvalDecision",
+            payload: sanitizeEventPayload(input.payload),
+            clientEventId: input.clientEventId ?? null,
+          })
+          .returning();
+        if (!event) throw new Error("Failed to append approval decision");
+        await tx
+          .update(schema.sessions)
+          .set({ lastSequence: session.lastSequence + 1, updatedAt: new Date() })
+          .where(eq(schema.sessions.id, session.id));
+        const mapped = mapEvent(event);
+        return { action: "accepted", event: mapped, events: [mapped] } as const;
       }),
   );
 }
@@ -22153,51 +22608,107 @@ export async function appendSessionEventsForTurnAttempt(
       if (!session) throw new Error(`Session not found: ${sessionId}`);
       let sequence = session.lastSequence;
       const now = new Date();
-      const values = inputs.map((input) =>
-        fence.allowed
-          ? {
-              accountId: session.accountId,
-              workspaceId,
-              sessionId,
-              sequence: ++sequence,
-              type: input.type,
-              payload: sanitizeEventPayload(input.payload ?? {}),
-              clientEventId: input.clientEventId ?? null,
-              turnId,
-              turnGeneration: executionGeneration,
-              turnAttemptId: attemptId,
-              turnAssociation: "current",
-              producerId: input.producerId ?? null,
-              producerSeq: input.producerSeq ?? null,
-              occurredAt: input.occurredAt ?? now,
-            }
-          : {
-              accountId: session.accountId,
-              workspaceId,
-              sessionId,
-              sequence: ++sequence,
-              type: "turn.event.rejected_late",
-              payload: sanitizeEventPayload({
-                rejectedType: input.type,
-                rejectedPayload: input.payload ?? {},
-                reason: fence.reason,
-                expectedExecutionGeneration: executionGeneration,
-                rejectedAttemptId: attemptId,
-                currentExecutionGeneration: fence.turn?.executionGeneration ?? null,
-                currentAttemptId: fence.turn?.activeAttemptId ?? null,
-                currentTurnStatus: fence.turn?.status ?? null,
-                currentActiveTurnId: session.activeTurnId,
-              }),
-              clientEventId: input.clientEventId ?? null,
-              turnId,
-              turnGeneration: executionGeneration,
-              turnAttemptId: attemptId,
-              turnAssociation: "late_rejected",
-              producerId: input.producerId ?? null,
-              producerSeq: input.producerSeq ?? null,
-              occurredAt: input.occurredAt ?? now,
-            },
-      );
+      const usageSourceKey = (input: AppendEventInput): string | null => {
+        if (
+          input.type !== "agent.model.usage" ||
+          !input.payload ||
+          typeof input.payload !== "object"
+        ) {
+          return null;
+        }
+        const value = (input.payload as Record<string, unknown>).sourceKey;
+        return typeof value === "string" && value.length > 0 ? value : null;
+      };
+      const incomingUsageKeys = [
+        ...new Set(inputs.map(usageSourceKey).filter((value): value is string => value !== null)),
+      ];
+      const existingUsageRows =
+        fence.allowed && incomingUsageKeys.length > 0
+          ? await tx
+              .select({ id: schema.sessionEvents.id, payload: schema.sessionEvents.payload })
+              .from(schema.sessionEvents)
+              .where(
+                and(
+                  eq(schema.sessionEvents.workspaceId, workspaceId),
+                  eq(schema.sessionEvents.sessionId, sessionId),
+                  eq(schema.sessionEvents.turnId, turnId),
+                  eq(schema.sessionEvents.type, "agent.model.usage"),
+                  eq(schema.sessionEvents.turnAssociation, "current"),
+                  inArray(
+                    sql<string>`${schema.sessionEvents.payload} ->> 'sourceKey'`,
+                    incomingUsageKeys,
+                  ),
+                ),
+              )
+          : [];
+      const canonicalUsageIds = new Map<string, string>();
+      for (const row of existingUsageRows) {
+        const value =
+          row.payload && typeof row.payload === "object"
+            ? (row.payload as Record<string, unknown>).sourceKey
+            : null;
+        if (typeof value === "string" && value.length > 0) {
+          canonicalUsageIds.set(value, row.id);
+        }
+      }
+      const values = inputs.map((input) => {
+        const id = crypto.randomUUID();
+        if (!fence.allowed) {
+          return {
+            id,
+            accountId: session.accountId,
+            workspaceId,
+            sessionId,
+            sequence: ++sequence,
+            type: "turn.event.rejected_late",
+            payload: sanitizeEventPayload({
+              rejectedType: input.type,
+              rejectedPayload: input.payload ?? {},
+              reason: fence.reason,
+              expectedExecutionGeneration: executionGeneration,
+              rejectedAttemptId: attemptId,
+              currentExecutionGeneration: fence.turn?.executionGeneration ?? null,
+              currentAttemptId: fence.turn?.activeAttemptId ?? null,
+              currentTurnStatus: fence.turn?.status ?? null,
+              currentActiveTurnId: session.activeTurnId,
+            }),
+            clientEventId: input.clientEventId ?? null,
+            turnId,
+            turnGeneration: executionGeneration,
+            turnAttemptId: attemptId,
+            turnAssociation: "late_rejected" as const,
+            duplicateOfEventId: null,
+            duplicateReason: null,
+            producerId: input.producerId ?? null,
+            producerSeq: input.producerSeq ?? null,
+            occurredAt: input.occurredAt ?? now,
+          };
+        }
+        const sourceKey = usageSourceKey(input);
+        const duplicateOfEventId = sourceKey ? (canonicalUsageIds.get(sourceKey) ?? null) : null;
+        if (sourceKey && !duplicateOfEventId) {
+          canonicalUsageIds.set(sourceKey, id);
+        }
+        return {
+          id,
+          accountId: session.accountId,
+          workspaceId,
+          sessionId,
+          sequence: ++sequence,
+          type: input.type,
+          payload: sanitizeEventPayload(input.payload ?? {}),
+          clientEventId: input.clientEventId ?? null,
+          turnId,
+          turnGeneration: executionGeneration,
+          turnAttemptId: attemptId,
+          turnAssociation: duplicateOfEventId ? ("duplicate" as const) : ("current" as const),
+          duplicateOfEventId,
+          duplicateReason: duplicateOfEventId ? "duplicate_provider_response_usage" : null,
+          producerId: input.producerId ?? null,
+          producerSeq: input.producerSeq ?? null,
+          occurredAt: input.occurredAt ?? now,
+        };
+      });
       const inserted = await tx.insert(schema.sessionEvents).values(values).returning();
       await tx
         .update(schema.sessions)
@@ -22520,6 +23031,8 @@ function mapEvent(row: typeof schema.sessionEvents.$inferSelect): SessionEvent {
     turnGeneration: row.turnGeneration,
     turnAttemptId: row.turnAttemptId,
     turnAssociation: row.turnAssociation as SessionEvent["turnAssociation"],
+    duplicateOfEventId: row.duplicateOfEventId,
+    duplicateReason: row.duplicateReason,
   };
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1338,6 +1338,8 @@ export const sessionEvents = pgTable(
     turnGeneration: integer("turn_generation"),
     turnAttemptId: uuid("turn_attempt_id"),
     turnAssociation: text("turn_association"),
+    duplicateOfEventId: uuid("duplicate_of_event_id"),
+    duplicateReason: text("duplicate_reason"),
     sequence: integer("sequence").notNull(),
     type: text("type").notNull(),
     payload: jsonb("payload").$type<unknown>().notNull().default({}),

--- a/packages/db/src/session-control-cutover-audit.ts
+++ b/packages/db/src/session-control-cutover-audit.ts
@@ -132,6 +132,12 @@ export type CutoverInvariantCounts = {
   queuedMachineTurns: number;
   activeOpaqueCompactionItems: number;
   invalidActiveTurnPointers: number;
+  runningTurnsWithoutAttempt: number;
+  attemptOwnedNonRunningTurns: number;
+  duplicateCurrentUsageSources: number;
+  invalidDuplicateUsageAssociations: number;
+  enrollableSessions: number;
+  workerDeathRedispatchExhausted: number;
 };
 
 export type SessionControlCutoverSnapshot = {
@@ -228,6 +234,11 @@ async function columnExists(sql: postgres.Sql, table: string, column: string): P
   return booleanValue(rows[0]?.present);
 }
 
+async function functionExists(sql: postgres.Sql, signature: string): Promise<boolean> {
+  const rows = await sql<Row[]>`select to_regprocedure(${signature}) is not null as present`;
+  return booleanValue(rows[0]?.present);
+}
+
 async function unsafeRows(sql: postgres.Sql, query: string): Promise<Row[]> {
   return (await sql.unsafe<Row[]>(query)) as unknown as Row[];
 }
@@ -316,6 +327,15 @@ export async function captureSessionControlCutoverSnapshot(
   const hasWorkspaceControl = await columnExists(sql, "workspaces", "inference_state");
   const hasUpdates = await tableExists(sql, "session_system_updates");
   const hasPendingTools = await tableExists(sql, "session_pending_tool_calls");
+  const hasUsageDuplicateAssociation = await columnExists(
+    sql,
+    "session_events",
+    "duplicate_of_event_id",
+  );
+  const hasEnrollableScan = await functionExists(
+    sql,
+    "opengeni_private.list_enrollable_sessions(integer)",
+  );
   const hasFrozenCredential = await columnExists(
     sql,
     "agent_run_states",
@@ -593,6 +613,48 @@ export async function captureSessionControlCutoverSnapshot(
     `select count(*)::integer as count from session_history_items
      where active = true and item ->> 'type' in ('compaction','compaction_summary')`,
   );
+  const ownershipRows = hasAttempts
+    ? await unsafeRows(
+        sql,
+        `select
+          count(*) filter (where status = 'running' and active_attempt_id is null)::integer
+            as running_without_attempt,
+          count(*) filter (where status <> 'running' and active_attempt_id is not null)::integer
+            as owned_non_running
+         from session_turns`,
+      )
+    : [{ running_without_attempt: 0, owned_non_running: 0 }];
+  const usageRows = hasUsageDuplicateAssociation
+    ? await unsafeRows(
+        sql,
+        `select
+          (select count(*)::integer from (
+             select workspace_id, session_id, turn_id, payload ->> 'sourceKey'
+             from session_events
+             where type = 'agent.model.usage' and turn_association = 'current'
+               and turn_id is not null and nullif(payload ->> 'sourceKey', '') is not null
+             group by workspace_id, session_id, turn_id, payload ->> 'sourceKey'
+             having count(*) > 1
+           ) duplicate_sources) as duplicate_current_sources,
+          (select count(*)::integer from session_events
+             where type = 'agent.model.usage' and turn_association = 'duplicate'
+               and (duplicate_of_event_id is null or duplicate_reason is null))
+            as invalid_duplicate_associations`,
+      )
+    : [{ duplicate_current_sources: 0, invalid_duplicate_associations: 0 }];
+  const enrollableRows = hasEnrollableScan
+    ? await unsafeRows(
+        sql,
+        `select count(*)::integer as count
+         from opengeni_private.list_enrollable_sessions(10000)`,
+      )
+    : [{ count: 0 }];
+  const casualtyRows = await unsafeRows(
+    sql,
+    `select count(*)::integer as count from session_events
+     where type = 'turn.failed'
+       and payload ->> 'code' = 'worker_death_redispatch_exhausted'`,
+  );
 
   const draft = {
     contractVersion: SESSION_CONTROL_CUTOVER_CONTRACT,
@@ -606,6 +668,27 @@ export async function captureSessionControlCutoverSnapshot(
       queuedMachineTurns,
       activeOpaqueCompactionItems: numberValue(opaqueRows[0]?.count ?? 0, "opaque count"),
       invalidActiveTurnPointers,
+      runningTurnsWithoutAttempt: numberValue(
+        ownershipRows[0]?.running_without_attempt ?? 0,
+        "running turns without attempt",
+      ),
+      attemptOwnedNonRunningTurns: numberValue(
+        ownershipRows[0]?.owned_non_running ?? 0,
+        "attempt-owned non-running turns",
+      ),
+      duplicateCurrentUsageSources: numberValue(
+        usageRows[0]?.duplicate_current_sources ?? 0,
+        "duplicate current usage sources",
+      ),
+      invalidDuplicateUsageAssociations: numberValue(
+        usageRows[0]?.invalid_duplicate_associations ?? 0,
+        "invalid duplicate usage associations",
+      ),
+      enrollableSessions: numberValue(enrollableRows[0]?.count ?? 0, "enrollable sessions"),
+      workerDeathRedispatchExhausted: numberValue(
+        casualtyRows[0]?.count ?? 0,
+        "worker death redispatch casualties",
+      ),
     },
     identityCount: sessions.reduce(
       (count, session) =>
@@ -681,6 +764,18 @@ export function reconcileSessionControlCutover(
   }
   if (observed.invariants.invalidActiveTurnPointers !== 0) {
     errors.push("observed snapshot has invalid active-turn pointers");
+  }
+  if (observed.invariants.runningTurnsWithoutAttempt !== 0) {
+    errors.push("observed snapshot has running turns without registered attempts");
+  }
+  if (observed.invariants.attemptOwnedNonRunningTurns !== 0) {
+    errors.push("observed snapshot has non-running turns with attempt owners");
+  }
+  if (observed.invariants.duplicateCurrentUsageSources !== 0) {
+    errors.push("observed snapshot has duplicate current usage sources");
+  }
+  if (observed.invariants.invalidDuplicateUsageAssociations !== 0) {
+    errors.push("observed snapshot has invalid duplicate usage associations");
   }
 
   const observedWorkspaces = new Map(

--- a/packages/db/test/codex-capacity-waiters.test.ts
+++ b/packages/db/test/codex-capacity-waiters.test.ts
@@ -9,7 +9,7 @@ import { eq } from "drizzle-orm";
 import * as schema from "../src/schema";
 import {
   armCodexCapacityWait,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   codexCapacityRefreshBackoffMs,
   createDb,
   encryptEnvironmentValue,
@@ -53,6 +53,22 @@ type CapacityScenario = Workspace & {
   goalId: string;
   workflowId: string;
 };
+
+async function claimTestTurn(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+  workflowId: string,
+) {
+  const result = await claimSessionWorkForAttempt(db, workspaceId, {
+    sessionId,
+    workflowId,
+    attemptId: crypto.randomUUID(),
+    dispatchId: crypto.randomUUID(),
+    trigger: { kind: "next" },
+  });
+  return result.action === "claimed" ? result.turn : null;
+}
 
 async function freshWorkspace(): Promise<Workspace> {
   const [account] = await admin<{ id: string }[]>`
@@ -264,18 +280,13 @@ describe("OPE-21 durable Codex capacity waits", () => {
     );
     if (resumed.action !== "resumed") throw new Error("expected resumed update");
 
-    let claim: ReturnType<typeof claimNextSessionExecution> | null = null;
+    let claim: ReturnType<typeof claimTestTurn> | null = null;
     await admin.begin(async (lockTx) => {
       await lockTx`
         select id from sessions
         where workspace_id = ${scenario.workspaceId} and id = ${scenario.sessionId}
         for update`;
-      claim = claimNextSessionExecution(
-        claimDb,
-        scenario.workspaceId,
-        scenario.sessionId,
-        scenario.workflowId,
-      );
+      claim = claimTestTurn(claimDb, scenario.workspaceId, scenario.sessionId, scenario.workflowId);
       await waitForAppSessionLockWait();
 
       // If claim took the pending update before waiting for the session, this
@@ -615,7 +626,7 @@ describe("OPE-21 durable Codex capacity waits", () => {
       sandboxBackend: "modal",
       metadata: {},
     });
-    const claimed = await claimNextSessionExecution(
+    const claimed = await claimTestTurn(
       dbA,
       scenario.workspaceId,
       scenario.sessionId,

--- a/packages/db/test/session-control-cutover-audit.test.ts
+++ b/packages/db/test/session-control-cutover-audit.test.ts
@@ -193,12 +193,90 @@ describe("session-control production cutover audit", () => {
       await sql`
           insert into schema_migrations (name)
           values ('0057_durable_queue_control.sql') on conflict do nothing`;
+
+      const migrated0057 = await captureSessionControlCutoverSnapshot(
+        sql,
+        "migrated",
+        "2026-07-14T10:00:30.000Z",
+      );
+      const migrated0057Result = reconcileSessionControlCutover(
+        baseline,
+        migrated0057,
+        "migration",
+      );
+      expect(migrated0057Result.errors).toEqual([]);
+      expect(migrated0057Result.ok).toBe(true);
+
+      const usageEventIds = [crypto.randomUUID(), crypto.randomUUID(), crypto.randomUUID()];
+      await sql`
+          insert into session_events (
+            id, account_id, workspace_id, session_id, turn_id, turn_generation,
+            turn_association, sequence, type, payload
+          ) values
+            (${usageEventIds[0]!}, ${accountId}, ${workspaceId}, ${sessionId}, ${runningTurnId}, 1,
+             'current', 35, 'agent.model.usage', ${sql.json({ sourceKey: "response-duplicate" })}),
+            (${usageEventIds[1]!}, ${accountId}, ${workspaceId}, ${sessionId}, ${runningTurnId}, 1,
+             'current', 36, 'agent.model.usage', ${sql.json({ sourceKey: "response-duplicate" })}),
+            (${usageEventIds[2]!}, ${accountId}, ${workspaceId}, ${sessionId}, ${runningTurnId}, 1,
+             'current', 37, 'agent.model.usage', ${sql.json({ sourceKey: "response-duplicate" })})`;
+
+      const remediationBaseline = await captureSessionControlCutoverSnapshot(
+        sql,
+        "baseline",
+        "2026-07-14T10:00:45.000Z",
+      );
+
+      await applyFile(sql, "0058_turn_admission_usage_enrollment.sql");
+      await sql`
+          insert into schema_migrations (name)
+          values ('0058_turn_admission_usage_enrollment.sql') on conflict do nothing`;
+
+      const classifiedUsage = await sql<
+        Array<{
+          id: string;
+          turn_association: string;
+          duplicate_of_event_id: string | null;
+          duplicate_reason: string | null;
+        }>
+      >`
+          select id, turn_association, duplicate_of_event_id, duplicate_reason
+          from session_events
+          where id in (${usageEventIds[0]!}, ${usageEventIds[1]!}, ${usageEventIds[2]!})
+          order by sequence`;
+      expect([...classifiedUsage]).toEqual([
+        {
+          id: usageEventIds[0]!,
+          turn_association: "current",
+          duplicate_of_event_id: null,
+          duplicate_reason: null,
+        },
+        {
+          id: usageEventIds[1]!,
+          turn_association: "duplicate",
+          duplicate_of_event_id: usageEventIds[0]!,
+          duplicate_reason: "duplicate_provider_response_usage",
+        },
+        {
+          id: usageEventIds[2]!,
+          turn_association: "duplicate",
+          duplicate_of_event_id: usageEventIds[0]!,
+          duplicate_reason: "duplicate_provider_response_usage",
+        },
+      ]);
+      const enrollable = await sql<Array<{ session_id: string }>>`
+          select session_id
+          from opengeni_private.list_enrollable_sessions(10000)
+          order by session_id`;
+      expect(enrollable.map((row) => row.session_id)).toEqual(
+        [sessionId, recoverySessionId].sort(),
+      );
+
       const migrated = await captureSessionControlCutoverSnapshot(
         sql,
         "migrated",
         "2026-07-14T10:01:00.000Z",
       );
-      const result = reconcileSessionControlCutover(baseline, migrated, "migration");
+      const result = reconcileSessionControlCutover(remediationBaseline, migrated, "migration");
       expect(result.errors).toEqual([]);
       expect(result.ok).toBe(true);
 

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   addSessionSystemUpdate,
+  acceptSessionApprovalDecision,
   applyCreditDebitUpToBalance,
   applyCreditLedgerEntry,
   applyContextCompaction,
@@ -10,7 +11,7 @@ import {
   appendSessionEventsForTurnAttempt,
   bootstrapWorkspace,
   cancelQueuedSessionTurnWithVersion,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   createDb,
   createSession,
   enqueueSessionMessageAtomically,
@@ -22,11 +23,13 @@ import {
   listPendingSessionSystemUpdates,
   listUsageEvents,
   isSessionCompactionRequested,
+  peekSessionWork,
+  recoverSessionDispatch,
+  reparkOrphanedSessionTurn,
   requestSessionCompaction,
   requestSessionControl,
   requestSessionTurnRecovery,
   registerPendingSessionToolCall,
-  registerSessionTurnDispatch,
   recordPendingSessionToolCallResult,
   recordUsageEvent,
   recordSkippedContextCompaction,
@@ -100,24 +103,39 @@ async function send(
   });
 }
 
+async function claimTestSessionWork(
+  db: Parameters<typeof claimSessionWorkForAttempt>[0],
+  workspaceId: string,
+  sessionId: string,
+  workflowId: string,
+  options: {
+    attemptId?: string;
+    dispatchId?: string;
+    trigger?: Parameters<typeof claimSessionWorkForAttempt>[2]["trigger"];
+  } = {},
+) {
+  const result = await claimSessionWorkForAttempt(db, workspaceId, {
+    sessionId,
+    workflowId,
+    attemptId: options.attemptId ?? crypto.randomUUID(),
+    dispatchId: options.dispatchId ?? `dispatch-${crypto.randomUUID()}`,
+    trigger: options.trigger ?? { kind: "next" },
+  });
+  return result.action === "claimed" ? result.turn : null;
+}
+
 describe("clean session control plane", () => {
   test("recovery closes an in-flight tool call with explicit unknown outcome exactly once", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "change the external state");
-    const turn = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     expect(
       await registerPendingSessionToolCall(client.db, {
         accountId: grant.accountId,
@@ -200,23 +218,127 @@ describe("clean session control plane", () => {
     ).toMatchObject({ action: "stale", events: [] });
   });
 
-  test("recovery preserves a completed parallel result and interrupts only its unresolved sibling", async () => {
+  test("cutover repark clears only the exact orphaned owner without creating queue work", async () => {
     const { grant, session } = await fixture();
-    await send(grant, session.id, "run A and B in parallel");
-    const turn = await claimNextSessionExecution(
+    await send(grant, session.id, "continue after the production cutover");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    await registerPendingSessionToolCall(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn!.id,
+      executionGeneration: turn!.executionGeneration,
+      attemptId,
+      callId: "cutover-call",
+      callType: "function_call",
+      callItem: {
+        type: "function_call",
+        name: "external_mutation",
+        callId: "cutover-call",
+        status: "in_progress",
+        arguments: "{}",
+      },
+    });
+
+    const result = await reparkOrphanedSessionTurn(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn!.id,
+      attemptId,
+      reason: "production_cutover",
+    });
+    expect(result).toMatchObject({
+      action: "recovering",
+      sessionStatus: "recovering",
+      closedToolCalls: 1,
+    });
+    expect(result.events.map((event) => event.type)).toEqual([
+      "agent.toolCall.output",
+      "turn.recovery.requested",
+      "session.status.changed",
+    ]);
+    expect(await getSessionTurn(client.db, grant.workspaceId!, turn!.id)).toMatchObject({
+      id: turn!.id,
+      status: "recovering",
+      activeAttemptId: null,
+      position: turn!.position,
+    });
+    expect(await getSessionQueueSnapshot(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      items: [],
+    });
+    expect(
+      await reparkOrphanedSessionTurn(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        turnId: turn!.id,
+        attemptId,
+        reason: "production_cutover",
+      }),
+    ).toMatchObject({ action: "stale", events: [], activeAttemptId: null });
+  });
+
+  test("cutover repark recovers a partially applied 0057 turn with no attempt owner", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "continue after the interrupted schema cutover");
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db
+        .update(schema.sessionTurns)
+        .set({ activeAttemptId: null })
+        .where(
+          and(
+            eq(schema.sessionTurns.workspaceId, grant.workspaceId!),
+            eq(schema.sessionTurns.id, turn!.id),
+          ),
+        );
+    });
+
+    const result = await reparkOrphanedSessionTurn(client.db, grant.workspaceId!, {
       sessionId: session.id,
       turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
+      attemptId: null,
+      reason: "production_cutover_partial_0057",
     });
+    expect(result).toMatchObject({
+      action: "recovering",
+      sessionStatus: "recovering",
+      closedToolCalls: 0,
+    });
+    expect(result.events.map((event) => event.type)).toEqual([
+      "turn.recovery.requested",
+      "session.status.changed",
+    ]);
+    expect(result.events.every((event) => event.turnAttemptId === null)).toBe(true);
+    expect(await getSessionTurn(client.db, grant.workspaceId!, turn!.id)).toMatchObject({
+      status: "recovering",
+      activeAttemptId: null,
+    });
+    expect(await getSessionQueueSnapshot(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      items: [],
+    });
+  });
+
+  test("recovery preserves a completed parallel result and interrupts only its unresolved sibling", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "run A and B in parallel");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
     for (const callId of ["call-a", "call-b"]) {
       await registerPendingSessionToolCall(client.db, {
         accountId: grant.accountId,
@@ -284,20 +406,14 @@ describe("clean session control plane", () => {
   test("a pending approval tool receipt follows the logical turn into its next attempt", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "use the protected tool");
-    const turn = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     await registerPendingSessionToolCall(client.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,
@@ -333,20 +449,24 @@ describe("clean session control plane", () => {
       },
     ]);
     const resumedAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: approval!.id,
-      attemptId: resumedAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
+    const resumedTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      {
+        attemptId: resumedAttemptId,
+        trigger: { kind: "approval", triggerEventId: approval!.id },
+      },
+    );
+    expect(resumedTurn?.id).toBe(turn!.id);
     expect(
       await recordPendingSessionToolCallResult(client.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId!,
         sessionId: session.id,
         turnId: turn!.id,
-        executionGeneration: turn!.executionGeneration,
+        executionGeneration: resumedTurn!.executionGeneration,
         attemptId: resumedAttemptId,
         callId: "approval-call",
         resultItem: {
@@ -382,20 +502,14 @@ describe("clean session control plane", () => {
   test("Pause preserves a pending approval, while Steer permanently closes it", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "ask before running");
-    const turn = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     await registerPendingSessionToolCall(client.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,
@@ -480,6 +594,86 @@ describe("clean session control plane", () => {
     expect(queue?.items.every((turn) => ["user", "api"].includes(turn.source))).toBe(true);
   });
 
+  test("workflow enrollment never marks a queued prompt running before turn capacity accepts it", async () => {
+    const { grant, session } = await fixture();
+    const queued = await send(grant, session.id, "wait for a bounded turn slot");
+
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "runnable",
+    });
+    const before = await getSession(client.db, grant.workspaceId!, session.id);
+    expect(before).toMatchObject({ status: "queued", activeTurnId: null });
+    expect(await getSessionTurn(client.db, grant.workspaceId!, queued.turn.id)).toMatchObject({
+      status: "queued",
+      activeAttemptId: null,
+      executionGeneration: 0,
+    });
+
+    const neverStartedAttemptId = crypto.randomUUID();
+    expect(
+      await recoverSessionDispatch(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        attemptId: neverStartedAttemptId,
+        timeoutType: "SCHEDULE_TO_START",
+        maxRedispatches: 3,
+      }),
+    ).toEqual({ action: "unclaimed", events: [] });
+    expect(await getSessionTurn(client.db, grant.workspaceId!, queued.turn.id)).toMatchObject({
+      status: "queued",
+      activeAttemptId: null,
+      executionGeneration: 0,
+    });
+  });
+
+  test("heartbeat recovery reparks only the exact owning attempt", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "survive a worker loss");
+    const firstAttemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: firstAttemptId },
+    );
+    if (!first) throw new Error("first recovery attempt was not claimed");
+    expect(
+      await recoverSessionDispatch(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        attemptId: firstAttemptId,
+        timeoutType: "HEARTBEAT",
+        maxRedispatches: 3,
+      }),
+    ).toMatchObject({ action: "recovering", turnId: first.id, redispatches: 1 });
+
+    const secondAttemptId = crypto.randomUUID();
+    const second = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: secondAttemptId },
+    );
+    expect(second).toMatchObject({
+      id: first.id,
+      status: "running",
+      activeAttemptId: secondAttemptId,
+      executionGeneration: first.executionGeneration + 1,
+    });
+    expect(
+      await recoverSessionDispatch(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        attemptId: firstAttemptId,
+        timeoutType: "HEARTBEAT",
+        maxRedispatches: 3,
+      }),
+    ).toMatchObject({ action: "stale", activeTurnId: first.id });
+    expect(await getSessionTurn(client.db, grant.workspaceId!, first.id)).toMatchObject({
+      status: "running",
+      activeAttemptId: secondAttemptId,
+    });
+  });
+
   test("a waiting prompt can only be deleted with exact queue and row versions", async () => {
     const { grant, session } = await fixture();
     const queued = await send(grant, session.id, "delete me");
@@ -527,7 +721,7 @@ describe("clean session control plane", () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
 
-    const compaction = await claimNextSessionExecution(
+    const compaction = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
@@ -548,7 +742,7 @@ describe("clean session control plane", () => {
     const promptCase = await fixture();
     await requestSessionCompaction(client.db, promptCase.grant.workspaceId!, promptCase.session.id);
     const prompt = await send(promptCase.grant, promptCase.session.id, "answer me first");
-    const claimedPrompt = await claimNextSessionExecution(
+    const claimedPrompt = await claimTestSessionWork(
       client.db,
       promptCase.grant.workspaceId!,
       promptCase.session.id,
@@ -570,7 +764,7 @@ describe("clean session control plane", () => {
       payload: { type: "runtime_notice" },
     });
     await requestSessionCompaction(client.db, updateCase.grant.workspaceId!, updateCase.session.id);
-    const claimedCompaction = await claimNextSessionExecution(
+    const claimedCompaction = await claimTestSessionWork(
       client.db,
       updateCase.grant.workspaceId!,
       updateCase.session.id,
@@ -589,20 +783,14 @@ describe("clean session control plane", () => {
   test("Pause fences an active compaction attempt without consuming its request", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const compaction = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const compaction = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: compaction!.id,
-      triggerEventId: compaction!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
 
     const paused = await requestSessionControl(client.db, {
       accountId: grant.accountId,
@@ -632,20 +820,14 @@ describe("clean session control plane", () => {
   test("Steer supersedes maintenance compaction and leaves the request for the new prompt", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const compaction = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const compaction = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: compaction!.id,
-      triggerEventId: compaction!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
 
     const steered = await send(grant, session.id, "use this instead", "steer");
     expect(steered.shouldSignalControl).toBe(true);
@@ -655,7 +837,13 @@ describe("clean session control plane", () => {
     expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
       true,
     );
-    const next = await claimNextSessionExecution(
+    await settlePendingSessionControl(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      steered.controlEvent!.id,
+    );
+    const next = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
@@ -671,20 +859,14 @@ describe("clean session control plane", () => {
   test("worker death recovers the same compaction execution without entering the queue", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const first = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: first!.id,
-      triggerEventId: first!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     expect(
       await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
         sessionId: session.id,
@@ -695,7 +877,7 @@ describe("clean session control plane", () => {
       }),
     ).toMatchObject({ action: "recovering" });
 
-    const recovered = await claimNextSessionExecution(
+    const recovered = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
@@ -718,20 +900,14 @@ describe("clean session control plane", () => {
   test("a prompt queued during compaction makes settlement publish queued, not idle", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
-    const compaction = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const compaction = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: compaction!.id,
-      triggerEventId: compaction!.triggerEventId,
-      attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     await send(grant, session.id, "wait for compaction");
 
     const settled = await applySessionTurnSettlement(client.db, grant.workspaceId!, {
@@ -822,20 +998,14 @@ describe("clean session control plane", () => {
   test("Pause blocks a racing terminal settlement and Resume admits a new attempt of the same turn", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "keep this inference resumable");
-    const turn = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     const paused = await requestSessionControl(client.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,
@@ -874,7 +1044,7 @@ describe("clean session control plane", () => {
       clientEventId: `resume-${crypto.randomUUID()}`,
     });
     expect(resumed.shouldWake).toBe(true);
-    const resumedTurn = await claimNextSessionExecution(
+    const resumedTurn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
@@ -885,37 +1055,20 @@ describe("clean session control plane", () => {
       status: "running",
       executionGeneration: turn!.executionGeneration + 1,
     });
-    expect(
-      await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-        sessionId: session.id,
-        turnId: turn!.id,
-        triggerEventId: turn!.triggerEventId,
-        attemptId: crypto.randomUUID(),
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
   });
 
   test("Send cannot erase an unsettled Pause fence", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "running prompt");
-    const running = await claimNextSessionExecution(
+    const attemptId = crypto.randomUUID();
+    const running = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
     expect(running?.status).toBe("running");
-    const attemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-        sessionId: session.id,
-        turnId: running!.id,
-        triggerEventId: running!.triggerEventId,
-        attemptId,
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
     const paused = await requestSessionControl(client.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,
@@ -959,20 +1112,14 @@ describe("clean session control plane", () => {
   test("a replaced attempt keeps late evidence but cannot publish it as current truth", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "do work");
-    const first = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: first!.id,
-      triggerEventId: first!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     expect(
       await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
         sessionId: session.id,
@@ -982,19 +1129,9 @@ describe("clean session control plane", () => {
         reason: "worker_shutdown",
       }),
     ).toMatchObject({ action: "recovering" });
-    const second = await claimNextSessionExecution(
-      client.db,
-      grant.workspaceId!,
-      session.id,
-      `session-${session.id}`,
-    );
     const secondAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: second!.id,
-      triggerEventId: second!.triggerEventId,
+    await claimTestSessionWork(client.db, grant.workspaceId!, session.id, `session-${session.id}`, {
       attemptId: secondAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
     });
 
     const rejected = await appendSessionEventsForTurnAttempt(
@@ -1025,20 +1162,14 @@ describe("clean session control plane", () => {
   test("a replaced attempt cannot compact history or overwrite its token signal", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "build it");
-    const first = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: first!.id,
-      triggerEventId: first!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     expect(
       await appendSessionHistoryItems(client.db, {
         accountId: grant.accountId,
@@ -1062,20 +1193,14 @@ describe("clean session control plane", () => {
       attemptId: firstAttemptId,
       reason: "worker_shutdown",
     });
-    const second = await claimNextSessionExecution(
+    const secondAttemptId = crypto.randomUUID();
+    const second = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: secondAttemptId },
     );
-    const secondAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: second!.id,
-      triggerEventId: second!.triggerEventId,
-      attemptId: secondAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
 
     const staleCompaction = await applyContextCompaction(client.db, {
       accountId: grant.accountId,
@@ -1150,23 +1275,77 @@ describe("clean session control plane", () => {
     ]);
   });
 
-  test("a completed model call keeps usage truth when its attempt is replaced before signals", async () => {
+  test("one provider response has one current usage event and auditable duplicates", async () => {
     const { grant, session } = await fixture();
-    await send(grant, session.id, "meter this completed call");
-    const turn = await claimNextSessionExecution(
+    await send(grant, session.id, "meter one provider response");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId },
     );
-    const attemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: turn!.id,
-      triggerEventId: turn!.triggerEventId,
+    if (!turn) throw new Error("usage test turn was not claimed");
+    const sourceKey = `response-${crypto.randomUUID()}`;
+
+    const firstBatch = await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      turn.id,
+      turn.executionGeneration,
       attemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
+      [
+        { type: "agent.model.usage", payload: { sourceKey, totalTokens: 100 } },
+        { type: "agent.model.usage", payload: { sourceKey, totalTokens: 100 } },
+      ],
+    );
+    expect(firstBatch.accepted).toBe(true);
+    expect(firstBatch.events).toHaveLength(2);
+    expect(firstBatch.events[0]).toMatchObject({
+      turnAssociation: "current",
+      duplicateOfEventId: null,
+      duplicateReason: null,
     });
+    expect(firstBatch.events[1]).toMatchObject({
+      turnAssociation: "duplicate",
+      duplicateOfEventId: firstBatch.events[0]!.id,
+      duplicateReason: "duplicate_provider_response_usage",
+    });
+
+    const later = await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      turn.id,
+      turn.executionGeneration,
+      attemptId,
+      [{ type: "agent.model.usage", payload: { sourceKey, totalTokens: 100 } }],
+    );
+    expect(later).toMatchObject({
+      accepted: true,
+      events: [
+        {
+          turnAssociation: "duplicate",
+          duplicateOfEventId: firstBatch.events[0]!.id,
+          duplicateReason: "duplicate_provider_response_usage",
+        },
+      ],
+    });
+  });
+
+  test("a completed model call keeps usage truth when its attempt is replaced before signals", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "meter this completed call");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
 
     await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
       sessionId: session.id,
@@ -1272,20 +1451,14 @@ describe("clean session control plane", () => {
   test("only the current attempt can consume an empty manual compaction request", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "first inference");
-    const first = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const first = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: first!.id,
-      triggerEventId: first!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
     expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
       true,
@@ -1316,19 +1489,9 @@ describe("clean session control plane", () => {
       attemptId: firstAttemptId,
       reason: "worker_shutdown",
     });
-    const second = await claimNextSessionExecution(
-      client.db,
-      grant.workspaceId!,
-      session.id,
-      `session-${session.id}`,
-    );
     const secondAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: second!.id,
-      triggerEventId: second!.triggerEventId,
+    await claimTestSessionWork(client.db, grant.workspaceId!, session.id, `session-${session.id}`, {
       attemptId: secondAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
     });
     expect(
       await recordSkippedContextCompaction(client.db, {
@@ -1349,20 +1512,14 @@ describe("clean session control plane", () => {
   test("approval dispatch advances the same turn's recovery trigger", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "use the protected tool");
-    const running = await claimNextSessionExecution(
+    const firstAttemptId = crypto.randomUUID();
+    const running = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       `session-${session.id}`,
+      { attemptId: firstAttemptId },
     );
-    const firstAttemptId = crypto.randomUUID();
-    await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-      sessionId: session.id,
-      turnId: running!.id,
-      triggerEventId: running!.triggerEventId,
-      attemptId: firstAttemptId,
-      dispatchId: `dispatch-${crypto.randomUUID()}`,
-    });
     expect(
       await applySessionTurnSettlement(client.db, grant.workspaceId!, {
         sessionId: session.id,
@@ -1382,15 +1539,17 @@ describe("clean session control plane", () => {
       },
     ]);
     const approvalAttemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(client.db, grant.workspaceId!, {
-        sessionId: session.id,
-        turnId: running!.id,
-        triggerEventId: approval!.id,
+    const approvalTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      {
         attemptId: approvalAttemptId,
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
+        trigger: { kind: "approval", triggerEventId: approval!.id },
+      },
+    );
+    expect(approvalTurn?.id).toBe(running!.id);
     expect((await getSessionTurn(client.db, grant.workspaceId!, running!.id))?.triggerEventId).toBe(
       approval!.id,
     );
@@ -1404,7 +1563,7 @@ describe("clean session control plane", () => {
         reason: "worker_shutdown",
       }),
     ).toMatchObject({ action: "recovering" });
-    const recovered = await claimNextSessionExecution(
+    const recovered = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
@@ -1412,7 +1571,77 @@ describe("clean session control plane", () => {
     );
     expect(recovered?.id).toBe(running!.id);
     expect(recovered?.triggerEventId).toBe(approval!.id);
-    expect(recovered?.executionGeneration).toBe(running!.executionGeneration + 1);
+    expect(recovered?.executionGeneration).toBe(approvalTurn!.executionGeneration + 1);
+  });
+
+  test("approval acceptance is single-winner and restores its durable wait after workflow loss", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "wait for approval");
+    const firstAttemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: firstAttemptId },
+    );
+    if (!turn) throw new Error("approval test turn was not claimed");
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn.id,
+      triggerEventId: turn.triggerEventId,
+      attemptId: firstAttemptId,
+      turnStatus: "requires_action",
+      sessionStatus: "requires_action",
+      activeTurnId: turn.id,
+      events: [{ type: "session.requiresAction", payload: { approvalId: "approval-race" } }],
+    });
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "approval-wait",
+    });
+
+    const decisions = await Promise.all([
+      acceptSessionApprovalDecision(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        payload: { approvalId: "approval-race", decision: "approve" },
+        clientEventId: `approval-a-${crypto.randomUUID()}`,
+      }),
+      acceptSessionApprovalDecision(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        payload: { approvalId: "approval-race", decision: "reject" },
+        clientEventId: `approval-b-${crypto.randomUUID()}`,
+      }),
+    ]);
+    expect(decisions.map((decision) => decision.action).sort()).toEqual(["accepted", "conflict"]);
+    const accepted = decisions.find((decision) => decision.action === "accepted");
+    if (!accepted || accepted.action !== "accepted") throw new Error("approval had no winner");
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "approval-pending",
+      triggerEventId: accepted.event.id,
+    });
+
+    const resumedAttemptId = crypto.randomUUID();
+    const resumed = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      {
+        attemptId: resumedAttemptId,
+        trigger: { kind: "approval", triggerEventId: accepted.event.id },
+      },
+    );
+    expect(resumed).toMatchObject({
+      id: turn.id,
+      status: "running",
+      activeAttemptId: resumedAttemptId,
+      triggerEventId: accepted.event.id,
+      executionGeneration: turn.executionGeneration + 1,
+    });
   });
 
   test("a workspace pause exception is generation-bound", async () => {
@@ -1459,7 +1688,7 @@ describe("clean session control plane", () => {
       exceptSessionIds: [],
     });
     expect(
-      await claimNextSessionExecution(
+      await claimTestSessionWork(
         client.db,
         grant.workspaceId!,
         session.id,
@@ -1495,7 +1724,7 @@ describe("clean session control plane", () => {
     expect(snapshot?.workspaceInferenceGeneration).toBe(pausedAgain.generation);
     expect(snapshot?.workspaceRunExceptionGeneration).toBeNull();
     expect(
-      await claimNextSessionExecution(
+      await claimTestSessionWork(
         client.db,
         grant.workspaceId!,
         session.id,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -46,6 +46,7 @@
     "openai": "6.47.0"
   },
   "devDependencies": {
+    "@openai/agents-core": "0.13.3",
     "tsup": "^8.5.0",
     "typescript": "^6.0.3"
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,14 +36,14 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@openai/agents": "0.11.6",
-    "@openai/agents-extensions": "0.11.6",
+    "@openai/agents": "0.13.3",
+    "@openai/agents-extensions": "0.13.3",
     "@opengeni/agent-proto": "workspace:*",
     "@opengeni/codex": "workspace:*",
     "@opengeni/config": "workspace:*",
     "@opengeni/contracts": "workspace:*",
-    "modal": "^0.7.4",
-    "openai": "6.36.0"
+    "modal": "0.7.6",
+    "openai": "6.47.0"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -119,7 +119,6 @@ import {
   sanitizeHistoryItemsForModel,
 } from "./history-sanitizer";
 import { installCodexToolSearch } from "./codex-tool-search";
-import { modelCallUsageTelemetry } from "./usage-telemetry";
 import {
   CompactionNeededError,
   SUMMARY_BUFFER_TOKENS,
@@ -3973,16 +3972,6 @@ export function normalizeSdkEvent(event: RunStreamEvent): NormalizedRuntimeEvent
       return out;
     }
     if (data?.type === "response_done") {
-      const responseUsage = modelResponseUsageFromSdkEvent(event);
-      if (responseUsage) {
-        out.push({
-          type: "agent.model.usage",
-          payload: {
-            responseId: responseUsage.responseId ?? null,
-            ...modelCallUsageTelemetry(responseUsage.usage),
-          },
-        });
-      }
       return out;
     }
   }
@@ -3990,18 +3979,6 @@ export function normalizeSdkEvent(event: RunStreamEvent): NormalizedRuntimeEvent
     const raw = (event as any).data?.event;
     if (raw?.type === "response.reasoning_summary_text.delta" && typeof raw.delta === "string") {
       out.push({ type: "agent.reasoning.delta", payload: { text: raw.delta } });
-    }
-    if (raw?.type === "response.completed") {
-      const responseUsage = modelResponseUsageFromSdkEvent(event);
-      if (responseUsage) {
-        out.push({
-          type: "agent.model.usage",
-          payload: {
-            responseId: responseUsage.responseId ?? null,
-            ...modelCallUsageTelemetry(responseUsage.usage),
-          },
-        });
-      }
     }
     return out;
   }

--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -74,10 +74,11 @@ export const modalProvider: ProviderRegistration = {
       sandboxCreateTimeoutS: Math.ceil(settings.sandboxWarmingTimeoutMs / 1000),
       exposedPorts,
       env: environment,
-      // The Modal JS SDK's sandbox default command already sleeps until timeout
-      // or explicit termination. Do not let the Agents extension stamp a separate
-      // hardcoded sleep command; OPENGENI_MODAL_TIMEOUT_SECONDS owns lifetime.
-      useSleepCmd: false,
+      // A registry image's own CMD is not a sandbox keepalive contract (for
+      // example, python:3.12-slim can exit immediately). Keep the provider's
+      // control process alive so exec/resume remains available; Modal's hard
+      // timeout and explicit OpenGeni teardown still own the box lifetime.
+      useSleepCmd: true,
     };
     // gap-fill (module 03 §4.1): these SDK options were previously unmapped.
     // ALWAYS pin idleTimeoutMs (sandbox-file-persistence): an UNSET idle timeout

--- a/packages/runtime/test/lazy-provisioning.test.ts
+++ b/packages/runtime/test/lazy-provisioning.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { ScriptedModel, testSettings } from "@opengeni/testing";
 import { buildManifest, buildOpenGeniAgent, runOwnedSandboxSetup } from "../src/index";
 import { RoutingSandboxSession, type RoutableBackendSession } from "../src/sandbox";
-import { applyManifestToProvidedSession } from "../../../node_modules/.bun/@openai+agents-core@0.11.6+4b65e697391ccbcb/node_modules/@openai/agents-core/dist/sandbox/runtime/providedSessionManifest.js";
+
+const agentsCoreEntry = import.meta.resolve("@openai/agents-core");
+const { applyManifestToProvidedSession } = (await import(
+  new URL("./sandbox/runtime/providedSessionManifest.mjs", agentsCoreEntry).href
+)) as {
+  applyManifestToProvidedSession: (session: never, manifest: never) => Promise<void>;
+};
 
 async function manifestEnv(manifest: {
   resolveEnvironment?: () => Promise<Record<string, string>>;

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -127,7 +127,7 @@ describe("runtime event normalization", () => {
     });
   });
 
-  test("extracts model usage from streamed response completion events", () => {
+  test("extracts streamed usage without manufacturing a durable event", () => {
     const event = {
       type: "raw_model_stream_event",
       data: {
@@ -156,21 +156,10 @@ describe("runtime event normalization", () => {
         outputTokensDetails: { reasoning_tokens: 2 },
       },
     });
-    expect(normalizeSdkEvent(event)).toEqual([
-      {
-        type: "agent.model.usage",
-        payload: {
-          responseId: "resp-1",
-          inputTokens: 10,
-          outputTokens: 5,
-          cachedTokens: 3,
-          reasoningTokens: 2,
-        },
-      },
-    ]);
+    expect(normalizeSdkEvent(event)).toEqual([]);
   });
 
-  test("extracts model usage from raw Responses completion events", () => {
+  test("extracts raw Responses usage without manufacturing a durable event", () => {
     const event = new RunRawModelStreamEvent({
       type: "model",
       providerData: {
@@ -202,18 +191,7 @@ describe("runtime event normalization", () => {
         outputTokensDetails: { reasoning_tokens: 6 },
       },
     });
-    expect(normalizeSdkEvent(event)).toEqual([
-      {
-        type: "agent.model.usage",
-        payload: {
-          responseId: "resp-2",
-          inputTokens: 20,
-          outputTokens: 8,
-          cachedTokens: 4,
-          reasoningTokens: 6,
-        },
-      },
-    ]);
+    expect(normalizeSdkEvent(event)).toEqual([]);
   });
 
   test("normalizes model-call usage telemetry fields defensively", () => {

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -95,7 +95,7 @@ describe("createSandboxClient — per-backend matrix construction", () => {
     expect(client.options?.sandboxCreateTimeoutS).toBe(600);
     // The Agents extension otherwise stamps a hardcoded sleep command; let
     // Modal's own timeout own lifetime instead.
-    expect(client.options?.useSleepCmd).toBe(false);
+    expect(client.options?.useSleepCmd).toBe(true);
     // sandbox-file-persistence: idleTimeoutMs is ALWAYS pinned; with no explicit
     // OPENGENI_MODAL_IDLE_TIMEOUT_SECONDS it DEFAULTS to the hard lifetime so
     // Modal's short server-default idle-reap can never kill an idle box before the
@@ -116,7 +116,7 @@ describe("createSandboxClient — per-backend matrix construction", () => {
     expect(client.options?.timeoutMs).toBe(7_200_000);
     expect(client.options?.idleTimeoutMs).toBe(7_200_000);
     expect(client.options?.sandboxCreateTimeoutS).toBe(123);
-    expect(client.options?.useSleepCmd).toBe(false);
+    expect(client.options?.useSleepCmd).toBe(true);
   });
 
   test("modal idleTimeoutMs honours an explicit override (still pinned, not the SDK default)", () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -621,7 +621,9 @@ export type SessionEvent = {
   turnId?: string | null | undefined;
   turnGeneration?: number | null | undefined;
   turnAttemptId?: string | null | undefined;
-  turnAssociation?: "current" | "late_rejected" | null | undefined;
+  turnAssociation?: "current" | "late_rejected" | "duplicate" | null | undefined;
+  duplicateOfEventId?: string | null | undefined;
+  duplicateReason?: string | null | undefined;
 };
 
 export type ToolAuthNeededPayload = {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/agents": "0.11.6",
+    "@openai/agents": "0.13.3",
     "@opengeni/config": "workspace:*",
     "@opengeni/contracts": "workspace:*",
     "@opengeni/db": "workspace:*",

--- a/packages/testing/src/e2e-worker.ts
+++ b/packages/testing/src/e2e-worker.ts
@@ -7,11 +7,16 @@ import type { Model, ModelRequest, ModelResponse, StreamEvent } from "@openai/ag
 import { functionCall, ScriptedModel, type ScriptedModelStep } from "./scripted-model";
 
 const settings = getSettings();
+const role = process.env.OPENGENI_WORKER_ROLE;
+if (role !== "control" && role !== "turn") {
+  throw new Error("OPENGENI_WORKER_ROLE must be 'control' or 'turn' for the E2E worker");
+}
 const dbClient = createDb(settings.databaseUrl);
 const bus = await createNatsEventBus(settings.natsUrl);
 const model = scriptedModelForScenario(process.env.OPENGENI_TEST_SCENARIO ?? "default");
 const runtime = createProductionAgentRuntime({ model });
 const { worker, connection } = await createOpenGeniWorker({
+  role,
   settings,
   activityDependencies: {
     settings,
@@ -21,7 +26,7 @@ const { worker, connection } = await createOpenGeniWorker({
   },
 });
 
-console.log(`OpenGeni test worker listening on ${settings.temporalTaskQueue}`);
+console.log(`OpenGeni ${role} test worker listening on ${settings.temporalTaskQueue}`);
 try {
   await worker.run();
 } finally {

--- a/packages/testing/src/process.ts
+++ b/packages/testing/src/process.ts
@@ -42,6 +42,42 @@ export type StartedProcess = {
   stop: () => Promise<void>;
 };
 
+export type StartedE2eWorkerTopology = {
+  control: StartedProcess;
+  turns: StartedProcess;
+  logs: () => string;
+  ready: () => boolean;
+  stop: () => Promise<void>;
+};
+
+/** Start the same isolated control/turn worker topology used in production. */
+export async function startE2eWorkerTopology(options: {
+  cwd: string;
+  env: Record<string, string | undefined>;
+}): Promise<StartedE2eWorkerTopology> {
+  const [control, turns] = await Promise.all([
+    startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+      ...options,
+      env: { ...options.env, OPENGENI_WORKER_ROLE: "control" },
+    }),
+    startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+      ...options,
+      env: { ...options.env, OPENGENI_WORKER_ROLE: "turn" },
+    }),
+  ]);
+  return {
+    control,
+    turns,
+    logs: () => `[control]\n${control.logs()}\n[turns]\n${turns.logs()}`,
+    ready: () =>
+      control.logs().includes("OpenGeni control test worker listening") &&
+      turns.logs().includes("OpenGeni turn test worker listening"),
+    stop: async () => {
+      await Promise.allSettled([control.stop(), turns.stop()]);
+    },
+  };
+}
+
 export async function startProcess(
   args: string[],
   options: {

--- a/scripts/operator/session-control-cutover.test.ts
+++ b/scripts/operator/session-control-cutover.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { schedulePauseOwnedByRun } from "./session-control-cutover";
+import { countBoundedWakeProgress, schedulePauseOwnedByRun } from "./session-control-cutover";
 
 describe("production cutover operator retry ownership", () => {
   it("re-emits only unpaused schedules or schedules already paused by the same run", () => {
@@ -8,5 +8,18 @@ describe("production cutover operator retry ownership", () => {
     expect(schedulePauseOwnedByRun(true, note, note)).toBe(true);
     expect(schedulePauseOwnedByRun(true, "manual operator pause", note)).toBe(false);
     expect(schedulePauseOwnedByRun(true, null, note)).toBe(false);
+  });
+});
+
+describe("production cutover bounded wake proof", () => {
+  it("counts each initially runnable session once across running, terminal, and waiting proofs", () => {
+    expect(
+      countBoundedWakeProgress(
+        ["running", "done", "capacity", "approval"],
+        ["running", "capacity"],
+        ["done", "running"],
+        ["capacity", "approval", "not-in-the-initial-runnable-set"],
+      ),
+    ).toBe(4);
   });
 });

--- a/scripts/operator/session-control-cutover.ts
+++ b/scripts/operator/session-control-cutover.ts
@@ -7,6 +7,7 @@ import {
   type CutoverPhase,
   type SessionControlCutoverSnapshot,
 } from "@opengeni/db/session-control-cutover-audit";
+import { createDb, reparkOrphanedSessionTurn } from "@opengeni/db";
 import { getSettings } from "@opengeni/config";
 import { createObjectStorage } from "@opengeni/storage";
 import { Client as TemporalClient, Connection } from "@temporalio/client";
@@ -190,16 +191,100 @@ async function reconcile(args: ParsedArgs): Promise<void> {
   );
 }
 
-type Claimable = {
+type Enrollable = {
   account_id: string;
   workspace_id: string;
   session_id: string;
   temporal_workflow_id: string;
 };
 
+type EnrollmentState = {
+  session_id: string;
+  approval_waiting: boolean;
+  capacity_waiting: boolean;
+  control_pending: boolean;
+  runnable: boolean;
+};
+
+export function countBoundedWakeProgress(
+  initiallyRunnableSessionIds: Iterable<string>,
+  ...proofSets: Array<Iterable<string>>
+): number {
+  const initiallyRunnable = new Set(initiallyRunnableSessionIds);
+  const proven = new Set<string>();
+  for (const proofSet of proofSets) {
+    for (const sessionId of proofSet) {
+      if (initiallyRunnable.has(sessionId)) proven.add(sessionId);
+    }
+  }
+  return proven.size;
+}
+
+function integerArg(
+  args: ParsedArgs,
+  name: string,
+  options: { defaultValue?: number; min: number; max: number },
+): number {
+  const raw =
+    args.values.get(name) ??
+    (options.defaultValue === undefined ? required(args, name) : String(options.defaultValue));
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < options.min || parsed > options.max) {
+    throw new Error(`${name} must be an integer between ${options.min} and ${options.max}`);
+  }
+  return parsed;
+}
+
+async function runningSessionWorkflowIds(temporal: TemporalClient): Promise<Set<string>> {
+  const running = new Set<string>();
+  for await (const execution of temporal.workflow.list({ query: "ExecutionStatus='Running'" })) {
+    if (execution.workflowId.startsWith("session-")) running.add(execution.workflowId);
+  }
+  return running;
+}
+
+async function enrollmentStates(
+  sql: postgres.Sql,
+  sessionIds: string[],
+): Promise<EnrollmentState[]> {
+  if (sessionIds.length === 0) return [];
+  return (await sql.unsafe<EnrollmentState[]>(
+    `select s.id as session_id,
+       exists (
+         select 1 from session_turns t
+         where t.workspace_id = s.workspace_id and t.session_id = s.id
+           and t.status = 'requires_action'
+       ) as approval_waiting,
+       exists (
+         select 1 from session_turns t
+         where t.workspace_id = s.workspace_id and t.session_id = s.id
+           and t.status = 'waiting_capacity'
+       ) as capacity_waiting,
+       (s.pending_control_event_id is not null) as control_pending,
+       exists (
+         select 1 from session_turns t
+         where t.workspace_id = s.workspace_id and t.session_id = s.id
+           and t.status in ('queued', 'recovering')
+       ) as runnable
+     from sessions s where s.id = any($1::uuid[]) order by s.id`,
+    [sessionIds],
+  )) as unknown as EnrollmentState[];
+}
+
 async function wake(args: ParsedArgs): Promise<void> {
   const output = required(args, "--output");
   const execute = args.flags.has("--execute");
+  const turnCapacity = integerArg(args, "--turn-capacity", { min: 1, max: 10_000 });
+  const stabilitySeconds = integerArg(args, "--stability-seconds", {
+    defaultValue: 150,
+    min: 121,
+    max: 900,
+  });
+  const sampleSeconds = integerArg(args, "--sample-seconds", {
+    defaultValue: 5,
+    min: 1,
+    max: 30,
+  });
   const temporalSettingsValue = temporalSettings();
   const sql = postgres(migrationDatabaseUrl(), {
     max: 1,
@@ -210,9 +295,9 @@ async function wake(args: ParsedArgs): Promise<void> {
   });
   let connection: Connection | null = null;
   try {
-    const rows = (await sql.unsafe<Claimable[]>(
-      "select * from opengeni_private.list_claimable_sessions(10000)",
-    )) as unknown as Claimable[];
+    const rows = (await sql.unsafe<Enrollable[]>(
+      "select * from opengeni_private.list_enrollable_sessions(10000)",
+    )) as unknown as Enrollable[];
     if (rows.length === 10_000) {
       throw new Error(
         "claimable-session scan reached its hard limit; refusing a partial wake repair",
@@ -221,6 +306,21 @@ async function wake(args: ParsedArgs): Promise<void> {
     const ordered = [...rows].sort((a, b) => a.session_id.localeCompare(b.session_id));
     const failures: Array<{ sessionId: string; error: string }> = [];
     const woken: string[] = [];
+    const enrollmentProof: Array<{
+      sessionId: string;
+      workflowId: string;
+      outcome: "running-workflow" | "authoritative-progress";
+    }> = [];
+    const samples: Array<{
+      capturedAt: string;
+      runningTurns: number;
+      recoveringTurns: number;
+      heartbeatRecoveries: number;
+    }> = [];
+    const initialStates = await enrollmentStates(
+      sql,
+      ordered.map((row) => row.session_id),
+    );
     if (execute) {
       connection = await Connection.connect({
         address: temporalSettingsValue.address,
@@ -258,14 +358,151 @@ async function wake(args: ParsedArgs): Promise<void> {
         }
       });
       await Promise.all(workers);
+      if (failures.length === 0) {
+        const initialRecoveryRows = await sql<Array<{ count: number }>>`
+          select count(*)::integer as count from session_events
+          where type = 'turn.recovery.requested'
+            and payload ->> 'reason' = 'worker_death'`;
+        const initialHeartbeatRecoveries = Number(initialRecoveryRows[0]?.count ?? 0);
+        const deadline = Date.now() + stabilitySeconds * 1_000;
+        let maxRunningTurns = 0;
+        const sampledRunningSessionIds = new Set<string>();
+        while (Date.now() <= deadline) {
+          const [[counts], runningSessions] = await Promise.all([
+            sql<
+              Array<{
+                running_turns: number;
+                recovering_turns: number;
+                heartbeat_recoveries: number;
+              }>
+            >`
+            select
+              (select count(*)::integer from session_turns where status = 'running') as running_turns,
+              (select count(*)::integer from session_turns where status = 'recovering') as recovering_turns,
+              (select count(*)::integer from session_events
+               where type = 'turn.recovery.requested'
+                 and payload ->> 'reason' = 'worker_death') as heartbeat_recoveries`,
+            sql<Array<{ session_id: string }>>`
+              select distinct session_id::text as session_id
+              from session_turns where status = 'running'`,
+          ]);
+          for (const running of runningSessions) {
+            sampledRunningSessionIds.add(running.session_id);
+          }
+          const runningTurns = Number(counts?.running_turns ?? 0);
+          const recoveringTurns = Number(counts?.recovering_turns ?? 0);
+          const heartbeatRecoveries = Number(counts?.heartbeat_recoveries ?? 0);
+          maxRunningTurns = Math.max(maxRunningTurns, runningTurns);
+          samples.push({
+            capturedAt: new Date().toISOString(),
+            runningTurns,
+            recoveringTurns,
+            heartbeatRecoveries,
+          });
+          if (runningTurns > turnCapacity) {
+            throw new Error(
+              `database reports ${runningTurns} running turns above configured capacity ${turnCapacity}`,
+            );
+          }
+          if (heartbeatRecoveries > initialHeartbeatRecoveries) {
+            throw new Error(
+              "new heartbeat-timeout recovery appeared during the wake stability window",
+            );
+          }
+          if (Date.now() >= deadline) break;
+          await Bun.sleep(sampleSeconds * 1_000);
+        }
+
+        const remainingRows = (await sql.unsafe<Enrollable[]>(
+          "select * from opengeni_private.list_enrollable_sessions(10000)",
+        )) as unknown as Enrollable[];
+        if (remainingRows.length === 10_000) {
+          throw new Error("post-wake enrollable scan reached its hard limit");
+        }
+        const remaining = new Set(remainingRows.map((row) => row.session_id));
+        const runningWorkflows = await runningSessionWorkflowIds(temporal);
+        for (const row of ordered) {
+          if (runningWorkflows.has(row.temporal_workflow_id)) {
+            enrollmentProof.push({
+              sessionId: row.session_id,
+              workflowId: row.temporal_workflow_id,
+              outcome: "running-workflow",
+            });
+          } else if (!remaining.has(row.session_id)) {
+            enrollmentProof.push({
+              sessionId: row.session_id,
+              workflowId: row.temporal_workflow_id,
+              outcome: "authoritative-progress",
+            });
+          } else {
+            failures.push({
+              sessionId: row.session_id,
+              error: "session remains enrollable without a running workflow",
+            });
+          }
+        }
+        const finalStates = await enrollmentStates(
+          sql,
+          ordered.map((row) => row.session_id),
+        );
+        const finalBySession = new Map(finalStates.map((state) => [state.session_id, state]));
+        for (const initial of initialStates) {
+          const current = finalBySession.get(initial.session_id);
+          const workflowId = ordered.find(
+            (row) => row.session_id === initial.session_id,
+          )?.temporal_workflow_id;
+          if (
+            current &&
+            (current.approval_waiting || current.capacity_waiting) &&
+            (!workflowId || !runningWorkflows.has(workflowId))
+          ) {
+            failures.push({
+              sessionId: initial.session_id,
+              error: "approval/capacity wait remains without a running workflow",
+            });
+          }
+          if (initial.control_pending && current?.control_pending) {
+            failures.push({
+              sessionId: initial.session_id,
+              error: "pending control fence did not settle during the stability window",
+            });
+          }
+        }
+        const initiallyRunnableSessionIds = initialStates
+          .filter((state) => state.runnable)
+          .map((state) => state.session_id);
+        const authoritativeProgressSessionIds = enrollmentProof
+          .filter((proof) => proof.outcome === "authoritative-progress")
+          .map((proof) => proof.sessionId);
+        const waitingSessionIds = finalStates
+          .filter((state) => state.approval_waiting || state.capacity_waiting)
+          .map((state) => state.session_id);
+        const initiallyRunnable = initiallyRunnableSessionIds.length;
+        const expectedProgress = Math.min(turnCapacity, initiallyRunnable);
+        const observedProgress = countBoundedWakeProgress(
+          initiallyRunnableSessionIds,
+          sampledRunningSessionIds,
+          authoritativeProgressSessionIds,
+          waitingSessionIds,
+        );
+        if (observedProgress < expectedProgress) {
+          throw new Error(
+            `wake proved progress for ${observedProgress} session(s), below expected bounded progress ${expectedProgress}`,
+          );
+        }
+      }
     }
     const draft = {
-      contractVersion: "opengeni/session-control-cutover-wake/v1",
+      contractVersion: "opengeni/session-control-cutover-wake/v2",
       executed: execute,
       capturedAt: new Date().toISOString(),
-      claimableSessionIds: ordered.map((row) => row.session_id),
+      turnCapacity,
+      stabilitySeconds,
+      enrollableSessionIds: ordered.map((row) => row.session_id),
       workflowIds: ordered.map((row) => row.temporal_workflow_id),
       wokenSessionIds: woken.sort(),
+      enrollmentProof: enrollmentProof.sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
+      samples,
       failures: failures.sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
     };
     const receipt = { ...draft, sha256: sha256(draft) };
@@ -274,7 +511,7 @@ async function wake(args: ParsedArgs): Promise<void> {
       throw new Error(`wake repair failed for ${failures.length} session(s)`);
     }
     process.stderr.write(
-      `[cutover-wake] ${execute ? "woke" : "found"} ${ordered.length} claimable sessions, sha256 ${receipt.sha256}\n`,
+      `[cutover-wake] ${execute ? "enrolled" : "found"} ${ordered.length} sessions, sha256 ${receipt.sha256}\n`,
     );
   } finally {
     await connection?.close().catch(() => undefined);
@@ -507,6 +744,122 @@ async function temporalWorkflows(args: ParsedArgs): Promise<void> {
   }
 }
 
+type OrphanedRunningTurn = {
+  workspace_id: string;
+  session_id: string;
+  turn_id: string;
+  active_attempt_id: string | null;
+};
+
+async function reparkOrphanedTurns(args: ParsedArgs): Promise<void> {
+  const output = required(args, "--output");
+  const runId = safeRunId(required(args, "--run-id"));
+  const execute = args.flags.has("--execute");
+  const settings = temporalSettings();
+  const connection = await Connection.connect({ address: settings.address });
+  const sql = postgres(migrationDatabaseUrl(), {
+    max: 1,
+    prepare: false,
+    idle_timeout: 5,
+    connect_timeout: 15,
+    connection: { application_name: "opengeni-cutover-repark" },
+  });
+  const client = createDb(migrationDatabaseUrl(), { max: 1 });
+  try {
+    const temporal = new TemporalClient({ connection, namespace: settings.namespace });
+    const runningWorkflows: Array<{ workflowId: string; runId: string }> = [];
+    for await (const execution of temporal.workflow.list({ query: "ExecutionStatus='Running'" })) {
+      if (execution.workflowId.startsWith("session-")) {
+        runningWorkflows.push({ workflowId: execution.workflowId, runId: execution.runId });
+      }
+    }
+    if (runningWorkflows.length > 0) {
+      throw new Error(
+        `refusing to repark while ${runningWorkflows.length} session workflow(s) remain running`,
+      );
+    }
+    const migrations = await sql<Array<{ name: string }>>`
+      select name from schema_migrations
+      where name in ('0057_durable_queue_control.sql', '0058_turn_admission_usage_enrollment.sql')
+      order by name`;
+    const migrationNames = new Set(migrations.map((row) => row.name));
+    if (
+      !migrationNames.has("0057_durable_queue_control.sql") ||
+      !migrationNames.has("0058_turn_admission_usage_enrollment.sql")
+    ) {
+      throw new Error("repark requires the complete ordered 0057+0058 schema");
+    }
+    const rows = (await sql.unsafe<OrphanedRunningTurn[]>(
+      `select workspace_id, session_id, id as turn_id, active_attempt_id
+       from session_turns
+       where status = 'running'
+       order by workspace_id, session_id, id`,
+    )) as unknown as OrphanedRunningTurn[];
+    const reparks: Array<{
+      workspaceId: string;
+      sessionId: string;
+      turnId: string;
+      attemptId: string | null;
+      sessionStatus: "recovering" | "paused";
+      closedToolCalls: number;
+      eventIds: string[];
+    }> = [];
+    if (execute) {
+      for (const row of rows) {
+        const result = await reparkOrphanedSessionTurn(client.db, row.workspace_id, {
+          sessionId: row.session_id,
+          turnId: row.turn_id,
+          attemptId: row.active_attempt_id,
+          reason: `production_cutover:${runId}`,
+        });
+        if (result.action !== "recovering") {
+          throw new Error(
+            `orphaned turn ${row.turn_id} changed ownership during the maintenance repark`,
+          );
+        }
+        reparks.push({
+          workspaceId: row.workspace_id,
+          sessionId: row.session_id,
+          turnId: row.turn_id,
+          attemptId: row.active_attempt_id,
+          sessionStatus: result.sessionStatus,
+          closedToolCalls: result.closedToolCalls,
+          eventIds: result.events.map((event) => event.id),
+        });
+      }
+    }
+    const remaining = await sql<Array<{ turn_id: string }>>`
+      select id as turn_id from session_turns where status = 'running' order by id`;
+    if (execute && remaining.length > 0) {
+      throw new Error(`${remaining.length} running turn(s) remain after cutover repark`);
+    }
+    const draft = {
+      contractVersion: "opengeni/session-control-cutover-repark/v2",
+      runId,
+      executed: execute,
+      capturedAt: new Date().toISOString(),
+      runningSessionWorkflowCount: runningWorkflows.length,
+      candidateTurns: rows.map((row) => ({
+        workspaceId: row.workspace_id,
+        sessionId: row.session_id,
+        turnId: row.turn_id,
+        attemptId: row.active_attempt_id,
+      })),
+      reparks,
+      remainingRunningTurnIds: remaining.map((row) => row.turn_id),
+    };
+    const artifact = { ...draft, sha256: sha256(draft) };
+    await writeJson(output, artifact);
+    process.stderr.write(
+      `[cutover-repark] ${execute ? "reparked" : "found"} ${rows.length} orphaned running turn(s), sha256 ${artifact.sha256}\n`,
+    );
+  } finally {
+    await client.close().catch(() => undefined);
+    await sql.end({ timeout: 2 }).catch(() => undefined);
+    await connection.close().catch(() => undefined);
+  }
+}
+
 async function responseJson(
   response: Response,
   operation: string,
@@ -565,6 +918,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
     const randomBytes = crypto.getRandomValues(new Uint8Array(32));
     const token = `ogk_${Buffer.from(randomBytes).toString("hex")}`;
     const keyHash = createHash("sha256").update(token).digest("hex");
+    const apiKeyTtlSeconds = timeoutSeconds + 300;
     const inserted = await sql<Array<{ id: string }>>`
       insert into api_keys (
         account_id, workspace_id, name, prefix, key_hash, permissions, expires_at
@@ -572,7 +926,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
         ${candidate.account_id}, ${candidate.workspace_id}, ${`OpenGeni production canary ${runId}`},
         ${token.slice(0, 14)}, ${keyHash},
         ${sql.json(["workspace:read", "sessions:create", "sessions:read", "sessions:control"])},
-        now() + interval '15 minutes'
+        now() + ${apiKeyTtlSeconds} * interval '1 second'
       ) returning id`;
     apiKeyId = inserted[0]?.id ?? null;
     if (!apiKeyId) throw new Error("failed to create the temporary canary API key");
@@ -582,34 +936,110 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
       "content-type": "application/json",
     };
     const canaryMarker = `OPENGENI_CANARY_OK_${runId.replaceAll(/[^A-Za-z0-9]/g, "_")}`;
-    const createResponse = await fetch(
-      `${apiBaseUrl}/v1/workspaces/${candidate.workspace_id}/sessions`,
-      {
-        method: "POST",
-        headers,
-        signal: AbortSignal.timeout(30_000),
-        body: JSON.stringify({
-          initialMessage: `Reply with exactly ${canaryMarker} and nothing else. Do not call tools.`,
-          resources: [],
-          tools: [],
-          metadata: { productionCutoverCanary: runId },
-          model,
-          reasoningEffort: "low",
-          sandbox: "new",
-          idempotencyKey: `production-cutover-canary:${runId}`,
-        }),
-      },
-    );
-    const created = await responseJson(createResponse, "canary session creation");
-    const sessionId = typeof created.id === "string" ? created.id : null;
+    const idempotencyKey = `production-cutover-canary:${runId}`;
+    const createBody = JSON.stringify({
+      initialMessage: `Reply with exactly ${canaryMarker} and nothing else. Do not call tools.`,
+      resources: [],
+      tools: [],
+      metadata: { productionCutoverCanary: runId },
+      model,
+      reasoningEffort: "low",
+      sandbox: "new",
+      idempotencyKey,
+    });
+    const overallDeadline = Date.now() + timeoutSeconds * 1_000;
+    const createAttempts: Array<{
+      attempt: number;
+      startedAt: string;
+      durationMs: number;
+      httpStatus: number | null;
+      outcome: "created" | "authoritative-existing" | "retryable";
+      error: string | null;
+    }> = [];
+    let sessionId: string | null = null;
+    for (let attempt = 1; attempt <= 5 && Date.now() < overallDeadline; attempt += 1) {
+      const startedAt = new Date().toISOString();
+      const startedMs = Date.now();
+      let httpStatus: number | null = null;
+      let retryableError: string | null = null;
+      let nonRetryable = false;
+      try {
+        const response = await fetch(
+          `${apiBaseUrl}/v1/workspaces/${candidate.workspace_id}/sessions`,
+          {
+            method: "POST",
+            headers,
+            signal: AbortSignal.timeout(
+              Math.max(1_000, Math.min(30_000, overallDeadline - Date.now())),
+            ),
+            body: createBody,
+          },
+        );
+        httpStatus = response.status;
+        if (response.ok) {
+          const created = await responseJson(response, "canary session creation");
+          sessionId = typeof created.id === "string" ? created.id : null;
+          if (!sessionId) throw new Error("canary session creation returned no session id");
+          createAttempts.push({
+            attempt,
+            startedAt,
+            durationMs: Date.now() - startedMs,
+            httpStatus,
+            outcome: "created",
+            error: null,
+          });
+          break;
+        }
+        if (response.status < 500) {
+          nonRetryable = true;
+          await responseJson(response, "canary session creation");
+        }
+        retryableError = `HTTP ${response.status}`;
+      } catch (error) {
+        retryableError = error instanceof Error ? error.message : String(error);
+      }
+      if (nonRetryable) throw new Error(retryableError ?? "canary session creation was rejected");
+      const [existing] = await sql<Array<{ id: string }>>`
+        select id from sessions
+        where workspace_id = ${candidate.workspace_id}
+          and create_idempotency_key = ${idempotencyKey}
+        limit 1`;
+      if (existing?.id) {
+        sessionId = existing.id;
+        createAttempts.push({
+          attempt,
+          startedAt,
+          durationMs: Date.now() - startedMs,
+          httpStatus,
+          outcome: "authoritative-existing",
+          error: retryableError,
+        });
+        break;
+      }
+      createAttempts.push({
+        attempt,
+        startedAt,
+        durationMs: Date.now() - startedMs,
+        httpStatus,
+        outcome: "retryable",
+        error: retryableError,
+      });
+      if (Date.now() < overallDeadline) await Bun.sleep(1_000);
+    }
     if (!sessionId) throw new Error("canary session creation returned no session id");
 
-    const deadline = Date.now() + timeoutSeconds * 1_000;
+    const deadline = overallDeadline;
     let completedEventId: string | null = null;
     let usageEventId: string | null = null;
     let observedProvider: string | null = null;
     let observedModel: string | null = null;
     let terminalFailure = false;
+    const turnStateSamples: Array<{
+      capturedAt: string;
+      turnId: string;
+      status: string;
+      activeAttemptId: string | null;
+    }> = [];
     while (Date.now() < deadline) {
       const response = await fetch(
         `${apiBaseUrl}/v1/workspaces/${candidate.workspace_id}/sessions/${sessionId}/events?limit=1000`,
@@ -636,6 +1066,24 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
         }
         if (event.type === "turn.failed" || event.type === "turn.cancelled") terminalFailure = true;
       }
+      const turnRows = await sql<
+        Array<{ id: string; status: string; active_attempt_id: string | null }>
+      >`
+        select id, status, active_attempt_id from session_turns
+        where workspace_id = ${candidate.workspace_id} and session_id = ${sessionId}
+        order by position desc, id desc limit 1`;
+      const sampledTurn = turnRows[0];
+      if (sampledTurn) {
+        turnStateSamples.push({
+          capturedAt: new Date().toISOString(),
+          turnId: sampledTurn.id,
+          status: sampledTurn.status,
+          activeAttemptId: sampledTurn.active_attempt_id,
+        });
+        if (sampledTurn.status === "running" && !sampledTurn.active_attempt_id) {
+          throw new Error("canary became running without a registered attempt owner");
+        }
+      }
       if (completedEventId && usageEventId) break;
       if (terminalFailure) throw new Error("production Codex canary turn failed or was cancelled");
       await Bun.sleep(2_000);
@@ -645,8 +1093,70 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
         "production Codex canary did not produce the exact reply and usage evidence in time",
       );
     }
+    if (observedProvider !== "codex-subscription") {
+      throw new Error(
+        `production canary used ${observedProvider ?? "an unknown provider"}, expected codex-subscription`,
+      );
+    }
+    const currentUsage = await sql<
+      Array<{ id: string; turn_id: string; source_key: string; provider: string; model: string }>
+    >`
+      select id, turn_id, payload ->> 'sourceKey' as source_key,
+        payload ->> 'provider' as provider, payload ->> 'model' as model
+      from session_events
+      where workspace_id = ${candidate.workspace_id}
+        and session_id = ${sessionId}
+        and type = 'agent.model.usage'
+        and turn_association = 'current'
+      order by sequence`;
+    if (
+      currentUsage.length !== 1 ||
+      currentUsage[0]?.id !== usageEventId ||
+      currentUsage[0]?.provider !== "codex-subscription" ||
+      currentUsage[0]?.model !== model ||
+      !currentUsage[0]?.source_key
+    ) {
+      throw new Error("canary did not produce exactly one authoritative Codex usage source");
+    }
+    const usage = currentUsage[0]!;
+    const duplicateUsage = await sql<Array<{ count: number }>>`
+      select count(*)::integer as count from session_events
+      where workspace_id = ${candidate.workspace_id}
+        and session_id = ${sessionId}
+        and type = 'agent.model.usage'
+        and payload ->> 'sourceKey' = ${usage.source_key}
+        and turn_association = 'duplicate'
+        and duplicate_of_event_id = ${usage.id}`;
+    const billingMarkers = await sql<Array<{ count: number }>>`
+      select count(*)::integer as count from usage_events
+      where workspace_id = ${candidate.workspace_id}
+        and event_type = 'model.cost'
+        and quantity = 0
+        and source_resource_id = ${`${usage.turn_id}:${usage.source_key}`}`;
+    const creditDebits = await sql<Array<{ count: number }>>`
+      select count(*)::integer as count from credit_ledger_entries
+      where workspace_id = ${candidate.workspace_id}
+        and source_type = 'model_response'
+        and source_id = ${`${usage.turn_id}:${usage.source_key}`}`;
+    const startedAttempts = await sql<Array<{ count: number }>>`
+      select count(*)::integer as count from session_events
+      where workspace_id = ${candidate.workspace_id}
+        and session_id = ${sessionId}
+        and turn_id = ${usage.turn_id}
+        and type = 'turn.started'
+        and turn_attempt_id is not null
+        and turn_association = 'current'`;
+    if (Number(billingMarkers[0]?.count ?? 0) !== 1) {
+      throw new Error("canary is missing its one idempotent zero-cost Codex billing marker");
+    }
+    if (Number(creditDebits[0]?.count ?? 0) !== 0) {
+      throw new Error("canary unexpectedly debited OpenGeni credits");
+    }
+    if (Number(startedAttempts[0]?.count ?? 0) !== 1) {
+      throw new Error("canary has no unique current turn.started attempt evidence");
+    }
     const draft = {
-      contractVersion: "opengeni/session-control-cutover-canary/v1",
+      contractVersion: "opengeni/session-control-cutover-canary/v2",
       runId,
       capturedAt: new Date().toISOString(),
       workspaceId: candidate.workspace_id,
@@ -656,6 +1166,15 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
       provider: observedProvider,
       model: observedModel,
       exactReplyMatched: true,
+      createIdempotencyKey: idempotencyKey,
+      createAttempts,
+      turnStateSamples,
+      usageSourceKey: usage.source_key,
+      classifiedDuplicateUsageCount: Number(duplicateUsage[0]?.count ?? 0),
+      zeroCostBillingMarkerCount: Number(billingMarkers[0]?.count ?? 0),
+      creditDebitCount: Number(creditDebits[0]?.count ?? 0),
+      currentStartedAttemptCount: Number(startedAttempts[0]?.count ?? 0),
+      azureModelTokensUsed: false,
       temporaryApiKeyRevoked: true,
     };
     await sql`update api_keys set revoked_at = now(), updated_at = now() where id = ${apiKeyId}`;
@@ -725,9 +1244,18 @@ async function preflight(args: ParsedArgs): Promise<void> {
     );
   }
 
-  const migrationPath = "packages/db/drizzle/0057_durable_queue_control.sql";
-  const migrationBytes = await readFile(migrationPath);
-  const migrationSha256 = createHash("sha256").update(migrationBytes).digest("hex");
+  const migrationPaths = [
+    "packages/db/drizzle/0057_durable_queue_control.sql",
+    "packages/db/drizzle/0058_turn_admission_usage_enrollment.sql",
+  ] as const;
+  const migrations = await Promise.all(
+    migrationPaths.map(async (path) => ({
+      path,
+      sha256: createHash("sha256")
+        .update(await readFile(path))
+        .digest("hex"),
+    })),
+  );
   const workerPackage = parseJson<{
     devDependencies?: Record<string, string>;
   }>(await readFile("apps/worker/package.json", "utf8"), "apps/worker/package.json");
@@ -761,12 +1289,20 @@ async function preflight(args: ParsedArgs): Promise<void> {
   }
 
   const draft = {
-    contractVersion: "opengeni/session-control-cutover-preflight/v1",
+    contractVersion: "opengeni/session-control-cutover-preflight/v2",
     capturedAt: new Date().toISOString(),
     sourceSha: bakedSourceSha,
-    migration: {
-      path: migrationPath,
-      sha256: migrationSha256,
+    migrations,
+    workerTopology: {
+      roles: ["control", "turn"],
+      turnTaskQueueSuffix: "-turns",
+      controlActivityConcurrencyPerPod: 32,
+      controlWorkflowConcurrencyPerPod: 40,
+      turnActivityConcurrencyPerPod: 8,
+    },
+    validationModelPolicy: {
+      allowedPrefix: "codex/",
+      azureModelTokensAllowed: false,
     },
     agentsCoreVersion,
     runStateSchemaVersion: schema.schemaVersion,
@@ -774,7 +1310,7 @@ async function preflight(args: ParsedArgs): Promise<void> {
   const artifact = { ...draft, sha256: sha256(draft) };
   await writeJson(output, artifact);
   process.stderr.write(
-    `[cutover-preflight] source ${bakedSourceSha}, migration ${migrationSha256}, RunState ${schema.schemaVersion}\n`,
+    `[cutover-preflight] source ${bakedSourceSha}, migrations ${migrations.map((migration) => migration.sha256).join(",")}, RunState ${schema.schemaVersion}\n`,
   );
 }
 
@@ -783,13 +1319,14 @@ function usage(): void {
   bun run operator:session-control-cutover preflight --source-sha SHA --output FILE
   bun run operator:session-control-cutover capture --phase baseline|migrated|final --output FILE [--allow-empty-baseline]
   bun run operator:session-control-cutover reconcile --baseline FILE --observed FILE --mode migration|final-fate --output FILE
-  bun run operator:session-control-cutover wake --output FILE [--execute]
+  bun run operator:session-control-cutover wake --turn-capacity N --output FILE [--execute] [--stability-seconds N]
   bun run operator:session-control-cutover temporal-schedules --action pause|resume|inspect --run-id ID [--input FILE] --output FILE
   bun run operator:session-control-cutover temporal-workflows --action inspect|terminate --run-id ID --output FILE [--execute]
+  bun run operator:session-control-cutover repark-orphaned-turns --run-id ID --output FILE [--execute]
   bun run operator:session-control-cutover canary --run-id ID --workspace-id UUID --model codex/MODEL --api-base-url URL --output FILE [--timeout-seconds N]
   bun run operator:session-control-cutover maintenance-server
 
-capture and wake require OPENGENI_MIGRATIONS_DATABASE_URL. wake also requires the production Temporal settings.
+capture, repark, canary, and wake require OPENGENI_MIGRATIONS_DATABASE_URL. repark and wake also require the production Temporal settings.
 `);
 }
 
@@ -802,6 +1339,7 @@ if (import.meta.main) {
     else if (args.command === "wake") await wake(args);
     else if (args.command === "temporal-schedules") await temporalSchedules(args);
     else if (args.command === "temporal-workflows") await temporalWorkflows(args);
+    else if (args.command === "repark-orphaned-turns") await reparkOrphanedTurns(args);
     else if (args.command === "canary") await productionCodexCanary(args);
     else if (args.command === "maintenance-server") await maintenanceServer();
     else if (args.command === "help" || args.flags.has("--help")) usage();

--- a/test/e2e/browser.e2e.ts
+++ b/test/e2e/browser.e2e.ts
@@ -4,8 +4,10 @@ import { chromium, type Browser } from "playwright";
 import { migrate } from "@opengeni/db/migrate";
 import {
   freePort,
+  startE2eWorkerTopology,
   startProcess,
   startTestServices,
+  type StartedE2eWorkerTopology,
   type StartedProcess,
   type TestServices,
   waitFor,
@@ -16,7 +18,7 @@ const repoRoot = new URL("../..", import.meta.url).pathname;
 describe("browser e2e", () => {
   let services: TestServices;
   let api: StartedProcess;
-  let worker: StartedProcess;
+  let worker: StartedE2eWorkerTopology;
   let web: StartedProcess;
   let browser: Browser;
   let apiPort: number;
@@ -40,11 +42,11 @@ describe("browser e2e", () => {
           (await fetch(`http://127.0.0.1:${apiPort}/healthz`).catch(() => null))?.ok === true,
         timeoutMs: 45_000,
       });
-      worker = await startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+      worker = await startE2eWorkerTopology({
         cwd: repoRoot,
         env,
       });
-      await waitFor(() => workerReady(worker), {
+      await waitFor(() => worker.ready(), {
         timeoutMs: 90_000,
         describe: () => worker.logs(),
       });
@@ -363,13 +365,6 @@ function stackEnv(
     OPENGENI_OBJECT_STORAGE_SECRET_ACCESS_KEY: "minioadmin",
     OPENGENI_TEST_SCENARIO: scenario,
   };
-}
-
-async function workerReady(process: StartedProcess | undefined): Promise<boolean> {
-  if (!process) {
-    return false;
-  }
-  return process.logs().includes("test worker listening");
 }
 
 async function startBrowserTestServices(): Promise<TestServices> {

--- a/test/e2e/channel-a.e2e.ts
+++ b/test/e2e/channel-a.e2e.ts
@@ -16,8 +16,10 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   buildSandboxImage,
   freePort,
+  startE2eWorkerTopology,
   startProcess,
   startTestServices,
+  type StartedE2eWorkerTopology,
   type StartedProcess,
   type TestServices,
   waitFor,
@@ -30,7 +32,7 @@ let workspaceId = "";
 describe("Channel-A structured services e2e (real Docker box, API-direct)", () => {
   let services: TestServices;
   let api: StartedProcess;
-  let worker: StartedProcess;
+  let worker: StartedE2eWorkerTopology;
   let sessionId = "";
 
   beforeAll(async () => {
@@ -47,11 +49,11 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
       timeoutMs: 45_000,
     });
     workspaceId = await discoverWorkspaceId();
-    worker = await startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+    worker = await startE2eWorkerTopology({
       cwd: repoRoot,
       env,
     });
-    await waitFor(() => worker.logs().includes("test worker listening"), {
+    await waitFor(() => worker.ready(), {
       timeoutMs: 90_000,
       describe: () => worker.logs(),
     });

--- a/test/e2e/rig-setup.e2e.ts
+++ b/test/e2e/rig-setup.e2e.ts
@@ -4,8 +4,10 @@ import { createDb, createRig, type DbClient } from "@opengeni/db";
 import {
   buildSandboxImage,
   freePort,
+  startE2eWorkerTopology,
   startProcess,
   startTestServices,
+  type StartedE2eWorkerTopology,
   type StartedProcess,
   type TestServices,
   waitFor,
@@ -32,7 +34,7 @@ let db: DbClient;
 describe("real Docker rig-setup e2e", () => {
   let services: TestServices;
   let api: StartedProcess;
-  let worker: StartedProcess;
+  let worker: StartedE2eWorkerTopology;
 
   beforeAll(async () => {
     await buildSandboxImage("opengeni-sandbox:local", repoRoot);
@@ -50,11 +52,11 @@ describe("real Docker rig-setup e2e", () => {
     workspaceId = await discoverWorkspaceId();
     accountId = await discoverAccountId();
     db = createDb(services.databaseUrl);
-    worker = await startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+    worker = await startE2eWorkerTopology({
       cwd: repoRoot,
       env,
     });
-    await waitFor(() => worker.logs().includes("test worker listening"), {
+    await waitFor(() => worker.ready(), {
       timeoutMs: 90_000,
       describe: () => worker.logs(),
     });

--- a/test/e2e/sandbox.e2e.ts
+++ b/test/e2e/sandbox.e2e.ts
@@ -4,8 +4,10 @@ import {
   buildSandboxImage,
   freePort,
   runCommand,
+  startE2eWorkerTopology,
   startProcess,
   startTestServices,
+  type StartedE2eWorkerTopology,
   type StartedProcess,
   type TestServices,
   waitFor,
@@ -18,7 +20,7 @@ let workspaceId = "";
 describe("real Docker sandbox e2e", () => {
   let services: TestServices;
   let api: StartedProcess;
-  let worker: StartedProcess;
+  let worker: StartedE2eWorkerTopology;
 
   beforeAll(async () => {
     await buildSandboxImage("opengeni-sandbox:local", repoRoot);
@@ -34,11 +36,11 @@ describe("real Docker sandbox e2e", () => {
       timeoutMs: 45_000,
     });
     workspaceId = await discoverWorkspaceId();
-    worker = await startProcess(["bun", "packages/testing/src/e2e-worker.ts"], {
+    worker = await startE2eWorkerTopology({
       cwd: repoRoot,
       env,
     });
-    await waitFor(() => worker.logs().includes("test worker listening"), {
+    await waitFor(() => worker.ready(), {
       timeoutMs: 90_000,
       describe: () => worker.logs(),
     });

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -4,9 +4,10 @@ import {
   allWorkspacePermissions,
   appendSessionEvents,
   applyCreditLedgerEntry,
+  applySessionTurnSettlement,
   bootstrapWorkspace,
   buildConnectionTokenResolver,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   isSessionCompactionRequested,
   createDb,
   createSession,
@@ -29,12 +30,12 @@ import {
   getWorkspaceEnvironmentValuesForRun,
   listSessionEvents,
   listScheduledTasks,
+  listPendingSessionSystemUpdates,
   listSessionTurns,
   listSessionMcpServersForRun,
   listUsageEvents,
   recordStripeWebhookEvent,
   recordUsageEvent,
-  registerSessionTurnDispatch,
   requireFile,
   requireSession,
   setSessionGoalStatus,
@@ -149,7 +150,9 @@ describe("API component integration", () => {
       "session.status.changed",
       "turn.queued",
     ]);
-    expect(buildTimeline(events).map((item) => item.kind)).toEqual(["user-message"]);
+    // The initial prompt is still waiting, so it exists only in the compact
+    // prompt queue. Timeline projection begins it when the turn actually starts.
+    expect(buildTimeline(events).map((item) => item.kind)).toEqual([]);
 
     const listed = await app.request(workspacePath(workspaceId, "/sessions?limit=10"));
     expect(listed.status).toBe(200);
@@ -3797,7 +3800,27 @@ describe("API component integration", () => {
     );
     expect(approvalRejected.status).toBe(409);
 
-    await setSessionStatus(dbClient.db, workspaceId, session.id, "requires_action", null);
+    const approvalWaitAttemptId = crypto.randomUUID();
+    const approvalWaitClaim = await claimSessionWorkForAttempt(dbClient.db, workspaceId, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      attemptId: approvalWaitAttemptId,
+      dispatchId: `dispatch-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    if (approvalWaitClaim.action !== "claimed") {
+      throw new Error(`failed to claim approval fixture: ${approvalWaitClaim.reason}`);
+    }
+    await applySessionTurnSettlement(dbClient.db, workspaceId, {
+      sessionId: session.id,
+      turnId: approvalWaitClaim.turn.id,
+      triggerEventId: approvalWaitClaim.turn.triggerEventId,
+      attemptId: approvalWaitAttemptId,
+      turnStatus: "requires_action",
+      sessionStatus: "requires_action",
+      activeTurnId: approvalWaitClaim.turn.id,
+      events: [{ type: "session.requiresAction", payload: { approvalId: "x" } }],
+    });
     const approvalAccepted = await app.request(
       workspacePath(workspaceId, `/sessions/${session.id}/events`),
       {
@@ -3811,24 +3834,18 @@ describe("API component integration", () => {
     );
     expect(approvalAccepted.status).toBe(202);
     expect(workflow.approvals).toHaveLength(1);
+    const approvalEvent = (await approvalAccepted.json()) as SessionEvent;
 
-    const running = await claimNextSessionExecution(
-      dbClient.db,
-      workspaceId,
-      session.id,
-      `session-${session.id}`,
-    );
-    expect(running).not.toBeNull();
     const attemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(dbClient.db, workspaceId, {
-        sessionId: session.id,
-        turnId: running!.id,
-        triggerEventId: running!.triggerEventId,
-        attemptId,
-        dispatchId: `dispatch-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
+    const running = await claimSessionWorkForAttempt(dbClient.db, workspaceId, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      attemptId,
+      dispatchId: `dispatch-${crypto.randomUUID()}`,
+      trigger: { kind: "approval", triggerEventId: approvalEvent.id },
+    });
+    expect(running).toMatchObject({ action: "claimed" });
+    if (running.action !== "claimed") throw new Error("approval fixture did not resume");
 
     const paused = await app.request(
       workspacePath(workspaceId, `/sessions/${session.id}/control`),
@@ -3845,7 +3862,7 @@ describe("API component integration", () => {
     expect(paused.status).toBe(202);
     expect(await paused.json()).toMatchObject({
       controlState: "paused",
-      expectedActiveTurnId: running!.id,
+      expectedActiveTurnId: running.turn.id,
       expectedAttemptId: attemptId,
       shouldSignalControl: true,
     });
@@ -5945,6 +5962,43 @@ describe("API component integration", () => {
     const turns = await listSessionTurns(dbClient.db, grant.workspaceId, created.id);
     expect(turns.some((turn) => turn.id === sent.turnId && turn.status === "queued")).toBe(true);
 
+    const workerMcpWithIdentity = buildOpenGeniMcpServer(mcpDeps, {
+      ...grant,
+      metadata: { delegated: true, sessionId: created.id },
+    });
+    const beforeInternalTurnIds = (
+      await listSessionTurns(dbClient.db, grant.workspaceId, created.id)
+    )
+      .map((turn) => turn.id)
+      .sort();
+    const internal = await callMcpTool<{
+      delivered: boolean;
+      updateId: string;
+      delivery: string;
+    }>(workerMcpWithIdentity, "session_send_message", {
+      sessionId: created.id,
+      text: "child result one of several",
+    });
+    expect(internal).toMatchObject({
+      delivered: true,
+      delivery: "coalesced_internal_update",
+    });
+    expect(
+      (await listSessionTurns(dbClient.db, grant.workspaceId, created.id))
+        .map((turn) => turn.id)
+        .sort(),
+    ).toEqual(beforeInternalTurnIds);
+    expect(
+      await listPendingSessionSystemUpdates(dbClient.db, grant.workspaceId, created.id),
+    ).toEqual([
+      expect.objectContaining({
+        id: internal.updateId,
+        kind: "runtime_notice",
+        sourceId: created.id,
+        summary: "child result one of several",
+      }),
+    ]);
+
     // The sandboxed worker's first-party delegated permission set sees none of
     // the manager tools: orchestration, environments, or the connect link.
     const workerGrant = {
@@ -7715,16 +7769,17 @@ async function createToolspaceMcpSession(
     delivery: "queue",
     reasoningEffortFallback: "medium",
   });
-  const running = await claimNextSessionExecution(
-    db,
-    grant.workspaceId,
-    session.id,
-    `session-${session.id}`,
-  );
-  if (!running || running.id !== queued.turn.id) {
+  const running = await claimSessionWorkForAttempt(db, grant.workspaceId, {
+    sessionId: session.id,
+    workflowId: `session-${session.id}`,
+    attemptId: crypto.randomUUID(),
+    dispatchId: `dispatch-${crypto.randomUUID()}`,
+    trigger: { kind: "next" },
+  });
+  if (running.action !== "claimed" || running.turn.id !== queued.turn.id) {
     throw new Error("failed to claim the toolspace fixture turn");
   }
-  return { session, turnId: running.id };
+  return { session, turnId: running.turn.id };
 }
 
 async function readSseEvents(

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -8,7 +8,7 @@ import {
   appendSessionEvents,
   applySessionTurnSettlement,
   bootstrapWorkspace,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   createKnowledgeMemory,
   getKnowledgeMemory,
   saveWorkspaceMemory,
@@ -47,7 +47,6 @@ import {
   listScheduledTaskRuns,
   listScheduledTasks,
   listSessionEvents,
-  registerSessionTurnDispatch,
   updateScheduledTask,
   updateScheduledTaskRun,
   updateSessionMcpServerCredentials,
@@ -555,12 +554,10 @@ describe("DB integration", () => {
         payload: { approvalId: "goal-test", decision: "approve" },
       },
     ]);
-    const resumedUserTurn = await registerTurnAttempt(
-      dbClient.db,
-      grant,
-      queuedUserTurn.turn,
-      approval!.id,
-    );
+    const resumedUserTurn = await claimRegisteredExecution(dbClient.db, grant, session.id, {
+      kind: "approval",
+      triggerEventId: approval!.id,
+    });
     await settleRegisteredExecution(dbClient.db, grant, resumedUserTurn, "completed");
 
     // First continuation.
@@ -2258,44 +2255,32 @@ describe("DB integration", () => {
 });
 
 type RegisteredExecution = {
-  turn: NonNullable<Awaited<ReturnType<typeof claimNextSessionExecution>>>;
+  turn: Extract<
+    Awaited<ReturnType<typeof claimSessionWorkForAttempt>>,
+    { action: "claimed" }
+  >["turn"];
   triggerEventId: string;
   attemptId: string;
 };
-
-async function registerTurnAttempt(
-  db: ReturnType<typeof createDb>["db"],
-  grant: AccessGrant,
-  turn: RegisteredExecution["turn"],
-  triggerEventId = turn.triggerEventId,
-): Promise<RegisteredExecution> {
-  const attemptId = crypto.randomUUID();
-  const registered = await registerSessionTurnDispatch(db, grant.workspaceId, {
-    sessionId: turn.sessionId,
-    turnId: turn.id,
-    triggerEventId,
-    attemptId,
-    dispatchId: `dispatch-${crypto.randomUUID()}`,
-  });
-  if (registered.action !== "registered") {
-    throw new Error(`goal fixture could not register turn ${turn.id}`);
-  }
-  return { turn, triggerEventId, attemptId };
-}
 
 async function claimRegisteredExecution(
   db: ReturnType<typeof createDb>["db"],
   grant: AccessGrant,
   sessionId: string,
+  trigger: Parameters<typeof claimSessionWorkForAttempt>[2]["trigger"] = { kind: "next" },
 ): Promise<RegisteredExecution> {
-  const turn = await claimNextSessionExecution(
-    db,
-    grant.workspaceId,
+  const attemptId = crypto.randomUUID();
+  const result = await claimSessionWorkForAttempt(db, grant.workspaceId, {
     sessionId,
-    `session-${sessionId}`,
-  );
-  if (!turn) throw new Error(`goal fixture could not claim work for ${sessionId}`);
-  return await registerTurnAttempt(db, grant, turn);
+    workflowId: `session-${sessionId}`,
+    attemptId,
+    dispatchId: `dispatch-${crypto.randomUUID()}`,
+    trigger,
+  });
+  if (result.action !== "claimed") {
+    throw new Error(`goal fixture could not claim work for ${sessionId}: ${result.reason}`);
+  }
+  return { turn: result.turn, triggerEventId: result.turn.triggerEventId, attemptId };
 }
 
 async function claimGoalContinuationExecution(

--- a/test/integration/durable-queue-control.integration.ts
+++ b/test/integration/durable-queue-control.integration.ts
@@ -6,6 +6,7 @@ import { postUserMessageTurn } from "@opengeni/core";
 import {
   addSessionSystemUpdate,
   bootstrapWorkspace,
+  claimSessionWorkForAttempt,
   createDb,
   createSession,
   enqueueSessionMessageAtomically,
@@ -15,7 +16,6 @@ import {
   listSessionEvents,
   listSessionSystemUpdatesForTurn,
   listSessionTurns,
-  registerSessionTurnDispatch,
 } from "@opengeni/db";
 import { migrate } from "@opengeni/db/migrate";
 import { createNatsEventBus, type EventBus } from "@opengeni/events";
@@ -27,8 +27,9 @@ import {
   waitFor,
   type TestServices,
 } from "@opengeni/testing";
-import { createActivities } from "../../apps/worker/src/activities";
+import { createActivityTestHarness } from "../../apps/worker/src/activities";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 type RequiredServices = Pick<
   TestServices,
@@ -96,7 +97,7 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
         temporalTaskQueue: taskQueue,
       });
       const workflowClient = sessionWorkflowClient(new Client({ connection }), taskQueue);
-      const activities = createActivities({
+      const activities = createActivityTestHarness({
         settings,
         db: dbClient.db,
         bus,
@@ -240,7 +241,7 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
       });
       const temporal = new Client({ connection });
       const workflowClient = sessionWorkflowClient(temporal, taskQueue);
-      const activities = createActivities({
+      const activities = createActivityTestHarness({
         settings,
         db: dbClient.db,
         bus,
@@ -371,7 +372,7 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
       });
       const temporal = new Client({ connection });
       const workflowClient = sessionWorkflowClient(temporal, taskQueue);
-      const realActivities = createActivities({
+      const realActivities = createActivityTestHarness({
         settings,
         db: dbClient.db,
         bus,
@@ -384,13 +385,16 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
         runAgentTurn: async (input: Parameters<typeof realActivities.runAgentTurn>[0]) => {
           dispatches += 1;
           if (dispatches === 1) {
-            await registerSessionTurnDispatch(dbClient.db, input.workspaceId, {
+            const claim = await claimSessionWorkForAttempt(dbClient.db, input.workspaceId, {
               sessionId: input.sessionId,
-              turnId: input.turnId,
-              triggerEventId: input.triggerEventId,
+              workflowId: input.workflowId,
               attemptId: input.attemptId,
               dispatchId: currentActivityContext()!.info.activityId,
+              trigger: input.trigger,
             });
+            if (claim.action !== "claimed") {
+              return { status: "unclaimed", reason: claim.reason } as const;
+            }
             return await hangWithoutHeartbeating();
           }
           return await realActivities.runAgentTurn(input);
@@ -589,14 +593,35 @@ async function integrationWorker(
   temporalConnection: NativeConnection,
   taskQueue: string,
   activities: Record<string, (...args: any[]) => Promise<unknown>>,
-): Promise<Worker> {
-  return await Worker.create({
-    connection: temporalConnection,
-    namespace: "default",
-    taskQueue,
-    workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
-    activities,
-  });
+): Promise<{ run: () => Promise<void>; shutdown: () => void }> {
+  const { runAgentTurn, ...controlActivities } = activities;
+  if (!runAgentTurn) throw new Error("turn activity is missing from the integration harness");
+  const [control, turns] = await Promise.all([
+    Worker.create({
+      connection: temporalConnection,
+      namespace: "default",
+      taskQueue,
+      workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
+      activities: controlActivities,
+      maxConcurrentActivityTaskExecutions: 32,
+    }),
+    Worker.create({
+      connection: temporalConnection,
+      namespace: "default",
+      taskQueue: turnTaskQueue(taskQueue),
+      activities: { runAgentTurn },
+      maxConcurrentActivityTaskExecutions: 8,
+    }),
+  ]);
+  return {
+    run: async () => {
+      await Promise.all([control.run(), turns.run()]);
+    },
+    shutdown: () => {
+      control.shutdown();
+      turns.shutdown();
+    },
+  };
 }
 
 async function hangWithoutHeartbeating(): Promise<{ status: "cancelled" }> {

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -3,6 +3,7 @@ import { Client, Connection } from "@temporalio/client";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { startTestServices, type TestServices, waitFor } from "@opengeni/testing";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 // An ungraceful worker death cannot be faked by throwing a TimeoutFailure
 // from the activity (the worker coerces thrown activity errors into
@@ -67,14 +68,14 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const calls: unknown[] = [];
       const queuedTurns = [queuedTurn("event-1")];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        calls.push(input);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          calls.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
       });
       const run = worker.run();
@@ -104,14 +105,14 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const calls: unknown[] = [];
       const queuedTurns = [queuedTurn("event-1")];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        calls.push(input);
+        return { status: calls.length === 1 ? "requires_action" : "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          calls.push(input);
-          return { status: calls.length === 1 ? "requires_action" : "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
       });
       const run = worker.run();
@@ -125,6 +126,7 @@ describe("Temporal workflow integration", () => {
         await waitFor(() => calls.length === 1);
         await Bun.sleep(300);
         expect(calls).toHaveLength(1);
+        admission.approve("approval-event");
         await handle.signal("approvalDecision", "approval-event");
         await waitFor(() => calls.length === 2);
       } finally {
@@ -143,14 +145,14 @@ describe("Temporal workflow integration", () => {
       let attempts = 0;
       const failures: unknown[] = [];
       const queuedTurns = [queuedTurn("event-1")];
+      const admission = createTurnAdmission(queuedTurns, async () => {
+        attempts += 1;
+        throw new Error("boom");
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async () => {
-          attempts += 1;
-          throw new Error("boom");
-        },
-        failSession: async (input: unknown) => {
+        failSessionAttempt: async (input: unknown) => {
           failures.push(input);
         },
         settleSessionControl: async () => undefined,
@@ -181,23 +183,16 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const turn = queuedTurn("event-1");
       const queuedTurns = [turn];
-      const runs: Array<{ turnId?: string; triggerEventId: string }> = [];
+      const runs: Array<{ trigger: { kind: string; triggerEventId?: string } }> = [];
       const failures: unknown[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        runs.push(input as (typeof runs)[number]);
+        return { status: runs.length === 1 ? "recovering" : "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { turnId?: string; triggerEventId: string }) => {
-          runs.push(input);
-          if (runs.length === 1) {
-            // Recovery preserves the exact turn and trigger. It becomes
-            // claimable again without entering the human prompt queue or
-            // fabricating a resume message.
-            queuedTurns.push({ id: turn.id, triggerEventId: turn.triggerEventId });
-            return { status: "recovering" };
-          }
-          return { status: "idle" };
-        },
-        failSession: async (input: unknown) => {
+        failSessionAttempt: async (input: unknown) => {
           failures.push(input);
         },
         settleSessionControl: async () => undefined,
@@ -212,8 +207,7 @@ describe("Temporal workflow integration", () => {
         });
         await handle.result();
         expect(runs).toHaveLength(2);
-        expect(runs[0]).toMatchObject({ turnId: turn.id, triggerEventId: "event-1" });
-        expect(runs[1]).toMatchObject({ turnId: turn.id, triggerEventId: "event-1" });
+        expect(runs.map((run) => run.trigger)).toEqual([{ kind: "next" }, { kind: "next" }]);
         expect(failures).toHaveLength(0);
       } finally {
         worker.shutdown();
@@ -230,40 +224,26 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const turn = queuedTurn("event-1");
       const queuedTurns = [turn];
-      const runs: Array<{ turnId?: string; triggerEventId: string }> = [];
-      const activityIds: string[] = [];
+      const runs: Array<{ attemptId: string; trigger: { kind: string } }> = [];
       const recoveries: Array<{
-        turnId: string;
-        triggerEventId: string;
-        dispatchId: string;
+        attemptId: string;
         timeoutType: string;
       }> = [];
       const failures: unknown[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        runs.push(input as (typeof runs)[number]);
+        if (runs.length === 1) return await hangWithoutHeartbeating();
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { turnId?: string; triggerEventId: string }) => {
-          runs.push(input);
-          if (runs.length === 1) {
-            activityIds.push(currentActivityContext()!.info.activityId);
-            // Ungracefully dead worker: never heartbeats, never returns.
-            return await hangWithoutHeartbeating();
-          }
-          return { status: "idle" };
-        },
-        recoverTurnAfterWorkerDeath: async (input: {
-          turnId: string;
-          triggerEventId: string;
-          dispatchId: string;
-          timeoutType: string;
-        }) => {
+        recoverDispatch: async (input: { attemptId: string; timeoutType: string }) => {
           recoveries.push(input);
-          // Mirror the real activity: the same inference becomes claimable
-          // under its original trigger; no prompt-queue row is created.
-          queuedTurns.push({ id: turn.id, triggerEventId: turn.triggerEventId });
-          return { action: "recovering", redispatches: 1 };
+          admission.recover();
+          return { action: "recovering", turnId: turn.id, redispatches: 1 };
         },
-        failSession: async (input: unknown) => {
+        failSessionAttempt: async (input: unknown) => {
           failures.push(input);
         },
         settleSessionControl: async () => undefined,
@@ -278,13 +258,10 @@ describe("Temporal workflow integration", () => {
         });
         await handle.result();
         expect(runs).toHaveLength(2);
-        expect(runs[0]).toMatchObject({ turnId: turn.id, triggerEventId: "event-1" });
-        expect(runs[1]).toMatchObject({ turnId: turn.id, triggerEventId: "event-1" });
+        expect(runs.map((run) => run.trigger)).toEqual([{ kind: "next" }, { kind: "next" }]);
         expect(recoveries).toEqual([
           expect.objectContaining({
-            turnId: turn.id,
-            triggerEventId: "event-1",
-            dispatchId: activityIds[0],
+            attemptId: runs[0]!.attemptId,
             timeoutType: "HEARTBEAT",
           }),
         ]);
@@ -309,23 +286,20 @@ describe("Temporal workflow integration", () => {
       const turn = queuedTurn("event-1");
       const queuedTurns = [turn];
       const runs: unknown[] = [];
-      const activityIds: string[] = [];
-      const recoveries: Array<{ dispatchId: string; timeoutType: string }> = [];
+      const recoveries: Array<{ attemptId: string; timeoutType: string }> = [];
       const failures: Array<{ error?: string }> = [];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        runs.push(input);
+        return await hangWithoutHeartbeating();
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          runs.push(input);
-          activityIds.push(currentActivityContext()!.info.activityId);
-          // Crash-looping turn: every dispatch takes its worker down.
-          return await hangWithoutHeartbeating();
-        },
-        recoverTurnAfterWorkerDeath: async (input: { dispatchId: string; timeoutType: string }) => {
+        recoverDispatch: async (input: { attemptId: string; timeoutType: string }) => {
           recoveries.push(input);
-          return { action: "exceeded", redispatches: 3 };
+          return { action: "exceeded", turnId: turn.id, redispatches: 3 };
         },
-        failSession: async (input: { error?: string }) => {
+        failSessionAttempt: async (input: { error?: string }) => {
           failures.push(input);
         },
         settleSessionControl: async () => undefined,
@@ -342,7 +316,6 @@ describe("Temporal workflow integration", () => {
         expect(runs).toHaveLength(1);
         expect(recoveries).toEqual([
           expect.objectContaining({
-            dispatchId: activityIds[0],
             timeoutType: "HEARTBEAT",
           }),
         ]);
@@ -365,15 +338,18 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const idleMarks: unknown[] = [];
       const controls: unknown[] = [];
+      const control = createPendingControlPeek("control-event");
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => null,
+        peekSessionWork: control.peekSessionWork,
         markSessionIdle: async (input: unknown) => {
           idleMarks.push(input);
         },
         runAgentTurn: async () => ({ status: "idle" }),
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async (input: unknown) => {
           controls.push(input);
+          control.settled();
+          return { action: "paused" as const };
         },
       });
       const run = worker.run();
@@ -422,15 +398,18 @@ describe("Temporal workflow integration", () => {
       const workflowId = `wf-${crypto.randomUUID()}`;
       const idleMarks: unknown[] = [];
       const controls: unknown[] = [];
+      const control = createPendingControlPeek("control-event", true);
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => null,
+        peekSessionWork: control.peekSessionWork,
         markSessionIdle: async (input: unknown) => {
           idleMarks.push(input);
         },
         runAgentTurn: async () => ({ status: "idle" }),
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async (input: unknown) => {
           controls.push(input);
+          control.settled();
+          return { action: "paused" as const };
         },
       });
       const run = worker.run();
@@ -478,25 +457,26 @@ describe("Temporal workflow integration", () => {
       const first = queuedTurn("event-1");
       const second = queuedTurn("event-2");
       const queuedTurns = [first];
-      const runs: unknown[] = [];
+      const runs: WorkflowTestTurn[] = [];
       const controls: unknown[] = [];
       let allowFirstRunToFinish = false;
-      const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
-        markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          runs.push(input);
-          if (runs.length === 1) {
-            while (!allowFirstRunToFinish) {
-              await Bun.sleep(10);
-            }
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn);
+        if (runs.length === 1) {
+          while (!allowFirstRunToFinish) {
+            await Bun.sleep(10);
           }
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        }
+        return { status: "idle" };
+      });
+      const worker = await testWorker(nativeConnection, taskQueue, {
+        ...admission.activities,
+        markSessionIdle: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async (input: unknown) => {
           controls.push(input);
           allowFirstRunToFinish = true;
+          return { action: "continue" as const };
         },
       });
       const run = worker.run();
@@ -515,13 +495,7 @@ describe("Temporal workflow integration", () => {
         expect(controls).toEqual([
           { ...scope, sessionId, triggerEventId: "control-event", workflowId },
         ]);
-        expect(runs[1]).toMatchObject({
-          ...scope,
-          sessionId,
-          turnId: second.id,
-          triggerEventId: second.triggerEventId,
-          workflowId,
-        });
+        expect(runs[1]).toEqual(second);
       } finally {
         allowFirstRunToFinish = true;
         worker.shutdown();
@@ -541,18 +515,20 @@ describe("Temporal workflow integration", () => {
       const first = queuedTurn("event-1");
       const second = queuedTurn("event-2");
       const queuedTurns = [first];
-      const runs: unknown[] = [];
+      const runs: WorkflowTestTurn[] = [];
       const controls: unknown[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn);
+        return { status: runs.length === 1 ? "requires_action" : "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          runs.push(input);
-          return { status: runs.length === 1 ? "requires_action" : "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async (input: unknown) => {
           controls.push(input);
+          admission.supersede();
+          return { action: "continue" as const };
         },
       });
       const run = worker.run();
@@ -571,13 +547,7 @@ describe("Temporal workflow integration", () => {
         expect(controls).toEqual([
           { ...scope, sessionId, triggerEventId: "control-event", workflowId },
         ]);
-        expect(runs[1]).toMatchObject({
-          ...scope,
-          sessionId,
-          turnId: second.id,
-          triggerEventId: second.triggerEventId,
-          workflowId,
-        });
+        expect(runs[1]).toEqual(second);
       } finally {
         worker.shutdown();
         await run;
@@ -592,18 +562,18 @@ describe("Temporal workflow integration", () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
       const sessionId = crypto.randomUUID();
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       const goalChecks: unknown[] = [];
       const queuedTurns = [queuedTurn("event-1")];
       let continuations = 0;
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async (input: unknown) => {
           goalChecks.push(input);
@@ -625,11 +595,7 @@ describe("Temporal workflow integration", () => {
           args: [{ ...scope, sessionId, initialEventId: "event-1" }],
         });
         await handle.result();
-        expect(runs.map((input) => input.triggerEventId)).toEqual([
-          "event-1",
-          "goal-event-1",
-          "goal-event-2",
-        ]);
+        expect(runs).toEqual(["event-1", "goal-event-1", "goal-event-2"]);
         expect(goalChecks.length).toBeGreaterThanOrEqual(3);
         expect(goalChecks[0]).toMatchObject({ ...scope, sessionId, workflowId });
       } finally {
@@ -649,19 +615,16 @@ describe("Temporal workflow integration", () => {
       const delayMs = 1500;
       let segmentReturnedAt = 0;
       let goalCheckedAt = 0;
+      const admission = createTurnAdmission([queuedTurn("event-1")], async () => {
+        segmentReturnedAt = Date.now();
+        // Provider backpressure idle: the workflow must hold the loop before
+        // admitting the goal continuation.
+        return { status: "idle", continueDelayMs: delayMs };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: (() => {
-          const queuedTurns = [queuedTurn("event-1")];
-          return async () => queuedTurns.shift() ?? null;
-        })(),
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async () => {
-          segmentReturnedAt = Date.now();
-          // Provider backpressure idle: the workflow must hold the loop before
-          // admitting the goal continuation.
-          return { status: "idle", continueDelayMs: delayMs };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async () => {
           if (!goalCheckedAt) {
@@ -698,15 +661,18 @@ describe("Temporal workflow integration", () => {
       const scope = workflowScope();
       const sessionId = crypto.randomUUID();
       const order: string[] = [];
+      const control = createPendingControlPeek("control-event");
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => null,
+        peekSessionWork: control.peekSessionWork,
         markSessionIdle: async () => {
           order.push("idle");
         },
         runAgentTurn: async () => ({ status: "idle" }),
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => {
           order.push("control");
+          control.settled();
+          return { action: "paused" as const };
         },
       });
       const run = worker.run();
@@ -737,16 +703,16 @@ describe("Temporal workflow integration", () => {
       const idleMarks: unknown[] = [];
       const queuedTurns = [queuedTurn("event-1")];
       const runs: unknown[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (input) => {
+        runs.push(input);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async (input: unknown) => {
           idleMarks.push(input);
         },
-        runAgentTurn: async (input: unknown) => {
-          runs.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async () => {
           throw new Error("goal store unavailable");
@@ -794,7 +760,7 @@ describe("Temporal workflow integration", () => {
           };
         },
         runAgentTurn: async () => ({ status: "idle" }),
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
       });
       const run = worker.run();
@@ -835,7 +801,12 @@ describe("Temporal workflow integration", () => {
       const sessionId = crypto.randomUUID();
       const triggerEventId = crypto.randomUUID();
       const childWorkflowId = `session-${sessionId}`;
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
+        ...admission.activities,
         dispatchScheduledTaskRun: async (input: unknown) => {
           dispatches.push(input);
           queuedTurns.push(queuedTurn(triggerEventId));
@@ -848,13 +819,8 @@ describe("Temporal workflow integration", () => {
             workflowId: childWorkflowId,
           };
         },
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          runs.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
       });
       const run = worker.run();
@@ -876,12 +842,7 @@ describe("Temporal workflow integration", () => {
           workspaceId: scope.workspaceId,
           triggerType: "scheduled",
         });
-        expect(runs[0]).toMatchObject({
-          ...scope,
-          sessionId,
-          triggerEventId,
-          workflowId: childWorkflowId,
-        });
+        expect(runs[0]).toEqual(expect.objectContaining({ triggerEventId }));
       } finally {
         worker.shutdown();
         await run;
@@ -895,12 +856,17 @@ describe("Temporal workflow integration", () => {
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
-      const calls: unknown[] = [];
+      const calls: string[] = [];
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
       const triggerEventId = crypto.randomUUID();
       const queuedTurns = [queuedTurn("event-1")];
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        calls.push(turn.triggerEventId);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
+        ...admission.activities,
         dispatchScheduledTaskRun: async () => {
           queuedTurns.push(queuedTurn(triggerEventId));
           return {
@@ -912,13 +878,8 @@ describe("Temporal workflow integration", () => {
             workflowId,
           };
         },
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: unknown) => {
-          calls.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
       });
       const run = worker.run();
@@ -937,7 +898,7 @@ describe("Temporal workflow integration", () => {
         });
         await fire.result();
         await waitFor(() => calls.length === 2);
-        expect(calls[1]).toMatchObject({ ...scope, sessionId, triggerEventId });
+        expect(calls[1]).toBe(triggerEventId);
       } finally {
         worker.shutdown();
         await run;
@@ -954,7 +915,7 @@ describe("Temporal workflow integration", () => {
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
       const queuedTurns = [queuedTurn("event-1")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       const reconciliations: Array<{ cause: string }> = [];
       const waiter = {
         waiterId: crypto.randomUUID(),
@@ -963,22 +924,23 @@ describe("Temporal workflow integration", () => {
         wakeRevision: 1,
       };
       let resumed = false;
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return turn.triggerEventId === "event-1"
+          ? { status: "idle", capacityWait: waiter }
+          : { status: "failed" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return input.triggerEventId === "event-1"
-            ? { status: "idle", capacityWait: waiter }
-            : { status: "failed" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         getCodexCapacityWait: async () => (resumed ? null : waiter),
         reconcileCodexCapacityWait: async (input: { cause: string }) => {
           reconciliations.push(input);
           if (!resumed) {
             resumed = true;
+            admission.resumeCapacity();
             queuedTurns.push(queuedTurn("capacity-resume"));
             return { action: "resumed", turnId: queuedTurns[0]!.id };
           }
@@ -1002,7 +964,7 @@ describe("Temporal workflow integration", () => {
         }
         await handle.signal("codexCapacityChanged", waiter.wakeRevision + 100);
         await handle.result();
-        expect(runs.map((input) => input.triggerEventId)).toEqual(["event-1", "capacity-resume"]);
+        expect(runs).toEqual(["event-1", "capacity-resume"]);
         expect(reconciliations).toHaveLength(1);
         expect(reconciliations[0]?.cause).toBe("signal");
       } finally {
@@ -1021,7 +983,7 @@ describe("Temporal workflow integration", () => {
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
       const queuedTurns = [queuedTurn("event-1")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       const reconciliationCauses: string[] = [];
       const waiter = {
         waiterId: crypto.randomUUID(),
@@ -1033,22 +995,23 @@ describe("Temporal workflow integration", () => {
       const firstRunBlocked = new Promise<void>((resolve) => {
         releaseFirstRun = resolve;
       });
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        if (turn.triggerEventId === "event-1") {
+          await firstRunBlocked;
+          return { status: "idle", capacityWait: waiter };
+        }
+        return { status: "failed" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          if (input.triggerEventId === "event-1") {
-            await firstRunBlocked;
-            return { status: "idle", capacityWait: waiter };
-          }
-          return { status: "failed" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         getCodexCapacityWait: async () => waiter,
         reconcileCodexCapacityWait: async (input: { cause: string }) => {
           reconciliationCauses.push(input.cause);
+          admission.resumeCapacity();
           queuedTurns.push(queuedTurn("capacity-resume"));
           return { action: "resumed", turnId: queuedTurns[0]!.id };
         },
@@ -1066,7 +1029,7 @@ describe("Temporal workflow integration", () => {
         releaseFirstRun();
         await handle.result();
         expect(reconciliationCauses).toEqual(["signal"]);
-        expect(runs.map((input) => input.triggerEventId)).toEqual(["event-1", "capacity-resume"]);
+        expect(runs).toEqual(["event-1", "capacity-resume"]);
       } finally {
         releaseFirstRun();
         worker.shutdown();
@@ -1084,7 +1047,7 @@ describe("Temporal workflow integration", () => {
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
       const queuedTurns = [queuedTurn("event-1")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       let goalChecks = 0;
       let reconciliations = 0;
       let resumed = false;
@@ -1094,16 +1057,16 @@ describe("Temporal workflow integration", () => {
         nextCheckAt: new Date(0).toISOString(),
         wakeRevision: 3,
       };
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return turn.triggerEventId === "event-1"
+          ? { status: "idle", capacityWait: waiter }
+          : { status: "failed" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return input.triggerEventId === "event-1"
-            ? { status: "idle", capacityWait: waiter }
-            : { status: "failed" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async () => {
           goalChecks += 1;
@@ -1116,6 +1079,7 @@ describe("Temporal workflow integration", () => {
             return { action: "waiting", ...waiter };
           }
           resumed = true;
+          admission.resumeCapacity();
           queuedTurns.push(queuedTurn("capacity-after-continue-as-new"));
           return { action: "resumed", turnId: queuedTurns[0]!.id };
         },
@@ -1136,10 +1100,7 @@ describe("Temporal workflow integration", () => {
           ],
         });
         await handle.result();
-        expect(runs.map((input) => input.triggerEventId)).toEqual([
-          "event-1",
-          "capacity-after-continue-as-new",
-        ]);
+        expect(runs).toEqual(["event-1", "capacity-after-continue-as-new"]);
         expect(reconciliations).toBe(2);
         expect(goalChecks).toBe(0);
 
@@ -1171,7 +1132,7 @@ describe("Temporal workflow integration", () => {
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
       const queuedTurns = [queuedTurn("event-1")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       const waiter = {
         waiterId: crypto.randomUUID(),
         generation: 11,
@@ -1180,21 +1141,22 @@ describe("Temporal workflow integration", () => {
       };
       let resumed = false;
       let reconciliations = 0;
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return turn.triggerEventId === "event-1"
+          ? { status: "idle", capacityWait: waiter }
+          : { status: "failed" };
+      });
       const activities = {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return input.triggerEventId === "event-1"
-            ? { status: "idle", capacityWait: waiter }
-            : { status: "failed" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         getCodexCapacityWait: async () => (resumed ? null : waiter),
         reconcileCodexCapacityWait: async () => {
           reconciliations += 1;
           resumed = true;
+          admission.resumeCapacity();
           queuedTurns.push(queuedTurn("capacity-after-worker-restart"));
           return { action: "resumed", turnId: queuedTurns[0]!.id };
         },
@@ -1221,10 +1183,7 @@ describe("Temporal workflow integration", () => {
           await Bun.sleep(25);
         }
         await handle.result();
-        expect(runs.map((input) => input.triggerEventId)).toEqual([
-          "event-1",
-          "capacity-after-worker-restart",
-        ]);
+        expect(runs).toEqual(["event-1", "capacity-after-worker-restart"]);
         expect(reconciliations).toBe(1);
       } finally {
         replacement.shutdown();
@@ -1247,16 +1206,16 @@ describe("Temporal workflow integration", () => {
       // continueAsNew boundary strands nothing and the fresh run re-claims from
       // the durable queue rather than a replayed seed event.
       const queuedTurns = [queuedTurn("event-1"), queuedTurn("event-2")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
       const goalChecks: unknown[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async (input: unknown) => {
           goalChecks.push(input);
@@ -1275,7 +1234,7 @@ describe("Temporal workflow integration", () => {
         // FINAL run completes (idle, after both turns drained).
         await handle.result();
         // Both turns ran exactly once, in order, across the continueAsNew split.
-        expect(runs.map((input) => input.triggerEventId)).toEqual(["event-1", "event-2"]);
+        expect(runs).toEqual(["event-1", "event-2"]);
 
         // The first run ended by continuing-as-new (history overflow guard), and
         // the continuation carried the self-contained input forward (same scope
@@ -1316,15 +1275,15 @@ describe("Temporal workflow integration", () => {
       // The continueAsNew drops the in-memory wakeup counter, but the turn lives
       // in the queue, so the fresh run must still dispatch it.
       const queuedTurns = [queuedTurn("event-1")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
+        runs.push(turn.triggerEventId);
+        return { status: "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          return { status: "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async () => ({ action: "none" }),
       });
@@ -1344,7 +1303,7 @@ describe("Temporal workflow integration", () => {
         await client.workflow.getHandle(workflowId).signal("queueChanged");
         await handle.result();
         // The follow-up turn was claimed by the continued run, not lost.
-        expect(runs.map((input) => input.triggerEventId)).toEqual(["event-1", "event-2"]);
+        expect(runs).toEqual(["event-1", "event-2"]);
       } finally {
         worker.shutdown();
         await run;
@@ -1354,39 +1313,28 @@ describe("Temporal workflow integration", () => {
   );
 
   test(
-    "a stale approval left in the queue does not wedge the continueAsNew boundary",
+    "a stale approval signal does not wedge the durable continueAsNew boundary",
     async () => {
       const taskQueue = `workflow-test-${crypto.randomUUID()}`;
       const scope = workflowScope();
       const sessionId = crypto.randomUUID();
       const workflowId = `session-${sessionId}`;
-      // Two turns are queued up front; the per-run backstop is 1, so the workflow
-      // must continue-as-new after the first turn settles. The first turn returns
-      // requires_action, blocking inside runTurn until an approval arrives. TWO
-      // approvalDecision signals are sent while it is blocked (the API guard only
-      // checks status==='requires_action', so two decisions both land in the
-      // in-memory approvalQueue). The first approval re-runs the turn to idle and
-      // settles it; the SECOND is left behind in the queue — a STALE entry.
-      //
-      // Regression: coupling the continueAsNew guard to `approvalQueue.length===0`
-      // let that stale entry wedge the boundary forever, so the workflow grew to
-      // the Temporal hard history cap and was force-terminated — the exact failure
-      // this branch exists to prevent. The fix drops the surplus at the boundary:
-      // continueAsNew must still fire and the continued run must dispatch event-2.
+      // Approval truth lives in Postgres. Temporal signals are wakeups only, so a
+      // duplicate/stale signal cannot manufacture another approval dispatch or
+      // prevent continue-as-new. The durable pending approval is accepted once;
+      // the surplus signal is ignored when the next peek observes normal work.
       const queuedTurns = [queuedTurn("event-1"), queuedTurn("event-2")];
-      const runs: Array<{ triggerEventId: string }> = [];
+      const runs: string[] = [];
+      const admission = createTurnAdmission(queuedTurns, async (input, turn) => {
+        const eventId =
+          input.trigger.kind === "approval" ? input.trigger.triggerEventId : turn.triggerEventId;
+        runs.push(eventId);
+        return { status: eventId === "event-1" ? "requires_action" : "idle" };
+      });
       const worker = await testWorker(nativeConnection, taskQueue, {
-        claimNextSessionExecution: async () => queuedTurns.shift() ?? null,
+        ...admission.activities,
         markSessionIdle: async () => undefined,
-        runAgentTurn: async (input: { triggerEventId: string }) => {
-          runs.push(input);
-          // Only the ORIGINAL event-1 dispatch blocks on approval; the approval
-          // re-run and event-2 settle straight to idle, so the turn completes
-          // without re-entering requires_action and the second approval is
-          // orphaned in the queue.
-          return { status: input.triggerEventId === "event-1" ? "requires_action" : "idle" };
-        },
-        failSession: async () => undefined,
+        failSessionAttempt: async () => undefined,
         settleSessionControl: async () => undefined,
         maybeContinueGoal: async () => ({ action: "none" }),
       });
@@ -1399,8 +1347,9 @@ describe("Temporal workflow integration", () => {
           args: [{ ...scope, sessionId, initialEventId: "event-1", maxTurnsPerRun: 1 }],
         });
         // Wait until the first turn is blocked on approval, then submit two
-        // decisions. The surplus second decision is the stale entry under test.
+        // signals. Only approval-1 exists in durable admission state.
         await waitFor(() => runs.length === 1);
+        admission.approve("approval-1");
         await client.workflow.getHandle(workflowId).signal("approvalDecision", "approval-1");
         await client.workflow.getHandle(workflowId).signal("approvalDecision", "approval-2");
         // The handle follows the continueAsNew chain: it resolves only if the
@@ -1408,11 +1357,7 @@ describe("Temporal workflow integration", () => {
         await handle.result();
         // event-1 (requires_action), approval-1 (re-run to idle), event-2 (on the
         // continued run). The stale approval-2 never drives a dispatch.
-        expect(runs.map((input) => input.triggerEventId)).toEqual([
-          "event-1",
-          "approval-1",
-          "event-2",
-        ]);
+        expect(runs).toEqual(["event-1", "approval-1", "event-2"]);
 
         // The first run ended by continuing-as-new despite the stale approval, and
         // event-2 was claimed by the fresh continued run — not stranded.
@@ -1457,7 +1402,127 @@ function decodeContinuedInput(
   return JSON.parse(Buffer.from(payload.data).toString("utf8")) as Record<string, unknown>;
 }
 
-function queuedTurn(triggerEventId: string): { id: string; triggerEventId: string } {
+type WorkflowTestTurn = { id: string; triggerEventId: string };
+
+function createPendingControlPeek(controlEventId: string, initiallyPending = false) {
+  let reads = 0;
+  let settled = false;
+  return {
+    peekSessionWork: async () => {
+      const pending = !settled && (initiallyPending || reads > 0);
+      reads += 1;
+      return pending
+        ? ({ kind: "fence-settle", controlEventId } as const)
+        : ({ kind: "idle" } as const);
+    },
+    settled() {
+      settled = true;
+    },
+  };
+}
+
+function createTurnAdmission(
+  queuedTurns: WorkflowTestTurn[],
+  run: (
+    input: {
+      attemptId: string;
+      trigger: { kind: "next" } | { kind: "approval"; triggerEventId: string };
+      [key: string]: unknown;
+    },
+    turn: WorkflowTestTurn,
+  ) => Promise<Record<string, unknown>>,
+) {
+  let current: WorkflowTestTurn | null = null;
+  let currentState: "running" | "approval" | "recovering" | "capacity" | null = null;
+  let approvalEventId: string | null = null;
+  let capacityRef: {
+    waiterId: string;
+    generation: number;
+    nextCheckAt: string;
+    wakeRevision: number;
+  } | null = null;
+  return {
+    approve(eventId: string) {
+      approvalEventId = eventId;
+    },
+    recover() {
+      if (!current) throw new Error("cannot recover without a current turn");
+      currentState = "recovering";
+    },
+    resumeCapacity() {
+      if (currentState !== "capacity") {
+        throw new Error("cannot resume without a durable capacity wait");
+      }
+      currentState = null;
+      capacityRef = null;
+    },
+    supersede() {
+      current = null;
+      currentState = null;
+      approvalEventId = null;
+      capacityRef = null;
+    },
+    activities: {
+      peekSessionWork: async () => {
+        if (currentState === "approval") {
+          return approvalEventId
+            ? ({ kind: "approval-pending", triggerEventId: approvalEventId } as const)
+            : ({ kind: "approval-wait" } as const);
+        }
+        if (currentState === "capacity") {
+          if (!capacityRef) throw new Error("capacity admission lost its durable waiter");
+          return { kind: "capacity-wait", ref: capacityRef } as const;
+        }
+        if (currentState === "recovering" || queuedTurns.length > 0) {
+          return { kind: "runnable" } as const;
+        }
+        return { kind: "idle" } as const;
+      },
+      runAgentTurn: async (input: {
+        attemptId: string;
+        trigger: { kind: "next" } | { kind: "approval"; triggerEventId: string };
+        [key: string]: unknown;
+      }) => {
+        if (input.trigger.kind === "approval") {
+          if (!current || currentState !== "approval") {
+            return { status: "unclaimed", reason: "stale-approval" } as const;
+          }
+          if (approvalEventId !== input.trigger.triggerEventId) {
+            return { status: "unclaimed", reason: "stale-approval" } as const;
+          }
+          approvalEventId = null;
+        } else if (currentState === "recovering") {
+          if (!current) throw new Error("recovering admission lost its current turn");
+        } else {
+          current = queuedTurns.shift() ?? null;
+          if (!current) return { status: "unclaimed", reason: "no-work" } as const;
+        }
+        currentState = "running";
+        const turn = current;
+        const result = await run(input, turn!);
+        if (result.status === "requires_action") {
+          currentState = "approval";
+        } else if (result.status === "recovering") {
+          currentState = "recovering";
+        } else if (result.capacityWait) {
+          current = null;
+          currentState = "capacity";
+          capacityRef = result.capacityWait as typeof capacityRef;
+        } else {
+          current = null;
+          currentState = null;
+        }
+        return {
+          ...result,
+          turnId: turn!.id,
+          attemptId: input.attemptId,
+        };
+      },
+    },
+  };
+}
+
+function queuedTurn(triggerEventId: string): WorkflowTestTurn {
   return {
     id: crypto.randomUUID(),
     triggerEventId,
@@ -1475,19 +1540,39 @@ async function testWorker(
   nativeConnection: NativeConnection,
   taskQueue: string,
   activities: Record<string, (...args: any[]) => Promise<unknown>>,
-): Promise<Worker> {
-  return await Worker.create({
-    connection: nativeConnection,
-    namespace: "default",
-    taskQueue,
-    workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
-    activities: {
-      // Goal-less defaults; individual tests override these to exercise the
-      // goal continuation loop.
-      maybeContinueGoal: async () => ({ action: "none" }),
-      getCodexCapacityWait: async () => null,
-      reconcileCodexCapacityWait: async () => ({ action: "stale" }),
-      ...activities,
+): Promise<{ run: () => Promise<void>; shutdown: () => void }> {
+  const defaults = {
+    maybeContinueGoal: async () => ({ action: "none" }),
+    getCodexCapacityWait: async () => null,
+    reconcileCodexCapacityWait: async () => ({ action: "stale" }),
+    ...activities,
+  };
+  const { runAgentTurn, ...controlActivities } = defaults;
+  if (!runAgentTurn) throw new Error("turn activity is missing from workflow test");
+  const [control, turns] = await Promise.all([
+    Worker.create({
+      connection: nativeConnection,
+      namespace: "default",
+      taskQueue,
+      workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
+      activities: controlActivities,
+      maxConcurrentActivityTaskExecutions: 32,
+    }),
+    Worker.create({
+      connection: nativeConnection,
+      namespace: "default",
+      taskQueue: turnTaskQueue(taskQueue),
+      activities: { runAgentTurn },
+      maxConcurrentActivityTaskExecutions: 8,
+    }),
+  ]);
+  return {
+    run: async () => {
+      await Promise.all([control.run(), turns.run()]);
     },
-  });
+    shutdown: () => {
+      control.shutdown();
+      turns.shutdown();
+    },
+  };
 }

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -15,7 +15,7 @@ import {
   bootstrapWorkspace,
   completeFileUpload,
   applyCreditLedgerEntry,
-  claimNextSessionExecution,
+  claimSessionWorkForAttempt,
   createDb,
   createFileUpload,
   createScheduledTask,
@@ -41,7 +41,6 @@ import {
   listSessionEvents,
   listScheduledTaskRuns,
   recordUsageEvent,
-  registerSessionTurnDispatch,
   requireScheduledTask,
   saveRunState,
   sumUsageQuantity,
@@ -57,7 +56,7 @@ import {
   MaxTurnsExceededError,
   type OpenGeniRuntime,
 } from "@opengeni/runtime";
-import { createActivities as createWorkerActivities } from "../../apps/worker/src/activities";
+import { createActivityTestHarness as createWorkerActivities } from "../../apps/worker/src/activities";
 import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
 import { PROVIDER_BACKPRESSURE_DELAY_MS } from "../../apps/worker/src/activities/agent-turn";
 import {
@@ -118,10 +117,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "run" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -133,10 +132,11 @@ describe("worker activities integration", () => {
     });
 
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-activity",
     });
     expect(result.status).toBe("idle");
@@ -234,7 +234,7 @@ describe("worker activities integration", () => {
           },
         ],
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      await appendOwnedEvents(dbClient.db, grant, session.id, [
         { type: "user.message", payload: { text: "search please" } },
       ]);
       const model = new ScriptedModel([
@@ -246,7 +246,7 @@ describe("worker activities integration", () => {
         },
         { id: "approval-call-2", outputText: "found it", chunks: ["found ", "it"] },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings,
         db: dbClient.db,
         bus,
@@ -255,10 +255,11 @@ describe("worker activities integration", () => {
 
       // Turn 1: the tool call is gated — the turn pauses instead of running it.
       const first = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-mcp-approval",
       });
       expect(first.status).toBe("requires_action");
@@ -286,15 +287,15 @@ describe("worker activities integration", () => {
         },
       ]);
       const second = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: approvalTrigger!.id,
+        trigger: { kind: "approval", triggerEventId: approvalTrigger!.id },
         // Distinct workflowId so the resume's event producerId
         // (`${workflowId}:${turnId}`) does not collide with turn 1's — the real
         // system disambiguates via the Temporal activityId, which is absent here.
         workflowId: "workflow-mcp-approval-resume",
-        turnId: activeTurnId!,
       });
       expect(second.status).toBe("idle");
       expect(mcp.calls).toEqual([{ tool: "search_documents", args: { query: "network policy" } }]);
@@ -369,20 +370,21 @@ describe("worker activities integration", () => {
         sandboxBackend: "none",
         firstPartyMcpPermissions: ["workspace:read", "sessions:read", "sessions:create"],
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      await appendOwnedEvents(dbClient.db, grant, session.id, [
         { type: "user.message", payload: { text: "list the fleet" } },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings,
         db: dbClient.db,
         bus,
         runtime: createProductionAgentRuntime({ model }),
       });
       const result = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-manager-mcp",
       });
       expect(result.status).toBe("idle");
@@ -466,20 +468,21 @@ describe("worker activities integration", () => {
         sandboxBackend: "none",
         firstPartyMcpPermissions: ["workspace:read", "sessions:read", "sessions:create"],
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, manager.id, [
+      await appendOwnedEvents(dbClient.db, grant, manager.id, [
         { type: "user.message", payload: { text: "spawn a worker" } },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings,
         db: dbClient.db,
         bus,
         runtime: createProductionAgentRuntime({ model }),
       });
       await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: manager.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-spawn-link",
       });
       // The manager created exactly one other session: the spawned worker.
@@ -505,30 +508,32 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
       runtime: createProductionAgentRuntime({ model }),
     });
-    const [firstTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "first question" } },
     ]);
     await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: firstTrigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-followup",
     });
-    const [secondTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "second question" } },
     ]);
     await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: secondTrigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-followup",
     });
 
@@ -562,10 +567,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "look at this", resources: [resource] } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -573,10 +578,11 @@ describe("worker activities integration", () => {
     });
 
     await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-image-context",
     });
 
@@ -613,10 +619,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "look at this", resources: [resource] } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -624,10 +630,11 @@ describe("worker activities integration", () => {
     });
 
     await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-oversized-image-context",
     });
 
@@ -677,10 +684,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "run" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -690,10 +697,11 @@ describe("worker activities integration", () => {
     });
 
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-pack-image-conflict",
     });
     expect(result.status).toBe("failed");
@@ -715,10 +723,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "fail" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -729,13 +737,14 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-fail",
       }),
-    ).resolves.toEqual({ status: "failed" });
+    ).resolves.toMatchObject({ status: "failed" });
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     expect(events.some((event) => event.type === "turn.failed")).toBe(true);
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("failed");
@@ -750,10 +759,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "long task" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -764,13 +773,14 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-max-turns",
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle" });
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     expect(events.some((event) => event.type === "turn.failed")).toBe(false);
     const completed = events.find((event) => event.type === "turn.completed");
@@ -789,12 +799,12 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "rate limit" } },
     ]);
     const error = new Error("Too Many Requests");
     Object.assign(error, { status: 429 });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -805,13 +815,14 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-rate-limit",
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle" });
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     const failed = events.find((event) => event.type === "turn.failed");
     expect(failed?.payload).toEqual({
@@ -844,12 +855,12 @@ describe("worker activities integration", () => {
       text: "finish the long-running provisioning",
       createdBy: "api",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "rate limit with goal" } },
     ]);
     const error = new Error("Too Many Requests");
     Object.assign(error, { status: 429 });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -860,13 +871,14 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-rate-limit-goal",
       }),
-    ).resolves.toEqual({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
+    ).resolves.toMatchObject({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 50);
     const failed = events.find((event) => event.type === "turn.failed");
     expect(failed?.payload).toEqual({
@@ -901,7 +913,7 @@ describe("worker activities integration", () => {
       text: "finish without repeating completed tool side effects",
       createdBy: "api",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "continue after transient MCP transport loss" } },
     ]);
     const callId = "call-before-mcp-timeout";
@@ -971,7 +983,7 @@ describe("worker activities integration", () => {
           finalOutput: "",
         }) as never,
     };
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -980,13 +992,14 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-mcp-timeout-after-output",
       }),
-    ).resolves.toEqual({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
+    ).resolves.toMatchObject({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
 
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
     const outputIndex = events.findIndex((event) => event.type === "agent.toolCall.output");
@@ -1031,7 +1044,7 @@ describe("worker activities integration", () => {
         exported.push({ body });
       },
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings,
       db: dbClient.db,
       bus,
@@ -1043,10 +1056,11 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: crypto.randomUUID(),
-        triggerEventId: crypto.randomUUID(),
+        trigger: { kind: "next" },
         workflowId: "workflow-missing-session",
       }),
     ).rejects.toThrow("Session not found");
@@ -1068,16 +1082,9 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "run" } },
     ]);
-    const claimed = await claimNextSessionExecution(
-      dbClient.db,
-      grant.workspaceId,
-      session.id,
-      "workflow-status-update-fails",
-    );
-    expect(claimed).not.toBeNull();
     let updateCalls = 0;
     const failSecondUpdate = (targetDb: typeof dbClient.db): typeof dbClient.db =>
       new Proxy(targetDb, {
@@ -1093,9 +1100,9 @@ describe("worker activities integration", () => {
           if (prop === "update" && typeof value === "function") {
             return (...args: unknown[]) => {
               updateCalls += 1;
-              // Dispatch registration is update 1. Failing update 2 lands after
-              // the atomic start settlement inserted its events, proving that
-              // the nested transaction rolls those events back with the turn.
+              // Atomic claim updates the turn then the session. Failing update 2
+              // proves the whole admission transaction rolls back before any
+              // turn-start event can become authoritative.
               if (updateCalls === 2) {
                 throw new Error("status update failed");
               }
@@ -1106,7 +1113,7 @@ describe("worker activities integration", () => {
         },
       }) as typeof dbClient.db;
     const failingDb = failSecondUpdate(dbClient.db);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: failingDb,
       bus,
@@ -1117,12 +1124,12 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-status-update-fails",
-        turnId: claimed!.id,
       }),
     ).rejects.toThrow("status update failed");
 
@@ -1143,32 +1150,27 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [initialTrigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "needs approval" } },
     ]);
-    const turn = await claimNextSessionExecution(
-      dbClient.db,
-      grant.workspaceId,
-      session.id,
-      workflowId,
-    );
-    expect(turn).not.toBeNull();
     const initialAttemptId = crypto.randomUUID();
-    expect(
-      await registerSessionTurnDispatch(dbClient.db, grant.workspaceId, {
-        sessionId: session.id,
-        turnId: turn!.id,
-        triggerEventId: initialTrigger!.id,
-        attemptId: initialAttemptId,
-        dispatchId: `approval-fixture-${crypto.randomUUID()}`,
-      }),
-    ).toMatchObject({ action: "registered" });
+    const initialClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
+      sessionId: session.id,
+      workflowId,
+      attemptId: initialAttemptId,
+      dispatchId: `approval-fixture-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    if (initialClaim.action !== "claimed") {
+      throw new Error(`approval fixture was not claimed: ${initialClaim.reason}`);
+    }
+    const turn = initialClaim.turn;
     await saveRunState(dbClient.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      turnId: turn!.id,
-      expectedExecutionGeneration: turn!.executionGeneration,
+      turnId: turn.id,
+      expectedExecutionGeneration: turn.executionGeneration,
       expectedAttemptId: initialAttemptId,
       serializedRunState: "saved-state",
       pendingApprovals: [{ id: "approval-1" }],
@@ -1176,12 +1178,12 @@ describe("worker activities integration", () => {
     expect(
       await applySessionTurnSettlement(dbClient.db, grant.workspaceId, {
         sessionId: session.id,
-        turnId: turn!.id,
-        triggerEventId: initialTrigger!.id,
+        turnId: turn.id,
+        triggerEventId: turn.triggerEventId,
         attemptId: initialAttemptId,
         turnStatus: "requires_action",
         sessionStatus: "requires_action",
-        activeTurnId: turn!.id,
+        activeTurnId: turn.id,
         events: [],
       }),
     ).toMatchObject({ action: "settled" });
@@ -1214,7 +1216,7 @@ describe("worker activities integration", () => {
       },
       serializeApprovals: () => [],
     };
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -1223,16 +1225,16 @@ describe("worker activities integration", () => {
 
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: approvalTrigger!.id,
+        trigger: { kind: "approval", triggerEventId: approvalTrigger!.id },
         workflowId,
-        turnId: turn!.id,
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle", turnId: turn.id });
 
-    expect(observedDuringRun).toEqual({ status: "running", activeTurnId: turn!.id });
+    expect(observedDuringRun).toEqual({ status: "running", activeTurnId: turn.id });
     expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
   });
 
@@ -1321,11 +1323,11 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "modal",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "read repo" } },
     ]);
     const sandboxExecCalls: Array<Record<string, unknown>> = [];
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -1345,10 +1347,11 @@ describe("worker activities integration", () => {
     });
 
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-modal-repo-clone",
     });
 
@@ -1392,10 +1395,10 @@ describe("worker activities integration", () => {
         model: "scripted-model",
         sandboxBackend: "none",
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      await appendOwnedEvents(dbClient.db, grant, session.id, [
         { type: "user.message", payload: { text: "search docs" } },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings: testSettings({
           databaseUrl: services.databaseUrl,
           natsUrl: services.natsUrl,
@@ -1415,10 +1418,11 @@ describe("worker activities integration", () => {
       });
 
       const result = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-mcp",
       });
 
@@ -1469,10 +1473,10 @@ describe("worker activities integration", () => {
         model: "scripted-model",
         sandboxBackend: "none",
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      await appendOwnedEvents(dbClient.db, grant, session.id, [
         { type: "user.message", payload: { text: "search docs" } },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings: testSettings({
           databaseUrl: services.databaseUrl,
           natsUrl: services.natsUrl,
@@ -1499,10 +1503,11 @@ describe("worker activities integration", () => {
       });
 
       const result = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-per-response-usage",
       });
 
@@ -1546,10 +1551,10 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "expensive run" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -1575,10 +1580,11 @@ describe("worker activities integration", () => {
     });
 
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-capped-model-debit",
     });
 
@@ -1620,24 +1626,25 @@ describe("worker activities integration", () => {
       { id: "items-t1", outputText: "noted: zebra", chunks: ["noted: zebra"] },
       { id: "items-t2", outputText: "the codeword is zebra", chunks: ["the codeword is zebra"] },
     ]);
-    const firstTurnActivities = createActivities({
+    const firstTurnActivities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
       runtime: createProductionAgentRuntime({ model }),
     });
-    const [trigger1] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "remember the codeword zebra" } },
     ]);
     await expect(
       firstTurnActivities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger1!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-items-turn-1",
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle" });
     const itemsAfterTurn1 = await getSessionHistoryItems(
       dbClient.db,
       grant.workspaceId,
@@ -1650,7 +1657,7 @@ describe("worker activities integration", () => {
     expect(JSON.stringify(itemsAfterTurn1[0]?.item)).toContain("remember the codeword zebra");
 
     // The follow-up reads conversation truth from the canonical items table.
-    const itemsActivities = createActivities({
+    const itemsActivities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -1659,18 +1666,19 @@ describe("worker activities integration", () => {
       bus,
       runtime: createProductionAgentRuntime({ model }),
     });
-    const [trigger2] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "what is the codeword?" } },
     ]);
     await expect(
       itemsActivities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger2!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-items-turn-2",
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle" });
     const lastRequestInput = JSON.stringify(
       (model.requests.at(-1) as { input?: unknown })?.input ?? "",
     );
@@ -1738,7 +1746,7 @@ describe("worker activities integration", () => {
     const model = new ScriptedModel([
       { id: "orphan-recover", outputText: "recovered", chunks: ["recovered"] },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -1747,20 +1755,21 @@ describe("worker activities integration", () => {
       bus,
       runtime: createProductionAgentRuntime({ model }),
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "continue please" } },
     ]);
 
     // The turn SUCCEEDS instead of failing the session with a 400.
     await expect(
       activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-orphan-recover",
       }),
-    ).resolves.toEqual({ status: "idle" });
+    ).resolves.toMatchObject({ status: "idle" });
 
     // The orphan never reached the model: the sanitized request omits it while
     // keeping the surrounding valid items and the new user turn.
@@ -1804,7 +1813,7 @@ describe("worker activities integration", () => {
       fileId: file.id,
     });
     let embedderCalled = false;
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -1906,7 +1915,7 @@ describe("worker activities integration", () => {
       fileId: fileTwo.id,
     });
     let embedCalls = 0;
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -1981,7 +1990,7 @@ describe("worker activities integration", () => {
       model: "scripted-model",
       sandboxBackend: "none",
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "allowed first run" } },
     ]);
     await recordUsageEvent(dbClient.db, {
@@ -1994,7 +2003,7 @@ describe("worker activities integration", () => {
       sourceResourceId: session.id,
       idempotencyKey: `test-agent-run-created:${session.id}`,
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2009,10 +2018,11 @@ describe("worker activities integration", () => {
     });
 
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-exact-run-cap",
     });
 
@@ -2045,7 +2055,7 @@ describe("worker activities integration", () => {
         model: "scripted-model",
         sandboxBackend: "none",
       });
-      const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+      await appendOwnedEvents(dbClient.db, grant, session.id, [
         {
           type: "user.message",
           payload: {
@@ -2054,7 +2064,7 @@ describe("worker activities integration", () => {
           },
         },
       ]);
-      const activities = createActivities({
+      const activities = createWorkerActivities({
         settings: testSettings({
           databaseUrl: services.databaseUrl,
           natsUrl: services.natsUrl,
@@ -2074,10 +2084,11 @@ describe("worker activities integration", () => {
       });
 
       const result = await activities.runAgentTurn({
+        attemptId: crypto.randomUUID(),
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         sessionId: session.id,
-        triggerEventId: trigger!.id,
+        trigger: { kind: "next" },
         workflowId: "workflow-follow-up-mcp",
       });
 
@@ -2106,7 +2117,7 @@ describe("worker activities integration", () => {
       },
       metadata: {},
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2183,7 +2194,7 @@ describe("worker activities integration", () => {
       sourceResourceId: task.id,
       idempotencyKey: `test:scheduled-cost-cap:${task.id}`,
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2235,7 +2246,7 @@ describe("worker activities integration", () => {
       sourceResourceId: task.id,
       idempotencyKey: reservationKey,
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2286,7 +2297,7 @@ describe("worker activities integration", () => {
       subscribe: async () => async () => undefined,
       close: async () => undefined,
     };
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2341,7 +2352,7 @@ describe("worker activities integration", () => {
       },
       metadata: {},
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2473,10 +2484,10 @@ describe("worker activities integration", () => {
       sandboxBackend: "none",
       variableSetId: environment.id,
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "run" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2494,10 +2505,11 @@ describe("worker activities integration", () => {
       }),
     });
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-environment-redaction",
     });
     expect(result.status).toBe("idle");
@@ -2524,10 +2536,10 @@ describe("worker activities integration", () => {
       sandboxBackend: "none",
       variableSetId: environment.id,
     });
-    const [trigger] = await appendOwnedEvents(dbClient.db, grant, session.id, [
+    await appendOwnedEvents(dbClient.db, grant, session.id, [
       { type: "user.message", payload: { text: "run" } },
     ]);
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -2536,10 +2548,11 @@ describe("worker activities integration", () => {
       }),
     });
     const result = await activities.runAgentTurn({
+      attemptId: crypto.randomUUID(),
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       sessionId: session.id,
-      triggerEventId: trigger!.id,
+      trigger: { kind: "next" },
       workflowId: "workflow-environment-missing-key",
     });
     expect(result.status).toBe("failed");
@@ -2565,7 +2578,7 @@ describe("worker activities integration", () => {
       variableSetId: environment.id,
       metadata: {},
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2624,7 +2637,7 @@ describe("worker activities integration", () => {
     await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, {
       reusableSessionId: session.id,
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({
         databaseUrl: services.databaseUrl,
         natsUrl: services.natsUrl,
@@ -2671,7 +2684,7 @@ describe("worker activities integration", () => {
     await updateScheduledTask(dbClient.db, grant.workspaceId, task.id, {
       reusableSessionId: session.id,
     });
-    const activities = createActivities({
+    const activities = createWorkerActivities({
       settings: testSettings({ databaseUrl: services.databaseUrl, natsUrl: services.natsUrl }),
       db: dbClient.db,
       bus,
@@ -2703,22 +2716,6 @@ describe("worker activities integration", () => {
 });
 
 type TestDb = ReturnType<typeof createDb>["db"];
-
-function createActivities(input: Parameters<typeof createWorkerActivities>[0]) {
-  const activities = createWorkerActivities(input);
-  return {
-    ...activities,
-    runAgentTurn: async (
-      turn: Omit<Parameters<typeof activities.runAgentTurn>[0], "attemptId"> & {
-        attemptId?: string;
-      },
-    ) =>
-      await activities.runAgentTurn({
-        ...turn,
-        attemptId: turn.attemptId ?? crypto.randomUUID(),
-      }),
-  };
-}
 
 const workerEnvironmentsKey = Buffer.alloc(32, 8).toString("base64");
 

--- a/test/integration/worker-restart.integration.ts
+++ b/test/integration/worker-restart.integration.ts
@@ -10,6 +10,7 @@ import {
   enqueueSessionMessageAtomically,
   getSession,
   getSessionHistoryItems,
+  getSessionTurn,
   listSessionEvents,
   listSessionTurns,
   requestSessionControl,
@@ -28,8 +29,9 @@ import {
 } from "@opengeni/testing";
 import { postUserMessageTurn } from "@opengeni/core";
 import type { SessionWorkflowClient } from "../../apps/api/src/app";
-import { createActivities } from "../../apps/worker/src/activities";
+import { createActivityTestHarness } from "../../apps/worker/src/activities";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 // Proves the campaign's robustness contract: a worker rollout restart
 // (graceful SIGTERM shutdown) mid-turn must not produce a failed session.
@@ -103,7 +105,7 @@ describe("worker restart resilience", () => {
         },
       ],
     });
-    const activities = createActivities({
+    const activities = createActivityTestHarness({
       settings,
       db: dbClient.db,
       bus,
@@ -223,7 +225,7 @@ describe("worker restart resilience", () => {
       temporalHost: services.temporalHost,
       temporalTaskQueue: taskQueue,
     });
-    const activities = createActivities({
+    const activities = createActivityTestHarness({
       settings,
       db: dbClient.db,
       bus,
@@ -365,7 +367,7 @@ describe("worker restart resilience", () => {
         outputText: "must not finish",
       },
     ]);
-    const baseActivities = createActivities({
+    const baseActivities = createActivityTestHarness({
       settings,
       db: dbClient.db,
       bus,
@@ -382,20 +384,24 @@ describe("worker restart resilience", () => {
       settleSessionControl: async (
         input: Parameters<typeof baseActivities.settleSessionControl>[0],
       ) => {
-        await baseActivities.settleSessionControl(input);
+        const result = await baseActivities.settleSessionControl(input);
         interruptSettled();
+        return result;
       },
       runAgentTurn: async (input: Parameters<typeof baseActivities.runAgentTurn>[0]) => {
         dispatchedAttemptId = input.attemptId;
         const result = await baseActivities.runAgentTurn(input);
+        if (result.status === "unclaimed") return result;
         // Deterministically model the production zombie boundary: the real
         // activity has observed cancellation, then this wrapper publishes a
         // terminal settlement from that fenced attempt after Pause committed.
         await interruptSettlement;
+        const turn = await getSessionTurn(dbClient.db, input.workspaceId, result.turnId);
+        if (!turn) throw new Error(`zombie fixture turn disappeared: ${result.turnId}`);
         lateSettlement = await applySessionTurnSettlement(dbClient.db, input.workspaceId, {
           sessionId: input.sessionId,
-          turnId: input.turnId!,
-          triggerEventId: input.triggerEventId,
+          turnId: result.turnId,
+          triggerEventId: turn.triggerEventId,
           attemptId: input.attemptId,
           turnStatus: "completed",
           sessionStatus: "idle",
@@ -498,7 +504,7 @@ describe("worker restart resilience", () => {
       temporalHost: services.temporalHost,
       temporalTaskQueue: taskQueue,
     });
-    const activities = createActivities({
+    const activities = createActivityTestHarness({
       settings,
       db: dbClient.db,
       bus,
@@ -656,13 +662,33 @@ describe("worker restart resilience", () => {
 async function restartTestWorker(
   nativeConnection: NativeConnection,
   taskQueue: string,
-  activities: ReturnType<typeof createActivities>,
-): Promise<Worker> {
-  return await Worker.create({
-    connection: nativeConnection,
-    namespace: "default",
-    taskQueue,
-    workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
-    activities,
-  });
+  activities: ReturnType<typeof createActivityTestHarness>,
+): Promise<{ run: () => Promise<void>; shutdown: () => void }> {
+  const { runAgentTurn, ...controlActivities } = activities;
+  const [control, turns] = await Promise.all([
+    Worker.create({
+      connection: nativeConnection,
+      namespace: "default",
+      taskQueue,
+      workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
+      activities: controlActivities,
+      maxConcurrentActivityTaskExecutions: 32,
+    }),
+    Worker.create({
+      connection: nativeConnection,
+      namespace: "default",
+      taskQueue: turnTaskQueue(taskQueue),
+      activities: { runAgentTurn },
+      maxConcurrentActivityTaskExecutions: 8,
+    }),
+  ]);
+  return {
+    run: async () => {
+      await Promise.all([control.run(), turns.run()]);
+    },
+    shutdown: () => {
+      control.shutdown();
+      turns.shutdown();
+    },
+  };
 }


### PR DESCRIPTION
Clean cutover to the durable session-admission plane. Removes superseded runtime paths; makes Send, Steer, Pause/Resume, recovery, compaction, internal updates, usage fencing, and split worker ownership authoritative; adds migrations 0057/0058, production audit/recovery operators, chart topology, and real-service regression coverage. Dependency audit is clean and the full real-service suite passes.