### PR TITLE
fix(db): bound production cutover audit memory

### DIFF
--- a/packages/db/src/session-control-cutover-audit.ts
+++ b/packages/db/src/session-control-cutover-audit.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type postgres from "postgres";
 
-export const SESSION_CONTROL_CUTOVER_CONTRACT = "opengeni/session-control-cutover/v1" as const;
+export const SESSION_CONTROL_CUTOVER_CONTRACT = "opengeni/session-control-cutover/v2" as const;
 
 export type CutoverPhase = "baseline" | "migrated" | "final";
 
@@ -29,18 +29,15 @@ export type CutoverGoal = {
   lastContinuationTurnId: string | null;
 };
 
-export type CutoverHistoryRef = {
-  id: string;
-  turnId: string | null;
-  position: number;
-  active: boolean;
-  producerCodexCredentialId: string | null;
-};
-
-export type CutoverEventRef = {
-  id: string;
-  turnId: string | null;
-  sequence: number;
+export type CutoverRelationProof = {
+  count: number;
+  maxOrdinal: number | null;
+  stableSha256: string;
+  identitySha256: string;
+  preservedCount: number;
+  preservedThroughOrdinal: number | null;
+  preservedStableSha256: string;
+  preservedIdentitySha256: string;
 };
 
 export type CutoverRunState = {
@@ -111,8 +108,8 @@ export type CutoverSession = {
   queueTailPosition: number | null;
   turns: CutoverTurn[];
   goals: CutoverGoal[];
-  history: CutoverHistoryRef[];
-  events: CutoverEventRef[];
+  historyProof: CutoverRelationProof;
+  eventProof: CutoverRelationProof;
   runStates: CutoverRunState[];
   capacityWaiters: CutoverCapacityWaiter[];
   sandboxLeases: CutoverSandboxLease[];
@@ -147,6 +144,7 @@ export type SessionControlCutoverSnapshot = {
   schemaMigrations: string[];
   workspaces: CutoverWorkspace[];
   sessions: CutoverSession[];
+  proofBaselineSha256: string | null;
   invariants: CutoverInvariantCounts;
   identityCount: number;
   sha256: string;
@@ -273,6 +271,108 @@ function groupBySession<T extends { sessionId: string }>(rows: T[]): Map<string,
   return grouped;
 }
 
+type RelationProofAccumulator = {
+  count: number;
+  maxOrdinal: number | null;
+  stable: ReturnType<typeof createHash>;
+  identity: ReturnType<typeof createHash>;
+  preservedCount: number;
+  preservedStable: ReturnType<typeof createHash>;
+  preservedIdentity: ReturnType<typeof createHash>;
+};
+
+function updateProofHash(hash: ReturnType<typeof createHash>, value: unknown): void {
+  const serialized = stableJson(value);
+  hash.update(String(Buffer.byteLength(serialized, "utf8")));
+  hash.update(":");
+  hash.update(serialized);
+}
+
+function newProofAccumulator(): RelationProofAccumulator {
+  return {
+    count: 0,
+    maxOrdinal: null,
+    stable: createHash("sha256"),
+    identity: createHash("sha256"),
+    preservedCount: 0,
+    preservedStable: createHash("sha256"),
+    preservedIdentity: createHash("sha256"),
+  };
+}
+
+async function captureRelationProofs(
+  sql: postgres.Sql,
+  query: string,
+  ordinalColumn: string,
+  stableRow: (row: Row) => Record<string, unknown>,
+  reference: SessionControlCutoverSnapshot | undefined,
+  referenceProof: (session: CutoverSession) => CutoverRelationProof,
+): Promise<Map<string, CutoverRelationProof>> {
+  const referenceBoundaries = new Map(
+    (reference?.sessions ?? []).map((session) => [session.id, referenceProof(session).maxOrdinal]),
+  );
+  const accumulators = new Map<string, RelationProofAccumulator>();
+  for await (const rows of sql.unsafe<Row[]>(query).cursor(2_048)) {
+    for (const row of rows) {
+      const sessionId = stringValue(row.session_id, "relation.session_id");
+      const ordinal = numberValue(row[ordinalColumn], `relation.${ordinalColumn}`);
+      const identity = { id: stringValue(row.id, "relation.id") };
+      const stable = stableRow(row);
+      const accumulator = accumulators.get(sessionId) ?? newProofAccumulator();
+      accumulator.count += 1;
+      accumulator.maxOrdinal = Math.max(accumulator.maxOrdinal ?? ordinal, ordinal);
+      updateProofHash(accumulator.stable, stable);
+      updateProofHash(accumulator.identity, identity);
+      const boundary = referenceBoundaries.get(sessionId);
+      const preservesRow = reference
+        ? boundary !== undefined && boundary !== null && ordinal <= boundary
+        : true;
+      if (preservesRow) {
+        accumulator.preservedCount += 1;
+        updateProofHash(accumulator.preservedStable, stable);
+        updateProofHash(accumulator.preservedIdentity, identity);
+      }
+      accumulators.set(sessionId, accumulator);
+    }
+  }
+
+  const proofs = new Map<string, CutoverRelationProof>();
+  const sessionIds = new Set([
+    ...accumulators.keys(),
+    ...(reference?.sessions.map((session) => session.id) ?? []),
+  ]);
+  for (const sessionId of sessionIds) {
+    const accumulator = accumulators.get(sessionId) ?? newProofAccumulator();
+    proofs.set(sessionId, {
+      count: accumulator.count,
+      maxOrdinal: accumulator.maxOrdinal,
+      stableSha256: accumulator.stable.digest("hex"),
+      identitySha256: accumulator.identity.digest("hex"),
+      preservedCount: accumulator.preservedCount,
+      preservedThroughOrdinal: reference
+        ? (referenceBoundaries.get(sessionId) ?? null)
+        : accumulator.maxOrdinal,
+      preservedStableSha256: accumulator.preservedStable.digest("hex"),
+      preservedIdentitySha256: accumulator.preservedIdentity.digest("hex"),
+    });
+  }
+  return proofs;
+}
+
+function emptyRelationProof(): CutoverRelationProof {
+  const digest = createHash("sha256").digest("hex");
+  return {
+    count: 0,
+    maxOrdinal: null,
+    stableSha256: digest,
+    identitySha256: digest,
+    preservedCount: 0,
+    preservedThroughOrdinal: null,
+    preservedStableSha256: digest,
+    preservedIdentitySha256: digest,
+  };
+}
+
 function idsEqual<T extends { id: string }>(before: T[], after: T[]): boolean {
   if (before.length !== after.length) return false;
   const afterIds = new Set(after.map((entry) => entry.id));
@@ -320,7 +420,19 @@ export async function captureSessionControlCutoverSnapshot(
   sql: postgres.Sql,
   phase: CutoverPhase,
   capturedAt = new Date().toISOString(),
+  reference?: SessionControlCutoverSnapshot,
 ): Promise<SessionControlCutoverSnapshot> {
+  if (phase === "baseline" && reference) {
+    throw new Error("a baseline capture cannot reference an earlier baseline");
+  }
+  if (phase !== "baseline") {
+    if (!reference || reference.contractVersion !== SESSION_CONTROL_CUTOVER_CONTRACT) {
+      throw new Error(`${phase} capture requires a v2 baseline proof`);
+    }
+    if (reference.phase !== "baseline") {
+      throw new Error(`${phase} capture reference is not a baseline`);
+    }
+  }
   await assertSessionControlCutoverAuditAuthority(sql);
   const hasControl = await columnExists(sql, "sessions", "control_state");
   const hasAttempts = await columnExists(sql, "session_turns", "execution_generation");
@@ -381,14 +493,36 @@ export async function captureSessionControlCutoverSnapshot(
     `select session_id, id, status, version, auto_continuations, no_progress_streak,
        last_continuation_turn_id from session_goals order by session_id, id`,
   );
-  const historyRows = await unsafeRows(
+  const historyProofs = await captureRelationProofs(
     sql,
     `select session_id, id, turn_id, position, active, producer_codex_credential_id
      from session_history_items order by session_id, position, id`,
+    "position",
+    (row) => ({
+      id: stringValue(row.id, "history.id"),
+      turnId: nullableString(row.turn_id, "history.turn_id"),
+      position: numberValue(row.position, "history.position"),
+      active: booleanValue(row.active),
+      producerCodexCredentialId: nullableString(
+        row.producer_codex_credential_id,
+        "history.producer_codex_credential_id",
+      ),
+    }),
+    reference,
+    (session) => session.historyProof,
   );
-  const eventRows = await unsafeRows(
+  const eventProofs = await captureRelationProofs(
     sql,
-    `select session_id, id, turn_id, sequence from session_events order by session_id, sequence, id`,
+    `select session_id, id, turn_id, sequence
+     from session_events order by session_id, sequence, id`,
+    "sequence",
+    (row) => ({
+      id: stringValue(row.id, "event.id"),
+      turnId: nullableString(row.turn_id, "event.turn_id"),
+      sequence: numberValue(row.sequence, "event.sequence"),
+    }),
+    reference,
+    (session) => session.eventProof,
   );
   const runStateRows = await unsafeRows(
     sql,
@@ -459,27 +593,6 @@ export async function captureSessionControlCutoverSnapshot(
         row.last_continuation_turn_id,
         "goal.last_continuation_turn_id",
       ),
-    })),
-  );
-  const history = groupBySession(
-    historyRows.map((row) => ({
-      sessionId: stringValue(row.session_id, "history.session_id"),
-      id: stringValue(row.id, "history.id"),
-      turnId: nullableString(row.turn_id, "history.turn_id"),
-      position: numberValue(row.position, "history.position"),
-      active: booleanValue(row.active),
-      producerCodexCredentialId: nullableString(
-        row.producer_codex_credential_id,
-        "history.producer_codex_credential_id",
-      ),
-    })),
-  );
-  const events = groupBySession(
-    eventRows.map((row) => ({
-      sessionId: stringValue(row.session_id, "event.session_id"),
-      id: stringValue(row.id, "event.id"),
-      turnId: nullableString(row.turn_id, "event.turn_id"),
-      sequence: numberValue(row.sequence, "event.sequence"),
     })),
   );
   const runStates = groupBySession(
@@ -578,8 +691,8 @@ export async function captureSessionControlCutoverSnapshot(
       queueTailPosition: nullableNumber(row.queue_tail_position, "session.queue_tail_position"),
       turns: turns.get(id) ?? [],
       goals: goals.get(id) ?? [],
-      history: history.get(id) ?? [],
-      events: events.get(id) ?? [],
+      historyProof: historyProofs.get(id) ?? emptyRelationProof(),
+      eventProof: eventProofs.get(id) ?? emptyRelationProof(),
       runStates: runStates.get(id) ?? [],
       capacityWaiters: capacityWaiters.get(id) ?? [],
       sandboxLeases: sandboxLeases.get(id) ?? [],
@@ -663,6 +776,7 @@ export async function captureSessionControlCutoverSnapshot(
     schemaMigrations: migrationRows.map((row) => stringValue(row.name, "schema_migration.name")),
     workspaces,
     sessions,
+    proofBaselineSha256: reference?.sha256 ?? null,
     invariants: {
       multipleCurrentInferences,
       queuedMachineTurns,
@@ -696,8 +810,8 @@ export async function captureSessionControlCutoverSnapshot(
         1 +
         session.turns.length +
         session.goals.length +
-        session.history.length +
-        session.events.length +
+        session.historyProof.count +
+        session.eventProof.count +
         session.runStates.length +
         session.capacityWaiters.length +
         session.sandboxLeases.length +
@@ -733,6 +847,36 @@ function compareStableRows<T extends { id: string }>(
   }
 }
 
+function compareRelationProof(
+  errors: string[],
+  sessionId: string,
+  name: string,
+  before: CutoverRelationProof,
+  after: CutoverRelationProof,
+  mode: "migration" | "final-fate",
+): void {
+  if (after.preservedThroughOrdinal !== before.maxOrdinal) {
+    errors.push(`${sessionId}: ${name} proof used the wrong baseline boundary`);
+    return;
+  }
+  if (mode === "migration") {
+    if (
+      after.count !== before.count ||
+      after.stableSha256 !== before.stableSha256 ||
+      after.identitySha256 !== before.identitySha256
+    ) {
+      errors.push(`${sessionId}: ${name} changed during migration`);
+    }
+    return;
+  }
+  if (
+    after.preservedCount !== before.count ||
+    after.preservedIdentitySha256 !== before.identitySha256
+  ) {
+    errors.push(`${sessionId}: baseline ${name} identities were not preserved`);
+  }
+}
+
 export function reconcileSessionControlCutover(
   baseline: SessionControlCutoverSnapshot,
   observed: SessionControlCutoverSnapshot,
@@ -752,6 +896,9 @@ export function reconcileSessionControlCutover(
   }
   if (mode === "final-fate" && observed.phase !== "final") {
     errors.push("final-fate reconciliation requires a final snapshot");
+  }
+  if (observed.proofBaselineSha256 !== baseline.sha256) {
+    errors.push("observed relation proofs were not derived from this baseline");
   }
   if (observed.invariants.multipleCurrentInferences !== 0) {
     errors.push("observed snapshot has multiple current inferences for a session");
@@ -857,22 +1004,15 @@ export function reconcileSessionControlCutover(
     }
 
     compareStableRows(errors, session.id, "goal", session.goals, next.goals, mode === "migration");
-    compareStableRows(
+    compareRelationProof(
       errors,
       session.id,
-      "history row",
-      session.history,
-      next.history,
-      mode === "migration",
+      "history",
+      session.historyProof,
+      next.historyProof,
+      mode,
     );
-    compareStableRows(
-      errors,
-      session.id,
-      "event",
-      session.events,
-      next.events,
-      mode === "migration",
-    );
+    compareRelationProof(errors, session.id, "event", session.eventProof, next.eventProof, mode);
     compareStableRows(
       errors,
       session.id,

--- a/packages/db/test/session-control-cutover-audit.test.ts
+++ b/packages/db/test/session-control-cutover-audit.test.ts
@@ -198,6 +198,7 @@ describe("session-control production cutover audit", () => {
         sql,
         "migrated",
         "2026-07-14T10:00:30.000Z",
+        baseline,
       );
       const migrated0057Result = reconcileSessionControlCutover(
         baseline,
@@ -275,6 +276,7 @@ describe("session-control production cutover audit", () => {
         sql,
         "migrated",
         "2026-07-14T10:01:00.000Z",
+        remediationBaseline,
       );
       const result = reconcileSessionControlCutover(remediationBaseline, migrated, "migration");
       expect(result.errors).toEqual([]);
@@ -293,12 +295,36 @@ describe("session-control production cutover audit", () => {
 
       const damaged = structuredClone(migrated);
       const damagedMain = damaged.sessions.find((session) => session.id === sessionId);
-      const damagedHistory = damagedMain?.history[0];
-      if (!damagedHistory) throw new Error("migrated history row is missing");
-      damagedHistory.active = false;
-      const rejected = reconcileSessionControlCutover(baseline, damaged, "migration");
+      if (!damagedMain) throw new Error("migrated session is missing");
+      damagedMain.historyProof.stableSha256 = "0".repeat(64);
+      const rejected = reconcileSessionControlCutover(remediationBaseline, damaged, "migration");
       expect(rejected.ok).toBe(false);
-      expect(rejected.errors.some((error) => error.includes("history row"))).toBe(true);
+      expect(rejected.errors.some((error) => error.includes("history changed"))).toBe(true);
+
+      await sql`
+          insert into session_events (
+            account_id, workspace_id, session_id, turn_id, sequence, type, payload
+          ) values (
+            ${accountId}, ${workspaceId}, ${sessionId}, ${queuedUserTurnId}, 38,
+            'agent.message', ${sql.json({ text: "POST_CUTOVER_EVENT" })}
+          )`;
+      await sql`
+          insert into session_history_items (
+            account_id, workspace_id, session_id, turn_id, position, item
+          ) values (
+            ${accountId}, ${workspaceId}, ${sessionId}, ${queuedUserTurnId}, 2,
+            ${sql.json({ role: "assistant", content: "POST_CUTOVER_HISTORY" })}
+          )`;
+      const final = await captureSessionControlCutoverSnapshot(
+        sql,
+        "final",
+        "2026-07-14T10:02:00.000Z",
+        remediationBaseline,
+      );
+      const finalResult = reconcileSessionControlCutover(remediationBaseline, final, "final-fate");
+      expect(finalResult.errors).toEqual([]);
+      expect(finalResult.ok).toBe(true);
+      expect(final.sessions.find((session) => session.id === sessionId)?.eventProof.count).toBe(5);
     } finally {
       await sql.end().catch(() => undefined);
     }

--- a/scripts/operator/session-control-cutover.ts
+++ b/scripts/operator/session-control-cutover.ts
@@ -143,6 +143,8 @@ async function capture(args: ParsedArgs): Promise<void> {
   const phase = required(args, "--phase");
   assertPhase(phase);
   const output = required(args, "--output");
+  const baseline =
+    phase === "baseline" ? undefined : await readSnapshot(required(args, "--baseline"));
   const sql = postgres(migrationDatabaseUrl(), {
     max: 1,
     prepare: false,
@@ -153,7 +155,12 @@ async function capture(args: ParsedArgs): Promise<void> {
   try {
     const snapshot = await sql.begin(async (transaction) => {
       await transaction.unsafe("set transaction isolation level repeatable read, read only");
-      return await captureSessionControlCutoverSnapshot(transaction, phase);
+      return await captureSessionControlCutoverSnapshot(
+        transaction,
+        phase,
+        new Date().toISOString(),
+        baseline,
+      );
     });
     if (
       phase === "baseline" &&
@@ -237,7 +244,9 @@ function integerArg(
 
 async function runningSessionWorkflowIds(temporal: TemporalClient): Promise<Set<string>> {
   const running = new Set<string>();
-  for await (const execution of temporal.workflow.list({ query: "ExecutionStatus='Running'" })) {
+  for await (const execution of temporal.workflow.list({
+    query: "ExecutionStatus='Running'",
+  })) {
     if (execution.workflowId.startsWith("session-")) running.add(execution.workflowId);
   }
   return running;
@@ -274,7 +283,10 @@ async function enrollmentStates(
 async function wake(args: ParsedArgs): Promise<void> {
   const output = required(args, "--output");
   const execute = args.flags.has("--execute");
-  const turnCapacity = integerArg(args, "--turn-capacity", { min: 1, max: 10_000 });
+  const turnCapacity = integerArg(args, "--turn-capacity", {
+    min: 1,
+    max: 10_000,
+  });
   const stabilitySeconds = integerArg(args, "--stability-seconds", {
     defaultValue: 150,
     min: 121,
@@ -766,11 +778,19 @@ async function reparkOrphanedTurns(args: ParsedArgs): Promise<void> {
   });
   const client = createDb(migrationDatabaseUrl(), { max: 1 });
   try {
-    const temporal = new TemporalClient({ connection, namespace: settings.namespace });
+    const temporal = new TemporalClient({
+      connection,
+      namespace: settings.namespace,
+    });
     const runningWorkflows: Array<{ workflowId: string; runId: string }> = [];
-    for await (const execution of temporal.workflow.list({ query: "ExecutionStatus='Running'" })) {
+    for await (const execution of temporal.workflow.list({
+      query: "ExecutionStatus='Running'",
+    })) {
       if (execution.workflowId.startsWith("session-")) {
-        runningWorkflows.push({ workflowId: execution.workflowId, runId: execution.runId });
+        runningWorkflows.push({
+          workflowId: execution.workflowId,
+          runId: execution.runId,
+        });
       }
     }
     if (runningWorkflows.length > 0) {
@@ -1099,7 +1119,13 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
       );
     }
     const currentUsage = await sql<
-      Array<{ id: string; turn_id: string; source_key: string; provider: string; model: string }>
+      Array<{
+        id: string;
+        turn_id: string;
+        source_key: string;
+        provider: string;
+        model: string;
+      }>
     >`
       select id, turn_id, payload ->> 'sourceKey' as source_key,
         payload ->> 'provider' as provider, payload ->> 'model' as model
@@ -1317,7 +1343,8 @@ async function preflight(args: ParsedArgs): Promise<void> {
 function usage(): void {
   process.stdout.write(`Usage:
   bun run operator:session-control-cutover preflight --source-sha SHA --output FILE
-  bun run operator:session-control-cutover capture --phase baseline|migrated|final --output FILE [--allow-empty-baseline]
+  bun run operator:session-control-cutover capture --phase baseline --output FILE [--allow-empty-baseline]
+  bun run operator:session-control-cutover capture --phase migrated|final --baseline FILE --output FILE
   bun run operator:session-control-cutover reconcile --baseline FILE --observed FILE --mode migration|final-fate --output FILE
   bun run operator:session-control-cutover wake --turn-capacity N --output FILE [--execute] [--stability-seconds N]
   bun run operator:session-control-cutover temporal-schedules --action pause|resume|inspect --run-id ID [--input FILE] --output FILE


### PR DESCRIPTION
Production restore validation exposed an unbounded cutover snapshot: 5M event rows were materialized as JS objects and the validator was OOM-killed.

This cleanly replaces large history/event arrays with cursor-streamed SHA-256 proofs bound to the exact baseline. Migrated/final proofs preserve the baseline prefix while allowing legitimate final appends. Operator captures now require the baseline explicitly.

Verified: real PostgreSQL audit test, typecheck, format, lint, UBS triage.