### PR TITLE
fix(db): collect cutover proof heap in bounded intervals

### DIFF
--- a/packages/db/src/session-control-cutover-audit.ts
+++ b/packages/db/src/session-control-cutover-audit.ts
@@ -281,6 +281,12 @@ type RelationProofAccumulator = {
   preservedIdentity: ReturnType<typeof createHash>;
 };
 
+const PROOF_GC_ROW_INTERVAL = 131_072;
+
+function collectProofGarbage(): void {
+  if (typeof Bun !== "undefined") Bun.gc(true);
+}
+
 function updateProofHash(hash: ReturnType<typeof createHash>, value: unknown): void {
   const serialized = stableJson(value);
   hash.update(String(Buffer.byteLength(serialized, "utf8")));
@@ -312,6 +318,7 @@ async function captureRelationProofs(
     (reference?.sessions ?? []).map((session) => [session.id, referenceProof(session).maxOrdinal]),
   );
   const accumulators = new Map<string, RelationProofAccumulator>();
+  let rowsSinceGarbageCollection = 0;
   for await (const rows of sql.unsafe<Row[]>(query).cursor(2_048)) {
     for (const row of rows) {
       const sessionId = stringValue(row.session_id, "relation.session_id");
@@ -334,7 +341,16 @@ async function captureRelationProofs(
       }
       accumulators.set(sessionId, accumulator);
     }
+    rowsSinceGarbageCollection += rows.length;
+    if (rowsSinceGarbageCollection >= PROOF_GC_ROW_INTERVAL) {
+      // Bun's adaptive heap threshold does not observe a Kubernetes cgroup
+      // limit soon enough for multi-million-row cursors. Bound the transient
+      // row/string heap before the kernel has to enforce the pod limit.
+      collectProofGarbage();
+      rowsSinceGarbageCollection = 0;
+    }
   }
+  collectProofGarbage();
 
   const proofs = new Map<string, CutoverRelationProof>();
   const sessionIds = new Set([


### PR DESCRIPTION
Production v4 proved cursor batching alone is insufficient under Bun: the 5M-row hash pass retained transient row/string allocations until the 1Gi cgroup OOM boundary.

Force a full Bun collection every 131,072 proof rows and after each relation. The exact 5.1M-row hashing pattern stays below 106MiB RSS locally; production remains protected by the existing disposable PITR validation.

Verified: real PostgreSQL audit test, typecheck, format, UBS.