### PR TITLE
fix(db): bound cutover audit by cursor batch

### DIFF
--- a/packages/db/src/session-control-cutover-audit.ts
+++ b/packages/db/src/session-control-cutover-audit.ts
@@ -281,8 +281,6 @@ type RelationProofAccumulator = {
   preservedIdentity: ReturnType<typeof createHash>;
 };
 
-const PROOF_GC_ROW_INTERVAL = 131_072;
-
 function collectProofGarbage(): void {
   if (typeof Bun !== "undefined") Bun.gc(true);
 }
@@ -318,7 +316,6 @@ async function captureRelationProofs(
     (reference?.sessions ?? []).map((session) => [session.id, referenceProof(session).maxOrdinal]),
   );
   const accumulators = new Map<string, RelationProofAccumulator>();
-  let rowsSinceGarbageCollection = 0;
   await sql.unsafe<Row[]>(query).cursor(2_048, (rows) => {
     for (const row of rows) {
       const sessionId = stringValue(row.session_id, "relation.session_id");
@@ -341,15 +338,11 @@ async function captureRelationProofs(
       }
       accumulators.set(sessionId, accumulator);
     }
-    rowsSinceGarbageCollection += rows.length;
-    if (rowsSinceGarbageCollection >= PROOF_GC_ROW_INTERVAL) {
-      // The callback cursor lets postgres.js release each portal Result before
-      // requesting the next batch. Its async iterator retains a promise chain
-      // that grows across multi-million-row relations under Bun. Explicit GC
-      // also keeps Bun's adaptive heap below the Kubernetes cgroup limit.
-      collectProofGarbage();
-      rowsSinceGarbageCollection = 0;
-    }
+    // The callback cursor makes the previous portal Result unreachable before
+    // this callback receives the next batch. Collect at that exact ownership
+    // boundary: a row-count interval is not a memory bound when event payload
+    // sizes vary, and Bun does not observe the pod's cgroup limit soon enough.
+    collectProofGarbage();
   });
   collectProofGarbage();
 


### PR DESCRIPTION
## Summary
- collect cutover proof garbage at every postgres cursor ownership boundary
- remove the row-count GC heuristic that failed on large production event payloads
- keep the audit memory bound independent of payload size

## Production evidence
- v6 callback cursor proved rows releasable (RSS dropped 594 MiB to 472 MiB)
- the old 131,072-row interval still allowed the next payload-heavy span to reach 952 MiB and OOM
- live production remained untouched; failure occurred on the disposable PITR clone

## Verification
- `bun run typecheck`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test packages/db/test/session-control-cutover-audit.test.ts`
- UBS delta triaged against `main`: no new findings