### PR TITLE
fix(worker): decouple model streaming from event flush latency

### DIFF
--- a/apps/worker/src/activities/streaming.ts
+++ b/apps/worker/src/activities/streaming.ts
@@ -8,6 +8,11 @@ import { Context } from "@temporalio/activity";
 // latency added by batching is bounded to ~one window (imperceptible, and far
 // cheaper than the per-delta DB round-trip it replaces).
 const TRAILING_FLUSH_MS = 33;
+const MAX_BATCH_EVENTS = 50;
+// Keep model ingestion independent from a slow durable append, but never let a
+// provider outrun storage without bound. At the high-water mark `push` waits for
+// the serialized drain before consuming more provider output.
+const MAX_BUFFERED_EVENTS = 1_000;
 
 /** Optional metrics seam for the batcher. `onFlush` fires once per flush (on both
  *  success and failure) with the coalesced event count and the flush duration, so
@@ -26,12 +31,15 @@ export function createRuntimeBatcher(
   let pending: AppendEventInput[] = [];
   let lastFlush = Date.now();
   let trailingTimer: ReturnType<typeof setTimeout> | null = null;
-  // Serializes flushEvents: each flush chains after the in-flight one so two
-  // flushEvents never overlap and the DB-assigned sequence order matches push
-  // order (the ordering invariant). A rejected flush resolves the gate (a
-  // single failed flush must not poison later flushes) while still rejecting
-  // the caller that awaited it.
-  let inFlight: Promise<void> | null = null;
+  let activeBatchSize = 0;
+  // One drain loop owns `flushEvents`, so DB-assigned sequence order always
+  // matches push order. Ordinary deltas do not await this promise; structural
+  // boundaries, explicit flushes, and the bounded high-water mark do.
+  let drainPromise: Promise<void> | null = null;
+  // A timer has no direct awaiter. Retain its failure so the next push or final
+  // flush terminates the turn instead of silently losing streamed evidence.
+  let flushFailed = false;
+  let flushFailure: unknown;
   // The high-volume token deltas (agent.message.delta, agent.reasoning.delta,
   // sandbox.command.output.delta) are DELIBERATELY NOT here: they coalesce
   // under the 50-event / 33ms policy into one appendSessionEvents txn + one
@@ -52,15 +60,26 @@ export function createRuntimeBatcher(
   ]);
   return {
     push: async (event: { type: SessionEventType; payload: unknown }) => {
+      throwIfFlushFailed();
       // Append BEFORE the structural check so a structural event's flush always
       // carries any pending deltas in order (same flush, order preserved).
       pending.push({ type: event.type, payload: event.payload });
       const elapsed = Date.now() - lastFlush;
-      if (pending.length >= 50 || elapsed >= 33 || structural.has(event.type)) {
+      if (structural.has(event.type)) {
         await flush();
-      } else {
-        armTrailingTimer();
+        return;
       }
+      if (pending.length >= MAX_BATCH_EVENTS || elapsed >= TRAILING_FLUSH_MS) {
+        // Start the serialized drain, but keep consuming provider deltas while
+        // the append/publish round-trip is in flight. The active drain records
+        // any failure for the next awaited boundary.
+        void startDrain().catch(() => undefined);
+      }
+      if (activeBatchSize + pending.length >= MAX_BUFFERED_EVENTS) {
+        await flush();
+        return;
+      }
+      armTrailingTimer();
     },
     flush,
   };
@@ -71,9 +90,8 @@ export function createRuntimeBatcher(
     }
     trailingTimer = setTimeout(() => {
       trailingTimer = null;
-      // Best-effort trailing flush: any error re-surfaces on the next awaited
-      // push or the turn-end flush, so swallow here (a timer has no awaiter and
-      // an unhandled rejection would crash the worker).
+      // A timer has no awaiter, so prevent an unhandled rejection. startDrain
+      // retains the exact error and the next push/final flush rethrows it.
       void flush().catch(() => undefined);
     }, TRAILING_FLUSH_MS);
     if ("unref" in trailingTimer && typeof trailingTimer.unref === "function") {
@@ -88,38 +106,61 @@ export function createRuntimeBatcher(
     }
   }
 
-  function flush(): Promise<void> {
-    // A flush is in-flight: wait for it, THEN drain whatever is pending now.
-    // Never start a second flushEvents concurrently. `() => flush()` on both
-    // settle paths so a failed in-flight flush still lets the queue drain.
-    if (inFlight) {
-      return inFlight.then(
-        () => flush(),
-        () => flush(),
-      );
+  async function flush(): Promise<void> {
+    throwIfFlushFailed();
+    clearTrailingTimer();
+    await startDrain();
+    throwIfFlushFailed();
+  }
+
+  function startDrain(): Promise<void> {
+    if (drainPromise) {
+      return drainPromise;
+    }
+    if (flushFailed) {
+      return Promise.reject(flushFailure);
     }
     if (pending.length === 0) {
       return Promise.resolve();
     }
     clearTrailingTimer();
-    const events = pending;
-    pending = [];
-    lastFlush = Date.now();
-    const startedAt = now();
-    inFlight = flushEvents(events).finally(() => {
-      inFlight = null;
-      if (options.onFlush) {
+    const running = (async () => {
+      while (pending.length > 0) {
+        const events = pending.splice(0, MAX_BATCH_EVENTS);
+        activeBatchSize = events.length;
+        lastFlush = Date.now();
+        const startedAt = now();
         try {
-          options.onFlush({
-            events: events.length,
-            durationSeconds: Math.max(0, (now() - startedAt) / 1000),
-          });
-        } catch {
-          // Metrics emission must never affect a flush.
+          await flushEvents(events);
+        } catch (error) {
+          flushFailed = true;
+          flushFailure = error;
+          throw error;
+        } finally {
+          activeBatchSize = 0;
+          if (options.onFlush) {
+            try {
+              options.onFlush({
+                events: events.length,
+                durationSeconds: Math.max(0, (now() - startedAt) / 1000),
+              });
+            } catch {
+              // Metrics emission must never affect a flush.
+            }
+          }
         }
       }
+    })();
+    drainPromise = running.finally(() => {
+      drainPromise = null;
     });
-    return inFlight;
+    return drainPromise;
+  }
+
+  function throwIfFlushFailed(): void {
+    if (flushFailed) {
+      throw flushFailure;
+    }
   }
 }
 

--- a/apps/worker/test/streaming-batcher.test.ts
+++ b/apps/worker/test/streaming-batcher.test.ts
@@ -8,7 +8,8 @@ import { createRuntimeBatcher } from "../src/activities/streaming";
 // tests pin: (1) coalescing under burst, (2) the trailing timer flushing on
 // model silence, (3) structural events still flushing immediately AND carrying
 // any pending deltas in order, (4) flushes never interleaving, and (5) the
-// before/after flush-count reduction for a 1000-delta turn.
+// before/after flush-count reduction for a 1000-delta turn, and (6) slow
+// storage never serializes provider ingestion while memory remains bounded.
 
 const DELTA: SessionEventType = "agent.message.delta";
 const REASONING: SessionEventType = "agent.reasoning.delta";
@@ -102,6 +103,72 @@ describe("createRuntimeBatcher", () => {
 
     await Promise.all([p1, p2]);
     expect(maxActive).toBe(1); // never two flushEvents in flight at once
+  });
+
+  test("a slow append does not block ordinary model deltas and the drain preserves order", async () => {
+    const starts: number[][] = [];
+    const gates: Array<() => void> = [];
+    const batcher = createRuntimeBatcher(async (events: AppendEventInput[]) => {
+      starts.push(events.map((event) => (event.payload as { n: number }).n));
+      await new Promise<void>((resolve) => gates.push(resolve));
+    });
+
+    // The 50th delta starts a flush. The next 50 pushes must still resolve while
+    // that slow append is blocked; this is the production regression where each
+    // model delta previously waited ~0.75s for its own DB transaction.
+    for (let n = 0; n < 100; n += 1) {
+      await batcher.push(delta(n));
+    }
+    expect(starts).toEqual([Array.from({ length: 50 }, (_, index) => index)]);
+
+    const drained = batcher.flush();
+    gates[0]!();
+    await sleep(10);
+    expect(starts[1]).toEqual(Array.from({ length: 50 }, (_, index) => index + 50));
+    gates[1]!();
+    await drained;
+  });
+
+  test("a failed timer flush is retained and rethrown at the next boundary", async () => {
+    const batcher = createRuntimeBatcher(async () => {
+      throw new Error("durable append failed");
+    });
+
+    await batcher.push(delta(1));
+    await sleep(60);
+    await expect(batcher.push(delta(2))).rejects.toThrow("durable append failed");
+    await expect(batcher.flush()).rejects.toThrow("durable append failed");
+  });
+
+  test("provider ingestion backpressures at the bounded high-water mark", async () => {
+    let releaseFirst: (() => void) | null = null;
+    let flushCount = 0;
+    const flushed: number[] = [];
+    const batcher = createRuntimeBatcher(async (events: AppendEventInput[]) => {
+      flushCount += 1;
+      flushed.push(...events.map((event) => (event.payload as { n: number }).n));
+      if (flushCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+    });
+
+    // 50 active + 949 pending stays below the 1,000-event high-water mark.
+    for (let n = 0; n < 999; n += 1) {
+      await batcher.push(delta(n));
+    }
+    let cappedPushSettled = false;
+    const cappedPush = batcher.push(delta(999)).then(() => {
+      cappedPushSettled = true;
+    });
+    await sleep(10);
+    expect(cappedPushSettled).toBe(false);
+
+    releaseFirst!();
+    await cappedPush;
+    await batcher.flush();
+    expect(flushed).toEqual(Array.from({ length: 1_000 }, (_, index) => index));
   });
 
   test("1000-delta turn: flush count collapses vs the per-delta (structural) path", async () => {


### PR DESCRIPTION
## Root cause
Production append+publish latency averaged about one second. `createRuntimeBatcher.push()` awaited any due flush, so the SDK stream iterator stopped consuming model output and almost every flush contained one delta.

## Fix
- keep a single ordered drain loop
- let ordinary deltas accumulate while a flush is in flight
- await structural boundaries and final flushes
- apply bounded high-water backpressure at 1,000 events
- retain timer-flush failures and surface them at the next boundary

## Evidence
- 11 focused batching regressions pass
- worker typecheck passes
- 86 worker/stream tests pass
- production baseline: 59,747 / 59,963 flushes were singleton batches; fresh affected session p50/p95 delta gap was 1.081s / 2.448s