### PR TITLE
fix(db): remove workspace-wide event lock queue

### DIFF
--- a/.changeset/fast-workspace-event-admission.md
+++ b/.changeset/fast-workspace-event-admission.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Allow independent sessions to persist attempt-fenced work concurrently while preserving an exclusive workspace Pause boundary, and align the durable control constraint with workspace Pause.

--- a/packages/db/drizzle/0059_workspace_pause_control_kind.sql
+++ b/packages/db/drizzle/0059_workspace_pause_control_kind.sql
@@ -1,0 +1,12 @@
+-- Workspace Pause is a first-class durable control kind. The 0057 constraint
+-- predates that control path and must match the canonical runtime state machine.
+
+ALTER TABLE "sessions"
+  DROP CONSTRAINT "sessions_pending_control_kind_check";
+
+ALTER TABLE "sessions"
+  ADD CONSTRAINT "sessions_pending_control_kind_check"
+  CHECK (
+    "pending_control_kind" IS NULL
+    OR "pending_control_kind" IN ('pause', 'workspace_pause', 'steer')
+  );

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -11428,7 +11428,16 @@ type TurnAttemptFenceResult =
       turn: typeof schema.sessionTurns.$inferSelect | null;
     };
 
-/** Lock order for every activity write fence: workspace -> session -> turn. */
+/**
+ * Lock order for every activity write fence: workspace -> session -> turn.
+ *
+ * Activity writes only need a shared workspace admission lock: concurrent
+ * sessions may write independently, while an exclusive workspace Pause/Resume
+ * still waits for every admitted write and prevents later writes from crossing
+ * the control boundary. Using FOR UPDATE here serialized every active session in
+ * one workspace behind a single row and turned streaming into a workspace-wide
+ * lock queue.
+ */
 async function lockTurnAttemptWriteFenceTx(
   tx: Database,
   input: {
@@ -11443,7 +11452,7 @@ async function lockTurnAttemptWriteFenceTx(
     .select()
     .from(schema.workspaces)
     .where(eq(schema.workspaces.id, input.workspaceId))
-    .for("update")
+    .for("share")
     .limit(1);
   const [session] = await tx
     .select()

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -1159,6 +1159,115 @@ describe("clean session control plane", () => {
     });
   });
 
+  test("attempt writes run concurrently across sessions while workspace control stays exclusive", async () => {
+    const { grant, session: firstSession } = await fixture();
+    const secondSession = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "second session",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await send(grant, firstSession.id, "first session work");
+    await send(grant, secondSession.id, "second session work");
+    const firstAttemptId = crypto.randomUUID();
+    const secondAttemptId = crypto.randomUUID();
+    const firstTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      firstSession.id,
+      `session-${firstSession.id}`,
+      { attemptId: firstAttemptId },
+    );
+    const secondTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      secondSession.id,
+      `session-${secondSession.id}`,
+      { attemptId: secondAttemptId },
+    );
+    if (!firstTurn || !secondTurn) throw new Error("both test turns must be running");
+
+    let releaseFirstWrite!: () => void;
+    const firstWriteReleased = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let firstWriteAdmitted!: () => void;
+    const firstWriteAdmission = new Promise<void>((resolve) => {
+      firstWriteAdmitted = resolve;
+    });
+    const heldFirstWrite = withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.transaction(async (tx) => {
+        await tx
+          .select({ id: schema.workspaces.id })
+          .from(schema.workspaces)
+          .where(eq(schema.workspaces.id, grant.workspaceId!))
+          .for("share")
+          .limit(1);
+        await tx
+          .select({ id: schema.sessions.id })
+          .from(schema.sessions)
+          .where(eq(schema.sessions.id, firstSession.id))
+          .for("update")
+          .limit(1);
+        await tx
+          .select({ id: schema.sessionTurns.id })
+          .from(schema.sessionTurns)
+          .where(eq(schema.sessionTurns.id, firstTurn.id))
+          .for("update")
+          .limit(1);
+        firstWriteAdmitted();
+        await firstWriteReleased;
+      });
+    });
+    await firstWriteAdmission;
+
+    const appendTimedOut = Symbol("append timed out behind another session");
+    const secondAppend = appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      secondSession.id,
+      secondTurn.id,
+      secondTurn.executionGeneration,
+      secondAttemptId,
+      [{ type: "agent.message.delta", payload: { text: "independent" } }],
+    );
+    const appendResult = await Promise.race([
+      secondAppend,
+      Bun.sleep(2_000).then(() => appendTimedOut),
+    ]);
+
+    let pauseSettled = false;
+    const pause = (async () => {
+      const result = await setWorkspaceInferenceControl(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        actor: grant.subjectId,
+        state: "paused",
+        reason: "concurrency test",
+        clientEventId: `workspace-pause-${crypto.randomUUID()}`,
+        expectedState: "active",
+        expectedGeneration: 0,
+        exceptSessionIds: [],
+      });
+      pauseSettled = true;
+      return result;
+    })();
+    await Bun.sleep(100);
+
+    try {
+      expect(appendResult).not.toBe(appendTimedOut);
+      expect(appendResult).toMatchObject({ accepted: true });
+      expect(pauseSettled).toBe(false);
+    } finally {
+      releaseFirstWrite();
+      await heldFirstWrite;
+    }
+    expect(await pause).toMatchObject({ state: "paused", generation: 1 });
+  });
+
   test("a replaced attempt cannot compact history or overwrite its token signal", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "build it");


### PR DESCRIPTION
## What\n- admit attempt-fenced writes with a shared workspace lock so independent sessions persist concurrently\n- preserve an exclusive workspace Pause/Resume boundary\n- align the database control-kind constraint with the canonical workspace Pause state\n- add a real-PostgreSQL concurrency/control regression\n\n## Production evidence\nA 10-second production sample found roughly 20-23 transactions continuously blocked on the same workspace `FOR UPDATE` row during streaming.\n\n## Verification\n- 32/32 `session-control-plane` tests pass on real PostgreSQL\n- focused concurrency test passes\n- `@opengeni/db` typecheck passes\n- oxfmt and oxlint pass (only pre-existing warnings in the large DB module)