### PR TITLE
perf(react): shrink initial session tail

### DIFF
--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -41,7 +41,8 @@ export type UseSessionEventsResult = {
   error: Error | null;
 };
 
-const TAIL_PAGE_SIZE = 5000;
+const INITIAL_TAIL_PAGE_SIZE = 1000;
+const OLDER_PAGE_SIZE = 5000;
 const INITIAL_FETCH_CAP = 1;
 const OLDER_GROUP_TARGET = 32;
 const OLDER_FETCH_CAP = 2;
@@ -133,7 +134,7 @@ export function useSessionEvents(
           // reader actually scrolls up (the sentinel drives loadOlder).
           const window = await loadEventWindow(client, workspaceId, sessionId, {
             before: Number.MAX_SAFE_INTEGER,
-            pageSize: TAIL_PAGE_SIZE,
+            pageSize: INITIAL_TAIL_PAGE_SIZE,
             targetGroups: Number.POSITIVE_INFINITY,
             maxFetches: INITIAL_FETCH_CAP,
             signal: controller.signal,
@@ -201,7 +202,7 @@ export function useSessionEvents(
     try {
       const window = await loadEventWindow(client, workspaceId, sessionId, {
         before,
-        pageSize: TAIL_PAGE_SIZE,
+        pageSize: OLDER_PAGE_SIZE,
         targetGroups: OLDER_GROUP_TARGET,
         maxFetches: OLDER_FETCH_CAP,
       });

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -79,12 +79,12 @@ describe("useSessionEvents", () => {
     }, undefined);
     await flush(20);
 
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
-    expect(hook.result.current.events).toHaveLength(1200);
-    expect(hook.result.current.events[0]?.sequence).toBe(1);
-    expect(hook.result.current.hasOlder).toBe(false);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true }]);
+    expect(hook.result.current.events).toHaveLength(1000);
+    expect(hook.result.current.events[0]?.sequence).toBe(201);
+    expect(hook.result.current.hasOlder).toBe(true);
     expect(streamCalls).toEqual([1200]);
-    expect(lengths.filter((length) => length === 1200)).toHaveLength(1);
+    expect(lengths.filter((length) => length === 1000)).toHaveLength(1);
 
     await hook.unmount();
   });
@@ -113,19 +113,18 @@ describe("useSessionEvents", () => {
     // TRIMMED to the oldest user message rather than fetching further down.
     // loadOlder's `before` cursor is the trimmed top, so the fragment is
     // refetched with its own turn.
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true }]);
     expect(hook.result.current.events[0]?.type).toBe("user.message");
-    expect(hook.result.current.events[0]?.sequence).toBe(5102);
+    expect(hook.result.current.events[0]?.sequence).toBe(6103);
     expect(hook.result.current.hasOlder).toBe(true);
 
     const more = await hook.result.current.loadOlder();
     await flush(20);
-    // The older window starts exactly below the kept window (before: 5102 —
-    // no overlap, no gap), recovers the trimmed fragment, and runs to the log
-    // start within the older fetch cap, so nothing older remains.
+    // The older window starts exactly below the kept window and reaches the log
+    // start within the older two-fetch cap.
     expect(more).toBe(false);
-    expect(listCalls[1]).toEqual({ before: 5102, limit: 5000, compact: true });
-    expect(listCalls[2]).toEqual({ before: 102, limit: 5000, compact: true });
+    expect(listCalls[1]).toEqual({ before: 6103, limit: 5000, compact: true });
+    expect(listCalls[2]).toEqual({ before: 1103, limit: 5000, compact: true });
     expect(hook.result.current.events[0]?.type).toBe("session.created");
     expect(hook.result.current.events[0]?.sequence).toBe(1);
     expect(hook.result.current.hasOlder).toBe(false);
@@ -147,7 +146,7 @@ describe("useSessionEvents", () => {
     const { client, listCalls } = scriptedClient({
       store,
       listEvents: async (options) => {
-        if (options.before === 1001) {
+        if (options.before === 5001) {
           await new Promise<void>((resolve) => {
             releaseOlder = resolve;
           });
@@ -164,7 +163,7 @@ describe("useSessionEvents", () => {
     const first = hook.result.current.loadOlder();
     const second = hook.result.current.loadOlder();
     await flush();
-    expect(listCalls.filter((call) => call.before === 1001)).toHaveLength(1);
+    expect(listCalls.filter((call) => call.before === 5001)).toHaveLength(1);
     releaseOlder();
     const [firstResult, secondResult] = await Promise.all([first, second]);
     await flush(20);
@@ -230,10 +229,10 @@ describe("useSessionEvents", () => {
     await flush(20);
 
     // First paint is exactly ONE fetch — deeper history is the sentinel's job.
-    expect(hook.result.current.events).toHaveLength(5000);
-    expect(hook.result.current.events[0]?.sequence).toBe(35_001);
+    expect(hook.result.current.events).toHaveLength(1000);
+    expect(hook.result.current.events[0]?.sequence).toBe(39_001);
     expect(hook.result.current.hasOlder).toBe(true);
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true }]);
 
     await hook.unmount();
   });
@@ -253,7 +252,7 @@ describe("useSessionEvents", () => {
     );
     await flush(20);
 
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true }]);
     expect(hook.result.current.events.map((item) => item.sequence)).toEqual([1, 10]);
     expect(streamCalls).toEqual([99]);
 
@@ -304,7 +303,7 @@ describe("useSessionEvents", () => {
 
     expect(more).toBe(false);
     expect(calls).toEqual([
-      { before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true },
+      { before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true },
       { before: 8, limit: 5000, compact: true },
       { before: 6, limit: 5000, compact: true },
       { before: 4, limit: 5000, compact: true },
@@ -344,9 +343,9 @@ describe("useSessionEvents", () => {
     );
     await flush(20);
 
-    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 5000, compact: true }]);
-    expect(hook.result.current.events).toHaveLength(5000);
-    expect(hook.result.current.events[0]?.sequence).toBe(15_001);
+    expect(listCalls).toEqual([{ before: Number.MAX_SAFE_INTEGER, limit: 1000, compact: true }]);
+    expect(hook.result.current.events).toHaveLength(1000);
+    expect(hook.result.current.events[0]?.sequence).toBe(19_001);
     expect(hook.result.current.hasOlder).toBe(true);
 
     await hook.unmount();


### PR DESCRIPTION
## What changed

- fetch 1,000 compact events for initial session paint
- retain 5,000-event pages for explicit older-history loading
- preserve boundary snapping, resume cursors, and full replay behavior

## Production evidence

On session 8965b932-3d2c-4a5e-8b9e-a0d95e911fa6:
- 1,000-event compact tail: 62.4 ms DB, 437,584 bytes
- 5,000-event compact tail: 659.8 ms DB, 4,654,132 bytes
- neither depth reached a user-message boundary for the monster turn, so the extra first-paint work bought no additional coherence

## Verification

- `bun test packages/react/test/use-session-events.test.tsx` (8/8)
- `bun run --cwd packages/react typecheck`
- `bunx oxfmt --check ...`
- `bunx oxlint ...`
- UBS scan: no critical findings; reported warnings are pre-existing generic assertions/non-null patterns outside this constant split