### PR TITLE
fix(worker): restore child-completion wake suppression

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@ OPENGENI_INTEGRATIONS_ENABLED=false
 # OPENGENI_GOAL_NO_PROGRESS_LIMIT=3
 # Temporary compatibility opt-in. Default false: child sessions retain their
 # own durable completion evidence without enqueueing synthetic parent chat work.
+# OPENGENI_CHILD_COMPLETION_PARENT_WAKE_ENABLED=false
 
 # Conversation-history source (issue #35; see docs/run-lifecycle.md). Items +
 # the sandbox envelope are dual-written unconditionally; this flips the READ

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1779,6 +1779,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           turnId: turnId!,
           triggerEventId: triggerEventId!,
           attemptId: input.attemptId,
+          childCompletionParentWakeEnabled: settings.childCompletionParentWakeEnabled,
           turnStatus: inputSettlement.turnStatus,
           sessionStatus: inputSettlement.sessionStatus,
           activeTurnId: inputSettlement.activeTurnId,

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -23,6 +23,11 @@ export type NotifyServices = {
   wakeSessionWorkflow: WakeSessionWorkflowSignal | null;
 };
 
+export type ReconcileParentSystemUpdateOverrides = Partial<{
+  claimPendingSessionSystemUpdateOutbox: typeof claimPendingSessionSystemUpdateOutbox;
+  listEnrollableSessions: typeof listEnrollableSessions;
+}>;
+
 /**
  * Deliver exactly one completion wake to a spawned worker's parent (manager)
  * session when the worker reaches a terminal-for-now state. No-op for a
@@ -55,6 +60,13 @@ export async function notifyParentOfChildTerminal(
   // per work batch and is stable across retries of that same idle transition.
   episodeKey?: string | null,
 ): Promise<void> {
+  // Temporarily disabled by default: child completion remains durable on the
+  // child session, but must not manufacture parent system-update/inference
+  // work. Keep this before every DB read, event publish, and workflow signal so
+  // the disabled path cannot mutate or wake the parent.
+  if (!svc.settings.childCompletionParentWakeEnabled) {
+    return;
+  }
   try {
     const child = await getSession(svc.db, workspaceId, childSessionId);
     if (!child || !child.parentSessionId) {
@@ -155,10 +167,14 @@ async function deliverParentSystemUpdateOutbox(
 export async function reconcilePendingParentSystemUpdates(
   svc: NotifyServices,
   limit = 100,
+  overrides: ReconcileParentSystemUpdateOverrides = {},
 ): Promise<{ claimed: number; delivered: number; failed: number; wakeRepairs: number }> {
+  const claimPendingSessionSystemUpdateOutboxFn =
+    overrides.claimPendingSessionSystemUpdateOutbox ?? claimPendingSessionSystemUpdateOutbox;
+  const listEnrollableSessionsFn = overrides.listEnrollableSessions ?? listEnrollableSessions;
   let wakeRepairs = 0;
   if (svc.wakeSessionWorkflow) {
-    const repairs = await listEnrollableSessions(svc.db, limit);
+    const repairs = await listEnrollableSessionsFn(svc.db, limit);
     for (const repair of repairs) {
       await svc.wakeSessionWorkflow({
         accountId: repair.accountId,
@@ -169,7 +185,13 @@ export async function reconcilePendingParentSystemUpdates(
       wakeRepairs += 1;
     }
   }
-  const rows = await claimPendingSessionSystemUpdateOutbox(svc.db, limit);
+  // Keep generic workflow wake repair active, but do not claim or deliver the
+  // child-terminal outbox while completion wakes are disabled. Atomic terminal
+  // producers use the same setting, so no new backlog is manufactured either.
+  if (!svc.settings.childCompletionParentWakeEnabled) {
+    return { claimed: 0, delivered: 0, failed: 0, wakeRepairs };
+  }
+  const rows = await claimPendingSessionSystemUpdateOutboxFn(svc.db, limit);
   let delivered = 0;
   let failed = 0;
   for (const row of rows) {

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -84,6 +84,7 @@ export function createSessionStateActivities(
       turnId: turn.id,
       triggerEventId: turn.triggerEventId,
       attemptId: input.attemptId,
+      childCompletionParentWakeEnabled: settings.childCompletionParentWakeEnabled,
       turnStatus: "failed",
       sessionStatus: "failed",
       activeTurnId: null,
@@ -142,6 +143,7 @@ export function createSessionStateActivities(
       attemptId: input.attemptId,
       timeoutType: input.timeoutType,
       maxRedispatches: WORKER_DEATH_MAX_REDISPATCHES,
+      childCompletionParentWakeEnabled: settings.childCompletionParentWakeEnabled,
     });
     if (result.action === "stale" || result.action === "unclaimed") {
       return { action: result.action };
@@ -182,6 +184,7 @@ export function createSessionStateActivities(
       db,
       input.workspaceId,
       input.sessionId,
+      settings.childCompletionParentWakeEnabled,
     );
     if (settled.events.length > 0) {
       await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, settled.events);

--- a/apps/worker/test/parent-wake.test.ts
+++ b/apps/worker/test/parent-wake.test.ts
@@ -1,0 +1,83 @@
+import { expect, mock, test } from "bun:test";
+import type { Settings } from "@opengeni/config";
+import type { Database } from "@opengeni/db";
+import type { EventBus } from "@opengeni/events";
+import {
+  notifyParentOfChildTerminal,
+  reconcilePendingParentSystemUpdates,
+  type NotifyServices,
+} from "../src/activities/parent-wake";
+
+test("disabled child-completion wakes return before every parent side effect", async () => {
+  const info = mock(() => undefined);
+  const error = mock(() => undefined);
+  const publish = mock(async () => undefined);
+  const wakeSessionWorkflow = mock(async () => undefined);
+  const db = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("disabled parent wake touched the database");
+      },
+    },
+  ) as Database;
+
+  await notifyParentOfChildTerminal(
+    {
+      db,
+      bus: { publish } as unknown as EventBus,
+      settings: { childCompletionParentWakeEnabled: false } as Settings,
+      observability: { info, error } as unknown as NotifyServices["observability"],
+      wakeSessionWorkflow,
+    },
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+    "idle",
+  );
+
+  expect(publish).not.toHaveBeenCalled();
+  expect(wakeSessionWorkflow).not.toHaveBeenCalled();
+  expect(info).not.toHaveBeenCalled();
+  expect(error).not.toHaveBeenCalled();
+});
+
+test("disabled child-completion wakes preserve generic workflow repair without claiming outboxes", async () => {
+  const wakeSessionWorkflow = mock(async () => undefined);
+  const listEnrollableSessions = mock(async () => [
+    {
+      accountId: "11111111-1111-4111-8111-111111111111",
+      workspaceId: "22222222-2222-4222-8222-222222222222",
+      sessionId: "33333333-3333-4333-8333-333333333333",
+      temporalWorkflowId: "session-33333333-3333-4333-8333-333333333333",
+    },
+  ]);
+  const claimPendingSessionSystemUpdateOutbox = mock(async () => {
+    throw new Error("disabled reaper claimed a child-completion outbox");
+  });
+  const db = {} as Database;
+
+  const result = await reconcilePendingParentSystemUpdates(
+    {
+      db,
+      bus: { publish: async () => undefined } as unknown as EventBus,
+      settings: { childCompletionParentWakeEnabled: false } as Settings,
+      observability: {
+        info: () => undefined,
+        error: () => undefined,
+      } as unknown as NotifyServices["observability"],
+      wakeSessionWorkflow,
+    },
+    17,
+    { claimPendingSessionSystemUpdateOutbox, listEnrollableSessions },
+  );
+
+  expect(result).toEqual({ claimed: 0, delivered: 0, failed: 0, wakeRepairs: 1 });
+  expect(listEnrollableSessions).toHaveBeenCalledWith(db, 17);
+  expect(wakeSessionWorkflow).toHaveBeenCalledWith({
+    accountId: "11111111-1111-4111-8111-111111111111",
+    workspaceId: "22222222-2222-4222-8222-222222222222",
+    sessionId: "33333333-3333-4333-8333-333333333333",
+    workflowId: "session-33333333-3333-4333-8333-333333333333",
+  });
+  expect(claimPendingSessionSystemUpdateOutbox).not.toHaveBeenCalled();
+});

--- a/apps/worker/test/session-state-worker-death.test.ts
+++ b/apps/worker/test/session-state-worker-death.test.ts
@@ -17,7 +17,11 @@ function makeActivities() {
       ({
         db: fakeDb,
         bus: { publish: async () => undefined },
-        settings: { sessionHistorySource: "items", openaiReasoningEffort: "medium" },
+        settings: {
+          sessionHistorySource: "items",
+          openaiReasoningEffort: "medium",
+          childCompletionParentWakeEnabled: false,
+        },
         observability: {},
         wakeSessionWorkflow: null,
       }) as any,
@@ -73,6 +77,7 @@ describe("recoverDispatch: exact attempt ownership fence", () => {
         attemptId: "attempt-1",
         timeoutType: "HEARTBEAT",
         maxRedispatches: 3,
+        childCompletionParentWakeEnabled: false,
       },
     ]);
     expect(publishedEvents).toEqual([{ id: "recovery-1", type: "turn.recovery.requested" }]);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -181,6 +181,10 @@ const SettingsSchema = z.object({
   // it then acts as a hard ceiling that per-goal overrides can only lower.
   goalMaxAutoContinuations: z.coerce.number().int().positive().optional(),
   goalNoProgressLimit: z.coerce.number().int().positive().default(3),
+  // Temporary safety valve: spawned child sessions still run and retain their
+  // own durable events/goals, but terminal child episodes do not create parent
+  // system updates or inference work unless explicitly enabled.
+  childCompletionParentWakeEnabled: EnvBoolean.default(false),
   // Per-segment ceiling on agent loop turns (model calls) within a single
   // session turn. Effectively unbounded by default for the same reason as
   // above; the graceful max-turns valve (idle + goal continuation, never a
@@ -1004,6 +1008,7 @@ export function getSettings(): Settings {
     integrationsOauthClientsJson: optional("OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON"),
     goalMaxAutoContinuations: optional("OPENGENI_GOAL_MAX_AUTO_CONTINUATIONS"),
     goalNoProgressLimit: optional("OPENGENI_GOAL_NO_PROGRESS_LIMIT"),
+    childCompletionParentWakeEnabled: optional("OPENGENI_CHILD_COMPLETION_PARENT_WAKE_ENABLED"),
     agentMaxModelCallsPerTurn: optional("OPENGENI_AGENT_MAX_MODEL_CALLS_PER_TURN"),
     contextWindowTokens: optional("OPENGENI_CONTEXT_WINDOW_TOKENS"),
     contextEffectiveWindowTokens: optional("OPENGENI_CONTEXT_EFFECTIVE_WINDOW_TOKENS"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -205,6 +205,14 @@ describe("sandbox preparation profiles", () => {
     expect(settings.authAllowMetrics).toBe(false);
   });
 
+  test("disables child-completion parent wakes by default and parses an explicit opt-in", () => {
+    expect(withEnv({}, () => getSettings()).childCompletionParentWakeEnabled).toBe(false);
+    expect(
+      withEnv({ OPENGENI_CHILD_COMPLETION_PARENT_WAKE_ENABLED: "true" }, () => getSettings())
+        .childCompletionParentWakeEnabled,
+    ).toBe(true);
+  });
+
   test("requires an access key when shared-key auth is enabled", () => {
     expect(() =>
       withEnv(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18475,15 +18475,17 @@ export async function peekSessionWork(
 }
 
 /**
- * Commit the workflow's terminal-for-now idle decision and its parent delivery
- * source in one transaction. A crash after commit leaves a pending outbox row
- * for the global reconciler; a normal caller immediately enriches/delivers the
- * same dedupe identity through notifyParentOfChildTerminal.
+ * Commit the workflow's terminal-for-now idle decision and, when child
+ * completion parent wakes are enabled, its parent delivery source in one
+ * transaction. A crash after an enabled commit leaves a pending outbox row for
+ * the global reconciler; a normal caller immediately enriches/delivers the same
+ * dedupe identity through notifyParentOfChildTerminal.
  */
 export async function settleSessionIdleWithParentOutbox(
   db: Database,
   workspaceId: string,
   sessionId: string,
+  childCompletionParentWakeEnabled: boolean,
 ): Promise<
   | { action: "settled"; changed: boolean; episodeKey: string; events: SessionEvent[] }
   | { action: "stale"; episodeKey: null; events: [] }
@@ -18564,7 +18566,7 @@ export async function settleSessionIdleWithParentOutbox(
       // notification to the newest non-status event, not to the idle status
       // event this settlement just appended (or a prior identical idle event).
       const episodeKey = String(Number(episodeSequence));
-      if (!session.parentSessionId) {
+      if (!childCompletionParentWakeEnabled || !session.parentSessionId) {
         return {
           action: "settled",
           changed: events.length > 0,
@@ -18789,6 +18791,7 @@ export type ApplySessionTurnSettlementInput = {
   turnId: string;
   triggerEventId: string;
   attemptId: string;
+  childCompletionParentWakeEnabled: boolean;
   fromStatuses?: SessionTurnStatus[];
   turnStatus: SessionTurnStatus;
   sessionStatus: SessionStatus;
@@ -18970,7 +18973,7 @@ export async function applySessionTurnSettlement(
             eq(schema.sessionTurns.id, input.turnId),
           ),
         );
-      if (input.turnStatus === "failed") {
+      if (input.turnStatus === "failed" && input.childCompletionParentWakeEnabled) {
         await enqueueFailedChildOutboxForTurnTx(
           tx as unknown as Database,
           workspaceId,
@@ -20033,6 +20036,7 @@ export type RecoverSessionDispatchInput = {
   attemptId: string;
   timeoutType: "HEARTBEAT" | "SCHEDULE_TO_START";
   maxRedispatches: number;
+  childCompletionParentWakeEnabled: boolean;
 };
 
 export type RecoverSessionDispatchResult =
@@ -20206,12 +20210,14 @@ export async function recoverSessionDispatch(
               eq(schema.sessionTurns.id, turn.id),
             ),
           );
-        await enqueueFailedChildOutboxForTurnTx(
-          tx as unknown as Database,
-          workspaceId,
-          session,
-          turn,
-        );
+        if (input.childCompletionParentWakeEnabled) {
+          await enqueueFailedChildOutboxForTurnTx(
+            tx as unknown as Database,
+            workspaceId,
+            session,
+            turn,
+          );
+        }
         await tx
           .update(schema.sessions)
           .set({

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -436,6 +436,7 @@ describe("clean session control plane", () => {
       turnId: turn!.id,
       triggerEventId: turn!.triggerEventId,
       attemptId: firstAttemptId,
+      childCompletionParentWakeEnabled: false,
       turnStatus: "requires_action",
       sessionStatus: "requires_action",
       activeTurnId: turn!.id,
@@ -531,6 +532,7 @@ describe("clean session control plane", () => {
       turnId: turn!.id,
       triggerEventId: turn!.triggerEventId,
       attemptId,
+      childCompletionParentWakeEnabled: false,
       turnStatus: "requires_action",
       sessionStatus: "requires_action",
       activeTurnId: turn!.id,
@@ -616,6 +618,7 @@ describe("clean session control plane", () => {
         attemptId: neverStartedAttemptId,
         timeoutType: "SCHEDULE_TO_START",
         maxRedispatches: 3,
+        childCompletionParentWakeEnabled: false,
       }),
     ).toEqual({ action: "unclaimed", events: [] });
     expect(await getSessionTurn(client.db, grant.workspaceId!, queued.turn.id)).toMatchObject({
@@ -643,6 +646,7 @@ describe("clean session control plane", () => {
         attemptId: firstAttemptId,
         timeoutType: "HEARTBEAT",
         maxRedispatches: 3,
+        childCompletionParentWakeEnabled: false,
       }),
     ).toMatchObject({ action: "recovering", turnId: first.id, redispatches: 1 });
 
@@ -666,6 +670,7 @@ describe("clean session control plane", () => {
         attemptId: firstAttemptId,
         timeoutType: "HEARTBEAT",
         maxRedispatches: 3,
+        childCompletionParentWakeEnabled: false,
       }),
     ).toMatchObject({ action: "stale", activeTurnId: first.id });
     expect(await getSessionTurn(client.db, grant.workspaceId!, first.id)).toMatchObject({
@@ -915,6 +920,7 @@ describe("clean session control plane", () => {
       turnId: compaction!.id,
       triggerEventId: compaction!.triggerEventId,
       attemptId,
+      childCompletionParentWakeEnabled: false,
       turnStatus: "completed",
       sessionStatus: "idle",
       activeTurnId: null,
@@ -971,6 +977,7 @@ describe("clean session control plane", () => {
         client.db,
         sessionPause.grant.workspaceId!,
         sessionPause.session.id,
+        false,
       ),
     ).toEqual({ action: "stale", episodeKey: null, events: [] });
 
@@ -991,8 +998,151 @@ describe("clean session control plane", () => {
         client.db,
         workspacePause.grant.workspaceId!,
         workspacePause.session.id,
+        false,
       ),
     ).toEqual({ action: "stale", episodeKey: null, events: [] });
+  });
+
+  test("child terminal settlement keeps child truth and gates every parent outbox producer", async () => {
+    const { grant, session: parent } = await fixture();
+    const createChild = async (label: string) => {
+      const child = await createSession(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        initialMessage: label,
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        parentSessionId: parent.id,
+      });
+      await send(grant, child.id, label);
+      return child;
+    };
+    const claimChild = async (child: Awaited<ReturnType<typeof createChild>>) => {
+      const attemptId = crypto.randomUUID();
+      const turn = await claimTestSessionWork(
+        client.db,
+        grant.workspaceId!,
+        child.id,
+        `session-${child.id}`,
+        { attemptId },
+      );
+      if (!turn) throw new Error(`child turn was not claimed: ${child.id}`);
+      return { attemptId, turn };
+    };
+    const createIdleReadyChild = async (label: string) => {
+      const child = await createChild(label);
+      const { attemptId, turn } = await claimChild(child);
+      expect(
+        await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+          sessionId: child.id,
+          turnId: turn.id,
+          triggerEventId: turn.triggerEventId,
+          attemptId,
+          childCompletionParentWakeEnabled: false,
+          turnStatus: "completed",
+          sessionStatus: "idle",
+          activeTurnId: null,
+          events: [],
+        }),
+      ).toMatchObject({ action: "settled" });
+      return child;
+    };
+    const childOutboxes = async (childSessionId: string) =>
+      await withWorkspaceRls(client.db, grant.workspaceId!, async (db) =>
+        db
+          .select({ id: schema.sessionSystemUpdateOutbox.id })
+          .from(schema.sessionSystemUpdateOutbox)
+          .where(eq(schema.sessionSystemUpdateOutbox.sourceSessionId, childSessionId)),
+      );
+
+    const idleChild = await createIdleReadyChild("disabled idle child");
+    expect(
+      await settleSessionIdleWithParentOutbox(client.db, grant.workspaceId!, idleChild.id, false),
+    ).toMatchObject({ action: "settled" });
+    expect(await getSession(client.db, grant.workspaceId!, idleChild.id)).toMatchObject({
+      status: "idle",
+    });
+    expect(await childOutboxes(idleChild.id)).toHaveLength(0);
+
+    const failedChild = await createChild("disabled failed child");
+    const { attemptId: failedAttemptId, turn: failedTurn } = await claimChild(failedChild);
+    expect(
+      await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+        sessionId: failedChild.id,
+        turnId: failedTurn.id,
+        triggerEventId: failedTurn.triggerEventId,
+        attemptId: failedAttemptId,
+        childCompletionParentWakeEnabled: false,
+        turnStatus: "failed",
+        sessionStatus: "failed",
+        activeTurnId: null,
+        events: [{ type: "turn.failed", payload: { error: "expected test failure" } }],
+      }),
+    ).toMatchObject({ action: "settled" });
+    expect(await getSession(client.db, grant.workspaceId!, failedChild.id)).toMatchObject({
+      status: "failed",
+    });
+    expect(await childOutboxes(failedChild.id)).toHaveLength(0);
+
+    const exhaustedChild = await createChild("disabled worker-death child");
+    const { attemptId: exhaustedAttemptId } = await claimChild(exhaustedChild);
+    expect(
+      await recoverSessionDispatch(client.db, grant.workspaceId!, {
+        sessionId: exhaustedChild.id,
+        attemptId: exhaustedAttemptId,
+        timeoutType: "HEARTBEAT",
+        maxRedispatches: 0,
+        childCompletionParentWakeEnabled: false,
+      }),
+    ).toMatchObject({ action: "exceeded" });
+    expect(await getSession(client.db, grant.workspaceId!, exhaustedChild.id)).toMatchObject({
+      status: "failed",
+    });
+    expect(await childOutboxes(exhaustedChild.id)).toHaveLength(0);
+
+    const enabledIdleChild = await createIdleReadyChild("enabled idle child");
+    expect(
+      await settleSessionIdleWithParentOutbox(
+        client.db,
+        grant.workspaceId!,
+        enabledIdleChild.id,
+        true,
+      ),
+    ).toMatchObject({ action: "settled" });
+    expect(await childOutboxes(enabledIdleChild.id)).toHaveLength(1);
+
+    const enabledFailedChild = await createChild("enabled failed child");
+    const { attemptId: enabledFailedAttemptId, turn: enabledFailedTurn } =
+      await claimChild(enabledFailedChild);
+    expect(
+      await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+        sessionId: enabledFailedChild.id,
+        turnId: enabledFailedTurn.id,
+        triggerEventId: enabledFailedTurn.triggerEventId,
+        attemptId: enabledFailedAttemptId,
+        childCompletionParentWakeEnabled: true,
+        turnStatus: "failed",
+        sessionStatus: "failed",
+        activeTurnId: null,
+        events: [{ type: "turn.failed", payload: { error: "expected enabled test failure" } }],
+      }),
+    ).toMatchObject({ action: "settled" });
+    expect(await childOutboxes(enabledFailedChild.id)).toHaveLength(1);
+
+    const enabledExhaustedChild = await createChild("enabled worker-death child");
+    const { attemptId: enabledExhaustedAttemptId } = await claimChild(enabledExhaustedChild);
+    expect(
+      await recoverSessionDispatch(client.db, grant.workspaceId!, {
+        sessionId: enabledExhaustedChild.id,
+        attemptId: enabledExhaustedAttemptId,
+        timeoutType: "HEARTBEAT",
+        maxRedispatches: 0,
+        childCompletionParentWakeEnabled: true,
+      }),
+    ).toMatchObject({ action: "exceeded" });
+    expect(await childOutboxes(enabledExhaustedChild.id)).toHaveLength(1);
   });
 
   test("Pause blocks a racing terminal settlement and Resume admits a new attempt of the same turn", async () => {
@@ -1021,6 +1171,7 @@ describe("clean session control plane", () => {
         turnId: turn!.id,
         triggerEventId: turn!.triggerEventId,
         attemptId: firstAttemptId,
+        childCompletionParentWakeEnabled: false,
         turnStatus: "completed",
         sessionStatus: "idle",
         activeTurnId: null,
@@ -1635,6 +1786,7 @@ describe("clean session control plane", () => {
         turnId: running!.id,
         triggerEventId: running!.triggerEventId,
         attemptId: firstAttemptId,
+        childCompletionParentWakeEnabled: false,
         turnStatus: "requires_action",
         sessionStatus: "requires_action",
         activeTurnId: running!.id,
@@ -1700,6 +1852,7 @@ describe("clean session control plane", () => {
       turnId: turn.id,
       triggerEventId: turn.triggerEventId,
       attemptId: firstAttemptId,
+      childCompletionParentWakeEnabled: false,
       turnStatus: "requires_action",
       sessionStatus: "requires_action",
       activeTurnId: turn.id,

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -43,6 +43,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     integrationsOauthClientsJson: "{}",
     goalMaxAutoContinuations: 20,
     goalNoProgressLimit: 3,
+    childCompletionParentWakeEnabled: false,
     agentMaxModelCallsPerTurn: 40,
     contextWindowTokens: 1_050_000,
     contextCompactionThresholdRatio: 0.9,

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -3816,6 +3816,7 @@ describe("API component integration", () => {
       turnId: approvalWaitClaim.turn.id,
       triggerEventId: approvalWaitClaim.turn.triggerEventId,
       attemptId: approvalWaitAttemptId,
+      childCompletionParentWakeEnabled: false,
       turnStatus: "requires_action",
       sessionStatus: "requires_action",
       activeTurnId: approvalWaitClaim.turn.id,

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -2339,6 +2339,7 @@ async function settleRegisteredExecution(
     turnId: execution.turn.id,
     triggerEventId: execution.triggerEventId,
     attemptId: execution.attemptId,
+    childCompletionParentWakeEnabled: false,
     turnStatus,
     sessionStatus: requiresAction ? "requires_action" : "idle",
     activeTurnId: requiresAction ? execution.turn.id : null,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -1181,6 +1181,7 @@ describe("worker activities integration", () => {
         turnId: turn.id,
         triggerEventId: turn.triggerEventId,
         attemptId: initialAttemptId,
+        childCompletionParentWakeEnabled: false,
         turnStatus: "requires_action",
         sessionStatus: "requires_action",
         activeTurnId: turn.id,

--- a/test/integration/worker-restart.integration.ts
+++ b/test/integration/worker-restart.integration.ts
@@ -403,6 +403,7 @@ describe("worker restart resilience", () => {
           turnId: result.turnId,
           triggerEventId: turn.triggerEventId,
           attemptId: input.attemptId,
+          childCompletionParentWakeEnabled: false,
           turnStatus: "completed",
           sessionStatus: "idle",
           activeTurnId: null,


### PR DESCRIPTION
## Summary
- restore the default-off child-completion parent-wake safety valve removed by the session-control refactor
- gate all atomic child-terminal outbox producers: idle settlement, ordinary failed-turn settlement, and worker-death exhaustion
- return before direct notifier parent side effects and before the global reaper claims/delivers child-terminal outboxes
- preserve unrelated generic workflow wake repair and an explicit compatibility opt-in
- require every DB settlement caller to declare the gate, with production callers using the runtime setting

## Validation
- exact head `2ed7ff741a83b3ee35836eb8cdc16161da84dfde`: [CI run 29412968641](https://github.com/Cloudgeni-ai/opengeni/actions/runs/29412968641) fully green — 2,983 pass, 3 gated skips, 0 fail across the main suite; deployment artifacts, workload images, browser acceptance, recovery integration, docs, and package guards also passed
- `bun test apps/worker/test/parent-wake.test.ts apps/worker/test/session-state-worker-death.test.ts packages/config/test/config.test.ts` — 67 pass
- `bun run typecheck` — all 19 projects clean
- `bun run format:check` — all 765 files clean
- `bun run lint` — zero errors (226 pre-existing warnings)
- full local `bun test` with injected Git pointer variables scrubbed — 2,947 pass, 3 gated skips; the only two failures were PostgreSQL setup hooks because this sandbox has no Docker daemon
- PostgreSQL/RLS regression passed in CI for disabled and enabled idle, failed-turn, and worker-death outbox production

## Safety
With the setting disabled, child terminal status/events and goal evidence remain authoritative on the child, but no child-completion outbox is created or claimed and the direct notifier performs no parent DB read, event publish, or workflow signal. Human-authored queue behavior and generic workflow wake repair are unchanged.
