### PR TITLE
test(worker): guard OPE-22 stale compaction signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,17 +68,20 @@ jobs:
             /tmp/ope26-session-pin-mobile-light.png
             /tmp/ope26-session-pin-mobile-dark.png
 
-      # OPE-22 production regressions cross the activity/DB/event boundary and
-      # therefore are not discovered by the unit-test command above. Keep the
-      # gate narrowly scoped to the incident cases while running them against
-      # the existing real Postgres + NATS integration harness on GitHub's Docker-
-      # capable runner.
+      # OPE-22's escaped MCP timeout and stale-input-token regressions cross the
+      # activity/DB/event boundary. Keep both explicit incident gates so a future
+      # suite split cannot silently drop either the exactly-once/active-goal proof
+      # or the real-Postgres shrink proof.
       - name: OPE-22 recovery integration regressions
-        run: >-
-          bun test --timeout 30000
-          --test-name-pattern
-          'a compaction-resumed turn may compact again|an MCP stream timeout after a successful tool output|requireShrink rejects a stale high provider signal'
-          ./test/integration/worker-activity.integration.ts
+        run: |
+          bun test --timeout 30000 \
+            --test-name-pattern \
+            'an MCP stream timeout after a successful tool output checkpoints once and continues the active goal' \
+            ./test/integration/worker-activity.integration.ts
+          bun test --timeout 180000 \
+            --test-name-pattern \
+            'forced overflow compaction proves shrink against active history, not stale input tokens' \
+            ./apps/worker/test/context-compaction-activity.test.ts
 
       - name: Workspace auth/billing static guard
         run: bun scripts/check-workspace-billing-static.ts

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -3653,11 +3653,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             executionGeneration,
             attemptId: input.attemptId,
           },
-          // Recovery must use the signal that triggered THIS compaction. A
-          // stale prior-turn value can be tiny (or refer to different active
-          // history), which would make the strict-shrink ceiling impossible.
-          // Proactive guards provide their exact current signal; provider
-          // overflows do not, so null derives the ceiling from active history.
+          // Never reuse the persisted prior-turn signal for recovery. Proactive
+          // guards provide their exact current signal; provider overflows do not,
+          // so null derives decision metadata from active history. Forced
+          // recovery proves progress separately by comparing the replacement
+          // with the current active-history estimate in maybeCompactContext.
           recoverySignalTokens,
           compactSummarizer,
           {

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -307,6 +307,102 @@ describe("standalone context compaction execution", () => {
     ).toEqual(originalItems);
   });
 
+  test("forced overflow compaction proves shrink against active history, not stale input tokens", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Stale compaction signal test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Stale compaction signal test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "initial",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values([
+        {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position: 0,
+          item: { type: "message", role: "user", content: "x".repeat(300_000) },
+        },
+        {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position: 1,
+          item: {
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "old answer" }],
+          },
+        },
+      ]);
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+    const attemptId = crypto.randomUUID();
+    const turn = await claimCompactionForAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      attemptId,
+    );
+
+    const outcome = await maybeCompactContext(
+      client.db,
+      testSettings({ contextWindowTokens: 100_000 }),
+      {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+      },
+      // This belongs to an earlier, tiny request. The forced overflow path must
+      // derive its shrink proof from the active transcript instead of treating
+      // this stale value as an impossible one-token replacement ceiling.
+      1,
+      async () => "Recovered compact context.",
+      { force: true, trigger: "overflow" },
+    );
+
+    expect(outcome).toMatchObject({
+      compacted: true,
+      events: [
+        expect.objectContaining({
+          type: "session.context.compacted",
+          payload: expect.objectContaining({ trigger: "overflow" }),
+        }),
+      ],
+    });
+    expect(
+      (await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id)).map(
+        (row) => row.item,
+      ),
+    ).toEqual([
+      expect.objectContaining({ type: "message", role: "user" }),
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        opengeni_context_summary: true,
+        content: expect.stringContaining("Recovered compact context"),
+      }),
+    ]);
+  });
+
   test("matches Codex's overflow floor by trying the checkpoint prompt alone once", async () => {
     const suffix = crypto.randomUUID();
     const access = await bootstrapWorkspace(client.db, {


### PR DESCRIPTION
## Summary

- lock the OPE-22 stale-low compaction failure as a database-backed regression
- seed a large active transcript with a stale prior-turn `lastInputTokens=1`
- prove forced overflow compaction installs a strictly smaller durable history and emits `session.context.compacted`
- replace the dedicated OPE-22 CI gate's removed test names with an exact invocation of this current real-Postgres regression

The late review finding is valid against PR #340's July 9 head, where strict shrink used `min(activeEstimate, providerSignal)`. Current main already removed that impossible one-token ceiling in `5a7a4d9f` and the overflow path now passes the current signal (or `null` for provider overflow). This PR changes no runtime behavior; it makes that correction deterministic in the current real-Postgres activity gate.

Linear: OPE-22 (archived record; Linear rejects new comments, so this PR is the durable follow-up evidence)

## Verification

- `bun run typecheck` — 19/19 projects clean
- `bun test apps/worker/test/agent-turn.test.ts` — 67 pass
- `bun test packages/runtime/test/context-compaction.test.ts` — 26 pass
- `bunx oxlint apps/worker/test/context-compaction-activity.test.ts` — 0 warnings/errors
- `bun run format:check` — 764 files clean
- `git diff --check` — clean

The local ephemeral rig can start Docker but cannot register pulled layers (`unshare: operation not permitted`), so the new PostgreSQL test intentionally requires the Docker-capable exact-head CI job before merge.
