### PR TITLE
fix(terraform): codify managed postgres capacity

### DIFF
--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -55,6 +55,26 @@ object_storage = {
 
 External mode means Terraform does not create that dependency. The Helm values or secret manager integration must still provide the runtime values expected by OpenGeni, such as `OPENGENI_OBJECT_STORAGE_AZURE_CONNECTION_STRING` for Azure Blob.
 
+## Managed PostgreSQL Capacity
+
+Keep non-secret production capacity separate from the credential-bearing `postgres`
+object. This lets private deployment automation pin the live capacity without
+copying or rewriting the administrator password:
+
+```hcl
+managed_postgres_capacity = {
+  sku_name          = "GP_Standard_D4ds_v5"
+  storage_mb        = 131072
+  storage_tier      = "P10"
+  auto_grow_enabled = true
+}
+```
+
+When set, this policy is authoritative for managed PostgreSQL compute and
+storage. When omitted, the existing `postgres.sku_name` and
+`postgres.storage_mb` behavior is unchanged and provider defaults apply to
+storage tier and autogrow.
+
 ## Resource Records
 
 Before applying this module, decide where the operator will keep exact resource

--- a/deploy/terraform/azure/main.tf
+++ b/deploy/terraform/azure/main.tf
@@ -267,8 +267,10 @@ resource "azurerm_postgresql_flexible_server" "this" {
   version                = var.postgres.version
   administrator_login    = var.postgres.administrator_login
   administrator_password = var.postgres.administrator_password
-  sku_name               = var.postgres.sku_name
-  storage_mb             = var.postgres.storage_mb
+  sku_name               = var.managed_postgres_capacity != null ? var.managed_postgres_capacity.sku_name : var.postgres.sku_name
+  storage_mb             = var.managed_postgres_capacity != null ? var.managed_postgres_capacity.storage_mb : var.postgres.storage_mb
+  storage_tier           = var.managed_postgres_capacity != null ? var.managed_postgres_capacity.storage_tier : null
+  auto_grow_enabled      = var.managed_postgres_capacity != null ? var.managed_postgres_capacity.auto_grow_enabled : null
   tags                   = local.tags
 }
 

--- a/deploy/terraform/azure/variables.tf
+++ b/deploy/terraform/azure/variables.tf
@@ -165,6 +165,27 @@ variable "postgres" {
   }
 }
 
+variable "managed_postgres_capacity" {
+  description = "Optional non-secret capacity policy for managed PostgreSQL. Keep this separate from the credential-bearing postgres object so production automation can pin compute and storage without duplicating secrets."
+  type = object({
+    sku_name          = string
+    storage_mb        = number
+    storage_tier      = string
+    auto_grow_enabled = bool
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.managed_postgres_capacity == null ? true : (
+      can(regex("^(B|GP|MO)_Standard_", var.managed_postgres_capacity.sku_name)) &&
+      contains([32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4193280, 4194304, 8388608, 16777216, 33553408], var.managed_postgres_capacity.storage_mb) &&
+      contains(["P4", "P6", "P10", "P15", "P20", "P30", "P40", "P50", "P60", "P70", "P80"], var.managed_postgres_capacity.storage_tier)
+    )
+    error_message = "managed_postgres_capacity must use a valid Azure PostgreSQL SKU, supported storage size, and supported storage tier."
+  }
+}
+
 variable "temporal" {
   description = "Temporal mode. Use external for an existing endpoint or officialChart for the stack-wrapper managed upstream Temporal chart."
   type = object({


### PR DESCRIPTION
## Summary
- add a non-secret managed PostgreSQL capacity policy
- wire SKU, storage size/tier, and autogrow into Azure Terraform
- document production-safe capacity separation from credentials

## Verification
- `terraform validate`
- `terraform fmt -check`
- `git diff --check`