### PR TITLE
Fix shared sandbox lease holder collisions

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -180,10 +180,12 @@ import type { ActivityServices, RunAgentTurnInput, RunAgentTurnResult } from "./
 import {
   resumeBoxForTurn,
   acquireSelfhostedLeaseForTurn,
+  sandboxLeaseHolderIdForAttempt,
   maybePersistWarmWorkspaceSnapshot,
   waitForWarmSnapshot,
   SandboxWarmingTimeoutError,
   type ResumedTurnSandbox,
+  type TurnSandboxLeaseHolderId,
 } from "../sandbox-resume";
 import {
   wrapTurnBoxWithRouting,
@@ -1285,10 +1287,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // THIS handle so a mid-turn sandbox_swap can never re-route those execs onto a
     // connected machine (the user's real computer).
     let setupBoxSession: unknown = null;
-    // The lease holder id (Temporal activityId, unique per scheduled execution)
-    // + the group id, captured so the lease heartbeat can refresh the lease TTL
-    // epoch-fenced (a superseded owner self-evicts) and finally can release.
-    let sandboxHolderId: string | null = null;
+    // The globally unique durable turn-attempt holder id + the group id,
+    // captured so the lease heartbeat can refresh the lease TTL epoch-fenced
+    // (a superseded owner self-evicts) and finally can release.
+    let sandboxHolderId: TurnSandboxLeaseHolderId | null = null;
     let sandboxGroupId: string | null = null;
     // Lease-TTL refresh timer (parallels the activity heartbeat): while the turn
     // runs it refreshes expires_at epoch-fenced so a legit multi-day turn is
@@ -2926,7 +2928,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // P1.2 ownership inversion (gated, default OFF). With the flag off this
       // block is skipped entirely: resolvedSandbox stays null and runStream
       // takes the legacy per-run build-and-discard path — byte-for-byte today.
-      // With it on, acquire the group lease ('turn' holder = the activityId),
+      // With it on, acquire the group lease (holder = the durable attempt id),
       // resume the one box by id, and inject it NON-OWNED into the run. The box
       // backend is "none" -> never resolve (no box to touch).
       //
@@ -2936,7 +2938,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // variableSet delta (validateNoEnvironmentDelta). Passing sandboxEnvironment
       // here makes current==target so the delta is empty.
       if (settings.sandboxOwnershipEnabled && turn.sandboxBackend !== "none") {
-        sandboxHolderId = dispatchId;
+        sandboxHolderId = sandboxLeaseHolderIdForAttempt(input.attemptId);
         sandboxGroupId = session.sandboxGroupId;
         // STAGE D honest-label guard: a machine-home session carries
         // turn.sandboxBackend "selfhosted", but a turn is only machine-PRIMARY

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -46,6 +46,22 @@ import {
 // Re-exported for callers that just want the ack-kind union.
 export type ResumeHolderKind = LeaseHolderKind;
 
+/**
+ * The durable identity of a turn holding a shared sandbox lease.
+ *
+ * Temporal activity ids cannot satisfy this type: they are workflow-local
+ * sequence numbers and collide across sessions that share a sandbox group.
+ */
+export type TurnSandboxLeaseHolderId = `turn-attempt:${string}`;
+
+export function sandboxLeaseHolderIdForAttempt(attemptId: string): TurnSandboxLeaseHolderId {
+  const normalized = attemptId.trim();
+  if (!normalized) {
+    throw new Error("Sandbox lease holder requires a turn attempt id");
+  }
+  return `turn-attempt:${normalized}`;
+}
+
 /** The minimal services surface resumeBoxForTurn needs. A subset of
  *  ActivityServices so a test (and the API later) can pass a lean bag. */
 export type SandboxResumeServices = {
@@ -430,13 +446,15 @@ export async function maybePersistWarmWorkspaceSnapshot(
  * the lifecycle: inject non-owned, run, then `await release()` and drop the
  * handle in `finally`.
  *
- * holderId is the unique-per-execution id (the Temporal activityId for a turn).
+ * holderId is the globally unique durable turn-attempt id. It must not be a
+ * Temporal activity id, because activity ids are only workflow-local and
+ * collide when sibling sessions share one sandbox group.
  */
 export async function resumeBoxForTurn(
   services: SandboxResumeServices,
   ids: ResumeBoxIds,
-  kind: LeaseHolderKind,
-  holderId: string,
+  kind: "turn",
+  holderId: TurnSandboxLeaseHolderId,
 ): Promise<ResumedTurnSandbox> {
   const { db, settings } = services;
   const os = ids.os ?? "linux";
@@ -690,7 +708,9 @@ export async function resumeBoxForTurn(
  * epoch + an idempotent release so the turn's lease-heartbeat + `finally` release are
  * identical to the cloud path.
  *
- * holderId is the unique-per-execution id (the Temporal activityId for a turn).
+ * holderId is the globally unique durable turn-attempt id. It must not be a
+ * Temporal activity id, because activity ids are only workflow-local and
+ * collide when sibling sessions share one sandbox group.
  */
 export async function acquireSelfhostedLeaseForTurn(
   services: SandboxResumeServices,
@@ -700,8 +720,8 @@ export async function acquireSelfhostedLeaseForTurn(
     sandboxGroupId: string;
     sessionId: string;
   },
-  kind: LeaseHolderKind,
-  holderId: string,
+  kind: "turn",
+  holderId: TurnSandboxLeaseHolderId,
 ): Promise<{ leaseEpoch: number; release: () => Promise<void> }> {
   const { db, settings } = services;
   const leaseTtlMs = settings.sandboxLeaseTtlMs;

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -32,6 +32,7 @@ import {
   resolveActiveSandboxBackend,
   shouldStartOnTurnRecording,
 } from "../src/activities/agent-turn";
+import { sandboxLeaseHolderIdForAttempt } from "../src/sandbox-resume";
 import { settingsWithPackSandboxImage } from "../src/activities/packs";
 
 // Item shapes mirror the SDK history representation persisted into
@@ -479,6 +480,29 @@ describe("model usage source key (re-dispatch charge stability)", () => {
         positionalKey: "aggregate",
       }),
     ).toBe("aggregate");
+  });
+});
+
+describe("sandbox lease holder identity", () => {
+  test("does not collide when sibling workflows reuse the same Temporal activity id", () => {
+    const siblingAttemptA = sandboxLeaseHolderIdForAttempt("11111111-1111-4111-8111-111111111111");
+    const siblingAttemptB = sandboxLeaseHolderIdForAttempt("22222222-2222-4222-8222-222222222222");
+
+    expect(siblingAttemptA).not.toBe(siblingAttemptB);
+    expect(siblingAttemptA).toBe("turn-attempt:11111111-1111-4111-8111-111111111111");
+  });
+
+  test("is stable for an activity retry of the same durable attempt", () => {
+    const attemptId = "33333333-3333-4333-8333-333333333333";
+    expect(sandboxLeaseHolderIdForAttempt(attemptId)).toBe(
+      sandboxLeaseHolderIdForAttempt(attemptId),
+    );
+  });
+
+  test("rejects a missing durable attempt identity", () => {
+    expect(() => sandboxLeaseHolderIdForAttempt("  ")).toThrow(
+      "Sandbox lease holder requires a turn attempt id",
+    );
   });
 });
 

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -37,7 +37,11 @@ import {
   type SharedTestDatabase,
   testSettings,
 } from "@opengeni/testing";
-import { resumeBoxForTurn, SandboxWarmingTimeoutError } from "../src/sandbox-resume";
+import {
+  resumeBoxForTurn,
+  sandboxLeaseHolderIdForAttempt,
+  SandboxWarmingTimeoutError,
+} from "../src/sandbox-resume";
 
 let available = true;
 let shared: SharedTestDatabase | null = null;
@@ -160,7 +164,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
         environment: sandboxEnvironment,
       },
       "turn",
-      "activity-1",
+      sandboxLeaseHolderIdForAttempt("activity-1"),
     );
     try {
       // The box is live (unix_local session) and the lease is WARM with epoch>=1.
@@ -205,13 +209,13 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       { db, settings },
       { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local" },
       "turn",
-      "activity-A",
+      sandboxLeaseHolderIdForAttempt("activity-A"),
     );
     const second = await resumeBoxForTurn(
       { db, settings },
       { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local" },
       "turn",
-      "activity-B",
+      sandboxLeaseHolderIdForAttempt("activity-B"),
     );
     try {
       // Both resolved against the SAME warm lease; the second attached (same
@@ -242,7 +246,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       { db, settings },
       { accountId, workspaceId, sandboxGroupId: groupId, sessionId: groupId, backend: "local" },
       "turn",
-      "activity-live",
+      sandboxLeaseHolderIdForAttempt("activity-live"),
     );
     const liveEpoch = resumed.leaseEpoch;
 
@@ -252,7 +256,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       workspaceId,
       sandboxGroupId: groupId,
       kind: "turn",
-      holderId: "activity-live",
+      holderId: sandboxLeaseHolderIdForAttempt("activity-live"),
       leaseTtlMs: settings.sandboxLeaseTtlMs,
       expectedEpoch: liveEpoch,
     });
@@ -270,7 +274,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       workspaceId,
       sandboxGroupId: groupId,
       kind: "turn",
-      holderId: "activity-new",
+      holderId: sandboxLeaseHolderIdForAttempt("activity-new"),
       backend: "local",
       leaseTtlMs: settings.sandboxLeaseTtlMs,
     });
@@ -296,7 +300,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       workspaceId,
       sandboxGroupId: groupId,
       kind: "turn",
-      holderId: "activity-new",
+      holderId: sandboxLeaseHolderIdForAttempt("activity-new"),
       leaseTtlMs: settings.sandboxLeaseTtlMs,
       expectedEpoch: liveEpoch,
     });
@@ -308,7 +312,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       workspaceId,
       sandboxGroupId: groupId,
       kind: "turn",
-      holderId: "activity-new",
+      holderId: sandboxLeaseHolderIdForAttempt("activity-new"),
       leaseTtlMs: settings.sandboxLeaseTtlMs,
       expectedEpoch: newEpoch,
     });
@@ -347,7 +351,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
           os: "linux",
         },
         "turn",
-        "activity-timeout",
+        sandboxLeaseHolderIdForAttempt("activity-timeout"),
       ),
     ).rejects.toThrow(SandboxWarmingTimeoutError);
 
@@ -363,12 +367,20 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
           os: "linux",
         },
         "turn",
-        "activity-timeout-message",
+        sandboxLeaseHolderIdForAttempt("activity-timeout-message"),
       ),
     ).rejects.toThrow(/Sandbox backend "local" capacity or creation timed out/);
 
-    expect(await holderCount(workspaceId, groupId, "activity-timeout")).toBe(0);
-    expect(await holderCount(workspaceId, groupId, "activity-timeout-message")).toBe(0);
+    expect(
+      await holderCount(workspaceId, groupId, sandboxLeaseHolderIdForAttempt("activity-timeout")),
+    ).toBe(0);
+    expect(
+      await holderCount(
+        workspaceId,
+        groupId,
+        sandboxLeaseHolderIdForAttempt("activity-timeout-message"),
+      ),
+    ).toBe(0);
     const row = await readRow(workspaceId, groupId);
     expect(row?.liveness).toBe("warming");
   }, 60_000);
@@ -444,7 +456,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
           os: "linux",
         },
         "turn",
-        "activity-f3",
+        sandboxLeaseHolderIdForAttempt("activity-f3"),
       );
     } catch (e) {
       spawnError = e instanceof Error ? e : new Error(String(e));
@@ -503,7 +515,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
         image: "img-A",
       },
       "turn",
-      "activity-1",
+      sandboxLeaseHolderIdForAttempt("activity-1"),
     );
     try {
       const warm = await readRow(workspaceId, groupId);
@@ -533,7 +545,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
         image: "img-A",
       },
       "turn",
-      "keeper",
+      sandboxLeaseHolderIdForAttempt("keeper"),
     );
     try {
       // A second holder resolving a DIFFERENT image while keeper holds -> conflict
@@ -553,7 +565,7 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
             image: "img-B",
           },
           "turn",
-          "newcomer",
+          sandboxLeaseHolderIdForAttempt("newcomer"),
         ),
       ).rejects.toThrow(SandboxImageConflictError);
       // The box is untouched — keeper's session keeps running.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13079,7 +13079,9 @@ export interface AcquireLeaseInput {
   // singleton group). The lease is per-group, not per-session.
   sandboxGroupId: string;
   kind: LeaseHolderKind;
-  holderId: string; // session_turns.id (turn) | viewer connection id (viewer)
+  // Globally unique durable turn-attempt id (turn) | viewer connection id
+  // (viewer). A workflow-local activity id is not a valid turn holder id.
+  holderId: string;
   subjectId?: string | null; // the attributing session within the group
   backend: string; // sessions.sandbox_backend
   os?: string; // default 'linux'


### PR DESCRIPTION
## Root cause
Temporal activity IDs are workflow-local sequence numbers. Shared sandbox groups used those values as globally unique holder IDs, so sibling session workflows commonly collapsed onto the same holder row (for example, many distinct turns all became holder `10`). One turn releasing that row prematurely reduced the refcount and let the box drain underneath other live turns, causing box-loss recovery fan-out and the production incident.

## Clean fix
- derive every turn sandbox holder from the globally unique durable turn-attempt UUID
- constrain both worker lease entry points to the typed turn-attempt holder
- update the real Postgres lease suite to exercise acquire, heartbeat fencing, cleanup, and conflicts with the corrected identity
- no compatibility or fallback path; current production has no live holder rows to migrate

## Verification
- focused worker activity tests: 70/70
- real Postgres sandbox-resume suite: 8/8
- repository typecheck: 19/19 projects
- format and diff checks clean
- oxlint: zero errors (four unrelated pre-existing warnings)
- durable Fable review: APPROVE
- UBS: changed-hunk triage clean; scanner exit reflects pre-existing whole-file false-positive baseline