### PR TITLE
fix(terraform): codify managed AKS capacity

### DIFF
--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -55,6 +55,20 @@ object_storage = {
 
 External mode means Terraform does not create that dependency. The Helm values or secret manager integration must still provide the runtime values expected by OpenGeni, such as `OPENGENI_OBJECT_STORAGE_AZURE_CONNECTION_STRING` for Azure Blob.
 
+## Managed AKS Capacity
+
+Keep non-secret production node capacity separate from the rest of the
+environment configuration:
+
+```hcl
+managed_aks_capacity = {
+  node_count = 5
+}
+```
+
+When set, this policy is authoritative for the managed AKS system-pool node
+count. When omitted, the existing `aks.node_count` behavior is unchanged.
+
 ## Managed PostgreSQL Capacity
 
 Keep non-secret production capacity separate from the credential-bearing `postgres`

--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -62,7 +62,7 @@ environment configuration:
 
 ```hcl
 managed_aks_capacity = {
-  node_count = 4
+  node_count = 5
 }
 ```
 

--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -62,7 +62,7 @@ environment configuration:
 
 ```hcl
 managed_aks_capacity = {
-  node_count = 5
+  node_count = 4
 }
 ```
 

--- a/deploy/terraform/azure/main.tf
+++ b/deploy/terraform/azure/main.tf
@@ -83,7 +83,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   default_node_pool {
     name       = "system"
-    node_count = var.aks.node_count
+    node_count = var.managed_aks_capacity != null ? var.managed_aks_capacity.node_count : var.aks.node_count
     vm_size    = var.aks.vm_size
 
     upgrade_settings {

--- a/deploy/terraform/azure/variables.tf
+++ b/deploy/terraform/azure/variables.tf
@@ -59,6 +59,24 @@ variable "aks" {
   default = {}
 }
 
+variable "managed_aks_capacity" {
+  description = "Optional non-secret capacity policy for the managed AKS system pool. Production automation can pin live node capacity without duplicating the rest of the environment configuration."
+  type = object({
+    node_count = number
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.managed_aks_capacity == null ? true : (
+      var.managed_aks_capacity.node_count >= 1 &&
+      var.managed_aks_capacity.node_count <= 1000 &&
+      floor(var.managed_aks_capacity.node_count) == var.managed_aks_capacity.node_count
+    )
+    error_message = "managed_aks_capacity.node_count must be a whole number between 1 and 1000."
+  }
+}
+
 variable "key_vault" {
   description = "Key Vault settings."
   type = object({


### PR DESCRIPTION
## Summary
- separate non-secret AKS node capacity from environment secrets
- make the capacity policy authoritative for system-pool node count
- document the managed AKS capacity contract

## Verification
- `terraform validate`
- `terraform fmt -check`
- `git diff --check`