### PR TITLE
Fix failed internal-update inference hot loop

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -32,6 +32,7 @@ import {
   failWarmingToCold,
   getSandboxSessionEnvelope,
   loadWorkspaceEnvironmentForRun,
+  markWarmLeaseInstanceLost,
   readLease,
   releaseLeaseHolder,
   type Database,
@@ -42,6 +43,8 @@ import { HTTPException } from "hono/http-exception";
 
 import {
   establishSandboxSessionFromEnvelope,
+  isProviderSandboxNotFoundError,
+  SandboxResumeStateUnavailableError,
   serializeEstablishedSandboxEnvelope,
   SandboxChannelAService,
   ChannelAConflictError,
@@ -182,6 +185,7 @@ export async function withChannelA<T>(
       try {
         established = await establishSandboxSessionFromEnvelope(settings, spawnEnvelope, {
           sessionId: session.id,
+          recovery: "create-or-restore",
           backendOverride: session.sandboxBackend,
           environment,
         });
@@ -218,13 +222,50 @@ export async function withChannelA<T>(
       // ATTACHED / REARMED: the box is live. Read the lease to get the
       // authoritative resume_state, then resume by id for this op.
       const live = await readLease(db, workspaceId, sandboxGroupId);
-      if (live) leaseSnapshot = live;
-      const resumeEnvelope = leaseSnapshot.resumeState ?? envelope;
-      established = await establishSandboxSessionFromEnvelope(settings, resumeEnvelope, {
-        sessionId: session.id,
-        backendOverride: session.sandboxBackend,
-        environment,
-      });
+      if (
+        !live ||
+        live.liveness !== "warm" ||
+        live.leaseEpoch !== acquired.lease.leaseEpoch ||
+        live.instanceId === null
+      ) {
+        throw new HTTPException(409, {
+          message: `sandbox lease is not attachable; retry`,
+        });
+      }
+      leaseSnapshot = live;
+      try {
+        established = await establishSandboxSessionFromEnvelope(settings, live.resumeState, {
+          sessionId: session.id,
+          recovery: "resume-only",
+          backendOverride: session.sandboxBackend,
+          environment,
+        });
+      } catch (error) {
+        if (
+          !(error instanceof SandboxResumeStateUnavailableError) &&
+          !isProviderSandboxNotFoundError(session.sandboxBackend, error)
+        ) {
+          throw error;
+        }
+        const marked = await markWarmLeaseInstanceLost(db, {
+          accountId,
+          workspaceId,
+          sandboxGroupId,
+          expectedEpoch: live.leaseEpoch,
+          expectedInstanceId: live.instanceId,
+        });
+        if (marked.status === "marked") {
+          await appendAndPublishEvents(db, bus, workspaceId, session.id, [
+            {
+              type: "sandbox.box.lost",
+              payload: { sandboxId: live.instanceId },
+            },
+          ]);
+        }
+        throw new HTTPException(409, {
+          message: `sandbox instance was lost; retry to restore it`,
+        });
+      }
     }
 
     const emit = async (events: { type: string; payload: unknown }[]): Promise<void> => {

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -37,6 +37,7 @@ import {
   getSandboxSessionEnvelope,
   heartbeatLeaseHolder,
   loadWorkspaceEnvironmentForRun,
+  markWarmLeaseInstanceLost,
   readLease,
   recordLeaseDataPlaneUrl,
   recordLeaseTerminalDataPlaneUrl,
@@ -56,6 +57,8 @@ import {
   ensureDisplayStack,
   ensureTerminalServer,
   establishSandboxSessionFromEnvelope,
+  isProviderSandboxNotFoundError,
+  SandboxResumeStateUnavailableError,
   exposeStreamPort,
   desktopCapableBackend,
   NatsControlRpc,
@@ -235,6 +238,7 @@ export async function attachViewer(
       const spawnEnvelope = acquired.lease.resumeState ?? envelope;
       established = await establishSandboxSessionFromEnvelope(settings, spawnEnvelope, {
         sessionId: session.id,
+        recovery: "create-or-restore",
         backendOverride: session.sandboxBackend,
         environment,
       });
@@ -393,6 +397,44 @@ async function dropEstablishedHandle(
   // Intentionally a no-op beyond dropping the reference: terminating the box here
   // is wrong (see above). The lease owns lifecycle; the reaper owns teardown.
   void established;
+}
+
+/** A stream resolver is an attached observer, never a box creator. If its
+ * resume-only call proves the exact warm provider instance gone, retire that
+ * epoch atomically so the next ordinary attach elects one replacement owner. */
+async function retireMissingWarmLease(
+  services: ViewerServices,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    session: Session;
+    lease: LeaseSnapshot;
+  },
+  error: unknown,
+): Promise<boolean> {
+  if (
+    input.lease.instanceId === null ||
+    (!(error instanceof SandboxResumeStateUnavailableError) &&
+      !isProviderSandboxNotFoundError(input.session.sandboxBackend, error))
+  ) {
+    return false;
+  }
+  const marked = await markWarmLeaseInstanceLost(services.db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    sandboxGroupId: input.session.sandboxGroupId,
+    expectedEpoch: input.lease.leaseEpoch,
+    expectedInstanceId: input.lease.instanceId,
+  });
+  if (marked.status === "marked" && services.bus) {
+    await appendAndPublishEvents(services.db, services.bus, input.workspaceId, input.session.id, [
+      {
+        type: "sandbox.box.lost",
+        payload: { sandboxId: input.lease.instanceId },
+      },
+    ]);
+  }
+  return true;
 }
 
 // ============================================================================
@@ -580,23 +622,28 @@ export async function mintDesktopStream(
     };
   }
 
-  // Resume the LIVE box by id. The lease's resume_state is authoritative (it is
-  // the box the lease currently fences); fall back to the session envelope only
-  // when the lease has none (a freshly-warmed lease always has it).
-  const envelope =
-    lease.resumeState ?? (await getSandboxSessionEnvelope(db, workspaceId, session.id));
+  // Resume the LIVE box by id from the authoritative lease descriptor. An
+  // attached stream resolver has no creation authority and never substitutes a
+  // per-session envelope for missing lease state.
+  const envelope = lease.resumeState;
   let established: EstablishedSandboxSession | undefined;
   try {
     // On a cold-restore (the lease's box is gone) this create() must carry the
     // SAME stable run-env the turn declares, so a later turn finds no env delta.
     const environment = await sessionAttachEnvironment(services, workspaceId, session);
-    established = input.establish
-      ? await input.establish(envelope)
-      : await establishSandboxSessionFromEnvelope(settings, envelope, {
-          sessionId: session.id,
-          backendOverride: session.sandboxBackend,
-          environment,
-        });
+    try {
+      established = input.establish
+        ? await input.establish(envelope)
+        : await establishSandboxSessionFromEnvelope(settings, envelope, {
+            sessionId: session.id,
+            recovery: "resume-only",
+            backendOverride: session.sandboxBackend,
+            environment,
+          });
+    } catch (error) {
+      await retireMissingWarmLease(services, { accountId, workspaceId, session, lease }, error);
+      return null;
+    }
 
     // Idempotent display stack (flock-guarded; a no-op when already up). A box
     // that genuinely can't run the stack degrades to transport:null, not a throw.
@@ -813,20 +860,25 @@ export async function mintTerminalStream(
 
   // Resume the LIVE box by id (lease.resume_state authoritative), ensure ttyd, and
   // resolve the 7681 tunnel + mint the scoped token, IN-PROCESS.
-  const envelope =
-    lease.resumeState ?? (await getSandboxSessionEnvelope(db, workspaceId, session.id));
+  const envelope = lease.resumeState;
   let established: EstablishedSandboxSession | undefined;
   try {
     // On a cold-restore this create() must carry the SAME stable run-env the turn
     // declares, so a later turn finds no manifest-env delta.
     const environment = await sessionAttachEnvironment(services, workspaceId, session);
-    established = input.establish
-      ? await input.establish(envelope)
-      : await establishSandboxSessionFromEnvelope(settings, envelope, {
-          sessionId: session.id,
-          backendOverride: session.sandboxBackend,
-          environment,
-        });
+    try {
+      established = input.establish
+        ? await input.establish(envelope)
+        : await establishSandboxSessionFromEnvelope(settings, envelope, {
+            sessionId: session.id,
+            recovery: "resume-only",
+            backendOverride: session.sandboxBackend,
+            environment,
+          });
+    } catch (error) {
+      await retireMissingWarmLease(services, { accountId, workspaceId, session, lease }, error);
+      return null;
+    }
 
     // Idempotent ttyd launch (flock-guarded; a no-op when already up). A box that
     // genuinely can't run it degrades to the sse-events firehose, not a throw.

--- a/apps/api/test/sandbox-consent-gate.test.ts
+++ b/apps/api/test/sandbox-consent-gate.test.ts
@@ -421,6 +421,11 @@ describe("P3.2 consent gate — shared-exposure (group >1 session)", () => {
       headers: { authorization: auth, "content-type": "application/json" },
       body: JSON.stringify({ desktop: true }),
     });
+    if (allowed.status !== 201) {
+      throw new Error(
+        `expected viewer attach 201, received ${allowed.status}: ${await allowed.text()}`,
+      );
+    }
     expect(allowed.status).toBe(201);
   }, 60_000);
 

--- a/apps/api/test/sandbox-consent-gate.test.ts
+++ b/apps/api/test/sandbox-consent-gate.test.ts
@@ -71,12 +71,18 @@ const settings = testSettings({
   sandboxDesktopEnabled: true,
   streamTokenSecret: "p32-stream-token-secret",
   sandboxOwnershipEnabled: true,
-  sandboxLeaseTtlMs: 5_000,
-  sandboxViewerHolderTtlMs: 5_000,
+  // This suite proves consent and holder semantics, not lease expiry. Keep the
+  // seeded warm lease comfortably alive under a loaded repository-wide CI run;
+  // a 5s TTL made the final attach nondeterministically become a cold spawner.
+  sandboxLeaseTtlMs: 60_000,
+  sandboxViewerHolderTtlMs: 60_000,
   sandboxIdleGraceMs: 500,
 });
 
-async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+async function freshWorkspace(): Promise<{
+  accountId: string;
+  workspaceId: string;
+}> {
   const [a] = await admin<{ id: string }[]>`
     insert into managed_accounts (name) values ('acct') returning id`;
   const [w] = await admin<{ id: string }[]>`
@@ -217,7 +223,12 @@ async function soloSession(): Promise<{
     sandboxBackend: BACKEND,
   });
   await seedWarmBox(accountId, workspaceId, session.id, session.sandboxGroupId);
-  return { accountId, workspaceId, sessionId: session.id, sandboxGroupId: session.sandboxGroupId };
+  return {
+    accountId,
+    workspaceId,
+    sessionId: session.id,
+    sandboxGroupId: session.sandboxGroupId,
+  };
 }
 
 describe("P3.2 consent gate — un-redacted acknowledgment (solo box)", () => {
@@ -351,7 +362,13 @@ describe("P3.2 consent gate — shared-exposure (group >1 session)", () => {
     });
     expect(b.sandboxGroupId).toBe(a.sandboxGroupId);
     await seedWarmBox(accountId, workspaceId, a.id, a.sandboxGroupId);
-    return { accountId, workspaceId, a: a.id, b: b.id, sandboxGroupId: a.sandboxGroupId };
+    return {
+      accountId,
+      workspaceId,
+      a: a.id,
+      b: b.id,
+      sandboxGroupId: a.sandboxGroupId,
+    };
   }
 
   test("a shared box → 409 shared_acknowledgment_required even after a bare un-redacted ack; shared ack unblocks", async () => {
@@ -377,7 +394,10 @@ describe("P3.2 consent gate — shared-exposure (group >1 session)", () => {
     await app.request(url(workspaceId, a, "/stream-capabilities/acknowledge"), {
       method: "POST",
       headers: { authorization: auth, "content-type": "application/json" },
-      body: JSON.stringify({ acknowledgeUnredacted: true, acknowledgeShared: false }),
+      body: JSON.stringify({
+        acknowledgeUnredacted: true,
+        acknowledgeShared: false,
+      }),
     });
     const blockedShared = await app.request(url(workspaceId, a, "/viewers"), {
       method: "POST",
@@ -391,7 +411,10 @@ describe("P3.2 consent gate — shared-exposure (group >1 session)", () => {
     await app.request(url(workspaceId, a, "/stream-capabilities/acknowledge"), {
       method: "POST",
       headers: { authorization: auth, "content-type": "application/json" },
-      body: JSON.stringify({ acknowledgeUnredacted: true, acknowledgeShared: true }),
+      body: JSON.stringify({
+        acknowledgeUnredacted: true,
+        acknowledgeShared: true,
+      }),
     });
     const allowed = await app.request(url(workspaceId, a, "/viewers"), {
       method: "POST",
@@ -608,7 +631,10 @@ describe("P3.2 route auth (stream:view / stream:acknowledge)", () => {
       url(workspaceId, sessionId, "/stream-capabilities/acknowledge"),
       {
         method: "POST",
-        headers: { authorization: viewOnly, "content-type": "application/json" },
+        headers: {
+          authorization: viewOnly,
+          "content-type": "application/json",
+        },
         body: JSON.stringify({ acknowledgeUnredacted: true }),
       },
     );

--- a/apps/api/test/sandbox-consent-gate.test.ts
+++ b/apps/api/test/sandbox-consent-gate.test.ts
@@ -69,13 +69,14 @@ const settings = testSettings({
   delegationSecret: DELEGATION_SECRET,
   sandboxBackend: BACKEND,
   sandboxDesktopEnabled: true,
+  // This suite proves desktop consent and holder semantics. Its warm lease is
+  // deliberately provider-free, so an unrelated terminal capability probe must
+  // not retire that fake descriptor and turn the attach into a Modal cold-create.
+  sandboxTerminalEnabled: false,
   streamTokenSecret: "p32-stream-token-secret",
   sandboxOwnershipEnabled: true,
-  // This suite proves consent and holder semantics, not lease expiry. Keep the
-  // seeded warm lease comfortably alive under a loaded repository-wide CI run;
-  // a 5s TTL made the final attach nondeterministically become a cold spawner.
-  sandboxLeaseTtlMs: 60_000,
-  sandboxViewerHolderTtlMs: 60_000,
+  sandboxLeaseTtlMs: 5_000,
+  sandboxViewerHolderTtlMs: 5_000,
   sandboxIdleGraceMs: 500,
 });
 

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1365,6 +1365,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         await publish(lifecycleEvents).catch(() => undefined);
       }
     };
+    const publishSandboxLost = async (input: { instanceId: string }): Promise<void> => {
+      if (!publish) return;
+      await publish([
+        {
+          type: "sandbox.box.lost",
+          payload: { sandboxId: input.instanceId },
+        },
+      ]).catch((publishError) => {
+        // The lease transition is already authoritative. A fenced/failed audit
+        // append must not prevent the same logical turn from recovering.
+        console.error("sandbox box lost event publish failed", publishError);
+      });
+    };
     const startLeaseHeartbeat = (
       sandbox: ResumedTurnSandbox,
       warmBackend: Settings["sandboxBackend"] | undefined,
@@ -3047,6 +3060,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               db,
               settings,
               sandboxMetrics: runtimeMetricsHooksForObservability(observability),
+              onSandboxLost: publishSandboxLost,
             },
             {
               accountId: input.accountId,
@@ -3346,6 +3360,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 db,
                 settings,
                 sandboxMetrics: runtimeMetricsHooksForObservability(observability),
+                onSandboxLost: publishSandboxLost,
               },
               {
                 accountId: input.accountId,

--- a/apps/worker/src/activities/rig-verification.ts
+++ b/apps/worker/src/activities/rig-verification.ts
@@ -219,6 +219,7 @@ export function createRigVerificationActivities(services: () => Promise<Activity
         const runSettings = settingsWithRigImage(settings, candidateVersion.image);
         established = await establishSandboxSessionFromEnvelope(runSettings, null, {
           sessionId: `rig-verification-${change.id}`,
+          recovery: "create-or-restore",
           environment: {},
         });
         if ((candidateVersion.setupScript ?? "").trim()) {
@@ -368,6 +369,7 @@ export function createRigVerificationActivities(services: () => Promise<Activity
         const runSettings = settingsWithRigImage(settings, version.image);
         established = await establishSandboxSessionFromEnvelope(runSettings, null, {
           sessionId: `rig-version-verification-${version.id}`,
+          recovery: "create-or-restore",
           environment: {},
         });
         if ((version.setupScript ?? "").trim()) {

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -6,8 +6,9 @@
 //
 //   1. acquireLease (group-keyed) under the DB FOR UPDATE + cold->warming CAS —
 //      the SOLE double-spawn guard (P1.1).
-//   2. establishSandboxSessionFromEnvelope — resume the one box BY ID (warm
-//      reattach, R4-safe) or cold-restore from snapshot on a provider NotFound.
+//   2. The cold->warming winner may create/restore. Every attached caller is
+//      resume-only; a missing provider box retires the exact warm epoch and
+//      re-enters admission instead of creating a rival.
 //   3. (spawner) commitWarmingToWarm (the lease_epoch++ fence + folds the resume
 //      envelope onto the lease). Optional desktop work is deliberately absent:
 //      the viewer and the first actual computer-use action initialize :0 lazily.
@@ -25,6 +26,7 @@ import {
   commitWarmingToWarm,
   failWarmingToCold,
   getSandboxSessionEnvelope,
+  markWarmLeaseInstanceLost,
   persistWarmSnapshot,
   readLease,
   recordWarmingSandboxCreated,
@@ -36,6 +38,8 @@ import {
 } from "@opengeni/db";
 import {
   establishSandboxSessionFromEnvelope,
+  isProviderSandboxNotFoundError,
+  SandboxResumeStateUnavailableError,
   serializeEstablishedSandboxEnvelope,
   deletePriorPersistedSnapshot,
   tagModalSandbox,
@@ -68,6 +72,12 @@ export type SandboxResumeServices = {
   db: Database;
   settings: Settings;
   sandboxMetrics?: RuntimeMetricsHooks;
+  /** Called only by the observer that wins the exact warm->cold loss CAS. */
+  onSandboxLost?: (input: {
+    sandboxGroupId: string;
+    instanceId: string;
+    leaseEpoch: number;
+  }) => Promise<void>;
 };
 
 export type ResumeBoxIds = {
@@ -135,6 +145,20 @@ export class SandboxWarmingTimeoutError extends Error {
       `Sandbox backend "${backend}" capacity or creation timed out after ${Math.ceil(timeoutMs / 1000)}s while warming the sandbox lease. Please try again; if this persists, sandbox capacity may be exhausted.`,
     );
     this.name = "SandboxWarmingTimeoutError";
+  }
+}
+
+/** The exact attached caller that won warm->cold after proving the provider
+ * instance gone. It is a lease supersession (the same logical turn recovers),
+ * plus the lost id needed for one durable observability event. */
+export class SandboxLeaseInstanceLostError extends SandboxLeaseSupersededError {
+  constructor(
+    sandboxGroupId: string,
+    leaseEpoch: number,
+    public readonly lostInstanceId: string,
+  ) {
+    super(sandboxGroupId, leaseEpoch);
+    this.name = "SandboxLeaseInstanceLostError";
   }
 }
 
@@ -554,6 +578,7 @@ export async function resumeBoxForTurn(
       const spawnEnvelope = acquired.lease.resumeState ?? envelope;
       const established = await establishSandboxSessionFromEnvelope(settings, spawnEnvelope, {
         sessionId: ids.sessionId,
+        recovery: "create-or-restore",
         backendOverride: ids.backend as never,
         ...(ids.environment ? { environment: ids.environment } : {}),
         ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
@@ -673,14 +698,54 @@ export async function resumeBoxForTurn(
     // manifest into a rival. Fall back to the session envelope only when the
     // lease carries no resume_state (matches channel-a.ts's attached branch).
     const live = await readLease(db, ids.workspaceId, ids.sandboxGroupId);
-    const envelope =
-      live?.resumeState ?? (await getSandboxSessionEnvelope(db, ids.workspaceId, ids.sessionId));
-    const established = await establishSandboxSessionFromEnvelope(settings, envelope, {
-      sessionId: ids.sessionId,
-      backendOverride: ids.backend as never,
-      ...(ids.environment ? { environment: ids.environment } : {}),
-      ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
-    });
+    if (
+      !live ||
+      live.liveness !== "warm" ||
+      live.leaseEpoch !== leaseEpoch ||
+      live.instanceId === null
+    ) {
+      throw new SandboxLeaseSupersededError(ids.sandboxGroupId, live?.leaseEpoch ?? leaseEpoch);
+    }
+    let established: EstablishedSandboxSession;
+    try {
+      established = await establishSandboxSessionFromEnvelope(settings, live.resumeState, {
+        sessionId: ids.sessionId,
+        recovery: "resume-only",
+        backendOverride: ids.backend as never,
+        ...(ids.environment ? { environment: ids.environment } : {}),
+        ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
+      });
+    } catch (error) {
+      if (
+        !(error instanceof SandboxResumeStateUnavailableError) &&
+        !isProviderSandboxNotFoundError(ids.backend, error)
+      ) {
+        throw error;
+      }
+      const marked = await markWarmLeaseInstanceLost(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.sandboxGroupId,
+        expectedEpoch: leaseEpoch,
+        expectedInstanceId: live.instanceId,
+      });
+      if (marked.status === "marked") {
+        await services.onSandboxLost?.({
+          sandboxGroupId: ids.sandboxGroupId,
+          instanceId: live.instanceId,
+          leaseEpoch: marked.lease.leaseEpoch,
+        });
+        throw new SandboxLeaseInstanceLostError(
+          ids.sandboxGroupId,
+          marked.lease.leaseEpoch,
+          live.instanceId,
+        );
+      }
+      throw new SandboxLeaseSupersededError(
+        ids.sandboxGroupId,
+        marked.lease?.leaseEpoch ?? leaseEpoch,
+      );
+    }
     return { established, leaseEpoch, release };
   } catch (error) {
     await release();

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -1320,6 +1320,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     try {
       established = await establishSandboxSessionFromEnvelope(settings, null, {
         sessionId: ws.groupId,
+        recovery: "create-or-restore",
         backendOverride: "modal",
       });
       // Fold the box onto the lease via the SAME serializer production uses

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -27,6 +27,7 @@ import {
   commitWarmingToWarm,
   createDb,
   heartbeatLeaseHolder,
+  markWarmLeaseInstanceLost,
   readLease,
   SandboxImageConflictError,
   type Database,
@@ -234,6 +235,112 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
     // both released -> draining.
     const row = await readRow(workspaceId, groupId);
     expect(row?.liveness).toBe("draining");
+  }, 60_000);
+
+  test("(2b) concurrent observers of one missing warm instance elect exactly one replacement owner", async () => {
+    if (!available) return;
+    const settings = settingsFor(true);
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const oldInstanceId = "box-dead";
+    const oldEpoch = 7;
+    const archive = Buffer.from("durable-workspace").toString("base64");
+    const resumeState = JSON.stringify({
+      backendId: "unix_local",
+      sessionState: {
+        providerState: { instanceId: oldInstanceId },
+        workspaceArchive: archive,
+      },
+    });
+    const [lease] = await admin<{ id: string }[]>`
+      insert into sandbox_leases (
+        account_id, workspace_id, sandbox_group_id, liveness, refcount,
+        turn_holders, viewer_holders, instance_id, backend, lease_epoch,
+        resume_backend_id, resume_state, expires_at
+      ) values (
+        ${accountId}, ${workspaceId}, ${groupId}, 'warm', 10,
+        10, 0, ${oldInstanceId}, 'local', ${oldEpoch},
+        'unix_local', ${resumeState}::text::jsonb, now() + interval '60 seconds'
+      ) returning id`;
+    for (let index = 0; index < 10; index += 1) {
+      await admin`
+        insert into sandbox_lease_holders (
+          account_id, workspace_id, lease_id, kind, holder_id, last_heartbeat_at
+        ) values (
+          ${accountId}, ${workspaceId}, ${lease!.id}, 'turn',
+          ${sandboxLeaseHolderIdForAttempt(`observer-${index}`)}, now()
+        )`;
+    }
+
+    const marks = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        markWarmLeaseInstanceLost(db, {
+          accountId,
+          workspaceId,
+          sandboxGroupId: groupId,
+          expectedEpoch: oldEpoch,
+          expectedInstanceId: oldInstanceId,
+        }),
+      ),
+    );
+    expect(marks.filter((result) => result.status === "marked")).toHaveLength(1);
+    expect(marks.filter((result) => result.status === "stale")).toHaveLength(9);
+
+    const [retired] = await admin<
+      {
+        liveness: string;
+        lease_epoch: number;
+        instance_id: string | null;
+        refcount: number;
+        archive: string | null;
+        dead_id: string | null;
+      }[]
+    >`
+      select liveness, lease_epoch, instance_id, refcount,
+             resume_state #>> '{sessionState,workspaceArchive}' as archive,
+             resume_state #>> '{sessionState,providerState,instanceId}' as dead_id
+      from sandbox_leases
+      where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+    expect(retired).toMatchObject({
+      liveness: "cold",
+      lease_epoch: oldEpoch + 1,
+      instance_id: null,
+      refcount: 10,
+      archive,
+      dead_id: null,
+    });
+
+    const admissions = await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        acquireLease(db, {
+          accountId,
+          workspaceId,
+          sandboxGroupId: groupId,
+          kind: "turn",
+          holderId: sandboxLeaseHolderIdForAttempt(`replacement-${index}`),
+          backend: "local",
+          leaseTtlMs: settings.sandboxLeaseTtlMs,
+          warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
+        }),
+      ),
+    );
+    expect(admissions.filter((result) => result.role === "spawner")).toHaveLength(1);
+    expect(admissions.filter((result) => result.role === "attached")).toHaveLength(9);
+    const winner = admissions.find((result) => result.role === "spawner")!;
+    const committed = await commitWarmingToWarm(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: winner.lease.leaseEpoch,
+      instanceId: "box-replacement",
+      resumeBackendId: "unix_local",
+      resumeState: {
+        backendId: "unix_local",
+        sessionState: { providerState: { instanceId: "box-replacement" } },
+      },
+      leaseTtlMs: settings.sandboxLeaseTtlMs,
+    });
+    expect(committed.committed).toBe(true);
+    expect(committed.lease?.instanceId).toBe("box-replacement");
   }, 60_000);
 
   test("(3) epoch fence on the HEARTBEAT path: a re-establish bumps lease_epoch -> the stale holder's heartbeat is rejected (self-evicts)", async () => {

--- a/docs/design/session-control-plane-clean-cutover-2026-07-13.md
+++ b/docs/design/session-control-plane-clean-cutover-2026-07-13.md
@@ -264,6 +264,38 @@ wake ordering. Round 31 restored first-class attempt ownership, found the cutove
 for `requires_action` workflows, and specified the durable usage-classification boundary.
 All three ended `SHIP-TO-IMPLEMENT`; later rounds explicitly corrected earlier mistakes.
 
+### 3.7 Why one dead shared sandbox produced dozens of live containers
+
+The first production remediation correctly replaced workflow-local activity IDs with
+globally unique turn-attempt lease holders. Under resumed load, the holder invariant was
+healthy—174 turn holders mapped to 174 distinct attempt identities with no refcount
+mismatch—but one shared group still produced 70 provider-loss observations and roughly
+70 fresh Modal containers in minutes.
+
+All affected sessions held the same warm lease and the same dead provider instance. The
+runtime helper used by both the elected lease spawner and ordinary attached callers
+automatically created a replacement after provider NotFound. Each attached turn therefore
+created its own untracked replacement, while none owned the warming lease transition or
+could commit the replacement. The authoritative lease stayed warm and continued pointing
+at the original dead instance, so every retry repeated the fan-out.
+
+Creation authority is now explicit and has no compatibility fallback:
+
+1. only the caller that wins the database `cold -> warming` transition uses
+   `create-or-restore`;
+2. attached turns, Channel-A operations, and desktop/terminal stream resolution use
+   `resume-only` and can never call provider create;
+3. the first attached observer that proves the exact warm `(epoch, instance)` missing
+   atomically transitions that lease to cold, advances the epoch, clears dead identity
+   and tunnel data, and preserves only the durable workspace archives;
+4. concurrent observers become stale no-ops, release their holders, and recover/retry;
+5. the next ordinary admission elects exactly one replacement spawner; and
+6. only the winning loss transition emits the durable `sandbox.box.lost` evidence.
+
+A real-Postgres concurrency proof drives ten observers against one dead warm instance:
+exactly one marks it cold, nine classify stale, then exactly one admission becomes the
+replacement spawner while nine attach. No attached path creates a provider box.
+
 ## 4. Locked product semantics
 
 ### 4.1 Prompt queue
@@ -411,6 +443,13 @@ context. They are never prompt queue rows.
   many updates arrived.
 - Additional updates coalesce into the same pending bundle rather than creating twenty
   sequential machine turns.
+- A failed ordinary update-only inference moves its attached updates to `deferred`: they
+  remain outstanding model context but are not independently eligible to manufacture the
+  same continuation again. An exact duplicate of a deferred update does not wake the
+  session. The next genuinely new pending update or human inference attaches both pending
+  and deferred updates in one bundle.
+- A failed goal-continuation update is terminal `failed`; cancellation or supersession
+  returns attached updates to `pending` because that attempt did not adjudicate them.
 - Updates wait for the next fresh inference; they are never injected into a live
   inference. Important failure/action-required state is visible in the UI immediately.
 - If a human prompt is waiting, that prompt claims first and carries the update bundle.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2117,7 +2117,13 @@ export const SessionSystemUpdateKind = z.enum([
 ]);
 export type SessionSystemUpdateKind = z.infer<typeof SessionSystemUpdateKind>;
 
-export const SessionSystemUpdateState = z.enum(["pending", "delivered", "cancelled", "failed"]);
+export const SessionSystemUpdateState = z.enum([
+  "pending",
+  "deferred",
+  "delivered",
+  "cancelled",
+  "failed",
+]);
 export type SessionSystemUpdateState = z.infer<typeof SessionSystemUpdateState>;
 
 export const SessionSystemUpdate = z.object({

--- a/packages/db/drizzle/0060_session_system_update_deferral.sql
+++ b/packages/db/drizzle/0060_session_system_update_deferral.sql
@@ -1,0 +1,10 @@
+-- A failed internal-only inference preserves ordinary internal updates without
+-- making them independently runnable again. They become eligible when a real
+-- prompt or a genuinely new pending internal update starts the next inference.
+
+ALTER TABLE "session_system_updates"
+  DROP CONSTRAINT "system_updates_state_check";
+
+ALTER TABLE "session_system_updates"
+  ADD CONSTRAINT "system_updates_state_check"
+  CHECK ("state" IN ('pending', 'deferred', 'delivered', 'cancelled', 'failed'));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17685,7 +17685,7 @@ export async function claimSessionWorkForAttempt(
               and(
                 eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
                 eq(schema.sessionSystemUpdates.sessionId, sessionId),
-                eq(schema.sessionSystemUpdates.state, "pending"),
+                inArray(schema.sessionSystemUpdates.state, ["pending", "deferred"]),
               ),
             )
             .orderBy(
@@ -18983,8 +18983,15 @@ export async function applySessionTurnSettlement(
           turn,
         );
       }
-      if (["failed", "cancelled", "superseded"].includes(input.turnStatus)) {
-        await rependSessionSystemUpdatesForTurnTx(
+      if (input.turnStatus === "failed") {
+        await deferFailedSessionSystemUpdatesForTurnTx(
+          tx as unknown as Database,
+          workspaceId,
+          input.sessionId,
+          input.turnId,
+        );
+      } else if (["cancelled", "superseded"].includes(input.turnStatus)) {
+        await requeueInterruptedSessionSystemUpdatesForTurnTx(
           tx as unknown as Database,
           workspaceId,
           input.sessionId,
@@ -19244,7 +19251,7 @@ export async function settleCodexCredentialLeaseLoss(
             ),
           );
         if (!input.checkpointDurable) {
-          await rependSessionSystemUpdatesForTurnTx(
+          await deferFailedSessionSystemUpdatesForTurnTx(
             tx as unknown as Database,
             input.workspaceId,
             input.sessionId,
@@ -20941,7 +20948,7 @@ export async function addSessionSystemUpdate(
   return await addSessionSystemUpdateWithSourceMutation(db, input, async () => undefined);
 }
 
-async function rependSessionSystemUpdatesForTurnTx(
+async function requeueInterruptedSessionSystemUpdatesForTurnTx(
   tx: Database,
   workspaceId: string,
   sessionId: string,
@@ -20950,6 +20957,36 @@ async function rependSessionSystemUpdatesForTurnTx(
   await tx
     .update(schema.sessionSystemUpdates)
     .set({ state: "pending", deliveredTurnId: null, deliveredAt: null })
+    .where(
+      and(
+        eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
+        eq(schema.sessionSystemUpdates.sessionId, sessionId),
+        eq(schema.sessionSystemUpdates.deliveredTurnId, turnId),
+        eq(schema.sessionSystemUpdates.state, "delivered"),
+      ),
+    );
+}
+
+/**
+ * A failed internal-only inference must not manufacture another inference by
+ * making its inputs immediately runnable again. Preserve ordinary internal
+ * updates as deferred input for the next real prompt/new update. Goal
+ * continuation notices are derivable from the durable goal and become terminal
+ * so the goal evaluator can pause or synthesize the next valid continuation.
+ */
+async function deferFailedSessionSystemUpdatesForTurnTx(
+  tx: Database,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<void> {
+  await tx
+    .update(schema.sessionSystemUpdates)
+    .set({
+      state: sql`case when ${schema.sessionSystemUpdates.payload} ->> 'type' = 'goal_continuation' then 'failed' else 'deferred' end`,
+      deliveredTurnId: null,
+      deliveredAt: null,
+    })
     .where(
       and(
         eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
@@ -21105,7 +21142,7 @@ export async function addSessionSystemUpdateWithSourceMutation(
   );
 }
 
-export async function listPendingSessionSystemUpdates(
+export async function listOutstandingSessionSystemUpdates(
   db: Database,
   workspaceId: string,
   sessionId: string,
@@ -21118,7 +21155,7 @@ export async function listPendingSessionSystemUpdates(
         and(
           eq(schema.sessionSystemUpdates.workspaceId, workspaceId),
           eq(schema.sessionSystemUpdates.sessionId, sessionId),
-          eq(schema.sessionSystemUpdates.state, "pending"),
+          inArray(schema.sessionSystemUpdates.state, ["pending", "deferred"]),
         ),
       )
       .orderBy(asc(schema.sessionSystemUpdates.createdAt), asc(schema.sessionSystemUpdates.id));
@@ -22309,7 +22346,7 @@ export async function enqueueSessionMessageAtomically(
               updatedAt: now,
             })
             .where(eq(schema.sessionTurns.id, currentTurn.id));
-          await rependSessionSystemUpdatesForTurnTx(
+          await requeueInterruptedSessionSystemUpdatesForTurnTx(
             tx as unknown as Database,
             input.workspaceId,
             session.id,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13511,6 +13511,92 @@ export async function recordWarmingSandboxCreated(
   );
 }
 
+export type MarkWarmLeaseInstanceLostResult =
+  | { status: "marked"; lease: LeaseSnapshot }
+  | { status: "stale"; lease: LeaseSnapshot | null };
+
+/**
+ * Atomically retire one exact warm provider instance after a resume-only caller
+ * receives a provider NotFound. The epoch + instance predicates are the
+ * ownership fence: concurrent attached callers may all observe the same missing
+ * box, but only the first one transitions the lease to cold and advances its
+ * epoch. The next ordinary acquire elects one cold->warming spawner.
+ *
+ * Holders remain intact because their logical work/viewer interest still exists.
+ * Only live provider identity is cleared. A persisted workspace archive is
+ * reduced to the same minimal cold envelope used by the drain/failure paths, so
+ * the elected replacement can hydrate it without carrying the dead box id.
+ */
+export async function markWarmLeaseInstanceLost(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sandboxGroupId: string;
+    expectedEpoch: number;
+    expectedInstanceId: string;
+  },
+): Promise<MarkWarmLeaseInstanceLostResult> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) =>
+      await scopedDb.transaction(async (txRaw) => {
+        const tx = txRaw as unknown as Database;
+        const currentRows = await tx.execute<LeaseRow>(sql`
+          select * from sandbox_leases
+          where workspace_id = ${input.workspaceId}
+            and sandbox_group_id = ${input.sandboxGroupId}
+          for update
+        `);
+        const current = currentRows[0];
+        if (
+          !current ||
+          current.liveness !== "warm" ||
+          Number(current.lease_epoch) !== input.expectedEpoch ||
+          current.instance_id !== input.expectedInstanceId
+        ) {
+          return {
+            status: "stale" as const,
+            lease: current ? mapLeaseRow(current) : null,
+          };
+        }
+
+        const updatedRows = await tx.execute<LeaseRow>(sql`
+          update sandbox_leases set
+            liveness = 'cold',
+            instance_id = null,
+            data_plane_url = null,
+            terminal_data_plane_url = null,
+            lease_epoch = lease_epoch + 1,
+            resume_state = case
+              when (resume_state #>> '{sessionState,workspaceArchive}') is not null
+                then jsonb_build_object(
+                  'backendId', coalesce(resume_state ->> 'backendId', to_jsonb(resume_backend_id) #>> '{}'),
+                  'sessionState', jsonb_strip_nulls(jsonb_build_object(
+                    'workspaceArchive', resume_state #> '{sessionState,workspaceArchive}',
+                    'workspaceArchivePrev', resume_state #> '{sessionState,workspaceArchivePrev}',
+                    'workspaceArchiveAt', resume_state #> '{sessionState,workspaceArchiveAt}')))
+              else null
+            end,
+            resume_backend_id = case
+              when (resume_state #>> '{sessionState,workspaceArchive}') is not null
+                then resume_backend_id
+              else null
+            end,
+            updated_at = now()
+          where id = ${current.id}
+          returning *
+        `);
+        const updated = updatedRows[0];
+        if (!updated) {
+          throw new Error(`Warm sandbox lease vanished while retiring instance ${current.id}`);
+        }
+        return { status: "marked" as const, lease: mapLeaseRow(updated) };
+      }),
+  );
+}
+
 // §4.3 — caught spawn failure: warming -> cold (W3). Holders are intentionally
 // left intact — the arrival that triggered the spawn still wants a box, so the
 // next acquireLease re-CAS cold->warming.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1103,6 +1103,10 @@ export const sessionSystemUpdates = pgTable(
     summary: text("summary").notNull(),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull().default({}),
     lineage: jsonb("lineage").$type<Record<string, unknown>>().notNull().default({}),
+    // pending: eligible to start/attach to an inference; deferred: preserved
+    // after a failed internal-only inference but dormant until a real prompt or
+    // a genuinely new pending update arrives; delivered/cancelled/failed are
+    // terminal for that delivery attempt.
     state: text("state").notNull().default("pending"),
     deliveredTurnId: uuid("delivered_turn_id").references(() => sessionTurns.id, {
       onDelete: "set null",

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -14,13 +14,16 @@ import {
   claimSessionWorkForAttempt,
   createDb,
   createSession,
+  createSessionGoal,
   enqueueSessionMessageAtomically,
   getSessionQueueSnapshot,
   getBillingBalance,
   getActiveSessionHistoryItems,
   getSession,
   getSessionTurn,
-  listPendingSessionSystemUpdates,
+  listEnrollableSessions,
+  listOutstandingSessionSystemUpdates,
+  listSessionSystemUpdatesForTurn,
   listUsageEvents,
   isSessionCompactionRequested,
   peekSessionWork,
@@ -715,11 +718,202 @@ describe("clean session control plane", () => {
     expect(first.reason).toBe("added");
     expect(duplicate.reason).toBe("duplicate");
     expect(
-      await listPendingSessionSystemUpdates(client.db, grant.workspaceId!, session.id),
+      await listOutstandingSessionSystemUpdates(client.db, grant.workspaceId!, session.id),
     ).toHaveLength(1);
     expect(
       (await getSessionQueueSnapshot(client.db, grant.workspaceId!, session.id))?.items,
     ).toHaveLength(0);
+  });
+
+  test("failed internal-only inference defers updates until a real prompt", async () => {
+    const { grant, session } = await fixture();
+    const update = await addSessionSystemUpdate(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      kind: "child_session_update",
+      classification: "success",
+      sourceId: crypto.randomUUID(),
+      dedupeKey: `child-${crypto.randomUUID()}`,
+      summary: "Child completed",
+      payload: { status: "completed" },
+    });
+    if (!update.added) throw new Error("system update was not inserted");
+
+    const failedAttemptId = crypto.randomUUID();
+    const internalTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: failedAttemptId },
+    );
+    expect(internalTurn).toMatchObject({ source: "system", status: "running" });
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: internalTurn!.id,
+      triggerEventId: internalTurn!.triggerEventId,
+      attemptId: failedAttemptId,
+      childCompletionParentWakeEnabled: false,
+      turnStatus: "failed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [
+        { type: "turn.failed", payload: { error: "provider unavailable" } },
+        { type: "session.status.changed", payload: { status: "idle" } },
+      ],
+    });
+
+    expect(
+      await listOutstandingSessionSystemUpdates(client.db, grant.workspaceId!, session.id),
+    ).toMatchObject([{ id: update.update.id, state: "deferred", deliveredTurnId: null }]);
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "idle",
+    });
+    expect(
+      (await listEnrollableSessions(client.db, 10_000)).some(
+        (entry) => entry.sessionId === session.id,
+      ),
+    ).toBe(false);
+
+    const prompt = await send(grant, session.id, "Use the child result now");
+    const promptTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+    );
+    expect(promptTurn?.id).toBe(prompt.turn.id);
+    expect(
+      await listSessionSystemUpdatesForTurn(
+        client.db,
+        grant.workspaceId!,
+        session.id,
+        promptTurn!.id,
+      ),
+    ).toMatchObject([{ id: update.update.id, state: "delivered" }]);
+  });
+
+  test("a new internal update collapses deferred updates into one inference", async () => {
+    const { grant, session } = await fixture();
+    const first = await addSessionSystemUpdate(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      kind: "child_session_update",
+      classification: "failure",
+      sourceId: crypto.randomUUID(),
+      dedupeKey: `child-${crypto.randomUUID()}`,
+      summary: "First child failed",
+      payload: { status: "failed" },
+    });
+    if (!first.added) throw new Error("first system update was not inserted");
+    const failedAttemptId = crypto.randomUUID();
+    const failedTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: failedAttemptId },
+    );
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: failedTurn!.id,
+      triggerEventId: failedTurn!.triggerEventId,
+      attemptId: failedAttemptId,
+      childCompletionParentWakeEnabled: false,
+      turnStatus: "failed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [{ type: "turn.failed", payload: { error: "provider unavailable" } }],
+    });
+
+    const second = await addSessionSystemUpdate(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      kind: "child_session_update",
+      classification: "success",
+      sourceId: crypto.randomUUID(),
+      dedupeKey: `child-${crypto.randomUUID()}`,
+      summary: "Second child completed",
+      payload: { status: "completed" },
+    });
+    if (!second.added) throw new Error("second system update was not inserted");
+    const retryTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+    );
+    expect(retryTurn).toMatchObject({ source: "system", metadata: { internalUpdateCount: 2 } });
+    expect(
+      (
+        await listSessionSystemUpdatesForTurn(
+          client.db,
+          grant.workspaceId!,
+          session.id,
+          retryTurn!.id,
+        )
+      ).map((entry) => entry.id),
+    ).toEqual(expect.arrayContaining([first.update.id, second.update.id]));
+  });
+
+  test("a failed goal-continuation notice is terminal instead of replayable", async () => {
+    const { grant, session } = await fixture();
+    const goal = await createSessionGoal(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      text: "Finish the task",
+      createdBy: "api",
+    });
+    const update = await addSessionSystemUpdate(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      kind: "lifecycle_event",
+      classification: "info",
+      sourceId: goal.id,
+      dedupeKey: `goal-continuation:${goal.id}:${goal.version}:1`,
+      summary: "Continue the goal",
+      payload: {
+        type: "goal_continuation",
+        goalId: goal.id,
+        goalVersion: goal.version,
+        autoContinuation: 1,
+      },
+    });
+    if (!update.added) throw new Error("goal update was not inserted");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn!.id,
+      triggerEventId: turn!.triggerEventId,
+      attemptId,
+      childCompletionParentWakeEnabled: false,
+      turnStatus: "failed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [{ type: "turn.failed", payload: { error: "policy blocked" } }],
+    });
+    const [stored] = await withWorkspaceRls(client.db, grant.workspaceId!, async (db) =>
+      db
+        .select({ state: schema.sessionSystemUpdates.state })
+        .from(schema.sessionSystemUpdates)
+        .where(eq(schema.sessionSystemUpdates.id, update.update.id)),
+    );
+    expect(stored?.state).toBe("failed");
+    expect(
+      await listOutstandingSessionSystemUpdates(client.db, grant.workspaceId!, session.id),
+    ).toEqual([]);
   });
 
   test("idle manual compaction is a born-running maintenance execution, never queue work", async () => {
@@ -777,7 +971,7 @@ describe("clean session control plane", () => {
     );
     expect(claimedCompaction?.source).toBe("compaction");
     expect(
-      await listPendingSessionSystemUpdates(
+      await listOutstandingSessionSystemUpdates(
         client.db,
         updateCase.grant.workspaceId!,
         updateCase.session.id,

--- a/packages/runtime/src/sandbox/errors.ts
+++ b/packages/runtime/src/sandbox/errors.ts
@@ -17,6 +17,19 @@ export class SandboxConfigError extends Error {
   }
 }
 
+/** A resume-only caller was handed a warm lease without a provider identity it
+ * can resume. The lease-aware caller must retire that exact epoch and re-enter
+ * admission; silently creating here would bypass the single-spawner guard. */
+export class SandboxResumeStateUnavailableError extends Error {
+  readonly backend: SandboxBackend | string;
+
+  constructor(backend: SandboxBackend | string) {
+    super(`Sandbox lease for backend "${backend}" has no resumable provider identity`);
+    this.name = "SandboxResumeStateUnavailableError";
+    this.backend = backend;
+  }
+}
+
 // Thrown by a provider's build() when its SDK client class is genuinely not
 // available in the installed @openai/agents-extensions. Per the P0.3 ruling we
 // NEVER fake a build body; if a provider cannot be constructed we register the

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -31,7 +31,7 @@ import type {
   SandboxSessionState,
 } from "@openai/agents/sandbox";
 import { PROVIDER_REGISTRY } from "./providers";
-import { SandboxConfigError } from "./errors";
+import { SandboxConfigError, SandboxResumeStateUnavailableError } from "./errors";
 import { isSelfhostedProviderNotFoundError } from "./selfhosted/session";
 import type { RuntimeMetricsHooks } from "../metrics";
 
@@ -51,7 +51,11 @@ export {
   assertDescriptorRegistryInvariants,
   type CapabilityDescriptor,
 } from "./capabilities";
-export { SandboxConfigError, SandboxProviderUnavailableError } from "./errors";
+export {
+  SandboxConfigError,
+  SandboxProviderUnavailableError,
+  SandboxResumeStateUnavailableError,
+} from "./errors";
 export {
   PROVIDER_REGISTRY,
   assertProviderRegistryInvariants,
@@ -684,14 +688,18 @@ export async function deserializeSandboxSessionStateEnvelope(
 // The ONE resume / recovery primitive (P1.2).
 //
 // establishSandboxSessionFromEnvelope is the single re-establish-from-envelope
-// path the stateless model leans on: a turn (or any API-direct op) resolves the
-// group lease, hands us the recovery envelope, and gets back a LIVE non-owned
-// session. On a warm box this is a no-lock warm reattach by id (Modal fromId,
-// e2b reconnect — R4-safe, a stray second handle never spawns a second box).
-// When the provider reports the box genuinely gone (NotFound) we cold-restore
-// from the snapshot via create(). NEVER create() on any OTHER resume error
-// (only on NotFound) — a resume-conflict means the box is alive and the caller
-// must back off, not spawn a rival.
+// path the stateless model leans on. Creation authority is explicit:
+//
+//   - `create-or-restore` is reserved for the caller that won the durable
+//     cold->warming lease transition. It may create a cold box, or replace a
+//     resumable box that the provider proves is gone.
+//   - `resume-only` is for attached turns and API-direct operations. It may
+//     resume the leased box by id, but a provider NotFound propagates to the
+//     caller so the lease can be atomically marked cold. It NEVER creates.
+//
+// This ownership boundary is the double-spawn guard. A provider NotFound alone
+// is not creation authority: many attached callers can observe the same dead id
+// concurrently, while only one caller may own cold->warming.
 // ============================================================================
 
 /** A live, externally-owned sandbox session re-established from the group lease
@@ -711,8 +719,8 @@ export type EstablishedSandboxSession = {
    *  2026-07-06 incidents near-unattributable. Optional so external/legacy
    *  constructors of this shape stay valid. */
   origin?: "resumed" | "created" | "restored";
-  /** Set when a warm reattach found the envelope's box GONE (provider NotFound)
-   *  and fell through to cold-restore: the id of the box that was lost. */
+  /** Set when a create-authorized reattach found the envelope's box GONE
+   *  (provider NotFound) and fell through to cold-restore. */
   lostInstanceId?: string;
 };
 
@@ -803,7 +811,12 @@ export function isProviderSandboxNotFoundError(backendId: string, error: unknown
 function readInstanceId(session: unknown): string {
   const state = (session as { state?: Record<string, unknown> }).state ?? {};
   const candidate =
-    state.sandboxId ?? state.instanceId ?? state.id ?? state.hostId ?? state.containerId;
+    state.sandboxId ??
+    state.instanceId ??
+    state.id ??
+    state.hostId ??
+    state.containerId ??
+    state.workspaceRootPath;
   return typeof candidate === "string" && candidate.length > 0 ? candidate : "";
 }
 
@@ -834,24 +847,24 @@ async function terminateCreatedSandbox(
 }
 
 /**
- * Resume the one box by id from its recovery envelope, or cold-restore from the
- * snapshot when the provider reports it gone. The envelope is the lease's
- * box-identity descriptor (the same per-turn `_sandbox` envelope upserted by the
- * turn activity). A null envelope means a cold session that was never warmed →
- * create() directly.
+ * Establish from one recovery envelope under an explicit creation policy. The
+ * envelope is the lease's box-identity descriptor (the same per-turn `_sandbox`
+ * envelope upserted by the turn activity).
  *
  *  - `opts.backendOverride ?? envelope.backendId ?? settings.sandboxBackend`
  *    selects the backend; the client is built for THAT backend (resume-by-id is
  *    fenced to the original provider).
  *  - warm reattach: deserialize the envelope sessionState → client.resume(state)
- *    (no lock; R4-safe). On a provider NotFound, cold-restore via create().
- *  - cold restore / cold session: client.create() — the ONLY create() site.
+ *    (no lock; R4-safe). `resume-only` propagates provider NotFound.
+ *  - `create-or-restore`: the elected owner may replace a missing warm instance,
+ *    or create directly from a cold/null envelope.
  */
 export async function establishSandboxSessionFromEnvelope(
   settings: Settings,
   envelope: Record<string, unknown> | null,
   opts: {
     sessionId: string;
+    recovery: "create-or-restore" | "resume-only";
     backendOverride?: SandboxBackend;
     environment?: Record<string, string>;
     onSandboxCreated?: SandboxCreatedCallback;
@@ -872,7 +885,7 @@ export async function establishSandboxSessionFromEnvelope(
       `Cannot establish a sandbox session for backend "${backend}" (no client; sandboxBackend=none?)`,
     );
   }
-  if (!client.create) {
+  if (opts.recovery === "create-or-restore" && !client.create) {
     throw new SandboxConfigError(backend, `Sandbox backend "${backend}" does not support create()`);
   }
 
@@ -1037,7 +1050,8 @@ export async function establishSandboxSessionFromEnvelope(
     (envelopeProviderState.sandboxId ||
       envelopeProviderState.instanceId ||
       envelopeProviderState.id ||
-      envelopeProviderState.containerId),
+      envelopeProviderState.containerId ||
+      envelopeProviderState.workspaceRootPath),
   );
 
   // (a) WARM REATTACH BY ID — only when the envelope carries a resumable box id.
@@ -1071,10 +1085,14 @@ export async function establishSandboxSessionFromEnvelope(
           origin: "resumed",
         };
       } catch (error) {
-        // ONLY a provider NotFound (box gone) licenses a cold-restore. Anything
-        // else (transient/auth/network/resume-conflict) propagates: the caller
-        // backs off and re-fences — NEVER spawns a rival box.
-        if (!isProviderSandboxNotFoundError(client.backendId, error)) {
+        // Attached callers never own replacement. Propagate the provider
+        // NotFound so their lease-aware caller can atomically mark this exact
+        // warm epoch/instance cold and re-enter normal admission. Only the
+        // cold->warming winner may replace the missing box.
+        if (
+          !isProviderSandboxNotFoundError(client.backendId, error) ||
+          opts.recovery === "resume-only"
+        ) {
           throw error;
         }
         // COLD-RESTORE: the box is genuinely gone. Modal does NOT restore via
@@ -1090,6 +1108,7 @@ export async function establishSandboxSessionFromEnvelope(
           envelopeProviderState?.instanceId,
           envelopeProviderState?.id,
           envelopeProviderState?.containerId,
+          envelopeProviderState?.workspaceRootPath,
         ].find((value): value is string => typeof value === "string" && value.length > 0);
         const restoredSession = await coldRestore(resumedState);
         return lostInstanceId ? { ...restoredSession, lostInstanceId } : restoredSession;
@@ -1102,6 +1121,9 @@ export async function establishSandboxSessionFromEnvelope(
   // envelope confirmDrainCold preserves across draining->cold), replay it so
   // /workspace survives the box churn (sandbox-file-persistence). No archive -> a
   // clean empty box (a never-warmed session).
+  if (opts.recovery === "resume-only") {
+    throw new SandboxResumeStateUnavailableError(backend);
+  }
   return await coldRestore();
 }
 

--- a/packages/runtime/test/cold-restore-hydrate.test.ts
+++ b/packages/runtime/test/cold-restore-hydrate.test.ts
@@ -69,6 +69,7 @@ const {
   establishSandboxSessionFromEnvelope,
   readWorkspaceArchiveFromEnvelopeSessionState,
   decodeModalSnapshotId,
+  SandboxResumeStateUnavailableError,
 } = await import("@opengeni/runtime");
 const { testSettings } = await import("@opengeni/testing");
 
@@ -131,6 +132,30 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
     expect(decodeModalSnapshotId(new TextEncoder().encode("PKtarbytes"))).toBeUndefined();
   });
 
+  test("resume-only propagates provider NotFound and never creates a replacement", async () => {
+    createArgs.length = 0;
+    await expect(
+      establishSandboxSessionFromEnvelope(modalSettings(), envelopeWithArchive(SNAPSHOT_B64), {
+        sessionId: "sess-attached",
+        recovery: "resume-only",
+        environment: {},
+      }),
+    ).rejects.toThrow(/not found/i);
+    expect(createArgs).toHaveLength(0);
+  });
+
+  test("resume-only rejects a missing provider identity and never creates", async () => {
+    createArgs.length = 0;
+    await expect(
+      establishSandboxSessionFromEnvelope(modalSettings(), null, {
+        sessionId: "sess-invalid-warm-lease",
+        recovery: "resume-only",
+        environment: {},
+      }),
+    ).rejects.toThrow(SandboxResumeStateUnavailableError);
+    expect(createArgs).toHaveLength(0);
+  });
+
   test("cold-restore creates a FRESH box (NO snapshot arg) and hydrates from the lease archive", async () => {
     hydrateCalls.length = 0;
     createArgs.length = 0;
@@ -138,7 +163,7 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
     const established = await establishSandboxSessionFromEnvelope(
       modalSettings(),
       envelopeWithArchive(SNAPSHOT_B64),
-      { sessionId: "sess-cold", environment: {} },
+      { sessionId: "sess-cold", recovery: "create-or-restore", environment: {} },
     );
 
     // (1) create() was called WITHOUT a `snapshot` arg (would throw on Modal).
@@ -158,7 +183,7 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
     const established = await establishSandboxSessionFromEnvelope(
       modalSettings(),
       envelopeWithArchive(undefined),
-      { sessionId: "sess-cold-noarch", environment: {} },
+      { sessionId: "sess-cold-noarch", recovery: "create-or-restore", environment: {} },
     );
 
     expect(createArgs).toHaveLength(1);
@@ -177,7 +202,7 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
       const established = await establishSandboxSessionFromEnvelope(
         modalSettings(),
         envelopeWithArchivePair(SNAPSHOT_B64, SNAPSHOT_PREV_B64),
-        { sessionId: "sess-hydrate-prev", environment: {} },
+        { sessionId: "sess-hydrate-prev", recovery: "create-or-restore", environment: {} },
       );
 
       expect(createArgs).toHaveLength(1);
@@ -200,7 +225,11 @@ describe("cold-restore archive+hydrate (sandbox-file-persistence)", () => {
       const established = await establishSandboxSessionFromEnvelope(
         modalSettings(),
         envelopeWithArchive(SNAPSHOT_B64),
-        { sessionId: "sess-hydrate-fail-open", environment: {} },
+        {
+          sessionId: "sess-hydrate-fail-open",
+          recovery: "create-or-restore",
+          environment: {},
+        },
       );
 
       expect(established.instanceId).toBe("sb-fresh");

--- a/packages/runtime/test/ownership-inversion.test.ts
+++ b/packages/runtime/test/ownership-inversion.test.ts
@@ -152,6 +152,7 @@ describe("P1.2 establishSandboxSessionFromEnvelope (unix_local)", () => {
     const settings = localSettings();
     const established = await establishSandboxSessionFromEnvelope(settings, null, {
       sessionId: "sess-cold",
+      recovery: "create-or-restore",
       backendOverride: "local",
     });
     expect(established.backendId).toBe("unix_local");
@@ -166,6 +167,7 @@ describe("P1.2 establishSandboxSessionFromEnvelope (unix_local)", () => {
     const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
     const established = await establishSandboxSessionFromEnvelope(settings, null, {
       sessionId: "sess-override",
+      recovery: "create-or-restore",
       backendOverride: "local",
     });
     expect(established.backendId).toBe("unix_local");
@@ -201,6 +203,7 @@ describe("P1.2 establishSandboxSessionFromEnvelope (unix_local)", () => {
 
     const established = await establishSandboxSessionFromEnvelope(settings, null, {
       sessionId: "sess-env",
+      recovery: "create-or-restore",
       backendOverride: "local",
       environment: sandboxEnvironment,
     });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1567,7 +1567,12 @@ export type SessionSystemUpdateKind =
   | "lifecycle_event"
   | "runtime_notice";
 
-export type SessionSystemUpdateState = "pending" | "delivered" | "cancelled" | "failed";
+export type SessionSystemUpdateState =
+  | "pending"
+  | "deferred"
+  | "delivered"
+  | "cancelled"
+  | "failed";
 
 export type SessionSystemUpdate = {
   id: string;

--- a/test/e2e/rig-verification.e2e.ts
+++ b/test/e2e/rig-verification.e2e.ts
@@ -214,6 +214,7 @@ async function expectFreshMaterializationHasTool(
   try {
     established = await establishSandboxSessionFromEnvelope(runSettings, null, {
       sessionId: `rig-verification-materialize-${crypto.randomUUID()}`,
+      recovery: "create-or-restore",
       environment: {},
     });
     await runRigSetupHook(established.session as never, {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -30,7 +30,7 @@ import {
   getWorkspaceEnvironmentValuesForRun,
   listSessionEvents,
   listScheduledTasks,
-  listPendingSessionSystemUpdates,
+  listOutstandingSessionSystemUpdates,
   listSessionTurns,
   listSessionMcpServersForRun,
   listUsageEvents,
@@ -5990,7 +5990,7 @@ describe("API component integration", () => {
         .sort(),
     ).toEqual(beforeInternalTurnIds);
     expect(
-      await listPendingSessionSystemUpdates(dbClient.db, grant.workspaceId, created.id),
+      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, created.id),
     ).toEqual([
       expect.objectContaining({
         id: internal.updateId,

--- a/test/integration/durable-queue-control.integration.ts
+++ b/test/integration/durable-queue-control.integration.ts
@@ -12,7 +12,7 @@ import {
   enqueueSessionMessageAtomically,
   getSession,
   getSessionQueueSnapshot,
-  listPendingSessionSystemUpdates,
+  listOutstandingSessionSystemUpdates,
   listSessionEvents,
   listSessionSystemUpdatesForTurn,
   listSessionTurns,
@@ -157,7 +157,7 @@ describe("durable queue control integration (real Postgres/NATS/Temporal)", () =
           true,
         );
         expect(
-          await listPendingSessionSystemUpdates(dbClient.db, grant.workspaceId, session.id),
+          await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, session.id),
         ).toHaveLength(100);
         const urgent = await postUserMessageTurn({
           db: dbClient.db,

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -35,7 +35,7 @@ import {
   getLatestRunState,
   getSessionHistoryItems,
   listSessions,
-  listPendingSessionSystemUpdates,
+  listOutstandingSessionSystemUpdates,
   listSessionTurns,
   listUsageEvents,
   listSessionEvents,
@@ -2146,7 +2146,7 @@ describe("worker activities integration", () => {
       "session.status.changed",
       "system.update.pending",
     ]);
-    const pendingUpdates = await listPendingSessionSystemUpdates(
+    const pendingUpdates = await listOutstandingSessionSystemUpdates(
       dbClient.db,
       grant.workspaceId,
       result.sessionId,
@@ -2384,7 +2384,7 @@ describe("worker activities integration", () => {
     expect(events.filter((event) => event.type === "user.message")).toHaveLength(0);
     expect(events.filter((event) => event.type === "system.update.pending")).toHaveLength(2);
     expect(
-      await listPendingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
+      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, first.sessionId),
     ).toHaveLength(2);
     expect(
       await listSessionTurns(dbClient.db, grant.workspaceId, first.sessionId, 10),

--- a/test/live/sandbox-ownership.live.ts
+++ b/test/live/sandbox-ownership.live.ts
@@ -42,6 +42,7 @@ describe("P1.2 live Modal keystone re-confirm (gated)", () => {
       // Establish a REAL Modal box by id from a cold (null) envelope -> create().
       const established = await establishSandboxSessionFromEnvelope(settings, null, {
         sessionId: `live-keystone-${crypto.randomUUID()}`,
+        recovery: "create-or-restore",
         backendOverride: "modal",
       });
       const session = established.session as {


### PR DESCRIPTION
## Root cause

A failed internal-only inference changed all attached system updates back to `pending`. The workflow enrollment repair therefore started another internal inference immediately. With all Codex subscriptions capped, one session replayed the same 34 child updates more than 80 times.

## Clean contract

- Failed ordinary internal updates become durable `deferred` input and cannot independently enroll/start inference.
- A later human/API prompt or genuinely new pending internal update attaches pending + deferred updates in one inference.
- Failed goal-continuation notices become terminal `failed`; the durable goal remains authoritative.
- Cancelled/superseded attempts still requeue attached updates because another control/prompt is advancing.
- No compatibility alias or legacy execution path.

## Verification

- 36 real-Postgres session control-plane tests
- 19-project TypeScript check
- repo-wide format check (766 files)
- 3 real Postgres/NATS/Temporal durable queue/recovery tests
- 41 worker-activity integration tests
- UBS changed-hunk triage clean (whole-file findings were pre-existing scanner noise)
- Claude Code Fable durable review: approved