### PR TITLE
fix(worker): preserve recovery state across provider and worker loss

### DIFF
--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -321,23 +321,36 @@ function recordSandboxWarmingTimeout(
   }
 }
 
-function workspaceArchiveFromEnvelope(
+function workspaceArchiveFieldsFromEnvelope(
   envelope: Record<string, unknown> | null | undefined,
-): string | null {
+): Record<string, string> | null {
   const sessionState =
     envelope && typeof envelope.sessionState === "object" && envelope.sessionState !== null
       ? (envelope.sessionState as Record<string, unknown>)
       : null;
   const archive = sessionState?.workspaceArchive;
-  return typeof archive === "string" && archive.length > 0 ? archive : null;
+  if (typeof archive !== "string" || archive.length === 0) {
+    return null;
+  }
+  const previous = sessionState?.workspaceArchivePrev;
+  const capturedAt = sessionState?.workspaceArchiveAt;
+  return {
+    workspaceArchive: archive,
+    ...(typeof previous === "string" && previous.length > 0
+      ? { workspaceArchivePrev: previous }
+      : {}),
+    ...(typeof capturedAt === "string" && capturedAt.length > 0
+      ? { workspaceArchiveAt: capturedAt }
+      : {}),
+  };
 }
 
-function preserveWorkspaceArchiveOnInterimResumeState(
+function preserveWorkspaceArchivesOnResumeState(
   resumeState: Record<string, unknown> | null,
   archiveSource: Record<string, unknown> | null,
 ): Record<string, unknown> | null {
-  const archive = workspaceArchiveFromEnvelope(archiveSource);
-  if (!archive) {
+  const archiveFields = workspaceArchiveFieldsFromEnvelope(archiveSource);
+  if (!archiveFields) {
     return resumeState;
   }
   const existingSessionState =
@@ -351,7 +364,7 @@ function preserveWorkspaceArchiveOnInterimResumeState(
       : {}),
     sessionState: {
       ...existingSessionState,
-      workspaceArchive: archive,
+      ...archiveFields,
     },
   };
 }
@@ -584,7 +597,7 @@ export async function resumeBoxForTurn(
         ...(services.sandboxMetrics ? { metrics: services.sandboxMetrics } : {}),
         onSandboxCreated: async (created) => {
           createdEstablished = created;
-          const resumeEnvelope = preserveWorkspaceArchiveOnInterimResumeState(
+          const resumeEnvelope = preserveWorkspaceArchivesOnResumeState(
             (await serializeEstablishedSandboxEnvelope(created)) ?? null,
             spawnEnvelope,
           );
@@ -626,8 +639,20 @@ export async function resumeBoxForTurn(
       // terminal, the desktop viewer, the reaper) cold-restored a FRESH rival box
       // and never saw the turn's live box. Fall back to the session envelope only
       // when the client cannot serialize live state.
+      const serializedResumeEnvelope =
+        (await serializeEstablishedSandboxEnvelope(established)) ?? envelope;
+      // A successful cold hydrate has already proved this archive usable and the
+      // replacement box now contains its files. Keep the current + fallback
+      // archive pointers on the committed live envelope until a later warm
+      // snapshot replaces them. Without this merge, serialization publishes only
+      // the new provider id; a second provider loss before the snapshot cadence
+      // fires would retire the lease with no archive and recreate an empty box.
+      // A failed hydrate falls back to a clean box with origin="created", so its
+      // unusable archive is deliberately cleared by the unmerged serialized state.
       const resumeEnvelope =
-        (await serializeEstablishedSandboxEnvelope(established)) ?? envelope ?? null;
+        established.origin === "restored"
+          ? preserveWorkspaceArchivesOnResumeState(serializedResumeEnvelope, spawnEnvelope)
+          : serializedResumeEnvelope;
       const committed = await commitWarmingToWarm(db, {
         accountId: ids.accountId,
         workspaceId: ids.workspaceId,

--- a/apps/worker/src/workflows/activities.ts
+++ b/apps/worker/src/workflows/activities.ts
@@ -1,11 +1,35 @@
 import { proxyActivities } from "@temporalio/workflow";
 import type * as activities from "../activities";
 
-type ControlActivities = Omit<typeof activities, "runAgentTurn">;
+type WorkflowControlActivities = Pick<
+  typeof activities,
+  | "dispatchScheduledTaskRun"
+  | "failSessionAttempt"
+  | "getCodexCapacityWait"
+  | "markSessionIdle"
+  | "maybeContinueGoal"
+  | "peekSessionWork"
+  | "reconcileCodexCapacityWait"
+  | "recoverDispatch"
+  | "settleSessionControl"
+>;
 
-export const activity = proxyActivities<ControlActivities>({
-  startToCloseTimeout: "30 days",
-  retry: { maximumAttempts: 1 },
+/**
+ * Session/schedule workflow control activities are bounded, idempotent database
+ * and provider-metadata operations. They must not inherit the agent turn's
+ * 30-day attempt: Temporal cannot otherwise detect that the pod which accepted
+ * a non-heartbeating control activity disappeared, leaving the workflow pinned
+ * to a dead worker for the full 30 days. A bounded attempt plus an unbounded
+ * Temporal retry keeps the durable workflow alive across rollout, node loss, or
+ * transient database/network failure; retries re-run on a healthy control pod.
+ */
+export const activity = proxyActivities<WorkflowControlActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: {
+    initialInterval: "1 second",
+    backoffCoefficient: 2,
+    maximumInterval: "30 seconds",
+  },
 });
 
 export function turnTaskQueue(baseTaskQueue: string): string {

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -38,6 +38,7 @@ import {
   type SharedTestDatabase,
   testSettings,
 } from "@opengeni/testing";
+import { establishSandboxSessionFromEnvelope } from "@opengeni/runtime";
 import {
   resumeBoxForTurn,
   sandboxLeaseHolderIdForAttempt,
@@ -583,6 +584,92 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
       select resume_state #>> '{sessionState,workspaceArchive}' as archive
       from sandbox_leases where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
     expect(archiveRow?.archive).toBeNull();
+  }, 60_000);
+
+  test("(F3-b) a successfully hydrated archive remains on the committed live lease", async () => {
+    if (!available) return;
+    const settings = settingsFor(true);
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+
+    const seed = await establishSandboxSessionFromEnvelope(settings, null, {
+      sessionId: groupId,
+      recovery: "create-or-restore",
+      backendOverride: "local",
+    });
+    let archiveBytes: Uint8Array;
+    try {
+      const persist = (seed.session as { persistWorkspace?: () => Promise<Uint8Array> })
+        .persistWorkspace;
+      if (typeof persist !== "function") {
+        throw new Error("Local sandbox test session cannot persist /workspace");
+      }
+      archiveBytes = await persist.call(seed.session);
+    } finally {
+      await dropSession(seed);
+    }
+
+    const currentArchive = Buffer.from(archiveBytes).toString("base64");
+    const previousArchive = Buffer.from("previous-valid-archive-pointer").toString("base64");
+    const archiveAt = "2030-03-04T05:06:07.000Z";
+    const archiveEnvelopeJson = JSON.stringify({
+      backendId: "unix_local",
+      sessionState: {
+        workspaceArchive: currentArchive,
+        workspaceArchivePrev: previousArchive,
+        workspaceArchiveAt: archiveAt,
+      },
+    });
+    await admin.unsafe(
+      `
+      insert into sandbox_leases (
+        account_id, workspace_id, sandbox_group_id, liveness, refcount,
+        turn_holders, viewer_holders, backend, lease_epoch,
+        resume_backend_id, resume_state, expires_at
+      ) values (
+        $1, $2, $3, 'cold', 0, 0, 0,
+        'local', 8, 'unix_local',
+        $4::text::jsonb,
+        now() + interval '60s'
+      )`,
+      [accountId, workspaceId, groupId, archiveEnvelopeJson],
+    );
+
+    const resumed = await resumeBoxForTurn(
+      { db, settings },
+      {
+        accountId,
+        workspaceId,
+        sandboxGroupId: groupId,
+        sessionId: groupId,
+        backend: "local",
+        os: "linux",
+      },
+      "turn",
+      sandboxLeaseHolderIdForAttempt("activity-f3-valid-archive"),
+    );
+    try {
+      expect(resumed.established.origin).toBe("restored");
+      const [archiveRow] = await admin<
+        {
+          current_archive: string | null;
+          previous_archive: string | null;
+          archive_at: string | null;
+        }[]
+      >`
+        select resume_state #>> '{sessionState,workspaceArchive}' as current_archive,
+               resume_state #>> '{sessionState,workspaceArchivePrev}' as previous_archive,
+               resume_state #>> '{sessionState,workspaceArchiveAt}' as archive_at
+        from sandbox_leases
+        where workspace_id = ${workspaceId} and sandbox_group_id = ${groupId}`;
+      expect(archiveRow).toEqual({
+        current_archive: currentArchive,
+        previous_archive: previousArchive,
+        archive_at: archiveAt,
+      });
+    } finally {
+      await resumed.release();
+      await dropSession(resumed.established);
+    }
   }, 60_000);
 
   test("(4) FLAG-OFF: the gate condition is false -> resumeBoxForTurn is NEVER invoked, so NO lease row is materialized", async () => {


### PR DESCRIPTION
Production verification of the shared-sandbox/control-plane cutover found two independent recovery holes.

1. A successful cold restore hydrated /workspace, but the final warm lease commit replaced the archive-bearing envelope with provider identity only. A second provider loss before the next periodic snapshot could recreate an empty workspace. The fix preserves current, previous, and capture-time archive fields only when the runtime proves origin=restored. Failed hydration still falls back to origin=created and clears the unusable archive.

2. Session workflow control activities inherited a 30-day non-heartbeating attempt with maximumAttempts=1. A worker rollout or transient DB failure could pin a workflow to a dead pod for 30 days or fail the workflow while PostgreSQL still claimed the turn was running. The fix narrows the proxy to the nine bounded idempotent workflow-control activities, gives each attempt a two-minute bound, and retries automatically on healthy control workers. The 30-day heartbeating agent-turn activity remains separate and unchanged.

Verification:
- repository-wide typecheck
- repository-wide lint
- 41 focused runtime/worker/database tests against the real PostgreSQL harness
- session workflow recovery unit tests
- new real-database regression proves successful hydration retains all archive fields
- existing failed-hydration regression proves unusable archives are still cleared
- UBS scan clean on the new workflow-control file; other reported test-file findings triaged as pre-existing false positives

After production deployment, already-scheduled 30-day activities will be reset once to the WorkflowTaskCompleted event immediately before their schedule, excluding later wake-only signals. Temporal records activity timeouts at schedule time, so code deployment alone cannot rewrite those already-pending attempts.