### PR TITLE
fix: make workspace capture announcements session-scoped

### DIFF
--- a/.changeset/quiet-workspace-capture-events.md
+++ b/.changeset/quiet-workspace-capture-events.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/react": patch
+---
+
+Commit workspace capture announcements atomically with their revision rows and keep harmless late capture bookkeeping out of the user timeline.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -5227,11 +5227,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           db,
           objectStorage,
           settings,
-          publish: publish
-            ? async (events) => {
-                await publish!(events);
-              }
-            : null,
+          publish: async (events) => {
+            await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, events);
+          },
           session: setupBoxSession as ChannelASession,
           leaseEpoch: resolvedSandbox.leaseEpoch,
           sandboxGroupId,

--- a/apps/worker/src/activities/workspace-capture.ts
+++ b/apps/worker/src/activities/workspace-capture.ts
@@ -52,7 +52,7 @@ import type {
   FsTreeNode,
   GitFileStatus,
   GitFileStatusCode,
-  SessionEventType,
+  SessionEvent,
   WorkspaceCaptureFile,
   WorkspaceCaptureDegradedReason,
   WorkspaceCaptureManifest,
@@ -173,11 +173,9 @@ function classifyCaptureEntryError(error: unknown): BoxExitingError | null {
 const TREE_MAX_ENTRIES = 20_000; // whole-tree node cap (truncate beyond)
 const TREE_MAX_DIRS = 600; // BFS round-trip cap (bounds turn-end latency)
 
-// The publish closure from agent-turn (Omit<AppendEventInput, producer/turn ids>)
-// is assignable to this. Announce-only — payload is metadata, never file content.
-export type CaptureEventPublisher = (
-  events: Array<{ type: SessionEventType; payload: Record<string, unknown> }>,
-) => Promise<void>;
+// The capture row and announcement are committed together by @opengeni/db. This
+// callback performs only best-effort live fanout of those already-durable events.
+export type CaptureEventPublisher = (events: SessionEvent[]) => Promise<void>;
 
 export type CaptureWorkspaceRevisionInput = {
   db: Database;
@@ -276,8 +274,13 @@ async function runCapture(
   // ── 1. per-repo status + diff, union the touched set ──────────────────────
   const discovery = await svc.detectReposDetailed();
   if (!discovery.complete) {
-    const capturedAt = new Date().toISOString();
+    const capturedAt = new Date();
     const reason = captureDegradedReason(discovery.degradedReason);
+    const stats = {
+      degradedReason: reason,
+      discoveredRepoCount: discovery.repos.length,
+      durationMs: Date.now() - startedAt,
+    };
     const inserted = await insertFailedWorkspaceCapture(input.db, {
       accountId: input.accountId,
       workspaceId: input.workspaceId,
@@ -286,11 +289,8 @@ async function runCapture(
       sandboxGroupId: input.sandboxGroupId,
       expectedEpoch: input.leaseEpoch,
       revision,
-      stats: {
-        degradedReason: reason,
-        discoveredRepoCount: discovery.repos.length,
-        durationMs: Date.now() - startedAt,
-      },
+      stats,
+      capturedAt,
     });
     if (!inserted) {
       observability.incrementCounter({
@@ -310,20 +310,7 @@ async function runCapture(
       labels: { result: "degraded_repository_discovery" },
     });
     if (input.publish) {
-      await input
-        .publish([
-          {
-            type: "workspace.revision.degraded",
-            payload: {
-              revision: inserted.revision,
-              turnId: input.turnId,
-              capturedAt,
-              leaseEpoch: input.leaseEpoch,
-              reason,
-            },
-          },
-        ])
-        .catch(() => undefined);
+      await input.publish(inserted.events).catch(() => undefined);
     }
     return;
   }
@@ -532,7 +519,7 @@ async function runCapture(
   const tree = await buildTreeIndex(svc, startedAt);
 
   // ── 6. serialize manifest ─────────────────────────────────────────────────
-  const capturedAt = new Date().toISOString();
+  const capturedAt = new Date();
   const stats: WorkspaceCaptureStats = {
     repoCount: repos.length,
     fileCount: files.length,
@@ -543,13 +530,13 @@ async function runCapture(
     binaryCount,
     treeEntryCount: tree.entryCount,
     treeTruncated: tree.truncated,
-    durationMs: 0, // filled just before publish
+    durationMs: 0, // filled after tree/content writes, before manifest serialization
     fingerprint,
   };
   const manifest: WorkspaceCaptureManifest = {
     version: 1,
     revision,
-    capturedAt,
+    capturedAt: capturedAt.toISOString(),
     turnId: input.turnId,
     leaseEpoch: input.leaseEpoch,
     treeIndex: tree.root,
@@ -578,6 +565,7 @@ async function runCapture(
     }),
   );
   await storage.putObject({ key: treeKey, contentType: "application/json", body: treeBytes });
+  stats.durationMs = Date.now() - startedAt;
   const manifestBytes = utf8(JSON.stringify(manifest));
   await storage.putObject({
     key: manifestKey,
@@ -600,6 +588,7 @@ async function runCapture(
     blobKeys: [...blobKeys],
     sizeBytes,
     stats,
+    capturedAt,
   });
   if (!inserted) {
     // Lease superseded/released between capture and commit. Best-effort clean up
@@ -611,6 +600,10 @@ async function runCapture(
     });
     await safeDelete(storage, [manifestKey, treeKey], observability);
     return;
+  }
+
+  if (input.publish) {
+    await input.publish(inserted.events).catch(() => undefined);
   }
 
   // ── 9. inline keep-latest-N GC (best-effort; F9 — after the commit) ────────
@@ -644,9 +637,8 @@ async function runCapture(
     });
   }
 
-  // ── 10. announce (announce-only; hits the timeline projection default case) ─
+  // ── 10. observe completion ────────────────────────────────────────────────
   const durationMs = Date.now() - startedAt;
-  stats.durationMs = durationMs;
   observability.incrementCounter({
     name: "opengeni_workspace_capture_total",
     labels: { result: "ok" },
@@ -655,22 +647,6 @@ async function runCapture(
     name: "opengeni_workspace_capture_duration_seconds",
     value: durationMs / 1000,
   });
-  if (input.publish) {
-    await input
-      .publish([
-        {
-          type: "workspace.revision.captured",
-          payload: {
-            revision: inserted.revision,
-            turnId: input.turnId,
-            capturedAt,
-            leaseEpoch: input.leaseEpoch,
-            stats,
-          },
-        },
-      ])
-      .catch(() => undefined);
-  }
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14607,6 +14607,11 @@ export type WorkspaceCaptureRow = {
   capturedAt: string;
 };
 
+export type WorkspaceCaptureCommitResult = {
+  revision: number;
+  events: SessionEvent[];
+};
+
 const WORKSPACE_CAPTURE_COLUMNS = sql`
   id, session_id, turn_id, revision, lease_epoch, state,
   manifest_key, tree_index_key, blob_keys, size_bytes, stats, captured_at
@@ -14642,6 +14647,142 @@ function mapWorkspaceCaptureRow(row: {
   };
 }
 
+type CommitWorkspaceCaptureRevisionInput = {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  turnId: string | null;
+  sandboxGroupId: string;
+  expectedEpoch: number;
+  revision: number;
+  state: "available" | "failed";
+  manifestKey: string | null;
+  treeIndexKey: string | null;
+  blobKeys: string[];
+  sizeBytes: number;
+  stats: Record<string, unknown>;
+  capturedAt?: Date;
+};
+
+/**
+ * Commit the epoch-fenced capture index and its session-scoped announcement as
+ * one durable transition. The announcement is metadata about an already
+ * captured revision, not output from the active turn attempt, so it deliberately
+ * carries no attempt/generation fence or current-turn association.
+ */
+async function commitWorkspaceCaptureRevision(
+  db: Database,
+  input: CommitWorkspaceCaptureRevisionInput,
+): Promise<WorkspaceCaptureCommitResult | null> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) =>
+      await scopedDb.transaction(async (tx) => {
+        // Match the canonical lifecycle lock order. The capture event has FKs to
+        // workspace/session/turn, so taking these locks later could deadlock a
+        // concurrent turn settlement that already owns them in this order.
+        await tx
+          .select({ id: schema.workspaces.id })
+          .from(schema.workspaces)
+          .where(eq(schema.workspaces.id, input.workspaceId))
+          .for("update")
+          .limit(1);
+        const [session] = await tx
+          .select()
+          .from(schema.sessions)
+          .where(
+            and(
+              eq(schema.sessions.workspaceId, input.workspaceId),
+              eq(schema.sessions.id, input.sessionId),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (!session) throw new Error(`Session not found: ${input.sessionId}`);
+
+        const capturedAt = input.capturedAt ?? new Date();
+        const rows = await tx.execute<{ revision: number | string }>(sql`
+          insert into workspace_captures
+            (account_id, workspace_id, session_id, turn_id, revision, lease_epoch, state,
+             manifest_key, tree_index_key, blob_keys, size_bytes, stats, captured_at)
+          select
+            ${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${input.turnId},
+            ${input.revision}, ${input.expectedEpoch}, ${input.state},
+            ${input.manifestKey}, ${input.treeIndexKey},
+            ${JSON.stringify(input.blobKeys)}::jsonb, ${input.sizeBytes},
+            ${JSON.stringify(input.stats)}::jsonb, ${capturedAt.toISOString()}::timestamptz
+          where exists (
+            select 1 from sandbox_leases
+            where workspace_id = ${input.workspaceId}
+              and sandbox_group_id = ${input.sandboxGroupId}
+              and lease_epoch = ${input.expectedEpoch}
+          )
+          returning revision
+        `);
+        const [capture] = rows;
+        if (!capture) return null;
+
+        const revision = Number(capture.revision);
+        const type: SessionEventType =
+          input.state === "available"
+            ? "workspace.revision.captured"
+            : "workspace.revision.degraded";
+        const payload =
+          input.state === "available"
+            ? {
+                revision,
+                turnId: input.turnId,
+                capturedAt: capturedAt.toISOString(),
+                leaseEpoch: input.expectedEpoch,
+                stats: input.stats,
+              }
+            : {
+                revision,
+                turnId: input.turnId,
+                capturedAt: capturedAt.toISOString(),
+                leaseEpoch: input.expectedEpoch,
+                reason:
+                  typeof input.stats.degradedReason === "string"
+                    ? input.stats.degradedReason
+                    : "repository_discovery_command_failed",
+              };
+        const [event] = await tx
+          .insert(schema.sessionEvents)
+          .values({
+            accountId: session.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            sequence: session.lastSequence + 1,
+            type,
+            payload: sanitizeEventPayload(payload),
+            clientEventId: `opengeni:workspace-capture:${revision}`,
+            turnId: input.turnId,
+            turnGeneration: null,
+            turnAttemptId: null,
+            turnAssociation: null,
+            duplicateOfEventId: null,
+            duplicateReason: null,
+            producerId: "workspace-capture",
+            producerSeq: revision,
+            occurredAt: capturedAt,
+          })
+          .returning();
+        if (!event) throw new Error("Workspace capture announcement was not inserted");
+        await tx
+          .update(schema.sessions)
+          .set({ lastSequence: event.sequence, updatedAt: new Date() })
+          .where(
+            and(
+              eq(schema.sessions.workspaceId, input.workspaceId),
+              eq(schema.sessions.id, input.sessionId),
+            ),
+          );
+        return { revision, events: [mapEvent(event)] };
+      }),
+  );
+}
+
 /**
  * Fenced insert of a capture revision at an EXPLICIT revision (the caller
  * assigns it as prevRevision+1 so the manifest blob — written before this insert
@@ -14667,34 +14808,13 @@ export async function insertWorkspaceCapture(
     blobKeys: string[];
     sizeBytes: number;
     stats: Record<string, unknown>;
+    capturedAt?: Date;
   },
-): Promise<{ revision: number } | null> {
-  return await withRlsContext(
-    db,
-    { accountId: input.accountId, workspaceId: input.workspaceId },
-    async (scopedDb) => {
-      const rows = await scopedDb.execute<{ revision: number | string }>(sql`
-        insert into workspace_captures
-          (account_id, workspace_id, session_id, turn_id, revision, lease_epoch, state,
-           manifest_key, tree_index_key, blob_keys, size_bytes, stats)
-        select
-          ${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${input.turnId},
-          ${input.revision}, ${input.expectedEpoch}, 'available',
-          ${input.manifestKey}, ${input.treeIndexKey},
-          ${JSON.stringify(input.blobKeys)}::jsonb, ${input.sizeBytes}, ${JSON.stringify(input.stats)}::jsonb
-        where exists (
-          select 1 from sandbox_leases
-          where workspace_id = ${input.workspaceId}
-            and sandbox_group_id = ${input.sandboxGroupId}
-            and lease_epoch = ${input.expectedEpoch}
-        )
-        returning revision
-      `);
-      const [row] = rows;
-      if (!row) return null;
-      return { revision: Number(row.revision) };
-    },
-  );
+): Promise<WorkspaceCaptureCommitResult | null> {
+  return await commitWorkspaceCaptureRevision(db, {
+    ...input,
+    state: "available",
+  });
 }
 
 /**
@@ -14717,33 +14837,17 @@ export async function insertFailedWorkspaceCapture(
     expectedEpoch: number;
     revision: number;
     stats: Record<string, unknown>;
+    capturedAt?: Date;
   },
-): Promise<{ revision: number } | null> {
-  return await withRlsContext(
-    db,
-    { accountId: input.accountId, workspaceId: input.workspaceId },
-    async (scopedDb) => {
-      const rows = await scopedDb.execute<{ revision: number | string }>(sql`
-        insert into workspace_captures
-          (account_id, workspace_id, session_id, turn_id, revision, lease_epoch, state,
-           manifest_key, tree_index_key, blob_keys, size_bytes, stats)
-        select
-          ${input.accountId}, ${input.workspaceId}, ${input.sessionId}, ${input.turnId},
-          ${input.revision}, ${input.expectedEpoch}, 'failed',
-          null, null, '[]'::jsonb, 0, ${JSON.stringify(input.stats)}::jsonb
-        where exists (
-          select 1 from sandbox_leases
-          where workspace_id = ${input.workspaceId}
-            and sandbox_group_id = ${input.sandboxGroupId}
-            and lease_epoch = ${input.expectedEpoch}
-        )
-        returning revision
-      `);
-      const [row] = rows;
-      if (!row) return null;
-      return { revision: Number(row.revision) };
-    },
-  );
+): Promise<WorkspaceCaptureCommitResult | null> {
+  return await commitWorkspaceCaptureRevision(db, {
+    ...input,
+    state: "failed",
+    manifestKey: null,
+    treeIndexKey: null,
+    blobKeys: [],
+    sizeBytes: 0,
+  });
 }
 
 /** The newest capture for a session (highest revision), or null if none. */

--- a/packages/db/test/workspace-captures.test.ts
+++ b/packages/db/test/workspace-captures.test.ts
@@ -7,6 +7,8 @@ import {
   createDb,
   createSession,
   insertFailedWorkspaceCapture,
+  insertWorkspaceCapture,
+  listSessionEvents,
   latestWorkspaceCapture,
   type Database,
   type DbClient,
@@ -49,8 +51,8 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
   return { accountId: account!.id, workspaceId: workspace!.id };
 }
 
-describe("workspace capture degraded revisions (real PostgreSQL + FORCE RLS)", () => {
-  test("failed discovery marker is epoch-fenced, monotonic, and blob-free", async () => {
+describe("workspace capture revisions (real PostgreSQL + FORCE RLS)", () => {
+  test("capture rows and announcements commit together behind the lease epoch fence", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const session = await createSession(db, {
@@ -99,9 +101,27 @@ describe("workspace capture degraded revisions (real PostgreSQL + FORCE RLS)", (
         expectedEpoch: liveEpoch + 1,
       }),
     ).toBeNull();
-    expect(await insertFailedWorkspaceCapture(db, { ...input, expectedEpoch: liveEpoch })).toEqual({
-      revision: 0,
+    const captureCommit = await insertFailedWorkspaceCapture(db, {
+      ...input,
+      expectedEpoch: liveEpoch,
     });
+    expect(captureCommit).not.toBeNull();
+    expect(captureCommit!.revision).toBe(0);
+    expect(captureCommit!.events).toEqual([
+      expect.objectContaining({
+        type: "workspace.revision.degraded",
+        turnId: null,
+        turnGeneration: null,
+        turnAttemptId: null,
+        turnAssociation: null,
+        clientEventId: "opengeni:workspace-capture:0",
+        payload: expect.objectContaining({
+          revision: 0,
+          leaseEpoch: liveEpoch,
+          reason: "repository_discovery_timed_out",
+        }),
+      }),
+    ]);
 
     const latest = await latestWorkspaceCapture(db, workspace.workspaceId, session.id);
     expect(latest).toMatchObject({
@@ -117,5 +137,61 @@ describe("workspace capture degraded revisions (real PostgreSQL + FORCE RLS)", (
     const [count] = await admin<{ count: number }[]>`
       select count(*)::int as count from workspace_captures where session_id = ${session.id}`;
     expect(count?.count).toBe(1);
+    const events = await listSessionEvents(db, workspace.workspaceId, session.id);
+    expect(events.filter((event) => event.type === "workspace.revision.degraded")).toEqual(
+      captureCommit!.events,
+    );
+
+    const capturedAt = new Date("2026-07-15T16:40:22.580Z");
+    const availableCommit = await insertWorkspaceCapture(db, {
+      ...workspace,
+      sessionId: session.id,
+      turnId: null,
+      sandboxGroupId,
+      expectedEpoch: liveEpoch,
+      revision: 1,
+      manifestKey: "workspace/manifests/1.json",
+      treeIndexKey: "workspace/trees/1.json",
+      blobKeys: ["workspace/blobs/sha256/content"],
+      sizeBytes: 123,
+      stats: {
+        fingerprint: "capture-1",
+        discoveredRepoCount: 1,
+        changedFileCount: 1,
+        durationMs: 850,
+      },
+      capturedAt,
+    });
+    expect(availableCommit).not.toBeNull();
+    expect(availableCommit!.events).toEqual([
+      expect.objectContaining({
+        sequence: captureCommit!.events[0]!.sequence + 1,
+        type: "workspace.revision.captured",
+        turnId: null,
+        turnGeneration: null,
+        turnAttemptId: null,
+        turnAssociation: null,
+        clientEventId: "opengeni:workspace-capture:1",
+        payload: expect.objectContaining({
+          revision: 1,
+          capturedAt: capturedAt.toISOString(),
+          leaseEpoch: liveEpoch,
+          stats: expect.objectContaining({ fingerprint: "capture-1" }),
+        }),
+      }),
+    ]);
+    expect(await latestWorkspaceCapture(db, workspace.workspaceId, session.id)).toMatchObject({
+      revision: 1,
+      state: "available",
+      manifestKey: "workspace/manifests/1.json",
+      treeIndexKey: "workspace/trees/1.json",
+      blobKeys: ["workspace/blobs/sha256/content"],
+      sizeBytes: 123,
+    });
+    expect(
+      (await listSessionEvents(db, workspace.workspaceId, session.id)).filter((event) =>
+        event.type.startsWith("workspace.revision."),
+      ),
+    ).toEqual([...captureCommit!.events, ...availableCommit!.events]);
   }, 60_000);
 });

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -435,9 +435,20 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "turn.event.rejected_late": {
-        closeStreamingTail();
         const rejectedType =
           typeof payload.rejectedType === "string" ? payload.rejectedType : "unknown event";
+        // Workspace revision events are session-scoped cache announcements, not
+        // user/agent turn evidence. Older servers could route them through the
+        // attempt fence after the turn settled; retain that audit row durably,
+        // but never present harmless internal bookkeeping as a user-visible
+        // failed action.
+        if (
+          rejectedType === "workspace.revision.captured" ||
+          rejectedType === "workspace.revision.degraded"
+        ) {
+          break;
+        }
+        closeStreamingTail();
         const reason =
           typeof payload.reason === "string"
             ? payload.reason.replaceAll("_", " ")

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -757,6 +757,23 @@ describe("buildTimeline", () => {
     ]);
   });
 
+  test("hides rejected workspace revision bookkeeping from the user timeline", () => {
+    reset();
+    const items = buildTimeline([
+      event("turn.event.rejected_late", {
+        rejectedType: "workspace.revision.captured",
+        rejectedPayload: { revision: 3 },
+        reason: "active_turn_changed",
+      }),
+      event("turn.event.rejected_late", {
+        rejectedType: "workspace.revision.degraded",
+        rejectedPayload: { revision: 4 },
+        reason: "active_turn_changed",
+      }),
+    ]);
+    expect(items).toEqual([]);
+  });
+
   test("routine repository-clone operations never render", () => {
     // Per-turn platform plumbing (idempotent clone check + token re-seed) —
     // rendering it every turn reads as the agent redoing work.

--- a/test/integration/workspace-capture.integration.ts
+++ b/test/integration/workspace-capture.integration.ts
@@ -396,7 +396,7 @@ describe("workspace capture — B-suite (real docker turns)", () => {
         expectedEpoch: leaseEpoch,
         stats: degradedStats,
       });
-      expect(degraded).toEqual({ revision: degradedRevision });
+      expect(degraded).toMatchObject({ revision: degradedRevision });
       const afterDegraded = await captureRows(session.id);
       const degradedRow = afterDegraded.at(-1)!;
       expect(degradedRow.state).toBe("failed");


### PR DESCRIPTION
## Root cause

Workspace capture finished after turn settlement, but its announcement was routed through the completed turn attempt fence. The snapshot was saved, while the announcement became a user-visible rejected-late audit event.

## Fix

- commit capture row and session-scoped announcement atomically
- preserve sandbox lease epoch fencing
- publish only the already-durable event
- hide historical rejected capture bookkeeping from the user timeline
- add successful, degraded, stale-epoch, and historical UI regressions

No schema migration.

## Verification

- bun run lint
- bun run format:check
- bun run check: 2,992 passed, 3 skipped, 0 failed; SDK, React, demo, and web builds passed