### PR TITLE
ops: run one steady production web replica

### DIFF
--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -49,6 +49,15 @@ worker:
               periodSeconds: 300
 
 web:
+  # One steady production web pod is sufficient at the current request rate.
+  # Surge by one during a rollout so that the single serving pod is never
+  # removed before its replacement is ready.
+  replicaCount: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   image:
     tag: "RELEASE_TAG"
     digest: "sha256:WEB_IMAGE_DIGEST"


### PR DESCRIPTION
## Summary
- set the Azure-managed production web tier to one steady replica
- retain zero-downtime web rollouts by temporarily surging to two and keeping the existing pod available until its replacement is ready

## Evidence
- current production web fleet: ~6–8m CPU total and ~200 MiB working set total across two pods
- `helm lint` passes
- rendered Deployment has `replicas: 1`, `maxSurge: 1`, and `maxUnavailable: 0`