### PR TITLE
fix(react): fence workbench state by session

### DIFF
--- a/.changeset/calm-ravens-switch.md
+++ b/.changeset/calm-ravens-switch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Fence session events, workspace capture, file tree, git state, warm intents, and tab latches by session identity; bound signed-manifest fetches; refresh same-shape diffs when hunk content changes; and clear stale file metadata during reconciliation.

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -13,7 +13,7 @@
 // (no `sonner` import), and every surface renders with package primitives + og
 // tokens only. `apps/web` consumes this through the exact public surface an
 // external embedder (cloudgeni #1577) uses — that is criterion F1.
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Popover } from "radix-ui";
 import type { SessionEvent } from "@opengeni/sdk";
 import { CpuIcon, LaptopIcon, RefreshCwIcon } from "lucide-react";
@@ -152,6 +152,17 @@ export type UseSandboxWorkspaceTabsResult = {
   machine: WorkspaceMachine;
 };
 
+type SessionWarmIntents = {
+  sessionId: string;
+  watchDesktop: boolean;
+  warmTerminal: boolean;
+  warmEdit: boolean;
+};
+
+function emptyWarmIntents(sessionId: string): SessionWarmIntents {
+  return { sessionId, watchDesktop: false, warmTerminal: false, warmEdit: false };
+}
+
 /**
  * Build the workbench tabs + the machine-chip model for one session. This is the
  * dock "brain": capability negotiation, capture-backed cold reads, prewarm
@@ -169,9 +180,21 @@ export function useSandboxWorkspaceTabs(
   // capture glance): desktop watch consent, terminal engagement (`onActivate`), and
   // the first wake-on-edit keystroke in the Files editor. Browsing capture-served
   // Changes/Files warms nothing — that is the whole point of Refinement 1.
-  const [watchDesktop, setWatchDesktop] = useState(false);
-  const [warmTerminal, setWarmTerminal] = useState(false);
-  const [warmEdit, setWarmEdit] = useState(false);
+  const [storedWarmIntents, setStoredWarmIntents] = useState<SessionWarmIntents>(() =>
+    emptyWarmIntents(sessionId),
+  );
+  const warmIntents =
+    storedWarmIntents.sessionId === sessionId ? storedWarmIntents : emptyWarmIntents(sessionId);
+  const { watchDesktop, warmTerminal, warmEdit } = warmIntents;
+  const requestWarmIntent = useCallback(
+    (intent: Exclude<keyof SessionWarmIntents, "sessionId">) => {
+      setStoredWarmIntents((previous) => {
+        const current = previous.sessionId === sessionId ? previous : emptyWarmIntents(sessionId);
+        return current[intent] ? current : { ...current, [intent]: true };
+      });
+    },
+    [sessionId],
+  );
 
   // The session's machine fleet + the active-sandbox pointer. Drives the header
   // chip (which machine + its connection state). Polls slowly — ambient context.
@@ -221,26 +244,33 @@ export function useSandboxWorkspaceTabs(
   // freshly-warm box's surfaces fill in.
   const provisioning = sandboxProvisionInFlight(events);
   const renegotiate = caps.renegotiate;
-  const provisioningRef = useRef(provisioning);
+  const provisioningRef = useRef({ sessionId, provisioning });
   useEffect(() => {
-    if (provisioningRef.current && !provisioning) {
+    const previous = provisioningRef.current;
+    if (previous.sessionId === sessionId && previous.provisioning && !provisioning) {
       renegotiate();
     }
-    provisioningRef.current = provisioning;
-  }, [provisioning, renegotiate]);
+    provisioningRef.current = { sessionId, provisioning };
+  }, [sessionId, provisioning, renegotiate]);
 
   // The cold-paint data source: the latest turn-end capture, fetched with a single
   // api round-trip on mount (no machine). Feeds the Files tree + the Changes/Git
   // diff when the box is not warm; a warm box always wins (live path unchanged).
   const captureState = useWorkspaceCapture(sessionId, { events });
   const captureAvailable = captureState.available;
-  const notifiedCaptureDegradedReason = useRef<string | null>(null);
+  const notifiedCaptureDegradedReason = useRef<{ sessionId: string; reason: string | null }>({
+    sessionId,
+    reason: null,
+  });
+  if (notifiedCaptureDegradedReason.current.sessionId !== sessionId) {
+    notifiedCaptureDegradedReason.current = { sessionId, reason: null };
+  }
   useEffect(() => {
     const reason = captureState.degradedReason;
-    if (!reason || notifiedCaptureDegradedReason.current === reason) return;
-    notifiedCaptureDegradedReason.current = reason;
+    if (!reason || notifiedCaptureDegradedReason.current.reason === reason) return;
+    notifiedCaptureDegradedReason.current = { sessionId, reason };
     onNotify?.({ kind: "error", message: captureDegradedMessage(reason) });
-  }, [captureState.degradedReason, onNotify]);
+  }, [sessionId, captureState.degradedReason, onNotify]);
 
   const files = useSandboxFiles(sessionId, {
     events,
@@ -288,7 +318,7 @@ export function useSandboxWorkspaceTabs(
         acknowledgeUnredacted: true,
         acknowledgeShared: shared,
       });
-      setWatchDesktop(true);
+      requestWarmIntent("watchDesktop");
       caps.renegotiate();
     } catch (error) {
       onNotify?.({
@@ -301,7 +331,7 @@ export function useSandboxWorkspaceTabs(
   // Re-warm WITHOUT re-acknowledging: the consent was already recorded, only the
   // box drained back to cold. Idempotent — the viewer auto-warm de-dupes.
   function rewarmDesktop() {
-    if (!watchDesktop) setWatchDesktop(true);
+    if (!watchDesktop) requestWarmIntent("watchDesktop");
     caps.renegotiate();
   }
 
@@ -326,17 +356,23 @@ export function useSandboxWorkspaceTabs(
   // first CONTENT paint (both bodies show a connecting/loading state until the
   // capture lands) — means the first real content is the correct tab, no switch. A
   // pure embedder that never preloads events now gets the right default for free.
-  const defaultTabRef = useRef<string | null>(null);
-  if (defaultTabRef.current === null) {
+  const defaultTabRef = useRef<{ sessionId: string; value: string | null }>({
+    sessionId,
+    value: null,
+  });
+  if (defaultTabRef.current.sessionId !== sessionId) {
+    defaultTabRef.current = { sessionId, value: null };
+  }
+  if (defaultTabRef.current.value === null) {
     if (initialTab) {
-      defaultTabRef.current = initialTab;
+      defaultTabRef.current.value = initialTab;
     } else if (captureState.fileCount !== null) {
-      defaultTabRef.current =
+      defaultTabRef.current.value =
         captureState.fileCount > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
     }
   }
   // null only during the brief pre-first-resolve window (no host override yet).
-  const defaultTab = defaultTabRef.current;
+  const defaultTab = defaultTabRef.current.value;
 
   const tabs = useMemo(() => {
     const list: WorkspaceTab[] = [];
@@ -373,7 +409,7 @@ export function useSandboxWorkspaceTabs(
           editable={filesEditable}
           // The first keystroke in the editor is the wake-on-edit INTENT: warm the
           // box (even cold) so the write lands fast. Opening/reading files does not.
-          onEditIntent={() => setWarmEdit(true)}
+          onEditIntent={() => requestWarmIntent("warmEdit")}
           className="h-full"
         />
       ),
@@ -389,7 +425,7 @@ export function useSandboxWorkspaceTabs(
             <SandboxTerminal
               result={terminal}
               terminalCapability={capabilities?.Terminal ?? null}
-              onActivate={() => setWarmTerminal(true)}
+              onActivate={() => requestWarmIntent("warmTerminal")}
               showHeader
               shell={capabilities?.Terminal.shell ?? undefined}
               liveness={liveness}
@@ -442,6 +478,7 @@ export function useSandboxWorkspaceTabs(
     caps.state,
     caps.error,
     caps.viewerCapReached,
+    requestWarmIntent,
   ]);
 
   return {
@@ -525,17 +562,24 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
   // we pass no controlled tab, so the dock renders its own first-tab fallback
   // (Changes) — whose body is a connecting/loading state until the capture lands,
   // so committing the real default at first-resolve produces no CONTENT switch.
-  const [selectedTab, setSelectedTab] = useState<string | null>(null);
-  const activeTab = selectedTab ?? defaultTab ?? undefined;
-
   const tabs: WorkspaceTab[] = [...(leadingTabs ?? []), ...workbenchTabs, ...(trailingTabs ?? [])];
+  const [storedSelection, setStoredSelection] = useState<{
+    sessionId: string;
+    tab: string;
+  } | null>(null);
+  const selectedTab = storedSelection?.sessionId === sessionId ? storedSelection.tab : null;
+  const activeTab = selectedTab ?? defaultTab ?? tabs[0]?.id;
+  const selectTab = useCallback(
+    (tab: string) => setStoredSelection({ sessionId, tab }),
+    [sessionId],
+  );
 
   return (
     <WorkspaceDock
       primary={primary}
       tabs={tabs}
       {...(activeTab !== undefined ? { activeTab } : {})}
-      onActiveTabChange={setSelectedTab}
+      onActiveTabChange={selectTab}
       headerAccessory={
         <MachineStateChip
           chip={machine.chip}

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -250,7 +250,8 @@ function sameNodeShallow(a: FileTreeNode, b: FileTreeNode): boolean {
     a.kind === b.kind &&
     a.name === b.name &&
     (a.size ?? null) === (b.size ?? null) &&
-    (a.status ?? undefined) === (b.status ?? undefined)
+    (a.status ?? undefined) === (b.status ?? undefined) &&
+    (a.truncated ?? false) === (b.truncated ?? false)
   );
 }
 
@@ -317,6 +318,14 @@ export function useSandboxFiles(
   // Which source the tree currently reflects — "capture" (cold paint) or "live".
   const [source, setSource] = useState<"live" | "capture" | null>(null);
   const statusRef = useRef<Map<string, FileTreeStatus>>(new Map());
+  // Async reads, event cursors, and debounced work are scoped to the hook's
+  // workspace/session/root identity. These refs are reset/fenced at that boundary.
+  const refreshGenerationRef = useRef(0);
+  const identityGenerationRef = useRef(0);
+  const lastSeqRef = useRef(0);
+  const pendingParentsRef = useRef<Set<string>>(new Set());
+  const pendingGitRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Self-emitted fs.changed de-dupe ───────────────────────────────────────
   // Every one of OUR mutations emits an `fs.changed` event back on the live log
@@ -335,12 +344,10 @@ export function useSandboxFiles(
   // Overlay the git-status tint onto the tree. IDENTITY-PRESERVING: a node whose
   // tint and children are unchanged is returned by reference (not rebuilt), so a
   // re-tint or a cold→warm reconcile does NOT remount unchanged rows — the
-  // no-flicker constraint (dossier §3 #6 / §12-D1). The `overlay.size === 0`
-  // short-circuit keeps the pre-existing "empty overlay leaves tints as-is"
-  // behavior (an empty status set does not strip prior tints).
+  // no-flicker constraint (dossier §3 #6 / §12-D1). An empty overlay is still
+  // meaningful: it strips stale tints after the repository becomes clean.
   const applyStatus = useCallback((nodes: FileTreeNode[]): FileTreeNode[] => {
     const overlay = statusRef.current;
-    if (overlay.size === 0) return nodes;
     const walk = (list: FileTreeNode[]): FileTreeNode[] => {
       let changed = false;
       const out = list.map((node) => {
@@ -365,6 +372,7 @@ export function useSandboxFiles(
 
   const refresh = useCallback(async () => {
     if (!sessionId) return;
+    const generation = (refreshGenerationRef.current += 1);
     setLoading(true);
     setError(null);
     try {
@@ -372,6 +380,7 @@ export function useSandboxFiles(
       // returns isRepo:false), then the tree, so the first paint is tinted.
       try {
         const status = await client.gitStatus(workspaceId, sessionId, { path: rootPath });
+        if (refreshGenerationRef.current !== generation) return;
         const overlay = new Map<string, FileTreeStatus>();
         for (const file of status.files) {
           const code = file.worktree ?? file.index;
@@ -380,9 +389,11 @@ export function useSandboxFiles(
         }
         statusRef.current = overlay;
       } catch {
+        if (refreshGenerationRef.current !== generation) return;
         statusRef.current = new Map();
       }
       const listed = await client.fsList(workspaceId, sessionId, { path: rootPath, depth: 1 });
+      if (refreshGenerationRef.current !== generation) return;
       const children = (listed.root.children ?? []).map(fsNodeToTree);
       // Merge rather than replace so an explicit refresh / cold→warm re-list folds
       // in new entries WITHOUT collapsing the dirs the user already expanded (and,
@@ -394,9 +405,10 @@ export function useSandboxFiles(
       // Live data is now serving — flip the source off the capture snapshot.
       setSource("live");
     } catch (cause) {
+      if (refreshGenerationRef.current !== generation) return;
       setError(cause instanceof Error ? cause : new Error(String(cause)));
     } finally {
-      setLoading(false);
+      if (refreshGenerationRef.current === generation) setLoading(false);
     }
   }, [client, workspaceId, sessionId, rootPath, applyStatus]);
 
@@ -427,6 +439,7 @@ export function useSandboxFiles(
   const expand = useCallback(
     async (path: string) => {
       if (!sessionId) return;
+      const identityGeneration = identityGenerationRef.current;
       // Mark this node as expanding so the FileBrowser can render a spinner while
       // the (often 2-3s) Channel-A fs/list is in flight — the tree never looks
       // frozen on a click.
@@ -437,17 +450,21 @@ export function useSandboxFiles(
       });
       try {
         const listed = await client.fsList(workspaceId, sessionId, { path, depth: 1 });
+        if (identityGenerationRef.current !== identityGeneration) return;
         const children = (listed.root.children ?? []).map(fsNodeToTree);
         setTree((prev) => applyStatus(replaceChildren(prev, path, children)));
       } catch (cause) {
+        if (identityGenerationRef.current !== identityGeneration) return;
         setError(cause instanceof Error ? cause : new Error(String(cause)));
       } finally {
-        setExpandingPaths((prev) => {
-          if (!prev.has(path)) return prev;
-          const next = new Set(prev);
-          next.delete(path);
-          return next;
-        });
+        if (identityGenerationRef.current === identityGeneration) {
+          setExpandingPaths((prev) => {
+            if (!prev.has(path)) return prev;
+            const next = new Set(prev);
+            next.delete(path);
+            return next;
+          });
+        }
       }
     },
     [client, workspaceId, sessionId, applyStatus],
@@ -471,11 +488,13 @@ export function useSandboxFiles(
   const reconcilePath = useCallback(
     async (path: string) => {
       if (!sessionId) return;
+      const identityGeneration = identityGenerationRef.current;
       // Skip parents that aren't currently loaded/expanded in the tree (nothing
       // visible to update; they re-list fresh on the next expand).
       if (!parentIsLoaded(treeRef.current, path)) return;
       try {
         const listed = await client.fsList(workspaceId, sessionId, { path, depth: 1 });
+        if (identityGenerationRef.current !== identityGeneration) return;
         const children = (listed.root.children ?? []).map(fsNodeToTree);
         if (path === "") setTree((prev) => applyStatus(mergeRootChildren(prev, children)));
         else
@@ -508,11 +527,13 @@ export function useSandboxFiles(
       op: () => Promise<T>,
       reconcileParents: string[],
     ): Promise<T> => {
+      const identityGeneration = identityGenerationRef.current;
       // Snapshot the pre-op tree from the ref (StrictMode-safe — see treeRef).
       const snapshot = treeRef.current;
       setTree(applyStatus(apply(snapshot)));
       try {
         const res = await op();
+        if (identityGenerationRef.current !== identityGeneration) return res;
         // Remember the revision WE caused so the matching fs.changed echo is
         // ignored by the event effect (no self-triggered refresh).
         if (res && typeof res === "object" && "revision" in res) {
@@ -521,10 +542,14 @@ export function useSandboxFiles(
         }
         // Reconcile loaded parents to fold the server's real metadata. Sequential
         // and best-effort — purely cosmetic over the already-correct optimistic UI.
-        for (const parent of reconcileParents) await reconcilePath(parent);
+        for (const parent of reconcileParents) {
+          if (identityGenerationRef.current !== identityGeneration) return res;
+          await reconcilePath(parent);
+        }
         return res;
       } catch (cause) {
         const err = cause instanceof Error ? cause : new Error(String(cause));
+        if (identityGenerationRef.current !== identityGeneration) throw err;
         // Revert the optimistic edit to the exact pre-op tree.
         setTree(applyStatus(snapshot));
         setError(err);
@@ -639,30 +664,57 @@ export function useSandboxFiles(
   const captureRef = useRef<WorkspaceCaptureManifest | null>(capture);
   captureRef.current = capture;
   const captureRevision = capture?.revision ?? null;
+  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${rootPath}`;
+  const previousIdentityRef = useRef(identityKey);
   useEffect(() => {
-    if (!enabled) {
+    // Any source-selection change supersedes an older root refresh. A true data
+    // identity change additionally fences all other async tree work and resets
+    // event/debounce state before the event-folding effect runs.
+    refreshGenerationRef.current += 1;
+    const identityChanged = previousIdentityRef.current !== identityKey;
+    previousIdentityRef.current = identityKey;
+    if (identityChanged || !enabled) {
+      identityGenerationRef.current += 1;
+      lastSeqRef.current = 0;
+      pendingParentsRef.current = new Set();
+      pendingGitRef.current = false;
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      ownRevisionsRef.current = new Set();
+      statusRef.current = new Map();
+      treeRef.current = [];
       setTree([]);
+      setExpandingPaths(new Set());
       setSource(null);
+      setLoading(false);
+      setError(null);
+    }
+    if (!enabled) {
       return;
     }
     if (isLive) {
       void refresh();
-      return;
-    }
-    if (captureRevision !== null && captureRef.current) {
+    } else if (captureRevision !== null && captureRef.current) {
       seedFromCapture(captureRef.current);
-      return;
+    } else {
+      void refresh();
     }
-    void refresh();
-  }, [enabled, isLive, captureRevision, refresh, seedFromCapture]);
+    return () => {
+      refreshGenerationRef.current += 1;
+    };
+  }, [enabled, isLive, captureRevision, identityKey, refresh, seedFromCapture]);
 
   // Re-pull JUST the git-status overlay and re-tint the existing tree in place —
   // no fs re-list, no collapse. This is all a `git.changed` (commit/stage/checkout)
   // needs: the tree SHAPE is unchanged, only the tints move.
   const refreshGitOverlay = useCallback(async () => {
     if (!sessionId) return;
+    const identityGeneration = identityGenerationRef.current;
     try {
       const status = await client.gitStatus(workspaceId, sessionId, { path: rootPath });
+      if (identityGenerationRef.current !== identityGeneration) return;
       const overlay = new Map<string, FileTreeStatus>();
       for (const file of status.files) {
         const code = file.worktree ?? file.index;
@@ -687,10 +739,6 @@ export function useSandboxFiles(
   //     preserved). Bursts are debounced into a single reconcile pass.
   //   • A git.changed just re-tints (refreshes the status overlay) — no fs re-list.
   const events = options.events;
-  const lastSeqRef = useRef(0);
-  const pendingParentsRef = useRef<Set<string>>(new Set());
-  const pendingGitRef = useRef(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!enabled || !events) return;
@@ -731,8 +779,10 @@ export function useSandboxFiles(
     if (!sawNew) return;
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    const identityGeneration = identityGenerationRef.current;
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
+      if (identityGenerationRef.current !== identityGeneration) return;
       const parents = pendingParentsRef.current;
       pendingParentsRef.current = new Set();
       const wantGit = pendingGitRef.current;
@@ -741,13 +791,18 @@ export function useSandboxFiles(
       // so the freshly-listed nodes get the correct overlay.
       void (async () => {
         if (wantGit) await refreshGitOverlay();
-        for (const parent of parents) await reconcilePath(parent);
+        if (identityGenerationRef.current !== identityGeneration) return;
+        for (const parent of parents) {
+          if (identityGenerationRef.current !== identityGeneration) return;
+          await reconcilePath(parent);
+        }
       })();
     }, 150);
   }, [enabled, events, reconcilePath, refreshGitOverlay]);
 
   useEffect(
     () => () => {
+      identityGenerationRef.current += 1;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     },
     [],

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -62,24 +62,57 @@ function repoForPath(
   return null;
 }
 
+/** Full diff equality for identity preservation. Hunk count/count summaries are
+ *  not sufficient: an edit can replace text without changing either shape. */
+function sameFileDiff(a: GitFileDiff, b: GitFileDiff): boolean {
+  if (
+    a.path !== b.path ||
+    a.oldPath !== b.oldPath ||
+    a.status !== b.status ||
+    a.isBinary !== b.isBinary ||
+    a.isImage !== b.isImage ||
+    a.additions !== b.additions ||
+    a.deletions !== b.deletions ||
+    a.truncated !== b.truncated ||
+    a.hunks.length !== b.hunks.length
+  )
+    return false;
+
+  return a.hunks.every((hunk, hunkIndex) => {
+    const other = b.hunks[hunkIndex];
+    if (
+      !other ||
+      hunk.oldStart !== other.oldStart ||
+      hunk.oldLines !== other.oldLines ||
+      hunk.newStart !== other.newStart ||
+      hunk.newLines !== other.newLines ||
+      hunk.header !== other.header ||
+      hunk.lines.length !== other.lines.length
+    )
+      return false;
+    return hunk.lines.every((line, lineIndex) => {
+      const otherLine = other.lines[lineIndex];
+      return (
+        otherLine !== undefined &&
+        line.type === otherLine.type &&
+        line.oldNo === otherLine.oldNo &&
+        line.newNo === otherLine.newNo &&
+        line.text === otherLine.text
+      );
+    });
+  });
+}
+
 /** Merge a freshly-served diff over the current one, preserving the identity of
- *  unchanged per-file entries (same path/status/counts/hunk-count) so a cold→warm
- *  reconcile does NOT remount unchanged file sections — no-flicker (§12-D1). */
+ *  genuinely unchanged per-file entries so a cold→warm reconcile does NOT
+ *  remount unchanged file sections — no-flicker (§12-D1). */
 function mergeDiffs(current: GitFileDiff[], next: GitFileDiff[]): GitFileDiff[] {
   if (current.length === 0) return next;
   const byPath = new Map(current.map((d) => [d.path, d] as const));
   let changed = current.length !== next.length;
   const merged = next.map((file, index) => {
     const existing = byPath.get(file.path);
-    if (
-      existing &&
-      existing.status === file.status &&
-      existing.additions === file.additions &&
-      existing.deletions === file.deletions &&
-      existing.isBinary === file.isBinary &&
-      existing.truncated === file.truncated &&
-      existing.hunks.length === file.hunks.length
-    ) {
+    if (existing && sameFileDiff(existing, file)) {
       if (current[index] !== existing) changed = true;
       return existing;
     }
@@ -116,13 +149,19 @@ export function useSandboxGit(
   const [source, setSource] = useState<"live" | "capture" | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  // Live requests and event cursors are identity-scoped. The refs deliberately
+  // survive renders, so they must be fenced/reset when that identity changes.
+  const refreshGenerationRef = useRef(0);
+  const lastChangeRef = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!sessionId) return;
+    const generation = (refreshGenerationRef.current += 1);
     setLoading(true);
     setError(null);
     try {
       const status = await client.gitStatus(workspaceId, sessionId, { path: repoPath });
+      if (refreshGenerationRef.current !== generation) return;
       setIsRepo(status.isRepo);
       setBranch(status.head);
       setAhead(status.ahead);
@@ -133,13 +172,15 @@ export function useSandboxGit(
         return;
       }
       const result = await client.gitDiff(workspaceId, sessionId, { path: repoPath, staged });
+      if (refreshGenerationRef.current !== generation) return;
       // Merge in place so the cold→warm swap keeps unchanged file sections mounted.
       setDiff((prev) => mergeDiffs(prev, result.files));
       setSource("live");
     } catch (cause) {
+      if (refreshGenerationRef.current !== generation) return;
       setError(cause instanceof Error ? cause : new Error(String(cause)));
     } finally {
-      setLoading(false);
+      if (refreshGenerationRef.current === generation) setLoading(false);
     }
   }, [client, workspaceId, sessionId, repoPath, staged]);
 
@@ -174,30 +215,44 @@ export function useSandboxGit(
   const captureRef = useRef<WorkspaceCaptureManifest | null>(capture);
   captureRef.current = capture;
   const captureRevision = capture?.revision ?? null;
+  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${repoPath}\u0000${staged}`;
+  const previousIdentityRef = useRef(identityKey);
   useEffect(() => {
-    if (!enabled) {
+    // A liveness/capture source change supersedes any older live request. Only a
+    // true data-identity change clears rendered state and the event high-water mark.
+    refreshGenerationRef.current += 1;
+    const identityChanged = previousIdentityRef.current !== identityKey;
+    previousIdentityRef.current = identityKey;
+    if (identityChanged || !enabled) {
+      lastChangeRef.current = 0;
       setDiff([]);
       setIsRepo(false);
       setBranch(null);
+      setAhead(0);
+      setBehind(0);
       setSource(null);
+      setLoading(false);
+      setError(null);
+    }
+    if (!enabled) {
       return;
     }
     if (isLive) {
       void refresh();
-      return;
-    }
-    if (captureRevision !== null && captureRef.current) {
+    } else if (captureRevision !== null && captureRef.current) {
       seedFromCapture(captureRef.current);
-      return;
+    } else {
+      void refresh();
     }
-    void refresh();
-  }, [enabled, isLive, captureRevision, refresh, seedFromCapture]);
+    return () => {
+      refreshGenerationRef.current += 1;
+    };
+  }, [enabled, isLive, captureRevision, identityKey, refresh, seedFromCapture]);
 
   // git.changed → re-fetch the LIVE diff. A git.changed only originates from a
   // live box, so this both keeps warm sessions fresh and folds a cold box that
   // just came up (unchanged from the pre-capture behavior).
   const events = options.events;
-  const lastChangeRef = useRef(0);
   useEffect(() => {
     if (!enabled || !events) return;
     let latest = lastChangeRef.current;

--- a/packages/react/src/hooks/use-session-events.ts
+++ b/packages/react/src/hooks/use-session-events.ts
@@ -47,6 +47,7 @@ const INITIAL_FETCH_CAP = 1;
 const OLDER_GROUP_TARGET = 32;
 const OLDER_FETCH_CAP = 2;
 const BOUNDARY_PAGE_CAP = 4;
+const EMPTY_EVENTS: SessionEvent[] = [];
 
 /**
  * Live-stream a session's event log with replay-by-sequence, reconnect, and
@@ -62,6 +63,7 @@ export function useSessionEvents(
   const after = options.after ?? 0;
   const replay = options.replay ?? "windowed";
   const fullReplay = replay === "full" || after !== 0;
+  const streamKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${after}\u0000${fullReplay ? "full" : "windowed"}`;
 
   const [events, setEvents] = useState<SessionEvent[]>([]);
   const [connectionState, setConnectionState] = useState<SessionEventsConnectionState>("idle");
@@ -75,14 +77,17 @@ export function useSessionEvents(
   const loadingOlderRef = useRef(false);
   const streamKeyRef = useRef<string | null>(null);
   const generationRef = useRef(0);
+  // Effects reset state after commit. Tag the state so the first render for a
+  // new stream identity cannot expose the previous session's event log.
+  const [stateStreamKey, setStateStreamKey] = useState(streamKey);
 
   useEffect(() => {
     // Reset the accumulated log only when the stream identity changes —
     // pausing via `enabled: false` keeps the timeline visible.
-    const streamKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${after}\u0000${fullReplay ? "full" : "windowed"}`;
     if (streamKeyRef.current !== streamKey) {
       streamKeyRef.current = streamKey;
       generationRef.current += 1;
+      setStateStreamKey(streamKey);
       setEvents([]);
       setError(null);
       setHasOlder(false);
@@ -184,7 +189,7 @@ export function useSessionEvents(
         clearTimeout(flushTimer);
       }
     };
-  }, [client, workspaceId, sessionId, after, enabled, fullReplay]);
+  }, [client, workspaceId, sessionId, after, enabled, fullReplay, streamKey]);
 
   const loadOlder = useCallback(async (): Promise<boolean> => {
     if (!sessionId || fullReplay || loadingOlderRef.current || !hasOlderRef.current) {
@@ -231,20 +236,22 @@ export function useSessionEvents(
     }
   }, [client, workspaceId, sessionId, fullReplay]);
 
-  const timeline = useMemo(() => buildTimeline(events), [events]);
-  const sessionStatus = useMemo(() => sessionStatusFromEvents(events), [events]);
+  const identityMatches = stateStreamKey === streamKey;
+  const visibleEvents = identityMatches ? events : EMPTY_EVENTS;
+  const timeline = useMemo(() => buildTimeline(visibleEvents), [visibleEvents]);
+  const sessionStatus = useMemo(() => sessionStatusFromEvents(visibleEvents), [visibleEvents]);
 
   return {
-    events,
+    events: visibleEvents,
     timeline,
     sessionStatus,
-    connectionState,
-    lastSequence: lastSequenceRef.current,
-    initialLoading: fullReplay ? false : initialLoading,
-    hasOlder: fullReplay ? false : hasOlder,
-    loadingOlder: fullReplay ? false : loadingOlder,
+    connectionState: identityMatches ? connectionState : "idle",
+    lastSequence: identityMatches ? lastSequenceRef.current : after,
+    initialLoading: fullReplay ? false : identityMatches ? initialLoading : true,
+    hasOlder: fullReplay || !identityMatches ? false : hasOlder,
+    loadingOlder: fullReplay || !identityMatches ? false : loadingOlder,
     loadOlder,
-    error,
+    error: identityMatches ? error : null,
   };
 }
 

--- a/packages/react/src/hooks/use-workspace-capture.ts
+++ b/packages/react/src/hooks/use-workspace-capture.ts
@@ -12,6 +12,7 @@ import { useOpenGeni, type ClientOverride } from "../provider";
 /** The announce event M1 emits at turn end (metadata only, never content). */
 const REVISION_CAPTURED = "workspace.revision.captured";
 const REVISION_DEGRADED = "workspace.revision.degraded";
+const MANIFEST_FETCH_TIMEOUT_MS = 15_000;
 
 export type UseWorkspaceCaptureOptions = ClientOverride & {
   /** Live event log (usually `useSessionEvents().events`) — a
@@ -67,6 +68,7 @@ export function useWorkspaceCapture(
 ): UseWorkspaceCaptureResult {
   const { client, workspaceId } = useOpenGeni(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
+  const identityKey = `${workspaceId}\u0000${sessionId ?? ""}`;
 
   const [capture, setCapture] = useState<WorkspaceCaptureManifest | null>(null);
   const [available, setAvailable] = useState(false);
@@ -79,14 +81,22 @@ export function useWorkspaceCapture(
   // The highest revision ANNOUNCED on the event log — compared against the loaded
   // manifest's revision to compute `isStale` and to gate refreshes.
   const [announcedRevision, setAnnouncedRevision] = useState<number | null>(null);
+  // State updates are asynchronous, so the previous session's capture still
+  // exists during the first render after an identity switch. Tag it and hide it
+  // synchronously until the new identity's request owns the state.
+  const [stateIdentity, setStateIdentity] = useState(identityKey);
 
   // A generation counter fences a slow in-flight fetch against a newer one (or an
   // identity change) so a stale response can never overwrite fresher state.
   const generationRef = useRef(0);
+  // Event sequence numbers are scoped to a session. Keeping this cursor across an
+  // identity switch would discard the new session's low-numbered announcements.
+  const lastSeqRef = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!sessionId) return;
     const generation = (generationRef.current += 1);
+    setStateIdentity(identityKey);
     setLoading(true);
     setError(null);
     try {
@@ -110,7 +120,9 @@ export function useWorkspaceCapture(
       // manifest is the <200ms common case; a >2MB manifest is a signed URL hop.
       let manifest = res.manifest;
       if (!manifest && res.manifestUrl) {
-        const response = await fetch(res.manifestUrl.url);
+        const response = await fetch(res.manifestUrl.url, {
+          signal: AbortSignal.timeout(MANIFEST_FETCH_TIMEOUT_MS),
+        });
         if (generationRef.current !== generation) return;
         if (!response.ok)
           throw new Error(`workspace capture manifest fetch failed: ${response.status}`);
@@ -136,19 +148,28 @@ export function useWorkspaceCapture(
     } finally {
       if (generationRef.current === generation) setLoading(false);
     }
-  }, [client, workspaceId, sessionId]);
+  }, [client, workspaceId, sessionId, identityKey]);
 
   // Mount fetch + reset on identity change.
   useEffect(() => {
+    // Invalidate a request started for the previous identity before clearing its
+    // state. The cleanup also fences a response that arrives after unmount.
+    generationRef.current += 1;
+    lastSeqRef.current = 0;
+    setCapture(null);
+    setAvailable(false);
+    setDegradedReason(null);
+    setFileCount(null);
+    setAnnouncedRevision(null);
+    setError(null);
     if (!enabled) {
-      setCapture(null);
-      setAvailable(false);
-      setDegradedReason(null);
-      setFileCount(null);
-      setAnnouncedRevision(null);
+      setLoading(false);
       return;
     }
     void refresh();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [enabled, refresh]);
 
   // Fold `workspace.revision.captured` announcements. A revision NEWER than the one
@@ -156,7 +177,6 @@ export function useWorkspaceCapture(
   // background. The event is announce-only (metadata) — we still re-fetch the
   // manifest, since the payload carries no content.
   const events = options.events;
-  const lastSeqRef = useRef(0);
   useEffect(() => {
     if (!enabled || !events) return;
     let newest: number | null = null;
@@ -181,28 +201,33 @@ export function useWorkspaceCapture(
   }, [enabled, events]);
 
   // A newer announced revision than the loaded manifest → refresh in the background.
-  const loadedRevision = capture?.revision ?? null;
+  const identityMatches = enabled && stateIdentity === identityKey;
+  const visibleCapture = identityMatches ? capture : null;
+  const visibleAnnouncedRevision = identityMatches ? announcedRevision : null;
+  const loadedRevision = visibleCapture?.revision ?? null;
   useEffect(() => {
     if (!enabled) return;
-    if (announcedRevision === null) return;
-    if (loadedRevision !== null && announcedRevision <= loadedRevision) return;
+    if (visibleAnnouncedRevision === null) return;
+    if (loadedRevision !== null && visibleAnnouncedRevision <= loadedRevision) return;
     // A newer capture exists than the one we hold (or we hold none) — pull it.
     void refresh();
-  }, [enabled, announcedRevision, loadedRevision, refresh]);
+  }, [enabled, visibleAnnouncedRevision, loadedRevision, refresh]);
 
   const isStale =
-    loadedRevision !== null && announcedRevision !== null && announcedRevision > loadedRevision;
+    loadedRevision !== null &&
+    visibleAnnouncedRevision !== null &&
+    visibleAnnouncedRevision > loadedRevision;
 
   return {
-    capture,
+    capture: visibleCapture,
     revision: loadedRevision,
-    capturedAt: capture?.capturedAt ?? null,
-    available,
-    degradedReason,
-    fileCount,
+    capturedAt: visibleCapture?.capturedAt ?? null,
+    available: identityMatches && available,
+    degradedReason: identityMatches ? degradedReason : null,
+    fileCount: identityMatches ? fileCount : null,
     isStale,
-    loading,
-    error,
+    loading: identityMatches && loading,
+    error: identityMatches ? error : null,
     refresh,
   };
 }

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -7,6 +7,8 @@ import { buildTimeline, type TimelineItem } from "../src/timeline";
 
 registerDom();
 
+const SECOND_SESSION_ID = "33333333-3333-4333-8333-333333333333";
+
 function event(
   sequence: number,
   type: SessionEvent["type"] = "user.message",
@@ -86,6 +88,56 @@ describe("useSessionEvents", () => {
     expect(streamCalls).toEqual([1200]);
     expect(lengths.filter((length) => length === 1000)).toHaveLength(1);
 
+    await hook.unmount();
+  });
+
+  test("a session switch never exposes the previous session's event log during render", async () => {
+    let resolveSecond!: (events: SessionEvent[]) => void;
+    const secondPage = new Promise<SessionEvent[]>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const firstEvent = event(1);
+    const secondEvent: SessionEvent = {
+      ...event(1),
+      id: "evt-second-1",
+      sessionId: SECOND_SESSION_ID,
+    };
+    const client = fakeClient({
+      listEvents: async (_workspaceId, sessionId) =>
+        sessionId === SESSION_ID ? [firstEvent] : await secondPage,
+      streamEvents: () =>
+        (async function* () {
+          // Keep the stream contract without yielding additional events.
+        })(),
+    });
+    const observed: Array<{ sessionId: string; eventSessionIds: string[] }> = [];
+    const hook = await renderHook(
+      (props: { sessionId: string }) => {
+        const result = useSessionEvents(props.sessionId, { client, workspaceId: WORKSPACE_ID });
+        observed.push({
+          sessionId: props.sessionId,
+          eventSessionIds: result.events.map((item) => item.sessionId),
+        });
+        return result;
+      },
+      { sessionId: SESSION_ID },
+    );
+    await flush(20);
+    expect(hook.result.current.events.map((item) => item.sessionId)).toEqual([SESSION_ID]);
+
+    observed.length = 0;
+    await hook.rerender({ sessionId: SECOND_SESSION_ID });
+    expect(
+      observed
+        .filter(({ sessionId }) => sessionId === SECOND_SESSION_ID)
+        .flatMap(({ eventSessionIds }) => eventSessionIds),
+    ).not.toContain(SESSION_ID);
+    expect(hook.result.current.events).toEqual([]);
+    expect(hook.result.current.lastSequence).toBe(0);
+
+    resolveSecond([secondEvent]);
+    await flush(20);
+    expect(hook.result.current.events.map((item) => item.sessionId)).toEqual([SECOND_SESSION_ID]);
     await hook.unmount();
   });
 

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -33,6 +33,7 @@ import {
 registerDom();
 
 const EMPTY_MACHINES = { activeSandboxId: null, activeEpoch: 0, machines: [] };
+const SECOND_SESSION_ID = "33333333-3333-4333-8333-333333333333";
 
 /** The composite dock hook's sub-hooks resolve the client from context, so it
  *  must run under a provider (unlike the leaf hooks). This renders it there and
@@ -215,7 +216,8 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     expect(spy.attachCalls).toBe(0);
     // Reach the Files tab's onEditIntent (the editor's first-keystroke signal).
     const filesTab = hook.result.current.tabs.find((t) => t.id === WORKBENCH_TAB_FILES);
-    const onEditIntent = (filesTab?.content as ReactElement<{ onEditIntent: () => void }>).props
+    expect(filesTab).toBeDefined();
+    const onEditIntent = (filesTab!.content as ReactElement<{ onEditIntent: () => void }>).props
       .onEditIntent;
     expect(typeof onEditIntent).toBe("function");
     await act(async () => {
@@ -245,6 +247,43 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     await flush(60);
     expect(spy.attachCalls).toBe(1);
     await hook.unmount();
+  });
+
+  test("switching sessions clears prior warm intent instead of prewarming the new session", async () => {
+    const { client, spy } = coldClient();
+    const result = { current: undefined as unknown as UseSandboxWorkspaceTabsResult };
+    function Harness({ sessionId }: { sessionId: string }) {
+      result.current = useSandboxWorkspaceTabs({ sessionId, events: [] });
+      return null;
+    }
+    const rendered = await renderComponent(
+      withProvider(client, <Harness sessionId={SESSION_ID} />),
+    );
+    await flush(60);
+    const firstFiles = result.current.tabs.find((tab) => tab.id === WORKBENCH_TAB_FILES);
+    expect(firstFiles).toBeDefined();
+    const firstEditIntent = (firstFiles!.content as ReactElement<{ onEditIntent: () => void }>)
+      .props.onEditIntent;
+    await act(async () => {
+      firstEditIntent();
+    });
+    await flush(60);
+    expect(spy.attachCalls).toBe(1);
+
+    await rendered.rerender(withProvider(client, <Harness sessionId={SECOND_SESSION_ID} />));
+    await flush(60);
+    expect(spy.attachCalls).toBe(1);
+
+    const secondFiles = result.current.tabs.find((tab) => tab.id === WORKBENCH_TAB_FILES);
+    expect(secondFiles).toBeDefined();
+    const secondEditIntent = (secondFiles!.content as ReactElement<{ onEditIntent: () => void }>)
+      .props.onEditIntent;
+    await act(async () => {
+      secondEditIntent();
+    });
+    await flush(60);
+    expect(spy.attachCalls).toBe(2);
+    await rendered.unmount();
   });
 });
 
@@ -312,6 +351,28 @@ describe("capture-driven default tab (Refinement 2)", () => {
     expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
     await hook.unmount();
   });
+
+  test("the capture-driven default is latched independently for each session", async () => {
+    const { client } = coldClient({
+      getWorkspaceCapture: async (_workspaceId, sessionId) =>
+        captureAvailable(fakeManifest(sessionId === SESSION_ID ? 2 : 0)),
+    });
+    const result = { current: undefined as unknown as UseSandboxWorkspaceTabsResult };
+    function Harness({ sessionId }: { sessionId: string }) {
+      result.current = useSandboxWorkspaceTabs({ sessionId, events: [] });
+      return null;
+    }
+    const rendered = await renderComponent(
+      withProvider(client, <Harness sessionId={SESSION_ID} />),
+    );
+    await flush();
+    expect(result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+
+    await rendered.rerender(withProvider(client, <Harness sessionId={SECOND_SESSION_ID} />));
+    await flush();
+    expect(result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await rendered.unmount();
+  });
 });
 
 // ── Refinement 2: no post-paint content switch (component level) ──────────────
@@ -368,6 +429,37 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
     );
     await flush();
     expect(selectedTabText(rendered.container)).toContain("Files");
+    await rendered.unmount();
+  });
+
+  test("a tab selection from the previous session does not override the new session default", async () => {
+    const { client } = coldClient({
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),
+    });
+    const workspace = (sessionId: string) =>
+      withProvider(
+        client,
+        <SandboxWorkspace
+          sessionId={sessionId}
+          events={[]}
+          primary={<div>chat</div>}
+          autoSaveId="og.test.prewarm.session-tab"
+        />,
+      );
+    const rendered = await renderComponent(workspace(SESSION_ID));
+    await flush();
+    const filesTab = [...rendered.container.querySelectorAll<HTMLElement>('[role="tab"]')].find(
+      (element) => element.textContent?.includes("Files"),
+    );
+    expect(filesTab).toBeDefined();
+    await act(async () => {
+      filesTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(selectedTabText(rendered.container)).toContain("Files");
+
+    await rendered.rerender(workspace(SECOND_SESSION_ID));
+    await flush();
+    expect(selectedTabText(rendered.container)).toContain("Changes");
     await rendered.unmount();
   });
 });

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -28,6 +28,7 @@ import { deriveMachineChip } from "../src/hooks/use-machine-chip";
 registerDom();
 
 const ctx = { workspaceId: WORKSPACE_ID };
+const SECOND_SESSION_ID = "33333333-3333-4333-8333-333333333333";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -196,8 +197,10 @@ describe("useWorkspaceCapture", () => {
     const manifest = fakeManifest({ revision: 5 });
     const originalFetch = globalThis.fetch;
     let fetched: string | null = null;
-    globalThis.fetch = (async (url: string) => {
+    let fetchSignal: AbortSignal | null = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
       fetched = String(url);
+      fetchSignal = init?.signal ?? null;
       return { ok: true, status: 200, json: async () => manifest } as unknown as Response;
     }) as typeof fetch;
     try {
@@ -223,6 +226,7 @@ describe("useWorkspaceCapture", () => {
       );
       await flush();
       expect(fetched as string | null).toBe("https://blob.example/manifest.json");
+      expect(fetchSignal).not.toBeNull();
       expect(hook.result.current.revision).toBe(5);
       expect(hook.result.current.capture?.files[0]?.path).toBe("src/app.py");
       await hook.unmount();
@@ -309,6 +313,118 @@ describe("useWorkspaceCapture", () => {
     expect(hook.result.current.available).toBe(false);
     expect(hook.result.current.capture).toBeNull();
     expect(hook.result.current.degradedReason).toBe("repository_discovery_command_failed");
+    await hook.unmount();
+  });
+
+  test("disabling the hook fences an older in-flight capture response", async () => {
+    let resolveRequest!: (response: GetWorkspaceCaptureResponse) => void;
+    const request = new Promise<GetWorkspaceCaptureResponse>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const client = fakeClient({ getWorkspaceCapture: async () => await request });
+    const hook = await renderHook(
+      (props: { sessionId: string | null }) =>
+        useWorkspaceCapture(props.sessionId, { ...ctx, client }),
+      { sessionId: SESSION_ID as string | null },
+    );
+
+    await hook.rerender({ sessionId: null });
+    resolveRequest(captureAvailable(fakeManifest({ revision: 99 })));
+    await flush();
+
+    expect(hook.result.current.available).toBe(false);
+    expect(hook.result.current.capture).toBeNull();
+    expect(hook.result.current.revision).toBeNull();
+    await hook.unmount();
+  });
+
+  test("a session change resets the capture announcement sequence cursor", async () => {
+    const responses = new Map<string, WorkspaceCaptureManifest>([
+      [SESSION_ID, fakeManifest({ revision: 50 })],
+      [SECOND_SESSION_ID, fakeManifest({ revision: 1 })],
+    ]);
+    const client = fakeClient({
+      getWorkspaceCapture: async (_workspaceId, sessionId) =>
+        captureAvailable(responses.get(sessionId)!),
+    });
+    const hook = await renderHook(
+      (props: { sessionId: string; events: SessionEvent[] }) =>
+        useWorkspaceCapture(props.sessionId, { ...ctx, client, events: props.events }),
+      {
+        sessionId: SESSION_ID,
+        events: [
+          fakeEvent(50, "workspace.revision.captured", {
+            revision: 50,
+            turnId: "turn-50",
+            capturedAt: "2026-07-08T12:00:00.000Z",
+            leaseEpoch: 1,
+            stats: fakeManifest().stats,
+          }),
+        ],
+      },
+    );
+    await flush();
+    expect(hook.result.current.revision).toBe(50);
+
+    await hook.rerender({ sessionId: SECOND_SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.revision).toBe(1);
+
+    responses.set(SECOND_SESSION_ID, fakeManifest({ revision: 2 }));
+    await hook.rerender({
+      sessionId: SECOND_SESSION_ID,
+      events: [
+        fakeEvent(1, "workspace.revision.captured", {
+          revision: 2,
+          turnId: "turn-2",
+          capturedAt: "2026-07-08T12:01:00.000Z",
+          leaseEpoch: 1,
+          stats: fakeManifest().stats,
+        }),
+      ],
+    });
+    await flush();
+
+    expect(hook.result.current.revision).toBe(2);
+    expect(hook.result.current.isStale).toBe(false);
+    await hook.unmount();
+  });
+
+  test("a session switch never exposes the previous session's capture during render", async () => {
+    let resolveSecond!: (response: GetWorkspaceCaptureResponse) => void;
+    const secondRequest = new Promise<GetWorkspaceCaptureResponse>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const client = fakeClient({
+      getWorkspaceCapture: async (_workspaceId, sessionId) =>
+        sessionId === SESSION_ID
+          ? captureAvailable(fakeManifest({ revision: 10 }))
+          : await secondRequest,
+    });
+    const observed: Array<{ sessionId: string; revision: number | null }> = [];
+    const hook = await renderHook(
+      (props: { sessionId: string }) => {
+        const state = useWorkspaceCapture(props.sessionId, { ...ctx, client });
+        observed.push({ sessionId: props.sessionId, revision: state.revision });
+        return state;
+      },
+      { sessionId: SESSION_ID },
+    );
+    await flush();
+    expect(hook.result.current.revision).toBe(10);
+
+    observed.length = 0;
+    await hook.rerender({ sessionId: SECOND_SESSION_ID });
+    expect(
+      observed
+        .filter(({ sessionId }) => sessionId === SECOND_SESSION_ID)
+        .map(({ revision }) => revision),
+    ).not.toContain(10);
+    expect(hook.result.current.capture).toBeNull();
+
+    resolveSecond(captureAvailable(fakeManifest({ revision: 1 })));
+    await flush();
+    expect(hook.result.current.revision).toBe(1);
     await hook.unmount();
   });
 });
@@ -483,6 +599,205 @@ describe("useSandboxFiles — capture source", () => {
     expect(hook.result.current.source).toBe("live");
     await hook.unmount();
   });
+
+  test("a session change resets the filesystem event sequence cursor", async () => {
+    const fileBySession = new Map([
+      [SESSION_ID, "first.ts"],
+      [SECOND_SESSION_ID, "second-old.ts"],
+    ]);
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      fsList: async (_workspaceId, sessionId) => {
+        const file = fileBySession.get(sessionId)!;
+        return {
+          root: treeDir("", "", [treeFile(file, file, 1)]),
+          revision: 0,
+          truncated: false,
+        };
+      },
+    });
+    const hook = await renderHook(
+      (props: { sessionId: string; events: SessionEvent[] }) =>
+        useSandboxFiles(props.sessionId, {
+          ...ctx,
+          client,
+          events: props.events,
+          liveness: "warm",
+        }),
+      { sessionId: SESSION_ID, events: [fakeEvent(50, "session.title_set")] },
+    );
+    await flush();
+
+    await hook.rerender({ sessionId: SECOND_SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.tree.map((node) => node.path)).toEqual(["second-old.ts"]);
+
+    fileBySession.set(SECOND_SESSION_ID, "second-new.ts");
+    await hook.rerender({
+      sessionId: SECOND_SESSION_ID,
+      events: [
+        fakeEvent(1, "fs.changed", {
+          revision: 1,
+          source: "agent",
+          changes: [{ path: "second-new.ts" }],
+        }),
+      ],
+    });
+    await flush(200);
+
+    expect(hook.result.current.tree.map((node) => node.path)).toEqual(["second-new.ts"]);
+    await hook.unmount();
+  });
+
+  test("a late filesystem response from the previous session cannot replace the new tree", async () => {
+    let resolveFirst!: (value: { root: FsTreeNode; revision: number; truncated: boolean }) => void;
+    const firstList = new Promise<{
+      root: FsTreeNode;
+      revision: number;
+      truncated: boolean;
+    }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      fsList: async (_workspaceId, sessionId) => {
+        if (sessionId === SESSION_ID) return await firstList;
+        return {
+          root: treeDir("", "", [treeFile("second.ts", "second.ts", 1)]),
+          revision: 0,
+          truncated: false,
+        };
+      },
+    });
+    const hook = await renderHook(
+      (props: { sessionId: string }) =>
+        useSandboxFiles(props.sessionId, { ...ctx, client, liveness: "warm" }),
+      { sessionId: SESSION_ID },
+    );
+    await flush();
+
+    await hook.rerender({ sessionId: SECOND_SESSION_ID });
+    await flush();
+    expect(hook.result.current.tree.map((node) => node.path)).toEqual(["second.ts"]);
+
+    resolveFirst({
+      root: treeDir("", "", [treeFile("first-late.ts", "first-late.ts", 1)]),
+      revision: 0,
+      truncated: false,
+    });
+    await flush();
+
+    expect(hook.result.current.tree.map((node) => node.path)).toEqual(["second.ts"]);
+    expect(hook.result.current.source).toBe("live");
+    await hook.unmount();
+  });
+
+  test("a newer capture updates truncated-directory metadata without remounting siblings", async () => {
+    const client = fakeClient({});
+    const first = fakeManifest({
+      revision: 1,
+      treeIndex: treeDir("", "", [
+        { ...treeDir("vendor", "vendor"), truncated: true },
+        treeFile("stable.ts", "stable.ts", 1),
+      ]),
+    });
+    const hook = await renderHook(
+      (props: { capture: WorkspaceCaptureManifest }) =>
+        useSandboxFiles(SESSION_ID, {
+          ...ctx,
+          client,
+          liveness: "cold",
+          capture: props.capture,
+        }),
+      { capture: first },
+    );
+    await flush();
+    const stableBefore = hook.result.current.tree.find((node) => node.path === "stable.ts");
+    expect(hook.result.current.tree.find((node) => node.path === "vendor")?.truncated).toBe(true);
+
+    await hook.rerender({
+      capture: fakeManifest({
+        revision: 2,
+        treeIndex: treeDir("", "", [
+          treeDir("vendor", "vendor"),
+          treeFile("stable.ts", "stable.ts", 1),
+        ]),
+      }),
+    });
+    await flush();
+
+    expect(hook.result.current.tree.find((node) => node.path === "vendor")?.truncated).toBeFalsy();
+    expect(hook.result.current.tree.find((node) => node.path === "stable.ts")).toBe(stableBefore);
+    await hook.unmount();
+  });
+
+  test("a clean git status removes stale file-tree modification tints", async () => {
+    let dirty = true;
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: dirty
+          ? [
+              {
+                path: "app.ts",
+                index: null,
+                worktree: "modified" as const,
+                oldPath: null,
+                isConflicted: false,
+              },
+            ]
+          : [],
+        revision: 0,
+      }),
+      fsList: async () => ({
+        root: treeDir("", "", [treeFile("app.ts", "app.ts", 1)]),
+        revision: 0,
+        truncated: false,
+      }),
+    });
+    const hook = await renderHook(
+      (props: { events: SessionEvent[] }) =>
+        useSandboxFiles(SESSION_ID, {
+          ...ctx,
+          client,
+          events: props.events,
+          liveness: "warm",
+        }),
+      { events: [] as SessionEvent[] },
+    );
+    await flush();
+    expect(hook.result.current.tree[0]?.status).toBe("modified");
+
+    dirty = false;
+    await hook.rerender({ events: [fakeEvent(1, "git.changed")] });
+    await flush(200);
+
+    expect(hook.result.current.tree[0]?.status).toBeUndefined();
+    await hook.unmount();
+  });
 });
 
 // ── use-sandbox-git: source selection + no-flicker ─────────────────────────────
@@ -589,6 +904,141 @@ describe("useSandboxGit — capture source", () => {
     expect(gitDiffCalls).toBeGreaterThan(0);
     expect(hook.result.current.source).toBe("live");
     expect(hook.result.current.diff.map((d) => d.path)).toEqual(["live-only.py"]);
+    await hook.unmount();
+  });
+
+  test("a session change resets the git event sequence cursor", async () => {
+    const pathBySession = new Map([
+      [SESSION_ID, "first.ts"],
+      [SECOND_SESSION_ID, "second-old.ts"],
+    ]);
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      gitDiff: async (_workspaceId, sessionId) => ({
+        files: [fakeDiff({ path: pathBySession.get(sessionId)! })],
+        revision: 0,
+      }),
+    });
+    const hook = await renderHook(
+      (props: { sessionId: string; events: SessionEvent[] }) =>
+        useSandboxGit(props.sessionId, {
+          ...ctx,
+          client,
+          events: props.events,
+          liveness: "warm",
+        }),
+      { sessionId: SESSION_ID, events: [fakeEvent(50, "git.changed")] },
+    );
+    await flush();
+
+    await hook.rerender({ sessionId: SECOND_SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.diff.map((file) => file.path)).toEqual(["second-old.ts"]);
+
+    pathBySession.set(SECOND_SESSION_ID, "second-new.ts");
+    await hook.rerender({
+      sessionId: SECOND_SESSION_ID,
+      events: [fakeEvent(1, "git.changed")],
+    });
+    await flush();
+
+    expect(hook.result.current.diff.map((file) => file.path)).toEqual(["second-new.ts"]);
+    await hook.unmount();
+  });
+
+  test("a same-shape git refresh replaces changed hunk content", async () => {
+    let lineText = "old line";
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      gitDiff: async () => ({
+        files: [
+          fakeDiff({
+            hunks: [
+              {
+                oldStart: 1,
+                oldLines: 1,
+                newStart: 1,
+                newLines: 2,
+                header: "@@ -1 +1,2 @@",
+                lines: [{ type: "add", oldNo: null, newNo: 2, text: lineText }],
+              },
+            ],
+          }),
+        ],
+        revision: 0,
+      }),
+    });
+    const hook = await renderHook(
+      (props: { events: SessionEvent[] }) =>
+        useSandboxGit(SESSION_ID, { ...ctx, client, events: props.events, liveness: "warm" }),
+      { events: [] as SessionEvent[] },
+    );
+    await flush();
+    expect(hook.result.current.diff[0]?.hunks[0]?.lines[0]?.text).toBe("old line");
+
+    lineText = "new line";
+    await hook.rerender({ events: [fakeEvent(1, "git.changed")] });
+    await flush();
+
+    expect(hook.result.current.diff[0]?.hunks[0]?.lines[0]?.text).toBe("new line");
+    await hook.unmount();
+  });
+
+  test("a late git response from the previous session cannot replace the new diff", async () => {
+    let resolveFirst!: (value: { files: GitFileDiff[]; revision: number }) => void;
+    const firstDiff = new Promise<{ files: GitFileDiff[]; revision: number }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      gitDiff: async (_workspaceId, sessionId) => {
+        if (sessionId === SESSION_ID) return await firstDiff;
+        return { files: [fakeDiff({ path: "second.ts" })], revision: 0 };
+      },
+    });
+    const hook = await renderHook(
+      (props: { sessionId: string }) =>
+        useSandboxGit(props.sessionId, { ...ctx, client, liveness: "warm" }),
+      { sessionId: SESSION_ID },
+    );
+    await flush();
+
+    await hook.rerender({ sessionId: SECOND_SESSION_ID });
+    await flush();
+    expect(hook.result.current.diff.map((file) => file.path)).toEqual(["second.ts"]);
+
+    resolveFirst({ files: [fakeDiff({ path: "first-late.ts" })], revision: 0 });
+    await flush();
+
+    expect(hook.result.current.diff.map((file) => file.path)).toEqual(["second.ts"]);
+    expect(hook.result.current.source).toBe("live");
     await hook.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- hide and reset session-owned events, captures, filesystem, git, warm intents, and tab latches at the identity boundary
- fence late async responses and debounced reconciles so prior sessions cannot repaint the current workbench
- compare full diff content, clear stale git tints and truncated metadata, and bound signed-manifest fetches

## Verification
- 567 React tests
- 19-project repository typecheck
- React package and demo production builds
- oxlint, oxfmt, diff check
- UBS plus manual changed-line triage

Cloudgeni PR #1577 is intentionally untouched and remains unmerged.