### PR TITLE
perf(worker): double turn concurrency to sixteen

### DIFF
--- a/apps/worker/src/concurrency.ts
+++ b/apps/worker/src/concurrency.ts
@@ -1,0 +1,11 @@
+/**
+ * Process-local Temporal execution ceilings.
+ *
+ * Turn workers host only runAgentTurn, so this is the exact number of agent
+ * turns one worker process may own concurrently. Keep the value centralized so
+ * production and the real Temporal integration harness exercise one topology.
+ */
+export const TURN_WORKER_MAX_CONCURRENT_TURNS = 16;
+
+export const CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES = 32;
+export const CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS = 40;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -35,6 +35,11 @@ import {
   SESSION_WORKFLOW_WAKE_DISPATCHER_SCHEDULE_ID,
   SESSION_WORKFLOW_WAKE_DISPATCHER_WORKFLOW_TYPE,
 } from "./workflow-wake-contract";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "./concurrency";
 
 // The deterministic id of the ONE global reaper Schedule. A single id means
 // create() is idempotent across every worker in the pool: the first worker to
@@ -106,11 +111,14 @@ export async function createOpenGeniWorker(options: WorkerOptions): Promise<{
       ? {
           workflowsPath:
             options.workflowsPath ?? new URL("../src/workflows.ts", import.meta.url).pathname,
-          maxConcurrentWorkflowTaskExecutions: 40,
+          maxConcurrentWorkflowTaskExecutions: CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
         }
       : {}),
     activities,
-    maxConcurrentActivityTaskExecutions: options.role === "turn" ? 8 : 32,
+    maxConcurrentActivityTaskExecutions:
+      options.role === "turn"
+        ? TURN_WORKER_MAX_CONCURRENT_TURNS
+        : CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
     // GRACEFUL DEPLOY SHUTDOWN (with the SIGTERM handler in startWorker):
     // after shutdown() stops polling, in-flight activities get this long to
     // finish naturally; the rest are then CANCELLED with WORKER_SHUTDOWN —
@@ -458,8 +466,12 @@ export async function startWorker() {
       role,
       temporalTaskQueue:
         role === "control" ? settings.temporalTaskQueue : turnTaskQueue(settings.temporalTaskQueue),
-      maxConcurrentActivityTaskExecutions: role === "turn" ? 8 : 32,
-      maxConcurrentWorkflowTaskExecutions: role === "control" ? 40 : 0,
+      maxConcurrentActivityTaskExecutions:
+        role === "turn"
+          ? TURN_WORKER_MAX_CONCURRENT_TURNS
+          : CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+      maxConcurrentWorkflowTaskExecutions:
+        role === "control" ? CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS : 0,
       httpPort: settings.workerHttpPort,
     });
     // GRACEFUL DEPLOY SHUTDOWN — the missing link that made every deploy a

--- a/apps/worker/test/concurrency.test.ts
+++ b/apps/worker/test/concurrency.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../src/concurrency";
+
+describe("worker concurrency contract", () => {
+  test("pins the temporary production turn density independently of control work", () => {
+    expect(TURN_WORKER_MAX_CONCURRENT_TURNS).toBe(16);
+    expect(CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES).toBe(32);
+    expect(CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS).toBe(40);
+  });
+});

--- a/deploy/helm/opengeni/values.azure-managed.example.yaml
+++ b/deploy/helm/opengeni/values.azure-managed.example.yaml
@@ -17,9 +17,9 @@ worker:
   turns:
     replicaCount: 4
     # Turn pods hold the in-flight model history and sandbox clients. The
-    # per-pod activity cap is enforced by the worker process; these limits cover
-    # the measured transient serialization peak without granting control work
-    # the same oversized footprint.
+    # worker process enforces an explicit activity cap; these requests and
+    # limits provide headroom for the temporary 16-turn density while OPE-52
+    # measures the final concurrency/resource optimum.
     resources:
       requests:
         cpu: 500m

--- a/docs/design/session-control-plane-clean-cutover-2026-07-13.md
+++ b/docs/design/session-control-plane-clean-cutover-2026-07-13.md
@@ -840,8 +840,9 @@ Store the report durably in the private release evidence location. Do not print 
    - **control worker**: workflow tasks and every short/control/recovery activity, never
      `runAgentTurn`, with explicit workflow/activity/cache caps;
    - **turn worker**: derived `<control-task-queue>-turns`, only `runAgentTurn`, explicit
-     fixed concurrency eight per pod, its own resources, HPA, PDB, service, readiness,
-     liveness, and termination grace.
+     fixed concurrency sixteen per pod, its own resources, HPA, PDB, service, readiness,
+     liveness, and termination grace. Sixteen is the evidence-informed temporary density;
+     OPE-52 owns the controlled concurrency/resource sweep that will select the final value.
 
    Both roles use one Worker per process. No same-process dual Worker, SDK default slot
    count, resource tuner, semaphore, activity alias, or dual-routing fallback ships.

--- a/test/integration/durable-queue-control.integration.ts
+++ b/test/integration/durable-queue-control.integration.ts
@@ -29,6 +29,10 @@ import {
 } from "@opengeni/testing";
 import { createActivityTestHarness } from "../../apps/worker/src/activities";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../../apps/worker/src/concurrency";
 import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 type RequiredServices = Pick<
@@ -603,14 +607,14 @@ async function integrationWorker(
       taskQueue,
       workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
       activities: controlActivities,
-      maxConcurrentActivityTaskExecutions: 32,
+      maxConcurrentActivityTaskExecutions: CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
     }),
     Worker.create({
       connection: temporalConnection,
       namespace: "default",
       taskQueue: turnTaskQueue(taskQueue),
       activities: { runAgentTurn },
-      maxConcurrentActivityTaskExecutions: 8,
+      maxConcurrentActivityTaskExecutions: TURN_WORKER_MAX_CONCURRENT_TURNS,
     }),
   ]);
   return {

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -3,6 +3,10 @@ import { Client, Connection } from "@temporalio/client";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { startTestServices, type TestServices, waitFor } from "@opengeni/testing";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../../apps/worker/src/concurrency";
 import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 // An ungraceful worker death cannot be faked by throwing a TimeoutFailure
@@ -1653,14 +1657,14 @@ async function testWorker(
       taskQueue,
       workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
       activities: controlActivities,
-      maxConcurrentActivityTaskExecutions: 32,
+      maxConcurrentActivityTaskExecutions: CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
     }),
     Worker.create({
       connection: nativeConnection,
       namespace: "default",
       taskQueue: turnTaskQueue(taskQueue),
       activities: { runAgentTurn },
-      maxConcurrentActivityTaskExecutions: 8,
+      maxConcurrentActivityTaskExecutions: TURN_WORKER_MAX_CONCURRENT_TURNS,
     }),
   ]);
   return {

--- a/test/integration/worker-restart.integration.ts
+++ b/test/integration/worker-restart.integration.ts
@@ -31,6 +31,10 @@ import { postUserMessageTurn } from "@opengeni/core";
 import type { SessionWorkflowClient } from "../../apps/api/src/app";
 import { createActivityTestHarness } from "../../apps/worker/src/activities";
 import { currentActivityContext } from "../../apps/worker/src/activities/streaming";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../../apps/worker/src/concurrency";
 import { turnTaskQueue } from "../../apps/worker/src/workflows/activities";
 
 // Proves the campaign's robustness contract: a worker rollout restart
@@ -673,14 +677,14 @@ async function restartTestWorker(
       taskQueue,
       workflowsPath: new URL("../../apps/worker/src/workflows.ts", import.meta.url).pathname,
       activities: controlActivities,
-      maxConcurrentActivityTaskExecutions: 32,
+      maxConcurrentActivityTaskExecutions: CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
     }),
     Worker.create({
       connection: nativeConnection,
       namespace: "default",
       taskQueue: turnTaskQueue(taskQueue),
       activities: { runAgentTurn },
-      maxConcurrentActivityTaskExecutions: 8,
+      maxConcurrentActivityTaskExecutions: TURN_WORKER_MAX_CONCURRENT_TURNS,
     }),
   ]);
   return {


### PR DESCRIPTION
## Summary
- centralize worker concurrency ceilings in one runtime contract
- raise turn-worker ownership from 8 to 16 concurrent `runAgentTurn` activities
- make the real Temporal integration harness consume the same contract
- leave control activity/workflow limits unchanged

## Why now
Production evidence at the previous 8-turn ceiling showed substantial CPU and memory headroom with zero throttling, OOMs, or restarts. Paired with a 10-pod floor, this preserves the current 160-slot minimum while reducing worker-process overhead. This is the temporary setting tracked for full optimization in OPE-52.

## Behavior proof
- Ordering preserved: Temporal task-queue ordering and session serialization are unchanged; only the number of different sessions a process may own concurrently changes.
- Tie-breaking unchanged: no allocator or queue selection logic changed.
- Conversation/turn semantics unchanged: exact same `runAgentTurn` implementation, attempt fencing, settlement, and recovery path.
- Failure behavior unchanged: each turn retains its existing attempt identity and graceful shutdown checkpoint.
- Tests: typecheck, lint, format, 394 worker tests, focused concurrency contract; real Temporal harness wired to the same constants.
- UBS: changed production source reports 0 critical / 0 warning; staged whole-file findings were pre-existing test-code heuristics outside changed lines.