### PR TITLE
fix(release): derive topology evidence from runtime

### DIFF
--- a/scripts/operator/session-control-cutover.test.ts
+++ b/scripts/operator/session-control-cutover.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { schedulePauseOwnedByRun } from "./session-control-cutover";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../../apps/worker/src/concurrency";
+import { schedulePauseOwnedByRun, workerTopologyEvidence } from "./session-control-cutover";
 
 describe("production cutover operator retry ownership", () => {
   it("re-emits only unpaused schedules or schedules already paused by the same run", () => {
@@ -8,5 +13,17 @@ describe("production cutover operator retry ownership", () => {
     expect(schedulePauseOwnedByRun(true, note, note)).toBe(true);
     expect(schedulePauseOwnedByRun(true, "manual operator pause", note)).toBe(false);
     expect(schedulePauseOwnedByRun(true, null, note)).toBe(false);
+  });
+});
+
+describe("production cutover preflight topology", () => {
+  it("reads every worker ceiling from the runtime concurrency contract", () => {
+    expect(workerTopologyEvidence()).toEqual({
+      roles: ["control", "turn"],
+      turnTaskQueueSuffix: "-turns",
+      controlActivityConcurrencyPerPod: CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+      controlWorkflowConcurrencyPerPod: CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+      turnActivityConcurrencyPerPod: TURN_WORKER_MAX_CONCURRENT_TURNS,
+    });
   });
 });

--- a/scripts/operator/session-control-cutover.ts
+++ b/scripts/operator/session-control-cutover.ts
@@ -27,12 +27,27 @@ import {
   SESSION_WORKFLOW_WAKE_DISPATCHER_SCHEDULE_ID,
   SESSION_WORKFLOW_WAKE_DISPATCHER_WORKFLOW_TYPE,
 } from "../../apps/worker/src/workflow-wake-contract";
+import {
+  CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+  CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+  TURN_WORKER_MAX_CONCURRENT_TURNS,
+} from "../../apps/worker/src/concurrency";
 
 type ParsedArgs = {
   command: string;
   values: Map<string, string>;
   flags: Set<string>;
 };
+
+export function workerTopologyEvidence() {
+  return {
+    roles: ["control", "turn"] as const,
+    turnTaskQueueSuffix: "-turns",
+    controlActivityConcurrencyPerPod: CONTROL_WORKER_MAX_CONCURRENT_ACTIVITIES,
+    controlWorkflowConcurrencyPerPod: CONTROL_WORKER_MAX_CONCURRENT_WORKFLOW_TASKS,
+    turnActivityConcurrencyPerPod: TURN_WORKER_MAX_CONCURRENT_TURNS,
+  };
+}
 
 function parseArgs(argv: string[]): ParsedArgs {
   const [command = "help", ...rest] = argv;
@@ -1422,13 +1437,7 @@ async function preflight(args: ParsedArgs): Promise<void> {
     capturedAt: new Date().toISOString(),
     sourceSha: bakedSourceSha,
     migrations,
-    workerTopology: {
-      roles: ["control", "turn"],
-      turnTaskQueueSuffix: "-turns",
-      controlActivityConcurrencyPerPod: 32,
-      controlWorkflowConcurrencyPerPod: 40,
-      turnActivityConcurrencyPerPod: 8,
-    },
+    workerTopology: workerTopologyEvidence(),
     validationModelPolicy: {
       allowedPrefix: "codex/",
       azureModelTokensAllowed: false,


### PR DESCRIPTION
## Summary
- remove stale worker-concurrency literals from the protected cutover/source preflight
- generate release topology evidence from the runtime concurrency contract
- add a regression test that compares the emitted topology object to the runtime constants

## Why
The first protected build for the 16-turn worker correctly built the runtime but exposed a contradictory `turnActivityConcurrencyPerPod: 8` in source-preflight evidence. That artifact will not be deployed. This PR makes duplicate drift impossible.

## Verification
- typecheck and format
- operator + worker concurrency tests
- real local preflight execution emits control 32/workflows 40/turns 16
- the superseded build run 29480358019 is retained as failure-detection evidence, not promoted