### PR TITLE
Fix deep workstream navigation and session timeline noise

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -223,6 +223,25 @@ describe("rail session grouping", () => {
     expect(forest.running[0]?.hasActiveDescendant).toBe(true);
   });
 
+  test("buildRailForest trusts server descendant activity before children are loaded", () => {
+    const manager = railSession({
+      id: "manager-summary",
+      status: "idle",
+      updatedAt: "2026-06-01T10:00:00.000Z",
+      treeStats: {
+        directChildren: 2,
+        totalDescendants: 7,
+        runningDescendants: 1,
+        queuedDescendants: 2,
+        attentionDescendants: 0,
+        pausedDescendants: 3,
+        failedDescendants: 0,
+      },
+    });
+    const forest = buildRailForest([manager], NOW);
+    expect(forest.running.map((node) => node.session.id)).toEqual(["manager-summary"]);
+  });
+
   test("visibleForestRows expands only where the set says so", () => {
     const forest = buildRailForest(
       [

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -26,8 +26,15 @@ import {
 } from "./lib/routes";
 import { sameSessionForContext } from "./lib/session-context";
 import {
+  defaultExpandedAncestors,
+  sessionAncestorPath,
+  sessionStateLabel,
+  visualTreeDepth,
+} from "./lib/session-rail";
+import {
   buildRailForest,
   groupSessionsForRail,
+  isRunningStatus,
   recencyGroupFor,
   relativeTimeLabel,
   visibleForestRows,
@@ -109,7 +116,11 @@ describe("rail session grouping", () => {
           status: "running",
           updatedAt: "2026-01-01T00:00:00.000Z",
         }),
-        railSession({ id: "today-idle", status: "idle", updatedAt: "2026-06-19T09:00:00.000Z" }),
+        railSession({
+          id: "today-idle",
+          status: "idle",
+          updatedAt: "2026-06-19T09:00:00.000Z",
+        }),
         railSession({
           id: "new-running",
           status: "running",
@@ -196,8 +207,16 @@ describe("rail session grouping", () => {
   test("buildRailForest keeps sessions in a parent cycle visible at the root", () => {
     const forest = buildRailForest(
       [
-        railSession({ id: "a", parentSessionId: "b", updatedAt: "2026-06-19T10:00:00.000Z" }),
-        railSession({ id: "b", parentSessionId: "a", updatedAt: "2026-06-19T11:00:00.000Z" }),
+        railSession({
+          id: "a",
+          parentSessionId: "b",
+          updatedAt: "2026-06-19T10:00:00.000Z",
+        }),
+        railSession({
+          id: "b",
+          parentSessionId: "a",
+          updatedAt: "2026-06-19T11:00:00.000Z",
+        }),
       ],
       NOW,
     );
@@ -209,7 +228,11 @@ describe("rail session grouping", () => {
   test("buildRailForest pins a manager whose only activity is a live child", () => {
     const forest = buildRailForest(
       [
-        railSession({ id: "manager", status: "idle", updatedAt: "2026-06-01T10:00:00.000Z" }),
+        railSession({
+          id: "manager",
+          status: "idle",
+          updatedAt: "2026-06-01T10:00:00.000Z",
+        }),
         railSession({
           id: "worker",
           status: "running",
@@ -263,6 +286,82 @@ describe("rail session grouping", () => {
   });
 });
 
+describe("rail effective state and deep-path presentation", () => {
+  const pausedWorkspace = {
+    inferenceState: "paused" as const,
+    inferenceGeneration: 7,
+  };
+
+  test("does not claim an idle exception is running", () => {
+    expect(
+      sessionStateLabel(
+        session({ status: "idle", workspaceRunExceptionGeneration: 7 }),
+        pausedWorkspace,
+      ),
+    ).toBe("Idle · Allowed while paused");
+    expect(
+      sessionStateLabel(
+        session({ status: "running", workspaceRunExceptionGeneration: 7 }),
+        pausedWorkspace,
+      ),
+    ).toBe("Running · Workspace exception");
+    expect(
+      sessionStateLabel(session({ status: "idle", workspaceRunExceptionGeneration: undefined }), {
+        inferenceState: "paused",
+      }),
+    ).toBe("Paused by workspace");
+  });
+
+  test("reports workspace pause transitions and attention honestly", () => {
+    expect(sessionStateLabel(session({ status: "running" }), pausedWorkspace)).toBe("Pausing…");
+    expect(sessionStateLabel(session({ status: "idle" }), pausedWorkspace)).toBe(
+      "Paused by workspace",
+    );
+    expect(sessionStateLabel(session({ status: "requires_action" }), pausedWorkspace)).toBe(
+      "Needs you · Workspace paused",
+    );
+  });
+
+  test("keeps direct session pause distinct from workspace pause", () => {
+    expect(sessionStateLabel(session({ status: "idle", controlState: "paused" }), undefined)).toBe(
+      "Paused",
+    );
+    expect(
+      sessionStateLabel(session({ status: "failed", controlState: "paused" }), undefined),
+    ).toBe("Failed · Session paused");
+  });
+
+  test("keeps recovering and capacity-waiting workstreams in the active group", () => {
+    expect(isRunningStatus("recovering")).toBe(true);
+    expect(isRunningStatus("waiting_capacity")).toBe(true);
+  });
+
+  test("defaults a deep active path to three visible levels and respects manual collapse", () => {
+    const parentOf = new Map([
+      ["current", "level-5"],
+      ["level-5", "level-4"],
+      ["level-4", "level-3"],
+      ["level-3", "level-2"],
+      ["level-2", "root"],
+    ]);
+    const path = sessionAncestorPath("current", parentOf);
+    expect(path).toEqual(["root", "level-2", "level-3", "level-4", "level-5"]);
+    expect([...defaultExpandedAncestors(path, new Set())]).toEqual(["root", "level-2"]);
+    expect([...defaultExpandedAncestors(path, new Set(["level-2"]))]).toEqual(["root"]);
+  });
+
+  test("guards corrupt parent cycles and caps visual indentation", () => {
+    const cyclicParents = new Map([
+      ["current", "a"],
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+    expect(sessionAncestorPath("current", cyclicParents)).toEqual(["b", "a"]);
+    expect(visualTreeDepth(1)).toBe(1);
+    expect(visualTreeDepth(20)).toBe(3);
+  });
+});
+
 describe("session context equality", () => {
   test("treats equivalent live-status overlay objects as unchanged", () => {
     const current = session({ status: "running" });
@@ -273,7 +372,11 @@ describe("session context equality", () => {
 
   test("detects meaningful session changes", () => {
     const current = session({ status: "queued", activeTurnId: null });
-    const next = { ...current, status: "running" as const, activeTurnId: "turn-1" };
+    const next = {
+      ...current,
+      status: "running" as const,
+      activeTurnId: "turn-1",
+    };
 
     expect(sameSessionForContext(current, next)).toBe(false);
   });
@@ -500,7 +603,11 @@ describe("session create draft", () => {
       goalMaxAutoContinuations: "-3",
     };
     expect(submissionFromSessionDraft(draft).extras).toEqual({});
-    const withGoal = { ...draft, goalText: "goal", goalMaxAutoContinuations: "not-a-number" };
+    const withGoal = {
+      ...draft,
+      goalText: "goal",
+      goalMaxAutoContinuations: "not-a-number",
+    };
     expect(submissionFromSessionDraft(withGoal).extras).toEqual({
       goal: { text: "goal", successCriteria: "criteria without a goal" },
     });
@@ -519,7 +626,10 @@ describe("session create draft", () => {
     };
     expect(submissionFromSessionDraft(draft)).toEqual({
       extras: {},
-      options: { targetSandboxId: "sbx-machine-1", workingDir: "~/repos/opengeni" },
+      options: {
+        targetSandboxId: "sbx-machine-1",
+        workingDir: "~/repos/opengeni",
+      },
       omitWorkspaceResources: true,
     });
   });
@@ -534,7 +644,10 @@ describe("session create draft", () => {
       },
     };
     const submission = submissionFromSessionDraft(draft);
-    expect(submission.options).toEqual({ targetSandboxId: "sbx-machine-2", workingDir: null });
+    expect(submission.options).toEqual({
+      targetSandboxId: "sbx-machine-2",
+      workingDir: null,
+    });
     expect(submission.omitWorkspaceResources).toBe(true);
   });
 
@@ -551,7 +664,11 @@ describe("session create draft", () => {
     expect(
       isSessionDraftComputeReady({
         ...emptySessionDraft(),
-        compute: { kind: "machine", sandboxId: "sbx-1", folder: { kind: "root" } },
+        compute: {
+          kind: "machine",
+          sandboxId: "sbx-1",
+          folder: { kind: "root" },
+        },
       }),
     ).toBe(true);
   });
@@ -560,7 +677,11 @@ describe("session create draft", () => {
     // §3 backend row: options = managed descriptors (backend !== "selfhosted");
     // the Connected Machine kind is the selfhosted target, never a backend choice.
     const options = managedBackendOptions();
-    expect(options[0]).toEqual({ value: "", label: "Deployment default", chips: [] });
+    expect(options[0]).toEqual({
+      value: "",
+      label: "Deployment default",
+      chips: [],
+    });
     const values = options.map((option) => option.value);
     expect(values).not.toContain("selfhosted");
     expect(values).toContain("modal");
@@ -578,7 +699,9 @@ describe("projectSessionTimeline", () => {
       event(1, "user.message", { text: "Inspect the repo" }),
       event(2, "turn.started", {}),
       event(3, "agent.message.delta", { text: "I will inspect first." }),
-      event(4, "agent.reasoning.delta", { text: "Checking the repository state." }),
+      event(4, "agent.reasoning.delta", {
+        text: "Checking the repository state.",
+      }),
       event(5, "agent.toolCall.created", {
         id: "call-1",
         name: "exec_command",
@@ -647,7 +770,9 @@ describe("projectSessionTimeline", () => {
       event(4, "turn.completed", { output: "Done." }),
     ]);
 
-    expect(items.find((item) => item.kind === "reasoning")).toMatchObject({ streaming: false });
+    expect(items.find((item) => item.kind === "reasoning")).toMatchObject({
+      streaming: false,
+    });
     expect(JSON.stringify(items)).not.toContain('"running"');
   });
 
@@ -671,7 +796,10 @@ describe("projectSessionTimeline", () => {
   test("falls back to the initial message while the event log is empty", () => {
     const items = projectSessionTimeline(session({ initialMessage: "Bootstrap the cluster" }), []);
     expect(items).toHaveLength(1);
-    expect(items[0]).toMatchObject({ kind: "user-message", text: "Bootstrap the cluster" });
+    expect(items[0]).toMatchObject({
+      kind: "user-message",
+      text: "Bootstrap the cluster",
+    });
   });
 
   test("hides archived terminal failure payloads in the main timeline projection", () => {
@@ -879,7 +1007,12 @@ describe("buildTools", () => {
             notes: null,
           },
         }),
-        capabilityItem({ id: "api:social", kind: "api", name: "Social API", enabled: true }),
+        capabilityItem({
+          id: "api:social",
+          kind: "api",
+          name: "Social API",
+          enabled: true,
+        }),
       ]),
     ).toEqual([{ id: "cap-ready", name: "Ready MCP" }]);
   });
@@ -1049,7 +1182,12 @@ describe("capability catalog helpers", () => {
             {
               id: "daily-social-analysis",
               name: "Daily social analysis",
-              defaultSchedule: { type: "calendar", timeZone: "UTC", hour: 9, minute: 0 },
+              defaultSchedule: {
+                type: "calendar",
+                timeZone: "UTC",
+                hour: 9,
+                minute: 0,
+              },
             },
           ],
         },
@@ -1093,11 +1231,19 @@ describe("scheduled task form helpers", () => {
 
     expect(form.scheduleType).toBe("interval");
     expect(form.intervalMinutes).toBe(30);
-    expect(scheduleFromFormState(form)).toEqual({ type: "interval", everySeconds: 1800 });
+    expect(scheduleFromFormState(form)).toEqual({
+      type: "interval",
+      everySeconds: 1800,
+    });
   });
 
   test("hydrates and serializes calendar schedules", () => {
-    const task = scheduledTask({ type: "calendar", timeZone: "Europe/Oslo", hour: 9, minute: 5 });
+    const task = scheduledTask({
+      type: "calendar",
+      timeZone: "Europe/Oslo",
+      hour: 9,
+      minute: 5,
+    });
     const form = formStateFromScheduledTask(task);
 
     expect(form.scheduleType).toBe("calendar");
@@ -1151,7 +1297,11 @@ describe("scheduled task form helpers", () => {
         },
       },
     );
-    const form = { ...formStateFromScheduledTask(task), prompt: "new", includeOpenGeniTool: false };
+    const form = {
+      ...formStateFromScheduledTask(task),
+      prompt: "new",
+      includeOpenGeniTool: false,
+    };
 
     expect(form.resources).toEqual(resources);
     expect(agentConfigFromFormState(form, task)).toEqual({
@@ -1196,7 +1346,10 @@ describe("scheduled task form helpers", () => {
         githubRepositoryId: 456,
       },
     ];
-    const form = { ...formStateFromScheduledTask(task), resources: selectedResources };
+    const form = {
+      ...formStateFromScheduledTask(task),
+      resources: selectedResources,
+    };
 
     expect(agentConfigFromFormState(form, task)).toMatchObject({
       resources: selectedResources,
@@ -1211,7 +1364,11 @@ describe("scheduled task form helpers", () => {
 describe("scheduled task run summaries", () => {
   test("summarizes the most recent run with honest tones", () => {
     const summary = summarizeLastRun([
-      taskRun({ id: "run-1", firedAt: "2026-06-10T08:00:00.000Z", status: "dispatched" }),
+      taskRun({
+        id: "run-1",
+        firedAt: "2026-06-10T08:00:00.000Z",
+        status: "dispatched",
+      }),
       taskRun({
         id: "run-2",
         firedAt: "2026-06-11T08:00:00.000Z",
@@ -1537,8 +1694,16 @@ describe("workspace switcher helpers", () => {
     const context = accessContext({
       defaultAccountId: "account-default",
       accountGrants: [
-        { accountId: "account-default", subjectId: "subject-1", permissions: ["workspace:create"] },
-        { accountId: "account-active", subjectId: "subject-1", permissions: ["account:admin"] },
+        {
+          accountId: "account-default",
+          subjectId: "subject-1",
+          permissions: ["workspace:create"],
+        },
+        {
+          accountId: "account-active",
+          subjectId: "subject-1",
+          permissions: ["account:admin"],
+        },
       ],
     });
     expect(workspaceCreationAccountId(context, "account-active")).toBe("account-active");
@@ -1548,14 +1713,22 @@ describe("workspace switcher helpers", () => {
     const context = accessContext({
       defaultAccountId: "account-default",
       accountGrants: [
-        { accountId: "account-default", subjectId: "subject-1", permissions: ["workspace:create"] },
+        {
+          accountId: "account-default",
+          subjectId: "subject-1",
+          permissions: ["workspace:create"],
+        },
       ],
     });
     expect(workspaceCreationAccountId(context, "account-other")).toBe("account-default");
 
     const indirect = accessContext({
       accountGrants: [
-        { accountId: "account-3", subjectId: "subject-1", permissions: ["workspace:create"] },
+        {
+          accountId: "account-3",
+          subjectId: "subject-1",
+          permissions: ["workspace:create"],
+        },
       ],
     });
     expect(workspaceCreationAccountId(indirect, null)).toBe("account-3");
@@ -1565,7 +1738,11 @@ describe("workspace switcher helpers", () => {
     const context = accessContext({
       defaultAccountId: "account-default",
       accountGrants: [
-        { accountId: "account-default", subjectId: "subject-1", permissions: ["billing:read"] },
+        {
+          accountId: "account-default",
+          subjectId: "subject-1",
+          permissions: ["billing:read"],
+        },
       ],
     });
     expect(workspaceCreationAccountId(context, null)).toBeNull();

--- a/apps/web/src/components/rail/rail-footer.tsx
+++ b/apps/web/src/components/rail/rail-footer.tsx
@@ -119,27 +119,29 @@ export function RailFooter() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
-              onClick={rail.toggleCollapsed}
-              className="shrink-0 text-fg-subtle hover:text-fg"
-            >
-              {rail.collapsed ? (
-                <ChevronsRightIcon className="size-4" />
-              ) : (
-                <ChevronsLeftIcon className="size-4" />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            {rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          </TooltipContent>
-        </Tooltip>
+        {!rail.isMobile ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
+                onClick={rail.toggleCollapsed}
+                className="shrink-0 text-fg-subtle hover:text-fg"
+              >
+                {rail.collapsed ? (
+                  <ChevronsRightIcon className="size-4" />
+                ) : (
+                  <ChevronsLeftIcon className="size-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {rail.collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -219,7 +219,9 @@ function RailResizeHandle({
 
 export function RailShell({ children }: { children: ReactNode }) {
   const rail = useRail();
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
   // Focus returns here when the mobile drawer closes (D9.1): the drawer is a
   // controlled Sheet with no in-tree trigger, so radix can't restore focus on
   // its own — we point it back at the hamburger that opened it.
@@ -368,7 +370,9 @@ export function RailShell({ children }: { children: ReactNode }) {
 function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonElement | null> }) {
   const rail = useRail();
   const context = useAppContext();
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
   const isSessionRoute = /\/sessions\/[^/]+/.test(pathname);
   const showSessionActions = Boolean(context.session) && isSessionRoute;
   // A lineage read for the header's "spawned by" breadcrumb (disabled when there
@@ -376,7 +380,9 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
   // spawn events can't trigger a refresh here; a modest poll keeps the ancestor
   // link honest without threading the stream into the rail. (The child-agents
   // count moved to the composer pill, which reads lineage off the live feed.)
-  const lineage = useSessionLineage(context.session?.id ?? null, { pollIntervalMs: 30_000 });
+  const lineage = useSessionLineage(context.session?.id ?? null, {
+    pollIntervalMs: 30_000,
+  });
   const ancestors = lineage.lineage?.ancestors ?? [];
   const parentSession = ancestors.length > 0 ? ancestors[ancestors.length - 1]! : null;
 
@@ -392,7 +398,13 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
       variant="ghost"
       size="icon-sm"
       aria-label="Open navigation"
-      onClick={() => rail.setDrawerOpen(true)}
+      onClick={() => {
+        // On phones the workspace inspector is also a full-screen surface.
+        // Make the two overlays mutually exclusive instead of stacking one
+        // modal beneath another and trapping the navigation out of sight.
+        context.setInspectorOpen(false);
+        rail.setDrawerOpen(true);
+      }}
       className="pointer-coarse:size-11"
     >
       <MenuIcon className="size-4" />
@@ -413,7 +425,10 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
         keyAuthRequired={context.keyAuthRequired}
         onForgetAccessKey={context.forgetAccessKey}
         inspectorOpen={context.inspectorOpen}
-        onToggleInspector={() => context.setInspectorOpen((open) => !open)}
+        onToggleInspector={() => {
+          if (!context.inspectorOpen && rail.isMobile) rail.setDrawerOpen(false);
+          context.setInspectorOpen((open) => !open);
+        }}
         onRename={context.updateSessionTitle}
         onPin={(target, pinned) =>
           context.updateSessionPin(target.workspaceId, target.id, pinned, target.pinVersion ?? 0)

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -5,7 +5,7 @@
 // from the brand, switcher, workspace nav, session list, and footer sections.
 import { useSessionLineage } from "@opengeni/react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { MenuIcon } from "lucide-react";
+import { MenuIcon, MessagesSquareIcon, Settings2Icon, XIcon } from "lucide-react";
 
 import { BrandMark } from "@/components/brand-mark";
 import {
@@ -32,7 +32,7 @@ import { SessionSandboxSwitcher } from "@/components/session/sandbox-switcher";
 import { CodexAccountIndicator } from "@/components/session/codex-account-indicator";
 import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
 import { cn } from "@/lib/utils";
@@ -40,12 +40,24 @@ import { cn } from "@/lib/utils";
 /** The rail body — shared between the fixed desktop column and the mobile drawer. */
 function RailBody() {
   const rail = useRail();
+  const [mobileSection, setMobileSection] = useState<"sessions" | "workspace">("sessions");
+  const sessionsTabRef = useRef<HTMLButtonElement>(null);
+  const workspaceTabRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (rail.drawerOpen) setMobileSection("sessions");
+  }, [rail.drawerOpen]);
+  const moveMobileTab = (section: "sessions" | "workspace") => {
+    setMobileSection(section);
+    window.requestAnimationFrame(() =>
+      (section === "sessions" ? sessionsTabRef : workspaceTabRef).current?.focus(),
+    );
+  };
   return (
     <div className="flex h-full min-h-0 flex-col bg-surface/40 pt-[env(safe-area-inset-top)]">
       {/* Brand */}
       <div
         className={cn(
-          "flex h-12 shrink-0 items-center",
+          "flex h-12 shrink-0 items-center gap-2",
           rail.collapsed ? "justify-center px-2" : "px-3",
         )}
       >
@@ -60,21 +72,110 @@ function RailBody() {
           </span>
           {!rail.collapsed ? <span className="truncate">OpenGeni</span> : null}
         </Link>
+        {rail.isMobile ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Close navigation"
+            onClick={() => rail.setDrawerOpen(false)}
+            className="ml-auto pointer-coarse:size-11"
+          >
+            <XIcon className="size-4" />
+          </Button>
+        ) : null}
       </div>
 
       <SwitcherBlock />
 
-      {/* Sessions — the product's primary object — sit directly under the
-          switcher (D4.1); the secondary workspace-config group drops below. */}
-      <div className="mt-2 flex min-h-0 flex-1 flex-col">
-        {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
-      </div>
-
-      <div className="my-2 border-t border-border" />
-
-      <WorkspaceNav />
-
-      <RailFooter />
+      {rail.isMobile ? (
+        <>
+          <div
+            role="tablist"
+            aria-label="Navigation section"
+            onKeyDown={(event) => {
+              if (event.key === "ArrowLeft" || event.key === "Home") {
+                event.preventDefault();
+                moveMobileTab("sessions");
+              } else if (event.key === "ArrowRight" || event.key === "End") {
+                event.preventDefault();
+                moveMobileTab("workspace");
+              }
+            }}
+            className="mx-3 mt-3 grid shrink-0 grid-cols-2 rounded-lg bg-surface-2/70 p-1"
+          >
+            <button
+              ref={sessionsTabRef}
+              id="mobile-nav-tab-sessions"
+              type="button"
+              role="tab"
+              aria-selected={mobileSection === "sessions"}
+              aria-controls="mobile-nav-panel-sessions"
+              tabIndex={mobileSection === "sessions" ? 0 : -1}
+              onClick={() => setMobileSection("sessions")}
+              className={cn(
+                "flex h-10 items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors",
+                mobileSection === "sessions"
+                  ? "bg-surface-3 text-fg shadow-sm"
+                  : "text-fg-muted hover:text-fg",
+              )}
+            >
+              <MessagesSquareIcon className="size-4" />
+              Sessions
+            </button>
+            <button
+              ref={workspaceTabRef}
+              id="mobile-nav-tab-workspace"
+              type="button"
+              role="tab"
+              aria-selected={mobileSection === "workspace"}
+              aria-controls="mobile-nav-panel-workspace"
+              tabIndex={mobileSection === "workspace" ? 0 : -1}
+              onClick={() => setMobileSection("workspace")}
+              className={cn(
+                "flex h-10 items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors",
+                mobileSection === "workspace"
+                  ? "bg-surface-3 text-fg shadow-sm"
+                  : "text-fg-muted hover:text-fg",
+              )}
+            >
+              <Settings2Icon className="size-4" />
+              Workspace
+            </button>
+          </div>
+          {mobileSection === "sessions" ? (
+            <div
+              id="mobile-nav-panel-sessions"
+              role="tabpanel"
+              aria-labelledby="mobile-nav-tab-sessions"
+              className="mt-2 flex min-h-0 flex-1 flex-col"
+            >
+              <SessionList />
+            </div>
+          ) : (
+            <div
+              id="mobile-nav-panel-workspace"
+              role="tabpanel"
+              aria-labelledby="mobile-nav-tab-workspace"
+              className="mt-2 flex min-h-0 flex-1 flex-col overflow-y-auto border-t border-border pt-2"
+            >
+              <WorkspaceNav />
+              <RailFooter />
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          {/* Sessions are the primary object. Workspace administration remains
+              secondary on desktop and becomes its own screen on phones. */}
+          <div className="mt-2 flex min-h-0 flex-1 flex-col">
+            {rail.collapsed ? <CollapsedSessionsButton /> : <SessionList />}
+          </div>
+          <div className="my-2 border-t border-border" />
+          <WorkspaceNav />
+          <RailFooter />
+        </>
+      )}
     </div>
   );
 }
@@ -232,12 +333,16 @@ export function RailShell({ children }: { children: ReactNode }) {
               side="left"
               showCloseButton={false}
               aria-label="Session navigation"
-              className="w-[260px] max-w-[85vw] gap-0 p-0"
+              className="w-screen max-w-none gap-0 p-0 sm:w-[380px] sm:max-w-[90vw]"
               onCloseAutoFocus={(event) => {
                 event.preventDefault();
                 hamburgerRef.current?.focus();
               }}
             >
+              <SheetTitle className="sr-only">Session navigation</SheetTitle>
+              <SheetDescription className="sr-only">
+                Browse workspace sessions or open workspace settings.
+              </SheetDescription>
               <nav aria-label="Primary" className="h-full">
                 <RailBody />
               </nav>

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -8,6 +8,7 @@ import { useRouterState } from "@tanstack/react-router";
 import {
   ChevronRightIcon,
   EllipsisIcon,
+  LocateFixedIcon,
   MessagesSquareIcon,
   PencilIcon,
   PinIcon,
@@ -40,6 +41,13 @@ import {
   sessionPageKey,
 } from "@/lib/session-pagination";
 import { SESSION_TITLE_MAX_LENGTH, useInlineRename } from "@/lib/session-rename";
+import {
+  MAX_VISUAL_TREE_DEPTH,
+  defaultExpandedAncestors,
+  sessionAncestorPath,
+  sessionStateLabel,
+  visualTreeDepth,
+} from "@/lib/session-rail";
 import { applySessionPinProjection, subscribeToSessionPinChanges } from "@/lib/session-pins";
 import {
   SESSION_GROUP_LABELS,
@@ -210,7 +218,10 @@ export function SessionList() {
       buildRailForest(
         hierarchyMode
           ? allSessions
-          : allSessions.map((session) => ({ ...session, parentSessionId: null })),
+          : allSessions.map((session) => ({
+              ...session,
+              parentSessionId: null,
+            })),
       ),
     [allSessions, hierarchyMode],
   );
@@ -381,9 +392,10 @@ export function SessionList() {
       );
   }, [allSessions, nodesById, pinnedSessions]);
 
-  // Which parents are expanded. Children start collapsed (the rail stays quiet);
-  // the active session's ancestors auto-expand so a deep child is never hidden.
-  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+  // Manual state is separate from the small derived active-path expansion.
+  // Polls can therefore never reopen a branch the user explicitly collapsed.
+  const [manualExpanded, setManualExpanded] = useState<ReadonlySet<string>>(() => new Set());
+  const [manualCollapsed, setManualCollapsed] = useState<ReadonlySet<string>>(() => new Set());
   const parentOf = useMemo(() => {
     const map = new Map<string, string>();
     const byId = new Set(allSessions.map((session) => session.id));
@@ -394,26 +406,22 @@ export function SessionList() {
     }
     return map;
   }, [allSessions]);
+  const activeAncestorIds = useMemo(
+    () => sessionAncestorPath(activeSessionId, parentOf),
+    [activeSessionId, parentOf],
+  );
+  const autoExpanded = useMemo(
+    () => defaultExpandedAncestors(activeAncestorIds, manualCollapsed),
+    [activeAncestorIds, manualCollapsed],
+  );
+  const expanded = useMemo(
+    () => new Set([...manualExpanded, ...autoExpanded]),
+    [autoExpanded, manualExpanded],
+  );
   useEffect(() => {
-    if (!activeSessionId) {
-      return;
-    }
-    setExpanded((current) => {
-      const next = new Set(current);
-      let cursor = parentOf.get(activeSessionId);
-      let added = false;
-      const seen = new Set<string>();
-      while (cursor && !seen.has(cursor)) {
-        seen.add(cursor);
-        if (!next.has(cursor)) {
-          next.add(cursor);
-          added = true;
-        }
-        cursor = parentOf.get(cursor);
-      }
-      return added ? next : current;
-    });
-  }, [activeSessionId, parentOf]);
+    setManualExpanded(new Set());
+    setManualCollapsed(new Set());
+  }, [rail.workspaceId]);
   const loadChildPage = useCallback(
     async (parentSessionId: string, cursor?: string): Promise<void> => {
       const epoch = childLoadEpoch.current;
@@ -468,9 +476,15 @@ export function SessionList() {
   const toggleExpand = useCallback(
     (sessionId: string) => {
       const opening = !expanded.has(sessionId);
-      setExpanded((current) => {
+      setManualExpanded((current) => {
         const next = new Set(current);
-        if (next.has(sessionId)) next.delete(sessionId);
+        if (opening) next.add(sessionId);
+        else next.delete(sessionId);
+        return next;
+      });
+      setManualCollapsed((current) => {
+        const next = new Set(current);
+        if (opening) next.delete(sessionId);
         else next.add(sessionId);
         return next;
       });
@@ -483,6 +497,14 @@ export function SessionList() {
     },
     [childPages, expanded, hierarchyMode, loadChildPage, nodesById],
   );
+  const revealActivePath = useCallback(() => {
+    setManualExpanded((current) => new Set([...current, ...activeAncestorIds]));
+    setManualCollapsed((current) => {
+      const next = new Set(current);
+      for (const sessionId of activeAncestorIds) next.delete(sessionId);
+      return next;
+    });
+  }, [activeAncestorIds]);
 
   const visibleRows = useMemo(() => {
     const seen = new Set<string>();
@@ -523,7 +545,10 @@ export function SessionList() {
         if (updated) {
           setPinOverrides((current) => {
             if (current.get(target.id)?.operation !== operation) return current;
-            return new Map(current).set(target.id, { session: updated, operation });
+            return new Map(current).set(target.id, {
+              session: updated,
+              operation,
+            });
           });
         }
         await Promise.all([refresh(), globalPinPage.refresh()]);
@@ -806,6 +831,7 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                onRevealActivePath={revealActivePath}
                 childPages={childPages}
                 onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
@@ -815,7 +841,7 @@ export function SessionList() {
             ) : null}
             {forest.running.length > 0 ? (
               <SessionGroup
-                label="Running"
+                label="Active"
                 nodes={forest.running}
                 flat={flat}
                 activeSessionId={activeSessionId}
@@ -823,6 +849,7 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                onRevealActivePath={revealActivePath}
                 childPages={childPages}
                 onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
@@ -841,6 +868,7 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                onRevealActivePath={revealActivePath}
                 childPages={childPages}
                 onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
@@ -885,6 +913,7 @@ function SessionGroup(props: {
   onFocusSession: (sessionId: string) => void;
   expanded: ReadonlySet<string>;
   onToggleExpand: (sessionId: string) => void;
+  onRevealActivePath: () => void;
   childPages: ReadonlyMap<string, ChildPageState>;
   onLoadMoreChildren: (sessionId: string, cursor?: string) => Promise<void>;
   onSelect: (sessionId: string) => void;
@@ -915,6 +944,7 @@ function SessionGroup(props: {
             onFocusSession={props.onFocusSession}
             expanded={props.expanded}
             onToggleExpand={props.onToggleExpand}
+            onRevealActivePath={props.onRevealActivePath}
             childPages={props.childPages}
             onLoadMoreChildren={props.onLoadMoreChildren}
             onSelect={props.onSelect}
@@ -927,12 +957,15 @@ function SessionGroup(props: {
   );
 }
 
-/** True when the URL-active session lives anywhere inside this node's subtree. */
-function subtreeContains(node: SessionTreeNode, id: string | null): boolean {
-  if (!id) {
-    return false;
+/** Loaded node path from this ancestor to the URL-active session. */
+function descendantPath(node: SessionTreeNode, id: string | null): SessionTreeNode[] | null {
+  if (!id) return null;
+  if (node.session.id === id) return [node];
+  for (const child of node.children) {
+    const path = descendantPath(child, id);
+    if (path) return [node, ...path];
   }
-  return node.children.some((child) => child.session.id === id || subtreeContains(child, id));
+  return null;
 }
 
 /** A node plus, when expanded, its spawned children rendered one level deeper. */
@@ -945,6 +978,7 @@ function SessionTreeRow(props: {
   onFocusSession: (sessionId: string) => void;
   expanded: ReadonlySet<string>;
   onToggleExpand: (sessionId: string) => void;
+  onRevealActivePath: () => void;
   childPages: ReadonlyMap<string, ChildPageState>;
   onLoadMoreChildren: (sessionId: string, cursor?: string) => Promise<void>;
   onSelect: (sessionId: string) => void;
@@ -965,12 +999,13 @@ function SessionTreeRow(props: {
   );
   const isExpanded = props.expanded.has(node.session.id);
   const childPage = props.childPages.get(node.session.id);
-  // Manual collapse always wins (auto-expand runs only on navigation) — but the
-  // OPEN session must never vanish from the rail: a collapsed ancestor hiding
-  // the URL-active session carries the active accent in its place, file-tree
-  // style, so orientation survives any collapse state.
-  const representsHiddenActive =
-    !isExpanded && hasChildren && subtreeContains(node, props.activeSessionId);
+  // Keep the current session findable without exploding a ten-level chain.
+  // The first collapsed ancestor gets one compact shortcut to the current leaf.
+  const hiddenActivePath = !isExpanded ? descendantPath(node, props.activeSessionId) : null;
+  const hiddenActiveSession =
+    hiddenActivePath && hiddenActivePath.length > 1
+      ? hiddenActivePath[hiddenActivePath.length - 1]!.session
+      : null;
   return (
     <>
       <SessionRow
@@ -982,13 +1017,21 @@ function SessionTreeRow(props: {
         expanded={isExpanded}
         hasActiveDescendant={node.hasActiveDescendant || treeHasActiveDescendant}
         onToggleExpand={() => props.onToggleExpand(node.session.id)}
-        active={node.session.id === props.activeSessionId || representsHiddenActive}
+        active={node.session.id === props.activeSessionId}
         focused={index >= 0 && index === props.focusIndex}
         onFocus={() => props.onFocusSession(node.session.id)}
         onSelect={props.onSelect}
         onRename={props.onRename}
         onPin={props.onPin}
       />
+      {hiddenActiveSession ? (
+        <ActivePathShortcut
+          session={hiddenActiveSession}
+          depth={props.depth + 1}
+          hiddenLevels={hiddenActivePath!.length - 1}
+          onReveal={props.onRevealActivePath}
+        />
+      ) : null}
       {childCount > 0 && isExpanded
         ? node.children.map((child) => (
             <SessionTreeRow
@@ -1001,6 +1044,7 @@ function SessionTreeRow(props: {
               onFocusSession={props.onFocusSession}
               expanded={props.expanded}
               onToggleExpand={props.onToggleExpand}
+              onRevealActivePath={props.onRevealActivePath}
               childPages={props.childPages}
               onLoadMoreChildren={props.onLoadMoreChildren}
               onSelect={props.onSelect}
@@ -1032,6 +1076,49 @@ function SessionTreeRow(props: {
   );
 }
 
+function ActivePathShortcut({
+  session,
+  depth,
+  hiddenLevels,
+  onReveal,
+}: {
+  session: Session;
+  depth: number;
+  hiddenLevels: number;
+  onReveal: () => void;
+}) {
+  const rail = useRail();
+  const app = useAppContext();
+  const title = session.title?.trim() || session.initialMessage?.trim() || "Untitled session";
+  const workspace = app.workspaces.find((candidate) => candidate.id === session.workspaceId);
+  const state = sessionStateLabel(session, workspace);
+  const style = { paddingLeft: 10 + visualTreeDepth(depth) * 12 };
+  return (
+    <div role="listitem" className="min-w-0" style={style}>
+      <button
+        type="button"
+        onClick={onReveal}
+        aria-label={`Show ${hiddenLevels}-level path to current session ${title}`}
+        className={cn(
+          "group flex h-9 w-full min-w-0 items-center gap-2 rounded-md border border-brand/20 bg-brand/5 px-2 text-left text-xs text-fg outline-none hover:border-brand/35 hover:bg-brand/10 focus-visible:ring-2 focus-visible:ring-ring/40",
+          rail.isMobile && "h-12",
+        )}
+      >
+        <LocateFixedIcon className="size-3.5 shrink-0 text-brand" />
+        <span className="flex min-w-0 flex-1 flex-col leading-tight">
+          <span className="truncate font-medium">
+            <span className="text-brand">Current</span> · {title}
+          </span>
+          <span className="mt-0.5 truncate text-2xs font-normal text-fg-subtle">
+            {hiddenLevels} level{hiddenLevels === 1 ? "" : "s"} deeper · {state}
+          </span>
+        </span>
+        <span className="shrink-0 text-2xs font-medium text-brand">Show path</span>
+      </button>
+    </div>
+  );
+}
+
 function TreeLoadRow({
   depth,
   text,
@@ -1041,7 +1128,7 @@ function TreeLoadRow({
   text: string;
   onClick?: () => void;
 }) {
-  const style = { paddingLeft: 26 + depth * 14 };
+  const style = { paddingLeft: 26 + visualTreeDepth(depth) * 12 };
   return onClick ? (
     <button
       type="button"
@@ -1086,11 +1173,14 @@ function SessionRow(props: {
   const workspace = app.workspaces.find((candidate) => candidate.id === props.session.workspaceId);
   const stateLabel = sessionStateLabel(props.session, workspace);
   const descendantLabel = sessionDescendantLabel(props.session);
+  const depthLabel = props.depth > MAX_VISUAL_TREE_DEPTH ? `Level ${props.depth + 1}` : null;
+  const relativeTime = relativeTimeLabel(props.session.updatedAt);
   // Indent nested rows; the leading affordance is a chevron for parents, else a
   // spacer of the same width — reserved at every depth (root included) so every
   // status dot sits in one column and the left edge is even whether a row is a
   // leaf or a parent.
-  const indentStyle = props.depth > 0 ? { paddingLeft: props.depth * 14 } : undefined;
+  const indentStyle =
+    props.depth > 0 ? { paddingLeft: visualTreeDepth(props.depth) * 12 } : undefined;
 
   const rowClassName = cn(
     "group relative flex h-8 w-full items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors pointer-coarse:h-11 pointer-coarse:py-0",
@@ -1163,7 +1253,7 @@ function SessionRow(props: {
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div role="listitem" title={title} className={rowClassName}>
+        <div role="listitem" title={`${title} — ${stateLabel}`} className={rowClassName}>
           <ActiveAccent active={props.active} />
           {lead}
           <button
@@ -1172,7 +1262,7 @@ function SessionRow(props: {
             data-session-focus
             tabIndex={props.focused ? 0 : -1}
             aria-current={props.active ? "page" : undefined}
-            aria-label={`Open ${title}. ${props.session.status}${
+            aria-label={`Open ${title}. ${stateLabel}${
               props.session.pinned ? ". Pinned" : ""
             }${hasChildren ? `. ${props.childCount} spawned sessions` : ""}`}
             onFocus={props.onFocus}
@@ -1180,21 +1270,23 @@ function SessionRow(props: {
             className="flex h-full min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
           >
             <RailStatusDot status={props.session.status} />
-            <span className="sr-only">{props.session.status}. </span>
+            <span className="sr-only">{stateLabel}. </span>
             {/* min-w-0 + truncate: the title must always ellipsis, never butt the
                 rail border. */}
             <span className="flex min-w-0 flex-1 flex-col pr-1 leading-tight">
               <span className="truncate">{title}</span>
               {rail.isMobile ? (
                 <span className="mt-0.5 truncate text-2xs font-normal text-fg-subtle">
-                  {[stateLabel, descendantLabel].filter(Boolean).join(" · ")}
+                  {[stateLabel, depthLabel, descendantLabel, relativeTime]
+                    .filter(Boolean)
+                    .join(" · ")}
                 </span>
               ) : null}
             </span>
             {/* A collapsed parent with a live child shows a quiet pulsing dot so
                 the activity isn't hidden with the subtree; the count badge sits
                 beside it. Both stay visible on hover (the time yields instead). */}
-            {hasChildren ? (
+            {!rail.isMobile && hasChildren ? (
               <span className="flex shrink-0 items-center gap-1 text-2xs tabular-nums text-fg-muted">
                 {!props.expanded && props.hasActiveDescendant ? (
                   <span className="relative inline-flex size-1.5 rounded-full bg-status-running">
@@ -1209,9 +1301,11 @@ function SessionRow(props: {
             {/* Relative time is visible at rest (the list is grouped by recency),
                 and steps aside on hover/focus so the rename overflow can slot in.
                 On coarse pointers there is no hover, so the time stays visible. */}
-            <span className="shrink-0 text-2xs tabular-nums text-fg transition-opacity group-hover:opacity-0 group-focus-within:opacity-0 pointer-coarse:group-hover:opacity-100">
-              {relativeTimeLabel(props.session.updatedAt)}
-            </span>
+            {!rail.isMobile ? (
+              <span className="shrink-0 text-2xs tabular-nums text-fg transition-opacity group-hover:opacity-0 group-focus-within:opacity-0 pointer-coarse:group-hover:opacity-100">
+                {relativeTime}
+              </span>
+            ) : null}
           </button>
           <RowActionsMenu
             session={props.session}
@@ -1235,38 +1329,6 @@ function SessionRow(props: {
       </ContextMenuContent>
     </ContextMenu>
   );
-}
-
-function sessionStateLabel(
-  session: Session,
-  workspace: { inferenceState?: "active" | "paused"; inferenceGeneration?: number } | undefined,
-): string {
-  if (session.controlState === "paused") return "Paused";
-  if (
-    workspace?.inferenceState === "paused" &&
-    session.workspaceRunExceptionGeneration !== workspace.inferenceGeneration
-  ) {
-    return "Paused by workspace";
-  }
-  if (workspace?.inferenceState === "paused") return "Running by exception";
-  switch (session.status) {
-    case "requires_action":
-      return "Needs you";
-    case "waiting_capacity":
-      return "Waiting for capacity";
-    case "recovering":
-      return "Recovering";
-    case "running":
-      return "Running";
-    case "queued":
-      return "Queued";
-    case "failed":
-      return "Failed";
-    case "cancelled":
-      return "Cancelled";
-    default:
-      return "Idle";
-  }
 }
 
 function sessionDescendantLabel(session: Session): string | null {
@@ -1357,8 +1419,8 @@ function RowActionsMenu({
  * failed, and idle/terminal states fall back to cancelled.
  */
 function RailStatusDot({ status }: { status: Session["status"] }) {
-  const running = status === "running" || status === "queued";
-  const needsAttention = status === "requires_action";
+  const running = status === "running" || status === "queued" || status === "recovering";
+  const needsAttention = status === "requires_action" || status === "waiting_capacity";
   const failed = status === "failed";
   const tone = running
     ? "bg-status-running"

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -3,7 +3,7 @@
 // and supports ArrowUp/Down + Enter keyboard navigation. Each row is a status
 // dot + single-line truncated title + relative time (visible at rest). The
 // active session (from the URL) is highlighted with an accent bar.
-import { useWorkspaceSessions } from "@opengeni/react";
+import { useSessionLineage, useWorkspaceSessions } from "@opengeni/react";
 import { useRouterState } from "@tanstack/react-router";
 import {
   ChevronRightIcon,
@@ -42,9 +42,14 @@ import {
 import { SESSION_TITLE_MAX_LENGTH, useInlineRename } from "@/lib/session-rename";
 import { applySessionPinProjection, subscribeToSessionPinChanges } from "@/lib/session-pins";
 import {
+  SESSION_GROUP_LABELS,
+  SESSION_GROUP_ORDER,
   buildRailForest,
   groupSessionsForRail,
+  nodeIsActive,
+  recencyGroupFor,
   relativeTimeLabel,
+  sessionActivityTime,
   visibleForestRows,
   type SessionTreeNode,
 } from "@/lib/sessions-group";
@@ -54,6 +59,12 @@ import type { Session } from "@/types";
 type RenameFn = (workspaceId: string, sessionId: string, title: string) => Promise<Session | null>;
 type PinFn = (session: Session, pinned: boolean) => Promise<Session | null>;
 type PinOverride = { session: Session; operation: number };
+type ChildPageState = {
+  sessions: Session[];
+  nextCursor: string | null;
+  loading: boolean;
+  failed: boolean;
+};
 
 export function SessionList() {
   const rail = useRail();
@@ -66,18 +77,33 @@ export function SessionList() {
     const timer = window.setTimeout(() => setSearch(searchDraft.trim()), 200);
     return () => window.clearTimeout(timer);
   }, [searchDraft]);
-  const { sessions, pinned, nextCursor, loading, error, refresh } = useWorkspaceSessions({
+  const hierarchyMode = search.length === 0;
+  const rootPage = useWorkspaceSessions({
     limit: 50,
     search,
+    ...(hierarchyMode ? { parentSessionId: null } : {}),
     pollIntervalMs: 15_000,
   });
+  // Pins are shortcuts and may point anywhere in a workstream. Fetch their
+  // complete global section separately from the root-only hierarchy page; a
+  // pinned child must never make either it or its descendants disappear from
+  // the actual tree.
+  const globalPinPage = useWorkspaceSessions({
+    limit: 1,
+    pollIntervalMs: 15_000,
+    enabled: hierarchyMode,
+  });
+  const { sessions, nextCursor, loading, error, refresh } = rootPage;
+  const pinned = hierarchyMode ? globalPinPage.pinned : rootPage.pinned;
   // Ordinary rows page independently of the complete pinned section. The
   // polled hook owns page one; additional pages are appended and deduplicated.
   // A filter change starts a fresh cursor chain rather than mixing snapshots.
   // The server cursor carries the first page's short-lived snapshot identity.
   // If a poll replaces that snapshot, any continuation loaded from the old
   // activity order is stale even when workspace/search are unchanged.
-  const paginationKey = `${sessionPageKey(rail.workspaceId, search)}\u0000${nextCursor ?? "complete"}`;
+  const paginationKey = `${sessionPageKey(rail.workspaceId, search)}\u0000${
+    hierarchyMode ? "roots" : "search"
+  }\u0000${nextCursor ?? "complete"}`;
   const paginationIdentity = useRef({ key: paginationKey, generation: 0 });
   paginationIdentity.current = advanceSessionPageIdentity(
     paginationIdentity.current,
@@ -94,6 +120,14 @@ export function SessionList() {
   const loadMoreAttempt = useRef(0);
   const loadMoreError = activeContinuation.failed;
   const [announcement, setAnnouncement] = useState("");
+  const [childPages, setChildPages] = useState<ReadonlyMap<string, ChildPageState>>(
+    () => new Map(),
+  );
+  const childLoadEpoch = useRef(0);
+  useEffect(() => {
+    childLoadEpoch.current += 1;
+    setChildPages(new Map());
+  }, [rail.workspaceId, hierarchyMode]);
   // Short-lived optimistic projections only. The page returned by the server
   // remains canonical; after each mutation we replace the projection with that
   // returned row and refresh once to reconcile tabs/devices/offline recovery.
@@ -102,23 +136,48 @@ export function SessionList() {
   );
   const pinOperation = useRef(0);
   const pinning = useRef(new Set<string>());
+  const activeLineage = useSessionLineage(context.session?.id ?? null, {
+    pollIntervalMs: 30_000,
+  });
+  const loadedChildren = useMemo(
+    () => [...childPages.values()].flatMap((page) => page.sessions),
+    [childPages],
+  );
   const allSessions = useMemo(() => {
     const source = new Map<string, Session>();
-    // Precedence is extra page < current first page < current pinned section;
-    // a row that became pinned since it was loaded as an old ordinary page must
-    // never be overwritten by that stale extra-page projection.
-    for (const session of [...extraSessions, ...sessions, ...pinned]) {
+    // Search is intentionally flat. Normal navigation starts with real roots,
+    // then adds only explicitly loaded child pages and the active session's
+    // lineage. A child can therefore never become a fake root merely because
+    // its parent fell outside a global recency page.
+    const lineageSessions = hierarchyMode
+      ? [...(activeLineage.lineage?.ancestors ?? []), ...(context.session ? [context.session] : [])]
+      : [];
+    // Precedence is continuation < current page < lazy children < active
+    // lineage < current pinned section. Pins carry the freshest personal pin
+    // revision, while route/SSE data wins for the currently open lifecycle.
+    for (const session of [
+      ...extraSessions,
+      ...sessions,
+      ...loadedChildren,
+      ...lineageSessions,
+      ...pinned,
+    ]) {
       source.set(session.id, session);
     }
     for (const [id, override] of pinOverrides) source.set(id, override.session);
     return [...source.values()];
-  }, [pinned, sessions, extraSessions, pinOverrides]);
+  }, [
+    activeLineage.lineage?.ancestors,
+    context.session,
+    extraSessions,
+    hierarchyMode,
+    loadedChildren,
+    pinOverrides,
+    pinned,
+    sessions,
+  ]);
   const pinnedSessions = useMemo(
     () => allSessions.filter((session) => Boolean(session.pinned)),
-    [allSessions],
-  );
-  const ordinarySessions = useMemo(
-    () => allSessions.filter((session) => !session.pinned),
     [allSessions],
   );
   const openSessionId = context.session?.id;
@@ -143,24 +202,184 @@ export function SessionList() {
     },
   });
 
-  // Lineage forest: spawned workers nest under their manager (parentSessionId),
-  // running roots pinned. The keyboard navigation walks the VISIBLE rows given
-  // the current expand state; the render nests them back into sections.
-  const forest = useMemo(() => buildRailForest(ordinarySessions), [ordinarySessions]);
-  // The API already returns pins in stable pinnedAt DESC/id DESC order. Keep
-  // this compact section flat: a pinned child is intentionally surfaced rather
-  // than hidden under an ordinary parent that was excluded from this section.
-  const pinnedNodes = useMemo<SessionTreeNode[]>(
+  // Search results are deliberately flat: a partial match set is not a tree.
+  // Normal navigation contains only true roots, lazily loaded children, and the
+  // active lineage, so buildRailForest never has to invent root placement.
+  const completeForest = useMemo(
     () =>
-      [...pinnedSessions]
-        .sort(
-          (left, right) =>
-            Date.parse(right.pinnedAt ?? "") - Date.parse(left.pinnedAt ?? "") ||
-            right.id.localeCompare(left.id),
-        )
-        .map((session) => ({ session, children: [], hasActiveDescendant: false })),
-    [pinnedSessions],
+      buildRailForest(
+        hierarchyMode
+          ? allSessions
+          : allSessions.map((session) => ({ ...session, parentSessionId: null })),
+      ),
+    [allSessions, hierarchyMode],
   );
+  const forest = useMemo(() => {
+    // A pinned node is promoted with its subtree into the Pinned section. Prune
+    // it recursively from the ordinary hierarchy so a pinned child is not
+    // rendered twice (and keyboard focus never has two rows with one identity).
+    type RemovedCounts = {
+      total: number;
+      running: number;
+      queued: number;
+      attention: number;
+      paused: number;
+      failed: number;
+    };
+    const emptyCounts = (): RemovedCounts => ({
+      total: 0,
+      running: 0,
+      queued: 0,
+      attention: 0,
+      paused: 0,
+      failed: 0,
+    });
+    const addCounts = (target: RemovedCounts, source: RemovedCounts): void => {
+      target.total += source.total;
+      target.running += source.running;
+      target.queued += source.queued;
+      target.attention += source.attention;
+      target.paused += source.paused;
+      target.failed += source.failed;
+    };
+    const subtreeCounts = (node: SessionTreeNode): RemovedCounts => {
+      const stats = node.session.treeStats;
+      const status = node.session.status;
+      const counts: RemovedCounts = {
+        total: 1,
+        running: status === "running" || status === "recovering" ? 1 : 0,
+        queued: status === "queued" || status === "waiting_capacity" ? 1 : 0,
+        attention: status === "requires_action" ? 1 : 0,
+        paused: status === "paused" ? 1 : 0,
+        failed: status === "failed" ? 1 : 0,
+      };
+      if (stats) {
+        counts.total += stats.totalDescendants;
+        counts.running += stats.runningDescendants;
+        counts.queued += stats.queuedDescendants;
+        counts.attention += stats.attentionDescendants;
+        counts.paused += stats.pausedDescendants;
+        counts.failed += stats.failedDescendants;
+      } else {
+        for (const child of node.children) addCounts(counts, subtreeCounts(child));
+      }
+      return counts;
+    };
+    const prune = (
+      node: SessionTreeNode,
+    ): { node: SessionTreeNode | null; removed: RemovedCounts } => {
+      if (node.session.pinned) return { node: null, removed: subtreeCounts(node) };
+      const removed = emptyCounts();
+      let removedDirectChildren = 0;
+      const children: SessionTreeNode[] = [];
+      for (const child of node.children) {
+        const result = prune(child);
+        addCounts(removed, result.removed);
+        if (result.node) children.push(result.node);
+        else removedDirectChildren += 1;
+      }
+      const stats = node.session.treeStats;
+      const session = stats
+        ? {
+            ...node.session,
+            treeStats: {
+              directChildren: Math.max(0, stats.directChildren - removedDirectChildren),
+              totalDescendants: Math.max(0, stats.totalDescendants - removed.total),
+              runningDescendants: Math.max(0, stats.runningDescendants - removed.running),
+              queuedDescendants: Math.max(0, stats.queuedDescendants - removed.queued),
+              attentionDescendants: Math.max(0, stats.attentionDescendants - removed.attention),
+              pausedDescendants: Math.max(0, stats.pausedDescendants - removed.paused),
+              failedDescendants: Math.max(0, stats.failedDescendants - removed.failed),
+            },
+          }
+        : node.session;
+      const pruned = {
+        session,
+        children,
+        hasActiveDescendant: children.some((child) => nodeIsActive(child)),
+      };
+      return { node: pruned, removed };
+    };
+    const roots = [
+      ...completeForest.running,
+      ...completeForest.grouped.flatMap((bucket) => bucket.sessions),
+    ];
+    const prunedRoots = roots.flatMap((node) => {
+      const result = prune(node).node;
+      return result ? [result] : [];
+    });
+    const running = prunedRoots
+      .filter((node) => nodeIsActive(node))
+      .sort(
+        (left, right) => sessionActivityTime(right.session) - sessionActivityTime(left.session),
+      );
+    const buckets = new Map<(typeof SESSION_GROUP_ORDER)[number], SessionTreeNode[]>();
+    for (const node of prunedRoots
+      .filter((candidate) => !nodeIsActive(candidate))
+      .sort(
+        (left, right) => sessionActivityTime(right.session) - sessionActivityTime(left.session),
+      )) {
+      const group = recencyGroupFor(sessionActivityTime(node.session));
+      const sessions = buckets.get(group) ?? [];
+      sessions.push(node);
+      buckets.set(group, sessions);
+    }
+    return {
+      running,
+      grouped: SESSION_GROUP_ORDER.flatMap((group) => {
+        const nodes = buckets.get(group);
+        return nodes?.length
+          ? [{ group, label: SESSION_GROUP_LABELS[group], sessions: nodes }]
+          : [];
+      }),
+    };
+  }, [completeForest]);
+  const nodesById = useMemo(() => {
+    const result = new Map<string, SessionTreeNode>();
+    const visit = (node: SessionTreeNode): void => {
+      if (result.has(node.session.id)) return;
+      result.set(node.session.id, node);
+      for (const child of node.children) visit(child);
+    };
+    for (const node of completeForest.running) visit(node);
+    for (const bucket of completeForest.grouped) {
+      for (const node of bucket.sessions) visit(node);
+    }
+    return result;
+  }, [completeForest]);
+  // Pins are promoted shortcuts, not a second ownership model. If both a
+  // parent and its descendant are pinned, the parent owns the visible pinned
+  // subtree so no session row appears twice.
+  const pinnedNodes = useMemo<SessionTreeNode[]>(() => {
+    const byId = new Map(allSessions.map((session) => [session.id, session]));
+    const hasPinnedAncestor = (session: Session): boolean => {
+      const seen = new Set<string>();
+      let parentId = session.parentSessionId;
+      while (parentId && !seen.has(parentId)) {
+        seen.add(parentId);
+        const parent = byId.get(parentId);
+        if (!parent) return false;
+        if (parent.pinned) return true;
+        parentId = parent.parentSessionId;
+      }
+      return false;
+    };
+    return [...pinnedSessions]
+      .filter((session) => !hasPinnedAncestor(session))
+      .sort(
+        (left, right) =>
+          Date.parse(right.pinnedAt ?? "") - Date.parse(left.pinnedAt ?? "") ||
+          right.id.localeCompare(left.id),
+      )
+      .map(
+        (session) =>
+          nodesById.get(session.id) ?? {
+            session,
+            children: [],
+            hasActiveDescendant: false,
+          },
+      );
+  }, [allSessions, nodesById, pinnedSessions]);
 
   // Which parents are expanded. Children start collapsed (the rail stays quiet);
   // the active session's ancestors auto-expand so a deep child is never hidden.
@@ -195,25 +414,87 @@ export function SessionList() {
       return added ? next : current;
     });
   }, [activeSessionId, parentOf]);
-  const toggleExpand = useCallback((sessionId: string) => {
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(sessionId)) {
-        next.delete(sessionId);
-      } else {
-        next.add(sessionId);
+  const loadChildPage = useCallback(
+    async (parentSessionId: string, cursor?: string): Promise<void> => {
+      const epoch = childLoadEpoch.current;
+      setChildPages((current) => {
+        const previous = current.get(parentSessionId);
+        return new Map(current).set(parentSessionId, {
+          sessions: previous?.sessions ?? [],
+          nextCursor: previous?.nextCursor ?? null,
+          loading: true,
+          failed: false,
+        });
+      });
+      try {
+        const page = await context.client.listSessionPage(rail.workspaceId, {
+          limit: 50,
+          parentSessionId,
+          ...(cursor ? { cursor } : {}),
+        });
+        if (childLoadEpoch.current !== epoch) return;
+        setChildPages((current) => {
+          const previous = current.get(parentSessionId);
+          const merged = new Map<string, Session>();
+          for (const session of [
+            ...(cursor ? (previous?.sessions ?? []) : []),
+            ...page.sessions,
+            ...page.pinned,
+          ]) {
+            merged.set(session.id, session);
+          }
+          return new Map(current).set(parentSessionId, {
+            sessions: [...merged.values()],
+            nextCursor: page.nextCursor,
+            loading: false,
+            failed: false,
+          });
+        });
+      } catch {
+        if (childLoadEpoch.current !== epoch) return;
+        setChildPages((current) => {
+          const previous = current.get(parentSessionId);
+          return new Map(current).set(parentSessionId, {
+            sessions: previous?.sessions ?? [],
+            nextCursor: previous?.nextCursor ?? null,
+            loading: false,
+            failed: true,
+          });
+        });
       }
-      return next;
-    });
-  }, []);
+    },
+    [context.client, rail.workspaceId],
+  );
+  const toggleExpand = useCallback(
+    (sessionId: string) => {
+      const opening = !expanded.has(sessionId);
+      setExpanded((current) => {
+        const next = new Set(current);
+        if (next.has(sessionId)) next.delete(sessionId);
+        else next.add(sessionId);
+        return next;
+      });
+      const node = nodesById.get(sessionId);
+      const knownDirectChildren =
+        node?.session.treeStats?.directChildren ?? node?.children.length ?? 0;
+      if (opening && hierarchyMode && knownDirectChildren > 0 && !childPages.has(sessionId)) {
+        void loadChildPage(sessionId);
+      }
+    },
+    [childPages, expanded, hierarchyMode, loadChildPage, nodesById],
+  );
 
-  const visibleRows = useMemo(
-    () => [
+  const visibleRows = useMemo(() => {
+    const seen = new Set<string>();
+    return [
       ...pinnedNodes.map((node) => ({ node, depth: 0 })),
       ...visibleForestRows(forest, expanded),
-    ],
-    [pinnedNodes, forest, expanded],
-  );
+    ].filter(({ node }) => {
+      if (seen.has(node.session.id)) return false;
+      seen.add(node.session.id);
+      return true;
+    });
+  }, [pinnedNodes, forest, expanded]);
   const flat = useMemo<Session[]>(() => visibleRows.map((row) => row.node.session), [visibleRows]);
 
   const onPin = useCallback<PinFn>(
@@ -245,7 +526,7 @@ export function SessionList() {
             return new Map(current).set(target.id, { session: updated, operation });
           });
         }
-        await refresh();
+        await Promise.all([refresh(), globalPinPage.refresh()]);
         const label = target.title?.trim() || target.initialMessage?.trim() || "Untitled session";
         setAnnouncement(
           updated
@@ -263,7 +544,7 @@ export function SessionList() {
         });
       }
     },
-    [context, refresh],
+    [context, globalPinPage.refresh, refresh],
   );
 
   const loadMore = useCallback(async () => {
@@ -280,6 +561,7 @@ export function SessionList() {
         limit: 50,
         cursor: continuationCursor,
         ...(search ? { search } : {}),
+        ...(hierarchyMode ? { parentSessionId: null } : {}),
       });
       if (
         paginationIdentity.current.generation !== requestGeneration ||
@@ -317,7 +599,15 @@ export function SessionList() {
         setLoadingMoreGeneration(null);
       }
     }
-  }, [context.client, continuationCursor, loadingMore, pageGeneration, rail.workspaceId, search]);
+  }, [
+    context.client,
+    continuationCursor,
+    hierarchyMode,
+    loadingMore,
+    pageGeneration,
+    rail.workspaceId,
+    search,
+  ]);
 
   // Cross-tab invalidation and lifecycle reconciliation. Cross-device changes
   // arrive on the 15s poll; returning to a tab or reconnecting refreshes now.
@@ -417,15 +707,15 @@ export function SessionList() {
 
   useEffect(() => {
     if (loading || !search) return;
-    const count = pinnedSessions.length + ordinarySessions.length;
+    const count = allSessions.length;
     setAnnouncement(`${count} matching session${count === 1 ? "" : "s"}.`);
-  }, [loading, ordinarySessions.length, pinnedSessions.length, search]);
+  }, [allSessions.length, loading, search]);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex min-w-0 items-center justify-between gap-2 px-3 pb-1 pt-1">
         <span className="text-2xs font-semibold uppercase tracking-wider text-fg-muted">
-          Sessions
+          {hierarchyMode ? "Workstreams" : "Search results"}
         </span>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -470,7 +760,7 @@ export function SessionList() {
       <div
         ref={listRef}
         role="region"
-        aria-label="Sessions"
+        aria-label={hierarchyMode ? "Workstreams" : "Session search results"}
         data-ope26-session-list
         onKeyDown={onKeyDown}
         className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2"
@@ -516,6 +806,8 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                childPages={childPages}
+                onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
                 onRename={context.updateSessionTitle}
                 onPin={onPin}
@@ -531,6 +823,8 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                childPages={childPages}
+                onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
                 onRename={context.updateSessionTitle}
                 onPin={onPin}
@@ -547,6 +841,8 @@ export function SessionList() {
                 onFocusSession={setFocusedSessionId}
                 expanded={expanded}
                 onToggleExpand={toggleExpand}
+                childPages={childPages}
+                onLoadMoreChildren={loadChildPage}
                 onSelect={rail.openSession}
                 onRename={context.updateSessionTitle}
                 onPin={onPin}
@@ -589,6 +885,8 @@ function SessionGroup(props: {
   onFocusSession: (sessionId: string) => void;
   expanded: ReadonlySet<string>;
   onToggleExpand: (sessionId: string) => void;
+  childPages: ReadonlyMap<string, ChildPageState>;
+  onLoadMoreChildren: (sessionId: string, cursor?: string) => Promise<void>;
   onSelect: (sessionId: string) => void;
   onRename: RenameFn;
   onPin: PinFn;
@@ -617,6 +915,8 @@ function SessionGroup(props: {
             onFocusSession={props.onFocusSession}
             expanded={props.expanded}
             onToggleExpand={props.onToggleExpand}
+            childPages={props.childPages}
+            onLoadMoreChildren={props.onLoadMoreChildren}
             onSelect={props.onSelect}
             onRename={props.onRename}
             onPin={props.onPin}
@@ -645,20 +945,32 @@ function SessionTreeRow(props: {
   onFocusSession: (sessionId: string) => void;
   expanded: ReadonlySet<string>;
   onToggleExpand: (sessionId: string) => void;
+  childPages: ReadonlyMap<string, ChildPageState>;
+  onLoadMoreChildren: (sessionId: string, cursor?: string) => Promise<void>;
   onSelect: (sessionId: string) => void;
   onRename: RenameFn;
   onPin: PinFn;
 }) {
   const { node } = props;
   const index = props.flat.indexOf(node.session);
-  const childCount = node.children.length;
+  const directChildCount = node.session.treeStats?.directChildren ?? node.children.length;
+  const childCount = node.session.treeStats?.totalDescendants ?? node.children.length;
+  const hasChildren = directChildCount > 0 || node.children.length > 0;
+  const treeHasActiveDescendant = Boolean(
+    node.session.treeStats &&
+    node.session.treeStats.runningDescendants +
+      node.session.treeStats.queuedDescendants +
+      node.session.treeStats.attentionDescendants >
+      0,
+  );
   const isExpanded = props.expanded.has(node.session.id);
+  const childPage = props.childPages.get(node.session.id);
   // Manual collapse always wins (auto-expand runs only on navigation) — but the
   // OPEN session must never vanish from the rail: a collapsed ancestor hiding
   // the URL-active session carries the active accent in its place, file-tree
   // style, so orientation survives any collapse state.
   const representsHiddenActive =
-    !isExpanded && childCount > 0 && subtreeContains(node, props.activeSessionId);
+    !isExpanded && hasChildren && subtreeContains(node, props.activeSessionId);
   return (
     <>
       <SessionRow
@@ -666,8 +978,9 @@ function SessionTreeRow(props: {
         index={index}
         depth={props.depth}
         childCount={childCount}
+        hasChildren={hasChildren}
         expanded={isExpanded}
-        hasActiveDescendant={node.hasActiveDescendant}
+        hasActiveDescendant={node.hasActiveDescendant || treeHasActiveDescendant}
         onToggleExpand={() => props.onToggleExpand(node.session.id)}
         active={node.session.id === props.activeSessionId || representsHiddenActive}
         focused={index >= 0 && index === props.focusIndex}
@@ -688,13 +1001,60 @@ function SessionTreeRow(props: {
               onFocusSession={props.onFocusSession}
               expanded={props.expanded}
               onToggleExpand={props.onToggleExpand}
+              childPages={props.childPages}
+              onLoadMoreChildren={props.onLoadMoreChildren}
               onSelect={props.onSelect}
               onRename={props.onRename}
               onPin={props.onPin}
             />
           ))
         : null}
+      {isExpanded && childPage?.loading ? (
+        <TreeLoadRow depth={props.depth + 1} text="Loading sessions…" />
+      ) : null}
+      {isExpanded && childPage?.failed ? (
+        <TreeLoadRow
+          depth={props.depth + 1}
+          text="Retry loading sessions"
+          onClick={() =>
+            void props.onLoadMoreChildren(node.session.id, childPage.nextCursor ?? undefined)
+          }
+        />
+      ) : null}
+      {isExpanded && !childPage?.loading && !childPage?.failed && childPage?.nextCursor ? (
+        <TreeLoadRow
+          depth={props.depth + 1}
+          text="Show more"
+          onClick={() => void props.onLoadMoreChildren(node.session.id, childPage.nextCursor!)}
+        />
+      ) : null}
     </>
+  );
+}
+
+function TreeLoadRow({
+  depth,
+  text,
+  onClick,
+}: {
+  depth: number;
+  text: string;
+  onClick?: () => void;
+}) {
+  const style = { paddingLeft: 26 + depth * 14 };
+  return onClick ? (
+    <button
+      type="button"
+      onClick={onClick}
+      style={style}
+      className="h-8 w-full rounded-md pr-2 text-left text-xs text-fg-subtle hover:bg-surface-2 hover:text-fg pointer-coarse:h-11"
+    >
+      {text}
+    </button>
+  ) : (
+    <div style={style} className="flex h-8 items-center text-xs text-fg-subtle" role="status">
+      {text}
+    </div>
   );
 }
 
@@ -705,6 +1065,7 @@ function SessionRow(props: {
   depth: number;
   /** Spawned-child count; a chevron + badge appear when > 0. */
   childCount: number;
+  hasChildren: boolean;
   expanded: boolean;
   /** A descendant is live — a collapsed parent shows a quiet activity dot. */
   hasActiveDescendant: boolean;
@@ -716,10 +1077,15 @@ function SessionRow(props: {
   onRename: RenameFn;
   onPin: PinFn;
 }) {
+  const rail = useRail();
+  const app = useAppContext();
   const title =
     props.session.title?.trim() || props.session.initialMessage?.trim() || "Untitled session";
   const rename = useInlineRename(props.session, props.onRename);
-  const hasChildren = props.childCount > 0;
+  const hasChildren = props.hasChildren;
+  const workspace = app.workspaces.find((candidate) => candidate.id === props.session.workspaceId);
+  const stateLabel = sessionStateLabel(props.session, workspace);
+  const descendantLabel = sessionDescendantLabel(props.session);
   // Indent nested rows; the leading affordance is a chevron for parents, else a
   // spacer of the same width — reserved at every depth (root included) so every
   // status dot sits in one column and the left edge is even whether a row is a
@@ -728,6 +1094,7 @@ function SessionRow(props: {
 
   const rowClassName = cn(
     "group relative flex h-8 w-full items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 text-left text-sm transition-colors pointer-coarse:h-11 pointer-coarse:py-0",
+    rail.isMobile && "h-12 py-1.5 pointer-coarse:h-12",
     "hover:bg-surface-2",
     props.active ? "bg-surface-3 font-medium text-fg" : "text-fg-muted",
     props.focused && !props.active ? "bg-surface-2/60" : "",
@@ -816,7 +1183,14 @@ function SessionRow(props: {
             <span className="sr-only">{props.session.status}. </span>
             {/* min-w-0 + truncate: the title must always ellipsis, never butt the
                 rail border. */}
-            <span className="min-w-0 flex-1 truncate pr-1">{title}</span>
+            <span className="flex min-w-0 flex-1 flex-col pr-1 leading-tight">
+              <span className="truncate">{title}</span>
+              {rail.isMobile ? (
+                <span className="mt-0.5 truncate text-2xs font-normal text-fg-subtle">
+                  {[stateLabel, descendantLabel].filter(Boolean).join(" · ")}
+                </span>
+              ) : null}
+            </span>
             {/* A collapsed parent with a live child shows a quiet pulsing dot so
                 the activity isn't hidden with the subtree; the count badge sits
                 beside it. Both stay visible on hover (the time yields instead). */}
@@ -827,7 +1201,9 @@ function SessionRow(props: {
                     <span className="absolute inset-0 animate-og-pulse rounded-full bg-status-running" />
                   </span>
                 ) : null}
-                <span aria-label={`${props.childCount} spawned sessions`}>{props.childCount}</span>
+                <span aria-label={`${props.childCount} descendant sessions`}>
+                  {props.childCount}
+                </span>
               </span>
             ) : null}
             {/* Relative time is visible at rest (the list is grouped by recency),
@@ -859,6 +1235,49 @@ function SessionRow(props: {
       </ContextMenuContent>
     </ContextMenu>
   );
+}
+
+function sessionStateLabel(
+  session: Session,
+  workspace: { inferenceState?: "active" | "paused"; inferenceGeneration?: number } | undefined,
+): string {
+  if (session.controlState === "paused") return "Paused";
+  if (
+    workspace?.inferenceState === "paused" &&
+    session.workspaceRunExceptionGeneration !== workspace.inferenceGeneration
+  ) {
+    return "Paused by workspace";
+  }
+  if (workspace?.inferenceState === "paused") return "Running by exception";
+  switch (session.status) {
+    case "requires_action":
+      return "Needs you";
+    case "waiting_capacity":
+      return "Waiting for capacity";
+    case "recovering":
+      return "Recovering";
+    case "running":
+      return "Running";
+    case "queued":
+      return "Queued";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Idle";
+  }
+}
+
+function sessionDescendantLabel(session: Session): string | null {
+  const stats = session.treeStats;
+  if (!stats || stats.totalDescendants === 0) return null;
+  const live = stats.runningDescendants + stats.queuedDescendants;
+  if (stats.attentionDescendants > 0) {
+    return `${stats.attentionDescendants} need you · ${stats.totalDescendants} total`;
+  }
+  if (live > 0) return `${live} active · ${stats.totalDescendants} total`;
+  return `${stats.totalDescendants} session${stats.totalDescendants === 1 ? "" : "s"}`;
 }
 
 /** The active-session accent bar shared by the row's display and edit modes. */

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -37,6 +37,7 @@ export function SessionWorkspace(props: {
   initialTab?: string;
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
+  mobileLeadingControl?: ReactNode;
 }) {
   return (
     <SandboxWorkspace
@@ -49,6 +50,7 @@ export function SessionWorkspace(props: {
       {...(props.initialTab ? { initialTab: props.initialTab } : {})}
       collapsed={props.collapsed}
       onCollapsedChange={props.onCollapsedChange}
+      {...(props.mobileLeadingControl ? { mobileLeadingControl: props.mobileLeadingControl } : {})}
       autoSaveId="og.session.dock"
       onNotify={notify}
     />

--- a/apps/web/src/lib/session-rail.ts
+++ b/apps/web/src/lib/session-rail.ts
@@ -1,0 +1,95 @@
+import type { Session } from "@/types";
+
+export const DEFAULT_VISIBLE_TREE_LEVELS = 3;
+export const MAX_VISUAL_TREE_DEPTH = 3;
+
+type WorkspaceInference =
+  | { inferenceState?: "active" | "paused"; inferenceGeneration?: number }
+  | undefined;
+
+export function sessionStatusLabel(status: Session["status"]): string {
+  switch (status) {
+    case "requires_action":
+      return "Needs you";
+    case "waiting_capacity":
+      return "Waiting for capacity";
+    case "recovering":
+      return "Recovering";
+    case "running":
+      return "Running";
+    case "queued":
+      return "Queued";
+    case "paused":
+      return "Paused";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Idle";
+  }
+}
+
+/** Honest user-facing state: lifecycle first, then the effective pause policy. */
+export function sessionStateLabel(session: Session, workspace: WorkspaceInference): string {
+  const lifecycle = sessionStatusLabel(session.status);
+  const transitionActive = session.status === "running" || session.status === "recovering";
+  const attentionOrTerminal =
+    session.status === "requires_action" ||
+    session.status === "failed" ||
+    session.status === "cancelled";
+
+  if (session.controlState === "paused") {
+    if (transitionActive) return "Pausing…";
+    return attentionOrTerminal ? `${lifecycle} · Session paused` : "Paused";
+  }
+
+  if (workspace?.inferenceState !== "paused") return lifecycle;
+
+  const hasWorkspaceException =
+    workspace.inferenceGeneration !== undefined &&
+    session.workspaceRunExceptionGeneration === workspace.inferenceGeneration;
+  if (!hasWorkspaceException) {
+    if (transitionActive) return "Pausing…";
+    return attentionOrTerminal ? `${lifecycle} · Workspace paused` : "Paused by workspace";
+  }
+
+  const exceptionLabel =
+    session.status === "idle" || session.status === "paused"
+      ? "Allowed while paused"
+      : "Workspace exception";
+  return `${lifecycle} · ${exceptionLabel}`;
+}
+
+/** Root-to-parent path for the URL-active session, guarded against corrupt cycles. */
+export function sessionAncestorPath(
+  activeSessionId: string | null,
+  parentOf: ReadonlyMap<string, string>,
+): string[] {
+  if (!activeSessionId) return [];
+  const reversePath: string[] = [];
+  const seen = new Set<string>([activeSessionId]);
+  let cursor = parentOf.get(activeSessionId);
+  while (cursor && !seen.has(cursor)) {
+    seen.add(cursor);
+    reversePath.push(cursor);
+    cursor = parentOf.get(cursor);
+  }
+  return reversePath.reverse();
+}
+
+/** Expand only enough ancestors to show the default number of real tree levels. */
+export function defaultExpandedAncestors(
+  ancestorPath: readonly string[],
+  manuallyCollapsed: ReadonlySet<string>,
+  visibleLevels = DEFAULT_VISIBLE_TREE_LEVELS,
+): ReadonlySet<string> {
+  const expansionCount = Math.max(0, visibleLevels - 1);
+  return new Set(
+    ancestorPath.slice(0, expansionCount).filter((sessionId) => !manuallyCollapsed.has(sessionId)),
+  );
+}
+
+export function visualTreeDepth(depth: number): number {
+  return Math.min(MAX_VISUAL_TREE_DEPTH, Math.max(0, depth));
+}

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -22,7 +22,13 @@ export const SESSION_GROUP_ORDER: SessionRecencyGroup[] = [
 ];
 
 /** Live states that earn the pinned-to-top, breathing-dot treatment. */
-const RUNNING_STATUSES = new Set<SessionStatus>(["running", "queued", "requires_action"]);
+const RUNNING_STATUSES = new Set<SessionStatus>([
+  "running",
+  "queued",
+  "waiting_capacity",
+  "recovering",
+  "requires_action",
+]);
 
 export function isRunningStatus(status: SessionStatus): boolean {
   return RUNNING_STATUSES.has(status);
@@ -98,7 +104,11 @@ export function groupSessionsForRail(sessions: Session[], now: Date = new Date()
   for (const group of SESSION_GROUP_ORDER) {
     const list = buckets.get(group);
     if (list && list.length > 0) {
-      grouped.push({ group, label: SESSION_GROUP_LABELS[group], sessions: list });
+      grouped.push({
+        group,
+        label: SESSION_GROUP_LABELS[group],
+        sessions: list,
+      });
     }
   }
   return { running, grouped };
@@ -124,7 +134,11 @@ export type SessionTreeNode = {
 
 export type SessionForest = {
   running: SessionTreeNode[];
-  grouped: { group: SessionRecencyGroup; label: string; sessions: SessionTreeNode[] }[];
+  grouped: {
+    group: SessionRecencyGroup;
+    label: string;
+    sessions: SessionTreeNode[];
+  }[];
 };
 
 /** Whether the node's own status, or any descendant, is in a live state. */
@@ -207,7 +221,11 @@ export function buildRailForest(sessions: Session[], now: Date = new Date()): Se
   for (const group of SESSION_GROUP_ORDER) {
     const list = buckets.get(group);
     if (list && list.length > 0) {
-      grouped.push({ group, label: SESSION_GROUP_LABELS[group], sessions: list });
+      grouped.push({
+        group,
+        label: SESSION_GROUP_LABELS[group],
+        sessions: list,
+      });
     }
   }
   return { running, grouped };
@@ -262,5 +280,8 @@ export function relativeTimeLabel(value: string, now: Date = new Date()): string
   if (days < 7) {
     return `${days}d`;
   }
-  return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -129,7 +129,11 @@ export type SessionForest = {
 
 /** Whether the node's own status, or any descendant, is in a live state. */
 export function nodeIsActive(node: SessionTreeNode): boolean {
-  return isRunningStatus(node.session.status) || node.hasActiveDescendant;
+  const stats = node.session.treeStats;
+  const summarizedActive = Boolean(
+    stats && stats.runningDescendants + stats.queuedDescendants + stats.attentionDescendants > 0,
+  );
+  return isRunningStatus(node.session.status) || node.hasActiveDescendant || summarizedActive;
 }
 
 /**

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -19,7 +19,7 @@ import {
   type UserMessageItem,
 } from "@opengeni/react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { CheckIcon, Loader2Icon, MessagesSquareIcon, XIcon } from "lucide-react";
+import { CheckIcon, Loader2Icon, MenuIcon, MessagesSquareIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -35,6 +35,7 @@ import {
   UserMessageBody,
 } from "@/components/session/banners";
 import { ComposerAgentsPill } from "@/components/session/composer-agents-pill";
+import { useRail } from "@/components/rail/rail-context";
 import { GoalSurface } from "@/components/session/goal-surface";
 import { SessionInspector } from "@/components/session/inspector";
 import { QueueSurface } from "@/components/session/queue-surface";
@@ -63,6 +64,7 @@ export function SessionRoute({
   sessionId: string;
 }) {
   const context = useAppContext();
+  const rail = useRail();
   const navigate = useNavigate();
 
   // Session record + live event log via @opengeni/react. Fresh opens load a
@@ -159,7 +161,9 @@ export function SessionRoute({
   );
   useEffect(() => {
     if (streamError && !isApiErrorStatus(streamError, 404)) {
-      toast.error("Event stream disconnected", { description: streamError.message });
+      toast.error("Event stream disconnected", {
+        description: streamError.message,
+      });
     }
   }, [streamError]);
   useEffect(() => {
@@ -184,9 +188,13 @@ export function SessionRoute({
     oauthReturnHandled.current = true;
     window.history.replaceState(null, "", window.location.pathname);
     if (outcome === "success") {
-      toast.success("Reconnected", { description: "Send your message again to continue." });
+      toast.success("Reconnected", {
+        description: "Send your message again to continue.",
+      });
     } else {
-      toast.error("Reconnect failed", { description: params.get("reason") ?? undefined });
+      toast.error("Reconnect failed", {
+        description: params.get("reason") ?? undefined,
+      });
     }
   }, []);
 
@@ -301,7 +309,10 @@ export function SessionRoute({
   // "running" count doesn't go stale on CHILD-side status changes that emit no
   // event on this parent's feed. Must sit above the loading/error early-returns
   // — it's a hook, so it has to run unconditionally on every render.
-  const lineage = useSessionLineage(sessionId, { events, pollIntervalMs: 30_000 });
+  const lineage = useSessionLineage(sessionId, {
+    events,
+    pollIntervalMs: 30_000,
+  });
   const agentNodes = lineage.lineage?.children ?? [];
 
   if (loading || !session) {
@@ -365,7 +376,10 @@ export function SessionRoute({
         })
       }
       onNewSession={() =>
-        void navigate({ to: "/workspaces/$workspaceId/sessions", params: { workspaceId } })
+        void navigate({
+          to: "/workspaces/$workspaceId/sessions",
+          params: { workspaceId },
+        })
       }
       onApprove={(approvalId) => approve(approvalId, "approve")}
       onReject={(approvalId) => approve(approvalId, "reject")}
@@ -386,13 +400,20 @@ export function SessionRoute({
         primary={chatPane}
         dockCollapsed={!context.inspectorOpen}
         onDockCollapsedChange={(collapsed) => context.setInspectorOpen(!collapsed)}
+        onOpenNavigation={() => {
+          context.setInspectorOpen(false);
+          rail.setDrawerOpen(true);
+        }}
       />
     </div>
   );
 
   async function approve(approvalId: string, decision: "approve" | "reject") {
     try {
-      await context.client.sendApprovalDecision(workspaceId, sessionId, { approvalId, decision });
+      await context.client.sendApprovalDecision(workspaceId, sessionId, {
+        approvalId,
+        decision,
+      });
     } catch (error) {
       toast.error("Couldn't submit the decision", {
         description: error instanceof Error ? error.message : String(error),
@@ -416,6 +437,7 @@ function SessionDock(props: {
   primary: React.ReactNode;
   dockCollapsed: boolean;
   onDockCollapsedChange: (collapsed: boolean) => void;
+  onOpenNavigation: () => void;
 }) {
   // The workbench (Changes | Files | Terminal | Desktop + machine chip) lives in
   // the package now; the app injects Debug around it. Agents remain in the one
@@ -441,6 +463,18 @@ function SessionDock(props: {
       trailingTabs={[debugTab]}
       collapsed={props.dockCollapsed}
       onCollapsedChange={props.onDockCollapsedChange}
+      mobileLeadingControl={
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Open navigation"
+          onClick={props.onOpenNavigation}
+          className="pointer-coarse:size-10"
+        >
+          <MenuIcon className="size-4" />
+        </Button>
+      }
     />
   );
 }
@@ -500,7 +534,10 @@ function SessionChatPane(props: {
       setApprovalPending((current) => ({ ...current, [approvalId]: decision }));
       try {
         await (decision === "approve" ? props.onApprove(approvalId) : props.onReject(approvalId));
-        setApprovalSettled((current) => ({ ...current, [approvalId]: decision }));
+        setApprovalSettled((current) => ({
+          ...current,
+          [approvalId]: decision,
+        }));
       } catch {
         // The route already surfaced a toast; leave the buttons live to retry.
       } finally {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3145,6 +3145,22 @@ export const Session = z.object({
   pinnedAt: z.string().nullable().default(null),
   /** Optimistic pin-state revision; zero represents an absent pin relation. */
   pinVersion: z.number().int().nonnegative().default(0),
+  /**
+   * Server-authoritative hierarchy summary populated on session-list reads.
+   * Detail reads may omit it. The rail uses this instead of guessing a tree
+   * from whichever global recency page happened to be loaded.
+   */
+  treeStats: z
+    .object({
+      directChildren: z.number().int().nonnegative(),
+      totalDescendants: z.number().int().nonnegative(),
+      runningDescendants: z.number().int().nonnegative(),
+      queuedDescendants: z.number().int().nonnegative(),
+      attentionDescendants: z.number().int().nonnegative(),
+      pausedDescendants: z.number().int().nonnegative(),
+      failedDescendants: z.number().int().nonnegative(),
+    })
+    .optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10584,6 +10584,97 @@ function mapSessionPin(
     : { pinned: false, pinnedAt: null, pinVersion: 0 };
 }
 
+type SessionTreeStats = NonNullable<Session["treeStats"]>;
+
+type SessionTreeStatsRow = {
+  rootId: string;
+  directChildren: number | string;
+  totalDescendants: number | string;
+  runningDescendants: number | string;
+  queuedDescendants: number | string;
+  attentionDescendants: number | string;
+  pausedDescendants: number | string;
+  failedDescendants: number | string;
+};
+
+/**
+ * Return complete descendant aggregates for the bounded set of rows being
+ * painted in the session rail. Parent links are immutable, so one recursive
+ * read inside the list transaction gives the client stable, authoritative
+ * expand affordances without loading the workspace's entire session table.
+ */
+async function sessionTreeStatsForSessions(
+  db: Database,
+  workspaceId: string,
+  rootIds: string[],
+): Promise<Map<string, SessionTreeStats>> {
+  if (rootIds.length === 0) return new Map();
+  const rows = await rawRows<SessionTreeStatsRow>(
+    db,
+    sql`
+      with recursive descendants(root_id, id, status, depth, path) as (
+        select
+          root.id,
+          root.id,
+          root.status,
+          0,
+          array[root.id]
+        from ${schema.sessions} root
+        where root.workspace_id = ${workspaceId}
+          and ${inArray(sql`root.id`, rootIds)}
+
+        union all
+
+        select
+          descendants.root_id,
+          child.id,
+          child.status,
+          descendants.depth + 1,
+          descendants.path || child.id
+        from ${schema.sessions} child
+        join descendants on child.parent_session_id = descendants.id
+        where child.workspace_id = ${workspaceId}
+          and not child.id = any(descendants.path)
+      )
+      select
+        root_id as "rootId",
+        count(*) filter (where depth = 1)::int as "directChildren",
+        count(*) filter (where depth > 0)::int as "totalDescendants",
+        count(*) filter (
+          where depth > 0 and status in ('running', 'recovering')
+        )::int as "runningDescendants",
+        count(*) filter (
+          where depth > 0 and status in ('queued', 'waiting_capacity')
+        )::int as "queuedDescendants",
+        count(*) filter (
+          where depth > 0 and status = 'requires_action'
+        )::int as "attentionDescendants",
+        count(*) filter (
+          where depth > 0 and status = 'paused'
+        )::int as "pausedDescendants",
+        count(*) filter (
+          where depth > 0 and status = 'failed'
+        )::int as "failedDescendants"
+      from descendants
+      group by root_id
+    `,
+  );
+  return new Map(
+    rows.map((row) => [
+      row.rootId,
+      {
+        directChildren: Number(row.directChildren),
+        totalDescendants: Number(row.totalDescendants),
+        runningDescendants: Number(row.runningDescendants),
+        queuedDescendants: Number(row.queuedDescendants),
+        attentionDescendants: Number(row.attentionDescendants),
+        pausedDescendants: Number(row.pausedDescendants),
+        failedDescendants: Number(row.failedDescendants),
+      },
+    ]),
+  );
+}
+
 function sessionFilters(
   options: Pick<ListSessionsForSubjectOptions, "parentSessionId" | "search">,
 ): SQL[] {
@@ -10883,13 +10974,24 @@ export async function listSessionsForSubject(
           ...pageRows.map((row) => row.session.id),
         ];
         const mcpServers = await sessionMcpServerMetadataForSessions(tx, workspaceId, ids);
+        const treeStats = await sessionTreeStatsForSessions(tx, workspaceId, ids);
+        const mapListSession = (
+          row: (typeof pinnedRows)[number] | (typeof pageRows)[number],
+        ): Session => ({
+          ...mapSession(row.session, mcpServers.get(row.session.id) ?? [], mapSessionPin(row.pin)),
+          treeStats: treeStats.get(row.session.id) ?? {
+            directChildren: 0,
+            totalDescendants: 0,
+            runningDescendants: 0,
+            queuedDescendants: 0,
+            attentionDescendants: 0,
+            pausedDescendants: 0,
+            failedDescendants: 0,
+          },
+        });
         return {
-          pinned: pinnedRows.map((row) =>
-            mapSession(row.session, mcpServers.get(row.session.id) ?? [], mapSessionPin(row.pin)),
-          ),
-          sessions: pageRows.map((row) =>
-            mapSession(row.session, mcpServers.get(row.session.id) ?? [], mapSessionPin(row.pin)),
-          ),
+          pinned: pinnedRows.map(mapListSession),
+          sessions: pageRows.map(mapListSession),
           nextCursor,
         };
       },

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -37,7 +37,12 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
   return { accountId: account!.id, workspaceId: workspace!.id };
 }
 
-async function session(input: { accountId: string; workspaceId: string; message: string }) {
+async function session(input: {
+  accountId: string;
+  workspaceId: string;
+  message: string;
+  parentSessionId?: string;
+}) {
   return await createSession(db, {
     accountId: input.accountId,
     workspaceId: input.workspaceId,
@@ -46,6 +51,7 @@ async function session(input: { accountId: string; workspaceId: string; message:
     metadata: {},
     model: "test-model",
     sandboxBackend: "none",
+    ...(input.parentSessionId ? { parentSessionId: input.parentSessionId } : {}),
   });
 }
 
@@ -127,6 +133,63 @@ afterAll(async () => {
 });
 
 describe("session pins (real PostgreSQL + FORCE RLS)", () => {
+  test("lists server-authoritative descendant summaries for roots and lazy child pages", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const subjectId = "user:tree-stats";
+    await grantMember(workspace, subjectId);
+    const root = await session({ ...workspace, message: "root" });
+    const child = await session({
+      ...workspace,
+      message: "child",
+      parentSessionId: root.id,
+    });
+    const grandchild = await session({
+      ...workspace,
+      message: "grandchild",
+      parentSessionId: child.id,
+    });
+    await session({ ...workspace, message: "unrelated root" });
+    await admin`
+      update sessions
+      set status = case
+        when id = ${child.id} then 'running'
+        when id = ${grandchild.id} then 'requires_action'
+        else status
+      end
+      where id in (${child.id}, ${grandchild.id})`;
+
+    const roots = await listSessionsForSubject(db, workspace.workspaceId, {
+      subjectId,
+      parentSessionId: null,
+    });
+    expect(roots.sessions.find((row) => row.id === root.id)?.treeStats).toEqual({
+      directChildren: 1,
+      totalDescendants: 2,
+      runningDescendants: 1,
+      queuedDescendants: 0,
+      attentionDescendants: 1,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+    });
+    expect(roots.sessions.some((row) => row.id === child.id)).toBe(false);
+
+    const children = await listSessionsForSubject(db, workspace.workspaceId, {
+      subjectId,
+      parentSessionId: root.id,
+    });
+    expect(children.sessions.map((row) => row.id)).toEqual([child.id]);
+    expect(children.sessions[0]?.treeStats).toEqual({
+      directChildren: 1,
+      totalDescendants: 1,
+      runningDescendants: 0,
+      queuedDescendants: 0,
+      attentionDescendants: 1,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+    });
+  });
+
   test("reaps expired list snapshots outside request transactions", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -160,7 +160,12 @@ type SessionWarmIntents = {
 };
 
 function emptyWarmIntents(sessionId: string): SessionWarmIntents {
-  return { sessionId, watchDesktop: false, warmTerminal: false, warmEdit: false };
+  return {
+    sessionId,
+    watchDesktop: false,
+    warmTerminal: false,
+    warmEdit: false,
+  };
 }
 
 /**
@@ -198,7 +203,11 @@ export function useSandboxWorkspaceTabs(
 
   // The session's machine fleet + the active-sandbox pointer. Drives the header
   // chip (which machine + its connection state). Polls slowly — ambient context.
-  const machines = useMachines({ workspaceId, sessionId, pollIntervalMs: 8000 });
+  const machines = useMachines({
+    workspaceId,
+    sessionId,
+    pollIntervalMs: 8000,
+  });
   const activeMachine: MachineView | null =
     machines.machines.find((m) => m.sandboxId === machines.activeSandboxId) ??
     machines.machines.find((m) => m.active) ??
@@ -231,7 +240,11 @@ export function useSandboxWorkspaceTabs(
   const ptyWsLive =
     capabilities?.Terminal.transport === "pty-ws" && Boolean(capabilities?.Terminal.url);
   const ptyCapable = (capabilities?.Terminal.ptyCapable ?? false) && !ptyWsLive;
-  const terminal = useSandboxTerminal(sessionId, { events, interactive: ptyCapable, liveness });
+  const terminal = useSandboxTerminal(sessionId, {
+    events,
+    interactive: ptyCapable,
+    liveness,
+  });
   const desktopAdvertised =
     (capabilities?.DesktopStream.transport ?? null) !== null ||
     capabilities?.DesktopStream.reason === "lease_cold";
@@ -258,7 +271,10 @@ export function useSandboxWorkspaceTabs(
   // diff when the box is not warm; a warm box always wins (live path unchanged).
   const captureState = useWorkspaceCapture(sessionId, { events });
   const captureAvailable = captureState.available;
-  const notifiedCaptureDegradedReason = useRef<{ sessionId: string; reason: string | null }>({
+  const notifiedCaptureDegradedReason = useRef<{
+    sessionId: string;
+    reason: string | null;
+  }>({
     sessionId,
     reason: null,
   });
@@ -280,7 +296,10 @@ export function useSandboxWorkspaceTabs(
     // A reverted optimistic mutation (e.g. a 409 rename collision) surfaces as a
     // host notification — the tree silently rolls back, the user sees why.
     onMutationError: (error, op) =>
-      onNotify?.({ kind: "error", message: `Could not ${op}: ${error.message}` }),
+      onNotify?.({
+        kind: "error",
+        message: `Could not ${op}: ${error.message}`,
+      }),
   });
   const git = useSandboxGit(sessionId, {
     events,
@@ -512,6 +531,8 @@ export type SandboxWorkspaceProps = ClientOverride & {
   /** Controlled collapsed state for hosts with their own dock toggle. */
   collapsed?: boolean | undefined;
   onCollapsedChange?: ((collapsed: boolean) => void) | undefined;
+  /** Host navigation shown only in the phone workspace overlay header. */
+  mobileLeadingControl?: ReactNode | undefined;
   autoSaveId?: string | undefined;
   defaultSize?: number | undefined;
   minSize?: number | undefined;
@@ -537,6 +558,7 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     onNotify,
     collapsed,
     onCollapsedChange,
+    mobileLeadingControl,
     autoSaveId,
     defaultSize,
     minSize,
@@ -588,6 +610,7 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
           onRetry={() => void machine.refresh()}
         />
       }
+      {...(mobileLeadingControl !== undefined ? { mobileLeadingControl } : {})}
       {...(collapsed !== undefined ? { collapsed } : {})}
       {...(onCollapsedChange ? { onCollapsedChange } : {})}
       {...(autoSaveId !== undefined ? { autoSaveId } : {})}

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -32,6 +32,9 @@ export type WorkspaceDockProps = {
    *  maximize/collapse controls (e.g. the machine-state chip). Renders in both
    *  the docked header and the full-screen overlay header. */
   headerAccessory?: ReactNode | undefined;
+  /** Optional host navigation shown at the start of the phone overlay header.
+   *  It is intentionally absent from desktop dock chrome. */
+  mobileLeadingControl?: ReactNode | undefined;
   /** Persisted layout id (localStorage key) for react-resizable-panels. */
   autoSaveId?: string | undefined;
   /** Default dock width as a percent of the session area. */
@@ -93,6 +96,7 @@ export function WorkspaceDock({
   collapsed: collapsedProp,
   onCollapsedChange,
   headerAccessory,
+  mobileLeadingControl,
   autoSaveId = "og.session.dock",
   defaultSize = 34,
   minSize = 22,
@@ -202,6 +206,7 @@ export function WorkspaceDock({
               tabs={tabs}
               current={current}
               onTab={setTab}
+              leading={mobileLeadingControl}
               accessory={headerAccessory}
               controls={
                 <ChromeButton onClick={collapse} title="Close workspace" label="Close workspace">
@@ -338,12 +343,15 @@ function DockChrome({
   tabs,
   current,
   onTab,
+  leading,
   accessory,
   controls,
 }: {
   tabs: WorkspaceTab[];
   current: string;
   onTab: (id: string) => void;
+  /** Host navigation at the start of mobile overlay chrome. */
+  leading?: ReactNode | undefined;
   /** A status accessory (machine chip) between the tab strip and the controls. */
   accessory?: ReactNode | undefined;
   /** Right-aligned chrome controls (maximize / collapse, or the overlay close). */
@@ -353,6 +361,7 @@ function DockChrome({
   return (
     <>
       <div className="flex shrink-0 items-center gap-2 border-b border-og-border px-1.5 py-1">
+        {leading ? <div className="flex shrink-0 items-center">{leading}</div> : null}
         {/* The tab list scrolls horizontally when it can't fit — it must never
             grow into or overlap the chrome controls (they stay shrink-0). The
             scrollbar is hidden to keep the strip calm. */}

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -420,15 +420,18 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
 
       case "turn.recovery.requested": {
         closeStreamingTail();
-        const reason =
-          typeof payload.reason === "string" ? payload.reason.replaceAll("_", " ") : null;
+        const rawReason = typeof payload.reason === "string" ? payload.reason : null;
+        const reason = rawReason?.replaceAll("_", " ") ?? null;
         items.push({
           kind: "notice",
           id: event.id,
           tone: "waiting",
-          text: reason
-            ? `The current turn is recovering after ${reason}. No new prompt was queued.`
-            : "The current turn is recovering. No new prompt was queued.",
+          text:
+            rawReason === "workspace_pause"
+              ? "Resuming paused work."
+              : reason
+                ? `Resuming this turn after ${reason}.`
+                : "Resuming this turn.",
           occurredAt: event.occurredAt,
         });
         break;
@@ -437,14 +440,13 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "turn.event.rejected_late": {
         const rejectedType =
           typeof payload.rejectedType === "string" ? payload.rejectedType : "unknown event";
-        // Workspace revision events are session-scoped cache announcements, not
-        // user/agent turn evidence. Older servers could route them through the
-        // attempt fence after the turn settled; retain that audit row durably,
-        // but never present harmless internal bookkeeping as a user-visible
-        // failed action.
+        // Workspace revision events are cache announcements and rejected
+        // reasoning deltas are discarded stream fragments. Both remain durable
+        // in Debug/audit evidence, but neither is a user-visible failed action.
         if (
           rejectedType === "workspace.revision.captured" ||
-          rejectedType === "workspace.revision.degraded"
+          rejectedType === "workspace.revision.degraded" ||
+          rejectedType === "agent.reasoning.delta"
         ) {
           break;
         }

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -734,7 +734,19 @@ describe("buildTimeline", () => {
       expect.objectContaining({
         kind: "notice",
         tone: "waiting",
-        text: "The current turn is recovering after worker shutdown. No new prompt was queued.",
+        text: "Resuming this turn after worker shutdown.",
+      }),
+    ]);
+  });
+
+  test("uses compact copy when workspace-paused work resumes", () => {
+    reset();
+    const items = buildTimeline([event("turn.recovery.requested", { reason: "workspace_pause" })]);
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: "notice",
+        tone: "waiting",
+        text: "Resuming paused work.",
       }),
     ]);
   });
@@ -769,6 +781,18 @@ describe("buildTimeline", () => {
         rejectedType: "workspace.revision.degraded",
         rejectedPayload: { revision: 4 },
         reason: "active_turn_changed",
+      }),
+    ]);
+    expect(items).toEqual([]);
+  });
+
+  test("hides rejected late reasoning fragments from the user timeline", () => {
+    reset();
+    const items = buildTimeline([
+      event("turn.event.rejected_late", {
+        rejectedType: "agent.reasoning.delta",
+        rejectedPayload: { text: "**internal discarded fragment**" },
+        reason: "workspace_paused",
       }),
     ]);
     expect(items).toEqual([]);

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { act, useState } from "react";
+import { act, type ReactNode, useState } from "react";
 import { WorkspaceDock } from "../src/components/workspace-dock";
 import { registerDom, renderComponent } from "./render-hook";
 
@@ -12,7 +12,10 @@ async function click(element: Element | null): Promise<void> {
   });
 }
 
-function ControlledDock(props: { onCollapsedChange: (collapsed: boolean) => void }) {
+function ControlledDock(props: {
+  onCollapsedChange: (collapsed: boolean) => void;
+  mobileLeadingControl?: ReactNode;
+}) {
   const [collapsed, setCollapsed] = useState(false);
   return (
     <WorkspaceDock
@@ -24,6 +27,7 @@ function ControlledDock(props: { onCollapsedChange: (collapsed: boolean) => void
         props.onCollapsedChange(next);
         setCollapsed(next);
       }}
+      mobileLeadingControl={props.mobileLeadingControl}
     />
   );
 }
@@ -92,7 +96,10 @@ describe("WorkspaceDock", () => {
     await withNarrowViewport(async () => {
       const changes: boolean[] = [];
       const rendered = await renderComponent(
-        <ControlledDock onCollapsedChange={(collapsed) => changes.push(collapsed)} />,
+        <ControlledDock
+          onCollapsedChange={(collapsed) => changes.push(collapsed)}
+          mobileLeadingControl={<button aria-label="Open navigation">Menu</button>}
+        />,
       );
 
       // No drag splitter renders on a phone-width viewport.
@@ -101,6 +108,7 @@ describe("WorkspaceDock", () => {
       const overlay = rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]');
       expect(overlay).not.toBeNull();
       expect(overlay?.textContent ?? "").toContain("Run content");
+      expect(overlay?.querySelector('[aria-label="Open navigation"]')).not.toBeNull();
 
       // The overlay's own close control drives the same collapsed contract.
       await click(rendered.container.querySelector('[aria-label="Close workspace"]'));

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -417,6 +417,18 @@ export type Session = {
   pinnedAt?: string | null;
   /** Optimistic pin-state revision; zero represents an absent pin relation. */
   pinVersion?: number;
+  /** Server-authoritative descendant counts populated by session-list reads. */
+  treeStats?:
+    | {
+        directChildren: number;
+        totalDescendants: number;
+        runningDescendants: number;
+        queuedDescendants: number;
+        attentionDescendants: number;
+        pausedDescendants: number;
+        failedDescendants: number;
+      }
+    | undefined;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## What changed
- root-only workstream hierarchy with descendant summaries and lazy children
- compact three-level active path with explicit full-path reveal
- truthful workspace/session pause labels and active grouping
- full-screen mobile Sessions/Workspace navigation with exclusive workspace overlay handoff
- hide rejected late reasoning/revision bookkeeping from the normal timeline

## Verification
- `bun run typecheck` (19 projects)
- 195 focused web/react tests
- real PostgreSQL + FORCE RLS session tree test (15/15)
- production web build
- in-app browser verification against live CloudGeni production data on desktop and phone
