### PR TITLE
Fix mobile pinned session reconciliation

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -103,6 +103,12 @@ export function SessionList() {
   });
   const { sessions, nextCursor, loading, error, refresh } = rootPage;
   const pinned = hierarchyMode ? globalPinPage.pinned : rootPage.pinned;
+  // The hierarchy and its global pinned shortcuts come from separate queries.
+  // Every invalidation must refresh both or a pin changed in another tab/device
+  // can disappear from the shortcut section until the next polling interval.
+  const refreshSessionPages = useCallback(async () => {
+    await Promise.all([refresh(), ...(hierarchyMode ? [globalPinPage.refresh()] : [])]);
+  }, [globalPinPage.refresh, hierarchyMode, refresh]);
   // Ordinary rows page independently of the complete pinned section. The
   // polled hook owns page one; additional pages are appended and deduplicated.
   // A filter change starts a fresh cursor chain rather than mixing snapshots.
@@ -551,7 +557,7 @@ export function SessionList() {
             });
           });
         }
-        await Promise.all([refresh(), globalPinPage.refresh()]);
+        await refreshSessionPages();
         const label = target.title?.trim() || target.initialMessage?.trim() || "Untitled session";
         setAnnouncement(
           updated
@@ -569,7 +575,7 @@ export function SessionList() {
         });
       }
     },
-    [context, globalPinPage.refresh, refresh],
+    [context, refreshSessionPages],
   );
 
   const loadMore = useCallback(async () => {
@@ -637,11 +643,11 @@ export function SessionList() {
   // Cross-tab invalidation and lifecycle reconciliation. Cross-device changes
   // arrive on the 15s poll; returning to a tab or reconnecting refreshes now.
   useEffect(
-    () => subscribeToSessionPinChanges(rail.workspaceId, () => void refresh()),
-    [rail.workspaceId, refresh],
+    () => subscribeToSessionPinChanges(rail.workspaceId, () => void refreshSessionPages()),
+    [rail.workspaceId, refreshSessionPages],
   );
   useEffect(() => {
-    const reconcile = () => void refresh();
+    const reconcile = () => void refreshSessionPages();
     const onVisibility = () => {
       if (document.visibilityState === "visible") reconcile();
     };
@@ -653,7 +659,7 @@ export function SessionList() {
       window.removeEventListener("online", reconcile);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [refresh]);
+  }, [refreshSessionPages]);
 
   const listRef = useRef<HTMLDivElement>(null);
   const [focusedSessionId, setFocusedSessionId] = useState<string | null>(null);
@@ -1276,7 +1282,7 @@ function SessionRow(props: {
             <span className="flex min-w-0 flex-1 flex-col pr-1 leading-tight">
               <span className="truncate">{title}</span>
               {rail.isMobile ? (
-                <span className="mt-0.5 truncate text-2xs font-normal text-fg-subtle">
+                <span className="mt-0.5 truncate text-2xs font-normal text-fg-muted">
                   {[stateLabel, depthLabel, descendantLabel, relativeTime]
                     .filter(Boolean)
                     .join(" · ")}

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -437,6 +437,12 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       );
       await setSessionPinThroughApi(page, apiBaseUrl, workspaceId, extra, true);
     }
+    // The stress rows above are test fixtures inserted through raw fetches,
+    // intentionally bypassing the application's mutation invalidation. Start
+    // the responsive assertion from a fresh server projection instead of
+    // racing the rail's 15-second background reconciliation interval.
+    await page.reload();
+    await page.getByRole("button", { name: "Unpin session" }).waitFor();
 
     for (const theme of ["light", "dark"] as const) {
       await setTheme(page, theme);
@@ -458,6 +464,10 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       expect(await page.getByRole("dialog").getAttribute("aria-label")).toBe("Session navigation");
       const targetRow = navigation.getByRole("button", { name: /^Open Mobile pin/ });
       await targetRow.waitFor();
+      // The active route row can render from its point read before the pinned
+      // page arrives. Wait for one seeded shortcut so this assertion measures
+      // the loaded global pin section rather than that intermediate state.
+      await navigation.getByRole("button", { name: /^Open Pinned mobile stress 7/ }).waitFor();
       expect(await navigation.getByRole("group", { name: "Pinned" }).count()).toBe(1);
       expect(
         await navigation.getByRole("button", { name: /^Open Pinned mobile stress/ }).count(),


### PR DESCRIPTION
Follow-up release fix for #426.

- refresh both root hierarchy and global pinned shortcuts on pin invalidation/focus/online
- make mobile session metadata WCAG-contrast-safe
- remove the 320px E2E race by waiting for the authoritative pinned page

Verified:
- root typecheck (19 projects)
- 128 focused unit tests
- 5/5 real-API, non-superuser PostgreSQL browser E2E tests
- 320px light/dark axe acceptance
- root lint + format check
- production web build