### PR TITLE
fix(worker): retain Codex computer-use recordings

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -3877,12 +3877,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 );
               }
             }
-            // Recording gate: a computer-use tool actually ran when an SDK
-            // `tool_call_item` whose rawItem.type is "computer_call" streams through
-            // (screenshot/click/type/scroll/etc. — the first computer action proves
-            // the desktop was driven). Match the raw SDK event (ground truth) BEFORE
+            // Recording gate: a computer-use tool actually ran when its SDK
+            // `tool_call_item` streams through. Hosted Responses emits a raw
+            // `computer_call`; Codex/chat transports emit one of the first-party
+            // `computer_*` function calls. Match both protocol shapes BEFORE
             // normalization. Only meaningful when a recording is live.
-            if (activeRecording && !didComputerUse && isComputerCallStreamEvent(next.value)) {
+            if (activeRecording && !didComputerUse && isComputerUseStreamEvent(next.value)) {
               didComputerUse = true;
             }
             const pendingToolCall = pendingToolCallFromSdkEvent(next.value);
@@ -5666,26 +5666,47 @@ const CODEX_USAGE_LIMIT_MAX_RESUME_MS = 60 * 60_000; // 1h
 
 /**
  * Recognize an SDK stream event that represents a COMPUTER-USE tool call actually
- * executing — a `run_item_stream_event` carrying a `tool_call_item` whose
- * underlying raw item is a `computer_call` (the @openai/agents computer tool's
- * action: screenshot/click/type/scroll/drag/keypress/move/wait/…). This is the
- * same shape `normalizeSdkEvent` reads (`event.item.rawItem`), matched here against
- * the raw SDK type rather than a tool NAME so it is robust to the computer tool's
- * configured name. Drives the on-turn recording gate (no computer-use → discard).
+ * executing. Hosted Responses emits `computer_call`; function transports emit one
+ * of OpenGeni's exact first-party `computer_*` names. Both are authoritative wire
+ * identities selected by `computerToolModeForTurn`. Drives the on-turn recording
+ * gate (no computer-use → discard).
  */
-function isComputerCallStreamEvent(event: unknown): boolean {
+export function isComputerUseStreamEvent(event: unknown): boolean {
   if (!event || typeof event !== "object") {
     return false;
   }
   if ((event as { type?: unknown }).type !== "run_item_stream_event") {
     return false;
   }
-  const item = (event as { item?: { type?: unknown; rawItem?: { type?: unknown } } }).item;
+  const item = (
+    event as {
+      item?: { type?: unknown; rawItem?: { type?: unknown; name?: unknown } };
+    }
+  ).item;
   if (!item || item.type !== "tool_call_item") {
     return false;
   }
-  return item.rawItem?.type === "computer_call";
+  const raw = item.rawItem;
+  if (raw?.type === "computer_call") {
+    return true;
+  }
+  return (
+    raw?.type === "function_call" &&
+    typeof raw.name === "string" &&
+    FUNCTION_COMPUTER_TOOL_NAMES.has(raw.name)
+  );
 }
+
+const FUNCTION_COMPUTER_TOOL_NAMES = new Set([
+  "computer_screenshot",
+  "computer_click",
+  "computer_double_click",
+  "computer_move",
+  "computer_scroll",
+  "computer_type",
+  "computer_keypress",
+  "computer_drag",
+]);
 
 function pendingToolCallFromSdkEvent(event: unknown): {
   callId: string;

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -21,6 +21,7 @@ import {
   ensureTurnModalRegistryImage,
   filterUnmaterializedSandboxFileDownloads,
   historyRowsToAppend,
+  isComputerUseStreamEvent,
   isLazySandboxProvisionRetryable,
   isTransientProviderError,
   isWorkerShutdownCancellation,
@@ -941,6 +942,42 @@ describe("on-turn recording gate (selfhosted machines have no in-box capture plu
 
   test("headless / non-desktop established backend: skips (existing static feasibility gate holds)", () => {
     expect(shouldStartOnTurnRecording({ ...base, establishedBackendId: "none" })).toBe(false);
+  });
+});
+
+describe("on-turn recording computer-use protocol gate", () => {
+  const event = (rawItem: Record<string, unknown>) => ({
+    type: "run_item_stream_event",
+    item: { type: "tool_call_item", rawItem },
+  });
+
+  test("recognizes the hosted Responses computer_call", () => {
+    expect(isComputerUseStreamEvent(event({ type: "computer_call" }))).toBe(true);
+  });
+
+  test("recognizes every first-party function-transport computer tool", () => {
+    for (const name of [
+      "computer_screenshot",
+      "computer_click",
+      "computer_double_click",
+      "computer_move",
+      "computer_scroll",
+      "computer_type",
+      "computer_keypress",
+      "computer_drag",
+    ]) {
+      expect(isComputerUseStreamEvent(event({ type: "function_call", name }))).toBe(true);
+    }
+  });
+
+  test("does not treat ordinary or similarly named function tools as computer use", () => {
+    expect(isComputerUseStreamEvent(event({ type: "function_call", name: "exec_command" }))).toBe(
+      false,
+    );
+    expect(
+      isComputerUseStreamEvent(event({ type: "function_call", name: "computer_screenshot_extra" })),
+    ).toBe(false);
+    expect(isComputerUseStreamEvent(event({ type: "computer_call_output" }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Root cause

The on-turn recording gate recognized only hosted Responses `computer_call` items. Codex uses the function-image transport and emits first-party `computer_*` function calls, so the recording started but `didComputerUse` stayed false and finalization discarded the artifact.

## Fix

- recognize both hosted `computer_call` and the exact eight first-party function computer tool names
- keep unrelated/similarly named functions excluded
- add regression coverage for both transports

## Production evidence

A real Codex canary on production revision `94ae6b8e` produced `recording.started` plus a `computer_screenshot` function call, but no recording row. The patched files pass all 73 agent-turn tests and worker typechecking in a temporary pod using the exact production worker image. No Azure model tokens were used.