### PR TITLE
fix(worker): settle recordings with turn ownership

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -59,11 +59,13 @@ import {
   SandboxImageConflictError,
   buildConnectionTokenResolver,
   getEnrollment,
+  abandonRecordingForTurnAttempt,
   type AppendEventInput,
   type ActiveSandboxPointer,
   type SandboxRecord,
   type CodexCredentialLeaseResult,
   type CodexCredentialLeaseSelectionContext,
+  type SessionTurnRecordingSettlement,
 } from "@opengeni/db";
 import { appendAndPublishTurnEventsFenced, publishDurableSessionEvents } from "@opengeni/events";
 import {
@@ -96,6 +98,8 @@ import {
   type BackendUnresolvableCode,
   type EstablishedSandboxSession,
   type GitCredentialTokenWriterSession,
+  deleteRecordingArtifacts,
+  stopRecording as stopRecordingOnBox,
 } from "@opengeni/runtime";
 import {
   builtinProviderId,
@@ -210,8 +214,8 @@ import {
 } from "../observability-metrics";
 import {
   beginRecording,
-  discardRecording,
-  finalizeRecording,
+  discardUnpublishedRecording,
+  prepareRecordingForSettlement,
   type ActiveRecording,
 } from "./recording";
 import { captureWorkspaceRevision } from "./workspace-capture";
@@ -1319,6 +1323,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // recording with NO storage PUT and NO recording.failed — a clean no-op (a
     // static frame of an untouched desktop is not worth uploading).
     let didComputerUse = false;
+    const abandonActiveRecording = async (
+      reason: string,
+      disposition: "failed" | "discard" = "failed",
+    ): Promise<void> => {
+      const recording = activeRecording as ActiveRecording | null;
+      if (!recording) return;
+      activeRecording = null;
+      if (resolvedSandbox) {
+        await stopRecordingOnBox(resolvedSandbox.established.session, recording.proc).catch(
+          () => undefined,
+        );
+      }
+      if (!turnId || executionGeneration <= 0) return;
+      await abandonRecordingForTurnAttempt(db, {
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        turnId,
+        executionGeneration,
+        attemptId: input.attemptId,
+        recordingId: recording.recordingId,
+        disposition,
+        reason,
+      }).catch(() => undefined);
+    };
     let batcher: ReturnType<typeof createRuntimeBatcher> | null = null;
     const flushRuntimeBatcher = async () => {
       const current = batcher as ReturnType<typeof createRuntimeBatcher> | null;
@@ -1498,8 +1527,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         })
       ) {
         computerUseRecordingStart = (async () => {
+          let begun: Awaited<ReturnType<typeof beginRecording>> | null = null;
           try {
-            const begun = await beginRecording({
+            begun = await beginRecording({
               settings,
               db,
               accountId: input.accountId,
@@ -1512,10 +1542,22 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               runAs: sandboxRunAs(settings),
               reason: null,
             });
+            if (!publish) {
+              throw new Error("recording started before the turn event publisher was ready");
+            }
+            await publish([{ type: "recording.started", payload: begun.started }]);
             activeRecording = begun.active;
-            await publish?.([{ type: "recording.started", payload: begun.started }]);
           } catch (recordingError) {
             activeRecording = null;
+            if (begun) {
+              await discardUnpublishedRecording({
+                db,
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                active: begun.active,
+                session: sandbox.established.session,
+              });
+            }
             console.error(
               "computer-use recording start failed (action outcome unaffected)",
               recordingError,
@@ -1790,6 +1832,36 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         return appended;
       };
       settle = async (inputSettlement) => {
+        const attemptClosing = ["completed", "failed", "cancelled", "requires_action"].includes(
+          inputSettlement.turnStatus,
+        );
+        const recordingForSettlement =
+          attemptClosing && activeRecording && resolvedSandbox
+            ? (activeRecording as ActiveRecording)
+            : null;
+        const preparedRecording = recordingForSettlement
+          ? await prepareRecordingForSettlement({
+              settings,
+              objectStorage,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              active: recordingForSettlement,
+              session: resolvedSandbox!.established.session,
+              didComputerUse,
+            })
+          : null;
+        let recordingMutation: SessionTurnRecordingSettlement | undefined;
+        if (preparedRecording) {
+          const mutation = preparedRecording.mutation;
+          recordingMutation =
+            mutation.action === "discard"
+              ? mutation
+              : {
+                  ...mutation,
+                  producerId,
+                  producerSeq: ++producerSeq,
+                };
+        }
         const inputs = inputSettlement.events.map((event) => ({
           ...event,
           payload: redact(event.payload),
@@ -1807,11 +1879,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           sessionStatus: inputSettlement.sessionStatus,
           activeTurnId: inputSettlement.activeTurnId,
           events: inputs,
+          ...(recordingMutation ? { recording: recordingMutation } : {}),
         });
         if (result.action === "stale") {
+          if (recordingForSettlement) {
+            await abandonActiveRecording(
+              "recording settlement lost attempt ownership",
+              preparedRecording?.mutation.action === "discard" ? "discard" : "failed",
+            );
+          }
           activityStatus = "cancelled";
           turnMetricOutcome = "cancelled";
           return false;
+        }
+        if (recordingForSettlement && preparedRecording) {
+          if (result.recordingMutationApplied) {
+            activeRecording = null;
+            if (preparedRecording.deleteArtifactsAfterCommit) {
+              await deleteRecordingArtifacts(
+                resolvedSandbox!.established.session,
+                recordingForSettlement.proc,
+              );
+            }
+          } else {
+            await abandonActiveRecording("recording row was unavailable during turn settlement");
+          }
         }
         await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, result.events);
         activityContext?.heartbeat({
@@ -5203,8 +5295,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // Workbench v2 turn-end workspace capture (dossier §10.1) — runs FIRST in
       // the turn-end finally, while the box is MAXIMALLY ALIVE. The agent's last
       // tool ran before this finally, so /workspace is already final; capture is
-      // FS-equivalent whether it runs before or after recording-finalize / the
-      // warm snapshot (neither mutates workspace files). Running it here — BEFORE
+      // FS-equivalent to the already-settled recording preparation and the warm
+      // snapshot (neither mutates workspace files). Running it here — BEFORE
       // preparedTools.close() (which tears down tools / computer-use / the display
       // stack and is what starts the Modal box exiting a few seconds later) —
       // gives capture the full live-box margin instead of racing the teardown
@@ -5259,68 +5351,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       if (leaseHeartbeatTimer) {
         clearInterval(leaseHeartbeatTimer);
       }
-      // Finalize the computer-use recording BEFORE releasing the box handle: the
-      // live session uploads its /tmp artifact directly to a scoped storage URL,
-      // then updateRecording(available) → publish recording.available. The box
-      // file is deleted only after the PUT confirms (F9). Best-effort: a finalize
-      // failure emits recording.failed and never masks the turn outcome. Recording
-      // bytes enter neither worker memory nor a Temporal payload (F10).
-      const recordingToFinalize = activeRecording as ActiveRecording | null;
-      if (recordingToFinalize && resolvedSandbox) {
-        try {
-          if (!didComputerUse) {
-            // Recording gate (P4.3): the turn never drove the desktop (a plain text
-            // turn), so the film is a static frame of an untouched screen. DISCARD
-            // it — stop ffmpeg, delete the box artifact, drop the row — with NO
-            // storage PUT and NO recording.failed (a clean no-op, not a failure).
-            await discardRecording({
-              db,
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              active: recordingToFinalize,
-              session: resolvedSandbox.established.session,
-            });
-          } else {
-            const outcome = await finalizeRecording({
-              settings,
-              db,
-              objectStorage,
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              active: recordingToFinalize,
-              session: resolvedSandbox.established.session,
-              runAs: sandboxRunAs(settings),
-            });
-            if (publish) {
-              await publish(
-                outcome.ok
-                  ? [
-                      {
-                        type: "recording.available",
-                        payload: outcome.available,
-                      },
-                    ]
-                  : [
-                      {
-                        type: "recording.failed",
-                        payload: {
-                          recordingId: recordingToFinalize.recordingId,
-                          turnId: recordingToFinalize.turnId,
-                          reason: outcome.reason,
-                          detail: outcome.detail,
-                        },
-                      },
-                    ],
-              );
-            }
-          }
-        } catch (finalizeError) {
-          console.error("recording finalize failed (turn outcome unaffected)", finalizeError);
-        } finally {
-          activeRecording = null;
-        }
-      }
+      // A recording normally closes inside the attempt-fenced turn settlement.
+      // Reaching finally with one still active means settlement threw, never ran,
+      // or lost ownership. Stop ffmpeg and mark only this exact attempt-owned row
+      // failed; publish no event and leave the artifact recoverable on the box.
+      await abandonActiveRecording(
+        "activity ended without recording settlement",
+        didComputerUse ? "failed" : "discard",
+      );
       if (resolvedSandbox) {
         // TURN-END mid-session snapshot (sandbox-file-persistence): fold the
         // turn's finished /workspace onto the lease before releasing the holder,

--- a/apps/worker/src/activities/recording.ts
+++ b/apps/worker/src/activities/recording.ts
@@ -11,9 +11,8 @@
 
 import type { Settings } from "@opengeni/config";
 import type { Database } from "@opengeni/db";
-import { deleteRecording, updateRecording } from "@opengeni/db";
+import { deleteRecording } from "@opengeni/db";
 import type {
-  RecordingAvailablePayload,
   RecordingCodec,
   RecordingFailedReason,
   RecordingStartedPayload,
@@ -41,6 +40,27 @@ export type ActiveRecording = {
   dimensions: [number, number];
   framerate: number;
 };
+
+export const RECORDING_SETTLEMENT_PREP_TIMEOUT_MS = 100_000;
+const RECORDING_SETTLEMENT_UPLOAD_MAX_SECONDS = 45;
+
+export async function withRecordingPreparationTimeout(
+  preparation: Promise<PreparedRecordingSettlement>,
+  timeoutResult: PreparedRecordingSettlement,
+  timeoutMs = RECORDING_SETTLEMENT_PREP_TIMEOUT_MS,
+): Promise<PreparedRecordingSettlement> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      preparation,
+      new Promise<PreparedRecordingSettlement>((resolve) => {
+        timer = setTimeout(() => resolve(timeoutResult), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 /**
  * Insert the recording row, launch ffmpeg on the box, and return the live handle.
@@ -80,14 +100,24 @@ export async function beginRecording(args: {
       reason: scrubFreeText(args.reason),
     }),
   );
-  const proc = await startRecordingOnBox(args.session, {
-    recordingId: args.recordingId,
-    codec,
-    framerate,
-    maxSeconds: settings.recordingMaxSeconds,
-    dimensions,
-    ...(args.runAs ? { runAs: args.runAs } : {}),
-  });
+  let proc: RecordingProcess;
+  try {
+    proc = await startRecordingOnBox(args.session, {
+      recordingId: args.recordingId,
+      codec,
+      framerate,
+      maxSeconds: settings.recordingMaxSeconds,
+      dimensions,
+      ...(args.runAs ? { runAs: args.runAs } : {}),
+    });
+  } catch (error) {
+    await deleteRecording(db, {
+      accountId: args.accountId,
+      workspaceId: args.workspaceId,
+      recordingId: args.recordingId,
+    }).catch(() => undefined);
+    throw error;
+  }
   const active: ActiveRecording = {
     recordingId: args.recordingId,
     turnId: args.turnId,
@@ -109,120 +139,116 @@ export async function beginRecording(args: {
   return { active, started };
 }
 
-export type FinalizeOutcome =
-  | { ok: true; available: RecordingAvailablePayload }
-  | { ok: false; reason: RecordingFailedReason; detail: string | null };
+export type PreparedRecordingSettlement =
+  | {
+      mutation: {
+        action: "available";
+        recordingId: string;
+        storageKey: string;
+        sizeBytes: number;
+        durationSeconds: number;
+      };
+      deleteArtifactsAfterCommit: true;
+    }
+  | {
+      mutation: {
+        action: "failed";
+        recordingId: string;
+        reason: RecordingFailedReason;
+        detail: string | null;
+      };
+      deleteArtifactsAfterCommit: false;
+    }
+  | {
+      mutation: { action: "discard"; recordingId: string };
+      deleteArtifactsAfterCommit: true;
+    };
 
 /**
- * Stop ffmpeg, upload directly from the box, commit `available`,
- * and (only then) delete the box file (F9). Returns the available payload, or a
- * failure reason. NEVER throws — finalize runs in a turn `finally` and must not
- * mask the turn outcome.
+ * Prepare an on-turn recording for the attempt-closing settlement. This performs
+ * only bounded box/storage work; it does not mutate canonical database state and
+ * never deletes the box artifact. The caller folds the returned mutation into the
+ * exact attempt-fenced turn settlement, then deletes artifacts only after commit.
+ * NEVER throws and never prevents turn truth from settling.
  */
-export async function finalizeRecording(args: {
+export async function prepareRecordingForSettlement(args: {
   settings: Settings;
-  db: Database;
   objectStorage: ObjectStorage | null;
-  accountId: string;
   workspaceId: string;
   sessionId: string;
   active: ActiveRecording;
   session: unknown;
-  runAs?: string | undefined;
-}): Promise<FinalizeOutcome> {
-  const { settings, db, objectStorage, active } = args;
-  const codec = settings.recordingDefaultCodec as RecordingCodec;
-  const fail = async (
+  didComputerUse: boolean;
+}): Promise<PreparedRecordingSettlement> {
+  const { settings, objectStorage, active } = args;
+  const codec = active.proc.codec;
+  const fail = (
     reason: RecordingFailedReason,
     detail: string | null,
-  ): Promise<FinalizeOutcome> => {
-    await updateRecording(db, {
-      accountId: args.accountId,
-      workspaceId: args.workspaceId,
-      recordingId: active.recordingId,
-      state: "failed",
-      reason: scrubFreeText(detail),
-    }).catch(() => undefined);
-    return { ok: false, reason, detail: scrubFreeText(detail) };
+  ): PreparedRecordingSettlement => {
+    return {
+      mutation: {
+        action: "failed",
+        recordingId: active.recordingId,
+        reason,
+        detail: scrubFreeText(detail),
+      },
+      deleteArtifactsAfterCommit: false,
+    };
   };
 
-  try {
-    await updateRecording(db, {
-      accountId: args.accountId,
-      workspaceId: args.workspaceId,
-      recordingId: active.recordingId,
-      state: "finalizing",
-    }).catch(() => undefined);
-
-    // 1. SIGINT ffmpeg and wait for the clean trailer.
-    await stopRecordingOnBox(args.session, active.proc);
-
-    if (!objectStorage) {
-      return await fail("upload-failed", "object storage is not configured");
-    }
-
-    // 2. Mint one short-lived write URL, then upload DIRECTLY from the box. This
-    // keeps worker memory independent of recording size.
-    const key = recordingStorageKey(args.workspaceId, args.sessionId, active.recordingId, codec);
-    let finalized: Awaited<ReturnType<typeof uploadRecordingArtifact>>;
+  const prepare = async (): Promise<PreparedRecordingSettlement> => {
     try {
+      await stopRecordingOnBox(args.session, active.proc);
+      if (!args.didComputerUse) {
+        return {
+          mutation: { action: "discard", recordingId: active.recordingId },
+          deleteArtifactsAfterCommit: true,
+        };
+      }
+      if (!objectStorage) {
+        return fail("upload-failed", "object storage is not configured");
+      }
+      const key = recordingStorageKey(args.workspaceId, args.sessionId, active.recordingId, codec);
       const upload = await objectStorage.createPutUrl({
         key,
         contentType: contentTypeForCodec(codec),
       });
-      finalized = await uploadRecordingArtifact(args.session, active.proc, {
+      const finalized = await uploadRecordingArtifact(args.session, active.proc, {
         url: upload.url,
         requiredHeaders: upload.requiredHeaders,
         maxBytes: settings.recordingMaxBytes,
+        maxSeconds: RECORDING_SETTLEMENT_UPLOAD_MAX_SECONDS,
       });
-    } catch (uploadError) {
-      if (uploadError instanceof RecordingError) throw uploadError;
-      return await fail(
-        "upload-failed",
-        uploadError instanceof Error ? uploadError.message : String(uploadError),
-      );
+      return {
+        mutation: {
+          action: "available",
+          recordingId: active.recordingId,
+          storageKey: key,
+          sizeBytes: finalized.sizeBytes,
+          durationSeconds: finalized.durationSeconds,
+        },
+        deleteArtifactsAfterCommit: true,
+      };
+    } catch (error) {
+      const reason: RecordingFailedReason =
+        error instanceof RecordingError ? error.reason : "upload-failed";
+      return fail(reason, error instanceof Error ? error.message : String(error));
     }
+  };
 
-    // 3. Commit `available` with the artifact ref.
-    await updateRecording(db, {
-      accountId: args.accountId,
-      workspaceId: args.workspaceId,
-      recordingId: active.recordingId,
-      state: "available",
-      storageKey: key,
-      sizeBytes: finalized.sizeBytes,
-      durationSeconds: finalized.durationSeconds,
-    });
-
-    // 4. ONLY NOW delete the box artifacts (F9 — never before a confirmed PUT).
-    await deleteRecordingArtifacts(args.session, active.proc);
-
-    const available: RecordingAvailablePayload = {
-      recordingId: active.recordingId,
-      turnId: active.turnId,
-      codec,
-      contentType: contentTypeForCodec(codec),
-      storageKey: key,
-      durationSeconds: finalized.durationSeconds,
-      sizeBytes: finalized.sizeBytes,
-      dimensions: active.dimensions,
-    };
-    return { ok: true, available };
-  } catch (error) {
-    const reason: RecordingFailedReason =
-      error instanceof RecordingError ? error.reason : "ffmpeg-error";
-    return await fail(reason, error instanceof Error ? error.message : String(error));
-  }
+  return await withRecordingPreparationTimeout(
+    prepare(),
+    fail("upload-failed", "recording settlement preparation timed out"),
+  );
 }
 
 /**
- * Discard an on-turn recording that captured NO computer-use activity (a plain
- * text turn): stop ffmpeg on the box, delete the box artifacts, and remove the
- * recording row entirely. NO storage PUT and NO `recording.failed` — a clean
- * no-op. NEVER throws (it runs in the turn `finally` and must not mask the turn
- * outcome). Returns nothing; the caller emits no recording event for a discard.
+ * Compensate a start whose fenced `recording.started` event was rejected. Since
+ * no canonical event was admitted, this exact recording id must leave no row,
+ * process, or box artifact behind.
  */
-export async function discardRecording(args: {
+export async function discardUnpublishedRecording(args: {
   db: Database;
   accountId: string;
   workspaceId: string;
@@ -231,14 +257,9 @@ export async function discardRecording(args: {
 }): Promise<void> {
   const { db, active } = args;
   try {
-    // Stop ffmpeg cleanly, then delete the partial artifact off the box. Both are
-    // best-effort: a stuck box must not strand the discard (the box rides the
-    // provider idle-timeout regardless).
     await stopRecordingOnBox(args.session, active.proc).catch(() => undefined);
     await deleteRecordingArtifacts(args.session, active.proc).catch(() => undefined);
   } finally {
-    // Remove the phantom row inserted at beginRecording so a no-activity turn
-    // leaves no recording trace at all.
     await deleteRecording(db, {
       accountId: args.accountId,
       workspaceId: args.workspaceId,

--- a/apps/worker/test/recording.test.ts
+++ b/apps/worker/test/recording.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { testSettings } from "@opengeni/testing";
+import type { ObjectStorage } from "@opengeni/storage";
+import {
+  prepareRecordingForSettlement,
+  withRecordingPreparationTimeout,
+  type ActiveRecording,
+  type PreparedRecordingSettlement,
+} from "../src/activities/recording";
+
+const active: ActiveRecording = {
+  recordingId: "00000000-0000-4000-8000-000000000001",
+  turnId: "00000000-0000-4000-8000-000000000002",
+  mode: "on-turn",
+  dimensions: [1280, 800],
+  framerate: 15,
+  proc: {
+    recordingId: "00000000-0000-4000-8000-000000000001",
+    codec: "h264-mp4",
+    boxPath: "/tmp/recording.mp4",
+    pidFile: "/tmp/recording.pid",
+    dimensions: [1280, 800],
+    framerate: 15,
+    startedAt: Date.now() - 3_000,
+    display: ":0",
+  },
+};
+
+const settings = testSettings({
+  recordingDefaultCodec: "h264-mp4",
+  recordingMaxBytes: 10_000,
+});
+
+describe("attempt-closing recording preparation", () => {
+  test("uploads directly with the bounded settlement timeout and returns no database side effect", async () => {
+    const commands: string[] = [];
+    const session = {
+      execCommand: async ({ cmd }: { cmd: string }) => {
+        commands.push(cmd);
+        if (cmd.includes("stat -c %s")) return "Output:\n1234";
+        if (cmd.includes("curl ")) return "Output:\nOPENGENI_RECORDING_UPLOAD_OK";
+        return "Output:\n";
+      },
+    };
+    const storage = {
+      createPutUrl: async () => ({
+        url: "https://storage.invalid/scoped",
+        requiredHeaders: { "x-ms-blob-type": "BlockBlob" },
+      }),
+    } as unknown as ObjectStorage;
+
+    await expect(
+      prepareRecordingForSettlement({
+        settings,
+        objectStorage: storage,
+        workspaceId: "workspace",
+        sessionId: "session",
+        active,
+        session,
+        didComputerUse: true,
+      }),
+    ).resolves.toMatchObject({
+      mutation: {
+        action: "available",
+        recordingId: active.recordingId,
+        sizeBytes: 1234,
+      },
+      deleteArtifactsAfterCommit: true,
+    });
+    expect(commands.some((command) => command.includes("--max-time 45"))).toBe(true);
+  });
+
+  test("plain desktop readiness becomes an atomic discard without a storage PUT", async () => {
+    let putUrls = 0;
+    const result = await prepareRecordingForSettlement({
+      settings,
+      objectStorage: {
+        createPutUrl: async () => {
+          putUrls += 1;
+          throw new Error("must not mint a URL");
+        },
+      } as unknown as ObjectStorage,
+      workspaceId: "workspace",
+      sessionId: "session",
+      active,
+      session: { execCommand: async () => "Output:\n" },
+      didComputerUse: false,
+    });
+    expect(result).toEqual({
+      mutation: { action: "discard", recordingId: active.recordingId },
+      deleteArtifactsAfterCommit: true,
+    });
+    expect(putUrls).toBe(0);
+  });
+
+  test("upload setup failure degrades to recording.failed instead of blocking turn settlement", async () => {
+    const result = await prepareRecordingForSettlement({
+      settings,
+      objectStorage: null,
+      workspaceId: "workspace",
+      sessionId: "session",
+      active,
+      session: { execCommand: async () => "Output:\n" },
+      didComputerUse: true,
+    });
+    expect(result).toMatchObject({
+      mutation: {
+        action: "failed",
+        recordingId: active.recordingId,
+        reason: "upload-failed",
+      },
+      deleteArtifactsAfterCommit: false,
+    });
+  });
+
+  test("a hung preparation resolves to the bounded failure outcome", async () => {
+    const timeoutResult: PreparedRecordingSettlement = {
+      mutation: {
+        action: "failed",
+        recordingId: active.recordingId,
+        reason: "upload-failed",
+        detail: "timed out",
+      },
+      deleteArtifactsAfterCommit: false,
+    };
+    const pending = new Promise<PreparedRecordingSettlement>(() => undefined);
+    await expect(withRecordingPreparationTimeout(pending, timeoutResult, 5)).resolves.toEqual(
+      timeoutResult,
+    );
+  });
+});

--- a/docs/design/turn-worker-density-2026-07-16.md
+++ b/docs/design/turn-worker-density-2026-07-16.md
@@ -62,8 +62,16 @@ paths outside the deterministic baseline:
   capture operation actually settles. A 60-second caller timeout therefore
   remains observable while an in-flight provider operation drains.
 - Recording finalize stats and size-gates the artifact on the sandbox, then
-  uses curl in that sandbox to PUT directly to the scoped URL. Artifact deletion
-  still occurs only after the PUT and the `available` database commit.
+  uses curl in that sandbox to PUT directly to the scoped URL. Codex's
+  first-party `computer_*` function transport and the hosted `computer_call`
+  transport share the same exact computer-use gate.
+- Recording preparation is bounded and happens before every attempt-closing
+  settlement, including approval suspension. The existing locked turn
+  settlement atomically commits the exact recording row and its
+  `recording.available` / `recording.failed` event under the same attempt fence
+  as terminal turn truth. Artifact deletion occurs only after that transaction
+  succeeds. A stale or aborted attempt can close only the recording named by its
+  accepted `recording.started` receipt and emits no authoritative event.
 - The old worker-buffered recording API and its live-test path are removed, not
   retained as a fallback.
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12934,6 +12934,85 @@ export async function deleteRecording(
   );
 }
 
+/**
+ * Close an attempt-owned recording that could not reach the atomic turn
+ * settlement. The accepted recording.started event is the durable ownership
+ * receipt: cleanup is allowed only for the exact turn generation and attempt
+ * that created this recording id. No timeline event is emitted from this
+ * hygiene path.
+ */
+export async function abandonRecordingForTurnAttempt(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sessionId: string;
+    turnId: string;
+    executionGeneration: number;
+    attemptId: string;
+    recordingId: string;
+    disposition: "failed" | "discard";
+    reason: string;
+  },
+): Promise<boolean> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) =>
+      await scopedDb.transaction(async (tx) => {
+        const [recording] = await tx
+          .select({ id: schema.sessionRecordings.id })
+          .from(schema.sessionRecordings)
+          .where(
+            and(
+              eq(schema.sessionRecordings.accountId, input.accountId),
+              eq(schema.sessionRecordings.workspaceId, input.workspaceId),
+              eq(schema.sessionRecordings.sessionId, input.sessionId),
+              eq(schema.sessionRecordings.turnId, input.turnId),
+              eq(schema.sessionRecordings.id, input.recordingId),
+              eq(schema.sessionRecordings.mode, "on-turn"),
+              inArray(schema.sessionRecordings.state, ["recording", "finalizing"]),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (!recording) return false;
+        const [started] = await tx
+          .select({ id: schema.sessionEvents.id })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, input.workspaceId),
+              eq(schema.sessionEvents.sessionId, input.sessionId),
+              eq(schema.sessionEvents.turnId, input.turnId),
+              eq(schema.sessionEvents.turnGeneration, input.executionGeneration),
+              eq(schema.sessionEvents.turnAttemptId, input.attemptId),
+              eq(schema.sessionEvents.turnAssociation, "current"),
+              eq(schema.sessionEvents.type, "recording.started"),
+              eq(sql<string>`${schema.sessionEvents.payload} ->> 'recordingId'`, input.recordingId),
+            ),
+          )
+          .limit(1);
+        if (!started) return false;
+        if (input.disposition === "discard") {
+          await tx
+            .delete(schema.sessionRecordings)
+            .where(eq(schema.sessionRecordings.id, recording.id));
+        } else {
+          await tx
+            .update(schema.sessionRecordings)
+            .set({
+              state: "failed",
+              reason: input.reason.slice(0, 2_000),
+              finalizedAt: new Date(),
+            })
+            .where(eq(schema.sessionRecordings.id, recording.id));
+        }
+        return true;
+      }),
+  );
+}
+
 export async function getRecording(
   db: Database,
   workspaceId: string,
@@ -19481,6 +19560,27 @@ async function isNewerApprovalTrigger(
   );
 }
 
+type SessionTurnRecordingSettlementBase = {
+  recordingId: string;
+  producerId?: string | null;
+  producerSeq?: number | null;
+  occurredAt?: Date;
+};
+
+export type SessionTurnRecordingSettlement =
+  | (SessionTurnRecordingSettlementBase & {
+      action: "available";
+      storageKey: string;
+      sizeBytes: number;
+      durationSeconds: number;
+    })
+  | (SessionTurnRecordingSettlementBase & {
+      action: "failed";
+      reason: string;
+      detail: string | null;
+    })
+  | (SessionTurnRecordingSettlementBase & { action: "discard" });
+
 export type ApplySessionTurnSettlementInput = {
   sessionId: string;
   turnId: string;
@@ -19492,10 +19592,11 @@ export type ApplySessionTurnSettlementInput = {
   sessionStatus: SessionStatus;
   activeTurnId: string | null;
   events: AppendEventInput[];
+  recording?: SessionTurnRecordingSettlement;
 };
 
 export type ApplySessionTurnSettlementResult =
-  | { action: "settled"; events: SessionEvent[] }
+  | { action: "settled"; events: SessionEvent[]; recordingMutationApplied: boolean }
   | {
       action: "stale";
       events: [];
@@ -19566,6 +19667,93 @@ export async function applySessionTurnSettlement(
         };
       }
 
+      let recordingEvent: AppendEventInput | null = null;
+      let recordingMutationApplied = false;
+      if (input.recording) {
+        const [recording] = await tx
+          .select()
+          .from(schema.sessionRecordings)
+          .where(
+            and(
+              eq(schema.sessionRecordings.accountId, session.accountId),
+              eq(schema.sessionRecordings.workspaceId, workspaceId),
+              eq(schema.sessionRecordings.sessionId, input.sessionId),
+              eq(schema.sessionRecordings.turnId, input.turnId),
+              eq(schema.sessionRecordings.id, input.recording.recordingId),
+              eq(schema.sessionRecordings.mode, "on-turn"),
+              inArray(schema.sessionRecordings.state, ["recording", "finalizing"]),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (recording) {
+          const recordingInput = input.recording;
+          if (recordingInput.action === "discard") {
+            await tx
+              .delete(schema.sessionRecordings)
+              .where(eq(schema.sessionRecordings.id, recording.id));
+          } else if (recordingInput.action === "available") {
+            await tx
+              .update(schema.sessionRecordings)
+              .set({
+                state: "available",
+                storageKey: recordingInput.storageKey,
+                sizeBytes: recordingInput.sizeBytes,
+                durationSeconds: recordingInput.durationSeconds,
+                reason: null,
+                finalizedAt: new Date(),
+              })
+              .where(eq(schema.sessionRecordings.id, recording.id));
+            recordingEvent = {
+              type: "recording.available",
+              payload: {
+                recordingId: recording.id,
+                turnId: input.turnId,
+                codec: recording.codec,
+                contentType: recording.codec === "vp9-webm" ? "video/webm" : "video/mp4",
+                storageKey: recordingInput.storageKey,
+                durationSeconds: recordingInput.durationSeconds,
+                sizeBytes: recordingInput.sizeBytes,
+                dimensions: [recording.width, recording.height],
+              },
+              ...(recordingInput.producerId != null
+                ? { producerId: recordingInput.producerId }
+                : {}),
+              ...(recordingInput.producerSeq != null
+                ? { producerSeq: recordingInput.producerSeq }
+                : {}),
+              ...(recordingInput.occurredAt ? { occurredAt: recordingInput.occurredAt } : {}),
+            };
+          } else {
+            await tx
+              .update(schema.sessionRecordings)
+              .set({
+                state: "failed",
+                reason: recordingInput.detail,
+                finalizedAt: new Date(),
+              })
+              .where(eq(schema.sessionRecordings.id, recording.id));
+            recordingEvent = {
+              type: "recording.failed",
+              payload: {
+                recordingId: recording.id,
+                turnId: input.turnId,
+                reason: recordingInput.reason,
+                detail: recordingInput.detail,
+              },
+              ...(recordingInput.producerId != null
+                ? { producerId: recordingInput.producerId }
+                : {}),
+              ...(recordingInput.producerSeq != null
+                ? { producerSeq: recordingInput.producerSeq }
+                : {}),
+              ...(recordingInput.occurredAt ? { occurredAt: recordingInput.occurredAt } : {}),
+            };
+          }
+          recordingMutationApplied = true;
+        }
+      }
+
       let effectiveSessionStatus = input.sessionStatus;
       if (input.sessionStatus === "idle" && input.activeTurnId === null) {
         const [waitingPrompt] = await tx
@@ -19597,7 +19785,8 @@ export async function applySessionTurnSettlement(
           })
         : { sequence, events: [] as SessionEvent[], closed: 0 };
       sequence = closedTools.sequence;
-      const values = input.events.map((event) => {
+      const settlementEvents = recordingEvent ? [recordingEvent, ...input.events] : input.events;
+      const values = settlementEvents.map((event) => {
         const payload =
           event.payload && typeof event.payload === "object"
             ? (event.payload as Record<string, unknown>)
@@ -19709,6 +19898,7 @@ export async function applySessionTurnSettlement(
       return {
         action: "settled" as const,
         events: [...closedTools.events, ...inserted.map(mapEvent)],
+        recordingMutationApplied,
       };
     });
   });

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -6,6 +6,7 @@ import {
   applyCreditLedgerEntry,
   applyContextCompaction,
   applySessionTurnSettlement,
+  abandonRecordingForTurnAttempt,
   appendSessionEvents,
   appendSessionHistoryItems,
   appendSessionEventsForTurnAttempt,
@@ -25,6 +26,8 @@ import {
   listSessionSystemUpdatesForTurn,
   listUsageEvents,
   isSessionCompactionRequested,
+  insertRecording,
+  getRecording,
   peekSessionWork,
   recoverSessionDispatch,
   reparkOrphanedSessionTurn,
@@ -2191,5 +2194,336 @@ describe("clean session control plane", () => {
           .where(eq(schema.sessions.id, session.id)),
     );
     expect(row?.status).toBe("paused");
+  });
+
+  test("atomically commits an available recording before terminal turn events", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "record this turn");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    if (!turn) throw new Error("recording turn was not claimed");
+    const recordingId = crypto.randomUUID();
+    await insertRecording(client.db, {
+      id: recordingId,
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn.id,
+      mode: "on-turn",
+      codec: "h264-mp4",
+      width: 1280,
+      height: 800,
+    });
+
+    const settled = await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn.id,
+      triggerEventId: turn.triggerEventId,
+      attemptId,
+      childCompletionParentWakeEnabled: false,
+      turnStatus: "completed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      recording: {
+        action: "available",
+        recordingId,
+        storageKey: `recordings/${recordingId}.mp4`,
+        sizeBytes: 42_000,
+        durationSeconds: 3,
+        producerId: "recording-test",
+        producerSeq: 1,
+      },
+      events: [{ type: "turn.completed", payload: { output: "done" } }],
+    });
+    expect(settled).toMatchObject({ action: "settled", recordingMutationApplied: true });
+    if (settled.action !== "settled") throw new Error("recording settlement became stale");
+    expect(settled.events.map((event) => event.type)).toEqual([
+      "recording.available",
+      "turn.completed",
+    ]);
+    expect(settled.events[0]).toMatchObject({
+      turnId: turn.id,
+      turnGeneration: turn.executionGeneration,
+      turnAttemptId: attemptId,
+      payload: {
+        recordingId,
+        storageKey: `recordings/${recordingId}.mp4`,
+        sizeBytes: 42_000,
+        dimensions: [1280, 800],
+      },
+    });
+    expect(await getRecording(client.db, grant.workspaceId!, recordingId)).toMatchObject({
+      state: "available",
+      storageKey: `recordings/${recordingId}.mp4`,
+      sizeBytes: 42_000,
+    });
+  });
+
+  test("settles recording failure with turn truth and discards approval-suspension phantoms", async () => {
+    const failed = await fixture();
+    await send(failed.grant, failed.session.id, "fail recording upload");
+    const failedAttemptId = crypto.randomUUID();
+    const failedTurn = await claimTestSessionWork(
+      client.db,
+      failed.grant.workspaceId!,
+      failed.session.id,
+      `session-${failed.session.id}`,
+      { attemptId: failedAttemptId },
+    );
+    if (!failedTurn) throw new Error("failed-recording turn was not claimed");
+    const failedRecordingId = crypto.randomUUID();
+    await insertRecording(client.db, {
+      id: failedRecordingId,
+      accountId: failed.grant.accountId,
+      workspaceId: failed.grant.workspaceId!,
+      sessionId: failed.session.id,
+      turnId: failedTurn.id,
+      mode: "on-turn",
+      codec: "h264-mp4",
+      width: 1280,
+      height: 800,
+    });
+    const failedSettlement = await applySessionTurnSettlement(
+      client.db,
+      failed.grant.workspaceId!,
+      {
+        sessionId: failed.session.id,
+        turnId: failedTurn.id,
+        triggerEventId: failedTurn.triggerEventId,
+        attemptId: failedAttemptId,
+        childCompletionParentWakeEnabled: false,
+        turnStatus: "completed",
+        sessionStatus: "idle",
+        activeTurnId: null,
+        recording: {
+          action: "failed",
+          recordingId: failedRecordingId,
+          reason: "upload-failed",
+          detail: "bounded upload timeout",
+        },
+        events: [{ type: "turn.completed", payload: { output: "done anyway" } }],
+      },
+    );
+    expect(failedSettlement).toMatchObject({
+      action: "settled",
+      recordingMutationApplied: true,
+    });
+    if (failedSettlement.action === "settled") {
+      expect(failedSettlement.events.map((event) => event.type)).toEqual([
+        "recording.failed",
+        "turn.completed",
+      ]);
+    }
+    expect(
+      await getRecording(client.db, failed.grant.workspaceId!, failedRecordingId),
+    ).toMatchObject({ state: "failed", reason: "bounded upload timeout" });
+
+    const approval = await fixture();
+    await send(approval.grant, approval.session.id, "request approval without computer use");
+    const approvalAttemptId = crypto.randomUUID();
+    const approvalTurn = await claimTestSessionWork(
+      client.db,
+      approval.grant.workspaceId!,
+      approval.session.id,
+      `session-${approval.session.id}`,
+      { attemptId: approvalAttemptId },
+    );
+    if (!approvalTurn) throw new Error("approval turn was not claimed");
+    const discardedRecordingId = crypto.randomUUID();
+    await insertRecording(client.db, {
+      id: discardedRecordingId,
+      accountId: approval.grant.accountId,
+      workspaceId: approval.grant.workspaceId!,
+      sessionId: approval.session.id,
+      turnId: approvalTurn.id,
+      mode: "on-turn",
+      codec: "h264-mp4",
+      width: 1280,
+      height: 800,
+    });
+    const suspended = await applySessionTurnSettlement(client.db, approval.grant.workspaceId!, {
+      sessionId: approval.session.id,
+      turnId: approvalTurn.id,
+      triggerEventId: approvalTurn.triggerEventId,
+      attemptId: approvalAttemptId,
+      childCompletionParentWakeEnabled: false,
+      turnStatus: "requires_action",
+      sessionStatus: "requires_action",
+      activeTurnId: approvalTurn.id,
+      recording: { action: "discard", recordingId: discardedRecordingId },
+      events: [{ type: "session.requiresAction", payload: { approvals: [] } }],
+    });
+    expect(suspended).toMatchObject({ action: "settled", recordingMutationApplied: true });
+    expect(await getRecording(client.db, approval.grant.workspaceId!, discardedRecordingId)).toBe(
+      null,
+    );
+    if (suspended.action === "settled") {
+      expect(suspended.events.map((event) => event.type)).toEqual(["session.requiresAction"]);
+    }
+  });
+
+  test("a stale attempt cannot mutate recording truth and cleanup requires its exact start receipt", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "race recording settlement");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    if (!turn) throw new Error("stale-recording turn was not claimed");
+    const recordingId = crypto.randomUUID();
+    await insertRecording(client.db, {
+      id: recordingId,
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn.id,
+      mode: "on-turn",
+      codec: "h264-mp4",
+      width: 1280,
+      height: 800,
+    });
+    const wrongAttemptId = crypto.randomUUID();
+    expect(
+      await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+        sessionId: session.id,
+        turnId: turn.id,
+        triggerEventId: turn.triggerEventId,
+        attemptId: wrongAttemptId,
+        childCompletionParentWakeEnabled: false,
+        turnStatus: "completed",
+        sessionStatus: "idle",
+        activeTurnId: null,
+        recording: {
+          action: "available",
+          recordingId,
+          storageKey: "recordings/stale.mp4",
+          sizeBytes: 1,
+          durationSeconds: 1,
+        },
+        events: [{ type: "turn.completed", payload: {} }],
+      }),
+    ).toEqual({
+      action: "stale",
+      events: [],
+      turnStatus: "running",
+      activeTurnId: turn.id,
+    });
+    expect(await getRecording(client.db, grant.workspaceId!, recordingId)).toMatchObject({
+      state: "recording",
+      storageKey: null,
+    });
+    expect(
+      await abandonRecordingForTurnAttempt(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn.id,
+        executionGeneration: turn.executionGeneration,
+        attemptId: wrongAttemptId,
+        recordingId,
+        disposition: "failed",
+        reason: "wrong owner",
+      }),
+    ).toBe(false);
+    await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      turn.id,
+      turn.executionGeneration,
+      attemptId,
+      [
+        {
+          type: "recording.started",
+          payload: {
+            recordingId,
+            turnId: turn.id,
+            mode: "on-turn",
+            codec: "h264-mp4",
+            dimensions: [1280, 800],
+            framerate: 15,
+            startedAt: new Date().toISOString(),
+            reason: null,
+          },
+        },
+      ],
+    );
+    expect(
+      await abandonRecordingForTurnAttempt(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn.id,
+        executionGeneration: turn.executionGeneration,
+        attemptId,
+        recordingId,
+        disposition: "failed",
+        reason: "exact owner cleanup",
+      }),
+    ).toBe(true);
+    expect(await getRecording(client.db, grant.workspaceId!, recordingId)).toMatchObject({
+      state: "failed",
+      reason: "exact owner cleanup",
+    });
+
+    const discardId = crypto.randomUUID();
+    await insertRecording(client.db, {
+      id: discardId,
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn.id,
+      mode: "on-turn",
+      codec: "h264-mp4",
+      width: 1280,
+      height: 800,
+    });
+    await appendSessionEventsForTurnAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      turn.id,
+      turn.executionGeneration,
+      attemptId,
+      [
+        {
+          type: "recording.started",
+          payload: {
+            recordingId: discardId,
+            turnId: turn.id,
+            mode: "on-turn",
+            codec: "h264-mp4",
+            dimensions: [1280, 800],
+            framerate: 15,
+            startedAt: new Date().toISOString(),
+            reason: null,
+          },
+        },
+      ],
+    );
+    expect(
+      await abandonRecordingForTurnAttempt(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn.id,
+        executionGeneration: turn.executionGeneration,
+        attemptId,
+        recordingId: discardId,
+        disposition: "discard",
+        reason: "no computer use",
+      }),
+    ).toBe(true);
+    expect(await getRecording(client.db, grant.workspaceId!, discardId)).toBeNull();
   });
 });

--- a/packages/runtime/src/sandbox/recording.ts
+++ b/packages/runtime/src/sandbox/recording.ts
@@ -270,7 +270,6 @@ export async function inspectRecordingArtifact(
 
 const RECORDING_UPLOAD_OK = "OPENGENI_RECORDING_UPLOAD_OK";
 const RECORDING_UPLOAD_MAX_SECONDS = 300;
-const RECORDING_UPLOAD_YIELD_MS = (RECORDING_UPLOAD_MAX_SECONDS + 10) * 1_000;
 
 /**
  * Upload the finalized artifact directly from the sandbox to a scoped object-
@@ -286,8 +285,13 @@ export async function uploadRecordingArtifact(
     url: string;
     requiredHeaders: Record<string, string>;
     maxBytes?: number;
+    maxSeconds?: number;
   },
 ): Promise<RecordingArtifactMetadata> {
+  const maxSeconds = input.maxSeconds ?? RECORDING_UPLOAD_MAX_SECONDS;
+  if (!Number.isSafeInteger(maxSeconds) || maxSeconds <= 0 || maxSeconds > 300) {
+    throw new Error("recording upload maxSeconds must be an integer between 1 and 300");
+  }
   const metadata = await inspectRecordingArtifact(session, proc, input.maxBytes);
   const headers = Object.entries(input.requiredHeaders)
     .sort(([left], [right]) => left.localeCompare(right))
@@ -295,7 +299,7 @@ export async function uploadRecordingArtifact(
     .join(" ");
   const upload = [
     "set -euo pipefail",
-    `curl --fail --silent --show-error --connect-timeout 20 --max-time ${RECORDING_UPLOAD_MAX_SECONDS} --request PUT ${headers} --upload-file ${shq(proc.boxPath)} ${shq(input.url)}`,
+    `curl --fail --silent --show-error --connect-timeout 20 --max-time ${maxSeconds} --request PUT ${headers} --upload-file ${shq(proc.boxPath)} ${shq(input.url)}`,
     `printf '${RECORDING_UPLOAD_OK}\\n'`,
   ].join("; ");
   const output = stripExecBanner(
@@ -303,7 +307,7 @@ export async function uploadRecordingArtifact(
       session as RecordingSession,
       `bash -lc ${shq(upload)}`,
       proc.runAs,
-      RECORDING_UPLOAD_YIELD_MS,
+      (maxSeconds + 10) * 1_000,
     ),
   );
   if (!output.includes(RECORDING_UPLOAD_OK)) {

--- a/packages/runtime/test/recording.test.ts
+++ b/packages/runtime/test/recording.test.ts
@@ -124,6 +124,7 @@ describe("recording loop (P4.3)", () => {
         "x-ms-blob-type": "BlockBlob",
       },
       maxBytes: 268_435_456,
+      maxSeconds: 45,
     });
     expect(result.sizeBytes).toBe(4);
     expect(uploadCalls).toHaveLength(1);
@@ -132,6 +133,7 @@ describe("recording loop (P4.3)", () => {
     expect(uploadCalls[0]).toContain("content-type: video/webm");
     expect(uploadCalls[0]).toContain("x-ms-blob-type: BlockBlob");
     expect(uploadCalls[0]).toContain("https://storage.example/upload?sig=secret");
+    expect(uploadCalls[0]).toContain("--max-time 45");
     expect(uploadCalls[0]).not.toContain("base64");
   });
 


### PR DESCRIPTION
## Production root cause

The live Codex canary proved two linked bugs:

1. Codex emits computer use as exact first-party `computer_*` function calls, while the old gate only recognized hosted `computer_call`. PR #429 fixed that transport mismatch.
2. Recording finalization still lived in the activity `finally`, after terminal turn settlement cleared `activeAttemptId`. Its `recording.available`/`failed` event was therefore rejected late on every recording, while the row could commit outside the attempt fence.

## Clean end state

- bounded stop/direct-upload preparation runs before every attempt-closing settlement, including `requires_action`
- the existing locked turn settlement atomically mutates/deletes the exact on-turn recording row and prepends the DB-constructed recording event under the same turn generation + attempt fence
- box artifacts are deleted only after that transaction commits
- stale/aborted cleanup requires the exact accepted `recording.started` receipt and emits no event
- a rejected start compensates ffmpeg, artifacts, and row
- the old post-settlement finalize/discard path is removed entirely; there is no fallback

## Verification

- 88 focused worker/runtime tests pass in a temporary pod using the exact production worker image
- runtime, DB, and worker project typechecks pass in that pod
- new isolated-real-Postgres tests cover available, failed, discard-on-approval, stale no-mutation, exact-receipt failure cleanup, and exact-receipt phantom deletion
- Fable reviewed the pre-design, found three blockers, then re-reviewed this implementation and returned `approved — no blockers`
- UBS findings on the changed large files were pre-existing broad-file heuristics; its only new-code narrowing warning is a guarded value followed by an immediate return

No Azure model tokens were used.