### PR TITLE
fix(worker): record computer execution before capture startup

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1317,11 +1317,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // null; the first actual computer action starts it after :0 is ready.
     let activeRecording: ActiveRecording | null = null;
     let computerUseRecordingStart: Promise<void> | null = null;
-    // P4.3 recording gate: flips true the first time a computer-use/desktop tool
-    // ACTUALLY executes this turn (an SDK `computer_call` item streams through). A
-    // plain text turn ("hey"/"continue") never flips it, so finalize discards the
-    // recording with NO storage PUT and NO recording.failed — a clean no-op (a
-    // static frame of an untouched desktop is not worth uploading).
+    // P4.3 recording gate: flips true in `onComputerUseReady`, the runtime's
+    // execution-time callback for the first real computer action. It must flip
+    // BEFORE awaiting recording startup: the SDK tool-call stream item can arrive
+    // before ffmpeg has finished starting. A plain text turn ("hey"/"continue")
+    // never invokes the callback, so settlement performs no storage PUT.
     let didComputerUse = false;
     const abandonActiveRecording = async (
       reason: string,
@@ -3394,6 +3394,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           if (!resolvedSandbox) {
             throw new Error("Computer-use display became ready without a resolved sandbox");
           }
+          // This callback is the authoritative execution boundary. Record the
+          // action before async ffmpeg startup so transport-event ordering cannot
+          // make settlement misclassify a real computer turn as unused.
+          didComputerUse = true;
           await maybeStartOnTurnRecording(resolvedSandbox, activeSandboxBackend);
         },
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
@@ -3968,14 +3972,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   serializedRunState,
                 );
               }
-            }
-            // Recording gate: a computer-use tool actually ran when its SDK
-            // `tool_call_item` streams through. Hosted Responses emits a raw
-            // `computer_call`; Codex/chat transports emit one of the first-party
-            // `computer_*` function calls. Match both protocol shapes BEFORE
-            // normalization. Only meaningful when a recording is live.
-            if (activeRecording && !didComputerUse && isComputerUseStreamEvent(next.value)) {
-              didComputerUse = true;
             }
             const pendingToolCall = pendingToolCallFromSdkEvent(next.value);
             if (pendingToolCall) {
@@ -5701,50 +5697,6 @@ export function codexUsageLimitFailurePayload(
 // open indefinitely for a goal-bearing session; cap the continuation hold so the
 // goal re-evaluates at most this far out (it will re-pause if still capped).
 const CODEX_USAGE_LIMIT_MAX_RESUME_MS = 60 * 60_000; // 1h
-
-/**
- * Recognize an SDK stream event that represents a COMPUTER-USE tool call actually
- * executing. Hosted Responses emits `computer_call`; function transports emit one
- * of OpenGeni's exact first-party `computer_*` names. Both are authoritative wire
- * identities selected by `computerToolModeForTurn`. Drives the on-turn recording
- * gate (no computer-use → discard).
- */
-export function isComputerUseStreamEvent(event: unknown): boolean {
-  if (!event || typeof event !== "object") {
-    return false;
-  }
-  if ((event as { type?: unknown }).type !== "run_item_stream_event") {
-    return false;
-  }
-  const item = (
-    event as {
-      item?: { type?: unknown; rawItem?: { type?: unknown; name?: unknown } };
-    }
-  ).item;
-  if (!item || item.type !== "tool_call_item") {
-    return false;
-  }
-  const raw = item.rawItem;
-  if (raw?.type === "computer_call") {
-    return true;
-  }
-  return (
-    raw?.type === "function_call" &&
-    typeof raw.name === "string" &&
-    FUNCTION_COMPUTER_TOOL_NAMES.has(raw.name)
-  );
-}
-
-const FUNCTION_COMPUTER_TOOL_NAMES = new Set([
-  "computer_screenshot",
-  "computer_click",
-  "computer_double_click",
-  "computer_move",
-  "computer_scroll",
-  "computer_type",
-  "computer_keypress",
-  "computer_drag",
-]);
 
 function pendingToolCallFromSdkEvent(event: unknown): {
   callId: string;

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -21,7 +21,6 @@ import {
   ensureTurnModalRegistryImage,
   filterUnmaterializedSandboxFileDownloads,
   historyRowsToAppend,
-  isComputerUseStreamEvent,
   isLazySandboxProvisionRetryable,
   isTransientProviderError,
   isWorkerShutdownCancellation,
@@ -942,42 +941,6 @@ describe("on-turn recording gate (selfhosted machines have no in-box capture plu
 
   test("headless / non-desktop established backend: skips (existing static feasibility gate holds)", () => {
     expect(shouldStartOnTurnRecording({ ...base, establishedBackendId: "none" })).toBe(false);
-  });
-});
-
-describe("on-turn recording computer-use protocol gate", () => {
-  const event = (rawItem: Record<string, unknown>) => ({
-    type: "run_item_stream_event",
-    item: { type: "tool_call_item", rawItem },
-  });
-
-  test("recognizes the hosted Responses computer_call", () => {
-    expect(isComputerUseStreamEvent(event({ type: "computer_call" }))).toBe(true);
-  });
-
-  test("recognizes every first-party function-transport computer tool", () => {
-    for (const name of [
-      "computer_screenshot",
-      "computer_click",
-      "computer_double_click",
-      "computer_move",
-      "computer_scroll",
-      "computer_type",
-      "computer_keypress",
-      "computer_drag",
-    ]) {
-      expect(isComputerUseStreamEvent(event({ type: "function_call", name }))).toBe(true);
-    }
-  });
-
-  test("does not treat ordinary or similarly named function tools as computer use", () => {
-    expect(isComputerUseStreamEvent(event({ type: "function_call", name: "exec_command" }))).toBe(
-      false,
-    );
-    expect(
-      isComputerUseStreamEvent(event({ type: "function_call", name: "computer_screenshot_extra" })),
-    ).toBe(false);
-    expect(isComputerUseStreamEvent(event({ type: "computer_call_output" }))).toBe(false);
   });
 });
 

--- a/apps/worker/test/display-stack-gating.test.ts
+++ b/apps/worker/test/display-stack-gating.test.ts
@@ -29,6 +29,9 @@ describe("turn sandbox resume is desktop-free", () => {
     const eagerCalls = agentTurnSource.match(/await maybeStartOnTurnRecording\(/g) ?? [];
     expect(eagerCalls).toHaveLength(1);
     const callback = agentTurnSource.slice(agentTurnSource.indexOf("onComputerUseReady: async"));
-    expect(callback.indexOf("await maybeStartOnTurnRecording(")).toBeGreaterThan(0);
+    const observation = callback.indexOf("didComputerUse = true");
+    const recordingStart = callback.indexOf("await maybeStartOnTurnRecording(");
+    expect(observation).toBeGreaterThan(0);
+    expect(recordingStart).toBeGreaterThan(observation);
   });
 });

--- a/docs/design/turn-worker-density-2026-07-16.md
+++ b/docs/design/turn-worker-density-2026-07-16.md
@@ -62,9 +62,10 @@ paths outside the deterministic baseline:
   capture operation actually settles. A 60-second caller timeout therefore
   remains observable while an in-flight provider operation drains.
 - Recording finalize stats and size-gates the artifact on the sandbox, then
-  uses curl in that sandbox to PUT directly to the scoped URL. Codex's
-  first-party `computer_*` function transport and the hosted `computer_call`
-  transport share the same exact computer-use gate.
+  uses curl in that sandbox to PUT directly to the scoped URL. The runtime's
+  `onComputerUseReady` execution callback is the sole computer-use gate for
+  every model transport; no transport-specific stream-event detector owns
+  recording truth.
 - Recording preparation is bounded and happens before every attempt-closing
   settlement, including approval suspension. The existing locked turn
   settlement atomically commits the exact recording row and its
@@ -74,6 +75,14 @@ paths outside the deterministic baseline:
   accepted `recording.started` receipt and emits no authoritative event.
 - The old worker-buffered recording API and its live-test path are removed, not
   retained as a fallback.
+
+The first production Codex canary after the atomic-settlement cutover exposed
+an ordering defect: the function-call stream event arrived before asynchronous
+ffmpeg startup completed, so a guard requiring an already-active recording
+missed the action and settlement discarded the row. The correction records
+computer use synchronously in `onComputerUseReady` before awaiting ffmpeg.
+This callback is the actual execution boundary, unlike a model stream item,
+and the ordering is enforced by the desktop-gating regression test.
 
 ## Reproducible gates
 


### PR DESCRIPTION
## What changed
- make the runtime actual-computer-execution callback the sole recording-use gate
- record execution synchronously before asynchronous ffmpeg startup
- remove the transport-specific stream-event detector and its obsolete tests
- pin the ordering in the existing desktop-gating regression test

## Production evidence
A real Codex computer_screenshot canary on c219da58 emitted the function-call event before recording startup completed. The prior activeRecording guard missed it, leaving didComputerUse false and causing settlement to discard the accepted recording row.

## Verification
- 72 focused worker tests pass in the production cluster verifier
- worker tsgo typecheck passes
- changed TypeScript formatting passes
- oxlint: zero errors; one unrelated pre-existing shadow warning
- Fable review: approved, no blockers
- existing runtime lazy-computer test already proves function-image tools invoke onComputerUseReady exactly once after desktop startup