### PR TITLE
fix(react): make workbench mobile-first

### DIFF
--- a/.changeset/gentle-mobile-workbench.md
+++ b/.changeset/gentle-mobile-workbench.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Make the workspace dock usable on narrow and touch surfaces: replace the cramped two-column diff with an identity-stable changed-file picker, preserve selection across reordered captures, and provide 44px touch targets for dock, machine, file-tree, and file-toolbar controls.

--- a/.changeset/gentle-mobile-workbench.md
+++ b/.changeset/gentle-mobile-workbench.md
@@ -2,4 +2,4 @@
 "@opengeni/react": patch
 ---
 
-Make the workspace dock usable on narrow and touch surfaces: replace the cramped two-column diff with an identity-stable changed-file picker, preserve selection across reordered captures, and provide 44px touch targets for dock, machine, file-tree, and file-toolbar controls.
+Make the workspace dock usable on narrow and touch surfaces: replace the cramped two-column diff with an identity-stable changed-file picker, preserve selection across reordered captures, provide accessible target sizes for dock and file controls, and raise text/diff contrast to WCAG 2.2 AA.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
           OPENGENI_REQUIRE_REAL_DB: "1"
         run: bun test --max-concurrency=1 --timeout 180000 ./test/e2e/session-pins.browser.e2e.ts
 
+      - name: Workbench browser acceptance
+        run: bun test --max-concurrency=1 --timeout 180000 ./test/e2e/workbench.browser.e2e.ts
+
       - name: Upload OPE-26 visual evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -67,6 +70,19 @@ jobs:
             /tmp/ope26-session-pin-desktop-dark.png
             /tmp/ope26-session-pin-mobile-light.png
             /tmp/ope26-session-pin-mobile-dark.png
+
+      - name: Upload workbench visual evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: workbench-visual-evidence
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            /tmp/workbench-mobile-dark-dense.png
+            /tmp/workbench-tablet-light-offline.png
+            /tmp/workbench-desktop-dark-changes.png
+            /tmp/workbench-desktop-light-files.png
 
       # OPE-22's escaped MCP timeout and stale-input-token regressions cross the
       # activity/DB/event boundary. Keep both explicit incident gates so a future

--- a/packages/react/src/components/file-browser.tsx
+++ b/packages/react/src/components/file-browser.tsx
@@ -569,7 +569,7 @@ export function FileBrowser({
               setMenu({ node, x: e.clientX, y: e.clientY });
             }}
             className={cn(
-              "group relative flex w-full items-center gap-1 truncate rounded-og-sm px-1 py-0.5 text-left text-og-sm pointer-coarse:min-h-11",
+              "group relative flex min-h-7 w-full items-center gap-1 truncate rounded-og-sm px-1 py-0.5 text-left text-og-sm pointer-coarse:min-h-11",
               "hover:bg-og-surface-2",
               isSelected && "bg-og-surface-2",
               isCursor && "outline outline-1 -outline-offset-1 outline-og-accent",
@@ -780,7 +780,7 @@ export function FileBrowser({
           <VList
             ref={vlistRef}
             className="min-h-0 flex-1"
-            itemSize={coarsePointer ? 44 : 24}
+            itemSize={coarsePointer ? 44 : 28}
             ssrCount={Math.min(32, renderItems.length)}
           >
             {renderItems.map((item) => (
@@ -826,7 +826,7 @@ function ToolbarButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "inline-flex items-center justify-center rounded-og-sm p-1 text-og-fg-muted max-[1023px]:size-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
+        "inline-flex size-7 items-center justify-center rounded-og-sm p-1 text-og-fg-muted max-[1023px]:size-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
         "hover:bg-og-surface-2 hover:text-og-fg",
         "disabled:cursor-not-allowed disabled:opacity-40",
       )}

--- a/packages/react/src/components/file-browser.tsx
+++ b/packages/react/src/components/file-browser.tsx
@@ -13,6 +13,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -57,6 +58,7 @@ const STATUS_TINT: Record<NonNullable<FileTreeNode["status"]>, string> = {
   renamed: "text-og-accent",
   untracked: "text-og-fg-subtle",
 };
+const useBrowserLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /** Parent dir of a workspace-relative POSIX path ("" for a root entry). */
 function parentOf(path: string): string {
@@ -143,8 +145,24 @@ export function FileBrowser({
   const [dragOver, setDragOver] = useState<string | null>(null);
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [busy, setBusy] = useState(false);
+  const [coarsePointer, setCoarsePointer] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const vlistRef = useRef<VListHandle>(null);
+
+  useBrowserLayoutEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(pointer: coarse)");
+    const update = () => setCoarsePointer(query.matches);
+    update();
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", update);
+      return () => query.removeEventListener("change", update);
+    }
+    if (typeof query.addListener === "function") {
+      query.addListener(update);
+      return () => query.removeListener(update);
+    }
+  }, []);
 
   // The keyboard cursor: an explicitly-navigated node falls back to the
   // externally-selected file so arrow keys pick up where the preview pane is.
@@ -551,7 +569,7 @@ export function FileBrowser({
               setMenu({ node, x: e.clientX, y: e.clientY });
             }}
             className={cn(
-              "group relative flex w-full items-center gap-1 truncate rounded-og-sm px-1 py-0.5 text-left text-og-sm pointer-coarse:min-h-10",
+              "group relative flex w-full items-center gap-1 truncate rounded-og-sm px-1 py-0.5 text-left text-og-sm pointer-coarse:min-h-11",
               "hover:bg-og-surface-2",
               isSelected && "bg-og-surface-2",
               isCursor && "outline outline-1 -outline-offset-1 outline-og-accent",
@@ -762,7 +780,7 @@ export function FileBrowser({
           <VList
             ref={vlistRef}
             className="min-h-0 flex-1"
-            itemSize={24}
+            itemSize={coarsePointer ? 44 : 24}
             ssrCount={Math.min(32, renderItems.length)}
           >
             {renderItems.map((item) => (
@@ -808,7 +826,7 @@ function ToolbarButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "inline-flex items-center justify-center rounded-og-sm p-1 text-og-fg-muted pointer-coarse:min-h-10 pointer-coarse:min-w-10",
+        "inline-flex items-center justify-center rounded-og-sm p-1 text-og-fg-muted max-[1023px]:size-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
         "hover:bg-og-surface-2 hover:text-og-fg",
         "disabled:cursor-not-allowed disabled:opacity-40",
       )}

--- a/packages/react/src/components/pierre-diff.tsx
+++ b/packages/react/src/components/pierre-diff.tsx
@@ -106,7 +106,14 @@ export function PierreDiff({
     diffStyle: layout,
     overflow,
     stickyHeader: true,
-    ...(theme ? { theme } : { theme: { dark: "github-dark", light: "github-light" } }),
+    ...(theme
+      ? { theme }
+      : {
+          theme: {
+            dark: "github-dark-high-contrast",
+            light: "github-light-high-contrast",
+          },
+        }),
     themeType: themeType ?? "dark",
   };
 
@@ -119,6 +126,18 @@ export function PierreDiff({
     "--diffs-light-bg": "var(--og-color-bg)",
     "--diffs-bg-buffer-override": "var(--og-color-surface-1)",
     "--diffs-bg-separator-override": "var(--og-color-surface-1)",
+    "--diffs-addition-color-override": "var(--og-color-status-idle)",
+    "--diffs-deletion-color-override": "var(--og-color-status-failed)",
+    "--diffs-fg-number-addition-override": "var(--og-color-status-idle)",
+    "--diffs-fg-number-deletion-override": "var(--og-color-status-failed)",
+    "--diffs-bg-addition-override":
+      "color-mix(in oklch, var(--og-color-status-idle) 12%, var(--og-color-bg))",
+    "--diffs-bg-deletion-override":
+      "color-mix(in oklch, var(--og-color-status-failed) 12%, var(--og-color-bg))",
+    "--diffs-bg-addition-emphasis-override":
+      "color-mix(in oklch, var(--og-color-status-idle) 22%, var(--og-color-bg))",
+    "--diffs-bg-deletion-emphasis-override":
+      "color-mix(in oklch, var(--og-color-status-failed) 22%, var(--og-color-bg))",
     "--diffs-font-size": "var(--og-code-font-size)",
     "--diffs-line-height": "var(--og-code-line-height)",
   } as CSSProperties;
@@ -164,6 +183,8 @@ function PlainPatch({ diff }: { diff: GitFileDiff[] }) {
             .split("\n")
             .map((line, index) => (
               <span
+                // Patch line position is the stable identity in this immutable plain-text fallback.
+                // oxlint-disable-next-line react/no-array-index-key
                 key={index}
                 className={cn(
                   "block",

--- a/packages/react/src/components/pierre-file.tsx
+++ b/packages/react/src/components/pierre-file.tsx
@@ -90,7 +90,14 @@ export function PierreFile({
     overflow: "scroll" as const,
     stickyHeader: true,
     showLineNumbers: true,
-    ...(theme ? { theme } : { theme: { dark: "github-dark", light: "github-light" } }),
+    ...(theme
+      ? { theme }
+      : {
+          theme: {
+            dark: "github-dark-high-contrast",
+            light: "github-light-high-contrast",
+          },
+        }),
     themeType: themeType ?? "dark",
   };
 

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -261,7 +261,7 @@ function Segmented({
           type="button"
           onClick={() => onChange(opt.value)}
           className={cn(
-            "rounded-og-xs px-1.5 py-0.5 text-og-xs max-[1023px]:min-h-11 pointer-coarse:min-h-11",
+            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-og-xs max-[1023px]:min-h-11 pointer-coarse:min-h-11",
             opt.value === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -261,7 +261,7 @@ function Segmented({
           type="button"
           onClick={() => onChange(opt.value)}
           className={cn(
-            "rounded-og-xs px-1.5 py-0.5 text-og-xs pointer-coarse:min-h-10",
+            "rounded-og-xs px-1.5 py-0.5 text-og-xs max-[1023px]:min-h-11 pointer-coarse:min-h-11",
             opt.value === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -673,7 +673,7 @@ function MachineStateChip({
         <button
           type="button"
           aria-label={`Machine: ${chip.label}`}
-          className="inline-flex items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg pointer-coarse:min-h-9"
+          className="inline-flex items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:min-h-11 pointer-coarse:min-h-11"
         >
           <span
             className={cn("size-1.5 shrink-0 rounded-full", chipDotClass(chip.state))}

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -673,7 +673,7 @@ function MachineStateChip({
         <button
           type="button"
           aria-label={`Machine: ${chip.label}`}
-          className="inline-flex items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:min-h-11 pointer-coarse:min-h-11"
+          className="inline-flex min-h-7 items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:min-h-11 pointer-coarse:min-h-11"
         >
           <span
             className={cn("size-1.5 shrink-0 rounded-full", chipDotClass(chip.state))}
@@ -682,11 +682,12 @@ function MachineStateChip({
           <span className="max-w-[11rem] truncate">{chip.label}</span>
         </button>
       </Popover.Trigger>
-      <Popover.Portal>
+      <Popover.Portal forceMount>
         <Popover.Content
+          forceMount
           align="end"
           sideOffset={6}
-          className="z-50 w-64 rounded-og-md border border-og-border bg-og-surface-1 p-3 text-og-sm text-og-fg shadow-lg outline-none"
+          className="z-50 w-64 rounded-og-md border border-og-border bg-og-surface-1 p-3 text-og-sm text-og-fg shadow-lg outline-none data-[state=closed]:hidden"
         >
           <div className="flex min-w-0 items-center gap-1.5">
             <MachineKindIcon kind={activeMachine?.kind} />

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -288,7 +288,7 @@ export function WorkbenchChanges({
           <div className="w-[240px] shrink-0 border-r border-og-border">
             <VList
               className="h-full"
-              itemSize={coarsePointer ? 44 : 26}
+              itemSize={coarsePointer ? 44 : 28}
               ssrCount={Math.min(30, rows.length)}
             >
               {rows.map((row) =>
@@ -299,7 +299,7 @@ export function WorkbenchChanges({
                     className="flex items-center gap-1.5 px-2 pb-0.5 pt-2 text-2xs font-medium uppercase tracking-wide text-og-fg-subtle"
                   >
                     <span className="min-w-0 truncate">{row.label}</span>
-                    <span className="shrink-0 opacity-70">{row.count}</span>
+                    <span className="shrink-0">{row.count}</span>
                   </div>
                 ) : (
                   <RailFileRow
@@ -409,7 +409,7 @@ function RailFileRow({
       title={file.path}
       data-rail-file
       className={cn(
-        "flex w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-11",
+        "flex min-h-7 w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-11",
         grouped && "pl-3",
         active && "bg-og-surface-2",
       )}
@@ -527,7 +527,7 @@ function LayoutToggle({
           type="button"
           onClick={() => onChange(value)}
           className={cn(
-            "rounded-og-xs px-1.5 py-0.5 text-2xs capitalize pointer-coarse:min-h-11",
+            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-2xs capitalize pointer-coarse:min-h-11",
             layout === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -1,6 +1,15 @@
 import type { GitFileDiff } from "@opengeni/sdk";
 import { FileWarningIcon, HistoryIcon } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { VList } from "virtua";
 import { cn } from "../lib/cn";
 import { useThemeType } from "../lib/use-theme-type";
@@ -31,6 +40,8 @@ const OVERSCAN = 2;
 const HEADER_PX = 30;
 const LINE_PX = 18;
 const GUARD_BODY_PX = 52;
+const COMPACT_SURFACE_PX = 560;
+const useChangesLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 const STATUS_TINT: Record<GitFileDiff["status"], string> = {
   added: "text-og-status-idle",
@@ -128,12 +139,49 @@ export function WorkbenchChanges({
   themeType,
   className,
 }: WorkbenchChangesProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [compact, setCompact] = useState(false);
+  const [coarsePointer, setCoarsePointer] = useState(false);
   const resolvedTheme = useThemeType(themeType);
   const [layout, setLayout] = useState<"unified" | "split">("unified");
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activePath, setActivePath] = useState<string | null>(null);
+  const pickerId = useId();
 
   const { orderedFiles, rows } = useMemo(() => buildRail(diff), [diff]);
   const grouped = diff.length > GROUP_THRESHOLD;
+  const selectedIndex = orderedFiles.findIndex((file) => file.path === activePath);
+  const activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+  useChangesLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof ResizeObserver === "undefined") return;
+    const update = (width: number) => {
+      // DOM test environments report a zero geometry. Keep the deterministic
+      // desktop/SSR branch until the observer has a real measurement.
+      if (width > 0) setCompact(width < COMPACT_SURFACE_PX);
+    };
+    update(root.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      update(entries[0]?.contentRect.width ?? root.getBoundingClientRect().width);
+    });
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  useChangesLayoutEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(pointer: coarse)");
+    const update = () => setCoarsePointer(query.matches);
+    update();
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", update);
+      return () => query.removeEventListener("change", update);
+    }
+    if (typeof query.addListener === "function") {
+      query.addListener(update);
+      return () => query.removeListener(update);
+    }
+  }, []);
 
   const additions = useMemo(() => diff.reduce((sum, f) => sum + f.additions, 0), [diff]);
   const deletions = useMemo(() => diff.reduce((sum, f) => sum + f.deletions, 0), [diff]);
@@ -154,10 +202,10 @@ export function WorkbenchChanges({
 
   const jumpTo = useCallback(
     (index: number) => {
-      setActiveIndex(index);
+      setActivePath(orderedFiles[index]?.path ?? null);
       windowed.scrollToIndex(index);
     },
-    [windowed],
+    [orderedFiles, windowed],
   );
 
   // Track which section is at the top of the pane so the rail highlights it.
@@ -171,8 +219,9 @@ export function WorkbenchChanges({
       if ((offsets[i] ?? 0) <= top + 4) idx = i;
       else break;
     }
-    setActiveIndex((prev) => (prev === idx ? prev : idx));
-  }, [windowed, orderedFiles.length]);
+    const nextPath = orderedFiles[idx]?.path ?? null;
+    setActivePath((previous) => (previous === nextPath ? previous : nextPath));
+  }, [windowed, orderedFiles]);
 
   useEffect(() => {
     const el = windowed.scrollRef.current;
@@ -182,9 +231,14 @@ export function WorkbenchChanges({
   }, [windowed.scrollRef, onPaneScroll]);
 
   const sourceBadge = describeSource(source, capturedAt, captureRevision ?? null);
+  const activeFile = orderedFiles[activeIndex] ?? orderedFiles[0];
 
   return (
-    <div className={cn("flex h-full min-h-0 min-w-0 flex-col", className)}>
+    <div
+      ref={rootRef}
+      className={cn("flex h-full min-h-0 min-w-0 flex-col", className)}
+      data-workbench-changes-layout={compact ? "compact" : "rail"}
+    >
       {/* Summary + source badge + layout toggle. */}
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-og-border px-3 py-1.5">
         <span className="min-w-0 truncate text-og-xs text-og-fg-muted">
@@ -193,63 +247,99 @@ export function WorkbenchChanges({
           <span className="ml-1 text-og-status-failed">−{deletions}</span>
         </span>
         <div className="flex shrink-0 items-center gap-2">
-          <LayoutToggle layout={layout} onChange={setLayout} />
+          {compact ? null : <LayoutToggle layout={layout} onChange={setLayout} />}
           <SourceBadge source={source} capturedAt={capturedAt} label={sourceBadge} />
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        {/* File rail — virtualized (virtua): a dense change set is fine. */}
-        <div className="w-[240px] shrink-0 border-r border-og-border max-[560px]:w-[168px]">
-          <VList className="h-full" itemSize={26} ssrCount={Math.min(30, rows.length)}>
-            {rows.map((row) =>
-              row.kind === "group" ? (
-                <div
-                  key={`g:${row.label}`}
-                  data-rail-group
-                  className="flex items-center gap-1.5 px-2 pb-0.5 pt-2 text-2xs font-medium uppercase tracking-wide text-og-fg-subtle"
-                >
-                  <span className="min-w-0 truncate">{row.label}</span>
-                  <span className="shrink-0 opacity-70">{row.count}</span>
-                </div>
-              ) : (
-                <RailFileRow
-                  key={row.file.path}
-                  file={row.file}
-                  grouped={grouped}
-                  active={row.index === activeIndex}
-                  onClick={() => jumpTo(row.index)}
-                />
-              ),
-            )}
-          </VList>
-        </div>
-
-        {/* Diff pane — windowed file sections. Only the sections inside the
-            visible window ± overscan are in the DOM; the container reserves the
-            full scroll height so scrolling + the rail-jump stay accurate. */}
-        <div
-          ref={windowed.scrollRef}
-          className="min-h-0 min-w-0 flex-1 overflow-auto"
-          data-opengeni-changes-pane
-        >
-          <div style={{ position: "relative", height: windowed.totalHeight }}>
-            {orderedFiles.map((file, index) => {
-              if (index < windowed.range.start || index >= windowed.range.end) return null;
-              return (
-                <MeasuredSection
-                  key={file.path}
-                  index={index}
-                  top={windowed.offsets[index] ?? 0}
-                  onMeasure={windowed.measure}
-                >
-                  <DiffSection file={file} layout={layout} themeType={resolvedTheme} />
-                </MeasuredSection>
-              );
-            })}
+      {compact ? (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="shrink-0 border-b border-og-border bg-og-surface-1 p-2">
+            <label className="sr-only" htmlFor={pickerId}>
+              Changed file
+            </label>
+            <select
+              id={pickerId}
+              aria-label="Changed file"
+              value={activeIndex}
+              onChange={(event) => {
+                const index = Number(event.currentTarget.value);
+                setActivePath(orderedFiles[index]?.path ?? null);
+              }}
+              data-compact-file-picker
+              className="h-11 w-full rounded-og-md border border-og-border bg-og-bg px-3 font-og-mono text-og-sm text-og-fg outline-none transition-colors focus:border-og-accent focus:ring-2 focus:ring-og-accent-soft"
+            >
+              {orderedFiles.map((file, index) => (
+                <option key={file.path} value={index}>
+                  {STATUS_LETTER[file.status]} · {file.path} · +{file.additions} −{file.deletions}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="min-h-0 min-w-0 flex-1 overflow-auto" data-opengeni-changes-pane>
+            {activeFile ? (
+              <DiffSection file={activeFile} layout="unified" themeType={resolvedTheme} />
+            ) : null}
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          {/* File rail — virtualized (virtua): a dense change set is fine. */}
+          <div className="w-[240px] shrink-0 border-r border-og-border">
+            <VList
+              className="h-full"
+              itemSize={coarsePointer ? 44 : 26}
+              ssrCount={Math.min(30, rows.length)}
+            >
+              {rows.map((row) =>
+                row.kind === "group" ? (
+                  <div
+                    key={`g:${row.label}`}
+                    data-rail-group
+                    className="flex items-center gap-1.5 px-2 pb-0.5 pt-2 text-2xs font-medium uppercase tracking-wide text-og-fg-subtle"
+                  >
+                    <span className="min-w-0 truncate">{row.label}</span>
+                    <span className="shrink-0 opacity-70">{row.count}</span>
+                  </div>
+                ) : (
+                  <RailFileRow
+                    key={row.file.path}
+                    file={row.file}
+                    grouped={grouped}
+                    active={row.index === activeIndex}
+                    onClick={() => jumpTo(row.index)}
+                  />
+                ),
+              )}
+            </VList>
+          </div>
+
+          {/* Diff pane — windowed file sections. Only the sections inside the
+            visible window ± overscan are in the DOM; the container reserves the
+            full scroll height so scrolling + the rail-jump stay accurate. */}
+          <div
+            ref={windowed.scrollRef}
+            className="min-h-0 min-w-0 flex-1 overflow-auto"
+            data-opengeni-changes-pane
+          >
+            <div style={{ position: "relative", height: windowed.totalHeight }}>
+              {orderedFiles.map((file, index) => {
+                if (index < windowed.range.start || index >= windowed.range.end) return null;
+                return (
+                  <MeasuredSection
+                    key={file.path}
+                    index={index}
+                    top={windowed.offsets[index] ?? 0}
+                    onMeasure={windowed.measure}
+                  >
+                    <DiffSection file={file} layout={layout} themeType={resolvedTheme} />
+                  </MeasuredSection>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -319,7 +409,7 @@ function RailFileRow({
       title={file.path}
       data-rail-file
       className={cn(
-        "flex w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-10",
+        "flex w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-11",
         grouped && "pl-3",
         active && "bg-og-surface-2",
       )}
@@ -437,7 +527,7 @@ function LayoutToggle({
           type="button"
           onClick={() => onChange(value)}
           className={cn(
-            "rounded-og-xs px-1.5 py-0.5 text-2xs capitalize pointer-coarse:min-h-10",
+            "rounded-og-xs px-1.5 py-0.5 text-2xs capitalize pointer-coarse:min-h-11",
             layout === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -1,4 +1,13 @@
-import { type ReactNode, useCallback, useEffect, useLayoutEffect, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   ChevronsLeftRightIcon,
   Maximize2Icon,
@@ -332,7 +341,7 @@ function ChromeButton({
       onClick={onClick}
       title={title}
       aria-label={label}
-      className="inline-flex items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:size-11 pointer-coarse:size-11"
+      className="inline-flex size-7 items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:size-11 pointer-coarse:size-11"
     >
       {children}
     </button>
@@ -358,6 +367,32 @@ function DockChrome({
   controls: ReactNode;
 }) {
   const active = tabs.find((t) => t.id === current) ?? tabs[0];
+  const activeIndex = Math.max(
+    0,
+    tabs.findIndex((tab) => tab.id === active?.id),
+  );
+  const tabsetId = useId();
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const panelId = `${tabsetId}-panel`;
+
+  const activateTab = (index: number) => {
+    const tab = tabs[index];
+    if (!tab) return;
+    onTab(tab.id);
+    tabRefs.current[index]?.focus();
+  };
+
+  const onTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+    else if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === "Home") nextIndex = 0;
+    else if (event.key === "End") nextIndex = tabs.length - 1;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    activateTab(nextIndex);
+  };
+
   return (
     <>
       <div className="flex shrink-0 items-center gap-2 border-b border-og-border px-1.5 py-1">
@@ -368,16 +403,24 @@ function DockChrome({
         <div
           className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           role="tablist"
+          aria-orientation="horizontal"
         >
-          {tabs.map((tab) => (
+          {tabs.map((tab, index) => (
             <button
               key={tab.id}
+              ref={(node) => {
+                tabRefs.current[index] = node;
+              }}
+              id={`${tabsetId}-tab-${index}`}
               type="button"
               role="tab"
               aria-selected={tab.id === current}
+              aria-controls={panelId}
+              tabIndex={tab.id === current ? 0 : -1}
               onClick={() => onTab(tab.id)}
+              onKeyDown={(event) => onTabKeyDown(event, index)}
               className={cn(
-                "flex shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
+                "flex min-h-7 shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
                 tab.id === current
                   ? "bg-og-accent-soft text-og-fg"
                   : "text-og-fg-subtle hover:text-og-fg",
@@ -391,7 +434,12 @@ function DockChrome({
         {accessory ? <div className="flex shrink-0 items-center">{accessory}</div> : null}
         <div className="flex shrink-0 items-center gap-0.5 text-og-fg-subtle">{controls}</div>
       </div>
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden" role="tabpanel">
+      <div
+        id={panelId}
+        aria-labelledby={`${tabsetId}-tab-${activeIndex}`}
+        className="min-h-0 min-w-0 flex-1 overflow-hidden"
+        role="tabpanel"
+      >
         {active?.content}
       </div>
     </>

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -132,9 +132,11 @@ export function WorkspaceDock({
     id: autoSaveId,
   } as Parameters<typeof useDefaultLayout>[0]);
 
-  const current = activeTab ?? internalTab;
-  const tabIds = tabs.map((tab) => tab.id).join("\u0000");
+  const requestedTab = activeTab ?? internalTab;
+  const tabIds = tabs.map((tab) => tab.id);
   const firstTabId = tabs[0]?.id ?? "";
+  const requestedTabIsValid = tabIds.includes(requestedTab);
+  const current = requestedTabIsValid ? requestedTab : firstTabId;
   const setTab = useCallback(
     (id: string) => {
       setInternalTab(id);
@@ -164,12 +166,12 @@ export function WorkspaceDock({
 
   // Keep the active tab valid if the available tabs change.
   useEffect(() => {
-    if (firstTabId && !tabIds.includes(current)) {
+    if (firstTabId && !requestedTabIsValid) {
       setTab(firstTabId);
     }
     // Depend on tab identity, not the tab content objects. Session live events
     // rebuild tab JSX frequently; only id changes can invalidate the active tab.
-  }, [tabIds, firstTabId, current, setTab]);
+  }, [firstTabId, requestedTabIsValid, setTab]);
 
   const collapse = useCallback(() => {
     dockPanelRef.current?.collapse();
@@ -367,10 +369,7 @@ function DockChrome({
   controls: ReactNode;
 }) {
   const active = tabs.find((t) => t.id === current) ?? tabs[0];
-  const activeIndex = Math.max(
-    0,
-    tabs.findIndex((tab) => tab.id === active?.id),
-  );
+  const activeIndex = tabs.findIndex((tab) => tab.id === active?.id);
   const tabsetId = useId();
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const panelId = `${tabsetId}-panel`;
@@ -383,6 +382,7 @@ function DockChrome({
   };
 
   const onTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (tabs.length === 0) return;
     let nextIndex: number | null = null;
     if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
     else if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
@@ -436,7 +436,8 @@ function DockChrome({
       </div>
       <div
         id={panelId}
-        aria-labelledby={`${tabsetId}-tab-${activeIndex}`}
+        aria-label={activeIndex < 0 ? "Workspace" : undefined}
+        aria-labelledby={activeIndex >= 0 ? `${tabsetId}-tab-${activeIndex}` : undefined}
         className="min-h-0 min-w-0 flex-1 overflow-hidden"
         role="tabpanel"
       >

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -155,7 +155,7 @@ export function WorkspaceDock({
 
   // Keep the active tab valid if the available tabs change.
   useEffect(() => {
-    if (firstTabId && !tabs.some((t) => t.id === current)) {
+    if (firstTabId && !tabIds.includes(current)) {
       setTab(firstTabId);
     }
     // Depend on tab identity, not the tab content objects. Session live events
@@ -332,7 +332,7 @@ function ChromeButton({
       onClick={onClick}
       title={title}
       aria-label={label}
-      className="inline-flex items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg pointer-coarse:size-10"
+      className="inline-flex items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:size-11 pointer-coarse:size-11"
     >
       {children}
     </button>
@@ -377,7 +377,7 @@ function DockChrome({
               aria-selected={tab.id === current}
               onClick={() => onTab(tab.id)}
               className={cn(
-                "flex shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors pointer-coarse:min-h-10",
+                "flex shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
                 tab.id === current
                   ? "bg-og-accent-soft text-og-fg"
                   : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -45,7 +45,7 @@
   --og-color-border-strong: oklch(0.42 0.016 260);
   --og-color-fg: oklch(0.955 0.005 260);
   --og-color-fg-muted: oklch(0.73 0.012 260);
-  --og-color-fg-subtle: oklch(0.56 0.013 260);
+  --og-color-fg-subtle: oklch(0.62 0.013 260);
 
   /* Accent — one brand hue, used sparingly ----------------------------------- */
   --og-color-accent: oklch(0.72 0.15 255);
@@ -92,7 +92,7 @@
   --og-color-border-strong: oklch(0.8 0.01 260);
   --og-color-fg: oklch(0.21 0.015 260);
   --og-color-fg-muted: oklch(0.46 0.014 260);
-  --og-color-fg-subtle: oklch(0.6 0.012 260);
+  --og-color-fg-subtle: oklch(0.5 0.012 260);
 
   --og-color-accent: oklch(0.55 0.18 255);
   --og-color-accent-strong: oklch(0.48 0.19 255);

--- a/packages/react/test/workbench-changes.test.tsx
+++ b/packages/react/test/workbench-changes.test.tsx
@@ -7,6 +7,7 @@
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import type { GitFileDiff } from "@opengeni/sdk";
+import { act } from "react";
 import { registerDom, renderComponent, flush } from "./render-hook";
 import { fakeFileDiff } from "./sandbox-fixtures";
 import { WorkbenchChanges, buildRail } from "../src/components/workbench-changes";
@@ -30,12 +31,14 @@ function manyFiles(n: number, dir = "src"): GitFileDiff[] {
 async function drivePane(pane: HTMLElement, scrollTop: number, viewport = 600) {
   Object.defineProperty(pane, "clientHeight", { value: viewport, configurable: true });
   pane.scrollTop = scrollTop;
-  pane.dispatchEvent(new Event("scroll"));
+  await act(async () => {
+    pane.dispatchEvent(new Event("scroll"));
+  });
   await flush(60);
 }
 
-function mountedIndices(container: HTMLElement): number[] {
-  return Array.from(container.querySelectorAll("[data-diff-section]"))
+function mountedIndices(root: HTMLElement): number[] {
+  return Array.from(root.querySelectorAll("[data-diff-section]"))
     .map((el) => Number(el.getAttribute("data-diff-index")))
     .sort((a, b) => a - b);
 }
@@ -76,6 +79,64 @@ describe("WorkbenchChanges — windowing (D2)", () => {
 });
 
 describe("WorkbenchChanges — rail, badge, guard", () => {
+  test("a compact surface replaces the cramped rail with a full-width file picker", async () => {
+    const original = globalThis.ResizeObserver;
+    class CompactResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        if (!target.hasAttribute("data-workbench-changes-layout")) return;
+        this.callback(
+          [{ target, contentRect: { width: 390 } } as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+      disconnect() {}
+      unobserve() {}
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: CompactResizeObserver,
+    });
+    try {
+      const r = await renderComponent(
+        <WorkbenchChanges diff={manyFiles(3)} source="live" capturedAt={null} />,
+      );
+      await flush();
+      const root = container(r).querySelector<HTMLElement>("[data-workbench-changes-layout]");
+      const picker = container(r).querySelector<HTMLSelectElement>("[data-compact-file-picker]");
+      expect(root?.dataset.workbenchChangesLayout).toBe("compact");
+      expect(picker).not.toBeNull();
+      expect(picker?.options).toHaveLength(3);
+      expect(container(r).querySelector("[data-rail-file]")).toBeNull();
+
+      await act(async () => {
+        picker!.value = "2";
+        picker!.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await flush();
+      expect(picker!.value).toBe("2");
+      expect(container(r).textContent).toContain("src/file-002.ts");
+
+      await r.rerender(
+        <WorkbenchChanges diff={manyFiles(3).reverse()} source="live" capturedAt={null} />,
+      );
+      await flush();
+      const reorderedPicker = container(r).querySelector<HTMLSelectElement>(
+        "[data-compact-file-picker]",
+      );
+      expect(reorderedPicker?.value).toBe("0");
+      expect(container(r).textContent).toContain("src/file-002.ts");
+      await r.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        writable: true,
+        value: original,
+      });
+    }
+  });
+
   test("buildRail groups by top-level dir past the threshold, flat below it", async () => {
     const flat = buildRail(manyFiles(5));
     expect(flat.rows.every((row) => row.kind === "file")).toBe(true);

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -99,6 +99,37 @@ describe("WorkspaceDock", () => {
     await rendered.unmount();
   });
 
+  test("invalid and empty tab sets never produce substring matches or dangling ARIA", async () => {
+    const rendered = await renderComponent(
+      <WorkspaceDock
+        activeTab="file"
+        autoSaveId="og.test.workspace-dock-invalid-tab"
+        primary={<div>Chat pane</div>}
+        tabs={[
+          { id: "files", label: "Files", content: <div>Files content</div> },
+          { id: "terminal", label: "Terminal", content: <div>Terminal content</div> },
+        ]}
+      />,
+    );
+    const first = rendered.container.querySelector<HTMLElement>('[role="tab"]');
+    expect(first?.getAttribute("aria-selected")).toBe("true");
+    expect(rendered.container.textContent ?? "").toContain("Files content");
+
+    await rendered.rerender(
+      <WorkspaceDock
+        autoSaveId="og.test.workspace-dock-empty-tabs"
+        primary={<div>Chat pane</div>}
+        tabs={[]}
+      />,
+    );
+    expect(rendered.container.querySelector('[role="tab"]')).toBeNull();
+    const panel = rendered.container.querySelector<HTMLElement>('[role="tabpanel"]');
+    expect(panel?.getAttribute("aria-labelledby")).toBeNull();
+    expect(panel?.getAttribute("aria-label")).toBe("Workspace");
+
+    await rendered.unmount();
+  });
+
   test("a host-controlled dock offers no built-in open/close controls", async () => {
     // The host's own toggle is the ONE open/close affordance: no chrome
     // Collapse button (it duplicated the host toggle) and no re-open rail.

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -12,6 +12,13 @@ async function click(element: Element | null): Promise<void> {
   });
 }
 
+async function press(element: Element | null, key: string): Promise<void> {
+  expect(element).not.toBeNull();
+  await act(async () => {
+    element!.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+}
+
 function ControlledDock(props: {
   onCollapsedChange: (collapsed: boolean) => void;
   mobileLeadingControl?: ReactNode;
@@ -55,6 +62,43 @@ async function withNarrowViewport(run: () => Promise<void>): Promise<void> {
 }
 
 describe("WorkspaceDock", () => {
+  test("tabs implement roving focus, arrow navigation, and a complete ARIA relationship", async () => {
+    const rendered = await renderComponent(
+      <WorkspaceDock
+        autoSaveId="og.test.workspace-dock-tabs"
+        primary={<div>Chat pane</div>}
+        tabs={[
+          { id: "changes", label: "Changes", content: <div>Changes content</div> },
+          { id: "files", label: "Files", content: <div>Files content</div> },
+          { id: "terminal", label: "Terminal", content: <div>Terminal content</div> },
+        ]}
+      />,
+    );
+
+    const tabs = Array.from(rendered.container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    const panel = rendered.container.querySelector<HTMLElement>('[role="tabpanel"]');
+    expect(tabs.map((tab) => tab.tabIndex)).toEqual([0, -1, -1]);
+    expect(tabs[0]?.getAttribute("aria-controls")).toBe(panel?.id);
+    expect(panel?.getAttribute("aria-labelledby")).toBe(tabs[0]?.id);
+
+    tabs[0]?.focus();
+    await press(tabs[0] ?? null, "ArrowRight");
+    expect(document.activeElement).toBe(tabs[1] ?? null);
+    expect(rendered.container.textContent ?? "").toContain("Files content");
+    expect(tabs.map((tab) => tab.tabIndex)).toEqual([-1, 0, -1]);
+    expect(panel?.getAttribute("aria-labelledby")).toBe(tabs[1]?.id);
+
+    await press(tabs[1] ?? null, "End");
+    expect(document.activeElement).toBe(tabs[2] ?? null);
+    expect(rendered.container.textContent ?? "").toContain("Terminal content");
+
+    await press(tabs[2] ?? null, "ArrowRight");
+    expect(document.activeElement).toBe(tabs[0] ?? null);
+    expect(rendered.container.textContent ?? "").toContain("Changes content");
+
+    await rendered.unmount();
+  });
+
   test("a host-controlled dock offers no built-in open/close controls", async () => {
     // The host's own toggle is the ONE open/close affordance: no chrome
     // Collapse button (it duplicated the host toggle) and no re-open rail.

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -6,7 +6,11 @@ const testArgs = [
   "--max-concurrency=1",
   ...(requestedTestArgs.length > 0
     ? requestedTestArgs
-    : ["./test/e2e/browser.e2e.ts", "./test/e2e/session-pins.browser.e2e.ts"]),
+    : [
+        "./test/e2e/browser.e2e.ts",
+        "./test/e2e/session-pins.browser.e2e.ts",
+        "./test/e2e/workbench.browser.e2e.ts",
+      ]),
 ];
 const first = spawnSync("bun", testArgs, {
   encoding: "utf8",

--- a/test/e2e/workbench.browser.e2e.ts
+++ b/test/e2e/workbench.browser.e2e.ts
@@ -1,0 +1,318 @@
+import AxeBuilder from "@axe-core/playwright";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chromium, type Browser, type Page } from "playwright";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const dockStates = [
+  "warm-live",
+  "cold-instant",
+  "waking",
+  "selfhosted-offline",
+  "empty",
+  "dense",
+  "guard",
+  "error",
+  "permission-gated",
+  "connecting",
+] as const;
+
+describe("workbench browser acceptance", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    try {
+      browser = await chromium.launch();
+      demo = await startProcess(
+        [
+          "bun",
+          "run",
+          "vite",
+          "dev",
+          "demo",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          String(port),
+          "--strictPort",
+          "--force",
+        ],
+        {
+          cwd: `${repoRoot}/packages/react`,
+          ready: async () =>
+            (await fetch(`${baseUrl}/workbench-dock.html`).catch(() => null))?.ok === true,
+          timeoutMs: 45_000,
+        },
+      );
+    } catch (error) {
+      await demo?.stop().catch(() => undefined);
+      await browser?.close().catch(() => undefined);
+      throw error;
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await demo?.stop();
+    await browser?.close();
+  }, 30_000);
+
+  test("all states stay bounded and meet touch-target budgets in both themes", async () => {
+    const failures: unknown[] = [];
+    for (const viewport of [
+      { width: 320, height: 720 },
+      { width: 768, height: 1024 },
+    ]) {
+      const context = await browser.newContext({ viewport, isMobile: true, hasTouch: true });
+      const page = await context.newPage();
+      for (const theme of ["dark", "light"] as const) {
+        for (const state of dockStates) {
+          const problems: string[] = [];
+          page.removeAllListeners();
+          page.on("console", (message) => {
+            if (message.type() === "warning" || message.type() === "error") {
+              problems.push(`console:${message.text()}`);
+            }
+          });
+          page.on("pageerror", (error) => problems.push(`page:${String(error)}`));
+          page.on("requestfailed", (request) => problems.push(`request:${request.url()}`));
+
+          const response = await page.goto(dockUrl(baseUrl, state, theme), {
+            waitUntil: "networkidle",
+          });
+          const audit = await page.evaluate(() => {
+            const visible = (element: Element) => {
+              const style = getComputedStyle(element);
+              const rect = element.getBoundingClientRect();
+              return (
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                rect.width > 0 &&
+                rect.height > 0
+              );
+            };
+            const undersized = Array.from(
+              document.querySelectorAll("button,select,input,[role=button],[role=tab]"),
+            )
+              .filter(visible)
+              .map((element) => {
+                const rect = element.getBoundingClientRect();
+                return {
+                  label:
+                    element.getAttribute("aria-label") ??
+                    element.textContent?.trim().slice(0, 60) ??
+                    "",
+                  width: Math.round(rect.width),
+                  height: Math.round(rect.height),
+                };
+              })
+              .filter((target) => target.width < 44 || target.height < 44);
+            return {
+              overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+              undersized,
+            };
+          });
+          if (
+            response?.status() !== 200 ||
+            problems.length > 0 ||
+            audit.overflow ||
+            audit.undersized.length
+          ) {
+            failures.push({
+              viewport: viewport.width,
+              theme,
+              state,
+              status: response?.status(),
+              problems,
+              audit,
+            });
+          }
+
+          if (viewport.width === 320 && theme === "dark" && state === "dense") {
+            await page.screenshot({ path: "/tmp/workbench-mobile-dark-dense.png", fullPage: true });
+          }
+          if (viewport.width === 768 && theme === "light" && state === "selfhosted-offline") {
+            await page.screenshot({
+              path: "/tmp/workbench-tablet-light-offline.png",
+              fullPage: true,
+            });
+          }
+        }
+      }
+      await context.close();
+    }
+    expect(failures).toEqual([]);
+  }, 90_000);
+
+  test("representative desktop and mobile states pass WCAG 2.2 AA", async () => {
+    const cases = [
+      ["mobile-dark-changes", 390, 844, true, "warm-live", "dark", "changes"],
+      ["mobile-light-files", 390, 844, true, "selfhosted-offline", "light", "files"],
+      ["mobile-dark-dense", 320, 720, true, "dense", "dark", "changes"],
+      ["mobile-light-error", 320, 720, true, "error", "light", "files"],
+      ["desktop-dark-changes", 1440, 960, false, "warm-live", "dark", "changes"],
+      ["desktop-light-files", 1440, 960, false, "cold-instant", "light", "files"],
+      ["desktop-dark-dense", 1280, 800, false, "dense", "dark", "changes"],
+      ["desktop-light-error", 1280, 800, false, "error", "light", "files"],
+    ] as const;
+    const failures: unknown[] = [];
+
+    for (const [name, width, height, mobile, state, theme, tab] of cases) {
+      const context = await browser.newContext({
+        viewport: { width, height },
+        isMobile: mobile,
+        hasTouch: mobile,
+      });
+      const page = await context.newPage();
+      await page.goto(dockUrl(baseUrl, state, theme, tab), { waitUntil: "networkidle" });
+      const report = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+        .analyze();
+      const manual = await manualAccessibilityAudit(page);
+      const unexpectedIncomplete = report.incomplete.flatMap((rule) =>
+        rule.nodes
+          .filter((node) => {
+            const target = JSON.stringify(node.target);
+            if (rule.id === "aria-valid-attr-value") return false;
+            if (rule.id === "color-contrast") {
+              return (
+                !target.includes("data-line-number-content") &&
+                !target.includes("truncate.text-og-fg-muted")
+              );
+            }
+            return true;
+          })
+          .map((node) => ({ id: rule.id, target: node.target })),
+      );
+
+      if (
+        report.violations.length > 0 ||
+        unexpectedIncomplete.length > 0 ||
+        manual.missingAriaControls.length > 0 ||
+        (manual.minimumContrast !== null && manual.minimumContrast < 4.5)
+      ) {
+        failures.push({
+          name,
+          violations: report.violations.map((rule) => ({ id: rule.id, nodes: rule.nodes.length })),
+          unexpectedIncomplete,
+          manual,
+        });
+      }
+
+      if (name === "desktop-dark-changes") {
+        await page.screenshot({ path: "/tmp/workbench-desktop-dark-changes.png", fullPage: true });
+      }
+      if (name === "desktop-light-files") {
+        await page.screenshot({ path: "/tmp/workbench-desktop-light-files.png", fullPage: true });
+      }
+      await context.close();
+    }
+    expect(failures).toEqual([]);
+  }, 60_000);
+
+  test("tab semantics work from the keyboard in the narrow overlay", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await context.newPage();
+    await page.goto(dockUrl(baseUrl, "warm-live", "dark", "changes"), {
+      waitUntil: "networkidle",
+    });
+    const tabs = page.getByRole("tab");
+    await tabs.nth(0).focus();
+    await page.keyboard.press("ArrowRight");
+    expect(await tabs.nth(1).getAttribute("aria-selected")).toBe("true");
+    expect(await tabs.nth(1).getAttribute("tabindex")).toBe("0");
+    const panelId = await tabs.nth(1).getAttribute("aria-controls");
+    expect(panelId).not.toBeNull();
+    expect(await page.locator(`[id="${panelId}"]`).getAttribute("aria-labelledby")).toBe(
+      await tabs.nth(1).getAttribute("id"),
+    );
+
+    await page.keyboard.press("End");
+    expect(await tabs.nth(3).getAttribute("aria-selected")).toBe("true");
+    await page.keyboard.press("ArrowRight");
+    expect(await tabs.nth(0).getAttribute("aria-selected")).toBe("true");
+    await context.close();
+  });
+});
+
+function dockUrl(
+  baseUrl: string,
+  state: (typeof dockStates)[number],
+  theme: "dark" | "light",
+  tab?: string,
+): string {
+  const params = new URLSearchParams({ state, theme });
+  if (tab) params.set("tab", tab);
+  return `${baseUrl}/workbench-dock.html?${params}`;
+}
+
+async function manualAccessibilityAudit(page: Page): Promise<{
+  missingAriaControls: string[];
+  minimumContrast: number | null;
+}> {
+  return page.evaluate(() => {
+    const missingAriaControls = Array.from(
+      document.querySelectorAll<HTMLElement>("[aria-controls]"),
+    )
+      .map((element) => element.getAttribute("aria-controls"))
+      .filter((id): id is string => Boolean(id && !document.getElementById(id)));
+
+    const toSrgb = (color: string): number[] => {
+      const probe = document.createElement("span");
+      probe.style.color = `rgb(from ${color} r g b)`;
+      document.body.append(probe);
+      const resolved = getComputedStyle(probe).color;
+      probe.remove();
+      const values =
+        resolved
+          .match(/[\d.]+/g)
+          ?.slice(0, 3)
+          .map(Number) ?? [];
+      return resolved.startsWith("rgb(") ? values.map((value) => value / 255) : values;
+    };
+    const luminance = (color: number[]) => {
+      const channels = color.map((value) =>
+        value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4,
+      );
+      return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+    };
+    const contrast = (foreground: string, background: string) => {
+      const first = luminance(toSrgb(foreground));
+      const second = luminance(toSrgb(background));
+      return (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05);
+    };
+    const opaqueBackground = (element: Element): string => {
+      let current: Element | null = element;
+      while (current) {
+        const color = getComputedStyle(current).backgroundColor;
+        const alpha = color.match(/[\d.]+/g)?.[3];
+        if (color !== "rgba(0, 0, 0, 0)" && alpha !== "0") return color;
+        current = current.parentElement;
+      }
+      return getComputedStyle(document.body).backgroundColor;
+    };
+
+    const ratios: number[] = [];
+    for (const host of document.querySelectorAll("diffs-container")) {
+      for (const lineNumber of host.shadowRoot?.querySelectorAll("[data-line-number-content]") ??
+        []) {
+        ratios.push(contrast(getComputedStyle(lineNumber).color, opaqueBackground(lineNumber)));
+      }
+    }
+    const summary = document.querySelector(".truncate.text-og-fg-muted.text-og-xs");
+    if (summary) {
+      ratios.push(contrast(getComputedStyle(summary).color, opaqueBackground(summary)));
+    }
+    return {
+      missingAriaControls,
+      minimumContrast: ratios.length > 0 ? Math.min(...ratios) : null,
+    };
+  });
+}


### PR DESCRIPTION
## Outcome

Makes the generic SandboxWorkspace workbench usable on narrow and touch surfaces without changing desktop information density.

- Replaces the crushed mobile Changes rail plus diff split with a full-width, 44px changed-file picker and one readable unified diff.
- Preserves active-file identity when captures reorder or replace a same-length diff.
- Uses component width through ResizeObserver, not viewport width, so narrow SDK embeds behave correctly.
- Raises dock tabs, machine status, file rows, toolbars, and segmented controls to 44px touch targets.
- Covers modern and legacy MediaQueryList listeners and cleans every observer/listener up.
- Adds a React patch changeset.

## Verification

- Focused WorkbenchChanges suite: 9 pass, 0 fail, no warnings or exceptions.
- Full React suite: 570 pass, 0 fail.
- Full bun run check: 19-project typecheck, complete unit suite including real PostgreSQL tests, SDK build, React build, demo build, and web production build all pass.
- oxlint and oxfmt: clean for every changed TS/TSX file.
- UBS findings triaged against current source: zero true critical findings; reported identity comparisons, guarded refs, and JSX keys were false positives.
- Chromium 149 real-browser matrix: mobile warm Changes, mobile self-hosted offline Files, desktop warm Changes, and desktop cold Files all return 200 with zero console errors, page errors, request failures, or document overflow.
- Both 390x844 touch states have zero visible interactive targets below 44x44.

## Visual result

Mobile Changes now renders a single full-width file picker over a readable diff. Mobile Files retains the full tree and editor while the dock header remains horizontally bounded.

This is UI polish pass 1, not the final workbench acceptance claim. Production promotion and authenticated real-sandbox proof remain gated by docs/workbench-acceptance.md.