### PR TITLE
perf(web): split routes and enforce zero-warning gates

### DIFF
--- a/.changeset/clean-react-workbench.md
+++ b/.changeset/clean-react-workbench.md
@@ -1,5 +1,9 @@
 ---
 "@opengeni/react": patch
+"@opengeni/config": patch
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
 ---
 
-Make workbench hooks dependency-safe, keep list identities stable, isolate desktop consent tests from real transports, and enforce warning-free React lint and aggregate tests in CI.
+Make the workbench and console dependency-safe, keep list identities stable, preserve caught error causes, isolate desktop consent tests from real transports, and enforce warning-free repository lint plus aggregate React tests in CI.

--- a/.changeset/clean-react-workbench.md
+++ b/.changeset/clean-react-workbench.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Make workbench hooks dependency-safe, keep list identities stable, isolate desktop consent tests from real transports, and enforce warning-free React lint and aggregate tests in CI.

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -350,7 +350,7 @@ jobs:
           if command -v sha256sum >/dev/null 2>&1; then sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"; else shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"; fi
 
       - name: Upload artifact bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ matrix.asset }}
           # The `.minisig` is only produced when the minisign key is present; the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
         run: bun run typecheck
 
       - name: Lint
-        run: |
-          bun run lint
-          bunx oxlint --deny-warnings packages/react
+        run: bun run lint
 
       - name: Format check
         run: bun run format:check
@@ -65,7 +63,7 @@ jobs:
 
       - name: Upload OPE-26 visual evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ope26-session-pin-visual-evidence
           if-no-files-found: error
@@ -78,7 +76,7 @@ jobs:
 
       - name: Upload workbench visual evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: workbench-visual-evidence
           if-no-files-found: error
@@ -118,6 +116,9 @@ jobs:
 
       - name: Build React demo harness
         run: cd packages/react && bun run demo:build
+
+      - name: Web bundle budget
+        run: bun run --cwd apps/web build
 
   deployment:
     name: Deployment artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -132,7 +132,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
         run: bun run typecheck
 
       - name: Lint
-        run: bun run lint
+        run: |
+          bun run lint
+          bunx oxlint --deny-warnings packages/react
 
       - name: Format check
         run: bun run format:check
@@ -45,6 +47,9 @@ jobs:
           # Never turn a missing Docker/PostgreSQL runner into green skipped tests.
           OPENGENI_REQUIRE_REAL_DB: "1"
         run: bun test
+
+      - name: React warning-free test gate
+        run: bun run test:react:clean
 
       - name: Install pinned Playwright Chromium runtime
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -31,7 +31,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}

--- a/apps/api/scripts/proveit-selfhosted-staging.ts
+++ b/apps/api/scripts/proveit-selfhosted-staging.ts
@@ -643,8 +643,8 @@ async function main() {
       } finally {
         await client.close();
       }
-      const sh = listResult.sandboxes?.find((s: any) => s.id === selfhostedSandboxId);
-      if (sh && sh.liveness === "online") {
+      const selfhosted = listResult.sandboxes?.find((s: any) => s.id === selfhostedSandboxId);
+      if (selfhosted && selfhosted.liveness === "online") {
         online = true;
         break;
       }

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -255,7 +255,7 @@ export async function completeMcpOAuthCallback(
     const key = requireEnvironmentEncryption(settings);
     const verifier = decryptEnvironmentValue(key, state.encryptedPkceVerifier);
     const client = await clientForState(db, settings, state);
-    const token = await stage("token_exchange", "token_exchange_failed", () =>
+    const token = await runCallbackStage("token_exchange", "token_exchange_failed", () =>
       exchangeAuthorizationCode(settings, {
         code: input.code!,
         verifier,
@@ -280,7 +280,7 @@ export async function completeMcpOAuthCallback(
       ...(verification.tools ? { mcpTools: verification.tools } : {}),
     };
     const credentialEncrypted = encryptEnvironmentValue(key, JSON.stringify(credential));
-    const connection = await stage("persist", "persist_failed", () =>
+    const connection = await runCallbackStage("persist", "persist_failed", () =>
       state.connectionId
         ? updateConnection(db, {
             workspaceId: state.workspaceId,
@@ -922,8 +922,8 @@ async function exchangeAuthorizationCode(
   };
 }
 
-async function stage<T>(
-  stage: OAuthCallbackStage,
+async function runCallbackStage<T>(
+  callbackStage: OAuthCallbackStage,
   fallbackReason: string,
   fn: () => Promise<T>,
 ): Promise<T> {
@@ -933,7 +933,7 @@ async function stage<T>(
     if (error instanceof OAuthCallbackStageError) {
       throw error;
     }
-    throw new OAuthCallbackStageError(stage, fallbackReason, error);
+    throw new OAuthCallbackStageError(callbackStage, fallbackReason, error);
   }
 }
 
@@ -1055,7 +1055,7 @@ async function verifyMcpToolsListNonFatal(
   tools?: Array<{ name: string; description?: string }>;
 }> {
   try {
-    const tools = await stage("tools_list", "tools_list_failed", () =>
+    const tools = await runCallbackStage("tools_list", "tools_list_failed", () =>
       verifyMcpToolsList(settings, state.mcpUrl, token),
     );
     return {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -276,7 +276,9 @@ export function buildOpenGeniMcpServer(
           });
         } catch (error) {
           if (error instanceof GitHubAppConfigurationError) {
-            throw new Error(`GitHub App is not configured: ${error.missing.join(", ")}`);
+            throw new Error(`GitHub App is not configured: ${error.missing.join(", ")}`, {
+              cause: error,
+            });
           }
           throw error;
         }
@@ -1080,7 +1082,7 @@ async function beginMcpRigVerificationAttempt(
       error instanceof RigChangeAlreadyVerifyingError ||
       error instanceof RigChangeTransitionError
     ) {
-      throw new Error(error.message);
+      throw new Error(error.message, { cause: error });
     }
     throw error;
   }

--- a/apps/api/test/toolspace-surface.test.ts
+++ b/apps/api/test/toolspace-surface.test.ts
@@ -197,13 +197,17 @@ describe("prepareToolspaceMcpSurface", () => {
     // Second call: active turn still present, budget now exhausted.
     const exhausted = await tool.call({ query: "again" });
     expect(exhausted.isError).toBe(true);
-    expect((exhausted.content?.[0] as { text: string }).text).toContain("budget exhausted");
+    expect((exhausted.content?.[0] as { text?: string } | undefined)?.text).toContain(
+      "budget exhausted",
+    );
 
     // Clear the active turn: the message flips to the no-active-turn variant.
     await admin`update sessions set active_turn_id = null where id = ${sessionId}`;
     const noTurn = await tool.call({ query: "later" });
     expect(noTurn.isError).toBe(true);
-    expect((noTurn.content?.[0] as { text: string }).text).toContain("no active turn");
+    expect((noTurn.content?.[0] as { text?: string } | undefined)?.text).toContain(
+      "no active turn",
+    );
     await surface!.close();
   }, 60_000);
 
@@ -237,7 +241,7 @@ describe("prepareToolspaceMcpSurface", () => {
     server.close();
     const result = await tool.call({ query: "boom" });
     expect(result.isError).toBe(true);
-    const text = (result.content?.[0] as { text: string }).text;
+    const text = (result.content?.[0] as { text?: string } | undefined)?.text;
     expect(text).toBe("upstream tool failed: flaky__search_documents");
     await surface!.close();
   }, 60_000);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3000 --host 0.0.0.0",
-    "build": "vite build",
+    "build": "vite build && bun ../../scripts/check-web-bundle-budget.ts",
     "start": "vite preview --port 3000 --host 0.0.0.0",
     "typecheck": "tsgo --noEmit"
   },
@@ -36,6 +36,7 @@
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "20.10.2",
     "@tanstack/react-router-devtools": "^1.167.0",
     "@tanstack/router-plugin": "^1.168.18",
     "@types/node": "^25.6.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,27 +23,53 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  lazyRouteComponent,
 } from "@tanstack/react-router";
 
 import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
-import { CapabilitiesRoute } from "@/routes/capabilities";
-import { DeviceRoute } from "@/routes/device";
-import { DocumentsRoute } from "@/routes/documents";
-import { VariableSetsRoute } from "@/routes/variable-sets";
-import { MachinesRoute } from "@/routes/machines";
-import { OrgSettingsRoute } from "@/routes/org-settings";
-import { ResetPasswordRoute } from "@/routes/reset-password";
-import { RigsRoute } from "@/routes/rigs";
-import { RigDetailRoute } from "@/routes/rig-detail";
-import { SchedulesRoute } from "@/routes/schedules";
-import { SessionRoute } from "@/routes/session";
-import { SessionsIndexRoute } from "@/routes/sessions-index";
-import { WorkspaceSettingsRoute } from "@/routes/workspace-settings";
-import { WorkspaceShellRoute } from "@/routes/workspace";
 
 export { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "@/lib/routes";
+
+const LazyCapabilitiesRoute = lazyRouteComponent(
+  () => import("@/routes/capabilities"),
+  "CapabilitiesRoute",
+);
+const LazyDeviceRoute = lazyRouteComponent(() => import("@/routes/device"), "DeviceRoute");
+const LazyDocumentsRoute = lazyRouteComponent(() => import("@/routes/documents"), "DocumentsRoute");
+const LazyVariableSetsRoute = lazyRouteComponent(
+  () => import("@/routes/variable-sets"),
+  "VariableSetsRoute",
+);
+const LazyMachinesRoute = lazyRouteComponent(() => import("@/routes/machines"), "MachinesRoute");
+const LazyOrgSettingsRoute = lazyRouteComponent(
+  () => import("@/routes/org-settings"),
+  "OrgSettingsRoute",
+);
+const LazyResetPasswordRoute = lazyRouteComponent(
+  () => import("@/routes/reset-password"),
+  "ResetPasswordRoute",
+);
+const LazyRigsRoute = lazyRouteComponent(() => import("@/routes/rigs"), "RigsRoute");
+const LazyRigDetailRoute = lazyRouteComponent(
+  () => import("@/routes/rig-detail"),
+  "RigDetailRoute",
+);
+const LazySchedulesRoute = lazyRouteComponent(() => import("@/routes/schedules"), "SchedulesRoute");
+const LazySessionRoute = lazyRouteComponent(() => import("@/routes/session"), "SessionRoute");
+const LazySessionsIndexRoute = lazyRouteComponent(
+  () => import("@/routes/sessions-index"),
+  "SessionsIndexRoute",
+);
+const LazyWorkspaceSettingsRoute = lazyRouteComponent(
+  () => import("@/routes/workspace-settings"),
+  "WorkspaceSettingsRoute",
+);
+const LazyWorkspaceShellRoute = lazyRouteComponent(
+  () => import("@/routes/workspace"),
+  "WorkspaceShellRoute",
+);
 
 const rootRoute = createRootRoute({
   component: RootRouteComponent,
@@ -259,22 +285,22 @@ function WorkspaceIndexRedirect() {
 
 function WorkspaceShell() {
   const { workspaceId } = workspaceRoute.useParams();
-  return <WorkspaceShellRoute workspaceId={workspaceId} />;
+  return <LazyWorkspaceShellRoute workspaceId={workspaceId} />;
 }
 
 function SessionsIndex() {
   const { workspaceId } = workspaceSessionsRoute.useParams();
-  return <SessionsIndexRoute workspaceId={workspaceId} />;
+  return <LazySessionsIndexRoute workspaceId={workspaceId} />;
 }
 
 function SessionView() {
   const { workspaceId, sessionId } = workspaceSessionRoute.useParams();
-  return <SessionRoute workspaceId={workspaceId} sessionId={sessionId} />;
+  return <LazySessionRoute workspaceId={workspaceId} sessionId={sessionId} />;
 }
 
 function VariableSets() {
   const { workspaceId } = workspaceVariableSetsRoute.useParams();
-  return <VariableSetsRoute workspaceId={workspaceId} />;
+  return <LazyVariableSetsRoute workspaceId={workspaceId} />;
 }
 
 function VariableSetsRedirect() {
@@ -284,17 +310,17 @@ function VariableSetsRedirect() {
 
 function Rigs() {
   const { workspaceId } = workspaceRigsRoute.useParams();
-  return <RigsRoute workspaceId={workspaceId} />;
+  return <LazyRigsRoute workspaceId={workspaceId} />;
 }
 
 function RigDetail() {
   const { workspaceId, rigId } = workspaceRigDetailRoute.useParams();
-  return <RigDetailRoute workspaceId={workspaceId} rigId={rigId} />;
+  return <LazyRigDetailRoute workspaceId={workspaceId} rigId={rigId} />;
 }
 
 function Machines() {
   const { workspaceId } = workspaceMachinesRoute.useParams();
-  return <MachinesRoute workspaceId={workspaceId} />;
+  return <LazyMachinesRoute workspaceId={workspaceId} />;
 }
 
 function PacksRedirect() {
@@ -312,29 +338,29 @@ function PacksRedirect() {
 function Capabilities() {
   const { workspaceId } = workspaceCapabilitiesRoute.useParams();
   const { section } = workspaceCapabilitiesRoute.useSearch();
-  return <CapabilitiesRoute workspaceId={workspaceId} initialSection={section} />;
+  return <LazyCapabilitiesRoute workspaceId={workspaceId} initialSection={section} />;
 }
 
 function Schedules() {
   const { workspaceId } = workspaceSchedulesRoute.useParams();
-  return <SchedulesRoute workspaceId={workspaceId} />;
+  return <LazySchedulesRoute workspaceId={workspaceId} />;
 }
 
 function Documents() {
   const { workspaceId } = workspaceDocumentsRoute.useParams();
   const { memory } = workspaceDocumentsRoute.useSearch();
-  return <DocumentsRoute workspaceId={workspaceId} focusMemoryId={memory} />;
+  return <LazyDocumentsRoute workspaceId={workspaceId} focusMemoryId={memory} />;
 }
 
 function WorkspaceSettings() {
   const { workspaceId } = workspaceSettingsRoute.useParams();
-  return <WorkspaceSettingsRoute workspaceId={workspaceId} />;
+  return <LazyWorkspaceSettingsRoute workspaceId={workspaceId} />;
 }
 
 function Organization() {
   const { workspaceId } = workspaceOrganizationRoute.useParams();
   const { checkout } = workspaceOrganizationRoute.useSearch();
-  return <OrgSettingsRoute workspaceId={workspaceId} checkout={checkout} />;
+  return <LazyOrgSettingsRoute workspaceId={workspaceId} checkout={checkout} />;
 }
 
 function AccountRedirect() {
@@ -352,12 +378,12 @@ function AccountRedirect() {
 
 function Device() {
   const { user_code } = deviceRoute.useSearch();
-  return <DeviceRoute userCode={user_code} />;
+  return <LazyDeviceRoute userCode={user_code} />;
 }
 
 function ResetPassword() {
   const { token } = resetPasswordRoute.useSearch();
-  return <ResetPasswordRoute token={token} />;
+  return <LazyResetPasswordRoute token={token} />;
 }
 
 function BillingReturnRoute() {

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -102,13 +102,14 @@ export function SessionList() {
     enabled: hierarchyMode,
   });
   const { sessions, nextCursor, loading, error, refresh } = rootPage;
-  const pinned = hierarchyMode ? globalPinPage.pinned : rootPage.pinned;
+  const { pinned: globalPinned, refresh: refreshGlobalPins } = globalPinPage;
+  const pinned = hierarchyMode ? globalPinned : rootPage.pinned;
   // The hierarchy and its global pinned shortcuts come from separate queries.
   // Every invalidation must refresh both or a pin changed in another tab/device
   // can disappear from the shortcut section until the next polling interval.
   const refreshSessionPages = useCallback(async () => {
-    await Promise.all([refresh(), ...(hierarchyMode ? [globalPinPage.refresh()] : [])]);
-  }, [globalPinPage.refresh, hierarchyMode, refresh]);
+    await Promise.all([refresh(), ...(hierarchyMode ? [refreshGlobalPins()] : [])]);
+  }, [hierarchyMode, refresh, refreshGlobalPins]);
   // Ordinary rows page independently of the complete pinned section. The
   // polled hook owns page one; additional pages are appended and deduplicated.
   // A filter change starts a fresh cursor chain rather than mixing snapshots.
@@ -337,9 +338,9 @@ export function SessionList() {
         (left, right) => sessionActivityTime(right.session) - sessionActivityTime(left.session),
       )) {
       const group = recencyGroupFor(sessionActivityTime(node.session));
-      const sessions = buckets.get(group) ?? [];
-      sessions.push(node);
-      buckets.set(group, sessions);
+      const groupSessions = buckets.get(group) ?? [];
+      groupSessions.push(node);
+      buckets.set(group, groupSessions);
     }
     return {
       running,
@@ -1523,10 +1524,17 @@ export function CollapsedSessionsButton() {
 }
 
 function SessionListSkeleton() {
+  const skeletonRows = [
+    "session-skeleton-1",
+    "session-skeleton-2",
+    "session-skeleton-3",
+    "session-skeleton-4",
+    "session-skeleton-5",
+  ];
   return (
     <div className="grid gap-1 px-1 pt-2">
-      {Array.from({ length: 5 }).map((_, index) => (
-        <div key={index} className="flex h-8 items-center gap-2 px-1">
+      {skeletonRows.map((rowKey) => (
+        <div key={rowKey} className="flex h-8 items-center gap-2 px-1">
           <span className="size-1.5 shrink-0 rounded-full bg-surface-3" />
           <span className="h-3 flex-1 animate-pulse rounded bg-surface-2" />
         </div>

--- a/apps/web/src/components/rigs/rig-definition-fields.tsx
+++ b/apps/web/src/components/rigs/rig-definition-fields.tsx
@@ -3,6 +3,7 @@
 // setup/definition edit that proposes a `definition_edit` change — one editor so
 // the two paths never drift.
 import { PlusIcon, Trash2Icon } from "lucide-react";
+import { useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,6 +35,15 @@ export function RigDefinitionFields({
   disabled?: boolean;
   idPrefix?: string;
 }) {
+  const checkKeys = useRef<string[]>([]);
+  const nextCheckKey = useRef(1);
+  while (checkKeys.current.length < value.checks.length) {
+    checkKeys.current.push(`${idPrefix}-check-row-${nextCheckKey.current}`);
+    nextCheckKey.current += 1;
+  }
+  if (checkKeys.current.length > value.checks.length) {
+    checkKeys.current.length = value.checks.length;
+  }
   const setChecks = (checks: RigCheck[]) => onChange({ ...value, checks });
   const toggleVariableSet = (id: string) => {
     const has = value.defaultVariableSetIds.includes(id);
@@ -101,10 +111,8 @@ export function RigDefinitionFields({
         ) : (
           <div className="grid gap-1.5">
             {value.checks.map((check, index) => (
-              // Index key: rows are positional and only edited/removed in place.
-              // eslint-disable-next-line react/no-array-index-key
               <div
-                key={index}
+                key={checkKeys.current[index]}
                 className="grid grid-cols-[10rem_minmax(0,1fr)_auto] items-center gap-1.5"
               >
                 <Input
@@ -142,7 +150,10 @@ export function RigDefinitionFields({
                   disabled={disabled}
                   aria-label={`Remove check ${index + 1}`}
                   className="hover:text-status-failed"
-                  onClick={() => setChecks(value.checks.filter((_, i) => i !== index))}
+                  onClick={() => {
+                    checkKeys.current.splice(index, 1);
+                    setChecks(value.checks.filter((_, i) => i !== index));
+                  }}
                 >
                   <Trash2Icon className="size-3.5" />
                 </Button>

--- a/apps/web/src/components/rigs/rig-overview.tsx
+++ b/apps/web/src/components/rigs/rig-overview.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { MetaChip } from "@/components/ui/meta-chip";
 import { Notice } from "@/components/ui/notice";
 import { formatTimestamp } from "@/lib/format";
+import { withOccurrenceKeys } from "@/lib/react-key";
 import { rigActorLabel, rigCheckHealthView, versionHasChecks } from "@/lib/rig-status";
 import type { Rig, RigChange, RigChangeVerification } from "@/types";
 
@@ -143,11 +144,11 @@ export function RigOverview({
         ) : (
           <div className="grid gap-1">
             <p className="text-xs text-fg-subtle">Not verified yet. The declared checks:</p>
-            {active.checks.map((check, index) => (
-              <div
-                key={`${check.name}-${index}`}
-                className="rounded-md border border-border/70 bg-bg/25 px-2.5 py-1.5"
-              >
+            {withOccurrenceKeys(
+              active.checks,
+              (check) => `${check.name}\u0000${check.command}`,
+            ).map(({ key, item: check }) => (
+              <div key={key} className="rounded-md border border-border/70 bg-bg/25 px-2.5 py-1.5">
                 <div className="truncate text-xs font-medium">{check.name}</div>
                 <div className="truncate font-mono text-2xs text-fg-subtle">{check.command}</div>
               </div>

--- a/apps/web/src/components/rigs/rig-versions-timeline.tsx
+++ b/apps/web/src/components/rigs/rig-versions-timeline.tsx
@@ -12,6 +12,7 @@ import { MetaChip } from "@/components/ui/meta-chip";
 import { StatusDot } from "@/components/ui/status-dot";
 import { formatTimestamp } from "@/lib/format";
 import { rigActorLabel } from "@/lib/rig-status";
+import { withOccurrenceKeys } from "@/lib/react-key";
 import { cn } from "@/lib/utils";
 import type { RigVersion } from "@/types";
 
@@ -173,9 +174,12 @@ function VersionRow({
               <span className="text-xs text-fg-subtle">None declared</span>
             ) : (
               <div className="grid gap-1">
-                {version.checks.map((check, index) => (
+                {withOccurrenceKeys(
+                  version.checks,
+                  (check) => `${check.name}\u0000${check.command}`,
+                ).map(({ key, item: check }) => (
                   <div
-                    key={`${check.name}-${index}`}
+                    key={key}
                     className="rounded-md border border-border/70 bg-bg/25 px-2.5 py-1.5"
                   >
                     <div className="truncate text-xs font-medium">{check.name}</div>

--- a/apps/web/src/components/rigs/verification-log.tsx
+++ b/apps/web/src/components/rigs/verification-log.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 
 import { StatusDot } from "@/components/ui/status-dot";
 import { formatTimestamp } from "@/lib/format";
+import { withOccurrenceKeys } from "@/lib/react-key";
 import { cn } from "@/lib/utils";
 import type { RigChangeVerification, RigCheckResult } from "@/types";
 
@@ -40,8 +41,12 @@ export function VerificationLog({ verification }: { verification: RigChangeVerif
       {checkResults.length > 0 ? (
         <div className="grid gap-1.5">
           <div className="text-2xs font-medium uppercase tracking-wide text-fg-subtle">Checks</div>
-          {checkResults.map((result, index) => (
-            <CheckResultRow key={`${result.name}-${index}`} result={result} />
+          {withOccurrenceKeys(
+            checkResults,
+            (result) =>
+              `${result.name}\u0000${result.command}\u0000${result.exitCode}\u0000${result.output}`,
+          ).map(({ key, item: result }) => (
+            <CheckResultRow key={key} result={result} />
           ))}
         </div>
       ) : null}

--- a/apps/web/src/components/session/inspector.tsx
+++ b/apps/web/src/components/session/inspector.tsx
@@ -14,6 +14,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { eventDisplayLabel, isTerminalSessionStatus, sanitizeEventForDisplay } from "@/lib/events";
 import { formatTimestamp } from "@/lib/format";
+import { withOccurrenceKeys } from "@/lib/react-key";
 import { repositoryDisplayName } from "@/lib/session-tools";
 import type { Session, SessionEvent } from "@/types";
 
@@ -148,29 +149,31 @@ export function SessionInspector(props: {
                   </p>
                 ) : (
                   <div className="min-w-0 space-y-2">
-                    {repositories.map((resource, index) => (
-                      <div
-                        key={`${resource.uri}:${index}`}
-                        className="min-w-0 rounded-md border border-border bg-bg/35 p-2"
-                      >
-                        <div className="min-w-0 truncate text-xs font-medium">
-                          {repositoryDisplayName(resource)}
-                        </div>
-                        <div className="mt-1 min-w-0 truncate font-mono text-2xs text-fg-subtle">
-                          {resource.uri}
-                        </div>
-                        <div className="mt-2 flex min-w-0 flex-wrap gap-1.5 text-2xs text-fg-subtle">
-                          <span className="max-w-full truncate rounded border border-border px-1.5 py-0.5">
-                            ref {resource.ref}
-                          </span>
-                          {resource.mountPath ? (
+                    {withOccurrenceKeys(repositories, (resource) => JSON.stringify(resource)).map(
+                      ({ key, item: resource }) => (
+                        <div
+                          key={key}
+                          className="min-w-0 rounded-md border border-border bg-bg/35 p-2"
+                        >
+                          <div className="min-w-0 truncate text-xs font-medium">
+                            {repositoryDisplayName(resource)}
+                          </div>
+                          <div className="mt-1 min-w-0 truncate font-mono text-2xs text-fg-subtle">
+                            {resource.uri}
+                          </div>
+                          <div className="mt-2 flex min-w-0 flex-wrap gap-1.5 text-2xs text-fg-subtle">
                             <span className="max-w-full truncate rounded border border-border px-1.5 py-0.5">
-                              {resource.mountPath}
+                              ref {resource.ref}
                             </span>
-                          ) : null}
+                            {resource.mountPath ? (
+                              <span className="max-w-full truncate rounded border border-border px-1.5 py-0.5">
+                                {resource.mountPath}
+                              </span>
+                            ) : null}
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      ),
+                    )}
                   </div>
                 )}
               </InspectorSection>

--- a/apps/web/src/context-callback.test.tsx
+++ b/apps/web/src/context-callback.test.tsx
@@ -1,0 +1,102 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, Suspense, useLayoutEffect } from "react";
+import { createRoot } from "react-dom/client";
+
+import { useLatestCallback } from "./context";
+
+GlobalRegistrator.register();
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+describe("useLatestCallback", () => {
+  test("keeps one identity while dispatching to the latest render", async () => {
+    let current: (() => string) | null = null;
+
+    function Harness({ value }: { value: string }) {
+      current = useLatestCallback(() => value);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => root.render(<Harness value="first" />));
+    const initial = current as unknown as () => string;
+
+    expect(initial()).toBe("first");
+
+    await act(async () => root.render(<Harness value="second" />));
+
+    expect(current as unknown as () => string).toBe(initial);
+    expect(initial()).toBe("second");
+    await act(async () => root.unmount());
+  });
+
+  test("never exposes a callback from a suspended, uncommitted render", async () => {
+    let current: (() => string) | null = null;
+    let blocked = false;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    function Harness({ value }: { value: string }) {
+      current = useLatestCallback(() => value);
+      return null;
+    }
+
+    function CommitGate() {
+      if (blocked) throw gate;
+      return null;
+    }
+
+    const view = (value: string) => (
+      <Suspense fallback={null}>
+        <Harness value={value} />
+        <CommitGate />
+      </Suspense>
+    );
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => root.render(view("committed")));
+    const committed = current as unknown as () => string;
+
+    blocked = true;
+    act(() => root.render(view("not-committed")));
+    expect(current as unknown as () => string).toBe(committed);
+    expect(committed()).toBe("committed");
+
+    blocked = false;
+    await act(async () => release());
+    expect(committed()).toBe("not-committed");
+    await act(async () => root.unmount());
+  });
+
+  test("publishes the committed body before descendant layout effects run", async () => {
+    const observed: string[] = [];
+
+    function Observer({ read }: { read: () => string }) {
+      useLayoutEffect(() => {
+        observed.push(read());
+      });
+      return null;
+    }
+
+    function Harness({ value }: { value: string }) {
+      const read = useLatestCallback(() => value);
+      return <Observer read={read} />;
+    }
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => root.render(<Harness value="first" />));
+    await act(async () => root.render(<Harness value="second" />));
+
+    expect(observed).toEqual(["first", "second"]);
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useState,
@@ -170,6 +171,19 @@ export type AppContextValue = {
 
 const AppContext = createContext<AppContextValue | null>(null);
 
+/** Stable event identity that dispatches only to the latest committed body. */
+export function useLatestCallback<Args extends unknown[], Result>(
+  callback: (...args: Args) => Result,
+): (...args: Args) => Result {
+  const callbackRef = useRef(callback);
+  // Insertion effects run at commit before descendant layout effects can invoke
+  // an event. A suspended/abandoned render therefore cannot leak its body.
+  useInsertionEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+  return useCallback((...args: Args) => callbackRef.current(...args), []);
+}
+
 export function useAppContext(): AppContextValue {
   const value = useContext(AppContext);
   if (!value) {
@@ -266,7 +280,12 @@ export function RootRouteComponent() {
   // The @opengeni/sdk client behind every console API call and hook. Auth
   // headers are read per request; a new identity per key version makes the
   // hooks re-fetch and the event streams reconnect with the new credentials.
-  const client = useMemo(() => createOpenGeniClient(), [accessKeyVersion]);
+  const client = useMemo(() => {
+    // The version is an explicit identity fence: credentials are read lazily,
+    // but consumers need a new client object to reconnect hooks and streams.
+    void accessKeyVersion;
+    return createOpenGeniClient();
+  }, [accessKeyVersion]);
   const setSession = useCallback<Dispatch<SetStateAction<Session | null>>>((value) => {
     setSessionState((current) => {
       const next =
@@ -590,62 +609,64 @@ export function RootRouteComponent() {
     return true;
   }
 
-  async function refreshGitHub(
-    workspaceId: string,
-    signal?: AbortSignal,
-    options?: { sync?: boolean },
-  ) {
-    const refreshId = githubRefreshId.current + 1;
-    githubRefreshId.current = refreshId;
-    setRepoBusy(true);
-    try {
-      const status = await client.getGitHubApp(workspaceId);
-      if (signal?.aborted || githubRefreshId.current !== refreshId) {
-        return;
-      }
-      setGithubStatus({
-        configured: status.configured,
-        missing: status.missing,
-        installUrl: status.installUrl,
-      });
-      setGithubAppOpen(!status.configured);
-      if (status.configured) {
-        // Explicit refreshes re-sync from GitHub (POST /github/repositories/sync)
-        // so installations changed after connect show up; passive loads read
-        // OpenGeni's cached rows.
-        const { repositories } = options?.sync
-          ? await client.syncGitHubRepositories(workspaceId)
-          : await client.listGitHubRepositories(workspaceId);
+  const refreshGitHub = useCallback(
+    async (workspaceId: string, signal?: AbortSignal, options?: { sync?: boolean }) => {
+      const refreshId = githubRefreshId.current + 1;
+      githubRefreshId.current = refreshId;
+      setRepoBusy(true);
+      try {
+        const status = await client.getGitHubApp(workspaceId);
         if (signal?.aborted || githubRefreshId.current !== refreshId) {
           return;
         }
-        setGithubRepos(repositories);
-      } else {
+        setGithubStatus({
+          configured: status.configured,
+          missing: status.missing,
+          installUrl: status.installUrl,
+        });
+        setGithubAppOpen(!status.configured);
+        if (status.configured) {
+          // Explicit refreshes re-sync from GitHub (POST /github/repositories/sync)
+          // so installations changed after connect show up; passive loads read
+          // OpenGeni's cached rows.
+          const { repositories } = options?.sync
+            ? await client.syncGitHubRepositories(workspaceId)
+            : await client.listGitHubRepositories(workspaceId);
+          if (signal?.aborted || githubRefreshId.current !== refreshId) {
+            return;
+          }
+          setGithubRepos(repositories);
+        } else {
+          setGithubRepos([]);
+        }
+      } catch (error) {
+        if (isAbortError(error) || signal?.aborted || githubRefreshId.current !== refreshId) {
+          return;
+        }
+        setGithubStatus({ configured: false, missing: [], installUrl: null });
         setGithubRepos([]);
+        toast.error("GitHub status unavailable", { description: String(error) });
+      } finally {
+        if (githubRefreshId.current === refreshId) {
+          setRepoBusy(false);
+        }
       }
-    } catch (error) {
-      if (isAbortError(error) || signal?.aborted || githubRefreshId.current !== refreshId) {
+    },
+    [client],
+  );
+
+  const refreshWorkspaceMcpServers = useCallback(
+    async (workspaceId: string, signal?: AbortSignal) => {
+      const refreshId = mcpRefreshId.current + 1;
+      mcpRefreshId.current = refreshId;
+      const catalog = await client.listCapabilities(workspaceId);
+      if (signal?.aborted || mcpRefreshId.current !== refreshId) {
         return;
       }
-      setGithubStatus({ configured: false, missing: [], installUrl: null });
-      setGithubRepos([]);
-      toast.error("GitHub status unavailable", { description: String(error) });
-    } finally {
-      if (githubRefreshId.current === refreshId) {
-        setRepoBusy(false);
-      }
-    }
-  }
-
-  async function refreshWorkspaceMcpServers(workspaceId: string, signal?: AbortSignal) {
-    const refreshId = mcpRefreshId.current + 1;
-    mcpRefreshId.current = refreshId;
-    const catalog = await client.listCapabilities(workspaceId);
-    if (signal?.aborted || mcpRefreshId.current !== refreshId) {
-      return;
-    }
-    setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
-  }
+      setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
+    },
+    [client],
+  );
 
   async function startSession(
     workspaceId: string,
@@ -811,29 +832,48 @@ export function RootRouteComponent() {
     await navigate({ to: "/", replace: true });
   }
 
-  function resetSessionView() {
+  const resetSessionView = useCallback(() => {
     setSession(null);
     setConnectionState("idle");
-  }
+  }, [setSession]);
 
   // Session-scoped model: read the session's override or fall back to the
   // deployment default; writing records it without disturbing other sessions
   // (or the new-session surface, which reads the bare `model`).
-  function modelForSession(sessionId: string): string {
-    return modelBySession[sessionId] ?? model;
-  }
-  function setModelForSession(sessionId: string, value: string): void {
+  const modelForSession = useCallback(
+    (sessionId: string): string => modelBySession[sessionId] ?? model,
+    [model, modelBySession],
+  );
+  const setModelForSession = useCallback((sessionId: string, value: string): void => {
     setModelBySession((current) => ({ ...current, [sessionId]: value }));
-  }
+  }, []);
 
-  function resetWorkspaceIntegrations() {
+  const resetWorkspaceIntegrations = useCallback(() => {
     setGithubStatus(null);
     setGithubRepos([]);
     setWorkspaceMcpServers([]);
-  }
+  }, []);
 
-  const appContext =
-    clientConfig && accessContext
+  // Context actions keep one identity while reading the newest committed state
+  // through the callback ref. This prevents unrelated provider renders
+  // (for example, an access-key draft keystroke) from invalidating the entire
+  // routed application tree.
+  const contextAddManualRepository = useLatestCallback(addManualRepository);
+  const contextForgetAccessKey = useLatestCallback(forgetAccessKey);
+  const contextHandleManagedSignOut = useLatestCallback(handleManagedSignOut);
+  const contextCreateWorkspace = useLatestCallback(createWorkspace);
+  const contextRenameWorkspace = useLatestCallback(renameWorkspace);
+  const contextUpdateWorkspaceSettings = useLatestCallback(updateWorkspaceSettings);
+  const contextSetWorkspaceDefaultRig = useLatestCallback(setWorkspaceDefaultRig);
+  const contextUpdateSessionTitle = useLatestCallback(updateSessionTitle);
+  const contextUpdateSessionPin = useLatestCallback(updateSessionPin);
+  const contextDeleteWorkspace = useLatestCallback(deleteWorkspace);
+  const contextStartGitHubAppManifestFlow = useLatestCallback(startGitHubAppManifestFlow);
+  const contextToggleGitHubRepository = useLatestCallback(toggleGitHubRepository);
+  const contextStartSession = useLatestCallback(startSession);
+
+  const appContext = useMemo<AppContextValue | null>(() => {
+    return clientConfig && accessContext
       ? ({
           client,
           clientConfig,
@@ -877,25 +917,75 @@ export function RootRouteComponent() {
           repositoryGroups,
           toolMcpServers,
           currentResources,
-          addManualRepository,
-          forgetAccessKey,
-          handleManagedSignOut,
-          createWorkspace,
-          renameWorkspace,
-          updateWorkspaceSettings,
-          setWorkspaceDefaultRig,
-          updateSessionTitle,
-          updateSessionPin,
-          deleteWorkspace,
+          addManualRepository: contextAddManualRepository,
+          forgetAccessKey: contextForgetAccessKey,
+          handleManagedSignOut: contextHandleManagedSignOut,
+          createWorkspace: contextCreateWorkspace,
+          renameWorkspace: contextRenameWorkspace,
+          updateWorkspaceSettings: contextUpdateWorkspaceSettings,
+          setWorkspaceDefaultRig: contextSetWorkspaceDefaultRig,
+          updateSessionTitle: contextUpdateSessionTitle,
+          updateSessionPin: contextUpdateSessionPin,
+          deleteWorkspace: contextDeleteWorkspace,
           refreshGitHub,
           refreshWorkspaceMcpServers,
-          startGitHubAppManifestFlow,
-          toggleGitHubRepository,
-          startSession,
+          startGitHubAppManifestFlow: contextStartGitHubAppManifestFlow,
+          toggleGitHubRepository: contextToggleGitHubRepository,
+          startSession: contextStartSession,
           resetSessionView,
           resetWorkspaceIntegrations,
         } satisfies AppContextValue)
       : null;
+  }, [
+    accessContext,
+    accessKeyVersion,
+    authSession,
+    busy,
+    client,
+    clientConfig,
+    connectionState,
+    contextAddManualRepository,
+    contextCreateWorkspace,
+    contextDeleteWorkspace,
+    contextForgetAccessKey,
+    contextHandleManagedSignOut,
+    contextRenameWorkspace,
+    contextSetWorkspaceDefaultRig,
+    contextStartGitHubAppManifestFlow,
+    contextStartSession,
+    contextToggleGitHubRepository,
+    contextUpdateSessionPin,
+    contextUpdateSessionTitle,
+    contextUpdateWorkspaceSettings,
+    currentResources,
+    githubAppBusy,
+    githubAppOpen,
+    githubOrg,
+    githubRepos,
+    githubStatus,
+    inspectorOpen,
+    keyAuthRequired,
+    manualRepos,
+    manualReposOpen,
+    model,
+    modelForSession,
+    reasoningEffort,
+    refreshGitHub,
+    refreshWorkspaceMcpServers,
+    repoBusy,
+    repositoryGroups,
+    resetSessionView,
+    resetWorkspaceIntegrations,
+    selectedCapabilityToolIds,
+    selectedInstallationId,
+    selectedRepoIds,
+    selectedRepoRefs,
+    session,
+    setModelForSession,
+    setSession,
+    toolMcpServers,
+    workspaces,
+  ]);
 
   return (
     <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-bg text-fg">

--- a/apps/web/src/lib/react-key.test.ts
+++ b/apps/web/src/lib/react-key.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { withOccurrenceKeys } from "./react-key";
+
+describe("withOccurrenceKeys", () => {
+  test("is deterministic and keeps duplicate content unique", () => {
+    const items = [{ name: "same" }, { name: "same" }, { name: "other" }];
+
+    const first = withOccurrenceKeys(items, (item) => item.name);
+    const second = withOccurrenceKeys(items, (item) => item.name);
+
+    expect(first.map(({ key }) => key)).toEqual(["same\u00001", "same\u00002", "other\u00001"]);
+    expect(second.map(({ key }) => key)).toEqual(first.map(({ key }) => key));
+    expect(first.map(({ item }) => item)).toEqual(items);
+  });
+
+  test("preserves content identity when unrelated rows are inserted", () => {
+    const before = withOccurrenceKeys(["alpha", "omega"], (item) => item);
+    const after = withOccurrenceKeys(["alpha", "middle", "omega"], (item) => item);
+
+    expect(after[0]?.key).toBe(before[0]?.key);
+    expect(after[2]?.key).toBe(before[1]?.key);
+  });
+});

--- a/apps/web/src/lib/react-key.ts
+++ b/apps/web/src/lib/react-key.ts
@@ -1,0 +1,19 @@
+/**
+ * Attach deterministic, duplicate-safe React keys to a rendered list.
+ *
+ * Content identifies an item across insertions and reorders; the occurrence
+ * suffix keeps intentionally duplicated rows unique without falling back to an
+ * array index.
+ */
+export function withOccurrenceKeys<T>(
+  items: readonly T[],
+  contentKey: (item: T) => string,
+): Array<{ key: string; item: T }> {
+  const occurrences = new Map<string, number>();
+  return items.map((item) => {
+    const content = contentKey(item);
+    const occurrence = (occurrences.get(content) ?? 0) + 1;
+    occurrences.set(content, occurrence);
+    return { key: `${content}\u0000${occurrence}`, item };
+  });
+}

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -795,8 +795,17 @@ export function CapabilitiesRoute({
 
               {catalogView === "loading" ? (
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                  {Array.from({ length: 8 }).map((_, index) => (
-                    <div key={index} className="rounded-xl border border-border bg-surface/50 p-4">
+                  {[
+                    "catalog-skeleton-1",
+                    "catalog-skeleton-2",
+                    "catalog-skeleton-3",
+                    "catalog-skeleton-4",
+                    "catalog-skeleton-5",
+                    "catalog-skeleton-6",
+                    "catalog-skeleton-7",
+                    "catalog-skeleton-8",
+                  ].map((rowKey) => (
+                    <div key={rowKey} className="rounded-xl border border-border bg-surface/50 p-4">
                       <Skeleton className="size-10 rounded-lg" />
                       <Skeleton className="mt-3 h-4 w-24" />
                       <Skeleton className="mt-2 h-3 w-full" />

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
@@ -100,9 +100,40 @@ export function DocumentsRoute({
     count: documents.length,
   });
 
+  const refreshBases = useCallback(async () => {
+    setBasesLoading(true);
+    try {
+      const next = await client.listDocumentBases(workspaceId);
+      setBases(next);
+      setBasesError(null);
+      setSelectedBaseId((current) => current ?? next[0]?.id ?? null);
+    } catch (error) {
+      setBasesError(error instanceof Error ? error : new Error(String(error)));
+      toast.error("Failed to load document bases", { description: String(error) });
+    } finally {
+      setBasesLoading(false);
+    }
+  }, [client, workspaceId]);
+
+  const refreshDocuments = useCallback(
+    async (baseId: string) => {
+      setDocumentsLoading(true);
+      try {
+        setDocuments(await client.listDocuments(workspaceId, baseId));
+        setDocumentsError(null);
+      } catch (error) {
+        setDocumentsError(error instanceof Error ? error : new Error(String(error)));
+        toast.error("Failed to load documents", { description: String(error) });
+      } finally {
+        setDocumentsLoading(false);
+      }
+    },
+    [client, workspaceId],
+  );
+
   useEffect(() => {
     void refreshBases();
-  }, [workspaceId]);
+  }, [refreshBases]);
 
   useEffect(() => {
     setResults([]);
@@ -114,7 +145,7 @@ export function DocumentsRoute({
       return;
     }
     void refreshDocuments(selectedBaseId);
-  }, [workspaceId, selectedBaseId]);
+  }, [selectedBaseId, refreshDocuments]);
 
   useEffect(() => {
     if (
@@ -133,35 +164,7 @@ export function DocumentsRoute({
         .catch(() => setPollFailed(true));
     }, 1200);
     return () => window.clearInterval(timer);
-  }, [workspaceId, selectedBaseId, documents]);
-
-  async function refreshBases() {
-    setBasesLoading(true);
-    try {
-      const next = await client.listDocumentBases(workspaceId);
-      setBases(next);
-      setBasesError(null);
-      setSelectedBaseId((current) => current ?? next[0]?.id ?? null);
-    } catch (error) {
-      setBasesError(error instanceof Error ? error : new Error(String(error)));
-      toast.error("Failed to load document bases", { description: String(error) });
-    } finally {
-      setBasesLoading(false);
-    }
-  }
-
-  async function refreshDocuments(baseId: string) {
-    setDocumentsLoading(true);
-    try {
-      setDocuments(await client.listDocuments(workspaceId, baseId));
-      setDocumentsError(null);
-    } catch (error) {
-      setDocumentsError(error instanceof Error ? error : new Error(String(error)));
-      toast.error("Failed to load documents", { description: String(error) });
-    } finally {
-      setDocumentsLoading(false);
-    }
-  }
+  }, [client, workspaceId, selectedBaseId, documents]);
 
   async function handleCreateBase() {
     const trimmed = name.trim();

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -14,7 +14,7 @@ import {
   SettingsIcon,
   UsersIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
@@ -64,25 +64,7 @@ export function OrgSettingsRoute({
     enabled: canReadBilling && Boolean(accountId),
   });
 
-  useEffect(() => {
-    if (!workspaceId) {
-      return;
-    }
-    void refresh();
-  }, [workspaceId, accountId]);
-
-  // Confirm the Stripe checkout outcome the /billing return redirect forwarded
-  // here. Credits post via the asynchronous webhook, so success is phrased as
-  // "shortly" rather than implying the balance already reflects the top-up.
-  useEffect(() => {
-    if (checkout === "success") {
-      toast.success("Payment received", { description: "Your credits will appear shortly." });
-    } else if (checkout === "cancelled") {
-      toast("Checkout cancelled", { description: "No charge was made." });
-    }
-  }, [checkout]);
-
-  async function refreshBilling() {
+  const refreshBilling = useCallback(async () => {
     if (!accountId || !canReadBilling) {
       setBilling(null);
       setBillingError(null);
@@ -98,9 +80,9 @@ export function OrgSettingsRoute({
     } finally {
       setBillingLoading(false);
     }
-  }
+  }, [accountId, canReadBilling, client]);
 
-  async function refreshEntitlements() {
+  const refreshEntitlements = useCallback(async () => {
     if (!accountId || !canReadBilling) {
       setEntitlements(null);
       setEntitlementsError(null);
@@ -113,11 +95,29 @@ export function OrgSettingsRoute({
       setEntitlements(null);
       setEntitlementsError(error instanceof Error ? error : new Error(String(error)));
     }
-  }
+  }, [accountId, canReadBilling, client]);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     await Promise.all([refreshBilling(), refreshEntitlements()]);
-  }
+  }, [refreshBilling, refreshEntitlements]);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+    void refresh();
+  }, [workspaceId, refresh]);
+
+  // Confirm the Stripe checkout outcome the /billing return redirect forwarded
+  // here. Credits post via the asynchronous webhook, so success is phrased as
+  // "shortly" rather than implying the balance already reflects the top-up.
+  useEffect(() => {
+    if (checkout === "success") {
+      toast.success("Payment received", { description: "Your credits will appear shortly." });
+    } else if (checkout === "cancelled") {
+      toast("Checkout cancelled", { description: "No charge was made." });
+    }
+  }, [checkout]);
 
   async function startCheckout(amountUsd: number) {
     setBusy(true);

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -15,7 +15,7 @@ import {
   WrenchIcon,
   ZapIcon,
 } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
@@ -68,15 +68,11 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
   // as an error with retry — never as the "No scheduled tasks." empty state.
   const tasksView = listViewState({ loading, error: loadError, count: tasks.length });
 
-  useEffect(() => {
-    void refresh();
-  }, [workspaceId]);
-
   // Handles its own failures (error state + toast) so a post-mutation reload
   // error can never masquerade as a failed mutation in the callers' catch
   // blocks. The toast still fires because a failed refresh with tasks already
   // on screen keeps rendering the stale list.
-  async function refresh() {
+  const refresh = useCallback(async () => {
     setLoading(true);
     try {
       const next = await client.listScheduledTasks(workspaceId);
@@ -106,7 +102,11 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
     } finally {
       setLoading(false);
     }
-  }
+  }, [client, workspaceId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
 
   // Retry a single task's run history after a failed load, without reloading
   // the whole list.

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -142,22 +142,23 @@ export function SessionRoute({
       session && (session.status === "failed" || creditExhausted)
         ? summarizeSessionFailure(events, session.status)
         : null,
-    [events, session?.status, creditExhausted],
+    [events, session, creditExhausted],
   );
 
   // Keep the workspace header (title, status badge, connection pill) in sync.
+  const { setSession: setContextSession, setConnectionState: setContextConnectionState } = context;
   useEffect(() => {
-    context.setSession(session);
-  }, [session]);
+    setContextSession(session);
+  }, [session, setContextSession]);
   useEffect(() => {
-    context.setConnectionState(connectionState);
-  }, [connectionState]);
+    setContextConnectionState(connectionState);
+  }, [connectionState, setContextConnectionState]);
   useEffect(
     () => () => {
-      context.setSession(null);
-      context.setConnectionState("idle");
+      setContextSession(null);
+      setContextConnectionState("idle");
     },
-    [],
+    [setContextConnectionState, setContextSession],
   );
   useEffect(() => {
     if (streamError && !isApiErrorStatus(streamError, 404)) {

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -74,13 +74,14 @@ export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
   const navigate = useNavigate();
   const attachments = useDraftAttachments(workspaceId);
+  const { resetSessionView } = context;
   const [message, setMessage] = useState("");
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [draft, setDraft] = useState<SessionDraft>(() => emptySessionDraft());
 
   useEffect(() => {
-    context.resetSessionView();
-  }, [workspaceId]);
+    resetSessionView();
+  }, [resetSessionView, workspaceId]);
 
   const computeReady = isSessionDraftComputeReady(draft);
 

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -20,7 +20,7 @@ import {
   UserPlusIcon,
   UsersIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { CodexSubscriptionsCard } from "@/components/codex-connection";
@@ -113,14 +113,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
     setNameDraft(activeWorkspace?.name ?? "");
   }, [activeWorkspace?.id, activeWorkspace?.name]);
 
-  useEffect(() => {
-    if (!workspaceId) {
-      return;
-    }
-    void refreshApiKeys();
-  }, [workspaceId]);
-
-  async function refreshApiKeys() {
+  const refreshApiKeys = useCallback(async () => {
     if (!canManageApiKeys) {
       setApiKeys([]);
       setApiKeysError(null);
@@ -136,7 +129,14 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
     } finally {
       setApiKeysLoaded(true);
     }
-  }
+  }, [canManageApiKeys, client, workspaceId]);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+    void refreshApiKeys();
+  }, [refreshApiKeys, workspaceId]);
 
   async function submitRename() {
     const name = nameDraft.trim();
@@ -491,11 +491,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   // section above and are excluded here.
   const userMembers = members.filter((member) => member.subjectId.startsWith("user:"));
 
-  useEffect(() => {
-    void refresh();
-  }, [workspaceId]);
-
-  async function refresh() {
+  const refresh = useCallback(async () => {
     try {
       setMembers(await client.listWorkspaceMembers(workspaceId));
       setError(null);
@@ -505,7 +501,11 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
     } finally {
       setLoaded(true);
     }
-  }
+  }, [client, workspaceId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
 
   async function addMember() {
     const trimmed = email.trim();

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -17,28 +17,48 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
   const activeWorkspace =
     context.workspaces.find((workspace) => workspace.id === workspaceId) ?? null;
+  const activeWorkspaceId = activeWorkspace?.id ?? null;
+  const {
+    accessKeyVersion,
+    resetSessionView,
+    resetWorkspaceIntegrations,
+    setSelectedRepoIds,
+    setSelectedRepoRefs,
+    refreshGitHub,
+    refreshWorkspaceMcpServers,
+  } = context;
   const previousWorkspaceId = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!activeWorkspace) {
+    if (!activeWorkspaceId) {
       return;
     }
     const abortController = new AbortController();
     if (previousWorkspaceId.current !== workspaceId) {
-      context.resetSessionView();
+      resetSessionView();
     }
     previousWorkspaceId.current = workspaceId;
-    context.resetWorkspaceIntegrations();
-    context.setSelectedRepoIds(new Set());
-    context.setSelectedRepoRefs({});
-    void context.refreshGitHub(workspaceId, abortController.signal);
-    void context.refreshWorkspaceMcpServers(workspaceId, abortController.signal).catch((error) => {
+    resetWorkspaceIntegrations();
+    setSelectedRepoIds(new Set());
+    setSelectedRepoRefs({});
+    void refreshGitHub(workspaceId, abortController.signal);
+    void refreshWorkspaceMcpServers(workspaceId, abortController.signal).catch((error) => {
       if (!isAbortError(error)) {
         toast.error("Failed to load workspace MCP tools", { description: String(error) });
       }
     });
     return () => abortController.abort();
-  }, [workspaceId, context.accessKeyVersion, activeWorkspace?.id]);
+  }, [
+    accessKeyVersion,
+    activeWorkspaceId,
+    refreshGitHub,
+    refreshWorkspaceMcpServers,
+    resetSessionView,
+    resetWorkspaceIntegrations,
+    setSelectedRepoIds,
+    setSelectedRepoRefs,
+    workspaceId,
+  ]);
 
   if (!activeWorkspace) {
     return (

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,6 +12,13 @@ const allowedHosts = process.env.OPENGENI_WEB_ALLOWED_HOSTS?.split(",")
   .filter(Boolean);
 
 export default defineConfig({
+  build: {
+    // Vite's default 500 kB raw threshold misclassifies deliberately lazy
+    // syntax/WASM assets. The post-build budget gate measures the recursive
+    // initial graph and every chunk by gzip size; 800 kB remains a hard raw cap.
+    chunkSizeWarningLimit: 800,
+    manifest: true,
+  },
   server: {
     port: 3000,
     ...(allowedHosts?.length ? { allowedHosts } : {}),

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -1394,12 +1394,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         await publish(lifecycleEvents).catch(() => undefined);
       }
     };
-    const publishSandboxLost = async (input: { instanceId: string }): Promise<void> => {
+    const publishSandboxLost = async (lostSandbox: { instanceId: string }): Promise<void> => {
       if (!publish) return;
       await publish([
         {
           type: "sandbox.box.lost",
-          payload: { sandboxId: input.instanceId },
+          payload: { sandboxId: lostSandbox.instanceId },
         },
       ]).catch((publishError) => {
         // The lease transition is already authoritative. A fenced/failed audit

--- a/apps/worker/test/packs.test.ts
+++ b/apps/worker/test/packs.test.ts
@@ -151,9 +151,9 @@ describe("rig sandbox image precedence (M3): rig > pack > deployment", () => {
     { rig: null, pack: null, expected: DEPLOYMENT, expectModal: undefined }, // deployment default
   ];
 
-  for (const { rig, pack, expected, expectModal } of matrix) {
-    test(`rig=${rig ? "set" : "none"} pack=${pack ? "set" : "none"} → ${expected}`, () => {
-      const resolved = resolve(rig, pack);
+  for (const { rig, pack: packImage, expected, expectModal } of matrix) {
+    test(`rig=${rig ? "set" : "none"} pack=${packImage ? "set" : "none"} → ${expected}`, () => {
+      const resolved = resolve(rig, packImage);
       expect(resolved.dockerImage).toBe(expected);
       expect(resolved.modalImageRef).toBe(expectModal as never);
     });

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -1308,7 +1308,7 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
       establishSandboxSessionFromEnvelope,
       serializeEstablishedSandboxEnvelope,
     } = await import("@opengeni/runtime");
-    const client = createSandboxClientForBackend("modal", settings) as {
+    const modalClient = createSandboxClientForBackend("modal", settings) as {
       backendId: string;
       delete?: (state: unknown) => Promise<unknown>;
       serializeSessionState?: (state: unknown) => Promise<Record<string, unknown>>;
@@ -1346,8 +1346,8 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     } finally {
       // Defensive: ensure the box is gone even if the reaper path didn't run it.
       try {
-        if (established && client.delete) {
-          await client.delete(established.sessionState);
+        if (established && modalClient.delete) {
+          await modalClient.delete(established.sessionState);
         }
       } catch {
         /* already terminated */

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "tailwindcss": "^4.2.4",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "20.10.2",
         "@tanstack/react-router-devtools": "^1.167.0",
         "@tanstack/router-plugin": "^1.168.18",
         "@types/node": "^25.6.0",

--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -180,6 +180,10 @@ with a warm cache. Reports include p50, p75, p95, p99, and worst observation.
 | Main-thread long tasks | No workbench task > 50 ms during ordinary interaction |
 | Memory | No monotonic growth across 100 session switches, 100 file opens, or 20 terminal attach/detach cycles |
 | Network | No duplicate identity-equivalent fetch and no request left alive after its identity is obsolete |
+| Initial web asset graph | ≤ 750 KiB raw and ≤ 210 KiB gzip, including HTML, CSS, and recursive static imports |
+| Direct session asset graph | ≤ 1,900 KiB raw and ≤ 540 KiB gzip before optional editor/diff/terminal chunks |
+| Lazy JavaScript chunk | ≤ 800 KiB raw and ≤ 240 KiB gzip |
+| CSS asset | ≤ 30 KiB gzip |
 
 Measure representative high-, mid-, and low-end desktop hardware plus current
 iOS and Android devices. Include a 4× CPU slowdown and constrained-network run.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "catalog:refresh": "bun scripts/refresh-integrations-catalog.ts",
     "catalog:import": "set -a; [ -f .env ] && . ./.env; set +a; bun scripts/import-integrations-catalog.ts",
     "typecheck": "bun scripts/typecheck.ts",
-    "lint": "oxlint",
+    "lint": "oxlint --deny-warnings .",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "format:check": "oxfmt --check",
     "test": "bun test",
     "test:unit": "bun test",
+    "test:react:clean": "bun scripts/test-react-clean.ts",
     "test:integration": "bun test --timeout 30000 ./test/integration/api.integration.ts && bun test --timeout 60000 ./test/integration/file-upload.integration.ts && bun test --timeout 30000 ./test/integration/db.integration.ts && bun test --timeout 30000 ./test/integration/nats.integration.ts && bun test --timeout 30000 ./test/integration/selfhosted-control-transport.integration.ts && bun test --timeout 120000 ./test/integration/selfhosted-auth-callout.integration.ts && bun test --timeout 30000 ./test/integration/workspace-isolation.integration.ts && bun test --timeout 30000 ./test/integration/temporal-workflow.integration.ts && bun test --timeout 300000 ./test/integration/durable-queue-control.integration.ts && bun test --timeout 30000 ./test/integration/worker-activity.integration.ts && bun test --timeout 30000 ./test/integration/worker-restart.integration.ts",
     "test:e2e": "bun scripts/run-browser-e2e.ts && bun test ./test/e2e/sandbox.e2e.ts && bun test --timeout 360000 ./test/e2e/rig-setup.e2e.ts && bun test --timeout 360000 ./test/e2e/channel-a.e2e.ts && bun test --timeout 2100000 ./apps/worker/test/desktop-image.e2e.ts",
     "test:live": "bun test ./test/live/*.live.ts",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1884,7 +1884,7 @@ export function parseMcpServers(raw: string | undefined): unknown[] | undefined 
     return parsed;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_MCP_SERVERS must be a JSON array: ${message}`);
+    throw new Error(`OPENGENI_MCP_SERVERS must be a JSON array: ${message}`, { cause: error });
   }
 }
 
@@ -1897,7 +1897,7 @@ export function parseModelPricingJson(raw: string): Record<string, ModelPricing>
     parsed = JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_MODEL_PRICING_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_MODEL_PRICING_JSON must be valid JSON: ${message}`, { cause: error });
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("OPENGENI_MODEL_PRICING_JSON must be a JSON object keyed by model name");
@@ -1927,6 +1927,7 @@ export function parseSandboxWarmRateJson(raw: string): Record<string, number> {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
       `OPENGENI_SANDBOX_WARM_RATE_MICROS_PER_SECOND_JSON must be valid JSON: ${message}`,
+      { cause: error },
     );
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -1973,7 +1974,9 @@ export function parseModelProvidersJson(raw: string): RegistryProvider[] {
     parsed = JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_MODEL_PROVIDERS_JSON must be valid JSON: ${message}`, {
+      cause: error,
+    });
   }
   if (!Array.isArray(parsed)) {
     throw new Error("OPENGENI_MODEL_PROVIDERS_JSON must be a JSON array of providers");
@@ -2000,7 +2003,9 @@ export function parseIntegrationsOauthClientsJson(
     parsed = JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_INTEGRATIONS_OAUTH_CLIENTS_JSON must be valid JSON: ${message}`, {
+      cause: error,
+    });
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(
@@ -2032,7 +2037,9 @@ export function parseStaticUsageLimitsJson(raw: string): StaticUsageLimitsConfig
     parsed = JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_STATIC_USAGE_LIMITS_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_STATIC_USAGE_LIMITS_JSON must be valid JSON: ${message}`, {
+      cause: error,
+    });
   }
   return StaticUsageLimits.parse(parsed);
 }
@@ -2046,7 +2053,9 @@ export function parseStaticEntitlementsJson(raw: string): EntitlementsConfig {
     parsed = JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_STATIC_ENTITLEMENTS_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_STATIC_ENTITLEMENTS_JSON must be valid JSON: ${message}`, {
+      cause: error,
+    });
   }
   return Entitlements.parse(parsed);
 }
@@ -2694,7 +2703,9 @@ function parseGcsCredentialsJson(raw: string): unknown {
     return JSON.parse(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`OPENGENI_OBJECT_STORAGE_GCS_CREDENTIALS_JSON must be valid JSON: ${message}`);
+    throw new Error(`OPENGENI_OBJECT_STORAGE_GCS_CREDENTIALS_JSON must be valid JSON: ${message}`, {
+      cause: error,
+    });
   }
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3381,6 +3381,7 @@ export async function loadConnectionCredentialForBroker(
     } catch (error) {
       throw new Error(
         `connection credential could not be decrypted for ${row.id}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
       );
     }
     if (!credential || typeof credential !== "object" || Array.isArray(credential)) {
@@ -3885,7 +3886,7 @@ export async function updateKnowledgeMemory(
         nextTextHash,
         memoryId,
       );
-      throw new Error(visibleTextHashConflictMessage(duplicate));
+      throw new Error(visibleTextHashConflictMessage(duplicate), { cause: error });
     }
     if (!row) {
       throw new Error(`Knowledge memory not found: ${memoryId}`);
@@ -6778,7 +6779,9 @@ export async function loadVariableSetForRun(
       values[name] = decryptEnvironmentValue(key, encrypted);
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
-      throw new Error(`failed to decrypt variable set variable ${name}: ${reason}`);
+      throw new Error(`failed to decrypt variable set variable ${name}: ${reason}`, {
+        cause: error,
+      });
     }
   }
   return {
@@ -6971,7 +6974,10 @@ export async function loadCodexCredentialForRun(
       };
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
-      throw new Error(`failed to decrypt codex credential for workspace ${workspaceId}: ${reason}`);
+      throw new Error(
+        `failed to decrypt codex credential for workspace ${workspaceId}: ${reason}`,
+        { cause: error },
+      );
     }
     return {
       id: row.id,

--- a/packages/db/test/session-workflow-wake-outbox.test.ts
+++ b/packages/db/test/session-workflow-wake-outbox.test.ts
@@ -62,12 +62,12 @@ async function fixture() {
 
 type WakeFixture = Awaited<ReturnType<typeof fixture>>;
 
-async function send(fixture: WakeFixture, text: string, clientEventId = crypto.randomUUID()) {
+async function send(wakeFixture: WakeFixture, text: string, clientEventId = crypto.randomUUID()) {
   return await enqueueSessionMessageAtomically(client.db, {
-    accountId: fixture.grant.accountId,
-    workspaceId: fixture.grant.workspaceId!,
-    sessionId: fixture.session.id,
-    actor: fixture.grant.subjectId,
+    accountId: wakeFixture.grant.accountId,
+    workspaceId: wakeFixture.grant.workspaceId!,
+    sessionId: wakeFixture.session.id,
+    actor: wakeFixture.grant.subjectId,
     origin: "human",
     text,
     resources: [],

--- a/packages/react/demo/machines-harness.tsx
+++ b/packages/react/demo/machines-harness.tsx
@@ -60,9 +60,8 @@ function Dashboard({ data }: { data: MachinesResponse }) {
   );
 }
 
-/** Side-by-side dock-parity: Modal vs selfhosted render IDENTICALLY below the bar. */
-function DockParity() {
-  const SurfaceStub = () => (
+function SurfaceStub() {
+  return (
     <div className="flex h-40 flex-col gap-2 p-2 font-og-mono text-[11px] text-og-fg-muted">
       <div className="flex gap-3 border-b border-og-border pb-1 text-og-fg">
         <span className="border-b-2 border-og-accent pb-1 text-og-fg">Files</span>
@@ -74,6 +73,10 @@ function DockParity() {
       <div className="text-og-fg-subtle">$ echo $HOSTNAME</div>
     </div>
   );
+}
+
+/** Side-by-side dock-parity: Modal vs selfhosted render IDENTICALLY below the bar. */
+function DockParity() {
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="overflow-hidden rounded-og-lg border border-og-border bg-og-surface-1">

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -123,7 +123,8 @@ class SessionBus {
     };
     this.listeners.add(listener);
     try {
-      while (!signal?.aborted) {
+      while (true) {
+        if (signal?.aborted) break;
         const next = queue.shift();
         if (next) {
           yield next;

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -165,9 +165,11 @@ function diffDense(count: number): GitFileDiff[] {
     "docs",
   ];
   return Array.from({ length: count }, (_, i) => {
-    const dir = dirs[i % dirs.length];
+    const directory = dirs[i % dirs.length];
     const size = 1 + (i % 5);
-    return file(`${dir}/module-${String(i).padStart(3, "0")}.ts`, size * 2, size, [hunk(1, size)]);
+    return file(`${directory}/module-${String(i).padStart(3, "0")}.ts`, size * 2, size, [
+      hunk(1, size),
+    ]);
   });
 }
 

--- a/packages/react/src/components/sandbox-terminal.tsx
+++ b/packages/react/src/components/sandbox-terminal.tsx
@@ -192,7 +192,12 @@ export function SandboxTerminal({
   const ptyWs = terminalCapability?.transport === "pty-ws" && Boolean(terminalCapability?.url);
   // Output frames buffer here until xterm has mounted; the write effect drains it.
   const ptyOutputQueueRef = useRef<string[]>([]);
-  const ptyStream = useTerminalStream({
+  const {
+    status: ptyStatus,
+    write: ptyWrite,
+    resize: resizePty,
+    connected: ptyConnected,
+  } = useTerminalStream({
     capability: ptyWs
       ? {
           transport: terminalCapability!.transport,
@@ -209,7 +214,7 @@ export function SandboxTerminal({
 
   // PTY mode = a live ttyd socket drives the screen. Firehose mode = the
   // read-only projection (or the legacy HTTP-write fallback).
-  const ptyMode = ptyWs && ptyStream.status !== "closed";
+  const ptyMode = ptyWs && ptyStatus !== "closed";
   const interactive = !readOnly && (ptyMode || result.write !== null);
 
   // Boot-in-terminal: after the user focuses a not-yet-warm box, show styled
@@ -433,20 +438,20 @@ export function SandboxTerminal({
   useEffect(() => {
     const term = termRef.current;
     if (!ready || !term || !interactive) return;
-    const sink = ptyMode ? ptyStream.write : result.write;
+    const sink = ptyMode ? ptyWrite : result.write;
     if (!sink) return;
     const sub = term.onData((data) => sink(data));
     return () => sub.dispose();
-  }, [ready, interactive, ptyMode, ptyStream.write, result.write]);
+  }, [ready, interactive, ptyMode, ptyWrite, result.write]);
 
   // In PTY mode, tell ttyd the window size on the xterm resize event.
   useEffect(() => {
     const term = termRef.current;
     if (!ready || !term || !ptyMode) return;
-    ptyStream.resize(term.cols, term.rows);
-    const sub = term.onResize(({ cols, rows }) => ptyStream.resize(cols, rows));
+    resizePty(term.cols, term.rows);
+    const sub = term.onResize(({ cols, rows }) => resizePty(cols, rows));
     return () => sub.dispose();
-  }, [ready, ptyMode, ptyStream.connected, ptyStream.resize]);
+  }, [ready, ptyMode, ptyConnected, resizePty]);
 
   // Refit on container resize (dock drag) AND window resize.
   useEffect(() => {

--- a/packages/react/src/hooks/use-codex-accounts.ts
+++ b/packages/react/src/hooks/use-codex-accounts.ts
@@ -129,12 +129,16 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
     };
   }, [codexClient, workspaceId, sessionId]);
 
-  const state = usePolledValue(load, {
+  const {
+    data: loadedData,
+    loading,
+    refresh,
+  } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
-  const usageMutation = useMutationRunner();
+  const { run: runMutation, mutating: pinning, mutationError } = useMutationRunner();
+  const { run: runUsageMutation, mutating: refreshingUsage } = useMutationRunner();
   const [pinningTarget, setPinningTarget] = useState<string | null>(null);
 
   // Live flip: a manual switch (P1) or a failover (P3) emits codex.account.switched;
@@ -144,7 +148,7 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
     workspaceId,
     sessionId,
     isCodexAccountEvent,
-    () => void state.refresh(),
+    () => void refresh(),
     {
       enabled: options.enabled ?? true,
       ...(sharedEvents !== undefined ? { events: sharedEvents } : {}),
@@ -157,15 +161,15 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
         return false;
       }
       setPinningTarget(target);
-      const result = await mutation.run(async () => {
+      const result = await runMutation(async () => {
         await codexClient.pinSessionCodexAccount!(workspaceId, sessionId, target);
         return true;
       });
       setPinningTarget(null);
-      if (result) await state.refresh();
+      if (result) await refresh();
       return result === true;
     },
-    [codexClient, workspaceId, sessionId, mutation.run, state.refresh],
+    [codexClient, workspaceId, sessionId, runMutation, refresh],
   );
 
   // Live usage refresh: hit the batched provider read, then re-read cached
@@ -175,15 +179,15 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
     if (!codexClient.refreshCodexUsage) {
       return false;
     }
-    const result = await usageMutation.run(async () => {
+    const result = await runUsageMutation(async () => {
       await codexClient.refreshCodexUsage!(workspaceId);
       return true;
     });
-    if (result) await state.refresh();
+    if (result) await refresh();
     return result === true;
-  }, [codexClient, workspaceId, usageMutation.run, state.refresh]);
+  }, [codexClient, workspaceId, runUsageMutation, refresh]);
 
-  const data = state.data ?? EMPTY_STATE;
+  const data = loadedData ?? EMPTY_STATE;
   const effectiveAccountId = data.pinnedAccountId ?? data.activeAccountId;
 
   return {
@@ -193,13 +197,13 @@ export function useCodexAccounts(options: UseCodexAccountsOptions = {}): UseCode
     effectiveAccountId,
     lastAccountId: data.lastAccountId,
     settings: data.settings,
-    loading: state.loading,
-    refresh: state.refresh,
+    loading,
+    refresh,
     refreshUsage,
-    refreshingUsage: usageMutation.mutating,
+    refreshingUsage,
     pin,
-    pinning: mutation.mutating,
+    pinning,
     pinningTarget,
-    mutationError: mutation.mutationError,
+    mutationError,
   };
 }

--- a/packages/react/src/hooks/use-environments.ts
+++ b/packages/react/src/hooks/use-environments.ts
@@ -44,21 +44,21 @@ export function useVariableSets(options: UseVariableSetsOptions = {}): UseVariab
     async () => await client.listVariableSets(workspaceId),
     [client, workspaceId],
   );
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
 
   const create = useCallback(
     async (request: CreateVariableSetRequest): Promise<VariableSet | null> => {
-      const result = await mutation.run(() => client.createVariableSet(workspaceId, request));
+      const result = await run(() => client.createVariableSet(workspaceId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const update = useCallback(
@@ -66,29 +66,27 @@ export function useVariableSets(options: UseVariableSetsOptions = {}): UseVariab
       variableSetId: string,
       request: UpdateVariableSetRequest,
     ): Promise<VariableSet | null> => {
-      const result = await mutation.run(() =>
-        client.updateVariableSet(workspaceId, variableSetId, request),
-      );
+      const result = await run(() => client.updateVariableSet(workspaceId, variableSetId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const remove = useCallback(
     async (variableSetId: string): Promise<boolean> => {
-      const result = await mutation.run(async () => {
+      const result = await run(async () => {
         await client.deleteVariableSet(workspaceId, variableSetId);
         return true;
       });
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result === true;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const setVariable = useCallback(
@@ -97,44 +95,44 @@ export function useVariableSets(options: UseVariableSetsOptions = {}): UseVariab
       name: string,
       value: string,
     ): Promise<VariableSetVariableMetadata | null> => {
-      const result = await mutation.run(() =>
+      const result = await run(() =>
         client.setVariableSetVariable(workspaceId, variableSetId, name, value),
       );
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const deleteVariable = useCallback(
     async (variableSetId: string, name: string): Promise<boolean> => {
-      const result = await mutation.run(async () => {
+      const result = await run(async () => {
         await client.deleteVariableSetVariable(workspaceId, variableSetId, name);
         return true;
       });
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result === true;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   return {
-    variableSets: state.data ?? [],
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    variableSets: data ?? [],
+    loading,
+    error,
+    refresh,
     create,
     update,
     remove,
     setVariable,
     deleteVariable,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }
 

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -60,7 +60,7 @@ export function useGoal(
   const [goal, setGoal] = useState<SessionGoal | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
   const generation = useRef(0);
   const targetKeyRef = useRef<string | null>(null);
 
@@ -134,7 +134,7 @@ export function useGoal(
       if (!sessionId) {
         return null;
       }
-      const result = await mutation.run(() =>
+      const result = await run(() =>
         client.updateGoal(workspaceId, sessionId, {
           status: "paused",
           ...(rationale !== undefined ? { rationale } : {}),
@@ -145,21 +145,19 @@ export function useGoal(
       }
       return result;
     },
-    [client, workspaceId, sessionId, mutation.run],
+    [client, workspaceId, sessionId, run],
   );
 
   const resume = useCallback(async (): Promise<SessionGoal | null> => {
     if (!sessionId) {
       return null;
     }
-    const result = await mutation.run(() =>
-      client.updateGoal(workspaceId, sessionId, { status: "active" }),
-    );
+    const result = await run(() => client.updateGoal(workspaceId, sessionId, { status: "active" }));
     if (result) {
       setGoal(result);
     }
     return result;
-  }, [client, workspaceId, sessionId, mutation.run]);
+  }, [client, workspaceId, sessionId, run]);
 
   const clearGoal = useCallback(async (): Promise<void> => {
     if (!sessionId) {
@@ -170,7 +168,7 @@ export function useGoal(
     // a failed one leaves the pill up so its mutationError renders. And invalidate
     // any in-flight load first so a slower getGoal started before the delete can't
     // commit and repopulate the just-cleared goal.
-    const ok = await mutation.run(async () => {
+    const ok = await run(async () => {
       await client.deleteGoal(workspaceId, sessionId);
       return true as const;
     });
@@ -179,7 +177,7 @@ export function useGoal(
       setGoal(null);
       setError(null);
     }
-  }, [client, workspaceId, sessionId, mutation.run]);
+  }, [client, workspaceId, sessionId, run]);
 
   return {
     goal,
@@ -193,8 +191,8 @@ export function useGoal(
     resume,
     clearGoal,
     deleteGoal: clearGoal,
-    updating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    updating: mutating,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/hooks/use-machine-chip.ts
+++ b/packages/react/src/hooks/use-machine-chip.ts
@@ -99,18 +99,36 @@ export type UseMachineChipOptions = DeriveMachineChipInput;
  * "as of" label to tick.
  */
 export function useMachineChip(input: UseMachineChipOptions): MachineChip {
+  const {
+    liveness,
+    capabilitiesState,
+    activeMachineState,
+    activeIsSelfhosted,
+    wantsWarm,
+    capturedAt,
+    now,
+  } = input;
   return useMemo(
-    () => deriveMachineChip(input),
+    () =>
+      deriveMachineChip({
+        liveness,
+        capabilitiesState,
+        activeMachineState,
+        activeIsSelfhosted,
+        wantsWarm,
+        capturedAt,
+        now,
+      }),
     // Depend on the primitive fields (not the object identity) so a caller passing
     // a fresh object each render doesn't recompute needlessly.
     [
-      input.liveness,
-      input.capabilitiesState,
-      input.activeMachineState,
-      input.activeIsSelfhosted,
-      input.wantsWarm,
-      input.capturedAt,
-      input.now,
+      liveness,
+      capabilitiesState,
+      activeMachineState,
+      activeIsSelfhosted,
+      wantsWarm,
+      capturedAt,
+      now,
     ],
   );
 }

--- a/packages/react/src/hooks/use-machines.ts
+++ b/packages/react/src/hooks/use-machines.ts
@@ -103,15 +103,20 @@ export function useMachines(options: UseMachinesOptions = {}): UseMachinesResult
     return await machinesClient.listMachines(workspaceId, sessionId ? { sessionId } : undefined);
   }, [machinesClient, workspaceId, sessionId]);
 
-  const state = usePolledValue(load, {
+  const {
+    data: loadedData,
+    loading,
+    error,
+    refresh,
+  } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
   // The sandbox id of the in-flight attach (drives the per-card spinner).
   const [attachingSandboxId, setAttachingSandboxId] = useState<string | null>(null);
 
-  const data = state.data ?? EMPTY;
+  const data = loadedData ?? EMPTY;
   // The swap is session-scoped: a host adapter (`attachMachine`) wins; otherwise
   // the default `swapActiveSandbox` path is wired whenever a sessionId is in
   // scope. Either way attach needs a sessionId to point at.
@@ -130,15 +135,15 @@ export function useMachines(options: UseMachinesOptions = {}): UseMachinesResult
           : null;
       if (!runSwap) return false;
       setAttachingSandboxId(sandboxId);
-      const result = await mutation.run(async () => {
+      const result = await run(async () => {
         await runSwap();
         return true;
       });
       setAttachingSandboxId(null);
-      if (result) await state.refresh();
+      if (result) await refresh();
       return result === true;
     },
-    [machinesClient, workspaceId, sessionId, mutation.run, state.refresh],
+    [machinesClient, workspaceId, sessionId, run, refresh],
   );
 
   const fetchSeries = useCallback(
@@ -156,15 +161,15 @@ export function useMachines(options: UseMachinesOptions = {}): UseMachinesResult
     machines: data.machines,
     activeSandboxId: data.activeSandboxId,
     activeEpoch: data.activeEpoch,
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    loading,
+    error,
+    refresh,
     attach,
     canAttach,
     fetchSeries,
-    attaching: mutation.mutating,
+    attaching: mutating,
     attachingSandboxId,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/hooks/use-packs.ts
+++ b/packages/react/src/hooks/use-packs.ts
@@ -9,6 +9,8 @@ import { useCallback } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { useMutationRunner, usePolledValue } from "./internal";
 
+const EMPTY_INSTALLATIONS: PackInstallation[] = [];
+
 export type UsePacksOptions = ClientOverride & {
   pollIntervalMs?: number | undefined;
   enabled?: boolean | undefined;
@@ -38,49 +40,49 @@ export type UsePacksResult = {
 export function usePacks(options: UsePacksOptions = {}): UsePacksResult {
   const { client, workspaceId } = useOpenGeni(options);
   const load = useCallback(async () => await client.listPacks(workspaceId), [client, workspaceId]);
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
 
   const register = useCallback(
     async (manifest: RegisterCapabilityPackRequest): Promise<WorkspaceRegisteredPack | null> => {
-      const result = await mutation.run(() => client.registerPack(workspaceId, manifest));
+      const result = await run(() => client.registerPack(workspaceId, manifest));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const enable = useCallback(
     async (packId: string, request: EnablePackRequest = {}): Promise<PackInstallation | null> => {
-      const result = await mutation.run(() => client.enablePack(workspaceId, packId, request));
+      const result = await run(() => client.enablePack(workspaceId, packId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const remove = useCallback(
     async (packId: string): Promise<boolean> => {
-      const result = await mutation.run(async () => {
+      const result = await run(async () => {
         await client.deletePack(workspaceId, packId);
         return true;
       });
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result === true;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
-  const installations = state.data?.installations ?? [];
+  const installations = data?.installations ?? EMPTY_INSTALLATIONS;
   const installationFor = useCallback(
     (packId: string): PackInstallation | null =>
       installations.find((installation) => installation.packId === packId) ?? null,
@@ -88,17 +90,17 @@ export function usePacks(options: UsePacksOptions = {}): UsePacksResult {
   );
 
   return {
-    packs: state.data?.packs ?? [],
+    packs: data?.packs ?? [],
     installations,
     installationFor,
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    loading,
+    error,
+    refresh,
     register,
     enable,
     remove,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/hooks/use-relay-frame-stream.ts
+++ b/packages/react/src/hooks/use-relay-frame-stream.ts
@@ -185,7 +185,8 @@ export function useRelayFrameStream(
       if (decoding) return;
       decoding = true;
       try {
-        while (!disposed && pending) {
+        while (pending) {
+          if (disposed) break;
           const data = pending;
           pending = null;
           let bmp: ImageBitmap;

--- a/packages/react/src/hooks/use-rigs.ts
+++ b/packages/react/src/hooks/use-rigs.ts
@@ -40,91 +40,89 @@ export type UseRigsResult = {
 export function useRigs(options: UseRigsOptions = {}): UseRigsResult {
   const { client, workspaceId } = useOpenGeni(options);
   const load = useCallback(async () => await client.listRigs(workspaceId), [client, workspaceId]);
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
 
   const create = useCallback(
     async (request: CreateRigRequest): Promise<Rig | null> => {
-      const result = await mutation.run(() => client.createRig(workspaceId, request));
+      const result = await run(() => client.createRig(workspaceId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const update = useCallback(
     async (rigId: string, request: UpdateRigRequest): Promise<Rig | null> => {
-      const result = await mutation.run(() => client.updateRig(workspaceId, rigId, request));
+      const result = await run(() => client.updateRig(workspaceId, rigId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const remove = useCallback(
     async (rigId: string): Promise<boolean> => {
-      const result = await mutation.run(async () => {
+      const result = await run(async () => {
         await client.deleteRig(workspaceId, rigId);
         return true;
       });
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result === true;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const listVersions = useCallback(
     async (rigId: string): Promise<RigVersion[] | null> => {
-      return await mutation.run(() => client.listRigVersions(workspaceId, rigId));
+      return await run(() => client.listRigVersions(workspaceId, rigId));
     },
-    [client, workspaceId, mutation.run],
+    [client, workspaceId, run],
   );
 
   const activateVersion = useCallback(
     async (rigId: string, versionId: string): Promise<RigVersion | null> => {
-      const result = await mutation.run(() =>
-        client.activateRigVersion(workspaceId, rigId, versionId),
-      );
+      const result = await run(() => client.activateRigVersion(workspaceId, rigId, versionId));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   const listChanges = useCallback(
     async (rigId: string): Promise<RigChange[] | null> => {
-      return await mutation.run(() => client.listRigChanges(workspaceId, rigId));
+      return await run(() => client.listRigChanges(workspaceId, rigId));
     },
-    [client, workspaceId, mutation.run],
+    [client, workspaceId, run],
   );
 
   const proposeChange = useCallback(
     async (rigId: string, request: ProposeRigChangeRequest): Promise<RigChange | null> => {
-      const result = await mutation.run(() => client.proposeRigChange(workspaceId, rigId, request));
+      const result = await run(() => client.proposeRigChange(workspaceId, rigId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, mutation.run, state.refresh],
+    [client, workspaceId, run, refresh],
   );
 
   return {
-    rigs: state.data ?? [],
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    rigs: data ?? [],
+    loading,
+    error,
+    refresh,
     create,
     update,
     remove,
@@ -132,9 +130,9 @@ export function useRigs(options: UseRigsOptions = {}): UseRigsResult {
     activateVersion,
     listChanges,
     proposeChange,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }
 
@@ -174,88 +172,84 @@ export function useRig(rigId: string, options: UseRigOptions = {}): UseRigResult
     async () => await client.getRig(workspaceId, rigId),
     [client, workspaceId, rigId],
   );
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
 
   const update = useCallback(
     async (request: UpdateRigRequest): Promise<Rig | null> => {
-      const result = await mutation.run(() => client.updateRig(workspaceId, rigId, request));
+      const result = await run(() => client.updateRig(workspaceId, rigId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, rigId, mutation.run, state.refresh],
+    [client, workspaceId, rigId, run, refresh],
   );
 
   const remove = useCallback(async (): Promise<boolean> => {
-    const result = await mutation.run(async () => {
+    const result = await run(async () => {
       await client.deleteRig(workspaceId, rigId);
       return true;
     });
     return result === true;
-  }, [client, workspaceId, rigId, mutation.run]);
+  }, [client, workspaceId, rigId, run]);
 
   const activateVersion = useCallback(
     async (versionId: string): Promise<RigVersion | null> => {
-      const result = await mutation.run(() =>
-        client.activateRigVersion(workspaceId, rigId, versionId),
-      );
+      const result = await run(() => client.activateRigVersion(workspaceId, rigId, versionId));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, rigId, mutation.run, state.refresh],
+    [client, workspaceId, rigId, run, refresh],
   );
 
   const proposeChange = useCallback(
     async (request: ProposeRigChangeRequest): Promise<RigChange | null> => {
-      const result = await mutation.run(() => client.proposeRigChange(workspaceId, rigId, request));
+      const result = await run(() => client.proposeRigChange(workspaceId, rigId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, rigId, mutation.run, state.refresh],
+    [client, workspaceId, rigId, run, refresh],
   );
 
   const verifyChange = useCallback(
     async (changeId: string): Promise<RigChange | null> => {
-      const result = await mutation.run(() => client.verifyRigChange(workspaceId, rigId, changeId));
+      const result = await run(() => client.verifyRigChange(workspaceId, rigId, changeId));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, rigId, mutation.run, state.refresh],
+    [client, workspaceId, rigId, run, refresh],
   );
 
   const promoteChange = useCallback(
     async (changeId: string): Promise<RigVersion | null> => {
-      const result = await mutation.run(() =>
-        client.promoteRigChange(workspaceId, rigId, changeId),
-      );
+      const result = await run(() => client.promoteRigChange(workspaceId, rigId, changeId));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, workspaceId, rigId, mutation.run, state.refresh],
+    [client, workspaceId, rigId, run, refresh],
   );
 
   const verify = useCallback(async (): Promise<{ ok: boolean; versionId: string } | null> => {
-    return await mutation.run(() => client.verifyRig(workspaceId, rigId));
-  }, [client, workspaceId, rigId, mutation.run]);
+    return await run(() => client.verifyRig(workspaceId, rigId));
+  }, [client, workspaceId, rigId, run]);
 
   return {
-    rig: state.data,
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    rig: data,
+    loading,
+    error,
+    refresh,
     update,
     remove,
     activateVersion,
@@ -263,9 +257,9 @@ export function useRig(rigId: string, options: UseRigOptions = {}): UseRigResult
     verifyChange,
     promoteChange,
     verify,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }
 

--- a/packages/react/src/hooks/use-session-control.ts
+++ b/packages/react/src/hooks/use-session-control.ts
@@ -29,30 +29,40 @@ export function useSessionControl(
   options: UseSessionControlOptions = {},
 ): UseSessionControlResult {
   const { client, workspaceId } = useOpenGeni(options);
-  const controlMutation = useMutationRunner();
-  const approvalMutation = useMutationRunner();
+  const {
+    run: runControl,
+    mutating: controlling,
+    mutationError: controlError,
+    clearMutationError: clearControlError,
+  } = useMutationRunner();
+  const {
+    run: runApproval,
+    mutating: responding,
+    mutationError: approvalError,
+    clearMutationError: clearApprovalError,
+  } = useMutationRunner();
 
   const pause = useCallback(
     async (reason?: string): Promise<SessionEvent | null> => {
       if (!sessionId) {
         return null;
       }
-      return await controlMutation.run(() =>
+      return await runControl(() =>
         client.pauseSession(workspaceId, sessionId, reason !== undefined ? { reason } : {}),
       );
     },
-    [client, workspaceId, sessionId, controlMutation.run],
+    [client, workspaceId, sessionId, runControl],
   );
 
   const resume = useCallback(
     async (reason?: string): Promise<SessionEvent | null> => {
       if (!sessionId) return null;
-      const result = await controlMutation.run(() =>
+      const result = await runControl(() =>
         client.resumeSession(workspaceId, sessionId, reason !== undefined ? { reason } : {}),
       );
       return result?.event ?? null;
     },
-    [client, workspaceId, sessionId, controlMutation.run],
+    [client, workspaceId, sessionId, runControl],
   );
 
   const decide = useCallback(
@@ -64,7 +74,7 @@ export function useSessionControl(
       if (!sessionId) {
         return null;
       }
-      return await approvalMutation.run(() =>
+      return await runApproval(() =>
         client.sendApprovalDecision(workspaceId, sessionId, {
           approvalId,
           decision,
@@ -72,7 +82,7 @@ export function useSessionControl(
         }),
       );
     },
-    [client, workspaceId, sessionId, approvalMutation.run],
+    [client, workspaceId, sessionId, runApproval],
   );
 
   const approve = useCallback(
@@ -84,19 +94,19 @@ export function useSessionControl(
     [decide],
   );
 
-  const error = approvalMutation.mutationError ?? controlMutation.mutationError;
+  const error = approvalError ?? controlError;
   const clearError = useCallback(() => {
-    controlMutation.clearMutationError();
-    approvalMutation.clearMutationError();
-  }, [controlMutation.clearMutationError, approvalMutation.clearMutationError]);
+    clearControlError();
+    clearApprovalError();
+  }, [clearControlError, clearApprovalError]);
 
   return {
     pause,
     resume,
-    controlling: controlMutation.mutating,
+    controlling,
     approve,
     reject,
-    responding: approvalMutation.mutating,
+    responding,
     error,
     clearError,
   };

--- a/packages/react/src/hooks/use-session.ts
+++ b/packages/react/src/hooks/use-session.ts
@@ -40,7 +40,7 @@ export function useSession(
   const { client, workspaceId } = useOpenGeni(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
   const [override, setOverride] = useState<Session | null>(null);
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
   const load = useCallback(async () => {
     if (!sessionId) {
       return null;
@@ -50,12 +50,12 @@ export function useSession(
     setOverride(null);
     return fetched;
   }, [client, workspaceId, sessionId]);
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled,
   });
 
-  const base = state.data ?? null;
+  const base = data ?? null;
   // The override only ever carries title/titleSource patches; it is reset on
   // every fresh load so it can never go stale against the server snapshot.
   const session =
@@ -94,25 +94,23 @@ export function useSession(
       if (!sessionId) {
         return null;
       }
-      const result = await mutation.run(() =>
-        client.updateSession(workspaceId, sessionId, { title }),
-      );
+      const result = await run(() => client.updateSession(workspaceId, sessionId, { title }));
       if (result) {
         setOverride(result);
       }
       return result;
     },
-    [client, workspaceId, sessionId, mutation.run],
+    [client, workspaceId, sessionId, run],
   );
 
   return {
     session,
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    loading,
+    error,
+    refresh,
     updateTitle,
-    updating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    updating: mutating,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/hooks/use-slash-commands.ts
+++ b/packages/react/src/hooks/use-slash-commands.ts
@@ -200,11 +200,11 @@ export function useSlashCommands(options: UseSlashCommandsOptions): UseSlashComm
   // exact-match heuristic) and a pointer click (which has ALREADY chosen the
   // command — the clicked row — and must not re-resolve to a near-match).
   const runResolved = useCallback(
-    async (command: SlashCommand, options?: { explicit?: boolean }): Promise<void> => {
+    async (command: SlashCommand, executionOptions?: { explicit?: boolean }): Promise<void> => {
       if (!parsed) {
         return;
       }
-      const explicit = options?.explicit ?? false;
+      const explicit = executionOptions?.explicit ?? false;
       // Token-vs-command equality is case-insensitive (matching the registry's
       // matchCommand/filterCommands), so a fully-typed "/Clear" counts as having
       // named `clear` and runs rather than autocompleting.

--- a/packages/react/src/hooks/use-turn-queue.ts
+++ b/packages/react/src/hooks/use-turn-queue.ts
@@ -55,7 +55,7 @@ export function useTurnQueue(
   const [snapshot, setSnapshot] = useState<SessionQueueSnapshot | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
   const generation = useRef(0);
   const targetKeyRef = useRef<string | null>(null);
   const snapshotRef = useRef<SessionQueueSnapshot | null>(null);
@@ -121,7 +121,7 @@ export function useTurnQueue(
       const current = snapshotRef.current;
       const item = current?.items.find((turn) => turn.id === turnId);
       if (!current || !item) return false;
-      const result = await mutation.run(() =>
+      const result = await run(() =>
         client.cancelQueueItem(workspaceId, sessionId, turnId, {
           expectedQueueVersion: current.version,
           expectedItemVersion: item.version,
@@ -134,7 +134,7 @@ export function useTurnQueue(
       replaceSnapshot(result.snapshot);
       return true;
     },
-    [client, workspaceId, sessionId, mutation.run, load, replaceSnapshot],
+    [client, workspaceId, sessionId, run, load, replaceSnapshot],
   );
 
   return {
@@ -149,8 +149,8 @@ export function useTurnQueue(
     error,
     refresh: load,
     removeTurn,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/hooks/use-workspaces.ts
+++ b/packages/react/src/hooks/use-workspaces.ts
@@ -27,43 +27,43 @@ export type UseWorkspacesResult = {
 export function useWorkspaces(options: UseWorkspacesOptions = {}): UseWorkspacesResult {
   const client = useOpenGeniClient(options);
   const load = useCallback(async () => await client.listWorkspaces(), [client]);
-  const state = usePolledValue(load, {
+  const { data, loading, error, refresh } = usePolledValue(load, {
     pollIntervalMs: options.pollIntervalMs,
     enabled: options.enabled,
   });
-  const mutation = useMutationRunner();
+  const { run, mutating, mutationError, clearMutationError } = useMutationRunner();
 
   const create = useCallback(
     async (request: CreateWorkspaceRequest): Promise<Workspace | null> => {
-      const result = await mutation.run(() => client.createWorkspace(request));
+      const result = await run(() => client.createWorkspace(request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, mutation.run, state.refresh],
+    [client, run, refresh],
   );
 
   const update = useCallback(
     async (workspaceId: string, request: UpdateWorkspaceRequest): Promise<Workspace | null> => {
-      const result = await mutation.run(() => client.updateWorkspace(workspaceId, request));
+      const result = await run(() => client.updateWorkspace(workspaceId, request));
       if (result) {
-        await state.refresh();
+        await refresh();
       }
       return result;
     },
-    [client, mutation.run, state.refresh],
+    [client, run, refresh],
   );
 
   return {
-    workspaces: state.data ?? [],
-    loading: state.loading,
-    error: state.error,
-    refresh: state.refresh,
+    workspaces: data ?? [],
+    loading,
+    error,
+    refresh,
     create,
     update,
-    mutating: mutation.mutating,
-    mutationError: mutation.mutationError,
-    clearMutationError: mutation.clearMutationError,
+    mutating,
+    mutationError,
+    clearMutationError,
   };
 }

--- a/packages/react/src/timeline/tool-diff.tsx
+++ b/packages/react/src/timeline/tool-diff.tsx
@@ -60,15 +60,21 @@ function LayoutToggle({
 
 /** Raw-patch fallback for a V4A hunk string the parser could not structure. */
 export function RawPatch({ diff }: { diff: string }) {
+  const occurrences = new Map<string, number>();
+  const lines = diff.split("\n").map((line) => {
+    const occurrence = (occurrences.get(line) ?? 0) + 1;
+    occurrences.set(line, occurrence);
+    return { key: `${line}\u0000${occurrence}`, line };
+  });
   return (
     <div className="min-w-0">
       <p className="mb-1 text-og-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle">
         raw patch (could not parse hunks)
       </p>
       <pre className="max-h-72 overflow-auto border-l-2 border-og-border pl-3 font-og-mono text-og-xs leading-5">
-        {diff.split("\n").map((line, index) => (
+        {lines.map(({ key, line }) => (
           <span
-            key={index}
+            key={key}
             className={cn(
               "block",
               line.startsWith("@@")

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -692,6 +692,13 @@ function WebSearchRenderer({ item }: ToolRendererProps) {
   const results = Array.isArray(rawResults)
     ? (rawResults as unknown[]).filter((r): r is WebSearchResult => !!r && typeof r === "object")
     : undefined;
+  const resultOccurrences = new Map<string, number>();
+  const keyedResults = results?.map((result) => {
+    const contentKey = `${result.domain}\u0000${result.title}\u0000${result.snippet}`;
+    const occurrence = (resultOccurrences.get(contentKey) ?? 0) + 1;
+    resultOccurrences.set(contentKey, occurrence);
+    return { key: `${contentKey}\u0000${occurrence}`, result };
+  });
 
   if (running) {
     return (
@@ -716,10 +723,10 @@ function WebSearchRenderer({ item }: ToolRendererProps) {
       failed={item.status === "failed"}
       cancelled={item.status === "cancelled"}
     >
-      {results && results.length ? (
+      {keyedResults && keyedResults.length ? (
         <ul className="flex flex-col gap-2">
-          {results.map((result, index) => (
-            <li key={index} className="flex gap-2.5">
+          {keyedResults.map(({ key, result }) => (
+            <li key={key} className="flex gap-2.5">
               <GlobeIcon className="mt-0.5 size-3.5 shrink-0 text-og-fg-subtle" />
               <div className="min-w-0">
                 <p className="truncate text-og-base text-og-fg">

--- a/packages/react/test/approvals.test.ts
+++ b/packages/react/test/approvals.test.ts
@@ -28,8 +28,8 @@ function reset(): void {
 
 const requiresAction = (approvals: unknown[], turnId = "turn-1") =>
   event("session.requiresAction", { approvals }, { turnId });
-const decision = (approvalId: string, decision: "approve" | "reject" = "approve") =>
-  event("user.approvalDecision", { approvalId, decision }, { turnId: null });
+const decision = (approvalId: string, decisionType: "approve" | "reject" = "approve") =>
+  event("user.approvalDecision", { approvalId, decision: decisionType }, { turnId: null });
 
 describe("approvalsFromRequiresAction", () => {
   test("maps id/name/arguments and falls back to callId, rawItem.callId, then index", () => {

--- a/packages/react/test/file-browser-virtualization.test.tsx
+++ b/packages/react/test/file-browser-virtualization.test.tsx
@@ -5,7 +5,7 @@
    (mounted `[role=treeitem]` counts), not proxy metrics.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
-import { registerDom, renderComponent, flush } from "./render-hook";
+import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 import { FileBrowser } from "../src/components/file-browser";
 import type { FileTreeNode, UseSandboxFilesResult } from "../src/hooks/use-sandbox-files";
 
@@ -72,7 +72,7 @@ describe("FileBrowser virtualization", () => {
       (b) => b.textContent?.includes("node_modules"),
     ) as HTMLButtonElement | undefined;
     expect(dirButton).toBeTruthy();
-    dirButton!.click();
+    await actRun(() => dirButton!.click());
     await flush();
     expect(r.container.textContent).toContain("contents on machine");
     await r.unmount();
@@ -89,7 +89,7 @@ describe("FileBrowser virtualization", () => {
     const dirButton = r.container.querySelector(
       '[role="treeitem"] button',
     ) as HTMLButtonElement | null;
-    dirButton?.click();
+    await actRun(() => dirButton?.click());
     await flush();
     expect(r.container.textContent).not.toContain("contents on machine");
     await r.unmount();

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
 import { MessageTimeline } from "../src";
-import { registerDom, renderComponent, flush } from "./render-hook";
+import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 
 registerDom();
 
@@ -78,9 +78,11 @@ describe("MessageTimeline pagination affordances", () => {
     );
     await flush();
     expect(observed).toHaveLength(1);
-    callback(
-      [{ isIntersecting: true, target: observed[0]! } as IntersectionObserverEntry],
-      instance!,
+    await actRun(() =>
+      callback(
+        [{ isIntersecting: true, target: observed[0]! } as IntersectionObserverEntry],
+        instance!,
+      ),
     );
     expect(calls).toBe(1);
     await r.unmount();
@@ -100,9 +102,11 @@ describe("MessageTimeline pagination affordances", () => {
     // appears later either (nothing is toggled, so nothing can replay).
     expect(r.container.querySelector(".animate-og-enter")).toBeNull();
 
-    for (const frame of frames.splice(0)) {
-      frame(performance.now());
-    }
+    await actRun(() => {
+      for (const frame of frames.splice(0)) {
+        frame(performance.now());
+      }
+    });
     await flush();
     expect(r.container.querySelector(".animate-og-enter")).toBeNull();
 

--- a/packages/react/test/render-hook.tsx
+++ b/packages/react/test/render-hook.tsx
@@ -89,6 +89,15 @@ export async function flush(ms = 0): Promise<void> {
   });
 }
 
+/** Run a user interaction or hook mutation and all of its state updates in `act`. */
+export async function actRun<T>(run: () => T | Promise<T>): Promise<T> {
+  let result!: T;
+  await act(async () => {
+    result = await run();
+  });
+  return result;
+}
+
 export type RenderedComponent = {
   /** The mount container — query it with `.querySelector` etc. */
   container: HTMLElement;

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -5,7 +5,7 @@
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import type { DesktopRfbFactory, DesktopRfbLike } from "@opengeni/sdk";
-import { registerDom, renderComponent, flush } from "./render-hook";
+import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 import { fakeCapabilities, fakeFileDiff, fakeHeadlessCapabilities } from "./sandbox-fixtures";
 import { DesktopViewer } from "../src/components/desktop-viewer";
 import { DiffView } from "../src/components/diff-view";
@@ -182,6 +182,7 @@ describe("DesktopViewer", () => {
 
   test("an un-acknowledged desktop renders the consent gate (and accept fires)", async () => {
     let accepted = false;
+    const { factory } = fakeRfb();
     const cap = fakeCapabilities({
       DesktopStream: {
         ...fakeCapabilities().DesktopStream,
@@ -195,13 +196,14 @@ describe("DesktopViewer", () => {
         onAcknowledge={() => {
           accepted = true;
         }}
+        rfbFactory={factory}
       />,
     );
     await flush();
     expect(r.container.textContent).toContain("un-redacted");
     const button = r.container.querySelector("button");
     expect(button).not.toBeNull();
-    button!.click();
+    await actRun(() => button!.click());
     await flush();
     expect(accepted).toBe(true);
     await r.unmount();

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -5,7 +5,7 @@
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import { OpenGeniApiError, type SessionEvent } from "@opengeni/sdk";
-import { registerDom, renderHook, flush } from "./render-hook";
+import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import {
   fakeAttachResponse,
@@ -535,7 +535,7 @@ describe("useSandboxFiles", () => {
     await flush();
     expect(hook.result.current.tree.map((n) => n.name)).toEqual(["src", "README.md"]);
     // Lazy expand "src".
-    await hook.result.current.expand("src");
+    await actRun(() => hook.result.current.expand("src"));
     await flush();
     const src = hook.result.current.tree.find((n) => n.path === "src");
     expect(src?.children?.[0]?.name).toBe("app.ts");
@@ -693,12 +693,12 @@ describe("useSandboxFiles", () => {
     );
     await flush();
     // Expand src so it has loaded children we must NOT lose.
-    await hook.result.current.expand("src");
+    await actRun(() => hook.result.current.expand("src"));
     await flush();
     expect(hook.result.current.tree.find((n) => n.path === "src")?.children?.length).toBe(1);
     const rootListsBefore = rootLists;
 
-    await hook.result.current.createFile("src/new.ts");
+    await actRun(() => hook.result.current.createFile("src/new.ts"));
     await flush();
     const src = hook.result.current.tree.find((n) => n.path === "src");
     // The new file is spliced in (optimistic) AND the existing app.ts survives —
@@ -761,7 +761,7 @@ describe("useSandboxFiles", () => {
       undefined,
     );
     await flush();
-    await hook.result.current.createFile("b.ts").catch(() => {});
+    await actRun(() => hook.result.current.createFile("b.ts").catch(() => {}));
     await flush();
     // The optimistic b.ts was rolled back — only the original a.ts remains.
     expect(hook.result.current.tree.map((n) => n.name)).toEqual(["a.ts"]);
@@ -918,7 +918,7 @@ describe("useSandboxFiles", () => {
       { events: [] as SessionEvent[] },
     );
     await flush();
-    await hook.result.current.expand("src");
+    await actRun(() => hook.result.current.expand("src"));
     await flush();
     listPaths.length = 0;
     // The AGENT writes src/added.ts → reconcile ONLY "src" (not a root re-list).

--- a/packages/react/test/slash-commands-hook.test.tsx
+++ b/packages/react/test/slash-commands-hook.test.tsx
@@ -9,7 +9,7 @@ import {
   type SlashCommandHandlers,
 } from "../src/hooks/use-slash-commands";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
-import { flush, registerDom, renderHook } from "./render-hook";
+import { actRun, flush, registerDom, renderHook } from "./render-hook";
 
 registerDom();
 
@@ -74,6 +74,13 @@ function setup(options: {
   }, undefined);
 }
 
+async function press(harness: Awaited<ReturnType<typeof setup>>, key: string): Promise<void> {
+  await actRun(async () => {
+    harness.result.current.command.onKeyDown(keyEvent({ key }));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 const sessionCtx: SlashCommandContext = {
   client: fakeClient({
     updateGoal: async () => ({}) as never,
@@ -110,16 +117,16 @@ describe("useSlashCommands", () => {
     const count = h.result.current.command.items.length;
     expect(count).toBeGreaterThan(1);
     expect(h.result.current.command.highlight).toBe(0);
-    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowDown" }));
+    await press(h, "ArrowDown");
     await h.rerender();
     expect(h.result.current.command.highlight).toBe(1);
     // Wrap back to top from the last item.
     for (let i = 1; i < count; i += 1) {
-      h.result.current.command.onKeyDown(keyEvent({ key: "ArrowDown" }));
+      await press(h, "ArrowDown");
       await h.rerender();
     }
     expect(h.result.current.command.highlight).toBe(0);
-    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowUp" }));
+    await press(h, "ArrowUp");
     await h.rerender();
     expect(h.result.current.command.highlight).toBe(count - 1);
     await h.unmount();
@@ -127,7 +134,7 @@ describe("useSlashCommands", () => {
 
   test("Tab autocompletes the highlighted command name + trailing space", async () => {
     const h = await setup({ initialValue: "/comp", context: sessionCtx });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Tab" }));
+    await press(h, "Tab");
     await h.rerender();
     expect(h.result.current.value).toBe("/compact ");
     await h.unmount();
@@ -136,12 +143,12 @@ describe("useSlashCommands", () => {
   test("Escape closes the palette but keeps the draft", async () => {
     const h = await setup({ initialValue: "/clear", context: sessionCtx });
     expect(h.result.current.command.open).toBe(true);
-    h.result.current.command.onKeyDown(keyEvent({ key: "Escape" }));
+    await press(h, "Escape");
     await h.rerender();
     expect(h.result.current.command.open).toBe(false);
     expect(h.result.current.value).toBe("/clear");
     // Editing re-opens.
-    h.result.current.setValue("/clear-");
+    await actRun(() => h.result.current.setValue("/clear-"));
     await h.rerender();
     expect(h.result.current.command.open).toBe(true);
     await h.unmount();
@@ -149,7 +156,7 @@ describe("useSlashCommands", () => {
 
   test("Enter runs a client command and clears the draft", async () => {
     const h = await setup({ initialValue: "/help", context: sessionCtx });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     await flush();
     await h.rerender();
     expect(h.result.current.helpOpened).toBe(1);
@@ -160,7 +167,7 @@ describe("useSlashCommands", () => {
   test("Enter on a required-arg command without the arg does not run (waits at the hint)", async () => {
     const h = await setup({ initialValue: "/goal ", context: sessionCtx });
     expect(h.result.current.command.activeCommand?.name).toBe("goal");
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     await h.rerender();
     // Still /goal with no notice — nothing fired.
     expect(h.result.current.value).toBe("/goal ");
@@ -170,7 +177,7 @@ describe("useSlashCommands", () => {
 
   test("Enter on /goal pause runs and surfaces an ok notice", async () => {
     const h = await setup({ initialValue: "/goal pause", context: sessionCtx });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     await flush();
     await h.rerender();
     expect(h.result.current.notices.at(-1)).toEqual({ tone: "ok", message: "Goal paused." });
@@ -189,7 +196,7 @@ describe("useSlashCommands", () => {
       }),
     };
     const h = await setup({ initialValue: "/clear", context: ctx, confirmAnswer: true });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -249,7 +256,7 @@ describe("useSlashCommands", () => {
     // The destructive clear is present too (the exact-match the override would pick).
     expect(items.some((c) => c.name === "clear")).toBe(true);
 
-    await h.result.current.command.runAt(clearViewIndex);
+    await actRun(() => h.result.current.command.runAt(clearViewIndex));
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -309,13 +316,13 @@ describe("useSlashCommands", () => {
     // clear-view sorts first, so highlight 0 is already clear-view; arrow-navigate
     // explicitly (down then up returns to 0) to mark the selection as deliberate.
     expect(h.result.current.command.items[0]?.name).toBe("clear-view");
-    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowDown" }));
+    await press(h, "ArrowDown");
     await h.rerender();
-    h.result.current.command.onKeyDown(keyEvent({ key: "ArrowUp" }));
+    await press(h, "ArrowUp");
     await h.rerender();
     expect(h.result.current.command.highlight).toBe(0);
 
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -342,7 +349,7 @@ describe("useSlashCommands", () => {
     };
     const h = await setup({ initialValue: "/clear", context: ctx, confirmAnswer: true });
     // No arrow keys — straight Enter.
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -366,7 +373,7 @@ describe("useSlashCommands", () => {
       }),
     };
     const h = await setup({ initialValue: "/Clear", context: ctx, confirmAnswer: true });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -386,7 +393,7 @@ describe("useSlashCommands", () => {
       }),
     };
     const h = await setup({ initialValue: "/clear", context: ctx, confirmAnswer: false });
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     for (let i = 0; i < 5; i += 1) {
       await flush();
     }
@@ -401,7 +408,7 @@ describe("useSlashCommands", () => {
     const h = await setup({ initialValue: "/clear", context: sessionCtx });
     expect(h.result.current.command.isCommandDraft).toBe(true);
     expect(h.result.current.command.open).toBe(true);
-    h.result.current.command.onKeyDown(keyEvent({ key: "Escape" }));
+    await press(h, "Escape");
     await h.rerender();
     // Popover closed, but the draft is still a command — the composer uses this
     // to keep "/clear" from being sent to the agent as chat.
@@ -421,7 +428,7 @@ describe("useSlashCommands", () => {
 
   test("runAt out of range is a no-op", async () => {
     const h = await setup({ initialValue: "/clear", context: sessionCtx });
-    await h.result.current.command.runAt(999);
+    await actRun(() => h.result.current.command.runAt(999));
     await h.rerender();
     expect(h.result.current.notices).toHaveLength(0);
     await h.unmount();
@@ -431,7 +438,7 @@ describe("useSlashCommands", () => {
     const h = await setup({ initialValue: "/clear", context: undefined });
     // open still derives from value (commands have no perm gate for help), but
     // running does nothing without a context.
-    h.result.current.command.onKeyDown(keyEvent({ key: "Enter" }));
+    await press(h, "Enter");
     await h.rerender();
     expect(h.result.current.notices).toHaveLength(0);
     await h.unmount();

--- a/packages/react/test/timeline-failed-status.test.tsx
+++ b/packages/react/test/timeline-failed-status.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { registerDom, renderComponent, flush } from "./render-hook";
+import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 import {
   defaultToolRegistry,
   ActivityRail,
@@ -396,7 +396,7 @@ describe("ComputerCallRenderer — failed status (flagged fix)", () => {
 
     // Expand the row.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     await flush();
 
     const text = r.container.textContent ?? "";

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -487,7 +487,9 @@ describe("ApplyPatchRenderer — multi-file with one malformed op", () => {
 
     // Expand the disclosure to see the body content.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     await flush();
 
     const bodyText = r.container.textContent ?? "";
@@ -589,7 +591,9 @@ describe("WebSearchRenderer — null/undefined entries in results array", () => 
 
     // Expand the disclosure to see the body.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     await flush();
 
     const text = r.container.textContent ?? "";
@@ -614,7 +618,9 @@ describe("WebSearchRenderer — null/undefined entries in results array", () => 
 
     // Expand.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     await flush();
 
     const text = r.container.textContent ?? "";
@@ -664,7 +670,9 @@ describe("ExecRenderer — failed status with non-empty output", () => {
 
     // Expand.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     await flush();
 
     const text = r.container.textContent ?? "";
@@ -819,7 +827,9 @@ describe("ViewImageRenderer — running state (in-flight affordance)", () => {
 
     // Expand the row to see the body note.
     const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
-    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     await flush();
 
     const text = r.container.textContent ?? "";

--- a/packages/react/test/use-codex-accounts.test.tsx
+++ b/packages/react/test/use-codex-accounts.test.tsx
@@ -5,7 +5,7 @@
    structural CodexAccountsClientLike surface.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
-import { registerDom, renderHook, flush } from "./render-hook";
+import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, WORKSPACE_ID } from "./fake-client";
 import { useCodexAccounts, type CodexAccountsClientLike } from "../src/hooks/use-codex-accounts";
 import type { CodexAccount, CodexAccountsResponse, CodexUsageWindow } from "@opengeni/sdk";
@@ -61,6 +61,7 @@ describe("useCodexAccounts — cached usage + refreshUsage", () => {
     await flush();
     expect(hook.result.current.accounts[0]?.fiveHour?.remaining).toBe(60);
     expect(hook.result.current.accounts[0]?.weekly?.percent).toBe(12);
+    await hook.unmount();
   });
 
   test("refreshUsage() calls the batched refresh then re-reads accounts with the fresh windows", async () => {
@@ -84,12 +85,11 @@ describe("useCodexAccounts — cached usage + refreshUsage", () => {
 
     let returned: boolean | undefined;
     await flush();
-    await (async () => {
-      returned = await hook.result.current.refreshUsage();
-    })();
+    returned = await actRun(() => hook.result.current.refreshUsage());
     await flush();
     expect(returned).toBe(true);
     expect(hook.result.current.accounts[0]?.fiveHour?.percent).toBe(55);
+    await hook.unmount();
   });
 
   test("refreshUsage() is a no-op (false) when the client can't refresh usage", async () => {
@@ -103,10 +103,9 @@ describe("useCodexAccounts — cached usage + refreshUsage", () => {
     );
     await flush();
     let returned: boolean | undefined;
-    await (async () => {
-      returned = await hook.result.current.refreshUsage();
-    })();
+    returned = await actRun(() => hook.result.current.refreshUsage());
     await flush();
     expect(returned).toBe(false);
+    await hook.unmount();
   });
 });

--- a/packages/react/test/use-machines.test.tsx
+++ b/packages/react/test/use-machines.test.tsx
@@ -5,7 +5,7 @@
    it reads only the structural client, so an adapter works in any frontend.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
-import { registerDom, renderHook, flush } from "./render-hook";
+import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, WORKSPACE_ID } from "./fake-client";
 import { useMachines, type MachinesClientLike } from "../src/hooks/use-machines";
 import type { MachinesResponse, MachineView } from "../src/types/machines";
@@ -76,7 +76,7 @@ describe("useMachines", () => {
     );
     await flush();
     expect(hook.result.current.canAttach).toBe(true);
-    const ok = await hook.result.current.attach("sh-1");
+    const ok = await actRun(() => hook.result.current.attach("sh-1"));
     await flush();
     expect(ok).toBe(true);
     expect(swappedTo).toEqual([{ sessionId: "sess-1", target: "sh-1" }]);
@@ -103,7 +103,7 @@ describe("useMachines", () => {
       undefined,
     );
     await flush();
-    const ok = await hook.result.current.attach("sh-1");
+    const ok = await actRun(() => hook.result.current.attach("sh-1"));
     await flush();
     expect(ok).toBe(true);
     expect(attachedTo).toEqual([{ sessionId: "sess-2", sandboxId: "sh-1" }]);
@@ -121,7 +121,7 @@ describe("useMachines", () => {
     );
     await flush();
     expect(hook.result.current.canAttach).toBe(false);
-    const ok = await hook.result.current.attach("sh-1");
+    const ok = await actRun(() => hook.result.current.attach("sh-1"));
     expect(ok).toBe(false);
     await hook.unmount();
   });

--- a/packages/react/test/use-session-events.test.tsx
+++ b/packages/react/test/use-session-events.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
-import { registerDom, renderHook, flush } from "./render-hook";
+import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import { useSessionEvents } from "../src/hooks/use-session-events";
 import { buildTimeline, type TimelineItem } from "../src/timeline";
@@ -170,7 +170,7 @@ describe("useSessionEvents", () => {
     expect(hook.result.current.events[0]?.sequence).toBe(6103);
     expect(hook.result.current.hasOlder).toBe(true);
 
-    const more = await hook.result.current.loadOlder();
+    const more = await actRun(() => hook.result.current.loadOlder());
     await flush(20);
     // The older window starts exactly below the kept window and reaches the log
     // start within the older two-fetch cap.
@@ -212,12 +212,18 @@ describe("useSessionEvents", () => {
     );
     await flush(20);
 
-    const first = hook.result.current.loadOlder();
-    const second = hook.result.current.loadOlder();
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    await actRun(() => {
+      first = hook.result.current.loadOlder();
+      second = hook.result.current.loadOlder();
+    });
     await flush();
     expect(listCalls.filter((call) => call.before === 5001)).toHaveLength(1);
-    releaseOlder();
-    const [firstResult, secondResult] = await Promise.all([first, second]);
+    const [firstResult, secondResult] = await actRun(async () => {
+      releaseOlder();
+      return await Promise.all([first, second]);
+    });
     await flush(20);
 
     expect(firstResult).toBe(false);
@@ -345,12 +351,12 @@ describe("useSessionEvents", () => {
     expect(hook.result.current.hasOlder).toBe(true);
     expect(hook.result.current.lastSequence).toBe(9);
 
-    const first = await hook.result.current.loadOlder();
+    const first = await actRun(() => hook.result.current.loadOlder());
     await flush(20);
     expect(first).toBe(true);
     expect(hook.result.current.events.map((item) => item.sequence)).toEqual([4, 6, 8]);
 
-    const more = await hook.result.current.loadOlder();
+    const more = await actRun(() => hook.result.current.loadOlder());
     await flush(20);
 
     expect(more).toBe(false);

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -16,7 +16,7 @@ import type {
   WorkspaceCaptureManifest,
   WorkspaceCaptureRepo,
 } from "@opengeni/sdk";
-import { registerDom, renderHook, flush } from "./render-hook";
+import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import { fakeEvent } from "./sandbox-fixtures";
 import { useWorkspaceCapture } from "../src/hooks/use-workspace-capture";
@@ -1081,7 +1081,7 @@ describe("useWorkspaceEdit", () => {
     await flush();
     expect(hook.result.current.state).toBe("viewing-cold");
 
-    hook.result.current.edit("hello world\n");
+    await actRun(() => hook.result.current.edit("hello world\n"));
     await flush();
     // Cold edit buffers and signals the host to warm ONCE.
     expect(hook.result.current.state).toBe("buffering");
@@ -1129,7 +1129,7 @@ describe("useWorkspaceEdit", () => {
       { liveness: "cold" },
     );
     await flush();
-    hook.result.current.edit("my local edit\n");
+    await actRun(() => hook.result.current.edit("my local edit\n"));
     await flush();
     await hook.rerender({ liveness: "warm" });
     await flush();
@@ -1139,7 +1139,7 @@ describe("useWorkspaceEdit", () => {
     expect(hook.result.current.conflict?.base).toBe("hello\n");
     expect(hook.result.current.conflict?.live).toBe("AGENT CHANGED THIS\n");
     // The user chooses "overwrite" → force flush (last-writer-wins).
-    await hook.result.current.overwrite();
+    await actRun(() => hook.result.current.overwrite());
     await flush();
     expect(hook.result.current.state).toBe("flushed");
     expect(writes.length).toBe(1);
@@ -1166,7 +1166,7 @@ describe("useWorkspaceEdit", () => {
     await flush();
     expect(hook.result.current.state).toBe("readonly-offline");
     expect(hook.result.current.readOnly).toBe(true);
-    hook.result.current.edit("nope");
+    await actRun(() => hook.result.current.edit("nope"));
     await flush();
     expect(hook.result.current.buffer).toBeNull();
     expect(hook.result.current.wantsWarm).toBe(false);
@@ -1189,7 +1189,7 @@ describe("useWorkspaceEdit", () => {
       { warming: false },
     );
     await flush();
-    hook.result.current.edit("edit");
+    await actRun(() => hook.result.current.edit("edit"));
     await flush();
     expect(hook.result.current.state).toBe("buffering");
     await hook.rerender({ warming: true });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5276,6 +5276,7 @@ export async function runRigSetupHook(
     });
     throw new Error(
       `Rig setup failed for rig "${rigSetup.rigName}" (version ${rigSetup.versionId}): ${message}`,
+      { cause: error },
     );
   }
   const output = sandboxCommandOutput(result);

--- a/packages/runtime/test/codex-hosted-apply-patch.test.ts
+++ b/packages/runtime/test/codex-hosted-apply-patch.test.ts
@@ -16,7 +16,9 @@ import { buildAgentCapabilities } from "../src/index";
 // A model instance the SDK reads as hosted-transport-capable: its constructor
 // name does NOT contain "ChatCompletions" (so supportsApplyPatchTransport → true,
 // exactly like the real OpenAIResponsesModel our codex turns bind).
-class OpenAIResponsesModel {}
+class OpenAIResponsesModel {
+  readonly transport = "responses";
+}
 
 // The exact bind chain the SandboxAgent runs: clone() a fresh per-run instance,
 // then bind → bindRunAs → bindModel, and call tools() on the object the CHAIN

--- a/packages/runtime/test/modal-registry-image.test.ts
+++ b/packages/runtime/test/modal-registry-image.test.ts
@@ -25,7 +25,6 @@ function fakeModal() {
       ModalClient: class {
         images = { fromRegistry };
         secrets = { fromName: secretFromName };
-        constructor(_opts: unknown) {}
       },
     }) as unknown as Awaited<ReturnType<ModalModuleLoader>>;
   return { loadModal, fromRegistry, secretFromName, fakeImage };

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -263,11 +263,11 @@ describe("MultiProviderModelProvider — routes a model NAME to its provider (th
   // provider. Without this router that hit the built-in (Azure) client, so a
   // Fireworks model 404'd ("deployment does not exist"). The router resolves
   // names back to their provider regardless of path.
-  const FIREWORKS_MODEL = "accounts/fireworks/models/glm-5p2";
+  const routedFireworksModel = "accounts/fireworks/models/glm-5p2";
 
   test("routes a registry model name to a chat-completions Model (NOT the built-in)", async () => {
     const provider = new MultiProviderModelProvider(multiProviderSettings());
-    const model = await provider.getModel(FIREWORKS_MODEL);
+    const model = await provider.getModel(routedFireworksModel);
     expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
     expect(model).not.toBeInstanceOf(OpenAIResponsesModel);
   });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -309,7 +309,7 @@ describe("runtime event normalization", () => {
     } as any);
 
     expect(event?.type).toBe("agent.toolCall.created");
-    expect((event?.payload as { id: string }).id).toBe("call-1");
+    expect((event?.payload as { id?: string } | undefined)?.id).toBe("call-1");
   });
 
   test("compacts a codex computer_screenshot Uint8Array output to a data-URL string in the event", () => {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -27,8 +27,12 @@ import {
 // constructor name (supportsStructuredToolOutputTransport): a name containing
 // "ChatCompletions" (and an UNBOUND model) → text/function transport; anything else
 // → structured/hosted. These two fakes make the branch explicit in the tests.
-class OpenAIResponsesModel {}
-class OpenAIChatCompletionsModel {}
+class OpenAIResponsesModel {
+  readonly transport = "responses";
+}
+class OpenAIChatCompletionsModel {
+  readonly transport = "chat-completions";
+}
 /** A structured-transport model instance → ComputerUseCapability emits the HOSTED tool. */
 const structuredModel = (): never => new OpenAIResponsesModel() as never;
 /** A ChatCompletions-family instance → ComputerUseCapability emits the FUNCTION tools. */

--- a/packages/runtime/test/selfhosted-session.test.ts
+++ b/packages/runtime/test/selfhosted-session.test.ts
@@ -101,17 +101,17 @@ describe("SelfhostedSession — structural surface over a ControlRpc (mock)", ()
   test("readFile of a missing path surfaces an OS NotFound (not a box-gone NotFound)", async () => {
     const mock = new MockAgentResponder();
     const session = sessionWith(mock);
-    let err: unknown;
+    let missingPathError: unknown;
     try {
       await session.readFile({ path: "/tmp/does-not-exist" });
     } catch (e) {
-      err = e;
+      missingPathError = e;
     }
-    expect(err).toBeInstanceOf(SelfhostedControlError);
-    expect((err as SelfhostedControlError).code).toBe(ErrorCode.ERROR_CODE_NOT_FOUND);
-    expect((err as SelfhostedControlError).osNotFound).toBe(true);
+    expect(missingPathError).toBeInstanceOf(SelfhostedControlError);
+    expect((missingPathError as SelfhostedControlError).code).toBe(ErrorCode.ERROR_CODE_NOT_FOUND);
+    expect((missingPathError as SelfhostedControlError).osNotFound).toBe(true);
     // crucially: an OS NotFound does NOT flip the provider-NotFound discriminator.
-    expect(isSelfhostedProviderNotFoundError(err)).toBe(false);
+    expect(isSelfhostedProviderNotFoundError(missingPathError)).toBe(false);
   });
 
   test("resolveExposedPort returns the relay URL shape + the M8b channel-key routing query", async () => {
@@ -465,15 +465,15 @@ describe("AgentError → runtime reason mapping (the M3 ruling)", () => {
 
   test("an offline mock surfaces agent_offline on exec (never a NotFound)", async () => {
     const mock = new MockAgentResponder({ online: false });
-    let err: unknown;
+    let offlineError: unknown;
     try {
       await sessionWith(mock).exec({ cmd: "true" });
     } catch (e) {
-      err = e;
+      offlineError = e;
     }
-    expect(err).toBeInstanceOf(SelfhostedControlError);
-    expect((err as SelfhostedControlError).reason).toBe("agent_offline");
-    expect(isProviderSandboxNotFoundError("selfhosted", err)).toBe(false);
+    expect(offlineError).toBeInstanceOf(SelfhostedControlError);
+    expect((offlineError as SelfhostedControlError).reason).toBe("agent_offline");
+    expect(isProviderSandboxNotFoundError("selfhosted", offlineError)).toBe(false);
   });
 });
 

--- a/packages/sdk/src/stream.ts
+++ b/packages/sdk/src/stream.ts
@@ -66,7 +66,8 @@ export async function* streamSessionEvents(
   let delayMs = baseDelayMs;
   let everConnected = false;
 
-  while (!signal?.aborted) {
+  while (true) {
+    if (signal?.aborted) break;
     options.onStateChange?.(everConnected || failedAttempts > 0 ? "reconnecting" : "connecting");
     const cursorAtOpen = cursor;
     try {

--- a/packages/testing/src/fakes.ts
+++ b/packages/testing/src/fakes.ts
@@ -39,11 +39,11 @@ export class MemoryEventBus implements EventBus {
   }
 
   async request(
-    subject: string,
+    requestSubject: string,
     payload: Uint8Array,
     _opts: { timeoutMs: number },
   ): Promise<RequestReply> {
-    const handler = this.responders.get(subject);
+    const handler = this.responders.get(requestSubject);
     if (!handler) {
       // No responder on the subject — model the NATS 503 NoResponders the real
       // transport surfaces, so a consumer's offline mapping is exercised in-memory.
@@ -51,15 +51,15 @@ export class MemoryEventBus implements EventBus {
       error.code = "503";
       throw error;
     }
-    const data = await handler(payload, subject);
+    const data = await handler(payload, requestSubject);
     return { data };
   }
 
-  subscribeRequests(subject: string, handler: RequestHandler): () => void {
-    this.responders.set(subject, handler);
+  subscribeRequests(requestSubject: string, handler: RequestHandler): () => void {
+    this.responders.set(requestSubject, handler);
     return () => {
-      if (this.responders.get(subject) === handler) {
-        this.responders.delete(subject);
+      if (this.responders.get(requestSubject) === handler) {
+        this.responders.delete(requestSubject);
       }
     };
   }
@@ -80,20 +80,20 @@ export class MemoryEventBus implements EventBus {
    *  `agent.<ws>.<id>.events`), delivering it to every subscriber whose pattern
    *  matches (`agent.*.*.events` ↔ the concrete subject). Mirrors NATS wildcard
    *  delivery so an ingestion test can drive a heartbeat without a real broker. */
-  async emitAgentEvent(subject: string, payload: Uint8Array): Promise<void> {
+  async emitAgentEvent(eventSubject: string, payload: Uint8Array): Promise<void> {
     const matching: Array<(payload: Uint8Array, subject: string) => void | Promise<void>> = [];
     for (const [pattern, subscribers] of this.agentEventSubscribers) {
-      if (subjectMatches(pattern, subject)) {
+      if (subjectMatches(pattern, eventSubject)) {
         matching.push(...subscribers);
       }
     }
-    await Promise.all(matching.map((handler) => handler(payload, subject)));
+    await Promise.all(matching.map((handler) => handler(payload, eventSubject)));
   }
 
   getRequestConnection(): RequestConnection {
     return {
-      request: (subject, payload, opts) =>
-        this.request(subject, payload, { timeoutMs: opts.timeout }),
+      request: (requestSubject, payload, opts) =>
+        this.request(requestSubject, payload, { timeoutMs: opts.timeout }),
     };
   }
 
@@ -102,9 +102,9 @@ export class MemoryEventBus implements EventBus {
 
 /** NATS-style subject wildcard match: `*` matches exactly one token. Used by the
  *  in-memory bus to mirror `agent.*.*.events` ↔ `agent.<ws>.<id>.events`. */
-function subjectMatches(pattern: string, subject: string): boolean {
+function subjectMatches(pattern: string, candidateSubject: string): boolean {
   const p = pattern.split(".");
-  const s = subject.split(".");
+  const s = candidateSubject.split(".");
   if (p.length !== s.length) {
     return false;
   }

--- a/scripts/check-docs-refs.ts
+++ b/scripts/check-docs-refs.ts
@@ -77,7 +77,7 @@ async function listWorkspacePackages(): Promise<Set<string>> {
 function checkReferences(
   file: string,
   text: string,
-  workspacePackages: Set<string>,
+  knownWorkspacePackages: Set<string>,
   out: Finding[],
 ): void {
   const lines = text.split("\n");
@@ -107,7 +107,7 @@ function checkReferences(
     }
 
     for (const token of extractPackageReferences(line)) {
-      if (!workspacePackages.has(token) && !externalPackageAllowlist.has(token)) {
+      if (!knownWorkspacePackages.has(token) && !externalPackageAllowlist.has(token)) {
         addFinding(out, seen, {
           file,
           line: lineNumber,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -1,0 +1,141 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+type ManifestEntry = {
+  file: string;
+  imports?: string[];
+  css?: string[];
+  isEntry?: boolean;
+};
+
+const kib = 1024;
+const budgets = {
+  initialRaw: 750 * kib,
+  initialGzip: 210 * kib,
+  initialFileGzip: 70 * kib,
+  directSessionRaw: 1900 * kib,
+  directSessionGzip: 540 * kib,
+  lazyChunkRaw: 800 * kib,
+  lazyChunkGzip: 240 * kib,
+  cssGzip: 30 * kib,
+} as const;
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const distDir = path.join(repoRoot, "apps/web/dist");
+const manifestPath = path.join(distDir, ".vite/manifest.json");
+const manifest = (await Bun.file(manifestPath).json()) as Record<string, ManifestEntry>;
+
+function staticGraph(startKeys: Iterable<string>): Set<string> {
+  const visited = new Set<string>();
+  const pending = [...startKeys];
+  while (pending.length > 0) {
+    const key = pending.pop()!;
+    if (visited.has(key)) continue;
+    const entry = manifest[key];
+    if (!entry) throw new Error(`bundle manifest is missing static import ${key}`);
+    visited.add(key);
+    pending.push(...(entry.imports ?? []));
+  }
+  return visited;
+}
+
+function assetPaths(keys: Iterable<string>, includeDocument = false): Set<string> {
+  const assets = new Set<string>();
+  if (includeDocument) assets.add("index.html");
+  for (const key of keys) {
+    const entry = manifest[key]!;
+    assets.add(entry.file);
+    for (const css of entry.css ?? []) assets.add(css);
+  }
+  return assets;
+}
+
+type AssetMetric = { file: string; raw: number; gzip: number };
+
+async function metric(file: string): Promise<AssetMetric> {
+  const bytes = await Bun.file(path.join(distDir, file)).bytes();
+  return { file, raw: bytes.byteLength, gzip: Bun.gzipSync(bytes).byteLength };
+}
+
+async function metrics(files: Iterable<string>): Promise<AssetMetric[]> {
+  return await Promise.all([...files].sort().map(metric));
+}
+
+function total(items: AssetMetric[]): { raw: number; gzip: number } {
+  return items.reduce((sum, item) => ({ raw: sum.raw + item.raw, gzip: sum.gzip + item.gzip }), {
+    raw: 0,
+    gzip: 0,
+  });
+}
+
+function largest(items: AssetMetric[], field: "raw" | "gzip"): AssetMetric {
+  const sorted = [...items].sort((left, right) => right[field] - left[field]);
+  const item = sorted[0];
+  if (!item) throw new Error("web bundle contains no measured assets");
+  return item;
+}
+
+const entryKeys = Object.entries(manifest)
+  .filter(([, entry]) => entry.isEntry)
+  .map(([key]) => key);
+if (entryKeys.length !== 1) {
+  throw new Error(`expected one web entry, found ${entryKeys.length}`);
+}
+
+const initialGraph = staticGraph(entryKeys);
+const initialMetrics = await metrics(assetPaths(initialGraph, true));
+const initialTotal = total(initialMetrics);
+const largestInitial = largest(initialMetrics, "gzip");
+
+const sessionRouteKey = "src/routes/session.tsx";
+if (!manifest[sessionRouteKey]) {
+  throw new Error(`bundle manifest is missing ${sessionRouteKey}`);
+}
+const directSessionGraph = staticGraph([...entryKeys, sessionRouteKey]);
+const directSessionMetrics = await metrics(assetPaths(directSessionGraph, true));
+const directSessionTotal = total(directSessionMetrics);
+
+const assetDir = path.join(distDir, "assets");
+const allChunkFiles = (await readdir(assetDir))
+  .filter((file) => file.endsWith(".js"))
+  .map((file) => `assets/${file}`);
+const initialFiles = assetPaths(initialGraph, true);
+const lazyMetrics = await metrics(allChunkFiles.filter((file) => !initialFiles.has(file)));
+const largestLazyRaw = largest(lazyMetrics, "raw");
+const largestLazyGzip = largest(lazyMetrics, "gzip");
+
+const cssMetrics = await metrics(
+  (await readdir(assetDir)).filter((file) => file.endsWith(".css")).map((file) => `assets/${file}`),
+);
+const largestCss = largest(cssMetrics, "gzip");
+
+const report = {
+  initial: { ...initialTotal, files: initialMetrics.length, largestGzip: largestInitial },
+  directSession: { ...directSessionTotal, files: directSessionMetrics.length },
+  lazy: {
+    files: lazyMetrics.length,
+    largestRaw: largestLazyRaw,
+    largestGzip: largestLazyGzip,
+  },
+  css: { files: cssMetrics.length, largestGzip: largestCss },
+  budgets,
+};
+console.log(JSON.stringify(report, null, 2));
+
+const failures: string[] = [];
+function enforce(label: string, actual: number, limit: number): void {
+  if (actual > limit) failures.push(`${label}: ${actual} bytes exceeds ${limit}`);
+}
+
+enforce("initial raw graph", initialTotal.raw, budgets.initialRaw);
+enforce("initial gzip graph", initialTotal.gzip, budgets.initialGzip);
+enforce("largest initial gzip asset", largestInitial.gzip, budgets.initialFileGzip);
+enforce("direct session raw graph", directSessionTotal.raw, budgets.directSessionRaw);
+enforce("direct session gzip graph", directSessionTotal.gzip, budgets.directSessionGzip);
+enforce("largest lazy raw chunk", largestLazyRaw.raw, budgets.lazyChunkRaw);
+enforce("largest lazy gzip chunk", largestLazyGzip.gzip, budgets.lazyChunkGzip);
+enforce("largest CSS gzip asset", largestCss.gzip, budgets.cssGzip);
+
+if (failures.length > 0) {
+  throw new Error(`web bundle budget failed:\n- ${failures.join("\n- ")}`);
+}

--- a/scripts/deployment-conformance.ts
+++ b/scripts/deployment-conformance.ts
@@ -351,13 +351,13 @@ async function deleteJson(url: URL): Promise<any> {
 }
 
 async function waitForTerminalSessionStatus(
-  sessionId: string,
+  targetSessionId: string,
   timeoutSeconds: number,
 ): Promise<string> {
   const deadline = Date.now() + timeoutSeconds * 1000;
   let status = "unknown";
   while (Date.now() < deadline) {
-    const current = await getJson(workspaceUrl(`/sessions/${sessionId}`));
+    const current = await getJson(workspaceUrl(`/sessions/${targetSessionId}`));
     status = stringField(current, "status");
     if (["idle", "failed", "cancelled"].includes(status)) {
       break;
@@ -411,14 +411,14 @@ async function preflightObjectPut(
   ]
     .sort()
     .join(", ");
-  const requestHeaders = {
+  const preflightHeaders = {
     origin,
     "access-control-request-method": "PUT",
     ...(accessControlHeaders ? { "access-control-request-headers": accessControlHeaders } : {}),
   };
   const response = connectTo
-    ? curlPreflight(url, requestHeaders, connectTo)
-    : await fetchPreflight(url, requestHeaders);
+    ? curlPreflight(url, preflightHeaders, connectTo)
+    : await fetchPreflight(url, preflightHeaders);
   if (response.status < 200 || response.status >= 300) {
     throw new Error(
       `browser upload CORS preflight returned HTTP ${response.status}: ${response.body.trim()}`,
@@ -525,8 +525,8 @@ async function readStreamUntilAbort(response: Response, signal: AbortSignal): Pr
   return text + decoder.decode();
 }
 
-function runCurl(args: string[], input?: string): string {
-  const result = spawnSync("curl", args, {
+function runCurl(curlArgs: string[], input?: string): string {
+  const result = spawnSync("curl", curlArgs, {
     encoding: "utf8",
     input,
     stdio: ["pipe", "pipe", "pipe"],

--- a/scripts/deployment-preflight.ts
+++ b/scripts/deployment-preflight.ts
@@ -203,10 +203,10 @@ function parseArgs(values: string[]): Args {
   return out;
 }
 
-async function runLiveProbes(contract: DeploymentContract): Promise<LiveProbeResult[]> {
+async function runLiveProbes(deploymentContract: DeploymentContract): Promise<LiveProbeResult[]> {
   const results: LiveProbeResult[] = [];
-  if (contract.runtime.platform === "kubernetes") {
-    results.push(runKubectlNamespaceProbe(contract.runtime.namespace));
+  if (deploymentContract.runtime.platform === "kubernetes") {
+    results.push(runKubectlNamespaceProbe(deploymentContract.runtime.namespace));
   }
 
   const databaseUrl = process.env.OPENGENI_DATABASE_URL;
@@ -251,8 +251,8 @@ async function runLiveProbes(contract: DeploymentContract): Promise<LiveProbeRes
 }
 
 function runKubectlNamespaceProbe(namespace: string | undefined): LiveProbeResult {
-  const args = namespace ? ["get", "namespace", namespace] : ["version", "--client=true"];
-  const result = spawnSync("kubectl", args, {
+  const kubectlArgs = namespace ? ["get", "namespace", namespace] : ["version", "--client=true"];
+  const result = spawnSync("kubectl", kubectlArgs, {
     encoding: "utf8",
     timeout: 10_000,
     stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/deployment-temporal-values.ts
+++ b/scripts/deployment-temporal-values.ts
@@ -92,12 +92,12 @@ schema:
 ${tlsCaMount ? `admintools:\n${tlsCaMount}` : ""}`;
 }
 
-function parseArgs(values: string[]): Args {
+function parseArgs(rawArgs: string[]): Args {
   const out: Args = { out: null };
-  for (let index = 0; index < values.length; index += 1) {
-    const value = values[index];
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const value = rawArgs[index];
     if (value === "--out") {
-      const next = values[index + 1];
+      const next = rawArgs[index + 1];
       if (!next) {
         throw new Error("--out requires a value");
       }

--- a/scripts/import-integrations-catalog.test.ts
+++ b/scripts/import-integrations-catalog.test.ts
@@ -22,15 +22,15 @@ describe("integrations.sh catalog import normalization", () => {
     expect(normalized.quarantined[0]?.row.domain).toBe("activepieces.com");
     expect(normalized.quarantined[0]?.reason).toContain("manual confirmation");
 
-    const accessOwl = normalized.rows.find((row) => row.domain === "accessowl.com");
+    const accessOwl = normalized.rows.find((candidate) => candidate.domain === "accessowl.com");
     expect(accessOwl?.tier).toBe("verified");
     expect(accessOwl?.authKind).toBe("oauth2");
 
-    const acko = normalized.rows.find((row) => row.domain === "acko.com");
+    const acko = normalized.rows.find((candidate) => candidate.domain === "acko.com");
     expect(acko?.tier).toBe("community");
     expect(acko?.authKind).toBe("none");
 
-    const bump = normalized.rows.filter((row) => row.domain === "bump.sh");
+    const bump = normalized.rows.filter((candidate) => candidate.domain === "bump.sh");
     expect(bump).toHaveLength(1);
     expect(bump[0]?.mcpUrl).toBe("https://developers.bump.sh/doc/portal/mcp");
     expect(

--- a/scripts/operator/session-control-cutover.ts
+++ b/scripts/operator/session-control-cutover.ts
@@ -120,6 +120,7 @@ function parseJson<T>(text: string, source: string): T {
   } catch (error) {
     throw new Error(
       `${source} contains malformed JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 }
@@ -1260,31 +1261,31 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
     ) {
       throw new Error("canary did not produce exactly one authoritative Codex usage source");
     }
-    const usage = currentUsage[0]!;
+    const usageRecord = currentUsage[0]!;
     const duplicateUsage = await sql<Array<{ count: number }>>`
       select count(*)::integer as count from session_events
       where workspace_id = ${candidate.workspace_id}
         and session_id = ${sessionId}
         and type = 'agent.model.usage'
-        and payload ->> 'sourceKey' = ${usage.source_key}
+        and payload ->> 'sourceKey' = ${usageRecord.source_key}
         and turn_association = 'duplicate'
-        and duplicate_of_event_id = ${usage.id}`;
+        and duplicate_of_event_id = ${usageRecord.id}`;
     const billingMarkers = await sql<Array<{ count: number }>>`
       select count(*)::integer as count from usage_events
       where workspace_id = ${candidate.workspace_id}
         and event_type = 'model.cost'
         and quantity = 0
-        and source_resource_id = ${`${usage.turn_id}:${usage.source_key}`}`;
+        and source_resource_id = ${`${usageRecord.turn_id}:${usageRecord.source_key}`}`;
     const creditDebits = await sql<Array<{ count: number }>>`
       select count(*)::integer as count from credit_ledger_entries
       where workspace_id = ${candidate.workspace_id}
         and source_type = 'model_response'
-        and source_id = ${`${usage.turn_id}:${usage.source_key}`}`;
+        and source_id = ${`${usageRecord.turn_id}:${usageRecord.source_key}`}`;
     const startedAttempts = await sql<Array<{ count: number }>>`
       select count(*)::integer as count from session_events
       where workspace_id = ${candidate.workspace_id}
         and session_id = ${sessionId}
-        and turn_id = ${usage.turn_id}
+        and turn_id = ${usageRecord.turn_id}
         and type = 'turn.started'
         and turn_attempt_id is not null
         and turn_association = 'current'`;
@@ -1311,7 +1312,7 @@ async function productionCodexCanary(args: ParsedArgs): Promise<void> {
       createIdempotencyKey: idempotencyKey,
       createAttempts,
       turnStateSamples,
-      usageSourceKey: usage.source_key,
+      usageSourceKey: usageRecord.source_key,
       classifiedDuplicateUsageCount: Number(duplicateUsage[0]?.count ?? 0),
       zeroCostBillingMarkerCount: Number(billingMarkers[0]?.count ?? 0),
       creditDebitCount: Number(creditDebits[0]?.count ?? 0),

--- a/scripts/rewrite-workspace-deps.ts
+++ b/scripts/rewrite-workspace-deps.ts
@@ -73,13 +73,13 @@ if (restore && stripDevDependencies) {
 function resolveWorkspaceSpec(
   depName: string,
   spec: string,
-  versions: Map<string, string>,
+  versionByPackage: Map<string, string>,
 ): string {
   if (!spec.startsWith("workspace:")) {
     return spec;
   }
   const rest = spec.slice("workspace:".length);
-  const version = versions.get(depName);
+  const version = versionByPackage.get(depName);
   if (!version) {
     throw new Error(
       `Cannot rewrite "${depName}": "${spec}" — no workspace package named "${depName}" with a version was found.`,

--- a/scripts/test-react-clean.ts
+++ b/scripts/test-react-clean.ts
@@ -1,0 +1,38 @@
+const child = Bun.spawn({
+  cmd: [process.execPath, "test", "packages/react"],
+  cwd: process.cwd(),
+  env: process.env,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+
+const [stdout, stderr, exitCode] = await Promise.all([
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+  child.exited,
+]);
+
+process.stdout.write(stdout);
+process.stderr.write(stderr);
+
+if (exitCode !== 0) {
+  process.exit(exitCode);
+}
+
+const warningLines = `${stdout}\n${stderr}`
+  .split(/\r?\n/u)
+  .filter(
+    (line) =>
+      /^An update to .* was not wrapped in act/u.test(line) ||
+      /^The current testing environment is not configured to support act/u.test(line) ||
+      /^(?:\[[^\]]+\]\s*)?Warning:/u.test(line) ||
+      /^warning:/iu.test(line),
+  );
+
+if (warningLines.length > 0) {
+  console.error("React tests emitted runtime warnings:");
+  for (const line of warningLines) {
+    console.error(`- ${line}`);
+  }
+  process.exit(1);
+}

--- a/test/e2e/browser.e2e.ts
+++ b/test/e2e/browser.e2e.ts
@@ -270,9 +270,13 @@ describe("browser e2e", () => {
       .slice(1);
     const resourceCount = async () =>
       await page.evaluate(
-        async ({ apiPort, workspaceId, sessionId }) => {
+        async ({
+          apiPort: browserApiPort,
+          workspaceId: targetWorkspaceId,
+          sessionId: targetSessionId,
+        }) => {
           const response = await fetch(
-            `http://127.0.0.1:${apiPort}/v1/workspaces/${workspaceId}/sessions/${sessionId}`,
+            `http://127.0.0.1:${browserApiPort}/v1/workspaces/${targetWorkspaceId}/sessions/${targetSessionId}`,
           );
           const session = (await response.json()) as { resources?: Array<{ kind?: string }> };
           return session.resources?.filter((resource) => resource.kind === "file").length ?? 0;

--- a/test/e2e/channel-a.e2e.ts
+++ b/test/e2e/channel-a.e2e.ts
@@ -256,7 +256,7 @@ function apiPath(path: string): string {
   return `http://127.0.0.1:${apiPort}/v1/workspaces/${workspaceId}${path}`;
 }
 
-function stackEnv(services: TestServices, apiPort: number): Record<string, string> {
+function stackEnv(services: TestServices, localApiPort: number): Record<string, string> {
   return {
     OPENGENI_ENVIRONMENT: "test",
     OPENGENI_DATABASE_URL: services.databaseUrl,
@@ -265,7 +265,7 @@ function stackEnv(services: TestServices, apiPort: number): Record<string, strin
     OPENGENI_TEMPORAL_NAMESPACE: "default",
     OPENGENI_TEMPORAL_TASK_QUEUE: `channel-a-e2e-${crypto.randomUUID()}`,
     OPENGENI_API_HOST: "127.0.0.1",
-    OPENGENI_API_PORT: String(apiPort),
+    OPENGENI_API_PORT: String(localApiPort),
     OPENGENI_PRODUCT_ACCESS_MODE: "local",
     OPENGENI_OPENAI_API_KEY: "test",
     OPENGENI_OPENAI_MODEL: "scripted-model",

--- a/test/e2e/rig-setup.e2e.ts
+++ b/test/e2e/rig-setup.e2e.ts
@@ -207,7 +207,7 @@ function apiPath(path: string): string {
   return `http://127.0.0.1:${apiPort}/v1/workspaces/${workspaceId}${path}`;
 }
 
-function stackEnv(services: TestServices, apiPort: number): Record<string, string> {
+function stackEnv(services: TestServices, localApiPort: number): Record<string, string> {
   return {
     OPENGENI_ENVIRONMENT: "test",
     OPENGENI_DATABASE_URL: services.databaseUrl,
@@ -216,7 +216,7 @@ function stackEnv(services: TestServices, apiPort: number): Record<string, strin
     OPENGENI_TEMPORAL_NAMESPACE: "default",
     OPENGENI_TEMPORAL_TASK_QUEUE: `rig-setup-e2e-${crypto.randomUUID()}`,
     OPENGENI_API_HOST: "127.0.0.1",
-    OPENGENI_API_PORT: String(apiPort),
+    OPENGENI_API_PORT: String(localApiPort),
     OPENGENI_PRODUCT_ACCESS_MODE: "local",
     OPENGENI_OPENAI_API_KEY: "test",
     OPENGENI_OPENAI_MODEL: "scripted-model",

--- a/test/e2e/rig-verification.e2e.ts
+++ b/test/e2e/rig-verification.e2e.ts
@@ -143,8 +143,11 @@ describe("real Docker rig verification e2e", () => {
     const stored = await getRigChange(db.db, workspaceId, change.id);
     expect(stored?.status).toBe("rejected");
     expect(
-      (stored?.verification as { commandResult?: { exitCode?: number | null; output?: string } })
-        .commandResult?.exitCode,
+      (
+        stored?.verification as
+          | { commandResult?: { exitCode?: number | null; output?: string } }
+          | undefined
+      )?.commandResult?.exitCode,
     ).toBe(1);
   }, 300_000);
 

--- a/test/e2e/sandbox.e2e.ts
+++ b/test/e2e/sandbox.e2e.ts
@@ -257,7 +257,7 @@ function apiPath(path: string): string {
   return `http://127.0.0.1:${apiPort}/v1/workspaces/${workspaceId}${path}`;
 }
 
-function stackEnv(services: TestServices, apiPort: number): Record<string, string> {
+function stackEnv(services: TestServices, localApiPort: number): Record<string, string> {
   return {
     OPENGENI_ENVIRONMENT: "test",
     OPENGENI_DATABASE_URL: services.databaseUrl,
@@ -266,7 +266,7 @@ function stackEnv(services: TestServices, apiPort: number): Record<string, strin
     OPENGENI_TEMPORAL_NAMESPACE: "default",
     OPENGENI_TEMPORAL_TASK_QUEUE: `sandbox-e2e-${crypto.randomUUID()}`,
     OPENGENI_API_HOST: "127.0.0.1",
-    OPENGENI_API_PORT: String(apiPort),
+    OPENGENI_API_PORT: String(localApiPort),
     OPENGENI_PRODUCT_ACCESS_MODE: "local",
     OPENGENI_OPENAI_API_KEY: "test",
     OPENGENI_OPENAI_MODEL: "scripted-model",

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -779,17 +779,25 @@ async function createSessionThroughApi(
   } = {},
 ): Promise<BrowserSession> {
   return await page.evaluate(
-    async ({ apiBaseUrl, workspaceId, initialMessage, options }) => {
-      const response = await fetch(`${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          initialMessage,
-          model: "scripted-model",
-          sandboxBackend: "none",
-          ...options,
-        }),
-      });
+    async ({
+      apiBaseUrl: browserApiBaseUrl,
+      workspaceId: targetWorkspaceId,
+      initialMessage: sessionMessage,
+      options: sessionOptions,
+    }) => {
+      const response = await fetch(
+        `${browserApiBaseUrl}/v1/workspaces/${targetWorkspaceId}/sessions`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            initialMessage: sessionMessage,
+            model: "scripted-model",
+            sandboxBackend: "none",
+            ...sessionOptions,
+          }),
+        },
+      );
       if (!response.ok) {
         throw new Error(`session create failed: ${response.status} ${await response.text()}`);
       }
@@ -807,13 +815,21 @@ async function setSessionPinThroughApi(
   pinned: boolean,
 ): Promise<BrowserSession> {
   return await page.evaluate(
-    async ({ apiBaseUrl, workspaceId, session, pinned }) => {
+    async ({
+      apiBaseUrl: browserApiBaseUrl,
+      workspaceId: targetWorkspaceId,
+      session: targetSession,
+      pinned: nextPinned,
+    }) => {
       const response = await fetch(
-        `${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions/${session.id}/pin`,
+        `${browserApiBaseUrl}/v1/workspaces/${targetWorkspaceId}/sessions/${targetSession.id}/pin`,
         {
           method: "PUT",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ pinned, expectedVersion: session.pinVersion ?? 0 }),
+          body: JSON.stringify({
+            pinned: nextPinned,
+            expectedVersion: targetSession.pinVersion ?? 0,
+          }),
         },
       );
       if (!response.ok) {
@@ -832,12 +848,16 @@ async function listPageFromBrowser(
   options: { limit: number; cursor?: string; search?: string },
 ): Promise<BrowserSessionPage> {
   return await page.evaluate(
-    async ({ apiBaseUrl, workspaceId, options }) => {
-      const query = new URLSearchParams({ view: "page", limit: String(options.limit) });
-      if (options.cursor) query.set("cursor", options.cursor);
-      if (options.search) query.set("search", options.search);
+    async ({
+      apiBaseUrl: browserApiBaseUrl,
+      workspaceId: targetWorkspaceId,
+      options: pageOptions,
+    }) => {
+      const query = new URLSearchParams({ view: "page", limit: String(pageOptions.limit) });
+      if (pageOptions.cursor) query.set("cursor", pageOptions.cursor);
+      if (pageOptions.search) query.set("search", pageOptions.search);
       const response = await fetch(
-        `${apiBaseUrl}/v1/workspaces/${workspaceId}/sessions?${query.toString()}`,
+        `${browserApiBaseUrl}/v1/workspaces/${targetWorkspaceId}/sessions?${query.toString()}`,
       );
       if (!response.ok) {
         throw new Error(`session page failed: ${response.status} ${await response.text()}`);

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1825,21 +1825,22 @@ describe("API component integration", () => {
     });
     expect(
       usage
-        .filter((event) => event.eventType === "agent_run.created")
+        .filter((usageEvent) => usageEvent.eventType === "agent_run.created")
         .filter(
-          (event) =>
-            event.sourceResourceId === session.id || turnIds.has(event.sourceResourceId ?? ""),
+          (usageEvent) =>
+            usageEvent.sourceResourceId === session.id ||
+            turnIds.has(usageEvent.sourceResourceId ?? ""),
         ),
     ).toHaveLength(3);
   });
 
   test("revives a failed session on a new user message but keeps cancelled terminal", async () => {
-    const workflow = new FakeWorkflowClient();
+    const workflowClient = new FakeWorkflowClient();
     const app = createApp({
       settings: testSettings({ databaseUrl: services.databaseUrl }),
       db: dbClient.db,
       bus: new MemoryEventBus(),
-      workflowClient: workflow,
+      workflowClient,
     });
     const workspaceId = await defaultWorkspaceId(app);
     const created = await app.request(workspacePath(workspaceId, "/sessions"), {
@@ -1853,7 +1854,7 @@ describe("API component integration", () => {
     // cleared), the status change is on the timeline, and the workflow is
     // woken via signalWithStart exactly as for idle sessions.
     await setSessionStatus(dbClient.db, workspaceId, session.id, "failed", null);
-    const wakeupsBefore = workflow.wakeups.length;
+    const wakeupsBefore = workflowClient.wakeups.length;
     const revived = await app.request(
       workspacePath(workspaceId, `/sessions/${session.id}/events`),
       {
@@ -1866,10 +1867,12 @@ describe("API component integration", () => {
     const afterRevival = await requireSession(dbClient.db, workspaceId, session.id);
     expect(afterRevival.status).toBe("queued");
     expect(afterRevival.activeTurnId).toBeNull();
-    expect(workflow.wakeups.length).toBe(wakeupsBefore + 1);
+    expect(workflowClient.wakeups.length).toBe(wakeupsBefore + 1);
     const events = await listSessionEvents(dbClient.db, workspaceId, session.id, 0, 100);
     const statusChanges = events.filter((event) => event.type === "session.status.changed");
-    expect((statusChanges.at(-1)?.payload as { status?: string }).status).toBe("queued");
+    expect((statusChanges.at(-1)?.payload as { status?: string } | undefined)?.status).toBe(
+      "queued",
+    );
 
     // Cancelled stays terminal: an explicit user act, not a failure.
     await setSessionStatus(dbClient.db, workspaceId, session.id, "cancelled", null);
@@ -2696,12 +2699,12 @@ describe("API component integration", () => {
   });
 
   test("a retried manual trigger (same triggerId) charges once and starts one run", async () => {
-    const workflow = new FakeWorkflowClient();
+    const workflowClient = new FakeWorkflowClient();
     const app = createApp({
       settings: testSettings({ databaseUrl: services.databaseUrl }),
       db: dbClient.db,
       bus: new MemoryEventBus(),
-      workflowClient: workflow,
+      workflowClient,
     });
     const workspaceId = await defaultWorkspaceId(app);
     const created = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
@@ -2735,7 +2738,7 @@ describe("API component integration", () => {
     // Both calls derive the SAME usage idempotency key AND the SAME workflowId
     // from the shared token, so the charge dedupes and the duplicate workflow
     // start collapses (deterministic id + REJECT_DUPLICATE at the worker).
-    const triggers = workflow.triggers as Array<{
+    const triggers = workflowClient.triggers as Array<{
       agentRunUsageIdempotencyKey?: string;
       triggerWorkflowId?: string;
     }>;
@@ -2760,7 +2763,7 @@ describe("API component integration", () => {
     // second charge.
     const third = await triggerWith("retry-token-2");
     expect(third.status).toBe(202);
-    const allTriggers = workflow.triggers as Array<{
+    const allTriggers = workflowClient.triggers as Array<{
       agentRunUsageIdempotencyKey?: string;
       triggerWorkflowId?: string;
     }>;
@@ -2771,12 +2774,12 @@ describe("API component integration", () => {
   });
 
   test("a manual trigger without a triggerId stays a distinct run each time", async () => {
-    const workflow = new FakeWorkflowClient();
+    const workflowClient = new FakeWorkflowClient();
     const app = createApp({
       settings: testSettings({ databaseUrl: services.databaseUrl }),
       db: dbClient.db,
       bus: new MemoryEventBus(),
-      workflowClient: workflow,
+      workflowClient,
     });
     const workspaceId = await defaultWorkspaceId(app);
     const created = await app.request(workspacePath(workspaceId, "/scheduled-tasks"), {
@@ -2801,7 +2804,7 @@ describe("API component integration", () => {
     });
     expect(a.status).toBe(202);
     expect(b.status).toBe(202);
-    const triggers = workflow.triggers as Array<{
+    const triggers = workflowClient.triggers as Array<{
       agentRunUsageIdempotencyKey?: string;
       triggerWorkflowId?: string;
     }>;
@@ -4008,9 +4011,13 @@ describe("API component integration", () => {
       type: "agent.message.delta",
       payload: { coalescedUntil: latestSequence },
     });
-    expect((compactEvents[4]?.payload as { text?: string }).text?.startsWith("bulk-0")).toBe(true);
     expect(
-      (compactEvents[4]?.payload as { text?: string }).text?.endsWith(`bulk-${bulkEventCount - 1}`),
+      (compactEvents[4]?.payload as { text?: string } | undefined)?.text?.startsWith("bulk-0"),
+    ).toBe(true);
+    expect(
+      (compactEvents[4]?.payload as { text?: string } | undefined)?.text?.endsWith(
+        `bulk-${bulkEventCount - 1}`,
+      ),
     ).toBe(true);
 
     const compactNewest = await app.request(
@@ -4023,9 +4030,9 @@ describe("API component integration", () => {
     const compactNewestEvents = (await compactNewest.json()) as SessionEvent[];
     expect(compactNewestEvents).toHaveLength(1);
     expect(compactNewestEvents[0]?.sequence).toBe(latestSequence - 2);
-    expect((compactNewestEvents[0]?.payload as { coalescedUntil?: number }).coalescedUntil).toBe(
-      latestSequence,
-    );
+    expect(
+      (compactNewestEvents[0]?.payload as { coalescedUntil?: number } | undefined)?.coalescedUntil,
+    ).toBe(latestSequence);
 
     const compactOlder = await app.request(
       workspacePath(
@@ -4037,10 +4044,12 @@ describe("API component integration", () => {
     const compactOlderEvents = (await compactOlder.json()) as SessionEvent[];
     expect(compactOlderEvents).toHaveLength(1);
     const compactPageChunks = [
-      ...(((compactOlderEvents[0]?.payload as { text?: string }).text ?? "").match(/bulk-\d+/g) ??
-        []),
-      ...(((compactNewestEvents[0]?.payload as { text?: string }).text ?? "").match(/bulk-\d+/g) ??
-        []),
+      ...(((compactOlderEvents[0]?.payload as { text?: string } | undefined)?.text ?? "").match(
+        /bulk-\d+/g,
+      ) ?? []),
+      ...(((compactNewestEvents[0]?.payload as { text?: string } | undefined)?.text ?? "").match(
+        /bulk-\d+/g,
+      ) ?? []),
     ];
     expect(compactPageChunks).toEqual(
       Array.from({ length: 6 }, (_, offset) => `bulk-${bulkEventCount - 6 + offset}`),
@@ -5299,7 +5308,7 @@ describe("API component integration", () => {
         preview: "Staging deploys from main only, via opengeni-ops.",
       });
       expect(
-        ((saveEvents[0]?.payload as { preview?: string }).preview ?? "").length,
+        ((saveEvents[0]?.payload as { preview?: string } | undefined)?.preview ?? "").length,
       ).toBeLessThanOrEqual(120);
 
       const search = JSON.parse(
@@ -6586,7 +6595,7 @@ describe("API component integration", () => {
             subjectId?: string;
             raw?: { serverId?: string; toolName?: string };
           }
-        ).origin,
+        )?.origin,
       ).toBe("toolspace");
       expect(
         (
@@ -6595,10 +6604,14 @@ describe("API component integration", () => {
             subjectId?: string;
             raw?: { serverId?: string; toolName?: string };
           }
-        ).subjectId,
+        )?.subjectId,
       ).toBe("sandbox:run-proxy");
       expect(
-        (toolspaceEvents[0]?.payload as { raw?: { serverId?: string; toolName?: string } }).raw,
+        (
+          toolspaceEvents[0]?.payload as
+            | { raw?: { serverId?: string; toolName?: string } }
+            | undefined
+        )?.raw,
       ).toEqual({
         type: "toolspace_call",
         serverId: "crm",

--- a/test/integration/temporal-workflow.integration.ts
+++ b/test/integration/temporal-workflow.integration.ts
@@ -218,7 +218,10 @@ describe("Temporal workflow integration", () => {
         });
         await handle.result();
         expect(runs).toHaveLength(2);
-        expect(runs.map((run) => run.trigger)).toEqual([{ kind: "next" }, { kind: "next" }]);
+        expect(runs.map((attempt) => attempt.trigger)).toEqual([
+          { kind: "next" },
+          { kind: "next" },
+        ]);
         expect(failures).toHaveLength(0);
       } finally {
         worker.shutdown();
@@ -269,7 +272,10 @@ describe("Temporal workflow integration", () => {
         });
         await handle.result();
         expect(runs).toHaveLength(2);
-        expect(runs.map((run) => run.trigger)).toEqual([{ kind: "next" }, { kind: "next" }]);
+        expect(runs.map((attempt) => attempt.trigger)).toEqual([
+          { kind: "next" },
+          { kind: "next" },
+        ]);
         expect(recoveries).toEqual([
           expect.objectContaining({
             attemptId: runs[0]!.attemptId,
@@ -540,7 +546,8 @@ describe("Temporal workflow integration", () => {
       const admission = createTurnAdmission(queuedTurns, async (_input, turn) => {
         runs.push(turn);
         if (runs.length === 1) {
-          while (!allowFirstRunToFinish) {
+          while (true) {
+            if (allowFirstRunToFinish) break;
             await Bun.sleep(10);
           }
         }

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -2595,7 +2595,7 @@ describe("worker activities integration", () => {
     expect(serialized).not.toContain(secret);
     expect(serialized).toContain("[redacted:LEAKED_TOKEN]");
     const completed = events.find((event) => event.type === "agent.message.completed");
-    expect((completed?.payload as { text: string }).text).toBe(
+    expect((completed?.payload as { text?: string } | undefined)?.text).toBe(
       "the token is [redacted:LEAKED_TOKEN] end",
     );
   });


### PR DESCRIPTION
Summary:
- make repository lint fail closed at zero warnings and remove every current warning without suppressions
- keep React context actions stable while exposing only committed callback bodies, including Suspense/concurrent-render guards
- split every heavy web route so the eager entry falls from 1,419.55 kB raw / 396.77 kB gzip to 200.10 kB raw / 63.59 kB gzip
- enforce immutable initial, direct-session, lazy-chunk, and CSS bundle budgets in CI
- keep duplicate list identities stable, preserve caught error causes, and isolate desktop tests from real transports
- upgrade cache/upload actions to their current stable runtimes so CI itself is warning-clean

Performance evidence:
- recursive initial graph: 681,493 bytes raw / 184,929 bytes gzip (budgets 768,000 / 215,040)
- direct session graph: 1,721,075 bytes raw / 510,198 bytes gzip (budgets 1,945,600 / 552,960)
- largest lazy raw chunk: 779,873 bytes (budget 819,200)
- largest lazy gzip chunk: 232,093 bytes (budget 245,760)
- 10-run warmed build median: 1.44 s baseline to about 1.33 s after route splitting
- route-split opportunity score: impact 5 x confidence 5 / effort 2 = 12.5

Behavior/isomorphism proof:
- route paths, params, search parsing, ordering, and wrappers are unchanged; only module load timing changes
- no tie-breaking, floating-point, or RNG behavior is involved
- real full-stack browser journey: 2 pass, 0 fail (API, worker, PostgreSQL, object storage, browser refresh/upload)
- workbench responsive/WCAG/keyboard browser acceptance: 3 pass, 0 fail
- real PostgreSQL session-pin browser acceptance: 5 pass, 0 fail, 100 assertions

Local verification on the rebased head:
- lint: zero warnings repository-wide
- format: 783 files clean
- typecheck: 19 of 19 projects clean
- warning-free React gate: 572 pass, 0 fail, 1,614 assertions
- web tests: 183 pass, 0 fail after the concurrent-render regression coverage
- bounded real-database suite: 3,048 pass, 0 fail, 12,125 assertions; 3 explicit opt-in real-Modal tests remain acceptance obligations
- both OPE-22 recovery incident regressions pass
- publish closure: all 16 packages; SDK, React, declarations, demo, and web builds pass
- UBS: modified-file critical/warning counts are identical to baseline; four new files have 0 critical and 0 warnings

This PR is intentionally not described as production proof. Exact-head CI must be green and warning-free before merge; exact-artifact staging, authenticated deployed acceptance with a real sandbox, production promotion, and post-promotion canaries remain separate fail-closed gates.
