### PR TITLE
fix(react): hide internal recovery evidence

### DIFF
--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -419,50 +419,16 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       }
 
       case "turn.recovery.requested": {
-        closeStreamingTail();
-        const rawReason = typeof payload.reason === "string" ? payload.reason : null;
-        const reason = rawReason?.replaceAll("_", " ") ?? null;
-        items.push({
-          kind: "notice",
-          id: event.id,
-          tone: "waiting",
-          text:
-            rawReason === "workspace_pause"
-              ? "Resuming paused work."
-              : reason
-                ? `Resuming this turn after ${reason}.`
-                : "Resuming this turn.",
-          occurredAt: event.occurredAt,
-        });
+        // Recovery requests are durable control-plane evidence, not a user
+        // message or proof that recovery succeeded. Live state already exposes
+        // a genuinely recovering session; keep the raw event in Debug/audit.
         break;
       }
 
       case "turn.event.rejected_late": {
-        const rejectedType =
-          typeof payload.rejectedType === "string" ? payload.rejectedType : "unknown event";
-        // Workspace revision events are cache announcements and rejected
-        // reasoning deltas are discarded stream fragments. Both remain durable
-        // in Debug/audit evidence, but neither is a user-visible failed action.
-        if (
-          rejectedType === "workspace.revision.captured" ||
-          rejectedType === "workspace.revision.degraded" ||
-          rejectedType === "agent.reasoning.delta"
-        ) {
-          break;
-        }
-        closeStreamingTail();
-        const reason =
-          typeof payload.reason === "string"
-            ? payload.reason.replaceAll("_", " ")
-            : "attempt fence";
-        items.push({
-          kind: "notice",
-          id: event.id,
-          tone: "cancelled",
-          text: `Late ${rejectedType} evidence was rejected by the ${reason} and did not change the current turn.`,
-          details: { label: "Inspect rejected evidence", value: payload },
-          occurredAt: event.occurredAt,
-        });
+        // Attempt-fence rejections prove stale callbacks did not alter current
+        // truth. They are useful diagnostics but never actionable chat content,
+        // regardless of the rejected event type. Debug/audit retains the event.
         break;
       }
 

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -727,46 +727,33 @@ describe("buildTimeline", () => {
     ]);
   });
 
-  test("shows same-turn recovery without pretending it is queued work", () => {
+  test("hides same-turn recovery control evidence from the user timeline", () => {
     reset();
     const items = buildTimeline([event("turn.recovery.requested", { reason: "worker_shutdown" })]);
-    expect(items).toEqual([
-      expect.objectContaining({
-        kind: "notice",
-        tone: "waiting",
-        text: "Resuming this turn after worker shutdown.",
-      }),
-    ]);
+    expect(items).toEqual([]);
   });
 
-  test("uses compact copy when workspace-paused work resumes", () => {
+  test("hides workspace recovery control evidence from the user timeline", () => {
     reset();
     const items = buildTimeline([event("turn.recovery.requested", { reason: "workspace_pause" })]);
-    expect(items).toEqual([
-      expect.objectContaining({
-        kind: "notice",
-        tone: "waiting",
-        text: "Resuming paused work.",
-      }),
-    ]);
+    expect(items).toEqual([]);
   });
 
-  test("keeps rejected zombie evidence visible and inspectable", () => {
+  test("hides all rejected attempt evidence from the user timeline", () => {
     reset();
-    const payload = {
-      rejectedType: "agent.toolCall.output",
-      rejectedPayload: { id: "call-1", output: "finished too late" },
-      reason: "attempt_changed",
-    };
-    const items = buildTimeline([event("turn.event.rejected_late", payload)]);
-    expect(items).toEqual([
-      expect.objectContaining({
-        kind: "notice",
-        tone: "cancelled",
-        text: expect.stringContaining("Late agent.toolCall.output evidence was rejected"),
-        details: { label: "Inspect rejected evidence", value: payload },
+    const items = buildTimeline([
+      event("turn.event.rejected_late", {
+        rejectedType: "agent.toolCall.output",
+        rejectedPayload: { id: "call-1", output: "finished too late" },
+        reason: "attempt_changed",
+      }),
+      event("turn.event.rejected_late", {
+        rejectedType: "agent.model.usage",
+        rejectedPayload: { inputTokens: 10, outputTokens: 5 },
+        reason: "session_paused",
       }),
     ]);
+    expect(items).toEqual([]);
   });
 
   test("hides rejected workspace revision bookkeeping from the user timeline", () => {


### PR DESCRIPTION
## Summary
- keep recovery requests out of the user timeline
- keep all rejected late-attempt evidence out of the user timeline
- retain both event families in raw Debug/audit data

## Verification
- bun test packages/react/test/timeline.test.ts
- bun test packages/react/test
- packages/react: bun run typecheck
- packages/react: bun run build
- oxfmt + oxlint on changed files