### PR TITLE
ci: remove deprecated action runtimes

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -380,7 +380,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,9 @@ jobs:
       # provenance. The publish command is guarded so a missing NPM_TOKEN does
       # not fail the run — changesets only publishes on the Version PR merge.
       - name: Set up Node for npm publish
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Create Version PR or publish


### PR DESCRIPTION
Summary:
- upgrade setup-node to verified stable v7.0.0 and use Node 24 for npm publishing
- upgrade download-artifact to verified stable v8.0.1, retaining fail-closed digest validation
- remove the Node 20 deprecation annotation seen in the post-merge Release run

Verification:
- official release contracts inspected for both major upgrades
- repository format and diff checks pass
- all first-party GitHub Actions now use their current Node 24-compatible stable majors

The prior Release run was functionally successful but emitted one warning annotation, so it does not satisfy the zero-warning gate. This PR repairs that gate.