### PR TITLE
ci: move release images to Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
   images:
     name: Workload image builds
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -225,11 +228,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build API image
-        run: docker build --platform linux/amd64 -f docker/opengeni.Dockerfile --target api -t opengeni-api:ci .
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: docker/opengeni.Dockerfile
+          target: api
+          platforms: linux/amd64
+          push: false
+          tags: opengeni-api:ci
 
       - name: Build worker image
-        run: docker build --platform linux/amd64 -f docker/opengeni.Dockerfile --target worker -t opengeni-worker:ci .
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: docker/opengeni.Dockerfile
+          target: worker
+          platforms: linux/amd64
+          push: false
+          tags: opengeni-worker:ci
 
       - name: Build web image
-        run: docker build --platform linux/amd64 -f docker/opengeni.Dockerfile --target web -t opengeni-web:ci .
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: docker/opengeni.Dockerfile
+          target: web
+          platforms: linux/amd64
+          push: false
+          tags: opengeni-web:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -189,7 +189,7 @@ jobs:
         run: scripts/bake-agent.sh
 
       - name: Build and push API image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           file: docker/opengeni.Dockerfile
@@ -204,7 +204,7 @@ jobs:
             ghcr.io/cloudgeni-ai/opengeni-api:latest
 
       - name: Build and push worker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           file: docker/opengeni.Dockerfile
@@ -219,7 +219,7 @@ jobs:
             ghcr.io/cloudgeni-ai/opengeni-worker:latest
 
       - name: Build and push web image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           file: docker/opengeni.Dockerfile
@@ -242,7 +242,7 @@ jobs:
       # (the ops-repo deploy passes it as the `relay_digest` input).
       - name: Build and push relay image
         id: build-relay
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: agent
           file: agent/crates/opengeni-relay/Dockerfile


### PR DESCRIPTION
Summary:
- upgrade all four release image builds to docker/build-push-action v7.3.0
- upgrade GHCR authentication to docker/login-action v4.4.0
- run the same action majors in PR image CI with read-only GHCR auth and push disabled
- remove the remaining Node 20 deprecation annotation from the exact image publication workflow

Verification contract:
- official v7/v4 major-release contracts inspected; existing release inputs remain supported
- repository format and diff checks pass
- exact-head PR CI must execute both upgraded actions while building API, worker, and web images
- all exact-head check annotations must be zero before merge

The prior release published every package and image successfully but its image job emitted one deprecated-runtime annotation. This PR repairs and directly exercises that remaining warning boundary.
