### PR TITLE
fix(react): harden workbench UX state and mobile flows

### DIFF
--- a/.changeset/bright-workbenches-focus.md
+++ b/.changeset/bright-workbenches-focus.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Harden the workspace dock with persistent tab state, authoritative live-versus-capture defaults, accessible mobile navigation, guarded-file routing, and deterministic browser acceptance coverage.

--- a/docs/embedding-workbench.md
+++ b/docs/embedding-workbench.md
@@ -117,7 +117,7 @@ authoritative-looking empty capture; consumers keep live files authoritative.
 | `primary` | the pane shown beside the dock (your chat/timeline). |
 | `onNotify` | host-routed `{ kind: "error" \| "info"; message }` — the package has no toast dependency, so you decide how errors surface. |
 | `leadingTabs` / `trailingTabs` | your own `WorkspaceTab[]` injected before / after the workbench tabs (this is how `apps/web` adds its Run and Debug tabs). |
-| `initialTab` | override the default landing tab. Omit it and the workbench decides **Changes when the session has changes, else Files** — pre-paint, from local capture stats, so there is never a post-render switch. |
+| `initialTab` | override the default landing tab. Omit it and the workbench decides **Changes when the session has changes, else Files** from the authoritative source: instant capture stats while cold/offline, live Git while warm. The choice latches before real content paints, so later edits never steal the current tab. |
 | `collapsed` / `onCollapsedChange` | drive the dock open/closed from your own toolbar. |
 
 The machine-state chip (live / waking… / offline — as of `<time>`) is rendered in

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -460,7 +460,13 @@ const statusReview = status([
     isConflicted: false,
   },
 ]);
-const statusClean = status([]);
+const statusClean: GitStatusResponse = {
+  ...status([]),
+  head: "main",
+  upstream: "origin/main",
+  ahead: 0,
+  behind: 0,
+};
 
 // ── the state matrix ─────────────────────────────────────────────────────────
 

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -30,6 +30,10 @@ export type SandboxFilesProps = {
   onEditIntent?: (() => void) | undefined;
   /** A guarded diff path routed here by the parent workspace. */
   requestedPath?: string | undefined;
+  /** Identity for one guarded-file request. Increment this when the same path is
+   *  deliberately requested again; it also lets a pending request be consumed
+   *  without overriding later manual tree navigation. Defaults to the path. */
+  requestedPathRequestId?: string | number | undefined;
   /** False while the parent is waking a cold sandbox for `requestedPath`. */
   requestedPathReady?: boolean | undefined;
   themeType?: "dark" | "light" | undefined;
@@ -51,6 +55,7 @@ export function SandboxFiles({
   editable = true,
   onEditIntent,
   requestedPath,
+  requestedPathRequestId,
   requestedPathReady = true,
   themeType,
   className,
@@ -59,12 +64,28 @@ export function SandboxFiles({
   // View vs Edit for the selected file. Resets to View on every new selection so
   // opening a file never lands you in a stale dirty editor for a different path.
   const [editMode, setEditMode] = useState(false);
+  const pendingRequestRef = useRef<string | number | null>(null);
+  const handledRequestRef = useRef<string | number | null>(null);
+  const requestKey = requestedPath ? (requestedPathRequestId ?? requestedPath) : null;
 
   useEffect(() => {
-    if (!requestedPath || !requestedPathReady) return;
+    if (!requestedPath || requestKey === null) {
+      pendingRequestRef.current = null;
+      handledRequestRef.current = null;
+      return;
+    }
+    if (handledRequestRef.current === requestKey) {
+      return;
+    }
+    if (!requestedPathReady) {
+      pendingRequestRef.current = requestKey;
+      return;
+    }
+    handledRequestRef.current = requestKey;
+    pendingRequestRef.current = null;
     setSelected(requestedPath);
     setEditMode(false);
-  }, [requestedPath, requestedPathReady]);
+  }, [requestKey, requestedPath, requestedPathReady]);
 
   // Side-by-side (tree left, viewer right) once the surface is wide enough;
   // stacked (tree over viewer) on a narrow dock. Tracked off the container so it
@@ -93,8 +114,14 @@ export function SandboxFiles({
   const fileView = useFileView(viewPath, files.readFile);
 
   // Selecting a (different) file always returns to View — never drop the user into
-  // an editor whose buffer belongs to the previously-selected path.
+  // an editor whose buffer belongs to the previously-selected path. Manual
+  // navigation also consumes a pending guarded-file request: a late cold→warm
+  // transition must never pull the user away from the file they chose meanwhile.
   const selectFile = useCallback((path: string) => {
+    if (pendingRequestRef.current !== null) {
+      handledRequestRef.current = pendingRequestRef.current;
+      pendingRequestRef.current = null;
+    }
     setSelected(path);
     setEditMode(false);
   }, []);
@@ -159,7 +186,10 @@ export function SandboxFiles({
           )}
         >
           <div className="flex shrink-0 items-center justify-between gap-2 border-b border-og-border bg-og-surface-1 px-2 py-1">
-            <span className="min-w-0 truncate font-og-mono text-og-xs text-og-fg-muted">
+            <span
+              data-opengeni-selected-file
+              className="min-w-0 truncate font-og-mono text-og-xs text-og-fg-muted"
+            >
               {selected ?? "No file selected"}
             </span>
             {/* View/Edit toggle — only for a real, fully-loaded text file the editor

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -1,4 +1,5 @@
 import type { FsReadResponse } from "@opengeni/sdk";
+import { FileCode2Icon, FileWarningIcon, LoaderCircleIcon } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import { useThemeType } from "../lib/use-theme-type";
@@ -27,6 +28,10 @@ export type SandboxFilesProps = {
    *  dock warms the box on this so the save lands fast; opening/reading never fires
    *  it. Browsing the tree/diff must not warm a box. */
   onEditIntent?: (() => void) | undefined;
+  /** A guarded diff path routed here by the parent workspace. */
+  requestedPath?: string | undefined;
+  /** False while the parent is waking a cold sandbox for `requestedPath`. */
+  requestedPathReady?: boolean | undefined;
   themeType?: "dark" | "light" | undefined;
   className?: string | undefined;
 };
@@ -45,6 +50,8 @@ export function SandboxFiles({
   usePierre = true,
   editable = true,
   onEditIntent,
+  requestedPath,
+  requestedPathReady = true,
   themeType,
   className,
 }: SandboxFilesProps) {
@@ -52,6 +59,12 @@ export function SandboxFiles({
   // View vs Edit for the selected file. Resets to View on every new selection so
   // opening a file never lands you in a stale dirty editor for a different path.
   const [editMode, setEditMode] = useState(false);
+
+  useEffect(() => {
+    if (!requestedPath || !requestedPathReady) return;
+    setSelected(requestedPath);
+    setEditMode(false);
+  }, [requestedPath, requestedPathReady]);
 
   // Side-by-side (tree left, viewer right) once the surface is wide enough;
   // stacked (tree over viewer) on a narrow dock. Tracked off the container so it
@@ -101,7 +114,15 @@ export function SandboxFiles({
   const showEditor = canEdit && editMode;
 
   if (!fileSystemAvailable) {
-    return <Notice className={className}>This sandbox does not expose a file system.</Notice>;
+    return (
+      <Notice
+        className={className}
+        icon={<FileWarningIcon className="size-5" aria-hidden />}
+        title="Files unavailable"
+      >
+        This sandbox does not expose a file system.
+      </Notice>
+    );
   }
 
   return (
@@ -206,9 +227,23 @@ export function SandboxFiles({
               ) : (
                 <Notice>Loading {viewPath}…</Notice>
               )
+            ) : // Nothing selected — the tree shows the whole workspace; pick a file.
+            requestedPath && !requestedPathReady ? (
+              <Notice
+                icon={
+                  <LoaderCircleIcon
+                    className="size-5 animate-spin motion-reduce:animate-none"
+                    aria-hidden
+                  />
+                }
+                title="Waking sandbox"
+              >
+                Opening {requestedPath} when the live workspace is ready…
+              </Notice>
             ) : (
-              // Nothing selected — the tree shows the whole workspace; pick a file.
-              <Notice>Select a file in the tree to view it.</Notice>
+              <Notice icon={<FileCode2Icon className="size-5" aria-hidden />} title="Choose a file">
+                Select a file in the tree to preview it.
+              </Notice>
             )}
           </div>
         </div>
@@ -238,7 +273,9 @@ function GitHeader({ git, dirtyCount }: { git: UseSandboxGitResult; dirtyCount: 
         </span>
       )}
       {dirty && (
-        <span className="ml-auto shrink-0 text-og-xs text-og-fg-subtle">{dirtyCount} changed</span>
+        <span data-contrast-audited className="ml-auto shrink-0 text-og-xs text-og-fg-subtle">
+          {dirtyCount} changed
+        </span>
       )}
     </div>
   );
@@ -261,7 +298,7 @@ function Segmented({
           type="button"
           onClick={() => onChange(opt.value)}
           className={cn(
-            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-og-xs max-[1023px]:min-h-11 pointer-coarse:min-h-11",
+            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-og-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 pointer-coarse:min-h-11",
             opt.value === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",
@@ -375,7 +412,17 @@ function decodeBase64Utf8(b64: string): string {
   return b64;
 }
 
-function Notice({ children, className }: { children: ReactNode; className?: string | undefined }) {
+function Notice({
+  children,
+  className,
+  icon,
+  title,
+}: {
+  children: ReactNode;
+  className?: string | undefined;
+  icon?: ReactNode | undefined;
+  title?: string | undefined;
+}) {
   return (
     <div
       className={cn(
@@ -383,7 +430,15 @@ function Notice({ children, className }: { children: ReactNode; className?: stri
         className,
       )}
     >
-      {children}
+      <div className="flex max-w-sm flex-col items-center gap-2.5">
+        {icon ? (
+          <span className="grid size-10 place-items-center rounded-og-lg border border-og-border bg-og-surface-1 text-og-fg-muted shadow-sm">
+            {icon}
+          </span>
+        ) : null}
+        {title ? <p className="font-medium text-og-fg">{title}</p> : null}
+        <div className="leading-5">{children}</div>
+      </div>
     </div>
   );
 }

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -16,7 +16,14 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Popover } from "radix-ui";
 import type { SessionEvent } from "@opengeni/sdk";
-import { CpuIcon, LaptopIcon, RefreshCwIcon } from "lucide-react";
+import {
+  CircleCheckIcon,
+  CpuIcon,
+  LaptopIcon,
+  LoaderCircleIcon,
+  RefreshCwIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
 
 import { type ClientOverride, useOpenGeni } from "../provider";
 import { cn } from "../lib/cn";
@@ -62,11 +69,9 @@ function captureDegradedMessage(reason: string): string {
  * "changes exist → Changes, else Files" needs zero machine round-trips. A host
  * `override` (e.g. a landing "run" tab) wins when supplied.
  *
- * NOTE: the dock no longer uses this for its default tab — `<SandboxWorkspace>`
- * now derives the default from its OWN capture fetch (`useWorkspaceCapture`'s
- * `fileCount`), so a pure embedder needs no events-at-mount contract (Refinement
- * 2). This remains exported as a standalone helper for hosts that already hold
- * the event log and want the same decision without the capture fetch.
+ * `<SandboxWorkspace>` uses this only as an optional early hint after its own
+ * capture GET reports no durable capture. A pure embedder needs no events-at-mount
+ * contract: it falls through to authoritative live Git instead.
  */
 export function initialWorkspaceTab(
   events: SessionEvent[] | undefined,
@@ -131,22 +136,25 @@ export type UseSandboxWorkspaceTabsOptions = ClientOverride & {
   sessionId: string;
   /** Live event log (usually `useSessionEvents().events`). */
   events: SessionEvent[];
-  /** Override the capture-driven default tab (e.g. a host landing tab id). When
-   *  omitted the workbench picks Changes-vs-Files from its own capture fetch. */
+  /** Override the source-driven default tab (e.g. a host landing tab id). When
+   *  omitted the workbench picks Changes-vs-Files from capture or live Git. */
   initialTab?: string | null | undefined;
   /** Host-routed notifications (mutation errors, desktop-consent failures). The
    *  package never imports a toast library — the host decides how to surface. */
   onNotify?: ((notification: WorkspaceNotification) => void) | undefined;
+  /** File requested by a Changes guard. The Files surface defers the read until
+   *  the sandbox is live, then reveals this path. */
+  requestedFilePath?: string | null | undefined;
+  /** Route a guarded diff into the host's Files tab. */
+  onOpenFile?: ((path: string) => void) | undefined;
 };
 
 export type UseSandboxWorkspaceTabsResult = {
   /** Changes | Files | Terminal | Desktop (capability-gated where noted). */
   tabs: WorkspaceTab[];
-  /** The capture-driven default tab: Changes when the session has changes, else
-   *  Files (a host `initialTab` overrides). null during the brief window before the
-   *  capture GET first resolves (and no host override was given) — consumers render
-   *  their dock's own first-tab fallback until it latches, which it does ONCE, so it
-   *  never causes a post-render switch. */
+  /** The source-driven default tab: Changes when the first authoritative capture
+   *  or live Git result has changes, else Files (a host `initialTab` overrides).
+   *  null while that source resolves; the choice latches once. */
   defaultTab: string | null;
   /** The machine-state model for the dock-header chip. */
   machine: WorkspaceMachine;
@@ -156,7 +164,7 @@ type SessionWarmIntents = {
   sessionId: string;
   watchDesktop: boolean;
   warmTerminal: boolean;
-  warmEdit: boolean;
+  warmFiles: boolean;
 };
 
 function emptyWarmIntents(sessionId: string): SessionWarmIntents {
@@ -164,7 +172,7 @@ function emptyWarmIntents(sessionId: string): SessionWarmIntents {
     sessionId,
     watchDesktop: false,
     warmTerminal: false,
-    warmEdit: false,
+    warmFiles: false,
   };
 }
 
@@ -177,20 +185,20 @@ export function useSandboxWorkspaceTabs(
   options: UseSandboxWorkspaceTabsOptions,
 ): UseSandboxWorkspaceTabsResult {
   const { client, workspaceId } = useOpenGeni(options);
-  const { sessionId, events, onNotify } = options;
+  const { sessionId, events, onNotify, requestedFilePath, onOpenFile } = options;
   const initialTab = options.initialTab ?? null;
 
-  // The three — and only three — box-warming INTENTS, each off by default and each
+  // The three box-warming INTENTS, each off by default and each
   // flipped true by a genuine user action (never on mount, never on a passive
   // capture glance): desktop watch consent, terminal engagement (`onActivate`), and
-  // the first wake-on-edit keystroke in the Files editor. Browsing capture-served
+  // a deliberate live-file open/edit in Files. Browsing capture-served
   // Changes/Files warms nothing — that is the whole point of Refinement 1.
   const [storedWarmIntents, setStoredWarmIntents] = useState<SessionWarmIntents>(() =>
     emptyWarmIntents(sessionId),
   );
   const warmIntents =
     storedWarmIntents.sessionId === sessionId ? storedWarmIntents : emptyWarmIntents(sessionId);
-  const { watchDesktop, warmTerminal, warmEdit } = warmIntents;
+  const { watchDesktop, warmTerminal, warmFiles } = warmIntents;
   const requestWarmIntent = useCallback(
     (intent: Exclude<keyof SessionWarmIntents, "sessionId">) => {
       setStoredWarmIntents((previous) => {
@@ -217,9 +225,9 @@ export function useSandboxWorkspaceTabs(
     events,
     attachDesktop: watchDesktop,
     attachTerminal: warmTerminal,
-    // Edit intent only — NOT "the Files tab is open". A cold edit warms the box
-    // (that is the wake); a cold glance at the tree/diff does not.
-    attachFiles: warmEdit,
+    // Explicit live-file intent only — NOT "the Files tab is open". A cold edit
+    // or guarded-file open wakes the box; a glance at the tree/diff does not.
+    attachFiles: warmFiles,
   });
   const capabilities = caps.capabilities;
   const liveness = capabilities?.liveness;
@@ -363,18 +371,18 @@ export function useSandboxWorkspaceTabs(
     capabilitiesState: caps.state,
     activeMachineState: activeMachine?.state ?? null,
     activeIsSelfhosted: activeMachine?.kind === "selfhosted",
-    wantsWarm: warmTerminal || watchDesktop || warmEdit,
+    wantsWarm: warmTerminal || watchDesktop || warmFiles,
     capturedAt: captureState.capturedAt,
   });
 
-  // The pre-paint default tab, decided from the workbench's OWN capture fetch — no
-  // embedder events-at-mount contract (Refinement 2). A host `initialTab` wins
-  // immediately; otherwise the default stays null until the capture GET first
-  // resolves, then latches Changes (changes exist) or Files, ONCE — live data can
-  // never switch it afterward. Committing at first-resolve — before the tab body's
-  // first CONTENT paint (both bodies show a connecting/loading state until the
-  // capture lands) — means the first real content is the correct tab, no switch. A
-  // pure embedder that never preloads events now gets the right default for free.
+  // The pre-paint default tab is decided from the first AUTHORITATIVE workspace
+  // source. A capture wins immediately on the cold/offline fast path; a warm box
+  // waits for live Git so a prior snapshot can never outrank the current tree.
+  // When the GET says no capture exists, `fileCount: 0` does NOT itself mean the
+  // working tree is clean. A captured-revision announce can
+  // resolve Changes earlier, but a pure embedder with no event preload still gets
+  // the correct live default. The choice latches once so later edits never steal
+  // the user's current tab.
   const defaultTabRef = useRef<{ sessionId: string; value: string | null }>({
     sessionId,
     value: null,
@@ -382,12 +390,42 @@ export function useSandboxWorkspaceTabs(
   if (defaultTabRef.current.sessionId !== sessionId) {
     defaultTabRef.current = { sessionId, value: null };
   }
+  const liveWorkspaceExpected = liveness === "warm" || liveness === "draining";
+  const captureIsAuthoritative =
+    !liveWorkspaceExpected && (liveness !== undefined || caps.error !== null);
+  const captureUnavailable = captureState.fileCount === 0 || captureState.error !== null;
   if (defaultTabRef.current.value === null) {
     if (initialTab) {
       defaultTabRef.current.value = initialTab;
-    } else if (captureState.fileCount !== null) {
+    } else if (git.source === "live") {
+      defaultTabRef.current.value =
+        git.diff.length > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
+    } else if (
+      captureIsAuthoritative &&
+      captureState.fileCount !== null &&
+      captureState.available
+    ) {
       defaultTabRef.current.value =
         captureState.fileCount > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
+    } else if (
+      captureIsAuthoritative &&
+      captureUnavailable &&
+      initialWorkspaceTab(events) === WORKBENCH_TAB_CHANGES
+    ) {
+      defaultTabRef.current.value = WORKBENCH_TAB_CHANGES;
+    } else if (captureState.available && git.error && captureState.fileCount !== null) {
+      // A warm live read failed but the durable capture is intact: retain an
+      // immediate, deterministic review surface instead of hanging unresolved.
+      defaultTabRef.current.value =
+        captureState.fileCount > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
+    } else if (captureUnavailable && caps.error) {
+      // The Changes surface owns the truthful sandbox-unavailable state + retry.
+      // Files would misleadingly describe this as a missing filesystem.
+      defaultTabRef.current.value = WORKBENCH_TAB_CHANGES;
+    } else if (captureUnavailable && git.error) {
+      // No capture and live Git failed: Files is the least surprising fallback
+      // and preserves the established no-capture degraded behavior.
+      defaultTabRef.current.value = WORKBENCH_TAB_FILES;
     }
   }
   // null only during the brief pre-first-resolve window (no host override yet).
@@ -411,6 +449,14 @@ export function useSandboxWorkspaceTabs(
           capabilitiesState={caps.state}
           capabilitiesError={caps.error}
           onRetry={caps.renegotiate}
+          {...(onOpenFile
+            ? {
+                onOpenFile: (path: string) => {
+                  requestWarmIntent("warmFiles");
+                  onOpenFile(path);
+                },
+              }
+            : {})}
         />
       ),
     });
@@ -421,14 +467,21 @@ export function useSandboxWorkspaceTabs(
       label: "Files",
       content: (
         <SandboxFiles
+          key={sessionId}
           files={files}
           git={git}
           stagedGit={stagedGit}
           fileSystemAvailable={fileSystemOn || captureAvailable}
           editable={filesEditable}
-          // The first keystroke in the editor is the wake-on-edit INTENT: warm the
-          // box (even cold) so the write lands fast. Opening/reading files does not.
-          onEditIntent={() => requestWarmIntent("warmEdit")}
+          {...(requestedFilePath
+            ? {
+                requestedPath: requestedFilePath,
+                requestedPathReady: liveness === "warm" || liveness === "draining",
+              }
+            : {})}
+          // Ordinary capture browsing does not warm a box. The first edit — or an
+          // explicit guarded-file open from Changes — is deliberate live-file intent.
+          onEditIntent={() => requestWarmIntent("warmFiles")}
           className="h-full"
         />
       ),
@@ -488,6 +541,10 @@ export function useSandboxWorkspaceTabs(
     dirtyCount,
     watchDesktop,
     warmTerminal,
+    requestedFilePath,
+    onOpenFile,
+    liveness,
+    sessionId,
     files,
     git,
     stagedGit,
@@ -524,7 +581,7 @@ export type SandboxWorkspaceProps = ClientOverride & {
   /** Host tabs injected AFTER the workbench tabs (e.g. a "Debug" tab). */
   trailingTabs?: WorkspaceTab[] | undefined;
   /** Override the pre-paint default tab (e.g. a host landing tab id). When
-   *  omitted the workbench decides Changes-vs-Files from local capture stats. */
+   *  omitted the workbench decides from capture, then live Git when no capture exists. */
   initialTab?: string | undefined;
   /** Host-routed notifications (no toast dependency in the package). */
   onNotify?: ((notification: WorkspaceNotification) => void) | undefined;
@@ -566,6 +623,22 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     className,
   } = props;
 
+  const [storedSelection, setStoredSelection] = useState<{
+    sessionId: string;
+    tab: string;
+  } | null>(null);
+  const [requestedFile, setRequestedFile] = useState<{
+    sessionId: string;
+    path: string;
+  } | null>(null);
+  const openFile = useCallback(
+    (path: string) => {
+      setRequestedFile({ sessionId, path });
+      setStoredSelection({ sessionId, tab: WORKBENCH_TAB_FILES });
+    },
+    [sessionId],
+  );
+
   const {
     tabs: workbenchTabs,
     machine,
@@ -577,18 +650,16 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     events,
     ...(initialTab ? { initialTab } : {}),
     ...(onNotify ? { onNotify } : {}),
+    requestedFilePath: requestedFile?.sessionId === sessionId ? requestedFile.path : null,
+    onOpenFile: openFile,
   });
 
-  // A user's tab click wins forever; before that we follow the capture-driven
+  // A user's tab click wins forever; before that we follow the source-driven
   // default. While it is still resolving (null, pure-embedder pre-first-resolve)
   // we pass no controlled tab, so the dock renders its own first-tab fallback
   // (Changes) — whose body is a connecting/loading state until the capture lands,
   // so committing the real default at first-resolve produces no CONTENT switch.
   const tabs: WorkspaceTab[] = [...(leadingTabs ?? []), ...workbenchTabs, ...(trailingTabs ?? [])];
-  const [storedSelection, setStoredSelection] = useState<{
-    sessionId: string;
-    tab: string;
-  } | null>(null);
   const selectedTab = storedSelection?.sessionId === sessionId ? storedSelection.tab : null;
   const activeTab = selectedTab ?? defaultTab ?? tabs[0]?.id;
   const selectTab = useCallback(
@@ -645,7 +716,7 @@ function MachineKindIcon({
 
 function chipDotClass(state: MachineChip["state"]): string {
   if (state === "live") return "bg-og-status-running";
-  if (state === "waking") return "bg-og-status-idle animate-pulse";
+  if (state === "waking") return "bg-og-status-idle animate-pulse motion-reduce:animate-none";
   return "bg-og-fg-subtle";
 }
 
@@ -673,7 +744,7 @@ function MachineStateChip({
         <button
           type="button"
           aria-label={`Machine: ${chip.label}`}
-          className="inline-flex min-h-7 items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:min-h-11 pointer-coarse:min-h-11"
+          className="inline-flex min-h-7 items-center gap-1.5 rounded-og-sm px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 pointer-coarse:min-h-11"
         >
           <span
             className={cn("size-1.5 shrink-0 rounded-full", chipDotClass(chip.state))}
@@ -740,7 +811,7 @@ function DockActionButton({ onClick, children }: { onClick: () => void; children
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg pointer-coarse:min-h-9"
+      className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 pointer-coarse:min-h-11"
     >
       {children}
     </button>
@@ -760,6 +831,7 @@ function ChangesTabBody({
   capabilitiesState,
   capabilitiesError,
   onRetry,
+  onOpenFile,
 }: {
   git: UseSandboxGitResult;
   captureAvailable: boolean;
@@ -767,6 +839,7 @@ function ChangesTabBody({
   capabilitiesState: string;
   capabilitiesError: Error | null;
   onRetry: () => void;
+  onOpenFile?: ((path: string) => void) | undefined;
 }) {
   const diff = git.diff;
 
@@ -777,13 +850,14 @@ function ChangesTabBody({
         source={git.source}
         capturedAt={git.capturedAt}
         captureRevision={captureRevision}
+        {...(onOpenFile ? { onOpenFile } : {})}
       />
     );
   }
 
   if (capabilitiesError && !captureAvailable) {
     return (
-      <CenteredState>
+      <CenteredState icon={<TriangleAlertIcon className="size-5" aria-hidden />} tone="danger">
         <p className="text-og-sm font-medium text-og-fg">Sandbox unavailable</p>
         <p className="text-og-sm leading-5 text-og-fg-muted">
           {capabilitiesError.message || "Couldn't reach the sandbox for this session."}
@@ -798,26 +872,74 @@ function ChangesTabBody({
 
   if ((capabilitiesState === "negotiating" || capabilitiesState === "cold") && !captureAvailable) {
     return (
-      <CenteredState>
-        <p className="text-og-sm text-og-fg-muted">Connecting sandbox…</p>
+      <CenteredState
+        icon={
+          <LoaderCircleIcon
+            className="size-5 animate-spin motion-reduce:animate-none"
+            aria-hidden
+          />
+        }
+      >
+        <p className="text-og-sm font-medium text-og-fg">Connecting workspace</p>
+        <p className="text-og-sm leading-5 text-og-fg-subtle">
+          Looking for the latest files and changes…
+        </p>
+      </CenteredState>
+    );
+  }
+
+  if (git.loading && git.source === null) {
+    return (
+      <CenteredState
+        icon={
+          <LoaderCircleIcon
+            className="size-5 animate-spin motion-reduce:animate-none"
+            aria-hidden
+          />
+        }
+      >
+        <p className="text-og-sm font-medium text-og-fg">Loading workspace</p>
+        <p className="text-og-sm leading-5 text-og-fg-subtle">Reading the current working tree…</p>
       </CenteredState>
     );
   }
 
   return (
-    <CenteredState>
-      <p className="text-og-sm font-medium text-og-fg">No changes yet</p>
+    <CenteredState icon={<CircleCheckIcon className="size-5" aria-hidden />} tone="success">
+      <p className="text-og-sm font-medium text-og-fg">Working tree is clean</p>
       <p className="text-og-sm leading-5 text-og-fg-subtle">
-        File edits from this session's turns show up here.
+        File edits from future turns will appear here.
       </p>
     </CenteredState>
   );
 }
 
-function CenteredState({ children }: { children: ReactNode }) {
+function CenteredState({
+  children,
+  icon,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  icon?: ReactNode | undefined;
+  tone?: "neutral" | "success" | "danger";
+}) {
   return (
     <div className="grid h-full place-items-center p-6 text-center">
-      <div className="flex max-w-sm flex-col items-center gap-2.5">{children}</div>
+      <div className="flex max-w-sm flex-col items-center gap-2.5">
+        {icon ? (
+          <span
+            className={cn(
+              "grid size-10 place-items-center rounded-og-lg border bg-og-surface-1 shadow-sm",
+              tone === "success" && "border-og-status-idle/30 text-og-status-idle",
+              tone === "danger" && "border-og-status-failed/30 text-og-status-failed",
+              tone === "neutral" && "border-og-border text-og-fg-muted",
+            )}
+          >
+            {icon}
+          </span>
+        ) : null}
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -145,6 +145,9 @@ export type UseSandboxWorkspaceTabsOptions = ClientOverride & {
   /** File requested by a Changes guard. The Files surface defers the read until
    *  the sandbox is live, then reveals this path. */
   requestedFilePath?: string | null | undefined;
+  /** Unique identity for `requestedFilePath`, including repeated requests for the
+   *  same path. */
+  requestedFileRequestId?: string | number | null | undefined;
   /** Route a guarded diff into the host's Files tab. */
   onOpenFile?: ((path: string) => void) | undefined;
 };
@@ -185,7 +188,8 @@ export function useSandboxWorkspaceTabs(
   options: UseSandboxWorkspaceTabsOptions,
 ): UseSandboxWorkspaceTabsResult {
   const { client, workspaceId } = useOpenGeni(options);
-  const { sessionId, events, onNotify, requestedFilePath, onOpenFile } = options;
+  const { sessionId, events, onNotify, requestedFilePath, requestedFileRequestId, onOpenFile } =
+    options;
   const initialTab = options.initialTab ?? null;
 
   // The three box-warming INTENTS, each off by default and each
@@ -476,6 +480,9 @@ export function useSandboxWorkspaceTabs(
           {...(requestedFilePath
             ? {
                 requestedPath: requestedFilePath,
+                ...(requestedFileRequestId !== null && requestedFileRequestId !== undefined
+                  ? { requestedPathRequestId: requestedFileRequestId }
+                  : {}),
                 requestedPathReady: liveness === "warm" || liveness === "draining",
               }
             : {})}
@@ -542,6 +549,7 @@ export function useSandboxWorkspaceTabs(
     watchDesktop,
     warmTerminal,
     requestedFilePath,
+    requestedFileRequestId,
     onOpenFile,
     liveness,
     sessionId,
@@ -630,10 +638,13 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
   const [requestedFile, setRequestedFile] = useState<{
     sessionId: string;
     path: string;
+    requestId: number;
   } | null>(null);
+  const nextFileRequestId = useRef(0);
   const openFile = useCallback(
     (path: string) => {
-      setRequestedFile({ sessionId, path });
+      nextFileRequestId.current += 1;
+      setRequestedFile({ sessionId, path, requestId: nextFileRequestId.current });
       setStoredSelection({ sessionId, tab: WORKBENCH_TAB_FILES });
     },
     [sessionId],
@@ -651,6 +662,7 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     ...(initialTab ? { initialTab } : {}),
     ...(onNotify ? { onNotify } : {}),
     requestedFilePath: requestedFile?.sessionId === sessionId ? requestedFile.path : null,
+    requestedFileRequestId: requestedFile?.sessionId === sessionId ? requestedFile.requestId : null,
     onOpenFile: openFile,
   });
 

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -1,5 +1,5 @@
 import type { GitFileDiff } from "@opengeni/sdk";
-import { FileWarningIcon, HistoryIcon } from "lucide-react";
+import { ArrowUpRightIcon, FileWarningIcon, HistoryIcon } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -77,6 +77,8 @@ export type WorkbenchChangesProps = {
   /** The capture's turn revision, for the "as of turn N" badge. */
   captureRevision?: number | null | undefined;
   themeType?: "dark" | "light" | undefined;
+  /** Route a guarded binary/oversize file into the live Files surface. */
+  onOpenFile?: ((path: string) => void) | undefined;
   className?: string | undefined;
 };
 
@@ -137,6 +139,7 @@ export function WorkbenchChanges({
   capturedAt,
   captureRevision,
   themeType,
+  onOpenFile,
   className,
 }: WorkbenchChangesProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -211,7 +214,9 @@ export function WorkbenchChanges({
   // Track which section is at the top of the pane so the rail highlights it.
   const onPaneScroll = useCallback(() => {
     const el = windowed.scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     const top = el.scrollTop;
     const offsets = windowed.offsets;
     let idx = 0;
@@ -240,13 +245,23 @@ export function WorkbenchChanges({
       data-workbench-changes-layout={compact ? "compact" : "rail"}
     >
       {/* Summary + source badge + layout toggle. */}
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-og-border px-3 py-1.5">
-        <span className="min-w-0 truncate text-og-xs text-og-fg-muted">
+      <div
+        className={cn(
+          "flex shrink-0 items-center justify-between gap-2 border-b border-og-border px-3 py-1.5",
+          compact && source === "capture" && "flex-col items-stretch gap-1.5 py-2",
+        )}
+      >
+        <span data-contrast-audited className="min-w-0 text-og-xs text-og-fg-muted">
           {diff.length} {diff.length === 1 ? "file" : "files"} changed
           <span className="ml-2 text-og-status-idle">+{additions}</span>
           <span className="ml-1 text-og-status-failed">−{deletions}</span>
         </span>
-        <div className="flex shrink-0 items-center gap-2">
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-2",
+            compact && source === "capture" && "self-start",
+          )}
+        >
           {compact ? null : <LayoutToggle layout={layout} onChange={setLayout} />}
           <SourceBadge source={source} capturedAt={capturedAt} label={sourceBadge} />
         </div>
@@ -271,21 +286,26 @@ export function WorkbenchChanges({
             >
               {orderedFiles.map((file, index) => (
                 <option key={file.path} value={index}>
-                  {STATUS_LETTER[file.status]} · {file.path} · +{file.additions} −{file.deletions}
+                  {STATUS_LETTER[file.status]} · {file.path}
                 </option>
               ))}
             </select>
           </div>
           <div className="min-h-0 min-w-0 flex-1 overflow-auto" data-opengeni-changes-pane>
             {activeFile ? (
-              <DiffSection file={activeFile} layout="unified" themeType={resolvedTheme} />
+              <DiffSection
+                file={activeFile}
+                layout="unified"
+                themeType={resolvedTheme}
+                {...(onOpenFile ? { onOpenFile } : {})}
+              />
             ) : null}
           </div>
         </div>
       ) : (
         <div className="flex min-h-0 flex-1">
           {/* File rail — virtualized (virtua): a dense change set is fine. */}
-          <div className="w-[240px] shrink-0 border-r border-og-border">
+          <div className="w-[clamp(12rem,28%,15rem)] shrink-0 border-r border-og-border bg-og-surface-1/35">
             <VList
               className="h-full"
               itemSize={coarsePointer ? 44 : 28}
@@ -332,7 +352,12 @@ export function WorkbenchChanges({
                     top={windowed.offsets[index] ?? 0}
                     onMeasure={windowed.measure}
                   >
-                    <DiffSection file={file} layout={layout} themeType={resolvedTheme} />
+                    <DiffSection
+                      file={file}
+                      layout={layout}
+                      themeType={resolvedTheme}
+                      {...(onOpenFile ? { onOpenFile } : {})}
+                    />
                   </MeasuredSection>
                 );
               })}
@@ -377,13 +402,13 @@ function SourceBadge({
   );
 }
 
-/** "live" · "as of turn 7 · 14:32" · "as of 14:32" (no revision). */
+/** "Live diff" · "as of turn 7 · 14:32" · "as of 14:32" (no revision). */
 function describeSource(
   source: "live" | "capture" | null,
   capturedAt: string | null,
   revision: number | null,
 ): string {
-  if (source !== "capture" || !capturedAt) return "live";
+  if (source !== "capture" || !capturedAt) return "Live diff";
   const time = formatAsOf(capturedAt, Date.now());
   return revision !== null ? `as of turn ${revision} · ${time}` : `as of ${time}`;
 }
@@ -409,9 +434,10 @@ function RailFileRow({
       title={file.path}
       data-rail-file
       className={cn(
-        "flex min-h-7 w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm hover:bg-og-surface-2 pointer-coarse:min-h-11",
+        "relative flex min-h-7 w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm transition-colors hover:bg-og-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-og-accent pointer-coarse:min-h-11",
         grouped && "pl-3",
-        active && "bg-og-surface-2",
+        active &&
+          "bg-og-accent-soft text-og-fg before:absolute before:inset-y-1 before:left-0 before:w-0.5 before:rounded-r-full before:bg-og-accent",
       )}
     >
       <span
@@ -468,10 +494,12 @@ function DiffSection({
   file,
   layout,
   themeType,
+  onOpenFile,
 }: {
   file: GitFileDiff;
   layout: "unified" | "split";
   themeType: "dark" | "light";
+  onOpenFile?: ((path: string) => void) | undefined;
 }) {
   // The guard files (binary / over-cap) get a minimal header + "open live" body
   // since Pierre has nothing to render; real diffs use Pierre's own sticky file
@@ -489,12 +517,12 @@ function DiffSection({
             <span className="text-og-status-failed">−{file.deletions}</span>
           </span>
         </header>
-        <GuardBody file={file} />
+        <GuardBody file={file} {...(onOpenFile ? { onOpenFile } : {})} />
       </section>
     );
   }
   return (
-    <section className="border-b border-og-border pb-2">
+    <section data-pierre-section className="border-b border-og-border pb-2">
       <PierreDiff diff={[file]} layout={layout} themeType={themeType} className="px-1" />
     </section>
   );
@@ -502,12 +530,28 @@ function DiffSection({
 
 /** The per-file guard: a binary file or an over-cap diff opens live rather than
  *  inlining a body we don't (fully) have. */
-function GuardBody({ file }: { file: GitFileDiff }) {
+function GuardBody({
+  file,
+  onOpenFile,
+}: {
+  file: GitFileDiff;
+  onOpenFile?: ((path: string) => void) | undefined;
+}) {
   const reason = file.isBinary ? "Binary file" : "Diff too large to show here";
   return (
-    <div className="flex items-center gap-2 px-3 py-3 text-og-sm text-og-fg-subtle">
-      <FileWarningIcon className="size-3.5 shrink-0" />
-      <span className="min-w-0">{reason} — open it on the machine to view.</span>
+    <div className="flex flex-wrap items-center gap-2 px-3 py-3 text-og-sm text-og-fg-subtle">
+      <FileWarningIcon className="size-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1">{reason}.</span>
+      {onOpenFile ? (
+        <button
+          type="button"
+          onClick={() => onOpenFile(file.path)}
+          className="inline-flex min-h-8 shrink-0 items-center gap-1.5 rounded-og-sm border border-og-border px-2 py-1 text-og-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:bg-og-surface-2 hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent pointer-coarse:min-h-11"
+        >
+          Open in Files
+          <ArrowUpRightIcon className="size-3.5" aria-hidden />
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -527,7 +571,7 @@ function LayoutToggle({
           type="button"
           onClick={() => onChange(value)}
           className={cn(
-            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-2xs capitalize pointer-coarse:min-h-11",
+            "min-h-7 rounded-og-xs px-1.5 py-0.5 text-2xs capitalize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent pointer-coarse:min-h-11",
             layout === value
               ? "bg-og-accent-soft text-og-fg"
               : "text-og-fg-subtle hover:text-og-fg",

--- a/packages/react/src/components/workspace-dock.tsx
+++ b/packages/react/src/components/workspace-dock.tsx
@@ -113,6 +113,9 @@ export function WorkspaceDock({
   className,
 }: WorkspaceDockProps) {
   const narrow = useIsNarrow(DOCK_OVERLAY_BREAKPOINT);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const reopenRef = useRef<HTMLButtonElement | null>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
   const dockPanelRef = usePanelRef();
   const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [maximized, setMaximized] = useState(false);
@@ -124,6 +127,7 @@ export function WorkspaceDock({
   // bug). Standalone (uncontrolled) usage keeps the built-in collapse button
   // and the thin re-open rail as its only affordances.
   const hostControlled = collapsedProp !== undefined;
+  const previousCollapsedRef = useRef(collapsed);
 
   // Persisted layout (width split) keyed by autoSaveId.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -164,6 +168,44 @@ export function WorkspaceDock({
     }
   }, [collapsedProp, dockPanelRef]);
 
+  // Treat the narrow overlay like a real modal: remember the external opener,
+  // move focus into the selected tab, and restore it on close. The standalone
+  // desktop dock instead focuses its newly-visible reopen rail after collapse.
+  useEffect(() => {
+    const previous = previousCollapsedRef.current;
+    previousCollapsedRef.current = collapsed;
+    if (previous === collapsed) return;
+
+    if (!collapsed) {
+      const active = document.activeElement;
+      const workspaceSurface = rootRef.current?.querySelector<HTMLElement>(
+        narrow ? '[role="dialog"]' : "[data-workspace-surface]",
+      );
+      if (active instanceof HTMLElement && !workspaceSurface?.contains(active)) {
+        returnFocusRef.current = active;
+      }
+      if (narrow) {
+        const frame = requestAnimationFrame(() => {
+          rootRef.current
+            ?.querySelector<HTMLElement>('[role="dialog"] [role="tab"][aria-selected="true"]')
+            ?.focus();
+        });
+        return () => cancelAnimationFrame(frame);
+      }
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      if (!hostControlled) {
+        reopenRef.current?.focus();
+        return;
+      }
+      const target = returnFocusRef.current;
+      if (target?.isConnected) target.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [collapsed, hostControlled, narrow]);
+
   // Keep the active tab valid if the available tabs change.
   useEffect(() => {
     if (firstTabId && !requestedTabIsValid) {
@@ -200,33 +242,45 @@ export function WorkspaceDock({
   // driven by the same `collapsed` contract (collapsed → hidden).
   if (narrow) {
     return (
-      <div className={cn("relative flex h-full min-h-0 w-full min-w-0", className)}>
+      <div ref={rootRef} className={cn("relative flex h-full min-h-0 w-full min-w-0", className)}>
         <div className="min-h-0 min-w-0 flex-1">{primary}</div>
-        {!collapsed && (
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Workspace"
-            className="fixed inset-0 z-40 flex flex-col bg-og-bg"
-            style={{
-              paddingTop: "env(safe-area-inset-top)",
-              paddingBottom: "env(safe-area-inset-bottom)",
-            }}
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Workspace"
+          className="fixed inset-0 z-40 flex flex-col bg-og-bg"
+          hidden={collapsed}
+          style={{
+            paddingTop: "env(safe-area-inset-top)",
+            paddingBottom: "env(safe-area-inset-bottom)",
+          }}
+        >
+          <DockChrome
+            tabs={tabs}
+            current={current}
+            onTab={setTab}
+            leading={mobileLeadingControl}
+            accessory={headerAccessory}
+            controls={
+              <ChromeButton onClick={collapse} title="Close workspace" label="Close workspace">
+                <XIcon className="size-4" />
+              </ChromeButton>
+            }
+          />
+        </div>
+        {collapsed && !hostControlled ? (
+          <button
+            ref={reopenRef}
+            type="button"
+            onClick={expand}
+            title="Open workspace"
+            aria-label="Open workspace"
+            className="absolute right-3 top-3 z-30 inline-flex size-11 items-center justify-center rounded-og-md border border-og-border bg-og-surface-1 text-og-fg-muted shadow-lg transition-colors hover:border-og-border-strong hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent"
+            style={{ marginTop: "env(safe-area-inset-top)" }}
           >
-            <DockChrome
-              tabs={tabs}
-              current={current}
-              onTab={setTab}
-              leading={mobileLeadingControl}
-              accessory={headerAccessory}
-              controls={
-                <ChromeButton onClick={collapse} title="Close workspace" label="Close workspace">
-                  <XIcon className="size-4" />
-                </ChromeButton>
-              }
-            />
-          </div>
-        )}
+            <ChevronsLeftRightIcon className="size-4" aria-hidden />
+          </button>
+        ) : null}
       </div>
     );
   }
@@ -261,7 +315,7 @@ export function WorkspaceDock({
   );
 
   return (
-    <div className={cn("relative flex h-full min-h-0 w-full min-w-0", className)}>
+    <div ref={rootRef} className={cn("relative flex h-full min-h-0 w-full min-w-0", className)}>
       <Group
         orientation="horizontal"
         className="min-h-0 flex-1"
@@ -296,13 +350,19 @@ export function WorkspaceDock({
           }}
           className="min-h-0 min-w-0"
         >
-          {/* Hidden behind the overlay while maximized (avoids double-mounting
-              the surfaces). */}
-          {!collapsed && !maximized && (
-            <div className="flex h-full min-h-0 min-w-0 flex-col border-l border-og-border bg-og-bg">
-              {dockChrome}
-            </div>
-          )}
+          {/* One persistent mount across normal, collapsed, and maximized modes:
+              layout changes must never destroy an editor buffer or terminal view. */}
+          <div
+            data-workspace-surface
+            aria-hidden={collapsed ? true : undefined}
+            className={cn(
+              "flex h-full min-h-0 min-w-0 flex-col bg-og-bg",
+              maximized ? "fixed inset-0 z-40" : "border-l border-og-border",
+              collapsed && "invisible pointer-events-none",
+            )}
+          >
+            {dockChrome}
+          </div>
         </Panel>
       </Group>
 
@@ -310,6 +370,7 @@ export function WorkspaceDock({
           when the host controls collapse — its own toggle is the one way in. */}
       {collapsed && !maximized && !hostControlled && (
         <button
+          ref={reopenRef}
           type="button"
           onClick={expand}
           title="Open workspace"
@@ -318,9 +379,6 @@ export function WorkspaceDock({
           <ChevronsLeftRightIcon className="size-3.5" />
         </button>
       )}
-
-      {/* Maximize overlay: full-workspace surface above everything. */}
-      {maximized && <div className="fixed inset-0 z-40 flex flex-col bg-og-bg">{dockChrome}</div>}
     </div>
   );
 }
@@ -343,7 +401,7 @@ function ChromeButton({
       onClick={onClick}
       title={title}
       aria-label={label}
-      className="inline-flex size-7 items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg max-[1023px]:size-11 pointer-coarse:size-11"
+      className="inline-flex size-7 items-center justify-center rounded-og-sm p-1 transition-colors hover:bg-og-surface-2 hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:size-11 pointer-coarse:size-11"
     >
       {children}
     </button>
@@ -369,14 +427,26 @@ function DockChrome({
   controls: ReactNode;
 }) {
   const active = tabs.find((t) => t.id === current) ?? tabs[0];
-  const activeIndex = tabs.findIndex((tab) => tab.id === active?.id);
   const tabsetId = useId();
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const panelId = `${tabsetId}-panel`;
+  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(() => new Set());
+  const activeId = active?.id ?? "";
+
+  useEffect(() => {
+    if (!activeId) return;
+    setVisitedTabs((previous) => {
+      if (previous.has(activeId)) return previous;
+      const next = new Set(previous);
+      next.add(activeId);
+      return next;
+    });
+  }, [activeId]);
 
   const activateTab = (index: number) => {
     const tab = tabs[index];
-    if (!tab) return;
+    if (!tab) {
+      return;
+    }
     onTab(tab.id);
     tabRefs.current[index]?.focus();
   };
@@ -395,13 +465,21 @@ function DockChrome({
 
   return (
     <>
-      <div className="flex shrink-0 items-center gap-2 border-b border-og-border px-1.5 py-1">
-        {leading ? <div className="flex shrink-0 items-center">{leading}</div> : null}
+      <div className="grid shrink-0 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-x-2 border-b border-og-border px-1.5 py-1 max-[1023px]:grid-cols-[auto_minmax(0,1fr)_auto] max-[1023px]:gap-y-0 max-[1023px]:px-2 max-[1023px]:pb-1 max-[1023px]:pt-0">
+        <div className="flex min-w-0 shrink-0 items-center max-[1023px]:min-h-11">
+          {leading ?? (
+            <span className="hidden truncate px-1 text-og-sm font-semibold text-og-fg max-[1023px]:inline">
+              Workspace
+            </span>
+          )}
+        </div>
         {/* The tab list scrolls horizontally when it can't fit — it must never
             grow into or overlap the chrome controls (they stay shrink-0). The
-            scrollbar is hidden to keep the strip calm. */}
+            scrollbar is hidden to keep the strip calm. On the narrow overlay it
+            owns a full second row, so status/close chrome can never squeeze the
+            canonical workspace navigation out of view. */}
         <div
-          className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-[1023px]:col-span-3 max-[1023px]:row-start-2 max-[1023px]:w-full"
           role="tablist"
           aria-orientation="horizontal"
         >
@@ -415,12 +493,12 @@ function DockChrome({
               type="button"
               role="tab"
               aria-selected={tab.id === current}
-              aria-controls={panelId}
+              aria-controls={`${tabsetId}-panel-${index}`}
               tabIndex={tab.id === current ? 0 : -1}
               onClick={() => onTab(tab.id)}
               onKeyDown={(event) => onTabKeyDown(event, index)}
               className={cn(
-                "flex min-h-7 shrink-0 items-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
+                "flex min-h-7 shrink-0 items-center justify-center gap-1 rounded-og-sm px-2 py-1 text-og-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent max-[1023px]:min-h-11 max-[1023px]:min-w-11 pointer-coarse:min-h-11 pointer-coarse:min-w-11",
                 tab.id === current
                   ? "bg-og-accent-soft text-og-fg"
                   : "text-og-fg-subtle hover:text-og-fg",
@@ -431,17 +509,30 @@ function DockChrome({
             </button>
           ))}
         </div>
-        {accessory ? <div className="flex shrink-0 items-center">{accessory}</div> : null}
+        <div className="flex min-w-0 shrink-0 items-center justify-self-end">{accessory}</div>
         <div className="flex shrink-0 items-center gap-0.5 text-og-fg-subtle">{controls}</div>
       </div>
-      <div
-        id={panelId}
-        aria-label={activeIndex < 0 ? "Workspace" : undefined}
-        aria-labelledby={activeIndex >= 0 ? `${tabsetId}-tab-${activeIndex}` : undefined}
-        className="min-h-0 min-w-0 flex-1 overflow-hidden"
-        role="tabpanel"
-      >
-        {active?.content}
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+        {tabs.length > 0 ? (
+          tabs.map((tab, index) => {
+            const selected = tab.id === activeId;
+            const shouldMount = selected || visitedTabs.has(tab.id);
+            return (
+              <div
+                key={tab.id}
+                id={`${tabsetId}-panel-${index}`}
+                aria-labelledby={`${tabsetId}-tab-${index}`}
+                className="h-full min-h-0 min-w-0 overflow-hidden"
+                hidden={!selected}
+                role="tabpanel"
+              >
+                {shouldMount ? tab.content : null}
+              </div>
+            );
+          })
+        ) : (
+          <div className="h-full min-h-0 min-w-0" aria-label="Workspace" role="tabpanel" />
+        )}
       </div>
     </>
   );

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -11,7 +11,9 @@ import { DesktopViewer } from "../src/components/desktop-viewer";
 import { DiffView } from "../src/components/diff-view";
 import { PierreDiff } from "../src/components/pierre-diff";
 import { FileBrowser } from "../src/components/file-browser";
+import { SandboxFiles } from "../src/components/sandbox-files";
 import type { UseSandboxFilesResult } from "../src/hooks/use-sandbox-files";
+import type { UseSandboxGitResult } from "../src/hooks/use-sandbox-git";
 
 registerDom();
 
@@ -51,6 +53,35 @@ function filesResult(overrides: Partial<UseSandboxFilesResult> = {}): UseSandbox
   };
 }
 
+function gitResult(): UseSandboxGitResult {
+  return {
+    diff: [],
+    branch: "main",
+    isRepo: true,
+    ahead: 0,
+    behind: 0,
+    refresh: async () => {},
+    source: "capture",
+    capturedAt: "2026-07-16T12:00:00.000Z",
+    loading: false,
+    error: null,
+  };
+}
+
+function selectedFile(container: HTMLElement): string | null {
+  return container.querySelector("[data-opengeni-selected-file]")?.textContent ?? null;
+}
+
+function fileButton(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>("[role=treeitem] button"),
+  ).find((candidate) => candidate.textContent?.includes(name));
+  if (!button) {
+    throw new Error(`Missing file button: ${name}`);
+  }
+  return button;
+}
+
 describe("FileBrowser", () => {
   test("renders the tree from useSandboxFiles data", async () => {
     const r = await renderComponent(<FileBrowser result={filesResult()} />);
@@ -80,6 +111,61 @@ describe("FileBrowser", () => {
     );
     await flush();
     expect(r.container.textContent).toContain("nothing here");
+    await r.unmount();
+  });
+});
+
+describe("SandboxFiles guarded-file routing", () => {
+  test("manual navigation consumes a pending cold request and wins after warm-up", async () => {
+    const files = filesResult();
+    const git = gitResult();
+    const r = await renderComponent(
+      <SandboxFiles
+        files={files}
+        git={git}
+        requestedPath="src/app.ts"
+        requestedPathRequestId={1}
+        requestedPathReady={false}
+      />,
+    );
+    await flush();
+
+    await actRun(() => fileButton(r.container, "README.md").click());
+    expect(selectedFile(r.container)).toBe("README.md");
+
+    await r.rerender(
+      <SandboxFiles
+        files={files}
+        git={git}
+        requestedPath="src/app.ts"
+        requestedPathRequestId={1}
+        requestedPathReady={true}
+      />,
+    );
+    await flush();
+    expect(selectedFile(r.container)).toBe("README.md");
+    await r.unmount();
+  });
+
+  test("a new request identity deliberately reopens the same guarded path", async () => {
+    const files = filesResult();
+    const git = gitResult();
+    const r = await renderComponent(
+      <SandboxFiles files={files} git={git} requestedPath="README.md" requestedPathRequestId={1} />,
+    );
+    await flush();
+    expect(selectedFile(r.container)).toBe("README.md");
+
+    await actRun(() => fileButton(r.container, "src").click());
+    await flush();
+    await actRun(() => fileButton(r.container, "app.ts").click());
+    expect(selectedFile(r.container)).toBe("src/app.ts");
+
+    await r.rerender(
+      <SandboxFiles files={files} git={git} requestedPath="README.md" requestedPathRequestId={2} />,
+    );
+    await flush();
+    expect(selectedFile(r.container)).toBe("README.md");
     await r.unmount();
   });
 });

--- a/packages/react/test/workbench-changes.test.tsx
+++ b/packages/react/test/workbench-changes.test.tsx
@@ -181,16 +181,17 @@ describe("WorkbenchChanges — rail, badge, guard", () => {
     await r.unmount();
   });
 
-  test("source badge reads 'live' for the live source", async () => {
+  test("source badge reads 'Live diff' for the live source", async () => {
     const r = await renderComponent(
       <WorkbenchChanges diff={manyFiles(3)} source="live" capturedAt={null} />,
     );
     await flush();
-    expect(container(r).textContent).toContain("live");
+    expect(container(r).textContent).toContain("Live diff");
     await r.unmount();
   });
 
   test("a binary file's section shows the open-live guard, not a diff body", async () => {
+    const openedPaths: string[] = [];
     const diff = [
       fakeFileDiff({
         path: "assets/logo.png",
@@ -201,11 +202,25 @@ describe("WorkbenchChanges — rail, badge, guard", () => {
       }),
     ];
     const r = await renderComponent(
-      <WorkbenchChanges diff={diff} source="live" capturedAt={null} />,
+      <WorkbenchChanges
+        diff={diff}
+        source="live"
+        capturedAt={null}
+        onOpenFile={(path) => {
+          openedPaths.push(path);
+        }}
+      />,
     );
     await flush();
     expect(container(r).textContent).toContain("Binary file");
-    expect(container(r).textContent).toContain("open it on the machine");
+    const open = [...container(r).querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Open in Files"),
+    );
+    expect(open).toBeDefined();
+    await act(async () => {
+      open!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(openedPaths).toEqual(["assets/logo.png"]);
     await r.unmount();
   });
 

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -7,11 +7,9 @@
    attaches a viewer. This closes a live prod cost (box-hours burned to serve reads
    the capture already answers for free).
 
-   Refinement 2 — the default tab is decided from the workbench's OWN capture fetch
-   (`fileCount`) at first-resolve, with no embedder events-at-mount contract, and
-   with no post-paint CONTENT switch (the dock's first-tab fallback body is a
-   loader until the capture lands, so the committed default is the first real
-   content).
+   Refinement 2 — the default tab is decided from the first authoritative source:
+   capture stats when present, otherwise live Git. No embedder events-at-mount
+   contract is required and the choice latches before real content paints.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import { act, type ReactElement, type ReactNode } from "react";
@@ -19,7 +17,12 @@ import type { GetWorkspaceCaptureResponse, WorkspaceCaptureManifest } from "@ope
 import { registerDom, renderComponent, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import type { SessionClientLike } from "../src/client";
-import { fakeAttachResponse, fakeColdCapabilities } from "./sandbox-fixtures";
+import {
+  fakeAttachResponse,
+  fakeCapabilities,
+  fakeColdCapabilities,
+  fakeFileDiff,
+} from "./sandbox-fixtures";
 import { OpenGeniProvider } from "../src/provider";
 import {
   useSandboxWorkspaceTabs,
@@ -249,6 +252,29 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     await hook.unmount();
   });
 
+  test("opening a guarded file is explicit live-file intent and warms a cold box", async () => {
+    const opened: string[] = [];
+    const { client, spy } = coldClient();
+    const hook = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [],
+      onOpenFile: (path) => opened.push(path),
+    });
+    await flush(60);
+    expect(spy.attachCalls).toBe(0);
+    const changes = hook.result.current.tabs.find((tab) => tab.id === WORKBENCH_TAB_CHANGES);
+    expect(changes).toBeDefined();
+    const onOpenFile = (changes!.content as ReactElement<{ onOpenFile: (path: string) => void }>)
+      .props.onOpenFile;
+    await act(async () => {
+      onOpenFile("large/output.json");
+    });
+    await flush(60);
+    expect(opened).toEqual(["large/output.json"]);
+    expect(spy.attachCalls).toBe(1);
+    await hook.unmount();
+  });
+
   test("switching sessions clears prior warm intent instead of prewarming the new session", async () => {
     const { client, spy } = coldClient();
     const result = { current: undefined as unknown as UseSandboxWorkspaceTabsResult };
@@ -316,6 +342,137 @@ describe("capture-driven default tab (Refinement 2)", () => {
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
     expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await hook.unmount();
+  });
+
+  test("warm live changes with no capture → default Changes from authoritative Git", async () => {
+    const diff = [fakeFileDiff({ path: "src/live-change.ts" })];
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => ({ available: false }),
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 1,
+      }),
+      gitDiff: async () => ({ files: diff, revision: 1 }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await hook.unmount();
+  });
+
+  test("warm clean workspace with no capture → default Files after live Git resolves", async () => {
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => ({ available: false }),
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 1,
+      }),
+      gitDiff: async () => ({ files: [], revision: 1 }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await hook.unmount();
+  });
+
+  test("warm live Git outranks an empty prior capture", async () => {
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(0)),
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 2,
+      }),
+      gitDiff: async () => ({ files: [fakeFileDiff()], revision: 2 }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await hook.unmount();
+  });
+
+  test("a fast empty capture cannot latch Files before warm capability negotiation", async () => {
+    let resolveCapabilities: (value: ReturnType<typeof fakeCapabilities>) => void = () => {};
+    const capabilitiesPromise = new Promise<ReturnType<typeof fakeCapabilities>>((resolve) => {
+      resolveCapabilities = resolve;
+    });
+    const { client } = coldClient({
+      getStreamCapabilities: () => capabilitiesPromise,
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(0)),
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 2,
+      }),
+      gitDiff: async () => ({ files: [fakeFileDiff()], revision: 2 }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBeNull();
+    await act(async () => resolveCapabilities(fakeCapabilities()));
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await hook.unmount();
+  });
+
+  test("warm clean Git outranks a changed prior capture", async () => {
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),
+      gitStatus: async () => ({
+        isRepo: true,
+        head: "main",
+        detached: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 2,
+      }),
+      gitDiff: async () => ({ files: [], revision: 2 }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    await hook.unmount();
+  });
+
+  test("capability failure with no capture → default Changes for the truthful retry state", async () => {
+    const { client } = coldClient({
+      getStreamCapabilities: async () => {
+        throw new Error("sandbox unreachable");
+      },
+      getWorkspaceCapture: async () => ({ available: false }),
+    });
+    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
     await hook.unmount();
   });
 

--- a/packages/react/test/workspace-dock.test.tsx
+++ b/packages/react/test/workspace-dock.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { act, type ReactNode, useState } from "react";
 import { WorkspaceDock } from "../src/components/workspace-dock";
-import { registerDom, renderComponent } from "./render-hook";
+import { flush, registerDom, renderComponent } from "./render-hook";
 
 registerDom();
 
@@ -27,7 +27,11 @@ function ControlledDock(props: {
   return (
     <WorkspaceDock
       autoSaveId="og.test.workspace-dock"
-      primary={<div>Chat pane</div>}
+      primary={
+        <button type="button" aria-label="Host open workspace" onClick={() => setCollapsed(false)}>
+          Chat pane
+        </button>
+      }
       tabs={[{ id: "run", label: "Run", content: <div>Run content</div> }]}
       collapsed={collapsed}
       onCollapsedChange={(next) => {
@@ -76,17 +80,26 @@ describe("WorkspaceDock", () => {
     );
 
     const tabs = Array.from(rendered.container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
-    const panel = rendered.container.querySelector<HTMLElement>('[role="tabpanel"]');
+    const panelFor = (tab: HTMLButtonElement | undefined) =>
+      tab
+        ? rendered.container.querySelector<HTMLElement>(
+            `[id="${tab.getAttribute("aria-controls")}"]`,
+          )
+        : null;
     expect(tabs.map((tab) => tab.tabIndex)).toEqual([0, -1, -1]);
-    expect(tabs[0]?.getAttribute("aria-controls")).toBe(panel?.id);
-    expect(panel?.getAttribute("aria-labelledby")).toBe(tabs[0]?.id);
+    expect(new Set(tabs.map((tab) => tab.getAttribute("aria-controls"))).size).toBe(3);
+    for (const tab of tabs) {
+      expect(panelFor(tab)?.getAttribute("aria-labelledby")).toBe(tab.id);
+    }
+    expect(panelFor(tabs[0])?.hidden).toBe(false);
 
     tabs[0]?.focus();
     await press(tabs[0] ?? null, "ArrowRight");
     expect(document.activeElement).toBe(tabs[1] ?? null);
     expect(rendered.container.textContent ?? "").toContain("Files content");
     expect(tabs.map((tab) => tab.tabIndex)).toEqual([-1, 0, -1]);
-    expect(panel?.getAttribute("aria-labelledby")).toBe(tabs[1]?.id);
+    expect(panelFor(tabs[0])?.hidden).toBe(true);
+    expect(panelFor(tabs[1])?.hidden).toBe(false);
 
     await press(tabs[1] ?? null, "End");
     expect(document.activeElement).toBe(tabs[2] ?? null);
@@ -95,6 +108,53 @@ describe("WorkspaceDock", () => {
     await press(tabs[2] ?? null, "ArrowRight");
     expect(document.activeElement).toBe(tabs[0] ?? null);
     expect(rendered.container.textContent ?? "").toContain("Changes content");
+
+    await rendered.unmount();
+  });
+
+  test("a visited tab stays mounted so file/editor/terminal state survives navigation", async () => {
+    function StatefulFiles() {
+      const [count, setCount] = useState(0);
+      return (
+        <button type="button" onClick={() => setCount((value) => value + 1)}>
+          File state {count}
+        </button>
+      );
+    }
+    const rendered = await renderComponent(
+      <WorkspaceDock
+        autoSaveId="og.test.workspace-dock-preserve-tabs"
+        primary={<div>Chat pane</div>}
+        tabs={[
+          { id: "changes", label: "Changes", content: <div>Changes content</div> },
+          { id: "files", label: "Files", content: <StatefulFiles /> },
+        ]}
+      />,
+    );
+    const findTab = (label: string) =>
+      [...rendered.container.querySelectorAll('[role="tab"]')].find(
+        (tab) => tab.textContent === label,
+      ) ?? null;
+
+    await click(findTab("Files"));
+    await click(
+      [...rendered.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.startsWith("File state"),
+      ) ?? null,
+    );
+    expect(rendered.container.textContent ?? "").toContain("File state 1");
+    await click(findTab("Changes"));
+    await click(findTab("Files"));
+    expect(rendered.container.textContent ?? "").toContain("File state 1");
+
+    await click(rendered.container.querySelector('[title="Collapse"]'));
+    await click(rendered.container.querySelector('[title="Open workspace"]'));
+    expect(rendered.container.textContent ?? "").toContain("File state 1");
+
+    await click(rendered.container.querySelector('[title="Maximize"]'));
+    expect(rendered.container.querySelector('[title="Restore (Esc)"]')).not.toBeNull();
+    await click(rendered.container.querySelector('[title="Restore (Esc)"]'));
+    expect(rendered.container.textContent ?? "").toContain("File state 1");
 
     await rendered.unmount();
   });
@@ -156,13 +216,20 @@ describe("WorkspaceDock", () => {
     expect(rendered.container.textContent ?? "").toContain("Run content");
 
     await click(rendered.container.querySelector('[title="Collapse"]'));
+    await flush(20);
 
-    expect(rendered.container.textContent ?? "").not.toContain("Run content");
+    expect(
+      rendered.container.querySelector("[data-workspace-surface]")?.getAttribute("aria-hidden"),
+    ).toBe("true");
     expect(rendered.container.querySelector('[title="Open workspace"]')).not.toBeNull();
+    expect(document.activeElement?.getAttribute("title")).toBe("Open workspace");
 
     await click(rendered.container.querySelector('[title="Open workspace"]'));
 
     expect(rendered.container.textContent ?? "").toContain("Run content");
+    expect(
+      rendered.container.querySelector("[data-workspace-surface]")?.getAttribute("aria-hidden"),
+    ).toBeNull();
 
     await rendered.unmount();
   });
@@ -189,9 +256,54 @@ describe("WorkspaceDock", () => {
       await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
       expect(changes.at(-1)).toBe(true);
       expect(
-        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]'),
+        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
       ).toBeNull();
+      expect(
+        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"][hidden]'),
+      ).not.toBeNull();
 
+      const hostOpen = rendered.container.querySelector<HTMLElement>(
+        '[aria-label="Host open workspace"]',
+      );
+      hostOpen?.focus();
+      await click(hostOpen);
+      await flush(20);
+      expect(
+        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
+      ).not.toBeNull();
+      expect(document.activeElement?.getAttribute("role")).toBe("tab");
+
+      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      await flush(20);
+      expect(document.activeElement).toBe(hostOpen ?? null);
+
+      await rendered.unmount();
+    });
+  });
+
+  test("an uncontrolled phone overlay always provides a focusable reopen affordance", async () => {
+    await withNarrowViewport(async () => {
+      const rendered = await renderComponent(
+        <WorkspaceDock
+          autoSaveId="og.test.workspace-dock-mobile-uncontrolled"
+          primary={<div>Chat pane</div>}
+          tabs={[{ id: "files", label: "Files", content: <div>Files content</div> }]}
+        />,
+      );
+      expect(
+        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
+      ).not.toBeNull();
+
+      await click(rendered.container.querySelector('[aria-label="Close workspace"]'));
+      await flush(20);
+      const reopen = rendered.container.querySelector<HTMLElement>('[title="Open workspace"]');
+      expect(reopen).not.toBeNull();
+      expect(document.activeElement).toBe(reopen ?? null);
+
+      await click(reopen);
+      expect(
+        rendered.container.querySelector('[role="dialog"][aria-label="Workspace"]:not([hidden])'),
+      ).not.toBeNull();
       await rendered.unmount();
     });
   });

--- a/test/e2e/workbench.browser.e2e.ts
+++ b/test/e2e/workbench.browser.e2e.ts
@@ -44,7 +44,11 @@ describe("workbench browser acceptance", () => {
         {
           cwd: `${repoRoot}/packages/react`,
           ready: async () =>
-            (await fetch(`${baseUrl}/workbench-dock.html`).catch(() => null))?.ok === true,
+            (
+              await fetch(`${baseUrl}/workbench-dock.html`, {
+                signal: AbortSignal.timeout(2_000),
+              }).catch(() => null)
+            )?.ok === true,
           timeoutMs: 45_000,
         },
       );
@@ -83,6 +87,7 @@ describe("workbench browser acceptance", () => {
           const response = await page.goto(dockUrl(baseUrl, state, theme), {
             waitUntil: "networkidle",
           });
+          await waitForWorkbenchVisualReady(page);
           const audit = await page.evaluate(() => {
             const visible = (element: Element) => {
               const style = getComputedStyle(element);
@@ -110,16 +115,33 @@ describe("workbench browser acceptance", () => {
                 };
               })
               .filter((target) => target.width < 44 || target.height < 44);
+            const tablist = document.querySelector('[role="tablist"]');
+            const tablistRect = tablist?.getBoundingClientRect();
+            const clippedTabs = tablistRect
+              ? Array.from(tablist.querySelectorAll<HTMLElement>('[role="tab"]'))
+                  .filter(visible)
+                  .map((tab) => ({
+                    label: tab.textContent?.trim() ?? "",
+                    rect: tab.getBoundingClientRect(),
+                  }))
+                  .filter(
+                    ({ rect }) =>
+                      rect.left < tablistRect.left - 1 || rect.right > tablistRect.right + 1,
+                  )
+                  .map(({ label }) => label)
+              : [];
             return {
               overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
               undersized,
+              clippedTabs,
             };
           });
           if (
             response?.status() !== 200 ||
             problems.length > 0 ||
             audit.overflow ||
-            audit.undersized.length
+            audit.undersized.length ||
+            audit.clippedTabs.length
           ) {
             failures.push({
               viewport: viewport.width,
@@ -168,6 +190,7 @@ describe("workbench browser acceptance", () => {
       });
       const page = await context.newPage();
       await page.goto(dockUrl(baseUrl, state, theme, tab), { waitUntil: "networkidle" });
+      await waitForWorkbenchVisualReady(page);
       const report = await new AxeBuilder({ page })
         .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
         .analyze();
@@ -180,7 +203,7 @@ describe("workbench browser acceptance", () => {
             if (rule.id === "color-contrast") {
               return (
                 !target.includes("data-line-number-content") &&
-                !target.includes("truncate.text-og-fg-muted")
+                !target.includes("data-contrast-audited")
               );
             }
             return true;
@@ -238,9 +261,101 @@ describe("workbench browser acceptance", () => {
     expect(await tabs.nth(3).getAttribute("aria-selected")).toBe("true");
     await page.keyboard.press("ArrowRight");
     expect(await tabs.nth(0).getAttribute("aria-selected")).toBe("true");
+
+    const dialog = page.locator('[role="dialog"][aria-label="Workspace"]');
+    const dialogHandle = await dialog.elementHandle();
+    await page.getByRole("button", { name: "Close workspace" }).click();
+    await expectEventually(async () => page.locator('[title="Open workspace"]:focus').count());
+    expect(await dialog.getAttribute("hidden")).not.toBeNull();
+    expect(await dialogHandle?.evaluate((element) => element.isConnected)).toBe(true);
+    await page.getByTitle("Open workspace").click();
+    expect(await dialog.getAttribute("hidden")).toBeNull();
+    expect(await dialogHandle?.evaluate((element) => element.isConnected)).toBe(true);
+    await context.close();
+  });
+
+  test("desktop maximize and collapse preserve one viewport-correct mounted surface", async () => {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 960 } });
+    const page = await context.newPage();
+    await page.goto(dockUrl(baseUrl, "warm-live", "dark", "changes"), {
+      waitUntil: "networkidle",
+    });
+    await waitForWorkbenchVisualReady(page);
+    const surface = page.locator("[data-workspace-surface]");
+    const surfaceHandle = await surface.elementHandle();
+
+    await page.getByTitle("Maximize").click();
+    const rect = await surface.boundingBox();
+    expect(rect).not.toBeNull();
+    expect(Math.round(rect?.x ?? -1)).toBe(0);
+    expect(Math.round(rect?.y ?? -1)).toBe(0);
+    expect(Math.round(rect?.width ?? -1)).toBe(1440);
+    expect(Math.round(rect?.height ?? -1)).toBe(960);
+    expect(await surfaceHandle?.evaluate((element) => element.isConnected)).toBe(true);
+
+    await page.getByTitle("Restore (Esc)").click();
+    await page.getByTitle("Collapse").click();
+    await expectEventually(async () => page.locator('[title="Open workspace"]:focus').count());
+    expect(await surface.getAttribute("aria-hidden")).toBe("true");
+    expect(await surfaceHandle?.evaluate((element) => element.isConnected)).toBe(true);
+    await page.getByTitle("Open workspace").click();
+    expect(await surface.getAttribute("aria-hidden")).toBeNull();
+    expect(await surfaceHandle?.evaluate((element) => element.isConnected)).toBe(true);
+    await context.close();
+  });
+
+  test("a guarded diff opens the requested path in Files on mobile", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await context.newPage();
+    await page.goto(dockUrl(baseUrl, "guard", "dark", "changes"), {
+      waitUntil: "networkidle",
+    });
+    await page.locator("[data-compact-file-picker]").selectOption({ index: 1 });
+    await page.getByRole("button", { name: "Open in Files" }).click();
+
+    expect(await page.getByRole("tab", { name: "Files" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    await expectEventually(async () =>
+      page
+        .locator('[role="tabpanel"]:not([hidden])')
+        .getByText("assets/logo.png", { exact: true })
+        .count(),
+    );
     await context.close();
   });
 });
+
+async function expectEventually(check: () => Promise<number>): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if ((await check()) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  expect(await check()).toBeGreaterThan(0);
+}
+
+async function waitForWorkbenchVisualReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-pierre-section]")).every(
+        (section) => {
+          const container = section.querySelector("diffs-container");
+          return Boolean(
+            container?.shadowRoot &&
+            container.shadowRoot.childElementCount > 0 &&
+            container.getBoundingClientRect().height > 40,
+          );
+        },
+      ),
+    undefined,
+    { timeout: 5_000 },
+  );
+}
 
 function dockUrl(
   baseUrl: string,
@@ -306,9 +421,8 @@ async function manualAccessibilityAudit(page: Page): Promise<{
         ratios.push(contrast(getComputedStyle(lineNumber).color, opaqueBackground(lineNumber)));
       }
     }
-    const summary = document.querySelector(".truncate.text-og-fg-muted.text-og-xs");
-    if (summary) {
-      ratios.push(contrast(getComputedStyle(summary).color, opaqueBackground(summary)));
+    for (const audited of document.querySelectorAll("[data-contrast-audited]")) {
+      ratios.push(contrast(getComputedStyle(audited).color, opaqueBackground(audited)));
     }
     return {
       missingAriaControls,


### PR DESCRIPTION
## Outcome

Hardens the generic OpenGeni workspace dock for persistent state, authoritative live/capture routing, accessible mobile navigation, and guarded-file recovery. This is the first implementation round against `docs/workbench-acceptance.md`; it does not claim production completion.

## UI/UX polish passes

1. Rebuilt the narrow overlay into a stable two-row hierarchy so all canonical tabs fit at 320 px.
2. Added an always-available 44 px reopen affordance for uncontrolled mobile docks.
3. Preserved the same tab-panel DOM across tab switches, collapse/reopen, and maximize/restore.
4. Completed tab/panel ARIA relationships, roving keyboard focus, focus entry, and focus restoration.
5. Added visible focus treatments, safe-area handling, and reduced-motion fallbacks.
6. Corrected default-tab authority: durable capture while cold/offline, live Git while warm.
7. Removed capture/capability races that could latch a stale or misleading landing tab.
8. Reworked compact Changes metadata and the desktop file rail for clearer hierarchy and more path space.
9. Replaced false binary/oversize affordance copy with a real Open in Files action and exact-path routing.
10. Added truthful icon-led loading, empty, clean, and error states with 44 px retry targets.
11. Made visual evidence deterministic by waiting for the Pierre diff shadow surface before capture.
12. Fenced cold guarded-file requests so later manual tree navigation wins, while a repeated same-path request remains a distinct deliberate intent.

## Verification on exact head `746aa340`

- lint: zero warnings
- format: 783 files clean
- typecheck: all 19 projects clean
- focused workbench and review-fix components: 37 passed, 0 failed
- React warning gate: 583 passed, 0 failed, 1,662 assertions, zero console warnings
- browser acceptance: 5 passed, 0 failed, 23 assertions
  - 320/768/desktop geometry and touch targets
  - both themes and dense/offline/error/empty/binary states
  - WCAG 2.2 AA checks
  - keyboard tab semantics and focus restoration
  - state persistence through collapse/maximize
  - guarded diff to exact file routing
- fail-closed real-Postgres suite: 3,059 passed, 0 failed, 12,173 assertions
- three live-Modal tests remain explicitly gated and must pass after exact-artifact deployment; they are not represented as complete here
- OPE22 separately gated regressions: 2 passed, 0 failed
- all 16 publishable packages build; publish closure guard passes
- demo and production web builds pass
- enforced bundle budgets pass:
  - initial: 185,206 B gzip / 215,040 B budget
  - direct session: 512,246 B gzip / 552,960 B budget
  - largest lazy chunk: 232,093 B gzip / 245,760 B budget
  - CSS: 23,854 B gzip / 30,720 B budget

## Adversarial scan

UBS found and prompted one real test-harness fix: the demo readiness fetch now has a bounded abort signal. The CI review then found a cold-wake navigation race; the exact current code confirmed it, and the request-identity/consumption fix plus two regressions are included here. Remaining scanner hits were re-opened against the exact lines: they are identifier equality checks (`sessionId`, `sandboxId`, request/tab ids), not secrets, plus a switch where every branch returns.

## Release

Includes a minor `@opengeni/react` changeset because the optional workbench routing behavior/API is expanded. Production deployment and authenticated live-sandbox verification happen only after this PR, its release PR, and exact-head CI are green.
