### PR TITLE
feat(react): per-machine telemetry detail + upgraded machine cards

### DIFF
--- a/.changeset/machine-telemetry-detail.md
+++ b/.changeset/machine-telemetry-detail.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Add a per-machine telemetry detail view and upgrade the machine cards. The card now leads with a fused health verdict (connection + resource pressure + sample freshness), previews a CPU trend, and shows live freshness; opening a card reveals full metric history (CPU, memory, disk, load, GPU) over 15m/1h/6h/24h with threshold guides and a hover crosshair — rendering the downsampled series the API already served but nothing consumed. Resource meters now read as a coherent green/amber/red traffic-light aligned with the health verdict, and load average renders neutral (it is not core-normalized) with the run queue carrying the real saturation signal.

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -7,10 +7,13 @@
 // manual device-flow approve kept as a secondary option).
 import {
   EnrollmentDeviceFlow,
+  MachineDetail,
   MachinesDashboard,
   connectionStatusForState,
   useMachines,
   type DeviceFlowPhase,
+  type MetricSample,
+  type MetricWindow,
 } from "@opengeni/react/machines";
 import {
   ArrowLeftIcon,
@@ -56,6 +59,90 @@ async function copyToClipboard(text: string, successMessage: string) {
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   const machines = useMachines({ pollIntervalMs: 5000 });
   const [enrollOpen, setEnrollOpen] = useState(false);
+
+  // The machine whose telemetry detail is open (by sandboxId), and its history.
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detailWindow, setDetailWindow] = useState<MetricWindow>("1h");
+  const [detailSeries, setDetailSeries] = useState<MetricSample[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+  // Short (15m) history per machine for the card sparklines, keyed by sandboxId.
+  const [cardSeries, setCardSeries] = useState<Record<string, MetricSample[]>>({});
+  // A shared, slowly-ticking clock so "Live / updated Xago" stays honest without
+  // re-rendering on every animation frame.
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { fetchSeries } = machines;
+  const selectedMachine = detailId
+    ? (machines.machines.find((m) => m.sandboxId === detailId) ?? null)
+    : null;
+  const selectedEnrollmentId = selectedMachine?.enrollmentId ?? null;
+
+  // Fetch the compact card sparkline history for every enrolled machine. Keyed on
+  // the SET of enrollment ids (not the 5s-polled array identity) + a 30s refresh,
+  // so it doesn't refetch on every liveness poll.
+  const enrolledKey = machines.machines
+    .filter((m) => m.enrollmentId && !m.isSessionGroup)
+    .map((m) => m.enrollmentId)
+    .sort()
+    .join(",");
+  useEffect(() => {
+    const enrolled = machines.machines.filter((m) => m.enrollmentId && !m.isSessionGroup);
+    if (enrolled.length === 0) {
+      setCardSeries({});
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      const entries = await Promise.all(
+        enrolled.map(async (m) => {
+          try {
+            return [m.sandboxId, await fetchSeries(m.enrollmentId!, "15m")] as const;
+          } catch {
+            return [m.sandboxId, [] as MetricSample[]] as const;
+          }
+        }),
+      );
+      if (!cancelled) setCardSeries(Object.fromEntries(entries));
+    };
+    void load();
+    const id = setInterval(() => void load(), 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enrolledKey, fetchSeries]);
+
+  // Fetch the open machine's detail history: on select, on window change, and on
+  // a 10s refresh while open.
+  useEffect(() => {
+    if (!selectedEnrollmentId) {
+      setDetailSeries([]);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    const load = async () => {
+      try {
+        const samples = await fetchSeries(selectedEnrollmentId, detailWindow);
+        if (!cancelled) setDetailSeries(samples);
+      } catch {
+        if (!cancelled) setDetailSeries([]);
+      } finally {
+        if (!cancelled) setDetailLoading(false);
+      }
+    };
+    void load();
+    const id = setInterval(() => void load(), 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [selectedEnrollmentId, detailWindow, fetchSeries]);
 
   // "Machine connected" moment: watch the polled fleet and, once a machine first
   // shows online (a fresh enrollment coming up, or a reconnect), toast it. The
@@ -112,12 +199,25 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
             Connected machines aren't enabled on this deployment. Sessions run on the managed
             sandbox.
           </Notice>
+        ) : selectedMachine ? (
+          <MachineDetail
+            machine={selectedMachine}
+            series={detailSeries}
+            window={detailWindow}
+            onWindowChange={setDetailWindow}
+            loadingSeries={detailLoading}
+            onBack={() => setDetailId(null)}
+            now={now}
+          />
         ) : (
           <MachinesDashboard
             machines={machines.machines}
             activeSandboxId={machines.activeSandboxId}
             loading={machines.loading}
             error={machines.error}
+            seriesByMachine={cardSeries}
+            onOpenDetail={(m) => setDetailId(m.sandboxId)}
+            now={now}
             onRefresh={() => void machines.refresh()}
             onEnroll={() => setEnrollOpen(true)}
             {...(machines.canAttach

--- a/packages/react/src/components/machine-card.tsx
+++ b/packages/react/src/components/machine-card.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowRightIcon,
   CpuIcon,
   LaptopIcon,
   MonitorIcon,
@@ -8,9 +9,10 @@ import {
 } from "lucide-react";
 import { cn } from "../lib/cn";
 import { formatRelativeTime } from "../lib/format";
-import type { MachineView } from "../types/machines";
+import type { MachineView, MetricSample } from "../types/machines";
+import { MachineHealthPill } from "./machine-health-pill";
 import { MachineMetrics } from "./machine-metrics";
-import { MachineStatusPill } from "./machine-status-pill";
+import { MetricSparkline } from "./machines/metric-sparkline";
 
 export type MachineCardProps = {
   machine: MachineView;
@@ -18,6 +20,11 @@ export type MachineCardProps = {
   onAttach?: ((machine: MachineView) => void) | undefined;
   /** Whether an attach/swap is currently in flight (disables the affordance). */
   attaching?: boolean | undefined;
+  /** Short recent history (e.g. 15m) — drives the card's CPU trend + preview. */
+  series?: MetricSample[] | undefined;
+  /** Open the full per-machine telemetry detail. Makes the whole card actionable. */
+  onOpenDetail?: ((machine: MachineView) => void) | undefined;
+  now?: number | undefined;
   className?: string | undefined;
 };
 
@@ -29,23 +36,52 @@ function KindIcon({ machine }: { machine: MachineView }) {
 }
 
 /**
- * One machine in the Machines dashboard: name + kind + OS/arch, the composite
- * connection/state/shared status, latest resource meters, last-seen recency, and
- * an attach/swap affordance. The session's currently-active sandbox carries an
- * accent edge + an "Active" marker (never an attach button — it's already active).
+ * One machine in the Machines dashboard: name + kind + OS/arch, the fused HEALTH
+ * verdict, latest resource meters, a CPU trend that previews the history, live
+ * freshness, and attach/swap. The whole card opens the telemetry detail when
+ * `onOpenDetail` is wired. The session's active sandbox carries an accent edge.
  */
-export function MachineCard({ machine, onAttach, attaching, className }: MachineCardProps) {
+export function MachineCard({
+  machine,
+  onAttach,
+  attaching,
+  series,
+  onOpenDetail,
+  now,
+  className,
+}: MachineCardProps) {
   const offline = machine.state === "offline";
   const attachable = !machine.active && !offline && Boolean(onAttach);
   const shared = machine.sharedSessionCount > 1;
+  const clockNow = now ?? Date.now();
+  const sampledAgo = machine.metrics
+    ? formatRelativeTime(machine.metrics.sampledAt, new Date(clockNow))
+    : null;
+  const cpuPts = (series ?? []).map((s) => ({ t: new Date(s.sampledAt).getTime(), v: s.cpuPct }));
+  const openable = Boolean(onOpenDetail);
 
   return (
     <div
       data-machine-card={machine.sandboxId}
       data-active={machine.active ? "true" : "false"}
+      role={openable ? "button" : undefined}
+      tabIndex={openable ? 0 : undefined}
+      onClick={openable ? () => onOpenDetail?.(machine) : undefined}
+      onKeyDown={
+        openable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onOpenDetail?.(machine);
+              }
+            }
+          : undefined
+      }
       className={cn(
-        "og-root relative flex flex-col gap-3 overflow-hidden rounded-og-lg border border-og-border",
-        "bg-og-surface-1 p-4 shadow-og-sm",
+        "og-root group relative flex flex-col gap-3 overflow-hidden rounded-og-lg border border-og-border",
+        "bg-og-surface-1 p-4 shadow-og-sm transition-colors",
+        openable &&
+          "cursor-pointer hover:border-og-border-strong focus-visible:border-og-accent/60 focus-visible:outline-none",
         machine.active && "border-og-accent/40",
         className,
       )}
@@ -91,9 +127,10 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
             </div>
           </div>
         </div>
-        <MachineStatusPill
+        <MachineHealthPill
           state={machine.state}
-          sharedSessionCount={machine.sharedSessionCount}
+          metrics={machine.metrics}
+          now={clockNow}
           size="sm"
           className="shrink-0"
         />
@@ -111,10 +148,36 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
 
       <MachineMetrics metrics={machine.metrics} />
 
+      {/* CPU trend — previews the history and invites opening the detail. */}
+      {cpuPts.length > 1 ? (
+        <div className="flex flex-col gap-1 rounded-og-md bg-og-surface-2/40 p-2.5">
+          <div className="flex items-center justify-between text-[10px] font-medium uppercase tracking-wide text-og-fg-subtle">
+            <span>CPU · last 15m</span>
+            {openable ? (
+              <span className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                Telemetry <ArrowRightIcon className="size-2.5" aria-hidden />
+              </span>
+            ) : null}
+          </div>
+          <MetricSparkline points={cpuPts} color="var(--og-color-accent)" yMax={100} height={26} />
+        </div>
+      ) : null}
+
       <div className="mt-1 flex items-center justify-between gap-3 text-og-xs text-og-fg-subtle">
-        <span>
-          {machine.lastSeenAt ? (
-            <>Last seen {formatRelativeTime(machine.lastSeenAt)}</>
+        <span className="inline-flex items-center gap-1.5">
+          {sampledAgo ? (
+            <>
+              <span
+                className={cn(
+                  "size-1.5 rounded-full",
+                  sampledAgo === "now" ? "bg-og-status-idle" : "bg-og-fg-subtle",
+                )}
+                aria-hidden
+              />
+              {sampledAgo === "now" ? "Live" : `Updated ${sampledAgo} ago`}
+            </>
+          ) : machine.lastSeenAt ? (
+            <>Last seen {formatRelativeTime(machine.lastSeenAt, new Date(clockNow))}</>
           ) : (
             "Never connected"
           )}
@@ -126,7 +189,10 @@ export function MachineCard({ machine, onAttach, attaching, className }: Machine
             type="button"
             data-attach
             disabled={attaching}
-            onClick={() => onAttach?.(machine)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAttach?.(machine);
+            }}
             className={cn(
               "rounded-og-sm border border-og-border px-2.5 py-1 text-og-xs font-medium text-og-fg-muted transition-colors pointer-coarse:min-h-10",
               "hover:border-og-border-strong hover:text-og-fg disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/react/src/components/machine-health-pill.tsx
+++ b/packages/react/src/components/machine-health-pill.tsx
@@ -1,0 +1,68 @@
+// The card's primary status: the fused HEALTH verdict (dot + label), which
+// subsumes plain connection state (offline/reconnecting fall out of it) and adds
+// resource-pressure + staleness. Capability limitations (consent / no display /
+// enrolling) are orthogonal to reachability, so they ride alongside as their own
+// quiet chip — reusing the existing badge meta so the two surfaces never drift.
+import { cn } from "../lib/cn";
+import type { MachineState, MetricSample } from "../types/machines";
+import { deriveHealth, HEALTH_TOKEN, healthPulses } from "./machines/health";
+import { MACHINE_STATE_BADGE_META } from "./machine-status-pill";
+
+export type MachineHealthPillProps = {
+  state: MachineState;
+  metrics: MetricSample | null;
+  now?: number | undefined;
+  size?: "sm" | "md" | undefined;
+  className?: string | undefined;
+};
+
+export function MachineHealthPill({
+  state,
+  metrics,
+  now,
+  size = "sm",
+  className,
+}: MachineHealthPillProps) {
+  const health = deriveHealth(state, metrics, now ?? Date.now());
+  const tone = HEALTH_TOKEN[health.level];
+  const badge = MACHINE_STATE_BADGE_META[state];
+  const pad = size === "md" ? "px-2.5 py-1 text-og-sm" : "px-2 py-0.5 text-og-xs";
+
+  return (
+    <div className={cn("flex shrink-0 items-center gap-1.5", className)}>
+      {badge ? (
+        <span
+          className={cn(
+            "rounded-full border px-2 py-0.5 text-og-xs font-medium",
+            badge.badgeClassName,
+          )}
+        >
+          {badge.label}
+        </span>
+      ) : null}
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full border font-medium",
+          pad,
+          tone.soft,
+          tone.text,
+        )}
+        data-health={health.level}
+        title={health.reason}
+      >
+        <span className="relative flex size-2">
+          {healthPulses(health.level) && (
+            <span
+              className={cn(
+                "absolute inline-flex size-full animate-og-pulse rounded-full opacity-60",
+                tone.dot,
+              )}
+            />
+          )}
+          <span className={cn("relative inline-flex size-2 rounded-full", tone.dot)} />
+        </span>
+        {health.label}
+      </span>
+    </div>
+  );
+}

--- a/packages/react/src/components/machine-metrics.tsx
+++ b/packages/react/src/components/machine-metrics.tsx
@@ -28,12 +28,14 @@ function Meter({
   fillPct: number;
   tone: "ok" | "warn" | "hot";
 }) {
+  // Traffic-light ramp, aligned with the fused health verdict: calm resources
+  // read green (idle), pressure ambers (running), near-the-wall reds (failed).
   const fillClass =
     tone === "hot"
       ? "bg-og-status-failed"
       : tone === "warn"
-        ? "bg-og-status-waiting"
-        : "bg-og-status-running";
+        ? "bg-og-status-running"
+        : "bg-og-status-idle";
   return (
     <div className="flex min-w-0 flex-col gap-1" data-metric={label.toLowerCase()}>
       <div className="flex items-baseline justify-between gap-2">
@@ -59,20 +61,12 @@ function toneFor(p: number): "ok" | "warn" | "hot" {
   return "ok";
 }
 
-/** The token text color for a tone (matches the `Meter` fill ramp). */
-function toneTextClass(tone: "ok" | "warn" | "hot"): string {
-  return tone === "hot"
-    ? "text-og-status-failed"
-    : tone === "warn"
-      ? "text-og-status-waiting"
-      : "text-og-status-running";
-}
-
 /**
  * Load average as three labeled mini-stats (1m / 5m / 15m) — an honest triple of
- * numbers, NOT a fake gauge. The whole triple is tinted by `load1`'s tone (load
- * isn't a 0..100 ratio, so we tone it but never draw a bar). Run queue rides
- * alongside as a quiet chip when there's pending work.
+ * numbers, NOT a fake gauge. Load is not a 0..100 ratio and we don't know the
+ * core count, so a raw load of 2 or 8 is not inherently "bad" — we render it
+ * NEUTRAL rather than falsely alarming. The real saturation signal is the run
+ * queue, which rides alongside as a quiet chip when there's pending work.
  */
 function StatTriple({
   load1,
@@ -85,9 +79,6 @@ function StatTriple({
   load15: number;
   runQueue: number;
 }) {
-  // Load isn't a percent — tone by load1 against a nominal single-core ceiling
-  // (≥0.9/core ≈ saturated). Used only to tint the labels/values, never a bar.
-  const tone = toneFor(load1 * 100);
   const stats: Array<{ label: string; value: number }> = [
     { label: "1m", value: load1 },
     { label: "5m", value: load5 },
@@ -102,15 +93,10 @@ function StatTriple({
         <div className="flex items-baseline gap-3">
           {stats.map((s) => (
             <div key={s.label} className="flex items-baseline gap-1">
-              <span
-                className={cn(
-                  "text-[10px] font-medium uppercase tracking-wide",
-                  toneTextClass(tone),
-                )}
-              >
+              <span className="text-[10px] font-medium uppercase tracking-wide text-og-fg-subtle">
                 {s.label}
               </span>
-              <span className={cn("font-og-mono text-[12px] tabular-nums", toneTextClass(tone))}>
+              <span className="font-og-mono text-[12px] tabular-nums text-og-fg">
                 {s.value.toFixed(2)}
               </span>
             </div>

--- a/packages/react/src/components/machines-dashboard.tsx
+++ b/packages/react/src/components/machines-dashboard.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { LaptopIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "../lib/cn";
-import type { MachineView } from "../types/machines";
+import type { MachineView, MetricSample } from "../types/machines";
 import { MachineCard } from "./machine-card";
 
 export type MachinesDashboardProps = {
@@ -14,6 +14,12 @@ export type MachinesDashboardProps = {
   onAttach?: ((machine: MachineView) => void) | undefined;
   /** The sandbox id currently being attached/swapped to (disables that card). */
   attachingSandboxId?: string | null | undefined;
+  /** Short recent history per machine (keyed by sandboxId) — drives card sparklines. */
+  seriesByMachine?: Record<string, MetricSample[]> | undefined;
+  /** Open the per-machine telemetry detail (makes each card actionable). */
+  onOpenDetail?: ((machine: MachineView) => void) | undefined;
+  /** Shared clock so freshness/relative times render consistently across cards. */
+  now?: number | undefined;
   /** Open the enrollment flow (the "Enroll a machine" CTA). */
   onEnroll?: (() => void) | undefined;
   onRefresh?: (() => void) | undefined;
@@ -109,6 +115,9 @@ export function MachinesDashboard({
   error,
   onAttach,
   attachingSandboxId,
+  seriesByMachine,
+  onOpenDetail,
+  now,
   onEnroll,
   onRefresh,
   className,
@@ -162,6 +171,9 @@ export function MachinesDashboard({
               }}
               onAttach={onAttach}
               attaching={attachingSandboxId === machine.sandboxId}
+              series={seriesByMachine?.[machine.sandboxId]}
+              onOpenDetail={onOpenDetail}
+              now={now}
             />
           ))}
         </div>

--- a/packages/react/src/components/machines/health.ts
+++ b/packages/react/src/components/machines/health.ts
@@ -1,0 +1,146 @@
+// ----------------------------------------------------------------------------
+// Machine health — the single derived signal.
+//
+// The dashboard already shows connection state (a pill) and per-resource meters
+// (independently tinted). What it lacks is ONE verdict that fuses the three
+// things that actually make a machine "in trouble":
+//
+//   1. reachability   — is the control plane still hearing from it?
+//   2. resource load  — is a resource (mem/disk/cpu) near the wall?
+//   3. freshness      — is the latest sample recent, or has telemetry gone quiet?
+//
+// This module is a PURE function from a machine's state + latest sample + clock
+// to a `HealthVerdict`. No React, no tokens — the UI maps `level` to a color.
+// Keeping it pure means it is trivially testable and reused by cards, the detail
+// hero, and any future fleet-summary count.
+// ----------------------------------------------------------------------------
+import type { MachineState, MetricSample } from "../../types/machines";
+
+export type HealthLevel = "healthy" | "degraded" | "critical" | "offline" | "unknown";
+
+export type HealthVerdict = {
+  level: HealthLevel;
+  /** Title-case label for the pill ("Healthy", "Under load", "Critical", …). */
+  label: string;
+  /** One short human clause naming the dominant cause ("Memory 94%", "No display"…). */
+  reason: string;
+  /** The latest sample is older than we'd expect from a live agent (~5s cadence). */
+  stale: boolean;
+};
+
+// Resource pressure thresholds. `warn` mirrors the existing meter ramp (>=70
+// tints), `crit` is the "near the wall" line. Disk is stricter than CPU/mem
+// because a full disk is a hard failure, whereas transient CPU/mem spikes are
+// normal on a working machine.
+const PRESSURE = {
+  cpu: { warn: 90, crit: 98 },
+  mem: { warn: 85, crit: 95 },
+  disk: { warn: 90, crit: 96 },
+} as const;
+
+// A live agent samples ~every 5s and the series downsamples to ~1/min. We treat
+// a latest sample older than 45s as "telemetry has gone quiet" — enough slack to
+// not flap on a single missed beat, tight enough to notice a wedged sampler.
+const STALE_AFTER_MS = 45_000;
+
+function pct(used: number, total: number): number {
+  if (!Number.isFinite(used) || !Number.isFinite(total) || total <= 0) return 0;
+  return (used / total) * 100;
+}
+
+/** Fold a machine's reachability + latest sample + wall-clock into one verdict. */
+export function deriveHealth(
+  state: MachineState,
+  metrics: MetricSample | null,
+  now: number = Date.now(),
+): HealthVerdict {
+  // Reachability dominates: an offline machine has no meaningful resource story.
+  if (state === "offline") {
+    return { level: "offline", label: "Offline", reason: "Not reachable", stale: true };
+  }
+  if (state === "enrolling") {
+    return { level: "unknown", label: "Enrolling", reason: "Completing enrollment", stale: false };
+  }
+
+  const stale = metrics ? now - new Date(metrics.sampledAt).getTime() > STALE_AFTER_MS : true;
+
+  // Reconnecting, or online-but-quiet: reachable yet we can't trust the numbers.
+  if (state === "reconnecting") {
+    return { level: "degraded", label: "Reconnecting", reason: "Re-establishing link", stale };
+  }
+  if (!metrics) {
+    return { level: "unknown", label: "Online", reason: "Awaiting first sample", stale };
+  }
+  if (stale) {
+    return { level: "degraded", label: "Telemetry stale", reason: "No recent sample", stale: true };
+  }
+
+  // Reachable + fresh: the verdict is now the worst resource pressure. Evaluate
+  // each resource, keep the most severe, and name it in the reason.
+  const memPct = pct(metrics.memUsedBytes, metrics.memTotalBytes);
+  const diskPct = pct(metrics.diskUsedBytes, metrics.diskTotalBytes);
+  const cpu = metrics.cpuPct;
+
+  const pressures: Array<{ level: HealthLevel; reason: string; sev: number }> = [
+    resolve("Disk", diskPct, PRESSURE.disk),
+    resolve("Memory", memPct, PRESSURE.mem),
+    resolve("CPU", cpu, PRESSURE.cpu),
+  ];
+  const worst = pressures.reduce((a, b) => (b.sev > a.sev ? b : a));
+
+  if (worst.sev === 2) return { level: "critical", label: "Critical", reason: worst.reason, stale };
+  if (worst.sev === 1)
+    return { level: "degraded", label: "Under load", reason: worst.reason, stale };
+  return { level: "healthy", label: "Healthy", reason: "All systems nominal", stale };
+}
+
+function resolve(
+  name: string,
+  value: number,
+  t: { warn: number; crit: number },
+): { level: HealthLevel; reason: string; sev: number } {
+  const rounded = Math.round(value);
+  if (value >= t.crit) return { level: "critical", reason: `${name} ${rounded}%`, sev: 2 };
+  if (value >= t.warn) return { level: "degraded", reason: `${name} ${rounded}%`, sev: 1 };
+  return { level: "healthy", reason: `${name} ${rounded}%`, sev: 0 };
+}
+
+// --- UI mapping helpers (color/token names live here so every surface agrees) --
+
+/**
+ * The token color ramp for a health level. Green/amber/red/grey is the
+ * universally-legible traffic model; we reserve it for the HEALTH verdict
+ * specifically (per-resource meters keep their own ramp in `machine-metrics`).
+ */
+export const HEALTH_TOKEN: Record<HealthLevel, { text: string; dot: string; soft: string }> = {
+  healthy: {
+    text: "text-og-status-idle",
+    dot: "bg-og-status-idle",
+    soft: "bg-og-status-idle/10 border-og-status-idle/25",
+  },
+  degraded: {
+    text: "text-og-status-running",
+    dot: "bg-og-status-running",
+    soft: "bg-og-status-running/10 border-og-status-running/25",
+  },
+  critical: {
+    text: "text-og-status-failed",
+    dot: "bg-og-status-failed",
+    soft: "bg-og-status-failed/10 border-og-status-failed/30",
+  },
+  offline: {
+    text: "text-og-fg-subtle",
+    dot: "bg-og-fg-subtle",
+    soft: "bg-og-surface-2 border-og-border",
+  },
+  unknown: {
+    text: "text-og-fg-muted",
+    dot: "bg-og-fg-muted",
+    soft: "bg-og-surface-2 border-og-border",
+  },
+};
+
+/** Live/transient levels breathe; settled levels hold still. */
+export function healthPulses(level: HealthLevel): boolean {
+  return level === "degraded" || level === "critical";
+}

--- a/packages/react/src/components/machines/machine-detail.tsx
+++ b/packages/react/src/components/machines/machine-detail.tsx
@@ -1,0 +1,220 @@
+// ----------------------------------------------------------------------------
+// MachineDetail — the marquee per-machine telemetry view.
+//
+// Opens from a machine card. Answers, at a glance and then in depth: is this
+// machine healthy right now (one fused verdict), what are its live numbers, and
+// how have they moved over the chosen window. Built entirely on the existing
+// `og-*` token system — no new visual language, just the missing depth.
+// ----------------------------------------------------------------------------
+import { ArrowLeftIcon, CpuIcon, LaptopIcon, RadioIcon, ServerIcon } from "lucide-react";
+import { cn } from "../../lib/cn";
+import { formatRelativeTime } from "../../lib/format";
+import type { MachineView, MetricSample } from "../../types/machines";
+import { deriveHealth, HEALTH_TOKEN, healthPulses } from "./health";
+import { MetricHistoryChart } from "./metric-history-chart";
+import { MetricSparkline } from "./metric-sparkline";
+import { METRICS, METRIC_WINDOWS, pointsFor, WINDOW_LABEL, type MetricWindow } from "./series";
+
+export type MachineDetailProps = {
+  machine: MachineView;
+  /** Downsampled history for the active window (from `fetchSeries`). */
+  series: MetricSample[];
+  window: MetricWindow;
+  onWindowChange: (w: MetricWindow) => void;
+  loadingSeries?: boolean | undefined;
+  onBack?: (() => void) | undefined;
+  now?: number | undefined;
+  className?: string | undefined;
+};
+
+function KindIcon({ kind, session }: { kind: string; session: boolean }) {
+  if (session) return <ServerIcon className="size-4 text-og-fg-subtle" aria-hidden />;
+  if (kind === "modal") return <CpuIcon className="size-4 text-og-fg-subtle" aria-hidden />;
+  return <LaptopIcon className="size-4 text-og-fg-subtle" aria-hidden />;
+}
+
+export function MachineDetail({
+  machine,
+  series,
+  window,
+  onWindowChange,
+  loadingSeries,
+  onBack,
+  now = Date.now(),
+  className,
+}: MachineDetailProps) {
+  const health = deriveHealth(machine.state, machine.metrics, now);
+  const tone = HEALTH_TOKEN[health.level];
+  const latest = machine.metrics;
+  const sampledAgo = latest ? formatRelativeTime(latest.sampledAt, new Date(now)) : null;
+
+  // Only render metrics that have a value (GPU is dropped on headless boxes).
+  const visible = METRICS.filter((m) => !(m.key === "gpu" && latest?.gpuUtilPct == null));
+  // The tile grid tracks the metric count exactly so it never leaves a dead cell.
+  const tileCols =
+    visible.length >= 5
+      ? "grid-cols-2 sm:grid-cols-3 lg:grid-cols-5"
+      : "grid-cols-2 sm:grid-cols-4";
+
+  return (
+    <div className={cn("og-root mx-auto flex w-full max-w-5xl flex-col gap-5", className)}>
+      {/* ── top bar ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="flex size-7 shrink-0 items-center justify-center rounded-og-sm border border-og-border bg-og-surface-1 text-og-fg-muted transition-colors hover:bg-og-surface-2 hover:text-og-fg"
+              aria-label="Back to machines"
+            >
+              <ArrowLeftIcon className="size-3.5" aria-hidden />
+            </button>
+          )}
+          <KindIcon kind={machine.kind} session={machine.isSessionGroup} />
+          <h1 className="truncate text-og-md font-semibold text-og-fg">{machine.name}</h1>
+          <span className="hidden shrink-0 rounded-og-sm border border-og-border bg-og-surface-1 px-1.5 py-0.5 font-og-mono text-og-xs text-og-fg-subtle sm:inline">
+            {machine.os} · {machine.arch}
+          </span>
+        </div>
+
+        {/* range selector */}
+        <div className="flex shrink-0 items-center gap-0.5 rounded-og-md border border-og-border bg-og-surface-1 p-0.5">
+          {METRIC_WINDOWS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => onWindowChange(w)}
+              data-active={w === window}
+              className={cn(
+                "rounded-og-sm px-2 py-1 font-og-mono text-og-xs transition-colors",
+                w === window
+                  ? "bg-og-surface-3 text-og-fg shadow-og-sm"
+                  : "text-og-fg-subtle hover:text-og-fg-muted",
+              )}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── health hero ─────────────────────────────────────────────────── */}
+      <div
+        className={cn(
+          "relative flex flex-col gap-4 overflow-hidden rounded-og-lg border p-5 shadow-og-sm",
+          tone.soft,
+        )}
+      >
+        <span aria-hidden className={cn("absolute inset-y-0 left-0 w-1", tone.dot)} />
+        <div className="flex flex-wrap items-center justify-between gap-3 pl-1">
+          <div className="flex items-center gap-3">
+            <span className="relative flex size-3">
+              {healthPulses(health.level) && (
+                <span
+                  className={cn(
+                    "absolute inline-flex size-full animate-og-pulse rounded-full opacity-60",
+                    tone.dot,
+                  )}
+                />
+              )}
+              <span className={cn("relative inline-flex size-3 rounded-full", tone.dot)} />
+            </span>
+            <div className="flex flex-col">
+              <span className={cn("text-og-md font-semibold", tone.text)}>{health.label}</span>
+              <span className="text-og-sm text-og-fg-muted">{health.reason}</span>
+            </div>
+          </div>
+          <div className="flex items-start gap-5 pr-1">
+            {sampledAgo && (
+              <div className="flex flex-col items-end gap-0.5">
+                <span className="text-[10px] font-medium uppercase tracking-wide text-og-fg-subtle">
+                  Sampled
+                </span>
+                <span className="flex items-center gap-1 font-og-mono text-og-sm tabular-nums text-og-fg">
+                  <RadioIcon
+                    className={cn("size-3", health.stale ? "text-og-fg-subtle" : tone.text)}
+                    aria-hidden
+                  />
+                  {sampledAgo === "now" ? "live" : `${sampledAgo} ago`}
+                </span>
+              </div>
+            )}
+            {machine.lastSeenAt && (
+              <div className="hidden flex-col items-end gap-0.5 sm:flex">
+                <span className="text-[10px] font-medium uppercase tracking-wide text-og-fg-subtle">
+                  Last seen
+                </span>
+                <span className="font-og-mono text-og-sm tabular-nums text-og-fg-muted">
+                  {formatRelativeTime(machine.lastSeenAt, new Date(now))}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* current-stat tiles */}
+        {latest && (
+          <div
+            className={cn(
+              "grid gap-px overflow-hidden rounded-og-md border border-og-border bg-og-border",
+              tileCols,
+            )}
+          >
+            {visible.map((m) => {
+              const pts = pointsFor(m, series);
+              return (
+                <div key={m.key} className="flex flex-col gap-1.5 bg-og-surface-1 p-3">
+                  <span className="text-[10px] font-medium uppercase tracking-wide text-og-fg-subtle">
+                    {m.title}
+                  </span>
+                  <span className="font-og-mono text-og-md font-medium tabular-nums text-og-fg">
+                    {m.current(latest)}
+                  </span>
+                  <MetricSparkline points={pts} color={m.color} yMax={m.yMax} height={22} />
+                  {m.sub && (
+                    <span className="truncate font-og-mono text-[10px] text-og-fg-subtle">
+                      {m.sub(latest)}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* ── history charts ──────────────────────────────────────────────── */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {visible.map((m) => {
+          const pts = pointsFor(m, series);
+          return (
+            <div
+              key={m.key}
+              className="flex flex-col gap-3 rounded-og-lg border border-og-border bg-og-surface-1 p-4 shadow-og-sm"
+            >
+              <div className="flex items-baseline justify-between">
+                <span className="text-og-sm font-medium text-og-fg">{m.title}</span>
+                {latest && (
+                  <span className="font-og-mono text-og-sm tabular-nums text-og-fg-muted">
+                    {m.current(latest)}
+                  </span>
+                )}
+              </div>
+              <MetricHistoryChart
+                points={pts}
+                yMax={m.yMax}
+                unit={m.unit}
+                color={m.color}
+                thresholds={m.thresholds}
+                rangeLabel={WINDOW_LABEL[window]}
+                height={128}
+                className={cn(loadingSeries && "opacity-50 transition-opacity")}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/machines/metric-history-chart.tsx
+++ b/packages/react/src/components/machines/metric-history-chart.tsx
@@ -173,7 +173,7 @@ export function MetricHistoryChart({
           {yTicks.map((v, i) => {
             const y = yOf(v);
             return (
-              <g key={i}>
+              <g key={`yt-${v}`}>
                 <line
                   x1={PAD.left}
                   x2={w - PAD.right}
@@ -223,7 +223,7 @@ export function MetricHistoryChart({
           {valued.length > 1 &&
             [tMin, tMax].map((t, i) => (
               <text
-                key={i}
+                key={i === 0 ? "x-start" : "x-end"}
                 x={i === 0 ? PAD.left : w - PAD.right}
                 y={H - 4}
                 textAnchor={i === 0 ? "start" : "end"}
@@ -249,7 +249,8 @@ export function MetricHistoryChart({
           />
 
           {/* sparse markers */}
-          {sparse && pxPts.map((p, i) => <circle key={i} cx={p.x} cy={p.y} r={2.5} fill={color} />)}
+          {sparse &&
+            pxPts.map((p) => <circle key={`m-${p.t}`} cx={p.x} cy={p.y} r={2.5} fill={color} />)}
 
           {/* hover crosshair */}
           {hoverPt && (

--- a/packages/react/src/components/machines/metric-history-chart.tsx
+++ b/packages/react/src/components/machines/metric-history-chart.tsx
@@ -1,0 +1,297 @@
+// ----------------------------------------------------------------------------
+// MetricHistoryChart — the per-metric history visual on the machine detail view.
+//
+// A dependency-free SVG line/area chart tuned for the calm dark aesthetic:
+// a soft gradient fill, a smoothed stroke that draws itself in, whisper-quiet
+// gridlines, dashed threshold guides, and a hover crosshair with a mono readout.
+// It degrades honestly — a handful of points render as markers, zero points show
+// a quiet "no samples" note rather than an empty axis.
+//
+// Pure presentational: it takes plotted {t, v} points + a little config and owns
+// no data-fetching. `color` is any CSS color (pass a token var for theme-safety).
+// ----------------------------------------------------------------------------
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "../../lib/cn";
+
+export type SeriesPoint = { t: number; v: number | null };
+
+export type MetricHistoryChartProps = {
+  points: SeriesPoint[];
+  /** Fixed ceiling (100 for %) or "auto" to fit the data with headroom. */
+  yMax?: number | "auto";
+  yMin?: number;
+  /** Format a value for the axis + readout (default: rounded + unit). */
+  format?: (v: number) => string;
+  unit?: string;
+  /** Stroke/fill hue — any CSS color; pass a token var to stay theme-safe. */
+  color?: string;
+  thresholds?: { warn?: number | undefined; crit?: number | undefined } | undefined;
+  height?: number;
+  /** Human range label for the empty state ("in the last hour"). */
+  rangeLabel?: string | undefined;
+  className?: string | undefined;
+};
+
+const PAD = { top: 10, right: 12, bottom: 18, left: 40 };
+
+function niceCeil(v: number): number {
+  if (v <= 0) return 1;
+  const mag = 10 ** Math.floor(Math.log10(v));
+  const n = v / mag;
+  const step = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10;
+  return step * mag;
+}
+
+/** Catmull-Rom → cubic-bezier path so the line is smooth without overshooting. */
+function smoothPath(pts: Array<{ x: number; y: number }>): string {
+  if (pts.length === 0) return "";
+  if (pts.length === 1) return `M${pts[0]!.x},${pts[0]!.y}`;
+  let d = `M${pts[0]!.x},${pts[0]!.y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? p2;
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    d += `C${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`;
+  }
+  return d;
+}
+
+function fmtClock(t: number): string {
+  const d = new Date(t);
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+}
+
+export function MetricHistoryChart({
+  points,
+  yMax = "auto",
+  yMin = 0,
+  format,
+  unit = "",
+  color = "var(--og-color-accent)",
+  thresholds,
+  height = 132,
+  rangeLabel = "in this range",
+  className,
+}: MetricHistoryChartProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(560);
+  const [hover, setHover] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const cw = entries[0]?.contentRect.width;
+      if (cw && cw > 0) setW(cw);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const valued = points.filter(
+    (p): p is { t: number; v: number } => p.v != null && Number.isFinite(p.v),
+  );
+  const fmt = format ?? ((v: number) => `${Math.round(v)}${unit}`);
+
+  const H = height;
+  const plotW = Math.max(1, w - PAD.left - PAD.right);
+  const plotH = Math.max(1, H - PAD.top - PAD.bottom);
+
+  const dataMax = valued.length ? Math.max(...valued.map((p) => p.v)) : 1;
+  const top = yMax === "auto" ? niceCeil(Math.max(dataMax * 1.15, thresholds?.warn ?? 0, 1)) : yMax;
+  const span = Math.max(1e-6, top - yMin);
+
+  const tMin = valued.length ? valued[0]!.t : 0;
+  const tMax = valued.length ? valued[valued.length - 1]!.t : 1;
+  const tSpan = Math.max(1, tMax - tMin);
+
+  const xOf = (t: number) => PAD.left + ((t - tMin) / tSpan) * plotW;
+  const yOf = (v: number) =>
+    PAD.top + (1 - (Math.min(top, Math.max(yMin, v)) - yMin) / span) * plotH;
+
+  const pxPts = valued.map((p) => ({ x: xOf(p.t), y: yOf(p.v), t: p.t, v: p.v }));
+  const sparse = pxPts.length > 0 && pxPts.length <= 4;
+
+  const line = smoothPath(pxPts);
+  const area =
+    pxPts.length > 1
+      ? `${line} L${pxPts[pxPts.length - 1]!.x},${PAD.top + plotH} L${pxPts[0]!.x},${PAD.top + plotH} Z`
+      : "";
+
+  // y gridlines at 0 / mid / top
+  const yTicks = [yMin, yMin + span / 2, top];
+  const gid = `og-mh-${Math.round(top)}-${Math.round(color.length)}`;
+
+  const hoverPt = hover != null ? pxPts[hover] : null;
+
+  return (
+    <div
+      ref={ref}
+      className={cn("relative w-full select-none", className)}
+      style={{ height: H }}
+      data-metric-chart
+    >
+      {valued.length === 0 ? (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-og-xs text-og-fg-subtle">No samples {rangeLabel}</span>
+        </div>
+      ) : (
+        <svg
+          width={w}
+          height={H}
+          className="overflow-visible"
+          role="img"
+          onMouseLeave={() => setHover(null)}
+          onMouseMove={(e) => {
+            const rect = (e.currentTarget as SVGSVGElement).getBoundingClientRect();
+            const mx = e.clientX - rect.left;
+            let best = 0;
+            let bestD = Infinity;
+            for (let i = 0; i < pxPts.length; i++) {
+              const d = Math.abs(pxPts[i]!.x - mx);
+              if (d < bestD) {
+                bestD = d;
+                best = i;
+              }
+            }
+            setHover(best);
+          }}
+        >
+          <defs>
+            <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity="0.26" />
+              <stop offset="100%" stopColor={color} stopOpacity="0" />
+            </linearGradient>
+          </defs>
+
+          {/* gridlines + y labels */}
+          {yTicks.map((v, i) => {
+            const y = yOf(v);
+            return (
+              <g key={i}>
+                <line
+                  x1={PAD.left}
+                  x2={w - PAD.right}
+                  y1={y}
+                  y2={y}
+                  stroke="var(--og-color-border)"
+                  strokeOpacity={i === 0 ? 0.9 : 0.4}
+                  strokeWidth={1}
+                />
+                <text
+                  x={PAD.left - 8}
+                  y={y + 3}
+                  textAnchor="end"
+                  className="font-og-mono"
+                  fontSize={10}
+                  fill="var(--og-color-fg-subtle)"
+                >
+                  {fmt(v)}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* threshold guides */}
+          {(["warn", "crit"] as const).map((k) => {
+            const tv = thresholds?.[k];
+            if (tv == null || tv > top) return null;
+            const y = yOf(tv);
+            const stroke =
+              k === "crit" ? "var(--og-color-status-failed)" : "var(--og-color-status-waiting)";
+            return (
+              <line
+                key={k}
+                x1={PAD.left}
+                x2={w - PAD.right}
+                y1={y}
+                y2={y}
+                stroke={stroke}
+                strokeOpacity={0.5}
+                strokeWidth={1}
+                strokeDasharray="3 4"
+              />
+            );
+          })}
+
+          {/* x time ticks (first + last) */}
+          {valued.length > 1 &&
+            [tMin, tMax].map((t, i) => (
+              <text
+                key={i}
+                x={i === 0 ? PAD.left : w - PAD.right}
+                y={H - 4}
+                textAnchor={i === 0 ? "start" : "end"}
+                className="font-og-mono"
+                fontSize={10}
+                fill="var(--og-color-fg-subtle)"
+              >
+                {fmtClock(t)}
+              </text>
+            ))}
+
+          {/* area + line */}
+          {area && <path d={area} fill={`url(#${gid})`} />}
+          <path
+            d={line}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.75}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            pathLength={1}
+            className="og-mh-draw"
+          />
+
+          {/* sparse markers */}
+          {sparse && pxPts.map((p, i) => <circle key={i} cx={p.x} cy={p.y} r={2.5} fill={color} />)}
+
+          {/* hover crosshair */}
+          {hoverPt && (
+            <g pointerEvents="none">
+              <line
+                x1={hoverPt.x}
+                x2={hoverPt.x}
+                y1={PAD.top}
+                y2={PAD.top + plotH}
+                stroke="var(--og-color-border-strong)"
+                strokeWidth={1}
+              />
+              <circle
+                cx={hoverPt.x}
+                cy={hoverPt.y}
+                r={3.5}
+                fill={color}
+                stroke="var(--og-color-bg)"
+                strokeWidth={1.5}
+              />
+            </g>
+          )}
+        </svg>
+      )}
+
+      {/* floating readout */}
+      {hoverPt && (
+        <div
+          className="pointer-events-none absolute z-10 flex flex-col rounded-og-sm border border-og-border-strong bg-og-surface-3/95 px-2 py-1 shadow-og-md backdrop-blur-sm"
+          style={{
+            left: Math.min(Math.max(hoverPt.x - 30, 0), w - 78),
+            top: Math.max(hoverPt.y - 42, 0),
+          }}
+        >
+          <span className="font-og-mono text-og-sm font-medium tabular-nums text-og-fg">
+            {fmt(hoverPt.v)}
+          </span>
+          <span className="font-og-mono text-[10px] tabular-nums text-og-fg-subtle">
+            {fmtClock(hoverPt.t)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/machines/metric-sparkline.tsx
+++ b/packages/react/src/components/machines/metric-sparkline.tsx
@@ -1,0 +1,76 @@
+// ----------------------------------------------------------------------------
+// MetricSparkline — an axis-less micro-trend for stat tiles and (later) cards.
+// Same smoothing as the full chart, no chrome: a hairline + a faint fill and a
+// dot on the latest point. Fixed viewBox so it scales crisply at any width.
+// ----------------------------------------------------------------------------
+import type { SeriesPoint } from "./metric-history-chart";
+
+export type MetricSparklineProps = {
+  points: SeriesPoint[];
+  color?: string;
+  yMax?: number | "auto";
+  height?: number;
+  className?: string | undefined;
+};
+
+const VW = 120;
+
+export function MetricSparkline({
+  points,
+  color = "var(--og-color-accent)",
+  yMax = "auto",
+  height = 28,
+  className,
+}: MetricSparklineProps) {
+  const valued = points.filter(
+    (p): p is { t: number; v: number } => p.v != null && Number.isFinite(p.v),
+  );
+  if (valued.length < 2) {
+    return <div className={className} style={{ height }} aria-hidden />;
+  }
+  const vh = height;
+  const top = yMax === "auto" ? Math.max(1, ...valued.map((p) => p.v)) * 1.1 : yMax;
+  const tMin = valued[0]!.t;
+  const tSpan = Math.max(1, valued[valued.length - 1]!.t - tMin);
+  const xy = valued.map((p) => ({
+    x: ((p.t - tMin) / tSpan) * VW,
+    y: vh - (Math.min(top, Math.max(0, p.v)) / Math.max(1e-6, top)) * (vh - 2) - 1,
+  }));
+  let d = `M${xy[0]!.x},${xy[0]!.y}`;
+  for (let i = 0; i < xy.length - 1; i++) {
+    const p0 = xy[i - 1] ?? xy[i]!;
+    const p1 = xy[i]!;
+    const p2 = xy[i + 1]!;
+    const p3 = xy[i + 2] ?? p2;
+    d += `C${p1.x + (p2.x - p0.x) / 6},${p1.y + (p2.y - p0.y) / 6} ${p2.x - (p3.x - p1.x) / 6},${p2.y - (p3.y - p1.y) / 6} ${p2.x},${p2.y}`;
+  }
+  const last = xy[xy.length - 1]!;
+  const gid = `spark-${Math.round(top)}-${color.length}`;
+  return (
+    <svg
+      viewBox={`0 0 ${VW} ${vh}`}
+      preserveAspectRatio="none"
+      className={className}
+      style={{ height, width: "100%" }}
+      aria-hidden
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.22" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={`${d} L${last.x},${vh} L${xy[0]!.x},${vh} Z`} fill={`url(#${gid})`} />
+      <path
+        d={d}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.25}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle cx={last.x} cy={last.y} r={1.6} fill={color} vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}

--- a/packages/react/src/components/machines/series.ts
+++ b/packages/react/src/components/machines/series.ts
@@ -1,0 +1,113 @@
+// Shared series helpers: project a MetricSample[] into per-metric {t, v} points,
+// and the metric catalog the detail view + tiles iterate over.
+import type { MetricSample } from "../../types/machines";
+import type { SeriesPoint } from "./metric-history-chart";
+
+export type MetricWindow = "15m" | "1h" | "6h" | "24h";
+export const METRIC_WINDOWS: MetricWindow[] = ["15m", "1h", "6h", "24h"];
+
+export const WINDOW_LABEL: Record<MetricWindow, string> = {
+  "15m": "in the last 15 min",
+  "1h": "in the last hour",
+  "6h": "in the last 6 hours",
+  "24h": "in the last 24 hours",
+};
+
+function ptsFrom(samples: MetricSample[], pick: (s: MetricSample) => number | null): SeriesPoint[] {
+  return samples.map((s) => ({ t: new Date(s.sampledAt).getTime(), v: pick(s) }));
+}
+
+const memPct = (s: MetricSample) =>
+  s.memTotalBytes > 0 ? (s.memUsedBytes / s.memTotalBytes) * 100 : null;
+const diskPct = (s: MetricSample) =>
+  s.diskTotalBytes > 0 ? (s.diskUsedBytes / s.diskTotalBytes) * 100 : null;
+
+export type MetricKey = "cpu" | "mem" | "disk" | "load" | "gpu";
+
+export type MetricDef = {
+  key: MetricKey;
+  title: string;
+  unit: string;
+  yMax: number | "auto";
+  color: string;
+  thresholds?: { warn?: number; crit?: number };
+  pick: (s: MetricSample) => number | null;
+  /** Big current-value string for tiles/badges. */
+  current: (s: MetricSample) => string;
+  /** Optional sub-line under the current value. */
+  sub?: (s: MetricSample) => string | null;
+};
+
+const fmtBytes = (b: number): string => {
+  if (b < 1024) return `${b} B`;
+  const u = ["KB", "MB", "GB", "TB"];
+  let v = b / 1024;
+  for (const unit of u) {
+    if (v < 1024 || unit === "TB") return `${v.toFixed(v < 10 ? 1 : 0)} ${unit}`;
+    v /= 1024;
+  }
+  return `${b} B`;
+};
+
+// The catalog. GPU is included but the detail view only renders it when the
+// latest sample actually reports a GPU (gpuUtilPct != null).
+export const METRICS: MetricDef[] = [
+  {
+    key: "cpu",
+    title: "CPU",
+    unit: "%",
+    yMax: 100,
+    color: "var(--og-color-accent)",
+    thresholds: { warn: 90, crit: 98 },
+    pick: (s) => s.cpuPct,
+    current: (s) => `${Math.round(s.cpuPct)}%`,
+    sub: (s) => `${s.runQueue} in run queue`,
+  },
+  {
+    key: "mem",
+    title: "Memory",
+    unit: "%",
+    yMax: 100,
+    color: "var(--og-color-status-idle)",
+    thresholds: { warn: 85, crit: 95 },
+    pick: memPct,
+    current: (s) => `${Math.round(memPct(s) ?? 0)}%`,
+    sub: (s) => `${fmtBytes(s.memUsedBytes)} / ${fmtBytes(s.memTotalBytes)}`,
+  },
+  {
+    key: "disk",
+    title: "Disk",
+    unit: "%",
+    yMax: 100,
+    color: "var(--og-color-status-waiting)",
+    thresholds: { warn: 90, crit: 96 },
+    pick: diskPct,
+    current: (s) => `${Math.round(diskPct(s) ?? 0)}%`,
+    sub: (s) => `${fmtBytes(s.diskUsedBytes)} / ${fmtBytes(s.diskTotalBytes)}`,
+  },
+  {
+    key: "load",
+    title: "Load average",
+    unit: "",
+    yMax: "auto",
+    color: "var(--og-color-accent-strong)",
+    pick: (s) => s.load1,
+    current: (s) => s.load1.toFixed(2),
+    sub: (s) => `5m ${s.load5.toFixed(2)} · 15m ${s.load15.toFixed(2)}`,
+  },
+  {
+    key: "gpu",
+    title: "GPU",
+    unit: "%",
+    yMax: 100,
+    color: "var(--og-color-status-running)",
+    thresholds: { warn: 90, crit: 98 },
+    pick: (s) => s.gpuUtilPct,
+    current: (s) => (s.gpuUtilPct == null ? "—" : `${Math.round(s.gpuUtilPct)}%`),
+    sub: (s) => (s.gpuMemBytes == null ? null : `${fmtBytes(s.gpuMemBytes)} used`),
+  },
+];
+
+export function pointsFor(def: MetricDef, samples: MetricSample[]): SeriesPoint[] {
+  return ptsFrom(samples, def.pick);
+}

--- a/packages/react/src/machines.ts
+++ b/packages/react/src/machines.ts
@@ -34,6 +34,22 @@ export { MachineMetrics } from "./components/machine-metrics";
 export type { MachineMetricsProps } from "./components/machine-metrics";
 export { MachineCard } from "./components/machine-card";
 export type { MachineCardProps } from "./components/machine-card";
+export { MachineHealthPill } from "./components/machine-health-pill";
+export type { MachineHealthPillProps } from "./components/machine-health-pill";
+// Telemetry: fused health signal + history charts + the per-machine detail view.
+export { deriveHealth, HEALTH_TOKEN, healthPulses } from "./components/machines/health";
+export type { HealthLevel, HealthVerdict } from "./components/machines/health";
+export { MetricSparkline } from "./components/machines/metric-sparkline";
+export type { MetricSparklineProps } from "./components/machines/metric-sparkline";
+export { MetricHistoryChart } from "./components/machines/metric-history-chart";
+export type {
+  MetricHistoryChartProps,
+  SeriesPoint,
+} from "./components/machines/metric-history-chart";
+export { MachineDetail } from "./components/machines/machine-detail";
+export type { MachineDetailProps } from "./components/machines/machine-detail";
+export { METRICS, METRIC_WINDOWS, WINDOW_LABEL, pointsFor } from "./components/machines/series";
+export type { MetricDef, MetricKey, MetricWindow } from "./components/machines/series";
 export { MachinesDashboard } from "./components/machines-dashboard";
 export type { MachinesDashboardProps } from "./components/machines-dashboard";
 export { MachineDockBar, SharedMachineDisclosure } from "./components/machine-dock-bar";

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -165,6 +165,28 @@
   }
 }
 
+/* Metric-history line draw-in. The chart path carries `pathLength={1}`, so the
+   dash math is resolution-independent: one full-length dash whose offset animates
+   from 1 (hidden) to 0 (drawn). Degrades to a solid line if animations are off. */
+@keyframes og-mh-draw {
+  from {
+    stroke-dashoffset: 1;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+.og-mh-draw {
+  stroke-dasharray: 1;
+  animation: og-mh-draw 900ms var(--og-ease-out) forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .og-mh-draw {
+    animation: none;
+    stroke-dasharray: none;
+  }
+}
+
 /* Shimmer helper: gradient text the keyframe scrolls through. */
 .og-shimmer-text {
   background: linear-gradient(

--- a/packages/react/test/machine-health.test.ts
+++ b/packages/react/test/machine-health.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for the fused machine-health verdict (deriveHealth). Pure function,
+// so these pin the reachability > pressure > freshness precedence directly.
+import { describe, expect, test } from "bun:test";
+import { deriveHealth } from "../src/components/machines/health";
+import type { MetricSample } from "../src/types/machines";
+
+const NOW = Date.parse("2026-07-16T12:00:00.000Z");
+const GB = 1024 ** 3;
+
+function sample(over: Partial<MetricSample> = {}, ageMs = 2000): MetricSample {
+  return {
+    cpuPct: 20,
+    load1: 1,
+    load5: 1,
+    load15: 1,
+    memUsedBytes: 8 * GB,
+    memTotalBytes: 32 * GB,
+    diskUsedBytes: 100 * GB,
+    diskTotalBytes: 512 * GB,
+    gpuUtilPct: null,
+    gpuMemBytes: null,
+    runQueue: 0,
+    sampledAt: new Date(NOW - ageMs).toISOString(),
+    ...over,
+  };
+}
+
+describe("deriveHealth", () => {
+  test("offline dominates regardless of metrics", () => {
+    const v = deriveHealth("offline", sample(), NOW);
+    expect(v.level).toBe("offline");
+  });
+
+  test("fresh + calm resources → healthy", () => {
+    const v = deriveHealth("online", sample(), NOW);
+    expect(v.level).toBe("healthy");
+  });
+
+  test("memory near the wall → critical, and names the cause", () => {
+    const v = deriveHealth(
+      "online",
+      sample({ memUsedBytes: 31 * GB, memTotalBytes: 32 * GB }),
+      NOW,
+    );
+    expect(v.level).toBe("critical");
+    expect(v.reason.toLowerCase()).toContain("memory");
+  });
+
+  test("elevated (but not critical) memory → degraded", () => {
+    const v = deriveHealth(
+      "online",
+      sample({ memUsedBytes: 29 * GB, memTotalBytes: 32 * GB }),
+      NOW,
+    );
+    expect(v.level).toBe("degraded");
+  });
+
+  test("a stale sample degrades even when the last numbers were calm", () => {
+    const v = deriveHealth("online", sample({}, 60_000), NOW);
+    expect(v.level).toBe("degraded");
+    expect(v.stale).toBe(true);
+  });
+
+  test("reconnecting is degraded, not offline", () => {
+    const v = deriveHealth("reconnecting", sample(), NOW);
+    expect(v.level).toBe("degraded");
+  });
+
+  test("no metrics yet → unknown, not a false healthy", () => {
+    const v = deriveHealth("online", null, NOW);
+    expect(v.level).toBe("unknown");
+  });
+
+  test("the worst resource wins (critical disk beats calm cpu/mem)", () => {
+    const v = deriveHealth(
+      "online",
+      sample({ diskUsedBytes: 505 * GB, diskTotalBytes: 512 * GB }),
+      NOW,
+    );
+    expect(v.level).toBe("critical");
+    expect(v.reason.toLowerCase()).toContain("disk");
+  });
+});


### PR DESCRIPTION
## What & why

The Connected-Machines pipeline already **collects and serves** rich host telemetry (the agent samples CPU / load 1·5·15 / mem / disk / GPU / run-queue every ~5s → `machine_metrics_latest` + a downsampled `…/metrics/series?window=` history), but the UI only ever showed the latest number. This surfaces the history and fuses the signals into one verdict — no new visual language, built entirely on the existing `og-*` tokens (dark + light native).

## Changes

- **`MachineDetail`** — a per-machine view opened from a card:
  - **One fused health verdict** (`deriveHealth`, pure + unit-tested): reachability → resource pressure → sample freshness, with the dominant cause named ("Memory 96%").
  - **Live stat tiles** (CPU / mem / disk / load / GPU) with micro-sparklines; GPU only when the machine reports one.
  - **Full history charts** over **15m / 1h / 6h / 24h** — smoothed area/line, dashed warn/crit guides, hover crosshair, draw-in animation, graceful sparse/empty states.
- **Upgraded `MachineCard`** — leads with the health verdict, previews a **CPU trend** sparkline, shows **live freshness** ("Live" / "Updated Xago"), and opens the detail on click (keyboard-accessible). Existing meters, capability badges, shared disclosure, and attach are preserved.
- **Coherent meters** — the resource ramp is now green/amber/red aligned with the health verdict. **Load renders neutral** (it isn't core-normalized; a load of 2–8 on a multi-core box is normal) — the **run queue** carries the real saturation signal.
- **Route wiring** — `/machines` fetches compact 15m series per card + windowed detail series, and navigates card ↔ detail.

## Verification

- `bun run check` green locally (typecheck all · unit tests · sdk/react/demo/web builds · web bundle budget).
- New unit tests for `deriveHealth`; existing `machines-components` suite passes unchanged (22/22).
- All new components proofed in both themes via an isolated render harness with mock telemetry across every health state (healthy / under-load / critical / stale / reconnecting / offline).

## Notes

- `@opengeni/react` minor changeset included.
- Pure-presentational components; the health core has no React/token deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)