### PR TITLE
feat(example): add embedded product agent demo

### DIFF
--- a/.changeset/render-persisted-mcp-output.md
+++ b/.changeset/render-persisted-mcp-output.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Render normalized persisted MCP text outputs in custom timeline tool cards.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Every session picks where it runs. A **managed sandbox** (a fresh cloud box Open
 
 If you want to try the managed version, go to [app.opengeni.ai](https://app.opengeni.ai).
 
+To see how a SaaS product embeds the React timeline, proxies sessions through its backend, exposes authenticated MCP tools, and reflects agent mutations live, run the [Northstar support example](examples/northstar-support).
+
 ## Why OpenGeni
 
 Most agent products give you some of these; OpenGeni's premise is that organizations need all four in one runtime:

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -124,7 +124,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -149,9 +149,32 @@
         "typescript": "^6.0.3",
       },
     },
+    "examples/northstar-support": {
+      "name": "@opengeni/example-northstar-support",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opengeni/react": "workspace:*",
+        "@opengeni/sdk": "workspace:*",
+        "@tailwindcss/vite": "^4.2.4",
+        "@vitejs/plugin-react": "^6.0.1",
+        "lucide-react": "^1.8.0",
+        "motion": "^12.0.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "tailwindcss": "^4.2.4",
+        "vite": "^8.0.9",
+        "zod": "^4.2.1",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "typescript": "^6.0.3",
+      },
+    },
     "packages/agent-proto": {
       "name": "@opengeni/agent-proto",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
       },
@@ -163,7 +186,7 @@
     },
     "packages/codex": {
       "name": "@opengeni/codex",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -174,7 +197,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -187,7 +210,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -198,7 +221,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/codex": "workspace:*",
@@ -220,7 +243,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -247,7 +270,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.3",
         "@opengeni/config": "workspace:*",
@@ -264,7 +287,7 @@
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -277,7 +300,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -301,7 +324,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@opengeni/sdk": "workspace:*",
@@ -379,7 +402,7 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "@openai/agents": "0.13.3",
@@ -399,7 +422,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "devDependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/deployment": "workspace:*",
@@ -410,7 +433,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -978,6 +1001,8 @@
     "@opengeni/documents": ["@opengeni/documents@workspace:packages/documents"],
 
     "@opengeni/events": ["@opengeni/events@workspace:packages/events"],
+
+    "@opengeni/example-northstar-support": ["@opengeni/example-northstar-support@workspace:examples/northstar-support"],
 
     "@opengeni/github": ["@opengeni/github@workspace:packages/github"],
 

--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -9,6 +9,7 @@ COPY package.json bun.lock tsconfig.base.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY apps/worker/package.json apps/worker/package.json
 COPY apps/web/package.json apps/web/package.json
+COPY examples/northstar-support/package.json examples/northstar-support/package.json
 COPY packages/agent-proto/package.json packages/agent-proto/package.json
 COPY packages/codex/package.json packages/codex/package.json
 COPY packages/config/package.json packages/config/package.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,7 @@ In `managed` mode, billing integrates with **Stripe**, which is confined to `app
 
 ## 6. Repository layout
 
-The monorepo is a **Bun workspace** (`workspaces: [apps/*, packages/*]`). TS packages are consumed as **source** for internal use (`main`/`types` point at `./src/index.ts`). The Stage C npm publish matrix is the full runtime closure needed by external hosts: the client closure (`@opengeni/contracts` -> `@opengeni/sdk` -> `@opengeni/react`) plus the engine/embed closure (`@opengeni/core`, `@opengeni/api-router`, `@opengeni/worker-bundle`, and their internal `@opengeni/*` dependencies such as `config`, `db`, `runtime`, `events`, `storage`, `documents`, `github`, `observability`, `codex`, and `agent-proto`). Package manifests and `.changeset/config.json` own the exact publish/build settings; ignored packages must be leaf-only. The Rust agent is a separate Cargo workspace under `agent/`.
+The monorepo is a **Bun workspace** (`workspaces: [apps/*, examples/*, packages/*]`). TS packages are consumed as **source** for internal use (`main`/`types` point at `./src/index.ts`). The Stage C npm publish matrix is the full runtime closure needed by external hosts: the client closure (`@opengeni/contracts` -> `@opengeni/sdk` -> `@opengeni/react`) plus the engine/embed closure (`@opengeni/core`, `@opengeni/api-router`, `@opengeni/worker-bundle`, and their internal `@opengeni/*` dependencies such as `config`, `db`, `runtime`, `events`, `storage`, `documents`, `github`, `observability`, `codex`, and `agent-proto`). Package manifests and `.changeset/config.json` own the exact publish/build settings; ignored packages must be leaf-only. The Rust agent is a separate Cargo workspace under `agent/`.
 
 ### 6.1 Applications (`apps/`)
 
@@ -340,6 +340,8 @@ A Cargo workspace building the box-side binary for the `selfhosted` backend. `ag
 ### 6.5 Docs, scripts, test
 
 `docs/` (this map + topic docs, §14), `scripts/` (dev-stack, release mechanics, static guards, deployment CLIs, plus control-plane-only operator helpers under `scripts/operator/`, §11), `test/` (integration/e2e/live tiers + `source-hygiene.test.ts`).
+
+`examples/northstar-support` is the executable product-integration reference: a fictional SaaS support screen embedding `@opengeni/react`, a server-side SDK proxy, an authenticated product MCP server, and independent OpenGeni/product SSE streams. It is private, built in the repository check, and never part of the publish closure.
 
 ### 6.6 The relay edge (BYO-compute data plane)
 
@@ -495,7 +497,7 @@ The current map:
 
 ## 11. Build, test & release
 
-- **Bun workspace.** `workspaces: [apps/*, packages/*]`; shared strict TS baseline in `tsconfig.base.json` (`strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, Bundler resolution, `@opengeni/* → packages/*/src` aliases).
+- **Bun workspace.** `workspaces: [apps/*, examples/*, packages/*]`; shared strict TS baseline in `tsconfig.base.json` (`strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, Bundler resolution, `@opengeni/* → packages/*/src` aliases).
 - **Dev stack.** `bun run dev` (= `scripts/dev-stack.sh`): copy `.env`, pick free ports, `docker compose up` Postgres/NATS/Temporal/MinIO, migrate, build the sandbox image, launch api+worker+web. It auto-selects alternate ports if defaults are taken.
 - **Test tiers.** `test`/`test:unit` (bun test, **no infra**), `test:integration` (a fixed enumerated list of `*.integration.ts`), `test:e2e` (browser harness + Docker sandbox + Channel-A), `test:live` (opt-in via `OPENGENI_ENABLE_LIVE_TESTS`). **Unit tests and typecheck require no Temporal/NATS/Postgres/sandbox/model credentials** — keep new unit tests in that tier.
 - **Typecheck/check/prep.** `typecheck` is a hand-ordered `cd`-chain (add new packages to it). `check` = typecheck + unit + build sdk/react + web build; `check:full`/`prep` add integration + e2e; `check:workspace-billing` adds the static auth/billing guard.

--- a/examples/northstar-support/.env.example
+++ b/examples/northstar-support/.env.example
@@ -1,0 +1,15 @@
+# Server-side only. Never expose these values through a VITE_* variable.
+OPENGENI_API_BASE_URL=https://app.opengeni.ai
+OPENGENI_WORKSPACE_ID=replace_with_your_workspace_id
+OPENGENI_API_KEY=ogk_replace_me
+
+# Leave blank to use the workspace default model.
+OPENGENI_MODEL=
+
+# Shared only by OpenGeni's encrypted per-session MCP credentials and this
+# example backend. Generate a long random value.
+OPENGENI_DEMO_MCP_TOKEN=replace_with_a_long_random_value
+
+# Optional. Set to the public HTTPS origin or full /mcp URL. When omitted, the
+# server auto-detects an ngrok tunnel forwarding local port 4101.
+OPENGENI_DEMO_MCP_URL=

--- a/examples/northstar-support/README.md
+++ b/examples/northstar-support/README.md
@@ -1,0 +1,59 @@
+# Northstar support agent example
+
+A small fictional SaaS product showing the complete OpenGeni integration:
+
+1. The browser renders product UI plus `@opengeni/react` session components.
+2. The product backend creates OpenGeni sessions and proxies workspace-scoped
+   API/SSE traffic, keeping the OpenGeni API key server-side.
+3. OpenGeni calls the product's authenticated Streamable HTTP MCP server.
+4. MCP tools read and mutate product data.
+5. Product SSE updates the ticket immediately while OpenGeni SSE updates the
+   agent timeline independently.
+
+The demo deliberately exposes four tools over one ticket: `get_ticket`,
+`get_customer`, `update_ticket`, and `add_internal_note`. Mutations are
+pre-approved and idempotent so the full loop is easy to demonstrate.
+
+## Run against managed OpenGeni
+
+Requirements: Bun, an OpenGeni workspace API key, and a public HTTPS tunnel for
+the MCP endpoint.
+
+```bash
+cd examples/northstar-support
+cp .env.example .env.local
+# Set OPENGENI_WORKSPACE_ID, OPENGENI_API_KEY, and a random MCP token.
+bun run server
+```
+
+In a second terminal, expose only the MCP port:
+
+```bash
+ngrok http 4101
+```
+
+In a third terminal:
+
+```bash
+cd examples/northstar-support
+bun run dev
+```
+
+Open <http://127.0.0.1:3101>. If not using ngrok, set
+`OPENGENI_DEMO_MCP_URL` to any public HTTPS origin or full `/mcp` endpoint.
+
+## What to inspect
+
+- `src/server.ts`: backend session creation, scoped API proxy, MCP tools, dummy
+  domain state, and product SSE.
+- `src/support-agent-panel.tsx`: OpenGeni React timeline, status, and composer.
+- `src/support-tool-renderers.tsx`: product-specific rendering of MCP activity.
+- `src/use-support-demo.ts`: product SSE plus missed-event reconciliation.
+
+This is a local integration example, not a production auth template. A real
+SaaS should authenticate its users, authorize each product resource and
+OpenGeni workspace mapping, deploy MCP on its backend, store secrets in a secret
+manager, and rate-limit both its session and tool endpoints. See
+[`docs/embedding.md`](../../docs/embedding.md),
+[`docs/session-mcp-servers.md`](../../docs/session-mcp-servers.md), and
+[`packages/sdk/README.md`](../../packages/sdk/README.md).

--- a/examples/northstar-support/index.html
+++ b/examples/northstar-support/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>Northstar — OpenGeni product-agent example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@opengeni/example-northstar-support",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1 --port 3101",
+    "server": "bun --env-file=.env.local src/server.ts",
+    "build": "vite build",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opengeni/react": "workspace:*",
+    "@opengeni/sdk": "workspace:*",
+    "@tailwindcss/vite": "^4.2.4",
+    "@vitejs/plugin-react": "^6.0.1",
+    "lucide-react": "^1.8.0",
+    "motion": "^12.0.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "tailwindcss": "^4.2.4",
+    "vite": "^8.0.9",
+    "zod": "^4.2.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/northstar-support/src/main.tsx
+++ b/examples/northstar-support/src/main.tsx
@@ -1,0 +1,123 @@
+import { OpenGeniClient } from "@opengeni/sdk";
+import { LifeBuoyIcon, SearchIcon, Settings2Icon } from "lucide-react";
+import { useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OpenGeniProvider } from "@opengeni/react";
+import { SupportAgentPanel } from "./support-agent-panel";
+import { SupportTicketView } from "./support-ticket";
+import { useSupportDemo } from "./use-support-demo";
+import "./styles.css";
+
+const client = new OpenGeniClient({ baseUrl: "/api/opengeni" });
+
+declare global {
+  interface Window {
+    __northstarDemoRoot?: Root;
+  }
+}
+
+function WorkspaceChatApp() {
+  const demo = useSupportDemo();
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  function selectSession(next: string | null) {
+    setSessionId(next);
+  }
+
+  if (demo.loading && !demo.state) {
+    return <LoadingScreen />;
+  }
+
+  if (!demo.state) {
+    return <BackendError message={demo.error?.message ?? "Demo backend unavailable."} />;
+  }
+
+  return (
+    <OpenGeniProvider client={client} workspaceId={demo.health?.workspaceId ?? "unconfigured"}>
+      <div className="northstar og-root h-dvh overflow-hidden bg-[#f7f7f9]" data-og-theme="light">
+        <TopNavigation />
+        <div className="grid h-[calc(100dvh-57px)] min-h-0 grid-cols-[minmax(520px,1fr)_minmax(390px,42%)] max-lg:grid-cols-[minmax(460px,1fr)_420px] max-md:block max-md:overflow-y-auto">
+          <SupportTicketView state={demo.state} lastEvent={demo.lastEvent} onReset={demo.reset} />
+          <div className="min-h-0 max-md:h-[780px]">
+            <SupportAgentPanel
+              health={demo.health}
+              sessionId={sessionId}
+              onSessionCreated={(id) => selectSession(id)}
+              onClearSession={() => selectSession(null)}
+            />
+          </div>
+        </div>
+      </div>
+    </OpenGeniProvider>
+  );
+}
+
+function TopNavigation() {
+  return (
+    <nav className="flex h-[57px] items-center justify-between border-b border-black/[0.07] bg-white px-5 text-[#242631]">
+      <div className="flex items-center gap-7">
+        <div className="flex items-center gap-2.5">
+          <div className="grid size-8 place-items-center rounded-[10px] bg-[#6762df] text-[13px] font-bold text-white shadow-[0_4px_10px_rgba(103,98,223,0.25)]">
+            N
+          </div>
+          <span className="text-sm font-semibold tracking-[-0.015em]">Northstar</span>
+        </div>
+        <div className="flex items-center gap-1 max-sm:hidden">
+          <span className="rounded-lg bg-[#f1f1f5] px-3 py-1.5 text-xs font-semibold text-[#40434d]">
+            Inbox
+          </span>
+          <span className="px-3 py-1.5 text-xs text-[#868a95]">Customers</span>
+          <span className="px-3 py-1.5 text-xs text-[#868a95]">Reports</span>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Search"
+          className="grid size-8 place-items-center rounded-lg text-[#898c96] hover:bg-[#f3f3f5]"
+        >
+          <SearchIcon className="size-4" />
+        </button>
+        <button
+          type="button"
+          aria-label="Settings"
+          className="grid size-8 place-items-center rounded-lg text-[#898c96] hover:bg-[#f3f3f5]"
+        >
+          <Settings2Icon className="size-4" />
+        </button>
+        <div className="ml-1 grid size-8 place-items-center rounded-full bg-[#e8e4db] text-[10px] font-bold text-[#6c6455]">
+          MC
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function LoadingScreen() {
+  return (
+    <div className="grid h-dvh place-items-center bg-[#f7f7f9] text-[#242631]">
+      <div className="text-center">
+        <div className="mx-auto size-7 animate-spin rounded-full border-2 border-[#d8d8e4] border-t-[#6762df]" />
+        <p className="mt-4 text-sm text-[#7c808b]">Loading Northstar…</p>
+      </div>
+    </div>
+  );
+}
+
+function BackendError({ message }: { message: string }) {
+  return (
+    <div className="grid h-dvh place-items-center bg-[#f7f7f9] px-6 text-[#242631]">
+      <div className="max-w-md rounded-2xl border border-black/[0.07] bg-white p-6 text-center shadow-sm">
+        <LifeBuoyIcon className="mx-auto size-6 text-[#6762df]" />
+        <h1 className="mt-3 text-lg font-semibold">Start the demo backend</h1>
+        <p className="mt-2 text-sm leading-6 text-[#757985]">{message}</p>
+        <code className="mt-4 block rounded-xl bg-[#f4f4f6] px-3 py-2 text-xs">bun run server</code>
+      </div>
+    </div>
+  );
+}
+
+const container = document.getElementById("root")!;
+const root = window.__northstarDemoRoot ?? createRoot(container);
+window.__northstarDemoRoot = root;
+root.render(<WorkspaceChatApp />);

--- a/examples/northstar-support/src/server.ts
+++ b/examples/northstar-support/src/server.ts
@@ -1,0 +1,481 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { OpenGeniClient, type CreateSessionRequest } from "@opengeni/sdk";
+import * as z from "zod/v4";
+import type {
+  DemoHealth,
+  SupportCustomer,
+  SupportDemoState,
+  SupportDomainEvent,
+  SupportTicket,
+  TicketPriority,
+  TicketStatus,
+} from "./types";
+
+const PRODUCT_PORT = 4100;
+const MCP_PORT = 4101;
+const MCP_SERVER_ID = "northstar_support";
+const MCP_TOOLS = ["get_ticket", "get_customer", "update_ticket", "add_internal_note"];
+const encoder = new TextEncoder();
+
+const apiKey = process.env.OPENGENI_API_KEY?.trim() ?? "";
+const workspaceId = process.env.OPENGENI_WORKSPACE_ID?.trim() ?? "";
+const apiBaseUrl = (process.env.OPENGENI_API_BASE_URL ?? "https://app.opengeni.ai").replace(
+  /\/+$/,
+  "",
+);
+const mcpToken = process.env.OPENGENI_DEMO_MCP_TOKEN?.trim() ?? "";
+const model = process.env.OPENGENI_MODEL?.trim() ?? "";
+const openGeni = new OpenGeniClient({ baseUrl: apiBaseUrl, apiKey });
+
+const initialCustomer: SupportCustomer = {
+  id: "cus_aster_01",
+  name: "Aster Labs",
+  initials: "AL",
+  plan: "Scale",
+  arr: 48_000,
+  healthScore: 82,
+  joinedAt: "2024-09-18T10:00:00.000Z",
+  primaryContact: {
+    name: "Nora Lind",
+    role: "Operations lead",
+    email: "nora@asterlabs.example",
+  },
+  recentUsage: {
+    activeSeats: 37,
+    totalSeats: 45,
+    exportsLast30Days: 186,
+    failedExportsLast7Days: 14,
+  },
+};
+
+const initialTicket: SupportTicket = {
+  id: "TKT-2847",
+  customerId: initialCustomer.id,
+  subject: "Monthly export stalls at 87%",
+  body: "Hi team — our monthly finance export has stopped at exactly 87% three times today. We need the report for tomorrow's board meeting. Can someone take a look?",
+  status: "open",
+  priority: "normal",
+  assignee: "Maya Chen",
+  channel: "email",
+  createdAt: "2026-07-15T08:42:00.000Z",
+  slaDueAt: "2026-07-15T16:42:00.000Z",
+  tags: ["exports", "finance"],
+  notes: [
+    {
+      id: "note_seed",
+      author: "Maya Chen",
+      authorKind: "human",
+      body: "No platform incident showing. Customer has retried from two browsers.",
+      createdAt: "2026-07-15T09:03:00.000Z",
+    },
+  ],
+  activity: [
+    {
+      id: "activity_seed",
+      actor: "Nora Lind",
+      summary: "Created the ticket by email",
+      createdAt: "2026-07-15T08:42:00.000Z",
+    },
+  ],
+};
+
+let state: SupportDemoState = freshState();
+const subscribers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
+function freshState(): SupportDemoState {
+  return {
+    revision: 1,
+    customer: structuredClone(initialCustomer),
+    ticket: structuredClone(initialTicket),
+  };
+}
+
+function json(value: unknown, status = 200): Response {
+  return Response.json(value, {
+    status,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+function emit(type: SupportDomainEvent["type"], summary: string): SupportDomainEvent {
+  state.revision += 1;
+  const event: SupportDomainEvent = {
+    id: crypto.randomUUID(),
+    type,
+    revision: state.revision,
+    summary,
+    occurredAt: new Date().toISOString(),
+  };
+  const frame = encoder.encode(
+    `id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+  );
+  for (const subscriber of subscribers) {
+    try {
+      subscriber.enqueue(frame);
+    } catch {
+      subscribers.delete(subscriber);
+    }
+  }
+  return event;
+}
+
+function addActivity(actor: string, summary: string): void {
+  state.ticket.activity.unshift({
+    id: crypto.randomUUID(),
+    actor,
+    summary,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+function domainEventStream(request: Request): Response {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+  const stream = new ReadableStream<Uint8Array>({
+    start(next) {
+      controller = next;
+      subscribers.add(next);
+      next.enqueue(
+        encoder.encode(
+          `event: connected\ndata: ${JSON.stringify({ revision: state.revision })}\n\n`,
+        ),
+      );
+      keepalive = setInterval(() => {
+        try {
+          next.enqueue(encoder.encode(": keepalive\n\n"));
+        } catch {
+          subscribers.delete(next);
+        }
+      }, 15_000);
+    },
+    cancel() {
+      if (controller) subscribers.delete(controller);
+      if (keepalive) clearInterval(keepalive);
+    },
+  });
+  request.signal.addEventListener(
+    "abort",
+    () => {
+      if (controller) subscribers.delete(controller);
+      if (keepalive) clearInterval(keepalive);
+    },
+    { once: true },
+  );
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    },
+  });
+}
+
+async function resolvePublicMcpUrl(): Promise<string | null> {
+  const configured = process.env.OPENGENI_DEMO_MCP_URL?.trim();
+  if (configured) {
+    try {
+      const endpoint = new URL(configured);
+      endpoint.pathname = endpoint.pathname.replace(/\/+$/, "");
+      if (!endpoint.pathname.endsWith("/mcp")) endpoint.pathname += "/mcp";
+      return endpoint.toString();
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const response = await fetch("http://127.0.0.1:4040/api/tunnels", {
+      signal: AbortSignal.timeout(1_500),
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      tunnels?: Array<{
+        public_url?: string;
+        proto?: string;
+        config?: { addr?: string };
+      }>;
+    };
+    const tunnel = payload.tunnels?.find(
+      (candidate) =>
+        candidate.proto === "https" && candidate.config?.addr?.includes(String(MCP_PORT)),
+    );
+    return tunnel?.public_url ? `${tunnel.public_url.replace(/\/+$/, "")}/mcp` : null;
+  } catch {
+    return null;
+  }
+}
+
+async function health(): Promise<DemoHealth> {
+  const mcpPublicUrl = await resolvePublicMcpUrl();
+  return {
+    ok: Boolean(apiKey && workspaceId && mcpToken && mcpPublicUrl),
+    workspaceId: workspaceId || null,
+    openGeniConfigured: Boolean(apiKey && workspaceId),
+    mcpTokenConfigured: Boolean(mcpToken),
+    mcpPublicUrl,
+  };
+}
+
+async function createAgentSession(request: Request): Promise<Response> {
+  if (!apiKey || !workspaceId || !mcpToken) {
+    return json({ error: "Demo server credentials are not configured." }, 503);
+  }
+  const mcpUrl = await resolvePublicMcpUrl();
+  if (!mcpUrl) {
+    return json(
+      {
+        error: "No public HTTPS MCP endpoint is configured or detected.",
+      },
+      503,
+    );
+  }
+  const input = (await request.json().catch(() => ({}))) as {
+    initialMessage?: unknown;
+  };
+  const initialMessage =
+    typeof input.initialMessage === "string" && input.initialMessage.trim()
+      ? input.initialMessage.trim()
+      : "Investigate this support ticket. Use the available support tools, explain the evidence, and take the appropriate actions.";
+
+  const mcpServer = {
+    id: MCP_SERVER_ID,
+    name: "Northstar Support",
+    url: mcpUrl,
+    allowedTools: MCP_TOOLS,
+    cacheToolsList: false,
+    timeoutMs: 60_000,
+    requireApproval: [],
+    headers: { Authorization: `Bearer ${mcpToken}` },
+  };
+  const sessionRequest: CreateSessionRequest = {
+    initialMessage,
+    instructions: `You are the embedded support copilot inside Northstar, a fictional SaaS product. You are working only on ticket TKT-2847 for Aster Labs. Always inspect the ticket and customer with Northstar Support tools before drawing conclusions. The failed-export evidence is important. When evidence warrants action, call update_ticket and add_internal_note immediately. Product actions are pre-approved for this demo, so execute them without asking for confirmation. Never invent customer data. Keep the final answer brief and operational.`,
+    ...(model ? { model } : {}),
+    reasoningEffort: "low",
+    tools: [{ kind: "mcp", id: MCP_SERVER_ID }],
+    mcpServers: [mcpServer] as CreateSessionRequest["mcpServers"],
+    metadata: { demo: "northstar-support", ticketId: state.ticket.id },
+    clientEventId: crypto.randomUUID(),
+    idempotencyKey: crypto.randomUUID(),
+  };
+  const session = await openGeni.createSession(workspaceId, sessionRequest);
+  return json(session, 201);
+}
+
+async function proxyOpenGeni(request: Request): Promise<Response> {
+  if (!apiKey || !workspaceId) {
+    return json({ error: "OpenGeni credentials are not configured." }, 503);
+  }
+
+  const incoming = new URL(request.url);
+  const upstreamPath = incoming.pathname.replace(/^\/api\/opengeni/, "");
+  const workspacePrefix = `/v1/workspaces/${workspaceId}`;
+  if (upstreamPath !== workspacePrefix && !upstreamPath.startsWith(`${workspacePrefix}/`)) {
+    return json({ error: "Workspace path is outside this demo's scope." }, 403);
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${apiKey}`);
+  headers.delete("host");
+  headers.delete("content-length");
+  headers.delete("cookie");
+  const body =
+    request.method === "GET" || request.method === "HEAD" ? null : await request.arrayBuffer();
+  const upstream = await fetch(`${apiBaseUrl}${upstreamPath}${incoming.search}`, {
+    method: request.method,
+    headers,
+    ...(body ? { body } : {}),
+    signal: request.signal,
+  });
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("content-length");
+  responseHeaders.delete("content-encoding");
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+async function productRequest(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname.startsWith("/api/opengeni/")) {
+    try {
+      return await proxyOpenGeni(request);
+    } catch (error) {
+      return json({ error: error instanceof Error ? error.message : String(error) }, 502);
+    }
+  }
+  if (url.pathname === "/api/demo/health" && request.method === "GET") return json(await health());
+  if (url.pathname === "/api/demo/state" && request.method === "GET") return json(state);
+  if (url.pathname === "/api/demo/events" && request.method === "GET")
+    return domainEventStream(request);
+  if (url.pathname === "/api/demo/sessions" && request.method === "POST") {
+    try {
+      return await createAgentSession(request);
+    } catch (error) {
+      return json({ error: error instanceof Error ? error.message : String(error) }, 502);
+    }
+  }
+  if (url.pathname === "/api/demo/reset" && request.method === "POST") {
+    state = freshState();
+    emit("demo.reset", "Demo data reset");
+    return json(state);
+  }
+  return new Response("Not found", { status: 404 });
+}
+
+function toolResult(value: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(value) }] };
+}
+
+function buildMcpServer(): McpServer {
+  const server = new McpServer({ name: "northstar-support", version: "1.0.0" });
+  server.registerTool(
+    "get_ticket",
+    {
+      description:
+        "Get the complete support ticket, including priority, status, SLA, customer message, internal notes, and activity.",
+      inputSchema: {
+        ticketId: z.string().describe("Ticket id, normally TKT-2847"),
+      },
+    },
+    async ({ ticketId }) =>
+      ticketId === state.ticket.id
+        ? toolResult(state.ticket)
+        : {
+            ...toolResult({ error: `Ticket ${ticketId} not found` }),
+            isError: true,
+          },
+  );
+  server.registerTool(
+    "get_customer",
+    {
+      description:
+        "Get the customer account behind the ticket, including plan, ARR, health, contact, seats, and recent export reliability.",
+      inputSchema: {
+        customerId: z.string().describe("Customer id from the ticket"),
+      },
+    },
+    async ({ customerId }) =>
+      customerId === state.customer.id
+        ? toolResult(state.customer)
+        : {
+            ...toolResult({ error: `Customer ${customerId} not found` }),
+            isError: true,
+          },
+  );
+  server.registerTool(
+    "update_ticket",
+    {
+      description:
+        "Update support ticket priority, status, or assignee. Include a short evidence-based reason. This changes product data immediately.",
+      inputSchema: {
+        ticketId: z.string(),
+        priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
+        status: z.enum(["open", "investigating", "waiting_on_customer", "resolved"]).optional(),
+        assignee: z.string().min(1).optional(),
+        reason: z.string().min(5),
+      },
+    },
+    async ({ ticketId, priority, status, assignee, reason }) => {
+      if (ticketId !== state.ticket.id) {
+        return {
+          ...toolResult({ error: `Ticket ${ticketId} not found` }),
+          isError: true,
+        };
+      }
+      const changes: string[] = [];
+      if (priority && priority !== state.ticket.priority) {
+        changes.push(`priority ${state.ticket.priority} → ${priority}`);
+        state.ticket.priority = priority as TicketPriority;
+      }
+      if (status && status !== state.ticket.status) {
+        changes.push(`status ${state.ticket.status} → ${status}`);
+        state.ticket.status = status as TicketStatus;
+      }
+      if (assignee && assignee !== state.ticket.assignee) {
+        changes.push(`assignee ${state.ticket.assignee} → ${assignee}`);
+        state.ticket.assignee = assignee;
+      }
+      const summary = changes.length
+        ? `Updated ${changes.join(", ")}`
+        : "Reviewed ticket; no field changes";
+      if (changes.length > 0) {
+        addActivity("OpenGeni agent", `${summary}. Reason: ${reason}`);
+        emit("ticket.updated", summary);
+      }
+      return toolResult({ ok: true, summary, ticket: state.ticket });
+    },
+  );
+  server.registerTool(
+    "add_internal_note",
+    {
+      description:
+        "Add a concise internal note to the ticket. Use this to preserve investigation evidence and the recommended next step.",
+      inputSchema: {
+        ticketId: z.string(),
+        body: z.string().min(10).max(1_000),
+      },
+    },
+    async ({ ticketId, body }) => {
+      if (ticketId !== state.ticket.id) {
+        return {
+          ...toolResult({ error: `Ticket ${ticketId} not found` }),
+          isError: true,
+        };
+      }
+      const existing = state.ticket.notes.find(
+        (note) => note.authorKind === "agent" && note.body === body,
+      );
+      if (existing) {
+        return toolResult({ ok: true, duplicate: true, note: existing });
+      }
+      const note = {
+        id: crypto.randomUUID(),
+        author: "OpenGeni agent",
+        authorKind: "agent" as const,
+        body,
+        createdAt: new Date().toISOString(),
+      };
+      state.ticket.notes.unshift(note);
+      addActivity("OpenGeni agent", "Added an internal investigation note");
+      emit("ticket.note_added", "Agent added an internal note");
+      return toolResult({ ok: true, note });
+    },
+  );
+  return server;
+}
+
+async function mcpRequest(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname !== "/mcp") return new Response("Not found", { status: 404 });
+  if (!mcpToken || request.headers.get("authorization") !== `Bearer ${mcpToken}`) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    enableJsonResponse: true,
+  });
+  const server = buildMcpServer();
+  await server.connect(transport);
+  return await transport.handleRequest(request);
+}
+
+const productServer = Bun.serve({
+  hostname: "127.0.0.1",
+  port: PRODUCT_PORT,
+  idleTimeout: 255,
+  fetch: productRequest,
+});
+const mcpServer = Bun.serve({
+  hostname: "127.0.0.1",
+  port: MCP_PORT,
+  idleTimeout: 255,
+  fetch: mcpRequest,
+});
+
+console.log(`Northstar product API  http://127.0.0.1:${productServer.port}/api/demo/health`);
+console.log(`Northstar MCP server   http://127.0.0.1:${mcpServer.port}/mcp`);
+console.log("MCP auth               ", mcpToken ? "configured" : "MISSING");
+console.log("OpenGeni auth          ", apiKey ? "configured" : "MISSING");
+console.log("OpenGeni workspace     ", workspaceId || "MISSING");

--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -1,0 +1,36 @@
+@import "tailwindcss";
+@import "@opengeni/react/styles.css";
+@source "../../../packages/react/src";
+
+html,
+body,
+#root {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--og-font-sans);
+}
+
+.northstar {
+  --og-color-accent: oklch(0.56 0.18 288);
+  --og-color-accent-strong: oklch(0.49 0.2 288);
+  --og-color-accent-deep: oklch(0.44 0.2 288);
+  --og-color-accent-soft: color-mix(in oklch, var(--og-color-accent) 10%, transparent);
+  --og-color-bg: #f7f7f9;
+  --og-color-surface-1: #ffffff;
+  --og-color-surface-2: #f5f5f8;
+  --og-color-surface-3: #eeeeF3;
+  --og-color-border: rgba(31, 34, 45, 0.08);
+  --og-color-border-strong: rgba(31, 34, 45, 0.17);
+  --og-color-fg: #242631;
+  --og-color-fg-muted: #666a75;
+  --og-color-fg-subtle: #9699a3;
+}
+
+.northstar ::selection {
+  background: color-mix(in oklch, var(--og-color-accent) 22%, white);
+}
+
+.northstar * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(45, 48, 60, 0.15) transparent;
+}

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -1,0 +1,198 @@
+import { ArrowRightIcon, LoaderCircleIcon, ShieldCheckIcon, SparklesIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  ChatComposer,
+  MessageTimeline,
+  SessionStatus,
+  useComposer,
+  useSession,
+  useSessionEvents,
+} from "@opengeni/react";
+import type { DemoHealth } from "./types";
+import { createDemoSession } from "./use-support-demo";
+import { supportToolRegistry } from "./support-tool-renderers";
+
+const DEMO_PROMPT =
+  "Investigate TKT-2847 using the support tools. If the evidence warrants it, mark it urgent and investigating, then add an internal note with the evidence and next step.";
+
+export function SupportAgentPanel({
+  health,
+  sessionId,
+  onSessionCreated,
+  onClearSession,
+}: {
+  health: DemoHealth | null;
+  sessionId: string | null;
+  onSessionCreated: (sessionId: string) => void;
+  onClearSession: () => void;
+}) {
+  const [starting, setStarting] = useState(false);
+  const [startError, setStartError] = useState<Error | null>(null);
+
+  async function startDemo() {
+    setStarting(true);
+    setStartError(null);
+    try {
+      const session = await createDemoSession(DEMO_PROMPT);
+      onSessionCreated(session.id);
+    } catch (cause) {
+      setStartError(cause instanceof Error ? cause : new Error(String(cause)));
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col border-l border-black/[0.07] bg-white text-og-fg">
+      <header className="flex h-[73px] shrink-0 items-center justify-between gap-4 border-b border-og-border px-5">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="relative grid size-9 shrink-0 place-items-center rounded-xl bg-[#20222b] text-white shadow-sm">
+            <SparklesIcon className="size-4" />
+            <span className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-white bg-[#47b881]" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold text-[#242631]">Northstar Copilot</h2>
+            <p className="mt-0.5 truncate text-[11px] text-[#8f929c]">
+              OpenGeni · live product tools
+            </p>
+          </div>
+        </div>
+        {sessionId ? (
+          <button
+            type="button"
+            onClick={onClearSession}
+            className="text-[11px] font-medium text-[#8b8e98] transition hover:text-[#3f424c]"
+          >
+            New run
+          </button>
+        ) : (
+          <McpIndicator health={health} />
+        )}
+      </header>
+
+      {sessionId ? (
+        <LiveAgentSession sessionId={sessionId} />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col justify-between overflow-y-auto px-6 py-7">
+          <div>
+            <div className="inline-flex items-center gap-1.5 rounded-full bg-[#f0efff] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[#625ed3]">
+              <ShieldCheckIcon className="size-3" /> Live product actions
+            </div>
+            <h3 className="mt-5 max-w-sm text-[25px] font-semibold leading-[1.15] tracking-[-0.035em] text-[#20222b]">
+              Let the agent investigate inside your product.
+            </h3>
+            <p className="mt-3 max-w-sm text-[13px] leading-6 text-[#717581]">
+              It reads this ticket and customer through MCP, then its actions appear in the product
+              instantly.
+            </p>
+
+            <div className="mt-7 space-y-2.5">
+              {[
+                ["1", "Read ticket and customer context"],
+                ["2", "Find the failed-export risk signal"],
+                ["3", "Update priority, status, and internal notes"],
+              ].map(([step, label]) => (
+                <div
+                  key={step}
+                  className="flex items-center gap-3 rounded-xl border border-black/[0.06] bg-[#fafafb] px-3.5 py-3 text-xs text-[#5f626d]"
+                >
+                  <span className="grid size-5 shrink-0 place-items-center rounded-full bg-white text-[10px] font-semibold text-[#6864dc] shadow-sm">
+                    {step}
+                  </span>
+                  {label}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-8">
+            {startError ? (
+              <p className="mb-3 rounded-xl bg-[#fff0ed] px-3 py-2 text-xs text-[#b44835]">
+                {startError.message}
+              </p>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void startDemo()}
+              disabled={starting || !health?.ok}
+              className="group flex w-full items-center justify-between rounded-[16px] bg-[#252732] px-4 py-3.5 text-left text-sm font-semibold text-white shadow-[0_10px_25px_rgba(36,38,49,0.16)] transition hover:-translate-y-0.5 hover:bg-[#30323e] disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              <span className="flex items-center gap-2.5">
+                {starting ? (
+                  <LoaderCircleIcon className="size-4 animate-spin" />
+                ) : (
+                  <SparklesIcon className="size-4 text-[#aaa7ff]" />
+                )}
+                {starting ? "Starting agent…" : "Run the investigation"}
+              </span>
+              <ArrowRightIcon className="size-4 transition-transform group-hover:translate-x-0.5" />
+            </button>
+            <p className="mt-3 text-center text-[10px] text-[#9da0a9]">
+              OpenGeni session · authenticated product MCP · live product SSE
+            </p>
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function McpIndicator({ health }: { health: DemoHealth | null }) {
+  const connected = Boolean(health?.ok);
+  return (
+    <span
+      className={
+        connected
+          ? "inline-flex items-center gap-1.5 rounded-full bg-[#eef9f4] px-2.5 py-1 text-[10px] font-semibold text-[#2e7a5d]"
+          : "inline-flex items-center gap-1.5 rounded-full bg-[#fff4e5] px-2.5 py-1 text-[10px] font-semibold text-[#94671f]"
+      }
+    >
+      <span
+        className={
+          connected ? "size-1.5 rounded-full bg-[#44aa7c]" : "size-1.5 rounded-full bg-[#d49737]"
+        }
+      />
+      {connected ? "Ready" : "Setup required"}
+    </span>
+  );
+}
+
+function LiveAgentSession({ sessionId }: { sessionId: string }) {
+  const { session } = useSession(sessionId, { pollIntervalMs: 4_000 });
+  const { timeline, sessionStatus, connectionState, hasOlder, loadingOlder, loadOlder } =
+    useSessionEvents(sessionId);
+  const composer = useComposer(sessionId);
+  const status = sessionStatus ?? session?.status ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between border-b border-og-border/70 px-5 py-2.5">
+        <span className="inline-flex items-center gap-1.5 text-[10px] text-og-fg-subtle">
+          <span
+            className={
+              connectionState === "live"
+                ? "size-1.5 rounded-full bg-og-status-idle"
+                : "size-1.5 rounded-full bg-og-status-waiting"
+            }
+          />
+          {connectionState === "live" ? "Live session" : connectionState}
+        </span>
+        {status ? <SessionStatus status={status} size="sm" /> : null}
+      </div>
+
+      <MessageTimeline
+        items={timeline}
+        status={status}
+        toolRegistry={supportToolRegistry}
+        hasOlder={hasOlder}
+        loadingOlder={loadingOlder}
+        onLoadOlder={() => void loadOlder()}
+        className="min-h-0 flex-1"
+      />
+
+      <div className="shrink-0 border-t border-og-border/70 bg-white px-4 pb-4 pt-3">
+        <ChatComposer composer={composer} status={status} placeholder="Ask a follow-up…" />
+      </div>
+    </div>
+  );
+}

--- a/examples/northstar-support/src/support-ticket.tsx
+++ b/examples/northstar-support/src/support-ticket.tsx
@@ -1,0 +1,285 @@
+import {
+  ActivityIcon,
+  Building2Icon,
+  CalendarClockIcon,
+  CheckCircle2Icon,
+  CircleUserRoundIcon,
+  Clock3Icon,
+  MailIcon,
+  RotateCcwIcon,
+  SparklesIcon,
+  TagIcon,
+  UsersIcon,
+} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import type { SupportDemoState, SupportDomainEvent, TicketPriority, TicketStatus } from "./types";
+
+const priorityLabel: Record<TicketPriority, string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+  urgent: "Urgent",
+};
+
+const statusLabel: Record<TicketStatus, string> = {
+  open: "Open",
+  investigating: "Investigating",
+  waiting_on_customer: "Waiting on customer",
+  resolved: "Resolved",
+};
+
+function relativeTime(value: string): string {
+  const minutes = Math.round((Date.now() - Date.parse(value)) / 60_000);
+  if (Math.abs(minutes) < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-2xl border border-black/[0.055] bg-white/80 px-4 py-3 shadow-[0_1px_2px_rgba(31,35,48,0.03)]">
+      <div className="text-[11px] font-medium text-[#8b8f9b]">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold text-[#242631]">{value}</div>
+    </div>
+  );
+}
+
+export function SupportTicketView({
+  state,
+  lastEvent,
+  onReset,
+}: {
+  state: SupportDemoState;
+  lastEvent: SupportDomainEvent | null;
+  onReset: () => Promise<void>;
+}) {
+  const { ticket, customer } = state;
+  const failureRate = Math.round(
+    (customer.recentUsage.failedExportsLast7Days / customer.recentUsage.exportsLast30Days) * 100,
+  );
+
+  return (
+    <article className="flex h-full min-h-0 flex-col bg-[#f7f7f9] text-[#242631]">
+      <header className="shrink-0 border-b border-black/[0.06] bg-white px-7 py-5 max-sm:px-4">
+        <div className="flex items-start justify-between gap-5">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-xs font-medium text-[#888c98]">
+              <span>Support</span>
+              <span className="text-[#c4c6cd]">/</span>
+              <span>{ticket.id}</span>
+            </div>
+            <h1 className="mt-2 truncate text-[22px] font-semibold tracking-[-0.025em] text-[#20222b]">
+              {ticket.subject}
+            </h1>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <motion.span
+                key={ticket.status}
+                initial={{ scale: 0.9, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="inline-flex items-center gap-1.5 rounded-full bg-[#eef0ff] px-2.5 py-1 text-[11px] font-semibold text-[#5653cf]"
+              >
+                <span className="size-1.5 rounded-full bg-[#6965e8]" />
+                {statusLabel[ticket.status]}
+              </motion.span>
+              <motion.span
+                key={ticket.priority}
+                initial={{ scale: 0.9, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className={
+                  ticket.priority === "urgent"
+                    ? "rounded-full bg-[#fff0ed] px-2.5 py-1 text-[11px] font-semibold text-[#c34b36]"
+                    : "rounded-full bg-[#f1f2f4] px-2.5 py-1 text-[11px] font-semibold text-[#686c77]"
+                }
+              >
+                {priorityLabel[ticket.priority]} priority
+              </motion.span>
+              {ticket.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1 rounded-full border border-black/[0.07] bg-white px-2.5 py-1 text-[11px] text-[#737782]"
+                >
+                  <TagIcon className="size-3" />
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void onReset()}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-xl border border-black/[0.08] bg-white px-3 py-2 text-xs font-medium text-[#666a75] shadow-sm transition hover:border-black/[0.14] hover:text-[#30323b]"
+          >
+            <RotateCcwIcon className="size-3.5" /> Reset demo
+          </button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <AnimatePresence>
+          {lastEvent ? (
+            <motion.div
+              key={lastEvent.id}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              className="mx-7 mt-5 flex items-center gap-2 rounded-xl border border-[#cfe9de] bg-[#effaf5] px-3.5 py-2.5 text-xs font-medium text-[#237455] max-sm:mx-4"
+              role="status"
+            >
+              <CheckCircle2Icon className="size-4" />
+              Live product update · {lastEvent.summary}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        <div className="grid gap-5 p-7 max-sm:p-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="space-y-5">
+            <section className="overflow-hidden rounded-[20px] border border-black/[0.06] bg-white shadow-[0_1px_3px_rgba(28,31,42,0.04)]">
+              <div className="flex items-center justify-between border-b border-black/[0.055] px-5 py-4">
+                <div className="flex items-center gap-3">
+                  <div className="grid size-9 place-items-center rounded-full bg-[#e9f1ff] text-xs font-bold text-[#486d9e]">
+                    NL
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold">Nora Lind</div>
+                    <div className="mt-0.5 text-[11px] text-[#9599a3]">
+                      {customer.primaryContact.role} · {relativeTime(ticket.createdAt)}
+                    </div>
+                  </div>
+                </div>
+                <MailIcon className="size-4 text-[#a3a6ae]" />
+              </div>
+              <div className="px-5 py-5 text-[14px] leading-7 text-[#4e515c]">{ticket.body}</div>
+            </section>
+
+            <section>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
+                  Internal notes
+                </h2>
+                <span className="text-[11px] text-[#a0a3ac]">{ticket.notes.length} notes</span>
+              </div>
+              <div className="space-y-3">
+                {ticket.notes.map((note) => (
+                  <motion.div
+                    layout
+                    key={note.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className={
+                      note.authorKind === "agent"
+                        ? "rounded-[18px] border border-[#dcdcff] bg-[#f4f4ff] p-4"
+                        : "rounded-[18px] border border-black/[0.06] bg-white p-4"
+                    }
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-2 text-xs font-semibold">
+                        {note.authorKind === "agent" ? (
+                          <SparklesIcon className="size-3.5 text-[#6561dc]" />
+                        ) : (
+                          <CircleUserRoundIcon className="size-3.5 text-[#8c909b]" />
+                        )}
+                        {note.author}
+                      </div>
+                      <time className="text-[10px] text-[#9a9da6]">
+                        {relativeTime(note.createdAt)}
+                      </time>
+                    </div>
+                    <p className="mt-2 text-[13px] leading-6 text-[#555965]">{note.body}</p>
+                  </motion.div>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
+                Activity
+              </h2>
+              <div className="space-y-1">
+                {ticket.activity.slice(0, 5).map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex gap-3 rounded-xl px-2 py-2.5 text-xs text-[#696d78]"
+                  >
+                    <ActivityIcon className="mt-0.5 size-3.5 shrink-0 text-[#9da0aa]" />
+                    <p className="min-w-0 flex-1">
+                      <span className="font-semibold text-[#484b55]">{item.actor}</span> ·{" "}
+                      {item.summary}
+                    </p>
+                    <time className="shrink-0 text-[10px] text-[#a0a3ac]">
+                      {relativeTime(item.createdAt)}
+                    </time>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <aside className="space-y-4">
+            <section className="rounded-[20px] border border-black/[0.06] bg-white p-5 shadow-[0_1px_3px_rgba(28,31,42,0.04)]">
+              <div className="flex items-center gap-3">
+                <div className="grid size-10 place-items-center rounded-xl bg-[#242631] text-xs font-bold text-white">
+                  {customer.initials}
+                </div>
+                <div className="min-w-0">
+                  <h2 className="truncate text-sm font-semibold">{customer.name}</h2>
+                  <p className="mt-0.5 text-[11px] text-[#92959f]">
+                    {customer.plan} plan · {money(customer.arr)} ARR
+                  </p>
+                </div>
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-2">
+                <Metric label="Health" value={`${customer.healthScore}/100`} />
+                <Metric
+                  label="Seats"
+                  value={`${customer.recentUsage.activeSeats}/${customer.recentUsage.totalSeats}`}
+                />
+                <Metric label="Exports" value={String(customer.recentUsage.exportsLast30Days)} />
+                <Metric label="Failures" value={`${failureRate}%`} />
+              </div>
+              <div className="mt-4 rounded-xl bg-[#fff7eb] px-3.5 py-3 text-[11px] leading-5 text-[#8a6228]">
+                <span className="font-semibold">Signal:</span> 14 failed exports in 7 days,
+                concentrated around month-end reporting.
+              </div>
+            </section>
+
+            <section className="rounded-[20px] border border-black/[0.06] bg-white p-5">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
+                Details
+              </h2>
+              <dl className="mt-4 space-y-3.5 text-xs">
+                <Detail icon={<UsersIcon />} label="Assignee" value={ticket.assignee} />
+                <Detail icon={<CalendarClockIcon />} label="SLA due" value="Today, 16:42" />
+                <Detail
+                  icon={<Clock3Icon />}
+                  label="Opened"
+                  value={relativeTime(ticket.createdAt)}
+                />
+                <Detail icon={<Building2Icon />} label="Customer since" value="Sep 2024" />
+              </dl>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Detail({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-[#a0a3ac] [&>svg]:size-3.5">{icon}</span>
+      <dt className="min-w-0 flex-1 text-[#888b96]">{label}</dt>
+      <dd className="max-w-[135px] truncate font-medium text-[#4a4d57]">{value}</dd>
+    </div>
+  );
+}

--- a/examples/northstar-support/src/support-tool-renderers.tsx
+++ b/examples/northstar-support/src/support-tool-renderers.tsx
@@ -1,0 +1,155 @@
+import {
+  Building2Icon,
+  FilePenLineIcon,
+  MessageSquarePlusIcon,
+  TicketCheckIcon,
+} from "lucide-react";
+import {
+  ActivityDisclosure,
+  createDefaultToolRegistry,
+  unwrapMcpOutput,
+  type ToolRendererProps,
+} from "@opengeni/react";
+
+function argumentsOf(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function outputOf(value: unknown): Record<string, unknown> | null {
+  const { text } = unwrapMcpOutput(value);
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function SupportToolRenderer({ item }: ToolRendererProps) {
+  const args = argumentsOf(item.arguments);
+  const output = outputOf(item.output);
+  const running = item.status === "running";
+  const failed = item.status === "failed";
+  const tool = item.name.split("__").at(-1) ?? item.name;
+
+  if (tool === "get_ticket") {
+    const ticket = output;
+    return (
+      <ActivityDisclosure
+        icon={<TicketCheckIcon className="size-3.5" />}
+        iconTone={failed ? "failed" : running ? "running" : "accent"}
+        title="Read support ticket"
+        running={running}
+        failed={failed}
+        preview={
+          running
+            ? "Loading ticket context…"
+            : `${String(ticket?.id ?? args.ticketId ?? "ticket")} · ${String(ticket?.subject ?? "context loaded")}`
+        }
+      >
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <ToolMetric label="Status" value={String(ticket?.status ?? "—")} />
+          <ToolMetric label="Priority" value={String(ticket?.priority ?? "—")} />
+          <ToolMetric label="Assignee" value={String(ticket?.assignee ?? "—")} />
+        </div>
+      </ActivityDisclosure>
+    );
+  }
+
+  if (tool === "get_customer") {
+    const customer = output;
+    const usage =
+      customer?.recentUsage && typeof customer.recentUsage === "object"
+        ? (customer.recentUsage as Record<string, unknown>)
+        : {};
+    return (
+      <ActivityDisclosure
+        icon={<Building2Icon className="size-3.5" />}
+        iconTone={failed ? "failed" : running ? "running" : "accent"}
+        title="Read customer signals"
+        running={running}
+        failed={failed}
+        preview={
+          running
+            ? "Loading customer health…"
+            : `${String(customer?.name ?? "Customer")} · ${String(customer?.healthScore ?? "—")}/100 health`
+        }
+      >
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <ToolMetric label="Plan" value={String(customer?.plan ?? "—")} />
+          <ToolMetric label="Active seats" value={String(usage.activeSeats ?? "—")} />
+          <ToolMetric label="Failed exports" value={String(usage.failedExportsLast7Days ?? "—")} />
+        </div>
+      </ActivityDisclosure>
+    );
+  }
+
+  if (tool === "update_ticket") {
+    const summary = typeof output?.summary === "string" ? output.summary : "Ticket updated";
+    const awaitingResult = output === null && !failed;
+    return (
+      <ActivityDisclosure
+        icon={<FilePenLineIcon className="size-3.5" />}
+        iconTone={failed ? "failed" : running ? "running" : "accent"}
+        title="Update support ticket"
+        running={running}
+        failed={failed}
+        chip={awaitingResult ? { tone: "muted", text: "running" } : { tone: "ok", text: "synced" }}
+        preview={awaitingResult ? String(args.reason ?? "Applying changes…") : summary}
+      >
+        <p className="text-xs leading-5 text-og-fg-muted">{String(args.reason ?? summary)}</p>
+      </ActivityDisclosure>
+    );
+  }
+
+  const awaitingResult = output === null && !failed;
+  return (
+    <ActivityDisclosure
+      icon={<MessageSquarePlusIcon className="size-3.5" />}
+      iconTone={failed ? "failed" : running ? "running" : "accent"}
+      title="Add internal note"
+      running={running}
+      failed={failed}
+      chip={awaitingResult ? { tone: "muted", text: "running" } : { tone: "ok", text: "added" }}
+      preview={String(args.body ?? "Recording investigation context…")}
+    >
+      <p className="text-xs leading-5 text-og-fg-muted">{String(args.body ?? "")}</p>
+    </ActivityDisclosure>
+  );
+}
+
+function ToolMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-og-md bg-og-surface-2 px-2.5 py-2">
+      <div className="text-[10px] text-og-fg-subtle">{label}</div>
+      <div className="mt-0.5 truncate font-medium capitalize text-og-fg">
+        {value.replaceAll("_", " ")}
+      </div>
+    </div>
+  );
+}
+
+export const supportToolRegistry = createDefaultToolRegistry({
+  entries: [
+    {
+      match: "name",
+      name: "northstar_support__get_ticket",
+      render: SupportToolRenderer,
+    },
+    {
+      match: "name",
+      name: "northstar_support__get_customer",
+      render: SupportToolRenderer,
+    },
+    {
+      match: "name",
+      name: "northstar_support__update_ticket",
+      render: SupportToolRenderer,
+    },
+    {
+      match: "name",
+      name: "northstar_support__add_internal_note",
+      render: SupportToolRenderer,
+    },
+  ],
+});

--- a/examples/northstar-support/src/types.ts
+++ b/examples/northstar-support/src/types.ts
@@ -1,0 +1,76 @@
+export type TicketPriority = "low" | "normal" | "high" | "urgent";
+export type TicketStatus = "open" | "investigating" | "waiting_on_customer" | "resolved";
+
+export type SupportNote = {
+  id: string;
+  author: string;
+  authorKind: "human" | "agent";
+  body: string;
+  createdAt: string;
+};
+
+export type SupportActivity = {
+  id: string;
+  actor: string;
+  summary: string;
+  createdAt: string;
+};
+
+export type SupportCustomer = {
+  id: string;
+  name: string;
+  initials: string;
+  plan: string;
+  arr: number;
+  healthScore: number;
+  joinedAt: string;
+  primaryContact: {
+    name: string;
+    role: string;
+    email: string;
+  };
+  recentUsage: {
+    activeSeats: number;
+    totalSeats: number;
+    exportsLast30Days: number;
+    failedExportsLast7Days: number;
+  };
+};
+
+export type SupportTicket = {
+  id: string;
+  customerId: string;
+  subject: string;
+  body: string;
+  status: TicketStatus;
+  priority: TicketPriority;
+  assignee: string;
+  channel: "email";
+  createdAt: string;
+  slaDueAt: string;
+  tags: string[];
+  notes: SupportNote[];
+  activity: SupportActivity[];
+};
+
+export type SupportDemoState = {
+  revision: number;
+  ticket: SupportTicket;
+  customer: SupportCustomer;
+};
+
+export type SupportDomainEvent = {
+  id: string;
+  type: "ticket.updated" | "ticket.note_added" | "demo.reset";
+  revision: number;
+  summary: string;
+  occurredAt: string;
+};
+
+export type DemoHealth = {
+  ok: boolean;
+  workspaceId: string | null;
+  openGeniConfigured: boolean;
+  mcpTokenConfigured: boolean;
+  mcpPublicUrl: string | null;
+};

--- a/examples/northstar-support/src/use-support-demo.ts
+++ b/examples/northstar-support/src/use-support-demo.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DemoHealth, SupportDemoState, SupportDomainEvent } from "./types";
+
+type SupportDemoResult = {
+  state: SupportDemoState | null;
+  health: DemoHealth | null;
+  loading: boolean;
+  error: Error | null;
+  lastEvent: SupportDomainEvent | null;
+  refresh: () => Promise<void>;
+  reset: () => Promise<void>;
+};
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, init);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({ error: response.statusText }));
+    throw new Error(
+      String((body as { error?: unknown }).error ?? `Request failed (${response.status})`),
+    );
+  }
+  return (await response.json()) as T;
+}
+
+export function useSupportDemo(): SupportDemoResult {
+  const [state, setState] = useState<SupportDemoState | null>(null);
+  const [health, setHealth] = useState<DemoHealth | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastEvent, setLastEvent] = useState<SupportDomainEvent | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [nextState, nextHealth] = await Promise.all([
+        fetchJson<SupportDemoState>("/api/demo/state"),
+        fetchJson<DemoHealth>("/api/demo/health"),
+      ]);
+      setState(nextState);
+      setHealth(nextHealth);
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause : new Error(String(cause)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const events = new EventSource("/api/demo/events");
+    const reconcile = window.setInterval(() => {
+      void fetchJson<SupportDemoState>("/api/demo/state")
+        .then((nextState) => {
+          setState(nextState);
+          setError(null);
+        })
+        .catch((cause: unknown) => {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+        });
+    }, 3_000);
+    const onDomainEvent = (event: MessageEvent<string>) => {
+      try {
+        const parsed = JSON.parse(event.data) as SupportDomainEvent;
+        setLastEvent(parsed);
+        void refresh();
+      } catch {
+        // Keep the last valid state if a non-domain SSE frame arrives.
+      }
+    };
+    events.addEventListener("ticket.updated", onDomainEvent as EventListener);
+    events.addEventListener("ticket.note_added", onDomainEvent as EventListener);
+    events.addEventListener("demo.reset", onDomainEvent as EventListener);
+    events.onerror = () => setError(new Error("Product update stream disconnected."));
+    return () => {
+      window.clearInterval(reconcile);
+      events.close();
+    };
+  }, [refresh]);
+
+  const reset = useCallback(async () => {
+    const next = await fetchJson<SupportDemoState>("/api/demo/reset", {
+      method: "POST",
+    });
+    setState(next);
+    setLastEvent(null);
+  }, []);
+
+  return { state, health, loading, error, lastEvent, refresh, reset };
+}
+
+export async function createDemoSession(initialMessage: string) {
+  return await fetchJson<{ id: string }>("/api/demo/sessions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ initialMessage }),
+  });
+}

--- a/examples/northstar-support/tsconfig.json
+++ b/examples/northstar-support/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["bun", "vite/client"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "vite.config.ts",
+    "../../packages/react/src/types/external.d.ts"
+  ]
+}

--- a/examples/northstar-support/vite.config.ts
+++ b/examples/northstar-support/vite.config.ts
@@ -1,0 +1,16 @@
+import tailwindcss from "@tailwindcss/vite";
+import viteReact from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [viteReact(), tailwindcss()],
+  server: {
+    strictPort: true,
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:4100",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "workspaces": [
     "apps/*",
+    "examples/*",
     "packages/*"
   ],
   "type": "module",
@@ -55,7 +56,7 @@
     "release:rewrite-deps": "bun scripts/rewrite-workspace-deps.ts",
     "release:rewrite-entry-points": "bun scripts/rewrite-entry-points.ts",
     "release:publish": "bash scripts/release-publish.sh",
-    "check": "bun run typecheck && bun run test:unit && cd packages/sdk && bun run build && cd ../react && bun run build && bun run demo:build && cd ../../apps/web && bun run build",
+    "check": "bun run typecheck && bun run test:unit && cd packages/sdk && bun run build && cd ../react && bun run build && bun run demo:build && cd ../../apps/web && bun run build && cd ../../examples/northstar-support && bun run build",
     "check:full": "bun run check && bun run test:integration && bun run test:e2e",
     "check:docs-refs": "bun scripts/check-docs-refs.ts",
     "check:rename": "bun scripts/check-variable-set-rename.ts",

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -148,17 +148,34 @@ export function v4aToGitFileDiff(op: ApplyPatchOperation): GitFileDiff {
           // `@@ -0,0 +1,N @@` from the range fields once newLines is counted — a
           // pre-baked partial header (e.g. `@@ +1 @@`) renders zero lines in a
           // generic unified-diff parser.
-          cur = { oldStart: 0, oldLines: 0, newStart: 1, newLines: 0, header: "", lines: [] };
+          cur = {
+            oldStart: 0,
+            oldLines: 0,
+            newStart: 1,
+            newLines: 0,
+            header: "",
+            lines: [],
+          };
           hunks.push(cur);
           oldNo = 0;
           newNo = 1;
         }
         if (raw.startsWith("+")) {
-          cur.lines.push({ type: "add", oldNo: null, newNo: newNo++, text: raw.slice(1) });
+          cur.lines.push({
+            type: "add",
+            oldNo: null,
+            newNo: newNo++,
+            text: raw.slice(1),
+          });
           cur.newLines += 1;
           additions += 1;
         } else if (raw.startsWith("-")) {
-          cur.lines.push({ type: "del", oldNo: oldNo++, newNo: null, text: raw.slice(1) });
+          cur.lines.push({
+            type: "del",
+            oldNo: oldNo++,
+            newNo: null,
+            text: raw.slice(1),
+          });
           cur.oldLines += 1;
           deletions += 1;
         } else {
@@ -200,7 +217,10 @@ export function v4aToGitFileDiff(op: ApplyPatchOperation): GitFileDiff {
  * renderer and the turn-summary facet counter never drift.
  */
 export function applyPatchOps(raw: unknown): ApplyPatchOperation[] {
-  const r = (raw ?? {}) as { operation?: ApplyPatchOperation; operations?: ApplyPatchOperation[] };
+  const r = (raw ?? {}) as {
+    operation?: ApplyPatchOperation;
+    operations?: ApplyPatchOperation[];
+  };
   if (Array.isArray(r.operations)) {
     return r.operations;
   }
@@ -264,7 +284,21 @@ export function tailPeek(text: string): string {
  * into a flat `{ text, isError }`. Non-MCP outputs pass through as their string
  * form.
  */
-export function unwrapMcpOutput(output: unknown): { text: string; isError: boolean } {
+export function unwrapMcpOutput(output: unknown): {
+  text: string;
+  isError: boolean;
+} {
+  // Managed MCP events persist a normalized single text part as
+  // `{ type: "text", text }`; accept it alongside the SDK-native content array.
+  if (
+    output &&
+    typeof output === "object" &&
+    (output as { type?: unknown }).type === "text" &&
+    typeof (output as { text?: unknown }).text === "string"
+  ) {
+    const record = output as { text: string; isError?: unknown };
+    return { text: record.text, isError: Boolean(record.isError) };
+  }
   if (output && typeof output === "object" && "content" in output) {
     const record = output as { content?: unknown; isError?: unknown };
     const isError = Boolean(record.isError);
@@ -273,7 +307,10 @@ export function unwrapMcpOutput(output: unknown): { text: string; isError: boole
         (part): part is { type: string; text: string } =>
           !!part && typeof part === "object" && (part as { type?: unknown }).type === "text",
       );
-      return { text: textPart ? String(textPart.text) : JSON.stringify(output), isError };
+      return {
+        text: textPart ? String(textPart.text) : JSON.stringify(output),
+        isError,
+      };
     }
     return { text: JSON.stringify(output), isError };
   }

--- a/packages/react/test/timeline-parsers.test.ts
+++ b/packages/react/test/timeline-parsers.test.ts
@@ -127,7 +127,11 @@ describe("V4A apply_patch parsing", () => {
   });
 
   test("v4aToGitFileDiff marks a delete_file and ignores any diff body", () => {
-    const diff = v4aToGitFileDiff({ type: "delete_file", path: "gone.txt", diff: "ignored" });
+    const diff = v4aToGitFileDiff({
+      type: "delete_file",
+      path: "gone.txt",
+      diff: "ignored",
+    });
     expect(diff.status).toBe("deleted");
     expect(diff.hunks).toHaveLength(0);
     expect(diff.additions).toBe(0);
@@ -155,7 +159,11 @@ describe("V4A apply_patch parsing", () => {
   });
 
   test("v4aToGitFileDiff tolerates an empty update diff (no throw)", () => {
-    const diff = v4aToGitFileDiff({ type: "update_file", path: "x.ts", diff: "" });
+    const diff = v4aToGitFileDiff({
+      type: "update_file",
+      path: "x.ts",
+      diff: "",
+    });
     expect(diff.status).toBe("modified");
     expect(diff.hunks).toHaveLength(0);
   });
@@ -169,7 +177,11 @@ describe("V4A apply_patch parsing", () => {
     // a structurally valid `@@ -0,0 +1,N @@` header and all N added lines.
     const N = 17;
     const body = Array.from({ length: N }, (_, i) => `+line ${i + 1}`).join("\n");
-    const file = v4aToGitFileDiff({ type: "create_file", path: "src/new.ts", diff: body });
+    const file = v4aToGitFileDiff({
+      type: "create_file",
+      path: "src/new.ts",
+      diff: body,
+    });
 
     // The chip count (additions) is what the collapsed header shows.
     expect(file.additions).toBe(N);
@@ -294,6 +306,13 @@ describe("MCP output unwrap", () => {
     });
   });
 
+  test("unwrapMcpOutput flattens a persisted MCP text part", () => {
+    expect(unwrapMcpOutput({ type: "text", text: '{"status":"open"}' })).toEqual({
+      text: '{"status":"open"}',
+      isError: false,
+    });
+  });
+
   test("unwrapMcpOutput surfaces isError and finds the text part among others", () => {
     const result = unwrapMcpOutput({
       isError: true,
@@ -306,7 +325,10 @@ describe("MCP output unwrap", () => {
   });
 
   test("unwrapMcpOutput passes a plain string through", () => {
-    expect(unwrapMcpOutput("plain stdout")).toEqual({ text: "plain stdout", isError: false });
+    expect(unwrapMcpOutput("plain stdout")).toEqual({
+      text: "plain stdout",
+      isError: false,
+    });
   });
 
   test("unwrapMcpOutput handles nullish output", () => {

--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -35,6 +35,7 @@ const projects = [
   "apps/api",
   "apps/worker",
   "apps/web",
+  "examples/northstar-support",
 ];
 
 const tsgo = join(process.cwd(), "node_modules", ".bin", "tsgo");


### PR DESCRIPTION
## Summary
- add durable `examples/northstar-support` SaaS integration reference
- keep OpenGeni credentials behind a workspace-scoped backend proxy
- expose authenticated MCP product tools and reconcile product/OpenGeni SSE independently
- render persisted MCP text outputs in custom React timeline cards
- include the example in workspace typecheck/build gates and architecture docs

## Verification
- live managed OpenGeni E2E: reads, rendered tool values, ticket mutation, note mutation, final idle state
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- SDK, React/demo, web, and Northstar builds
- docs reference guard
- timeline parser tests (30 pass)
- full local unit run: 3021 pass, 3 skip; remaining Postgres-backed context-compaction setup fails only because local Docker/OrbStack is unavailable