### PR TITLE
fix(worker): recover transient provider failures in-place

### DIFF
--- a/.changeset/recover-provider-turns.md
+++ b/.changeset/recover-provider-turns.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Recover retryable provider failures as new fenced attempts of the same accepted turn, independent of goal state, while preserving durable tool history and pause controls.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           bun test --timeout 30000 \
             --test-name-pattern \
-            'an MCP stream timeout after a successful tool output checkpoints once and continues the active goal' \
+            'an MCP stream timeout after a successful tool output checkpoints once and recovers the same turn' \
             ./test/integration/worker-activity.integration.ts
           bun test --timeout 180000 \
             --test-name-pattern \

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -243,26 +243,17 @@ import { createHash, randomUUID } from "node:crypto";
 // budget against the same window.
 export const PROVIDER_BACKPRESSURE_DELAY_MS = 60_000;
 
-/**
- * Recovery routing for a turn failed by a RETRYABLE provider error, once the
- * activity knows whether the session still has an active goal: a goal-bearing
- * session idles and auto-continues after the backpressure delay, a goal-less one
- * idles and waits for the next user message. A NON-retryable failure never reaches
- * here — it takes the terminal session.failed path — so the contrast this encodes
- * is "retryable provider blip ⇒ idle-with-recovery, not a dead session." Single
- * source of truth for the recovery mode and continuation delay the retryable
- * turn-failure branch publishes.
- */
-export function providerRetryRecovery(goalActive: boolean): {
-  recovery: "goal_continuation" | "user_message";
-  continueDelayMs?: number;
+/** A retryable provider fault recovers the accepted turn itself. Goal state is
+ * irrelevant: autonomous continuation and infrastructure recovery are separate
+ * concerns. */
+export function providerRecoveryResult(): {
+  status: "recovering";
+  continueDelayMs: number;
 } {
-  return goalActive
-    ? {
-        recovery: "goal_continuation",
-        continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
-      }
-    : { recovery: "user_message" };
+  return {
+    status: "recovering",
+    continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
+  };
 }
 
 /**
@@ -5106,52 +5097,37 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         return claimedResult({ status: "idle" });
       }
       // A retryable provider/MCP failure is transient external backpressure,
-      // not a session failure: the in-client retry budget is already
-      // exhausted by the time the error reaches here, so fail the turn
-      // truthfully but idle the session. With an active goal the continuation
-      // loop resumes after a pacing delay; without one the session simply
-      // waits for the next user message. Long-lived sessions (a per-customer
-      // ops channel between goals) must never go terminal because the
-      // provider had a bad minute -- a failed session would reject the very
-      // retry message the failure asks for.
+      // not a session or goal failure. The in-client retry budget is already
+      // exhausted by the time the error reaches here. Checkpoint conversation
+      // truth, recover this SAME accepted turn, then let the workflow re-claim
+      // it after a pacing delay. This is independent of goal state and never
+      // relies on a synthetic continuation prompt.
       const failure = agentRunFailurePayload(error);
       if (failure.retryable && publish && turnId && turnStartedPublished) {
-        const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(() => null);
-        const goalActive = Boolean(goal && goal.status === "active");
-        const recoveryRouting = providerRetryRecovery(goalActive);
+        const recoveryResult = providerRecoveryResult();
         await flushRuntimeBatcher();
-        // Provider/MCP errors rarely carry SDK run state; a null falls back to
-        // the previous snapshot, same degraded-context contract as the
-        // max-turns path above.
-        await reconcileConversationTruth();
-        if (
-          !(await settle!({
-            events: [
-              {
-                type: "turn.failed",
-                payload: {
-                  ...failure,
-                  recovery: recoveryRouting.recovery,
-                },
-              },
-              { type: "session.status.changed", payload: { status: "idle" } },
-            ],
-            turnStatus: "failed",
-            sessionStatus: "idle",
-            activeTurnId: null,
-          }))
-        ) {
+        await reconcileConversationTruth({ requireDurable: true });
+        const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
+          sessionId: input.sessionId,
+          turnId,
+          triggerEventId: triggerEventId!,
+          attemptId: input.attemptId,
+          reason: failure.code ?? "provider_unavailable",
+          detail: {
+            ...failure,
+            continueDelayMs: recoveryResult.continueDelayMs,
+          },
+        });
+        if (recovery.action === "stale") {
+          activityStatus = "cancelled";
+          turnMetricOutcome = "cancelled";
           return claimedResult({ status: "cancelled" });
         }
-        turnMetricOutcome = "failed";
-        activityStatus = "idle";
+        await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, recovery.events);
+        turnMetricOutcome = "recovering";
+        activityStatus = "recovering";
         activityError = error;
-        return claimedResult({
-          status: "idle",
-          ...(recoveryRouting.continueDelayMs !== undefined
-            ? { continueDelayMs: recoveryRouting.continueDelayMs }
-            : {}),
-        });
+        return claimedResult(recoveryResult);
       }
       activityStatus = "failed";
       activityError = error;
@@ -5407,11 +5383,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
 /**
  * True when the error is transient upstream backpressure — a model-provider 5xx,
  * a "server had a bad minute" body, or a dropped/again-able network connection —
- * rather than a request the session got wrong. These are safe to retry: the turn
- * routes into the SAME idle + goal-continuation recovery the rate-limit branch
- * uses (a goal-bearing session auto-continues after PROVIDER_BACKPRESSURE_DELAY_MS;
- * a goal-less one waits for the next user message), and the resume notice tells the
- * model to re-check side effects before repeating them.
+ * rather than a request the session got wrong. These are safe to recover as a new
+ * fenced attempt of the SAME turn after PROVIDER_BACKPRESSURE_DELAY_MS. Durable
+ * tool results are preserved and ambiguous in-flight effects are closed before
+ * the new attempt, independent of whether the session has an active goal.
  *
  * This is the classification gap that hard-failed a fleet of prod sessions during a
  * provider degradation window: their errors ("Our servers are currently overloaded",

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -206,9 +206,8 @@ type ClaimedRunAgentTurnResult = {
   status: "idle" | "requires_action" | "failed" | "cancelled" | "recovering";
   turnId: string;
   attemptId: string;
-  // Provider backpressure pacing: when set on an idle result, the session
-  // workflow holds the loop this long before admitting the next turn (an
-  // active goal's continuation would otherwise immediately re-hit the limit).
+  // Provider backpressure pacing: when set on an idle or recovering result, the
+  // session workflow holds the loop this long before admitting the next attempt.
   continueDelayMs?: number;
   // Multi-account rotation all-capped idle: every connected Codex subscription is
   // rate-limited/cooling. This is a MANDATORY hold — session.ts must wait

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -54,7 +54,7 @@ export function continuationHoldMs(
   result: { status: string; continueDelayMs?: number; idleUntilReset?: boolean },
   floorMs: number,
 ): number {
-  if (result.status !== "idle") {
+  if (result.status !== "idle" && result.status !== "recovering") {
     return 0;
   }
   const delay = result.continueDelayMs ?? 0;
@@ -503,10 +503,6 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
       return outcome.result.status === "cancelled";
     }
 
-    if (outcome.result.status === "recovering") {
-      return true;
-    }
-
     if (outcome.result.capacityWait) {
       await waitForCodexCapacity(outcome.result.capacityWait, capacityWaitEntryBaseline);
       return true;
@@ -520,8 +516,8 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
 
     const holdMs = continuationHoldMs(outcome.result, ROTATION_IDLE_FLOOR_MS);
     if (holdMs > 0) {
-      // Provider backpressure / rotation all-capped idle: hold the loop so an active
-      // goal's continuation does not immediately re-enter the same rate-limit window.
+      // Provider recovery / rotation all-capped idle: hold the loop so the same
+      // turn or an active goal does not immediately re-enter the same rate-limit window.
       // A rotation all-capped idle is a MANDATORY hold (idleUntilReset) — a 0/elapsed
       // delay can never skip it (invariant 4: NO THRASH). A control or user signal
       // ends the wait early and is handled by the main loop.

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -28,7 +28,7 @@ import {
   modelUsageSourceKey,
   pointerReconcileReason,
   PROVIDER_BACKPRESSURE_DELAY_MS,
-  providerRetryRecovery,
+  providerRecoveryResult,
   resolveActiveSandboxBackend,
   shouldStartOnTurnRecording,
 } from "../src/activities/agent-turn";
@@ -1235,22 +1235,19 @@ describe("transient provider error classifier", () => {
     expect(payload.error).toBe("Invalid 'input': expected a string");
   });
 
-  test("a 503 with an active goal idles and auto-continues instead of failing (end-to-end routing)", () => {
-    // Classifier → retryable, then the retryable turn-failure branch's recovery
-    // routing → idle + goal_continuation + backpressure delay. This is the exact
-    // path that was missing when ~29 prod sessions hard-failed on provider 5xx.
+  test("a 503 recovers the same turn after backpressure pacing, independent of goal state", () => {
+    // Classifier → retryable, then the retryable turn-failure branch recovers the
+    // accepted turn itself. No goal lookup or synthetic continuation is involved.
     const failure = agentRunFailurePayload(
       Object.assign(new Error("Our servers are currently overloaded. Please try again later."), {
         status: 503,
       }),
     );
-    expect(failure.retryable).toBe(true); // enters the retryable branch (not the terminal one)
-    expect(providerRetryRecovery(true)).toEqual({
-      recovery: "goal_continuation",
+    expect(failure.retryable).toBe(true); // enters the recovery branch (not the terminal one)
+    expect(providerRecoveryResult()).toEqual({
+      status: "recovering",
       continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
     });
-    // A goal-less session idles too, but waits for the next user message (no auto-continue).
-    expect(providerRetryRecovery(false)).toEqual({ recovery: "user_message" });
   });
 
   test("agentRunFailurePayload keeps a ChatGPT/Codex usage cap non-retryable (429 that won't clear)", () => {

--- a/apps/worker/test/session-continuation-hold.test.ts
+++ b/apps/worker/test/session-continuation-hold.test.ts
@@ -37,7 +37,13 @@ describe("continuationHoldMs — the all-capped idle is a real wait", () => {
     expect(continuationHoldMs({ status: "idle", continueDelayMs: 60_000 }, FLOOR)).toBe(60_000);
   });
 
-  test("a non-idle result never holds (even if idleUntilReset is somehow set)", () => {
+  test("same-turn provider recovery honors the interruptible backpressure delay", () => {
+    expect(continuationHoldMs({ status: "recovering", continueDelayMs: 60_000 }, FLOOR)).toBe(
+      60_000,
+    );
+  });
+
+  test("a non-idle, non-recovering result never holds", () => {
     expect(
       continuationHoldMs({ status: "failed", continueDelayMs: 99, idleUntilReset: true }, FLOOR),
     ).toBe(0);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -20375,6 +20375,7 @@ export type RequestSessionTurnRecoveryInput = {
   triggerEventId: string;
   attemptId: string;
   reason: string;
+  detail?: Record<string, unknown>;
   fromStatuses?: SessionTurnStatus[];
 };
 
@@ -20666,6 +20667,7 @@ export async function requestSessionTurnRecovery(
             turnAttemptId: turn.activeAttemptId,
             turnAssociation: "current",
             payload: sanitizeEventPayload({
+              ...(input.detail ?? {}),
               triggerEventId: input.triggerEventId,
               reason: input.reason,
             }),

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -166,7 +166,13 @@ describe("clean session control plane", () => {
       turnId: turn!.id,
       triggerEventId: turn!.triggerEventId,
       attemptId,
-      reason: "worker_shutdown",
+      reason: "provider_unavailable",
+      detail: {
+        code: "provider_unavailable",
+        retryable: true,
+        error: "503 upstream connection termination",
+        continueDelayMs: 60_000,
+      },
     });
     expect(recovery.action).toBe("recovering");
     expect(recovery.events.map((event) => event.type)).toEqual([
@@ -180,7 +186,17 @@ describe("clean session control plane", () => {
       turnAttemptId: attemptId,
       payload: {
         id: "call-interrupted",
-        recovery: { interrupted: true, outcome: "unknown", reason: "worker_shutdown" },
+        recovery: { interrupted: true, outcome: "unknown", reason: "provider_unavailable" },
+      },
+    });
+    expect(recovery.events[1]).toMatchObject({
+      type: "turn.recovery.requested",
+      payload: {
+        reason: "provider_unavailable",
+        code: "provider_unavailable",
+        retryable: true,
+        error: "503 upstream connection termination",
+        continueDelayMs: 60_000,
       },
     });
     const history = await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id);

--- a/test/integration/worker-activity.integration.ts
+++ b/test/integration/worker-activity.integration.ts
@@ -898,7 +898,7 @@ describe("worker activities integration", () => {
     );
   });
 
-  test("an MCP stream timeout after a successful tool output checkpoints once and continues the active goal", async () => {
+  test("an MCP stream timeout after a successful tool output checkpoints once and recovers the same turn", async () => {
     const grant = await testGrant(dbClient.db);
     const session = await createOwnedSession(dbClient.db, grant, {
       initialMessage: "continue after transient MCP transport loss",
@@ -1000,18 +1000,22 @@ describe("worker activities integration", () => {
         trigger: { kind: "next" },
         workflowId: "workflow-mcp-timeout-after-output",
       }),
-    ).resolves.toMatchObject({ status: "idle", continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS });
+    ).resolves.toMatchObject({
+      status: "recovering",
+      continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
+    });
 
     const events = await listSessionEvents(dbClient.db, grant.workspaceId, session.id, 0, 100);
     const outputIndex = events.findIndex((event) => event.type === "agent.toolCall.output");
-    const failedIndex = events.findIndex((event) => event.type === "turn.failed");
+    const recoveryIndex = events.findIndex((event) => event.type === "turn.recovery.requested");
     expect(outputIndex).toBeGreaterThanOrEqual(0);
-    expect(failedIndex).toBeGreaterThan(outputIndex);
-    expect(events[failedIndex]?.payload).toMatchObject({
+    expect(recoveryIndex).toBeGreaterThan(outputIndex);
+    expect(events[recoveryIndex]?.payload).toMatchObject({
       code: "mcp_transport_timeout",
       retryable: true,
-      recovery: "goal_continuation",
+      continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
     });
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
     expect(events.filter((event) => event.type === "agent.toolCall.output")).toHaveLength(1);
     const activeHistory = await getActiveSessionHistoryItems(
       dbClient.db,
@@ -1025,7 +1029,15 @@ describe("worker activities integration", () => {
           (row.item as Record<string, unknown>).callId === callId,
       ),
     ).toHaveLength(1);
-    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe("idle");
+    expect((await getSession(dbClient.db, grant.workspaceId, session.id))?.status).toBe(
+      "recovering",
+    );
+    expect(
+      (await listSessionTurns(dbClient.db, grant.workspaceId, session.id)).at(-1),
+    ).toMatchObject({
+      status: "recovering",
+      activeAttemptId: null,
+    });
     expect((await getSessionGoal(dbClient.db, grant.workspaceId, session.id))?.status).toBe(
       "active",
     );


### PR DESCRIPTION
## Summary
- recover retryable provider/MCP failures as new fenced attempts of the same accepted turn
- remove goal-state dependency from infrastructure recovery
- preserve durable tool history and honor interruptible provider backpressure pacing

## Verification
- `bun run typecheck` — 20/20 projects
- focused worker/control tests — 78/78
- PostgreSQL session control-plane tests — 39/39
- formatting + affected-file lint clean