### PR TITLE
fix(release): verify the full publishable closure

### DIFF
--- a/scripts/verify-release-packages.test.ts
+++ b/scripts/verify-release-packages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  loadPublishablePackages,
   parseExpectedPackages,
   reconcileReleasePackages,
   type PublishablePackage,
@@ -19,6 +20,13 @@ function published(pkg: PublishablePackage, gitHead = sha): RegistryPackage {
 }
 
 describe("release package evidence", () => {
+  test("inventories the exact publishable workspace closure, including app packages", () => {
+    const publishable = loadPublishablePackages();
+    expect(publishable).toContainEqual({ name: "@opengeni/api-router", version: "0.5.5" });
+    expect(publishable).toContainEqual({ name: "@opengeni/worker-bundle", version: "0.7.3" });
+    expect(publishable).not.toContainEqual(expect.objectContaining({ name: "opengeni-web" }));
+  });
+
   test("parses a bounded comma/newline package set and rejects duplicates", () => {
     expect(parseExpectedPackages("@opengeni/react@0.14.0,\n@opengeni/sdk@0.13.0")).toEqual([
       react,

--- a/scripts/verify-release-packages.ts
+++ b/scripts/verify-release-packages.ts
@@ -1,11 +1,6 @@
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-
-type PackageManifest = {
-  name?: unknown;
-  version?: unknown;
-  private?: unknown;
-};
+import { publishableWorkspacePackages } from "./publishable-workspaces";
 
 export type PublishablePackage = {
   name: string;
@@ -132,30 +127,15 @@ export function reconcileReleasePackages(options: {
   return { needsPublish, releaseReady: !needsPublish, packages };
 }
 
-async function loadPublishablePackages(root: string): Promise<PublishablePackage[]> {
-  const packages: PublishablePackage[] = [];
-  const glob = new Bun.Glob("packages/*/package.json");
-  for await (const relativePath of glob.scan({ cwd: root, onlyFiles: true })) {
-    let manifest: PackageManifest;
-    try {
-      manifest = JSON.parse(await readFile(resolve(root, relativePath), "utf8")) as PackageManifest;
-    } catch (error) {
-      throw new Error(`could not parse publishable package manifest: ${relativePath}`, {
-        cause: error,
-      });
-    }
-    if (manifest.private === true) continue;
-    if (
-      typeof manifest.name !== "string" ||
-      !packageNamePattern.test(manifest.name) ||
-      typeof manifest.version !== "string" ||
-      !packageVersionPattern.test(manifest.version)
-    ) {
-      throw new Error(`invalid publishable package manifest: ${relativePath}`);
-    }
-    packages.push({ name: manifest.name, version: manifest.version });
-  }
-  return packages.sort((a, b) => a.name.localeCompare(b.name));
+export function loadPublishablePackages(): PublishablePackage[] {
+  return publishableWorkspacePackages()
+    .map(({ name, version }) => {
+      if (!packageNamePattern.test(name) || !packageVersionPattern.test(version)) {
+        throw new Error(`invalid publishable package manifest: ${name}@${version}`);
+      }
+      return { name, version };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 async function fetchRegistryPackage(pkg: PublishablePackage): Promise<RegistryPackage | null> {
@@ -224,7 +204,7 @@ async function main(): Promise<void> {
     throw new Error("OPENGENI_RELEASE_PACKAGE_PHASE must be plan or verify");
   }
 
-  const publishable = await loadPublishablePackages(root);
+  const publishable = loadPublishablePackages();
   const expectedNames = new Set(expected.map((pkg) => pkg.name));
   const registryEntries = await Promise.all(
     publishable.map(


### PR DESCRIPTION
## Problem

The evidence-bound release planner enumerated only `packages/*`, while the actual Changesets publish closure also includes publishable `apps/*` workspaces. The current release would therefore publish `@opengeni/api-router` and `@opengeni/worker-bundle` without including either in the declared expected set or post-publication receipt.

## Clean fix

Use the existing canonical `publishableWorkspacePackages()` inventory shared by the closure guard. This removes the duplicate glob/parser and makes the plan fail closed for every package Changesets can publish.

## Evidence

- 7/7 focused tests; new regression asserts app packages are inventoried and ignored web is excluded.
- All 20 TypeScript projects clean on the temporary Azure verification VM.
- UBS: 0 critical, 0 warnings.
- Live registry plan with only React/SDK now fails and identifies the six omitted versioned packages.
- Complete eight-package plan succeeds and marks all eight exact versions pending.

No npm or production mutation has occurred.