### PR TITLE
fix: preserve failed child turn provenance

### DIFF
--- a/.changeset/clean-failed-child-ownership.md
+++ b/.changeset/clean-failed-child-ownership.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep failed-child result provenance owned by the atomic turn settlement. Worker activities now read and deliver the exact committed outbox row without rewriting its turn-scoped payload or lineage.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -171,7 +171,7 @@ import {
   settingsWithPackSandboxImage,
   settingsWithRigImage,
 } from "./packs";
-import { notifyParentOfChildTerminal } from "./parent-wake";
+import { deliverFailedChildTurnToParent } from "./parent-wake";
 import { createSecretRedactor, identityRedactor } from "./redaction";
 import { applyCodexHistoryStrip, turnInput, type TurnCodexAccount } from "./run-input";
 import {
@@ -4515,12 +4515,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (settlement.action === "failed") {
           activityStatus = "failed";
           turnMetricOutcome = "failed";
-          await notifyParentOfChildTerminal(
+          await deliverFailedChildTurnToParent(
             { db, bus, settings, observability, wakeSessionWorkflow },
             input.workspaceId,
             input.sessionId,
-            "failed",
-            `turn:${lostTurnId}`,
+            lostTurnId,
           );
           return claimedResult({ status: "failed" });
         }
@@ -5163,15 +5162,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // failed and returns "failed", and the session workflow then exits
       // WITHOUT calling failSession/markSessionIdle. Wake a spawned worker's
       // parent here too, so a manager learns of a worker that died inside its
-      // turn (not just one failed by the workflow's failSession path). Deduped
-      // per terminal episode by the child's lastSequence, so it never
-      // double-fires with the workflow-level wake.
-      await notifyParentOfChildTerminal(
+      // turn (not just one failed by the workflow's failSession path). Turn
+      // settlement already owns the durable outbox payload; this call only
+      // delivers that exact turn-scoped row.
+      await deliverFailedChildTurnToParent(
         { db, bus, settings, observability, wakeSessionWorkflow },
         input.workspaceId,
         input.sessionId,
-        "failed",
-        `turn:${turnId}`,
+        turnId,
       );
       return claimedResult({ status: "failed" });
     } finally {

--- a/apps/worker/src/activities/parent-wake.ts
+++ b/apps/worker/src/activities/parent-wake.ts
@@ -6,6 +6,7 @@ import {
   addSessionSystemUpdateWithSourceMutation,
   claimPendingSessionSystemUpdateOutbox,
   claimPendingSessionWorkflowWakes,
+  getSessionSystemUpdateOutboxByDedupeKey,
   getOrCreateSessionSystemUpdateOutbox,
   markSessionWorkflowWakeFailed,
   markSessionSystemUpdateOutboxDeliveredInTransaction,
@@ -33,36 +34,15 @@ export type ReconcileSessionWorkflowWakeOverrides = Partial<{
 }>;
 
 /**
- * Deliver exactly one completion wake to a spawned worker's parent (manager)
- * session when the worker reaches a terminal-for-now state. No-op for a
- * parentless session (direct API create / scheduled run). Idempotent per
- * terminal episode: the idempotency key is the child's current lastSequence,
- * which advances every time the child does work, so a retry of the same
- * terminal transition (activity retry, the workflow's idle re-check, the
- * runAgentTurn-failed path overlapping a workflow-level wake) is deduped while
- * a genuinely new idle-after-work episode notifies again. The parent receives
- * one typed internal update; signalling its workflow ensures an idle parent can
- * coalesce and process all pending updates in one inference. Failures here never
- * fail the child because the durable outbox remains retryable.
- *
- * Lives in its own module so both the session-state terminal activities
- * (markSessionIdle / failSession) and runAgentTurn's in-turn failure path can
- * call it without a circular import between those two activity modules.
+ * Enrich and deliver the durable idle-boundary row committed by
+ * settleSessionIdleWithParentOutbox. Idle has no single owning turn, so its
+ * stable episode identity is the newest non-status event sequence.
  */
-export async function notifyParentOfChildTerminal(
+export async function notifyParentOfChildIdle(
   svc: NotifyServices,
   workspaceId: string,
   childSessionId: string,
-  terminalStatus: "idle" | "failed",
-  // Stable identifier for the terminal episode, used as the idempotency key so
-  // the same completion never wakes the parent twice. A FAILURE passes the
-  // failed turn's id: both the in-turn wake (runAgentTurn) and the
-  // workflow-level wake (failSession, after it appends more events that would
-  // shift lastSequence) key on the same turn, so a finally-throw that turns one
-  // failure into both paths still dedupes. An idle episode has no single
-  // owning turn, so it falls back to the child's lastSequence — which advances
-  // per work batch and is stable across retries of that same idle transition.
-  episodeKey?: string | null,
+  episodeKey: string,
 ): Promise<void> {
   try {
     const child = await getSession(svc.db, workspaceId, childSessionId);
@@ -75,23 +55,18 @@ export async function notifyParentOfChildTerminal(
     // what re-arms the loop the user just stopped. Suppress the resume nudge and
     // tell the agent to stay paused. Paired with the goal_set reactivation
     // guard so a nudge that slips through still cannot revive the goal.
-    const clientEventId = `child-completion:${childSessionId}:${episodeKey ?? child.lastSequence}`;
-    const payload = childCompletionPayload(child, goal, terminalStatus);
+    const clientEventId = `child-completion:${childSessionId}:${episodeKey}`;
+    const payload = childCompletionPayload(child, goal);
     const outbox = await getOrCreateSessionSystemUpdateOutbox(svc.db, {
       accountId: child.accountId,
       workspaceId,
       sourceSessionId: child.id,
       targetSessionId: child.parentSessionId,
       kind: "child_terminal_result",
-      classification:
-        terminalStatus === "failed"
-          ? "failure"
-          : goal?.status === "paused"
-            ? "action_required"
-            : "success",
+      classification: goal?.status === "paused" ? "action_required" : "success",
       sourceId: child.id,
       dedupeKey: clientEventId,
-      summary: childCompletionSummary(child, goal, terminalStatus),
+      summary: childCompletionSummary(child, goal, "idle"),
       payload,
       lineage: { childSessionId: child.id, parentSessionId: child.parentSessionId },
     });
@@ -102,8 +77,44 @@ export async function notifyParentOfChildTerminal(
   } catch (error) {
     // A durable pending outbox row survives this boundary. The global worker
     // reaper retries it; child terminal settlement never depends on this turn.
-    svc.observability.error("Failed to wake parent session on worker completion", {
+    svc.observability.error("Failed to wake parent session on worker idle boundary", {
       childSessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Deliver the exact failure row already committed by turn settlement. This
+ * layer deliberately cannot create or rewrite the row: the settlement
+ * transaction is the sole owner of the failed turn id, payload, and lineage.
+ */
+export async function deliverFailedChildTurnToParent(
+  svc: NotifyServices,
+  workspaceId: string,
+  childSessionId: string,
+  turnId: string,
+): Promise<void> {
+  try {
+    const child = await getSession(svc.db, workspaceId, childSessionId);
+    if (!child || !child.parentSessionId) return;
+    const dedupeKey = `child-completion:${childSessionId}:turn:${turnId}`;
+    const outbox = await getSessionSystemUpdateOutboxByDedupeKey(svc.db, {
+      accountId: child.accountId,
+      workspaceId,
+      dedupeKey,
+    });
+    if (!outbox) {
+      throw new Error(`Committed failed-child outbox disappeared: ${dedupeKey}`);
+    }
+    if (outbox.status === "delivered") return;
+    await deliverParentSystemUpdateOutbox(svc, outbox);
+  } catch (error) {
+    // Settlement already committed the retryable outbox row. The global
+    // reconciler remains the recovery path if immediate delivery fails.
+    svc.observability.error("Failed to deliver committed child-turn failure", {
+      childSessionId,
+      turnId,
       error: error instanceof Error ? error.message : String(error),
     });
   }
@@ -231,12 +242,11 @@ export async function reconcilePendingSessionWorkflowWakes(
 function childCompletionPayload(
   child: Session,
   goal: SessionGoal | null,
-  terminalStatus: "idle" | "failed",
 ): Extract<SessionSystemUpdatePayload, { type: "child_terminal_result" }> {
   return {
     type: "child_terminal_result",
     childSessionId: child.id,
-    status: terminalStatus,
+    status: "idle",
     ...(goal
       ? {
           goal: {

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -10,7 +10,7 @@ import {
   settleSessionIdleWithParentOutbox,
 } from "@opengeni/db";
 import { publishDurableSessionEvents } from "@opengeni/events";
-import { notifyParentOfChildTerminal } from "./parent-wake";
+import { deliverFailedChildTurnToParent, notifyParentOfChildIdle } from "./parent-wake";
 import { recordTurnsQueuedGauge } from "../observability-metrics";
 import type {
   ActivityServices,
@@ -33,7 +33,8 @@ export type SessionStateActivityOverrides = Partial<{
   requireSession: typeof requireSession;
   settleSessionIdleWithParentOutbox: typeof settleSessionIdleWithParentOutbox;
   publishDurableSessionEvents: typeof publishDurableSessionEvents;
-  notifyParentOfChildTerminal: typeof notifyParentOfChildTerminal;
+  deliverFailedChildTurnToParent: typeof deliverFailedChildTurnToParent;
+  notifyParentOfChildIdle: typeof notifyParentOfChildIdle;
   recordTurnsQueuedGauge: typeof recordTurnsQueuedGauge;
 }>;
 
@@ -61,8 +62,9 @@ export function createSessionStateActivities(
     overrides.settleSessionIdleWithParentOutbox ?? settleSessionIdleWithParentOutbox;
   const publishDurableSessionEventsFn =
     overrides.publishDurableSessionEvents ?? publishDurableSessionEvents;
-  const notifyParentOfChildTerminalFn =
-    overrides.notifyParentOfChildTerminal ?? notifyParentOfChildTerminal;
+  const deliverFailedChildTurnToParentFn =
+    overrides.deliverFailedChildTurnToParent ?? deliverFailedChildTurnToParent;
+  const notifyParentOfChildIdleFn = overrides.notifyParentOfChildIdle ?? notifyParentOfChildIdle;
   const recordTurnsQueuedGaugeFn = overrides.recordTurnsQueuedGauge ?? recordTurnsQueuedGauge;
 
   async function failSessionAttempt(input: FailSessionAttemptInput): Promise<void> {
@@ -103,12 +105,11 @@ export function createSessionStateActivities(
       return;
     }
     await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, result.events);
-    await notifyParentOfChildTerminalFn(
+    await deliverFailedChildTurnToParentFn(
       { db, bus, settings, observability, wakeSessionWorkflow },
       input.workspaceId,
       input.sessionId,
-      "failed",
-      `turn:${turn.id}`,
+      turn.id,
     );
   }
 
@@ -150,12 +151,11 @@ export function createSessionStateActivities(
     await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, result.events);
     await refreshQueuedTurnsGauge(db, observability, countQueuedTurnsFn, recordTurnsQueuedGaugeFn);
     if (result.action === "exceeded") {
-      await notifyParentOfChildTerminalFn(
+      await deliverFailedChildTurnToParentFn(
         { db, bus, settings, observability, wakeSessionWorkflow },
         input.workspaceId,
         input.sessionId,
-        "failed",
-        `turn:${result.turnId}`,
+        result.turnId,
       );
       return {
         action: "exceeded",
@@ -196,11 +196,10 @@ export function createSessionStateActivities(
     // point for a spawned worker, whatever the cause (goal completed, agent or
     // system paused goal, goalless work finished, idle control settlement). Wake
     // the parent here, deduped per idle episode so the manager is nudged once.
-    await notifyParentOfChildTerminalFn(
+    await notifyParentOfChildIdleFn(
       { db, bus, settings, observability, wakeSessionWorkflow },
       input.workspaceId,
       input.sessionId,
-      "idle",
       settled.episodeKey,
     );
   }

--- a/apps/worker/test/session-state-failure-dedupe.test.ts
+++ b/apps/worker/test/session-state-failure-dedupe.test.ts
@@ -25,7 +25,7 @@ describe("failSessionAttempt child-terminal identity", () => {
           recordingMutationApplied: false,
         })),
         publishDurableSessionEvents: mock(async () => undefined),
-        notifyParentOfChildTerminal: mock(async (...args: unknown[]) => {
+        deliverFailedChildTurnToParent: mock(async (...args: unknown[]) => {
           parentWakeCalls.push(args);
         }),
       },
@@ -41,7 +41,7 @@ describe("failSessionAttempt child-terminal identity", () => {
 
     expect(parentWakeCalls).toHaveLength(1);
     expect(parentWakeCalls[0]).toEqual(
-      expect.arrayContaining(["workspace-1", "child-1", "failed", "turn:turn-1"]),
+      expect.arrayContaining(["workspace-1", "child-1", "turn-1"]),
     );
   });
 });

--- a/apps/worker/test/session-state-worker-death.test.ts
+++ b/apps/worker/test/session-state-worker-death.test.ts
@@ -35,7 +35,7 @@ function makeActivities() {
           publishedEvents.push(...events);
         },
       ),
-      notifyParentOfChildTerminal: mock(async (...args: unknown[]) => {
+      deliverFailedChildTurnToParent: mock(async (...args: unknown[]) => {
         parentWakeCalls.push(args);
       }),
       recordTurnsQueuedGauge: mock(() => undefined),
@@ -123,7 +123,7 @@ describe("recoverDispatch: exact attempt ownership fence", () => {
     expect(publishedEvents).toEqual([{ id: "failed-1", type: "turn.failed" }]);
     expect(parentWakeCalls).toHaveLength(1);
     expect(parentWakeCalls[0]).toEqual(
-      expect.arrayContaining(["workspace-1", "session-1", "failed", "turn:turn-1"]),
+      expect.arrayContaining(["workspace-1", "session-1", "turn-1"]),
     );
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19826,7 +19826,7 @@ export async function peekSessionWork(
  * Commit the workflow's terminal-for-now idle decision and its parent delivery
  * source in one transaction. A crash after commit leaves a pending outbox row for
  * the global reconciler; a normal caller immediately enriches/delivers the same
- * dedupe identity through notifyParentOfChildTerminal.
+ * dedupe identity through notifyParentOfChildIdle.
  */
 export async function settleSessionIdleWithParentOutbox(
   db: Database,
@@ -21770,6 +21770,52 @@ function mapSystemUpdateOutboxRow(row: {
     payload: parseChildTerminalResultPayload(row.payload),
     lineage: row.lineage,
   };
+}
+
+/**
+ * Read the exact durable parent-update row created by terminal turn settlement.
+ * Failure delivery must never upsert this row: settlement owns its payload and
+ * turn provenance, while the activity layer only delivers the committed fact.
+ */
+export async function getSessionSystemUpdateOutboxByDedupeKey(
+  db: Database,
+  input: { accountId: string; workspaceId: string; dedupeKey: string },
+): Promise<SessionSystemUpdateOutboxDelivery | null> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const [row] = await scopedDb
+        .select()
+        .from(schema.sessionSystemUpdateOutbox)
+        .where(
+          and(
+            eq(schema.sessionSystemUpdateOutbox.workspaceId, input.workspaceId),
+            eq(schema.sessionSystemUpdateOutbox.dedupeKey, input.dedupeKey),
+          ),
+        )
+        .limit(1);
+      if (!row) return null;
+      if (row.kind !== "child_terminal_result") {
+        throw new Error(`System-update outbox contains retired kind ${row.kind}`);
+      }
+      return {
+        id: row.id,
+        status: row.status as "pending" | "delivered",
+        accountId: row.accountId,
+        workspaceId: row.workspaceId,
+        sourceSessionId: row.sourceSessionId,
+        targetSessionId: row.targetSessionId,
+        dedupeKey: row.dedupeKey,
+        kind: "child_terminal_result",
+        classification: row.classification as SystemUpdateClassification,
+        sourceId: row.sourceId,
+        summary: row.summary,
+        payload: parseChildTerminalResultPayload(row.payload),
+        lineage: row.lineage,
+      };
+    },
+  );
 }
 
 export async function claimPendingSessionSystemUpdateOutbox(

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -1260,7 +1260,12 @@ describe("clean session control plane", () => {
     const childOutboxes = async (childSessionId: string) =>
       await withWorkspaceRls(client.db, grant.workspaceId!, async (db) =>
         db
-          .select({ id: schema.sessionSystemUpdateOutbox.id })
+          .select({
+            id: schema.sessionSystemUpdateOutbox.id,
+            dedupeKey: schema.sessionSystemUpdateOutbox.dedupeKey,
+            payload: schema.sessionSystemUpdateOutbox.payload,
+            lineage: schema.sessionSystemUpdateOutbox.lineage,
+          })
           .from(schema.sessionSystemUpdateOutbox)
           .where(eq(schema.sessionSystemUpdateOutbox.sourceSessionId, childSessionId)),
       );
@@ -1291,22 +1296,42 @@ describe("clean session control plane", () => {
     expect(await getSession(client.db, grant.workspaceId!, failedChild.id)).toMatchObject({
       status: "failed",
     });
-    expect(await childOutboxes(failedChild.id)).toHaveLength(1);
+    expect(await childOutboxes(failedChild.id)).toEqual([
+      expect.objectContaining({
+        dedupeKey: `child-completion:${failedChild.id}:turn:${failedTurn.id}`,
+        payload: expect.objectContaining({
+          type: "child_terminal_result",
+          childSessionId: failedChild.id,
+          status: "failed",
+          turnId: failedTurn.id,
+        }),
+        lineage: expect.objectContaining({
+          childSessionId: failedChild.id,
+          parentSessionId: parent.id,
+          turnId: failedTurn.id,
+        }),
+      }),
+    ]);
 
     const exhaustedChild = await createChild("worker-death child");
-    const { attemptId: exhaustedAttemptId } = await claimChild(exhaustedChild);
-    expect(
-      await recoverSessionDispatch(client.db, grant.workspaceId!, {
-        sessionId: exhaustedChild.id,
-        attemptId: exhaustedAttemptId,
-        timeoutType: "HEARTBEAT",
-        maxRedispatches: 0,
-      }),
-    ).toMatchObject({ action: "exceeded" });
+    const { attemptId: exhaustedAttemptId, turn: exhaustedTurn } = await claimChild(exhaustedChild);
+    const exhausted = await recoverSessionDispatch(client.db, grant.workspaceId!, {
+      sessionId: exhaustedChild.id,
+      attemptId: exhaustedAttemptId,
+      timeoutType: "HEARTBEAT",
+      maxRedispatches: 0,
+    });
+    expect(exhausted).toMatchObject({ action: "exceeded", turnId: exhaustedTurn.id });
     expect(await getSession(client.db, grant.workspaceId!, exhaustedChild.id)).toMatchObject({
       status: "failed",
     });
-    expect(await childOutboxes(exhaustedChild.id)).toHaveLength(1);
+    expect(await childOutboxes(exhaustedChild.id)).toEqual([
+      expect.objectContaining({
+        dedupeKey: `child-completion:${exhaustedChild.id}:turn:${exhaustedTurn.id}`,
+        payload: expect.objectContaining({ turnId: exhaustedTurn.id }),
+        lineage: expect.objectContaining({ turnId: exhaustedTurn.id }),
+      }),
+    ]);
   });
 
   test("Pause blocks a racing terminal settlement and Resume admits a new attempt of the same turn", async () => {


### PR DESCRIPTION
## Summary
- make failed turn settlement the sole writer of failed-child outbox payload and lineage
- make worker failure notification read and deliver the exact committed row without upserting it
- keep idle child completion on its separate episode-keyed enrichment path
- add turn-provenance regression coverage for ordinary failure and worker-death exhaustion

## Verification
- full typecheck
- lint and format check
- publishable package build and publish-closure guard
- focused worker tests: 10/10
- real PostgreSQL session-control-plane suite: 42/42
- serialized Fable review: CLEAN, no P0/P1/P2
- production canary identified the pre-fix overwrite; exact rerun is required after deployment