### PR TITLE
feat: rotation-enabled is always sticky-sharded — remove the strategy picker (OPE-36)

### DIFF
--- a/.changeset/rotation-sharded-always.md
+++ b/.changeset/rotation-sharded-always.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+The codex rotation strategy picker is gone: rotation-enabled always behaves as sticky-sharded (OPE-36). Sessions stick to one subscription each for maximum prompt-cache reuse, spread across all connected accounts, rebalancing only when a plan caps. The legacy strategies (most-remaining, round-robin, drain-then-next) are all strictly dominated post-cache-affinity and are now normalized to sharded at every worker read site; their branch code is kept but unreachable (rollback safety). The API accepts-but-ignores `rotationStrategy` writes (deprecated no-op, no caller breaks) and reports `sharded` as the effective truth; migration 0064 backfills stored legacy values and flips the column default. The web settings surface drops the strategy dropdown for honest copy. Remaining user controls are the real intents: rotation on/off, manual per-session pins, and (with OPE-24) per-account allocator include/exclude.

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -42,10 +42,8 @@ import {
   updateCodexRotationSettings,
   upsertCodexSubscriptionCredential,
   withCodexCapacityMutation,
-  CODEX_ROTATION_STRATEGIES,
   type CodexAccountStatus,
   type CodexCapacityWakeTarget,
-  type CodexRotationStrategy,
 } from "@opengeni/db";
 
 // The picker surfaces codex models under their own "no credits" provider group so
@@ -369,7 +367,9 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       activeAccountId,
       settings: {
         rotationEnabled: rotation?.rotationEnabled ?? false,
-        rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
+        // OPE-36: rotation-enabled always behaves as sticky-sharded; report the
+        // effective truth, never the stored legacy residue.
+        rotationStrategy: "sharded",
         activeCredentialId: activeAccountId,
       },
     });
@@ -397,8 +397,11 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
     return c.json({ activated: true, accountId });
   });
 
-  // P3: update rotation settings (enable auto-rotation + pick the strategy). admin access.
-  // ensureCodexRotationSettings guarantees the row exists, then a one-cell patch.
+  // Update rotation settings. admin access. OPE-36: the strategy picker is GONE —
+  // rotation-enabled always behaves as sticky-sharded (worker-side
+  // effectiveRotationStrategy normalization). `rotationStrategy` in the body is
+  // ACCEPTED-BUT-IGNORED so no existing SDK/UI caller breaks (deprecation), and
+  // the stored column is only legacy residue kept for old-binary rollback.
   app.patch("/v1/workspaces/:workspaceId/codex/settings", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "workspace:admin");
@@ -406,18 +409,21 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       rotationEnabled?: unknown;
       rotationStrategy?: unknown;
     };
-    const patch: { rotationEnabled?: boolean; rotationStrategy?: CodexRotationStrategy } = {};
+    const patch: { rotationEnabled?: boolean } = {};
     if (typeof body.rotationEnabled === "boolean") {
       patch.rotationEnabled = body.rotationEnabled;
     }
-    if (typeof body.rotationStrategy === "string") {
-      if (!CODEX_ROTATION_STRATEGIES.includes(body.rotationStrategy as CodexRotationStrategy)) {
-        throw new HTTPException(400, { message: "invalid rotation strategy" });
-      }
-      patch.rotationStrategy = body.rotationStrategy as CodexRotationStrategy;
-    }
-    if (patch.rotationEnabled === undefined && patch.rotationStrategy === undefined) {
+    if (patch.rotationEnabled === undefined && body.rotationStrategy === undefined) {
       throw new HTTPException(400, { message: "no settings to update" });
+    }
+    if (patch.rotationEnabled === undefined) {
+      // Strategy-only writes are a deprecated no-op: report the (only) truth.
+      const rotation = await getCodexRotationSettings(db, workspaceId);
+      return c.json({
+        rotationEnabled: rotation?.rotationEnabled ?? false,
+        rotationStrategy: "sharded",
+        rotationStrategyDeprecated: true,
+      });
     }
     await ensureCodexRotationSettings(db, grant.accountId, workspaceId);
     const mutation = await withCodexCapacityMutation(
@@ -435,7 +441,8 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
     await signalCodexCapacityTargets(deps, mutation.wakeTargets);
     return c.json({
       rotationEnabled: updated.rotationEnabled,
-      rotationStrategy: updated.rotationStrategy,
+      // OPE-36: sharded is the only behavior; the stored column is residue.
+      rotationStrategy: "sharded",
       activeCredentialId: updated.activeCredentialId,
     });
   });

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -417,13 +417,9 @@ export function registerCodexRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(400, { message: "no settings to update" });
     }
     if (patch.rotationEnabled === undefined) {
-      // Strategy-only writes are a deprecated no-op: report the (only) truth.
-      const rotation = await getCodexRotationSettings(db, workspaceId);
-      return c.json({
-        rotationEnabled: rotation?.rotationEnabled ?? false,
-        rotationStrategy: "sharded",
-        rotationStrategyDeprecated: true,
-      });
+      // Strategy-only writes are a deprecated no-op (no db touch): report the
+      // (only) truth. Callers that also flip rotationEnabled fall through.
+      return c.json({ rotationStrategy: "sharded", rotationStrategyDeprecated: true });
     }
     await ensureCodexRotationSettings(db, grant.accountId, workspaceId);
     const mutation = await withCodexCapacityMutation(

--- a/apps/api/test/codex-usage-routes.test.ts
+++ b/apps/api/test/codex-usage-routes.test.ts
@@ -286,22 +286,29 @@ describe("PATCH /codex/settings — rotation settings", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { rotationEnabled: boolean; rotationStrategy: string };
     expect(body.rotationEnabled).toBe(true);
-    expect(body.rotationStrategy).toBe("most_remaining");
+    expect(body.rotationStrategy).toBe("sharded"); // OPE-36: the only effective strategy
     expect(ensure).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledWith(expect.anything(), WS, { rotationEnabled: true });
   });
 
-  test("rejects an unknown strategy with 400 (never reaches the db)", async () => {
+  test("OPE-36: a strategy-only write is a deprecated no-op (200, db untouched)", async () => {
+    // The strategy picker is gone — rotation-enabled always behaves as sharded.
+    // Old SDK/UI callers that PATCH a strategy (valid or bogus) must not break
+    // and must not write anything.
     const { update } = spySettings();
-    const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
-      method: "PATCH",
-      headers: {
-        authorization: await bearer(["workspace:admin"]),
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ rotationStrategy: "bogus" }),
-    });
-    expect(res.status).toBe(400);
+    for (const rotationStrategy of ["most_remaining", "bogus"]) {
+      const res = await app().request(`/v1/workspaces/${WS}/codex/settings`, {
+        method: "PATCH",
+        headers: {
+          authorization: await bearer(["workspace:admin"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ rotationStrategy }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { rotationStrategy: string };
+      expect(body.rotationStrategy).toBe("sharded");
+    }
     expect(update).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -26,7 +26,6 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MetaChip } from "@/components/ui/meta-chip";
-import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 
 // Cache TTL: a row whose cached snapshot is older than this (or never fetched)
@@ -372,12 +371,6 @@ export function CodexSubscriptionsCard({
   const accounts = data?.accounts ?? [];
   const activeAccountId = data?.activeAccountId ?? null;
   const rotationEnabled = data?.settings?.rotationEnabled ?? false;
-  const rotationStrategy = data?.settings?.rotationStrategy ?? "most_remaining";
-  const ROTATION_STRATEGY_LABELS: Record<CodexRotationSettings["rotationStrategy"], string> = {
-    most_remaining: "most remaining quota",
-    round_robin: "round-robin",
-    drain_then_next: "drain then next",
-  };
 
   return (
     <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
@@ -412,7 +405,8 @@ export function CodexSubscriptionsCard({
             <span className="text-xs">
               <span className="font-medium">Auto-rotate subscriptions</span>
               <span className="ml-1 text-fg-subtle">
-                — fail over to another plan when one hits its cap, never mid-turn.
+                — each session sticks to one plan for maximum prompt-cache reuse, spread across all
+                of them; a capped plan hands its sessions to the others, never mid-turn.
               </span>
             </span>
             <input
@@ -423,25 +417,6 @@ export function CodexSubscriptionsCard({
               onChange={(e) => void setRotation({ rotationEnabled: e.target.checked })}
             />
           </label>
-          {rotationEnabled ? (
-            <label className="flex items-center justify-between gap-3 text-xs">
-              <span className="text-fg-muted">Strategy</span>
-              <Select
-                className="h-7 bg-surface text-xs"
-                value={rotationStrategy}
-                disabled={busy}
-                onChange={(e) =>
-                  void setRotation({
-                    rotationStrategy: e.target.value as CodexRotationSettings["rotationStrategy"],
-                  })
-                }
-              >
-                <option value="most_remaining">Most remaining quota</option>
-                <option value="round_robin">Round-robin</option>
-                <option value="drain_then_next">Drain then next</option>
-              </Select>
-            </label>
-          ) : null}
         </div>
       ) : null}
 
@@ -624,9 +599,8 @@ export function CodexSubscriptionsCard({
           <p className="text-2xs text-fg-subtle">
             {rotationEnabled ? (
               <>
-                Auto-rotating across {accounts.length} subscriptions by{" "}
-                <span className="font-medium">{ROTATION_STRATEGY_LABELS[rotationStrategy]}</span>.
-                Pinned sessions stay on their pin.
+                Sessions are spread across all {accounts.length} subscriptions, each sticking to its
+                own plan for maximum prompt-cache reuse. Pinned sessions stay on their pin.
               </>
             ) : (
               <>

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -22,6 +22,25 @@ export type CodexRotationStrategy =
   | "sharded";
 
 /**
+ * The ONE strategy rotation-enabled workspaces run: sticky-sharded. The legacy
+ * strategies are all strictly dominated post-cache-affinity — session
+ * stickiness is worth ~half the prompt-cache hit rate, and round_robin /
+ * most_remaining churn accounts per turn while drain_then_next concentrates
+ * every concurrent session on ONE account (the measured concurrency-eviction
+ * failure sharding replaced). Stored `rotation_strategy` values are therefore
+ * NORMALIZED here at every read site: legacy values (and any future unknown
+ * string) behave as "sharded". The column and the legacy branch code are kept
+ * intact for old-binary rollback safety — they are simply unreachable through
+ * this normalization. The API accepts-but-ignores strategy writes for the same
+ * reason (no SDK caller breaks). User-facing choice is intentionally gone: the
+ * remaining real intents are rotation on/off, per-account allocator
+ * include/exclude, and manual pins — not algorithm selection.
+ */
+export function effectiveRotationStrategy(_stored: string): CodexRotationStrategy {
+  return "sharded";
+}
+
+/**
  * How a session's codex pin governs THIS turn's account selection (pure). Encodes the
  * policy-pin LIFECYCLE rule: a 'policy' pin is meaningful ONLY while the sharded policy
  * is active.
@@ -55,7 +74,7 @@ export function classifyCodexPin(args: {
   if (pinned && pinSource !== "policy") {
     return "manual";
   }
-  const shardedActive = rotationEnabled && strategy === "sharded";
+  const shardedActive = rotationEnabled && effectiveRotationStrategy(strategy) === "sharded";
   if (shardedActive) {
     return "sharded";
   }
@@ -502,14 +521,11 @@ export function chooseRotationActive(args: {
   // P3 (every account trivially covers → Tier 1 == all eligibles). Self-gating.
   usedConnectors?: string[];
 }): RotationDecision {
-  const {
-    rotationStrategy,
-    activeCredentialId,
-    priorCredentialId,
-    accounts,
-    nearExhaustionPct,
-    now,
-  } = args;
+  const { activeCredentialId, priorCredentialId, accounts, nearExhaustionPct, now } = args;
+  // Normalize at the entry point: rotation-enabled ALWAYS behaves as sharded
+  // (see effectiveRotationStrategy). args keeps the field so call sites and
+  // tests can still express stored legacy values.
+  const rotationStrategy = effectiveRotationStrategy(args.rotationStrategy);
   const allocatableAccounts = accounts.filter((account) => account.allocatorEnabled);
   const usedConnectors = args.usedConnectors ?? [];
 
@@ -674,7 +690,9 @@ export function selectCodexCredentialLeaseForTurn(args: {
     existingCredentialId,
   } = args.context;
   const leasingEnabled = args.leasingEnabled && leaseRotationEnabled;
-  const strategy = rotationStrategy as CodexRotationStrategy;
+  // Normalized: rotation-enabled always behaves as sharded (see
+  // effectiveRotationStrategy); the stored value is only ever legacy residue.
+  const strategy = effectiveRotationStrategy(rotationStrategy);
   const existing = existingCredentialId
     ? accounts.find((account) => account.id === existingCredentialId)
     : undefined;

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -373,7 +373,14 @@ describe("P3 self-heal + bounded reactive walk (invariant 4)", () => {
 
 describe("effectiveRotationStrategy (OPE-36)", () => {
   test("every stored value — legacy, sharded, or unknown — normalizes to sharded", () => {
-    for (const stored of ["most_remaining", "round_robin", "drain_then_next", "sharded", "", "future_strategy"]) {
+    for (const stored of [
+      "most_remaining",
+      "round_robin",
+      "drain_then_next",
+      "sharded",
+      "",
+      "future_strategy",
+    ]) {
       expect(effectiveRotationStrategy(stored)).toBe("sharded");
     }
   });

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -371,31 +371,37 @@ describe("P3 self-heal + bounded reactive walk (invariant 4)", () => {
   });
 });
 
-describe("chooseRotationActive — round_robin / drain_then_next", () => {
-  test("round_robin picks the next eligible after the prior account (wraps)", () => {
+describe("effectiveRotationStrategy (OPE-36)", () => {
+  test("every stored value — legacy, sharded, or unknown — normalizes to sharded", () => {
+    for (const stored of ["most_remaining", "round_robin", "drain_then_next", "sharded", "", "future_strategy"]) {
+      expect(effectiveRotationStrategy(stored)).toBe("sharded");
+    }
+  });
+});
+
+describe("chooseRotationActive — legacy strategies normalize to sharded ranking (OPE-36)", () => {
+  // The strategy picker is gone: rotation-enabled ALWAYS behaves as sticky-sharded
+  // (effectiveRotationStrategy normalizes every stored value). A stored legacy
+  // strategy must NOT reproduce its old behavior — it ranks by load like sharded.
+  test("stored round_robin does NOT advance to the next account; the load ranker decides", () => {
     const accounts = [acct("a"), acct("b"), acct("c")];
+    // Old round_robin picked "b" (next after prior "a"). Normalized: equal-load
+    // tie → stable created_at order → "a" (no pointless account hop, cache kept).
     expect(
       chooseRotationActive({
         ...base,
         rotationStrategy: "round_robin",
         activeCredentialId: "a",
         priorCredentialId: "a",
-        accounts,
-      }),
-    ).toEqual({ kind: "active", credentialId: "b", moved: true });
-    expect(
-      chooseRotationActive({
-        ...base,
-        rotationStrategy: "round_robin",
-        activeCredentialId: "a",
-        priorCredentialId: "c",
         accounts,
       }),
     ).toEqual({ kind: "active", credentialId: "a", moved: false });
   });
 
-  test("round_robin skips a cooling/capped successor", () => {
+  test("stored round_robin with a capped account still ranks (old behavior picked the successor)", () => {
     const accounts = [acct("a"), acct("b", { primaryUsedPercent: 99 }), acct("c")];
+    // Old round_robin skipped capped "b" to pick "c". Normalized: "a" is eligible
+    // and first on the equal-load tie — stay.
     expect(
       chooseRotationActive({
         ...base,
@@ -404,7 +410,7 @@ describe("chooseRotationActive — round_robin / drain_then_next", () => {
         priorCredentialId: "a",
         accounts,
       }),
-    ).toEqual({ kind: "active", credentialId: "c", moved: true });
+    ).toEqual({ kind: "active", credentialId: "a", moved: false });
   });
 
   test("round_robin all-capped wake ignores allocator-disabled credentials", () => {
@@ -427,7 +433,8 @@ describe("chooseRotationActive — round_robin / drain_then_next", () => {
     ).toEqual({ kind: "allCapped", earliestResetAt: enabledReset });
   });
 
-  test("drain_then_next stays on the prior account while eligible, else first eligible", () => {
+  test("stored drain_then_next no longer sticks to the prior account; capped accounts still fail over", () => {
+    // Old drain_then_next stuck to prior "b". Normalized: equal-load tie → "a".
     const accounts = [acct("a"), acct("b")];
     expect(
       chooseRotationActive({
@@ -437,7 +444,8 @@ describe("chooseRotationActive — round_robin / drain_then_next", () => {
         priorCredentialId: "b",
         accounts,
       }),
-    ).toEqual({ kind: "active", credentialId: "b", moved: true });
+    ).toEqual({ kind: "active", credentialId: "a", moved: false });
+    // Cap failover is strategy-independent and must keep working.
     const capped = [acct("a", { primaryUsedPercent: 99 }), acct("b")];
     expect(
       chooseRotationActive({
@@ -981,37 +989,34 @@ describe("classifyCodexPin — pin lifecycle (manual sacrosanct, policy meaningf
     }
   });
 
-  test("a leftover POLICY pin under drain_then_next → clearStale (ignore + clear, follow strategy)", () => {
-    expect(
-      classifyCodexPin({
-        pinnedCredentialId: "ex-home",
-        pinSource: "policy",
-        strategy: "drain_then_next",
-        rotationEnabled: true,
-      }),
-    ).toBe("clearStale");
+  test("OPE-36: a POLICY pin with rotation ENABLED → sharded under EVERY stored strategy (normalized)", () => {
+    // Pre-OPE-36 a stored legacy strategy made policy pins "clearStale" — that
+    // path is gone: rotation-enabled IS the sharded regime, pins are kept.
+    for (const strategy of ALL) {
+      expect(
+        classifyCodexPin({
+          pinnedCredentialId: "home",
+          pinSource: "policy",
+          strategy,
+          rotationEnabled: true,
+        }),
+      ).toBe("sharded");
+    }
   });
 
-  test("a POLICY pin is stale under ANY non-sharded strategy (and when rotation is off)", () => {
-    for (const strategy of NON_SHARDED) {
+  test("a POLICY pin with rotation DISABLED → clearStale under every stored strategy", () => {
+    // Rotation off is the one remaining non-sharded regime: a leftover policy
+    // pin is stale residue and must be ignored + lazily cleared.
+    for (const strategy of ALL) {
       expect(
         classifyCodexPin({
           pinnedCredentialId: "ex-home",
           pinSource: "policy",
           strategy,
-          rotationEnabled: true,
+          rotationEnabled: false,
         }),
       ).toBe("clearStale");
     }
-    // sharded strategy but rotation DISABLED → the sharded policy is not active → stale.
-    expect(
-      classifyCodexPin({
-        pinnedCredentialId: "ex-home",
-        pinSource: "policy",
-        strategy: "sharded",
-        rotationEnabled: false,
-      }),
-    ).toBe("clearStale");
   });
 
   test("a POLICY pin under an ACTIVE sharded policy → sharded (keep / re-shard, never clear)", () => {
@@ -1036,8 +1041,8 @@ describe("classifyCodexPin — pin lifecycle (manual sacrosanct, policy meaningf
     ).toBe("sharded");
   });
 
-  test("an UNPINNED session under a non-sharded strategy (or rotation off) → unpinned (follow the active strategy)", () => {
-    for (const strategy of NON_SHARDED) {
+  test("an UNPINNED session with rotation ENABLED → sharded under every stored strategy (lazy home assignment)", () => {
+    for (const strategy of ALL) {
       expect(
         classifyCodexPin({
           pinnedCredentialId: null,
@@ -1045,16 +1050,21 @@ describe("classifyCodexPin — pin lifecycle (manual sacrosanct, policy meaningf
           strategy,
           rotationEnabled: true,
         }),
+      ).toBe("sharded");
+    }
+  });
+
+  test("an UNPINNED session with rotation DISABLED → unpinned (workspace active pointer governs)", () => {
+    for (const strategy of ALL) {
+      expect(
+        classifyCodexPin({
+          pinnedCredentialId: null,
+          pinSource: null,
+          strategy,
+          rotationEnabled: false,
+        }),
       ).toBe("unpinned");
     }
-    expect(
-      classifyCodexPin({
-        pinnedCredentialId: null,
-        pinSource: null,
-        strategy: "sharded",
-        rotationEnabled: false,
-      }),
-    ).toBe("unpinned");
   });
 });
 
@@ -1253,8 +1263,8 @@ describe("OPE-21 pin and rollout policy", () => {
     expect(selected.credentialId).toBe("a");
   });
 
-  test("round_robin advances from session-last when it differs from workspace active", () => {
-    const decision = selectCodexCredentialLeaseForTurn({
+  test("OPE-36: stored round_robin behaves EXACTLY as sharded in the lease selector (sticky, never advancing)", () => {
+    const args = (rotationStrategy: string) => ({
       context: {
         accounts: [acct("a"), acct("b"), acct("c")].map((candidate) => ({
           ...candidate,
@@ -1265,7 +1275,7 @@ describe("OPE-21 pin and rollout policy", () => {
         activeCredentialId: "a",
         rotationEnabled: true,
         leaseRotationEnabled: true,
-        rotationStrategy: "round_robin",
+        rotationStrategy,
         existingCredentialId: null,
         policyScope: null,
         unavailableDiagnostics: [],
@@ -1278,7 +1288,13 @@ describe("OPE-21 pin and rollout policy", () => {
       nearExhaustionPct: 90,
       now: NOW,
     });
-    expect(decision.credentialId).toBe("c");
+    // Old round_robin advanced past session-last "b" to "c". Normalized: the
+    // stored legacy value is byte-equivalent to sharded (deterministic sticky
+    // home for the session), and repeated selection never advances.
+    const legacy = selectCodexCredentialLeaseForTurn(args("round_robin"));
+    const sharded = selectCodexCredentialLeaseForTurn(args("sharded"));
+    expect(legacy).toEqual(sharded);
+    expect(selectCodexCredentialLeaseForTurn(args("round_robin"))).toEqual(legacy);
   });
 
   test("same-turn frozen continuation keeps a healthy disabled credential without admitting new work", () => {

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -8,6 +8,7 @@ import {
   computeIdleDelayMs,
   computeReactiveRotationResume,
   DEFAULT_RESET_COOLDOWN_MS,
+  effectiveRotationStrategy,
   isCodexAccountEligible,
   MIN_IDLE_MS,
   REACTIVE_CIRCUIT_BREAKER_IDLE_MS,

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "0.5.4",
+      "version": "0.5.7",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -85,9 +85,6 @@
       "name": "opengeni-web",
       "version": "0.1.0",
       "dependencies": {
-        "@dnd-kit/core": "6.3.1",
-        "@dnd-kit/sortable": "10.0.0",
-        "@dnd-kit/utilities": "3.2.2",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@novnc/novnc": "1.7.0",
@@ -127,7 +124,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.7.2",
+      "version": "0.7.5",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -154,7 +151,7 @@
     },
     "examples/northstar-support": {
       "name": "@opengeni/example-northstar-support",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/react": "workspace:*",
@@ -189,7 +186,7 @@
     },
     "packages/codex": {
       "name": "@opengeni/codex",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -200,7 +197,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -224,7 +221,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "0.4.7",
+      "version": "0.4.10",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/codex": "workspace:*",
@@ -246,7 +243,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "0.7.0",
+      "version": "0.7.3",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -273,7 +270,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.2.9",
+      "version": "0.2.12",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.3",
         "@opengeni/config": "workspace:*",
@@ -290,7 +287,7 @@
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -303,7 +300,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -327,7 +324,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -408,7 +405,7 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "@openai/agents": "0.13.3",
@@ -428,7 +425,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/deployment": "workspace:*",
@@ -439,7 +436,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",

--- a/packages/db/drizzle/0064_rotation_strategy_sharded_backfill.sql
+++ b/packages/db/drizzle/0064_rotation_strategy_sharded_backfill.sql
@@ -1,0 +1,14 @@
+-- OPE-36: the strategy picker is gone — rotation-enabled always behaves as
+-- sticky-sharded (worker-side effectiveRotationStrategy normalizes every read).
+-- Backfill stored legacy values so the column tells the truth going forward.
+-- The column itself is KEPT (old-binary rollback safety): an old worker reading
+-- 'sharded' runs the strategy that was already live on every real workspace.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+UPDATE "codex_rotation_settings"
+SET "rotation_strategy" = 'sharded'
+WHERE "rotation_strategy" IS DISTINCT FROM 'sharded';
+
+ALTER TABLE "codex_rotation_settings" ALTER COLUMN "rotation_strategy" SET DEFAULT 'sharded';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -432,7 +432,7 @@ export const codexRotationSettings = pgTable(
     // code reads this bit; old binaries safely ignore it and keep the legacy
     // pin/rotation policy.
     leaseRotationEnabled: boolean("lease_rotation_enabled").notNull().default(false),
-    rotationStrategy: text("rotation_strategy").notNull().default("most_remaining"), // P3, inert
+    rotationStrategy: text("rotation_strategy").notNull().default("sharded"), // OPE-36: legacy residue; behavior is always sharded
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/test/migration-0053.test.ts
+++ b/packages/db/test/migration-0053.test.ts
@@ -4,7 +4,11 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { selectCodexCredentialLeaseForTurn } from "../../../apps/worker/src/activities/codex-rotation";
+import {
+  chooseShardedHome,
+  selectCodexCredentialLeaseForTurn,
+  type CodexRotationAccount,
+} from "../../../apps/worker/src/activities/codex-rotation";
 import { acquireCodexCredentialLease, createDb } from "../src/index";
 import { migrate } from "../src/migrate";
 
@@ -165,6 +169,30 @@ describe("migration 0053 (Codex credential leases)", () => {
             rotation_enabled = true,
             lease_rotation_enabled = false
         where workspace_id = ${workspaceId}`;
+      const rollbackAccounts: CodexRotationAccount[] = [credentialA, credentialB].map((id) => ({
+        id,
+        chatgptAccountId: null,
+        label: null,
+        accountEmail: null,
+        planType: "pro",
+        status: "active",
+        allocatorEnabled: true,
+        isActive: id === credentialB,
+        expiresAt: null,
+        lastRefreshAt: null,
+        lastError: null,
+        primaryUsedPercent: 0,
+        primaryResetAt: null,
+        secondaryUsedPercent: 0,
+        secondaryResetAt: null,
+        usageCheckedAt: null,
+        exhaustedUntil: null,
+        connectorNamespaces: null,
+        connectorsCheckedAt: null,
+        activeLeaseCount: 0,
+        selectionCount: 0,
+        lastSelectedAt: null,
+      }));
       const rollbackSelection = selectCodexCredentialLeaseForTurn({
         context: {
           accounts: [credentialA, credentialB].map((id) => ({
@@ -207,7 +235,21 @@ describe("migration 0053 (Codex credential leases)", () => {
         nearExhaustionPct: 90,
         now: new Date(),
       });
-      expect(rollbackSelection.credentialId).toBe(credentialB);
+      // OPE-36: rotation-enabled always behaves as sticky-sharded, so the
+      // rollback selection is the session's deterministic sharded home (the
+      // stored legacy strategy is normalized) — what matters for old-binary
+      // compatibility is that selection WORKS and never touches the lease table.
+      const expectedHome = chooseShardedHome({
+        sessionId: "session-test",
+        currentPolicyPin: null,
+        accounts: rollbackAccounts,
+        nearExhaustionPct: 90,
+        now: new Date(),
+      });
+      expect(expectedHome.kind).toBe("home");
+      expect(rollbackSelection.credentialId).toBe(
+        expectedHome.kind === "home" ? expectedHome.credentialId : null,
+      );
       const [inert] = await admin<{ count: number }[]>`
         select count(*)::int as count from codex_credential_leases`;
       expect(inert!.count).toBe(0);
@@ -241,7 +283,11 @@ describe("migration 0053 (Codex credential leases)", () => {
             now: new Date(),
           }),
       );
-      expect(beforeWorkspaceCutover.credentialId).toBe(credentialB);
+      // OPE-36: unpinned + rotation-enabled selects the session's sharded home
+      // (stored strategy normalized), not the workspace active pointer.
+      expect(beforeWorkspaceCutover.credentialId).toBe(
+        expectedHome.kind === "home" ? expectedHome.credentialId : null,
+      );
       expect(beforeWorkspaceCutover.holderId).toBeNull();
       expect(beforeWorkspaceCutover.generation).toBeNull();
       const [stillInert] = await admin<{ count: number }[]>`
@@ -313,6 +359,8 @@ describe("migration 0053 (Codex credential leases)", () => {
         nearExhaustionPct: 90,
         now: new Date(),
       });
+      // Rotation OFF is untouched by OPE-36: the selector returns the workspace
+      // active pointer, exactly as before.
       expect(featureOffAgain.credentialId).toBe(oldWorkerAfterCutover!.active_credential_id);
       await migrate(databaseUrl);
       const [afterIdempotentMigrate] = await admin<


### PR DESCRIPTION
## Why (OPE-36, measured rationale in OPE-21/OPE-31)

Session-to-account stickiness is worth roughly half the prompt-cache hit rate (48→96% fleet-wide once sharding + wire affinity shipped). Against that, every legacy strategy is strictly dominated: **round-robin** and **most-remaining** churn accounts per turn (cache-hostile by construction), and **drain-then-next** concentrates all concurrent sessions on one account — the measured ~30%-cache concurrency-eviction failure sharding replaced. The UI dropdown offering exactly these three (and not `sharded`, which real workspaces actually run — rendering an undefined label for it) meant one click silently halved a workspace's cache. Choice here was a footgun disguised as flexibility; the remaining real intents are rotation **on/off**, **manual pins**, and (OPE-24) per-account allocator include/exclude.

## What

- **Worker**: `effectiveRotationStrategy(stored)` → `"sharded"` always, applied at the three strategy authorities (`chooseRotationActive`, the lease selector, `classifyCodexPin`). Legacy branches kept intact but unreachable (old-binary rollback safety). Notable semantics: with rotation enabled, a policy pin is never `clearStale` anymore — rotation-enabled IS the sharded regime.
- **API**: `PATCH codex/settings` accepts-but-ignores `rotationStrategy` (strategy-only writes are a deprecated 200 no-op that never touches the db); GET/PATCH report `rotationStrategy: "sharded"` — the effective truth, never stored residue.
- **DB**: migration 0064 backfills stored legacy values to `sharded` and flips the column default; column retained for rollback (old workers run sharded anyway — it shipped in #377).
- **Web**: strategy dropdown removed; toggle + footer copy state the actual behavior ("each session sticks to one plan for maximum prompt-cache reuse; a capped plan hands its sessions to the others, never mid-turn").

## Not in this PR

Per-account allocator include/exclude UI (OPE-24's scope; no route exists yet). Lease-allocator cutover stays gated as before (`lease_rotation_enabled` untouched).

## Tests

Legacy-contract tests consciously rewritten to the normalized contract (they documented the removed behaviors): stored `round_robin`/`drain_then_next` no longer advance/stick but rank exactly as sharded (byte-equal lease decisions, sticky across repeats); policy pins under any stored strategy + rotation-enabled → `sharded`, rotation-disabled → `clearStale`. New unit test pins the normalizer for all stored values incl. unknown strings. Worker rotation suite 73/73; api codex routes 11/11; full typecheck, oxfmt, oxlint clean; changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)