### PR TITLE
chore(db): classify migration 0064 as deployment-mode rolling

### DIFF
--- a/packages/db/drizzle/0064_rotation_strategy_sharded_backfill.sql
+++ b/packages/db/drizzle/0064_rotation_strategy_sharded_backfill.sql
@@ -1,3 +1,4 @@
+-- deployment-mode: rolling
 -- OPE-36: the strategy picker is gone — rotation-enabled always behaves as
 -- sticky-sharded (worker-side effectiveRotationStrategy normalizes every read).
 -- Backfill stored legacy values so the column tells the truth going forward.


### PR DESCRIPTION
One-line classification required by the OPE-25 schema-contract gate (Deploy Production rejected #453's train with 'new migration is not classified rolling'). 0064 is rolling-safe: sub-second UPDATE + ALTER DEFAULT on the tiny codex_rotation_settings table; old binaries already run the 'sharded' value (shipped in #377). Staging tracks migrations by name, so the content edit does not re-run it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)